### PR TITLE
refactor: remodel emit invariants

### DIFF
--- a/crates/emit/src/abi/callable.rs
+++ b/crates/emit/src/abi/callable.rs
@@ -20,7 +20,7 @@ impl PayloadLayout {
 /// Physical encoding of an `Option<T>` result at a callable boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OptionReturnAbi {
-    CommaOk,
+    CommaOk { payload: PayloadLayout },
     Nullable,
     Sentinel(i64),
 }
@@ -32,17 +32,15 @@ pub(crate) enum CallableReturnAbi {
     Tagged,
     /// No generated tagged/lowered boundary encoding is required.
     Direct,
+    /// A `Result<(), E>` represented by its error value alone.
+    BareError,
     Result {
-        bare_error: bool,
         payload: PayloadLayout,
     },
     Partial {
         payload: PayloadLayout,
     },
-    Option {
-        encoding: OptionReturnAbi,
-        payload: PayloadLayout,
-    },
+    Option(OptionReturnAbi),
     Tuple {
         arity: usize,
     },
@@ -74,14 +72,9 @@ impl CallableReturnAbi {
     pub(crate) fn is_multi_return(&self) -> bool {
         matches!(
             self,
-            Self::Result {
-                bare_error: false,
-                ..
-            } | Self::Partial { .. }
-                | Self::Option {
-                    encoding: OptionReturnAbi::CommaOk,
-                    ..
-                }
+            Self::Result { .. }
+                | Self::Partial { .. }
+                | Self::Option(OptionReturnAbi::CommaOk { .. })
                 | Self::Tuple { .. }
         )
     }

--- a/crates/emit/src/abi/catalog.rs
+++ b/crates/emit/src/abi/catalog.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Symbol, Type};
 
@@ -11,7 +11,6 @@ use crate::names::go_name;
 pub(crate) struct GoAbiCatalog {
     callables: HashMap<String, GoCallableSlots>,
     fields: HashMap<String, HashMap<String, GoSlotDescriptor>>,
-    imported_types: HashSet<String>,
 }
 
 #[derive(Debug)]
@@ -63,7 +62,7 @@ impl GoAbiCatalog {
     }
 
     pub(crate) fn is_imported_type(&self, qualified_name: &str) -> bool {
-        self.imported_types.contains(qualified_name)
+        self.fields.contains_key(qualified_name)
     }
 
     fn register_callable(
@@ -103,7 +102,6 @@ impl GoAbiCatalog {
         let DefinitionBody::Struct { fields, .. } = &definition.body else {
             return;
         };
-        self.imported_types.insert(qualified_name.to_string());
         let slots = self.fields.entry(qualified_name.to_string()).or_default();
         for field in fields {
             slots.insert(

--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -10,11 +10,7 @@ use crate::plan::bodies::LoweredStatement;
 use super::callable::AbiTransition;
 use super::layout::{FunctionLayout, ValueLayout};
 
-pub(crate) struct CoercionPlan {
-    kind: CoercionKind,
-}
-
-enum CoercionKind {
+pub(crate) enum CoercionPlan {
     Identity,
     WrapAsInterface(AdapterPlan),
     WrapNewtype { ty: Type },
@@ -92,14 +88,13 @@ impl LayoutBridge {
 
 impl CoercionPlan {
     pub(crate) fn internal(planner: &Planner<'_>, from: &Type, to: &Type) -> Self {
-        let kind = if let Some(plan) = planner.needs_adapter(from, to) {
-            CoercionKind::WrapAsInterface(plan)
+        if let Some(plan) = planner.needs_adapter(from, to) {
+            Self::WrapAsInterface(plan)
         } else if needs_newtype_wrap(planner, from, to) {
-            CoercionKind::WrapNewtype { ty: to.clone() }
+            Self::WrapNewtype { ty: to.clone() }
         } else {
-            CoercionKind::Identity
-        };
-        Self { kind }
+            Self::Identity
+        }
     }
 
     pub(crate) fn bridge(
@@ -108,16 +103,15 @@ impl CoercionPlan {
         target: &ValueLayout,
     ) -> Self {
         let bridge = resolve_layout_bridge(planner, source, target);
-        let kind = if bridge.is_identity() {
-            CoercionKind::Identity
+        if bridge.is_identity() {
+            Self::Identity
         } else {
-            CoercionKind::Layout(bridge)
-        };
-        Self { kind }
+            Self::Layout(bridge)
+        }
     }
 
     pub(crate) fn is_identity(&self) -> bool {
-        matches!(self.kind, CoercionKind::Identity)
+        matches!(self, Self::Identity)
     }
 
     pub(crate) fn lower(
@@ -126,19 +120,17 @@ impl CoercionPlan {
         value: String,
     ) -> (Vec<LoweredStatement>, String) {
         let mut statements = Vec::new();
-        let value = match self.kind {
-            CoercionKind::Identity => value,
-            CoercionKind::WrapAsInterface(plan) => {
+        let value = match self {
+            Self::Identity => value,
+            Self::WrapAsInterface(plan) => {
                 let adapter_name = planner.ensure_adapter_type(plan);
                 format!("{}{{inner: {}}}", adapter_name, value)
             }
-            CoercionKind::WrapNewtype { ty } => {
+            Self::WrapNewtype { ty } => {
                 let type_name = planner.go_type_string(&ty);
                 format!("{}({})", type_name, value)
             }
-            CoercionKind::Layout(bridge) => {
-                planner.plan_layout_bridge(&mut statements, &value, &bridge)
-            }
+            Self::Layout(bridge) => planner.plan_layout_bridge(&mut statements, &value, &bridge),
         };
         (statements, value)
     }

--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -55,11 +55,12 @@ impl FunctionLayout {
         match self.return_abi {
             CallableReturnAbi::Result { .. }
             | CallableReturnAbi::Partial { .. }
-            | CallableReturnAbi::Option { .. } => {
+            | CallableReturnAbi::Option(_) => {
                 optional_layouts_match(self.payload.as_deref(), other.payload.as_deref())
             }
             CallableReturnAbi::Tagged
             | CallableReturnAbi::Direct
+            | CallableReturnAbi::BareError
             | CallableReturnAbi::Tuple { .. } => self.result.same_representation(&other.result),
         }
     }
@@ -85,9 +86,9 @@ impl FunctionLayout {
         }
         match &self.return_abi {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.result.go_type(planner),
-            CallableReturnAbi::Result {
-                bare_error: true, ..
-            } => planner.go_type_string(&self.result.logical_type().err_type()),
+            CallableReturnAbi::BareError => {
+                planner.go_type_string(&self.result.logical_type().err_type())
+            }
             CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
                 let payload = self
                     .payload
@@ -96,28 +97,19 @@ impl FunctionLayout {
                 let error = planner.go_type_string(&self.result.logical_type().err_type());
                 format!("({}, {error})", payload.go_type(planner))
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
                 let payload = self
                     .payload
                     .as_deref()
                     .expect("option callable layout has a payload");
                 format!("({}, bool)", payload.go_type(planner))
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                ..
-            } => self
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable) => self
                 .payload
                 .as_deref()
                 .expect("option callable layout has a payload")
                 .go_type(planner),
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Sentinel(_),
-                ..
-            } => self
+            CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => self
                 .payload
                 .as_deref()
                 .expect("option callable layout has a payload")

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -36,9 +36,12 @@ impl Planner<'_> {
     pub(crate) fn classify_direct_emission(&self, return_ty: &Type) -> Option<CallableReturnAbi> {
         let peeled = self.facts.peel_alias(return_ty);
         if peeled.is_result() && self.err_slot_is_nilable(&peeled) {
-            return Some(CallableReturnAbi::Result {
-                bare_error: peeled.ok_type().is_unit(),
-                payload: PayloadLayout::Packed,
+            return Some(if peeled.ok_type().is_unit() {
+                CallableReturnAbi::BareError
+            } else {
+                CallableReturnAbi::Result {
+                    payload: PayloadLayout::Packed,
+                }
             });
         }
         if peeled.is_partial() && self.err_slot_is_nilable(&peeled) {
@@ -47,14 +50,14 @@ impl Planner<'_> {
             });
         }
         if peeled.is_option() {
-            return Some(CallableReturnAbi::Option {
-                encoding: if self.facts.is_nullable_option(&peeled) {
-                    OptionReturnAbi::Nullable
-                } else {
-                    OptionReturnAbi::CommaOk
-                },
-                payload: PayloadLayout::Packed,
-            });
+            let encoding = if self.facts.is_nullable_option(&peeled) {
+                OptionReturnAbi::Nullable
+            } else {
+                OptionReturnAbi::CommaOk {
+                    payload: PayloadLayout::Packed,
+                }
+            };
+            return Some(CallableReturnAbi::Option(encoding));
         }
         if let Some(arity) = peeled.tuple_arity()
             && arity >= 2
@@ -81,28 +84,19 @@ impl Planner<'_> {
         let peeled = self.facts.peel_alias(return_ty);
         match shape {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type_string(&peeled),
-            CallableReturnAbi::Result {
-                bare_error: true, ..
-            } => self.go_type_string(&peeled.err_type()),
-            CallableReturnAbi::Result {
-                bare_error: false, ..
-            }
-            | CallableReturnAbi::Partial { .. } => {
+            CallableReturnAbi::BareError => self.go_type_string(&peeled.err_type()),
+            CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
                 let ok_str = self.go_type_string(&peeled.ok_type());
                 let err_str = self.go_type_string(&peeled.err_type());
                 format!("({}, {})", ok_str, err_str)
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
                 let inner_str = self.go_type_string(&peeled.ok_type());
                 format!("({}, bool)", inner_str)
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_),
-                ..
-            } => self.go_type_string(&peeled.ok_type()),
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_)) => {
+                self.go_type_string(&peeled.ok_type())
+            }
             CallableReturnAbi::Tuple { .. } => {
                 let parts: Vec<String> = tuple_element_types(&peeled)
                     .iter()
@@ -133,13 +127,8 @@ impl Planner<'_> {
         let peeled = self.facts.peel_alias(return_ty);
         match shape {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type(&peeled),
-            CallableReturnAbi::Result {
-                bare_error: true, ..
-            } => self.go_type(&peeled.err_type()),
-            CallableReturnAbi::Result {
-                bare_error: false, ..
-            }
-            | CallableReturnAbi::Partial { .. } => {
+            CallableReturnAbi::BareError => self.go_type(&peeled.err_type()),
+            CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
                 let ok_go = self.go_type(&peeled.ok_type());
                 let err_go = self.go_type(&peeled.err_type());
                 let mut result = GoType::new(format!("({}, {})", ok_go.code, err_go.code));
@@ -147,19 +136,15 @@ impl Planner<'_> {
                 result.merge(&err_go);
                 result
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
                 let inner_go = self.go_type(&peeled.ok_type());
                 let mut result = GoType::new(format!("({}, bool)", inner_go.code));
                 result.merge(&inner_go);
                 result
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_),
-                ..
-            } => self.go_type(&peeled.ok_type()),
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_)) => {
+                self.go_type(&peeled.ok_type())
+            }
             CallableReturnAbi::Tuple { .. } => {
                 let elements = tuple_element_types(&peeled);
                 let element_gos: Vec<GoType> = elements

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -66,21 +66,15 @@ pub(crate) fn lowered_err_values(
     err_expr: &str,
 ) -> Vec<String> {
     match shape {
-        CallableReturnAbi::Result {
-            bare_error: true, ..
-        } => vec![err_expr.to_string()],
-        CallableReturnAbi::Result {
-            bare_error: false, ..
-        } => {
+        CallableReturnAbi::BareError => vec![err_expr.to_string()],
+        CallableReturnAbi::Result { .. } => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
             vec![lowered_zero(planner, &ok_ty), err_expr.to_string()]
         }
         CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
         }
-        CallableReturnAbi::Tagged
-        | CallableReturnAbi::Direct
-        | CallableReturnAbi::Option { .. } => {
+        CallableReturnAbi::Tagged | CallableReturnAbi::Direct | CallableReturnAbi::Option(_) => {
             unreachable!("Option's failure constructor `None` carries no payload")
         }
     }
@@ -90,29 +84,20 @@ pub(crate) fn lowered_err_values(
 /// enclosing function's lowered shape (e.g. `[ok, "nil"]`).
 pub(crate) fn lowered_ok_values(shape: &CallableReturnAbi, ok_expr: &str) -> Vec<String> {
     match shape {
-        CallableReturnAbi::Result {
-            bare_error: true, ..
-        } => vec!["nil".to_string()],
-        CallableReturnAbi::Result {
-            bare_error: false, ..
-        } => vec![ok_expr.to_string(), "nil".to_string()],
+        CallableReturnAbi::BareError => vec!["nil".to_string()],
+        CallableReturnAbi::Result { .. } => vec![ok_expr.to_string(), "nil".to_string()],
         CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
             unreachable!("not reached for shapes with their own emission paths")
         }
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::CommaOk,
-            ..
-        } => vec![ok_expr.to_string(), "true".to_string()],
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Nullable,
-            ..
-        } => vec![ok_expr.to_string()],
+        CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
+            vec![ok_expr.to_string(), "true".to_string()]
+        }
+        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec![ok_expr.to_string()],
         CallableReturnAbi::Tagged
         | CallableReturnAbi::Direct
-        | CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Sentinel(_),
-            ..
-        } => unreachable!("not a lowered Lisette return ABI"),
+        | CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => {
+            unreachable!("not a lowered Lisette return ABI")
+        }
     }
 }
 
@@ -124,17 +109,11 @@ pub(crate) fn lowered_none_values(
     return_ty: &Type,
 ) -> Vec<String> {
     match shape {
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::CommaOk,
-            ..
-        } => {
+        CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
             vec![lowered_zero(planner, &inner), "false".to_string()]
         }
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Nullable,
-            ..
-        } => vec!["nil".to_string()],
+        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec!["nil".to_string()],
         _ => unreachable!("only Option's `None` lacks a payload"),
     }
 }
@@ -154,18 +133,14 @@ pub(crate) fn emit_lowered_result_return(
         lowered_zero(planner, &ok_ty)
     };
     match shape {
-        CallableReturnAbi::Result {
-            bare_error: true, ..
-        } => vec![
+        CallableReturnAbi::BareError => vec![
             tag_check(
                 format!("{p}.Tag == {RESULT_OK_TAG}"),
                 vec!["nil".to_string()],
             ),
             multi_value_return(vec![format!("{p}.ErrVal")]),
         ],
-        CallableReturnAbi::Result {
-            bare_error: false, ..
-        } => {
+        CallableReturnAbi::Result { .. } => {
             let zero = ok_zero(planner);
             vec![
                 tag_check(
@@ -189,10 +164,7 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(vec![format!("{p}.OkVal"), format!("{p}.ErrVal")]),
             ]
         }
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::CommaOk,
-            ..
-        } => {
+        CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
             let zero = ok_zero(planner);
             vec![
                 tag_check(
@@ -202,10 +174,7 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(vec![zero, "false".to_string()]),
             ]
         }
-        CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Nullable,
-            ..
-        } => vec![
+        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec![
             tag_check(
                 format!("{p}.Tag == {OPTION_SOME_TAG}"),
                 vec![format!("{p}.SomeVal")],
@@ -217,10 +186,9 @@ pub(crate) fn emit_lowered_result_return(
         }
         CallableReturnAbi::Tagged
         | CallableReturnAbi::Direct
-        | CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Sentinel(_),
-            ..
-        } => unreachable!("not a lowered Lisette return ABI"),
+        | CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => {
+            unreachable!("not a lowered Lisette return ABI")
+        }
     }
 }
 

--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -8,41 +8,21 @@ use syntax::ast::{Expression, Generic, Visibility};
 use syntax::program::{DefinitionBody, File};
 
 impl Planner<'_> {
-    pub(crate) fn collect_local_method_facts(&mut self, files: &[&File]) {
-        for item in files.iter().flat_map(|file| &file.items) {
-            match item {
-                Expression::Interface {
-                    visibility: Visibility::Public,
-                    method_signatures,
-                    ..
-                } => {
-                    for method in method_signatures {
-                        let func = method.function_definition_view();
-                        self.module
-                            .record_exported_method_name(func.name.to_string());
-                    }
-                }
-                Expression::ImplBlock {
-                    receiver_name,
-                    methods,
-                    ..
-                } => self.record_impl_method_facts(receiver_name, methods),
-                _ => {}
-            }
-        }
-    }
-
-    fn record_impl_method_facts(&mut self, receiver_name: &str, methods: &[Expression]) {
-        for method in methods {
-            if let Expression::Function {
-                name,
-                visibility: Visibility::Public,
-                ..
-            } = method
-            {
-                self.module.record_exported_method_name(name.to_string());
-            }
-            if is_display_to_string(method)
+    pub(crate) fn collect_user_to_string_facts(&mut self, files: &[&File]) {
+        for (receiver_name, methods) in
+            files
+                .iter()
+                .flat_map(|file| &file.items)
+                .filter_map(|item| match item {
+                    Expression::ImplBlock {
+                        receiver_name,
+                        methods,
+                        ..
+                    } => Some((receiver_name, methods)),
+                    _ => None,
+                })
+        {
+            if methods.iter().any(is_display_to_string)
                 && !self
                     .facts
                     .is_ufcs_method(&self.facts.qualified_current(receiver_name), "to_string")

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -316,7 +316,7 @@ impl Planner<'_> {
                 .entry(tag_constant)
                 .or_default()
                 .push(variant.name_span);
-            let constructor = format!("Make{}{}", go_name::escape_type_name(name), variant.name);
+            let constructor = go_name::enum_make_function(name, &variant.name);
             package_block
                 .entry(constructor)
                 .or_default()

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -196,10 +196,6 @@ impl<'a> EmitFacts<'a> {
         &self.current_module
     }
 
-    pub(crate) fn set_current_module(&mut self, module_id: &str) {
-        self.current_module = module_id.to_string();
-    }
-
     pub(crate) fn is_current_module(&self, module: &str) -> bool {
         module == self.current_module.as_str()
     }
@@ -251,11 +247,26 @@ impl<'a> EmitFacts<'a> {
         self.globals.exported_method_names.contains(method)
     }
 
-    pub(crate) fn make_function_name(&self, key: &str) -> Option<&str> {
-        self.globals
-            .make_function_names
-            .get(key)
-            .map(String::as_str)
+    pub(crate) fn make_function_name(&self, enum_id: &str, variant_name: &str) -> Option<String> {
+        let definition = self.definition(enum_id)?;
+        let DefinitionBody::Enum { variants, .. } = &definition.body else {
+            return None;
+        };
+        variants
+            .iter()
+            .any(|variant| variant.name == variant_name)
+            .then(|| {
+                let enum_name = definition
+                    .name
+                    .as_deref()
+                    .unwrap_or_else(|| syntax::types::unqualified_name(enum_id));
+                let make_function = go_name::enum_make_function(enum_name, variant_name);
+                if enum_id.starts_with(go_name::PRELUDE_PREFIX) {
+                    format!("{}{}", go_name::PRELUDE_PREFIX, make_function)
+                } else {
+                    make_function
+                }
+            })
     }
 
     pub(crate) fn go_callable_return(&self, qualified_name: &str) -> Option<&CallableReturnAbi> {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -86,7 +86,6 @@ impl Planner<'_> {
 
     pub(crate) fn method_needs_export(&self, method_name: &str) -> bool {
         self.facts.has_global_exported_method_name(method_name)
-            || self.module.has_local_exported_method_name(method_name)
             || matches!(method_name, "string" | "goString" | "error")
     }
 
@@ -209,14 +208,13 @@ impl Planner<'_> {
 
 impl Planner<'_> {
     pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<Rc<EnumLayout>> {
-        let file_id = self.file_namespace().file_id();
-        if let Some(layout) = self.module.enum_layout(file_id, enum_id) {
+        if let Some(layout) = self.file_namespace().enum_layout(enum_id) {
             return Some(layout);
         }
-        let layout = self.compute_enum_layout(enum_id)?;
-        self.module
-            .record_enum_layout(file_id, enum_id.to_string(), layout);
-        self.module.enum_layout(file_id, enum_id)
+        let layout = Rc::new(self.compute_enum_layout(enum_id)?);
+        self.file_namespace_mut()
+            .record_enum_layout(enum_id.to_string(), layout.clone());
+        Some(layout)
     }
 
     fn compute_enum_layout(&self, enum_id: &str) -> Option<EnumLayout> {

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -82,10 +82,7 @@ impl Planner<'_> {
         let target = self.value_layout(result_ty, SlotOrigin::Lisette);
         match abi.result {
             CallableReturnAbi::Direct => {}
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let source_payload = abi.return_layout.option_payload()?;
                 let target_payload = target.option_payload()?;
                 if source_payload.same_representation(target_payload) {
@@ -156,7 +153,11 @@ impl Planner<'_> {
             | CallableReturnAbi::Tuple { .. } => {
                 unreachable!("direct and tuple results do not use a scalar wrapper")
             }
-            CallableReturnAbi::Result { payload, .. } => {
+            CallableReturnAbi::BareError => {
+                self.require_stdlib();
+                self.lower_bare_error_wrapping(call_str, result_ty, target)
+            }
+            CallableReturnAbi::Result { payload } => {
                 self.require_stdlib();
                 self.lower_result_wrapping(call_str, result_ty, *payload, payload_bridge, target)
             }
@@ -164,26 +165,19 @@ impl Planner<'_> {
                 self.require_stdlib();
                 self.lower_partial_wrapping(call_str, result_ty, *payload, payload_bridge, target)
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                payload,
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { payload }) => {
                 self.lower_comma_ok_wrapping(call_str, result_ty, *payload, payload_bridge, target)
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let mut statements = Vec::new();
                 let raw_var = self.hoist_tmp_value_statement(&mut statements, "raw", call_str);
                 let (wrap, outcome) = self.lower_nil_check_option_wrap(&raw_var, result_ty, target);
                 statements.extend(wrap);
                 (statements, outcome)
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Sentinel(value),
-                ..
-            } => self.lower_sentinel_wrapping(call_str, result_ty, *value, target),
+            CallableReturnAbi::Option(OptionReturnAbi::Sentinel(value)) => {
+                self.lower_sentinel_wrapping(call_str, result_ty, *value, target)
+            }
         }
     }
 

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -5,7 +5,7 @@ use crate::abi::layout::ValueLayout;
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
-use crate::plan::bodies::{ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::plan::bodies::{ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -497,8 +497,7 @@ impl Planner<'_> {
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
-            target: None,
-            label: None,
+            kind: LoopKind::Generated { label: None },
             header: format!("for {index}, {element} := range {source} {{\n"),
             body,
         }));

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -133,15 +133,10 @@ impl Planner<'_> {
                 let value = self.plan_layout_bridge(statements, call, &bridge);
                 statements.push(plain_return(value));
             }
-            CallableReturnAbi::Result {
-                bare_error: true, ..
-            } => statements.push(plain_return(call.to_string())),
+            CallableReturnAbi::BareError => statements.push(plain_return(call.to_string())),
             CallableReturnAbi::Result { .. }
             | CallableReturnAbi::Partial { .. }
-            | CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                ..
-            } => {
+            | CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
                 let value = self.fresh_var(Some("ret"));
                 self.declare(&value);
                 let auxiliary = self.fresh_var(Some("ret"));
@@ -176,10 +171,7 @@ impl Planner<'_> {
                 let value = self.plan_layout_bridge(statements, &value, &bridge);
                 statements.push(plain_return(format!("{value}, {auxiliary}")));
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Nullable,
-                ..
-            } => {
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let raw = self.hoist_tmp_value_statement(statements, "raw", call);
                 let condition = if self.is_interface_option(source.result.logical_type()) {
                     self.require_stdlib();
@@ -207,10 +199,9 @@ impl Planner<'_> {
                 let value = self.plan_layout_bridge(statements, &raw, &bridge);
                 statements.push(plain_return(value));
             }
-            CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Sentinel(_),
-                ..
-            } => statements.push(plain_return(call.to_string())),
+            CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => {
+                statements.push(plain_return(call.to_string()))
+            }
             CallableReturnAbi::Tuple { arity } => {
                 let values = self.create_temp_vars("ret", *arity);
                 statements.push(LoweredStatement::RawGo(format!(
@@ -450,10 +441,7 @@ impl Planner<'_> {
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, WrapperOutcome) {
         let fallible = Fallible::from_type(result_ty).expect("Result type expected");
-
-        if fallible.ok_ty().is_unit() {
-            return self.lower_unit_result_wrapping(call_str, &fallible, target);
-        }
+        debug_assert!(!fallible.ok_ty().is_unit());
 
         let mut statements = Vec::new();
         let ok_ty = fallible.ok_ty();
@@ -524,6 +512,18 @@ impl Planner<'_> {
             else_arm,
         }));
         (statements, outcome)
+    }
+
+    /// Lower a bare `error` Go return into a tagged `Result<(), E>`.
+    pub(crate) fn lower_bare_error_wrapping(
+        &mut self,
+        call_str: &str,
+        result_ty: &Type,
+        target: WrapperTarget<'_>,
+    ) -> (Vec<LoweredStatement>, WrapperOutcome) {
+        let fallible = Fallible::from_type(result_ty).expect("Result type expected");
+        debug_assert!(fallible.ok_ty().is_unit());
+        self.lower_unit_result_wrapping(call_str, &fallible, target)
     }
 
     fn plan_optional_payload_bridge(

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -264,7 +264,6 @@ impl<'a> Planner<'a> {
     }
 
     fn callee_collapsed_recipe(&self, callee: &ResolvedCallee<'_>) -> Option<String> {
-        callee.id.as_deref()?;
         callee
             .definition?
             .go_type_param_recipe()
@@ -280,7 +279,7 @@ impl<'a> Planner<'a> {
         callee: &ResolvedCallee<'_>,
         arg_shape: CallArgShape,
     ) -> bool {
-        let Some(Type::Forall { vars, body }) = callee.declared.as_ref() else {
+        let Some(Type::Forall { vars, body }) = callee.declared_type() else {
             return false;
         };
         let Type::Function(f) = body.as_ref() else {
@@ -294,12 +293,11 @@ impl<'a> Planner<'a> {
         callee: &ResolvedCallee<'_>,
         recipe: &str,
     ) -> Option<String> {
-        let definition_ty = callee.declared.clone()?;
-        let Type::Forall { body, .. } = definition_ty else {
+        let Type::Forall { body, .. } = callee.declared_type()? else {
             return None;
         };
         let mut mapping = rustc_hash::FxHashMap::default();
-        extract_type_mapping(&body, &callee.instantiated, &mut mapping);
+        extract_type_mapping(body, &callee.instantiated, &mut mapping);
         self.reconstruct_collapsed_type_args(recipe, &mapping)
     }
 
@@ -334,7 +332,7 @@ impl<'a> Planner<'a> {
 
         if type_args_string.is_empty()
             && let Some(inferred) =
-                self.infer_return_only_type_args(function, callee.declared.as_ref(), arg_shape)
+                self.infer_return_only_type_args(function, callee.declared_type(), arg_shape)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t).unwrap_or(inferred),
@@ -394,8 +392,7 @@ impl<'a> Planner<'a> {
             ctx.spread,
             ctx.plan
                 .resolved
-                .declared
-                .as_ref()
+                .declared_type()
                 .and_then(|ty| ty.unwrap_forall().get_function_params()),
             ctx.wrap_spread_to_any,
             ctx.combine_variadic.clone(),
@@ -546,9 +543,11 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         raw_param_ty: &Type,
     ) -> Option<(CallableReturnAbi, Type, CallableReturnAbi)> {
-        let variadic_inner = (raw_param_ty.get_name() == Some("VarArgs"))
-            .then(|| raw_param_ty.inner())
-            .flatten();
+        let variadic_inner = if raw_param_ty.get_name() == Some("VarArgs") {
+            raw_param_ty.inner()
+        } else {
+            None
+        };
         let param_ty = variadic_inner.as_ref().unwrap_or(raw_param_ty);
         let param_fn = self
             .facts
@@ -895,7 +894,7 @@ impl<'a> Planner<'a> {
 }
 
 fn callee_curries_receiver(callee: &ResolvedCallee<'_>) -> bool {
-    let Some(Type::Forall { body, .. }) = callee.declared.as_ref() else {
+    let Some(Type::Forall { body, .. }) = callee.declared_type() else {
         return false;
     };
     let Type::Function(declared_fn) = body.as_ref() else {

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -25,7 +25,7 @@ impl Planner<'_> {
         type_args: &[Type],
         arg_shape: CallArgShape,
     ) -> Option<String> {
-        let definition_ty = callee.declared.as_ref()?;
+        let definition_ty = callee.declared_type()?;
 
         // A method with no type parameters lowers to a non-generic free function.
         let Type::Forall { vars, body } = &definition_ty else {
@@ -222,8 +222,7 @@ impl Planner<'_> {
             (!callee.is_prelude_dispatch)
                 .then(|| {
                     callee
-                        .declared
-                        .as_ref()
+                        .declared_type()
                         .and_then(|ty| ty.unwrap_forall().get_function_params())
                 })
                 .flatten(),

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -21,16 +21,9 @@ pub(crate) const PARTIAL_OK_CTOR: &str = "lisette.MakePartialOk";
 pub(crate) const PARTIAL_BOTH_CTOR: &str = "lisette.MakePartialBoth";
 pub(crate) const PARTIAL_ERR_CTOR: &str = "lisette.MakePartialErr";
 
-pub(crate) struct Fallible {
-    kind: FallibleKind,
-    ok_ty: Type,
-    err_ty: Option<Type>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FallibleKind {
-    Result,
-    Option,
+pub(crate) enum Fallible {
+    Result { ok_ty: Type, err_ty: Type },
+    Option { ok_ty: Type },
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -43,16 +36,13 @@ impl Fallible {
     pub(crate) fn from_type(ty: &Type) -> Option<Self> {
         if ty.is_result() {
             let args = ty.get_type_params()?;
-            Some(Self {
-                kind: FallibleKind::Result,
+            Some(Self::Result {
                 ok_ty: args.first()?.clone(),
-                err_ty: args.get(1).cloned(),
+                err_ty: args.get(1)?.clone(),
             })
         } else if ty.is_option() {
-            Some(Self {
-                kind: FallibleKind::Option,
+            Some(Self::Option {
                 ok_ty: ty.ok_type(),
-                err_ty: None,
             })
         } else {
             None
@@ -60,7 +50,7 @@ impl Fallible {
     }
 
     pub(crate) fn is_result(&self) -> bool {
-        self.kind == FallibleKind::Result
+        matches!(self, Self::Result { .. })
     }
 
     pub(crate) fn classify_constructor(&self, expression: &Expression) -> Option<ConstructorKind> {
@@ -77,59 +67,64 @@ impl Fallible {
     }
 
     pub(crate) fn ok_ty(&self) -> &Type {
-        &self.ok_ty
+        match self {
+            Self::Result { ok_ty, .. } | Self::Option { ok_ty } => ok_ty,
+        }
     }
 
     fn err_ty(&self) -> Option<&Type> {
-        self.err_ty.as_ref()
+        match self {
+            Self::Result { err_ty, .. } => Some(err_ty),
+            Self::Option { .. } => None,
+        }
     }
 
     fn struct_name(&self) -> &'static str {
-        match self.kind {
-            FallibleKind::Result => "Result",
-            FallibleKind::Option => "Option",
+        match self {
+            Self::Result { .. } => "Result",
+            Self::Option { .. } => "Option",
         }
     }
 
     pub(crate) fn success_tag(&self) -> &'static str {
-        match self.kind {
-            FallibleKind::Result => RESULT_OK_TAG,
-            FallibleKind::Option => OPTION_SOME_TAG,
+        match self {
+            Self::Result { .. } => RESULT_OK_TAG,
+            Self::Option { .. } => OPTION_SOME_TAG,
         }
     }
 
     pub(crate) fn ok_field(&self) -> &'static str {
-        match self.kind {
-            FallibleKind::Result => RESULT_OK_FIELD,
-            FallibleKind::Option => OPTION_SOME_FIELD,
+        match self {
+            Self::Result { .. } => RESULT_OK_FIELD,
+            Self::Option { .. } => OPTION_SOME_FIELD,
         }
     }
 
     pub(crate) fn ok_constructor(&self) -> &'static str {
-        match self.kind {
-            FallibleKind::Result => RESULT_OK_CTOR,
-            FallibleKind::Option => OPTION_SOME_CTOR,
+        match self {
+            Self::Result { .. } => RESULT_OK_CTOR,
+            Self::Option { .. } => OPTION_SOME_CTOR,
         }
     }
 
     pub(crate) fn err_constructor(&self) -> &'static str {
-        match self.kind {
-            FallibleKind::Result => RESULT_ERR_CTOR,
-            FallibleKind::Option => OPTION_NONE_CTOR,
+        match self {
+            Self::Result { .. } => RESULT_ERR_CTOR,
+            Self::Option { .. } => OPTION_NONE_CTOR,
         }
     }
 
     pub(crate) fn err_constructor_takes_arg(&self) -> bool {
-        self.kind == FallibleKind::Result
+        self.is_result()
     }
 
     fn make_success(&self, value: &str, inner_ty: &str, err_ty: Option<&str>) -> String {
         let pkg = go_name::GO_STDLIB_PKG;
-        match self.kind {
-            FallibleKind::Option => {
+        match self {
+            Self::Option { .. } => {
                 format!("{pkg}.MakeOptionSome[{}]({})", inner_ty, value)
             }
-            FallibleKind::Result => {
+            Self::Result { .. } => {
                 let err_ty = err_ty.expect("Result must have error type");
                 format!("{pkg}.MakeResultOk[{}, {}]({})", inner_ty, err_ty, value)
             }

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -18,7 +18,7 @@ impl Planner<'_> {
         self.require_stdlib();
 
         let return_ctx = self.return_ctx();
-        let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
+        let effective_ty = resolve_fallible_block_type(items, ty, Some(&return_ctx));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("`try` block must have Result or Option type");
 
@@ -30,9 +30,9 @@ impl Planner<'_> {
         };
 
         let body_ctx = ReturnContext::TaggedBlock(effective_ty);
-        self.push_return_ctx(body_ctx.clone());
-        let body = self.with_fresh_scope(|planner| planner.lower_try_body(items, &fallible));
-        self.pop_return_ctx();
+        let body = self.with_return_context(body_ctx, |planner| {
+            planner.with_fresh_scope(|planner| planner.lower_try_body(items, &fallible))
+        });
 
         let setup = vec![LoweredStatement::ClosureBind {
             name: result_var.clone(),
@@ -172,7 +172,7 @@ impl Planner<'_> {
         self.require_stdlib();
 
         let return_ctx = self.return_ctx();
-        let effective_ty = resolve_fallible_block_type(items, ty, Some(return_ctx.as_ref()));
+        let effective_ty = resolve_fallible_block_type(items, ty, Some(&return_ctx));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("recover block type must be Result<T, PanicValue>");
 
@@ -181,10 +181,9 @@ impl Planner<'_> {
         let inner_ty_str = self.go_type_string(fallible.ok_ty());
 
         let body_return_ctx = self.return_context_for_type(fallible.ok_ty().clone());
-        self.push_return_ctx(body_return_ctx.clone());
-        let body =
-            self.with_fresh_scope(|planner| planner.lower_recover_body_block(items, &fallible));
-        self.pop_return_ctx();
+        let body = self.with_return_context(body_return_ctx, |planner| {
+            planner.with_fresh_scope(|planner| planner.lower_recover_body_block(items, &fallible))
+        });
 
         let setup = vec![LoweredStatement::ClosureBind {
             name: result_var.clone(),

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -40,27 +40,26 @@ impl Planner<'_> {
         let map_tuple = self.for_loop_is_map_tuple(binding, iterable);
 
         let directive = self.maybe_line_directive(&full_expression.get_span());
-        self.push_loop("_");
+        let plan = self.with_loop("_", |this| {
+            let (prologue, header, lowered_body) = if is_range {
+                this.lower_range_for(binding, iterable, body)
+            } else if let Some(range_shape) = stored_range {
+                this.lower_stored_range_for(binding, iterable, range_shape, body)
+            } else if let Some((kind, receiver)) = string_view {
+                match kind {
+                    StringViewKind::Runes => this.lower_runes_for(binding, receiver, body),
+                    StringViewKind::Bytes => this.lower_bytes_for(binding, receiver, body),
+                }
+            } else if map_tuple {
+                this.lower_map_tuple_for(binding, iterable, body)
+            } else if is_simple {
+                this.lower_simple_for(binding, iterable, body)
+            } else {
+                this.lower_pattern_site_for(binding, iterable, body)
+            };
 
-        let (prologue, header, lowered_body) = if is_range {
-            self.lower_range_for(binding, iterable, body)
-        } else if let Some(range_shape) = stored_range {
-            self.lower_stored_range_for(binding, iterable, range_shape, body)
-        } else if let Some((kind, receiver)) = string_view {
-            match kind {
-                StringViewKind::Runes => self.lower_runes_for(binding, receiver, body),
-                StringViewKind::Bytes => self.lower_bytes_for(binding, receiver, body),
-            }
-        } else if map_tuple {
-            self.lower_map_tuple_for(binding, iterable, body)
-        } else if is_simple {
-            self.lower_simple_for(binding, iterable, body)
-        } else {
-            self.lower_pattern_site_for(binding, iterable, body)
-        };
-
-        let plan = self.build_source_loop(prologue, header, lowered_body);
-        self.pop_loop();
+            this.build_source_loop(prologue, header, lowered_body)
+        });
         directed(directive, LoweredStatement::Loop(plan))
     }
 
@@ -85,39 +84,39 @@ impl Planner<'_> {
         range_shape: RangeShape,
         body: &Expression,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        self.enter_scope();
-        let mut prologue = Vec::new();
-        let range_var = if self.is_unmutated_identifier(iterable) {
-            self.capture_operand_into(&mut prologue, iterable)
-        } else {
-            self.capture_value_at_boundary(
-                &mut prologue,
-                iterable,
-                "_range",
-                CaptureBoundary::LoopLifetime,
-            )
-        };
-        let loop_var = self.bind_loop_pattern(&binding.pattern, Some("_i"));
-        let header = match range_shape {
-            RangeShape::Range => format!(
-                "for {} := {}.Start; {} < {}.End; {}++ {{\n",
-                loop_var, range_var, loop_var, range_var, loop_var
-            ),
-            RangeShape::RangeInclusive => format!(
-                "for {} := {}.Start; {} <= {}.End; {}++ {{\n",
-                loop_var, range_var, loop_var, range_var, loop_var
-            ),
-            RangeShape::RangeFrom => format!(
-                "for {} := {}.Start; ; {}++ {{\n",
-                loop_var, range_var, loop_var
-            ),
-            RangeShape::RangeTo | RangeShape::RangeToInclusive => {
-                unreachable!("RangeTo/RangeToInclusive are not iterable")
-            }
-        };
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
-        (prologue, header, lowered_body)
+        self.with_scope(|this| {
+            let mut prologue = Vec::new();
+            let range_var = if this.is_unmutated_identifier(iterable) {
+                this.capture_operand_into(&mut prologue, iterable)
+            } else {
+                this.capture_value_at_boundary(
+                    &mut prologue,
+                    iterable,
+                    "_range",
+                    CaptureBoundary::LoopLifetime,
+                )
+            };
+            let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+            let header = match range_shape {
+                RangeShape::Range => format!(
+                    "for {} := {}.Start; {} < {}.End; {}++ {{\n",
+                    loop_var, range_var, loop_var, range_var, loop_var
+                ),
+                RangeShape::RangeInclusive => format!(
+                    "for {} := {}.Start; {} <= {}.End; {}++ {{\n",
+                    loop_var, range_var, loop_var, range_var, loop_var
+                ),
+                RangeShape::RangeFrom => format!(
+                    "for {} := {}.Start; ; {}++ {{\n",
+                    loop_var, range_var, loop_var
+                ),
+                RangeShape::RangeTo | RangeShape::RangeToInclusive => {
+                    unreachable!("RangeTo/RangeToInclusive are not iterable")
+                }
+            };
+            let lowered_body = this.lower_block_as_body(body);
+            (prologue, header, lowered_body)
+        })
     }
 
     /// `for r in s.runes()`.
@@ -127,18 +126,18 @@ impl Planner<'_> {
         receiver: &Expression,
         body: &Expression,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        self.enter_scope();
-        let mut prologue = Vec::new();
-        let receiver_str = self.capture_operand_into(&mut prologue, receiver);
-        let loop_var = self.bind_loop_pattern(&binding.pattern, None);
-        let header = if loop_var == "_" {
-            format!("for range {} {{\n", receiver_str)
-        } else {
-            format!("for _, {} := range {} {{\n", loop_var, receiver_str)
-        };
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
-        (prologue, header, lowered_body)
+        self.with_scope(|this| {
+            let mut prologue = Vec::new();
+            let receiver_str = this.capture_operand_into(&mut prologue, receiver);
+            let loop_var = this.bind_loop_pattern(&binding.pattern, None);
+            let header = if loop_var == "_" {
+                format!("for range {} {{\n", receiver_str)
+            } else {
+                format!("for _, {} := range {} {{\n", loop_var, receiver_str)
+            };
+            let lowered_body = this.lower_block_as_body(body);
+            (prologue, header, lowered_body)
+        })
     }
 
     /// `for b in s.bytes()`.
@@ -148,33 +147,33 @@ impl Planner<'_> {
         receiver: &Expression,
         body: &Expression,
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
-        self.enter_scope();
-        let mut prologue = Vec::new();
-        let receiver_var = if self.is_unmutated_identifier(receiver) {
-            self.capture_operand_into(&mut prologue, receiver)
-        } else {
-            self.capture_value_at_boundary(
-                &mut prologue,
-                receiver,
-                "_s",
-                CaptureBoundary::LoopLifetime,
-            )
-        };
-        let index_var = self.fresh_var(Some("_i"));
-        let loop_var = self.bind_loop_pattern(&binding.pattern, None);
-        let mut header = format!(
-            "for {} := 0; {} < len({}); {}++ {{\n",
-            index_var, index_var, receiver_var, index_var
-        );
-        if loop_var != "_" {
-            header.push_str(&format!(
-                "{} := {}[{}]\n",
-                loop_var, receiver_var, index_var
-            ));
-        }
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
-        (prologue, header, lowered_body)
+        self.with_scope(|this| {
+            let mut prologue = Vec::new();
+            let receiver_var = if this.is_unmutated_identifier(receiver) {
+                this.capture_operand_into(&mut prologue, receiver)
+            } else {
+                this.capture_value_at_boundary(
+                    &mut prologue,
+                    receiver,
+                    "_s",
+                    CaptureBoundary::LoopLifetime,
+                )
+            };
+            let index_var = this.fresh_var(Some("_i"));
+            let loop_var = this.bind_loop_pattern(&binding.pattern, None);
+            let mut header = format!(
+                "for {} := 0; {} < len({}); {}++ {{\n",
+                index_var, index_var, receiver_var, index_var
+            );
+            if loop_var != "_" {
+                header.push_str(&format!(
+                    "{} := {}[{}]\n",
+                    loop_var, receiver_var, index_var
+                ));
+            }
+            let lowered_body = this.lower_block_as_body(body);
+            (prologue, header, lowered_body)
+        })
     }
 
     /// Returns `(prologue, range_expression, single_var)`. Refs are deref'd;
@@ -208,17 +207,17 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
-        self.enter_scope();
-        let loop_var = self.bind_loop_pattern(&binding.pattern, None);
-        let header = if loop_var == "_" {
-            format!("for range {} {{\n", iter_expression)
-        } else if single_var {
-            format!("for {} := range {} {{\n", loop_var, iter_expression)
-        } else {
-            format!("for _, {} := range {} {{\n", loop_var, iter_expression)
-        };
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
+        let (header, lowered_body) = self.with_scope(|this| {
+            let loop_var = this.bind_loop_pattern(&binding.pattern, None);
+            let header = if loop_var == "_" {
+                format!("for range {} {{\n", iter_expression)
+            } else if single_var {
+                format!("for {} := range {} {{\n", loop_var, iter_expression)
+            } else {
+                format!("for _, {} := range {} {{\n", loop_var, iter_expression)
+            };
+            (header, this.lower_block_as_body(body))
+        });
         (prologue, header, lowered_body)
     }
 
@@ -246,13 +245,19 @@ impl Planner<'_> {
             Pattern::Identifier { .. } | Pattern::WildCard { .. }
         );
 
-        self.enter_scope();
-        let (header, lowered_body) = if first_is_simple && second_is_simple {
-            self.lower_map_tuple_simple_body(first, second, &iter_expression, body)
-        } else {
-            self.lower_map_tuple_compound_body(first, second, &binding.ty, &iter_expression, body)
-        };
-        self.exit_scope();
+        let (header, lowered_body) = self.with_scope(|this| {
+            if first_is_simple && second_is_simple {
+                this.lower_map_tuple_simple_body(first, second, &iter_expression, body)
+            } else {
+                this.lower_map_tuple_compound_body(
+                    first,
+                    second,
+                    &binding.ty,
+                    &iter_expression,
+                    body,
+                )
+            }
+        });
         (prologue, header, lowered_body)
     }
 
@@ -303,41 +308,41 @@ impl Planner<'_> {
             key_var, value_var, iter_expression
         );
 
-        self.scope.enter_use_region();
-        let mut bindings = String::new();
-        let key_statements = self.lower_irrefutable_pattern_site(
-            PatternSubject::for_value(key_var.clone()),
-            first,
-            None,
-            first_ty,
-        );
-        Renderer.render_lowered_block(
-            &mut bindings,
-            &LoweredBlock {
-                statements: key_statements,
-            },
-        );
-        if !bindings.is_empty() {
-            self.scope.record_go_use(&key_var);
-        }
-        let after_key = bindings.len();
-        let value_statements = self.lower_irrefutable_pattern_site(
-            PatternSubject::for_value(value_var.clone()),
-            second,
-            None,
-            second_ty,
-        );
-        Renderer.render_lowered_block(
-            &mut bindings,
-            &LoweredBlock {
-                statements: value_statements,
-            },
-        );
-        if bindings.len() > after_key {
-            self.scope.record_go_use(&value_var);
-        }
-        let lowered_body = self.lower_block_as_body(body);
-        let used = self.scope.exit_use_region();
+        let ((bindings, lowered_body), used) = self.capture_go_uses(|this| {
+            let mut bindings = String::new();
+            let key_statements = this.lower_irrefutable_pattern_site(
+                PatternSubject::for_value(key_var.clone()),
+                first,
+                None,
+                first_ty,
+            );
+            Renderer.render_lowered_block(
+                &mut bindings,
+                &LoweredBlock {
+                    statements: key_statements,
+                },
+            );
+            if !bindings.is_empty() {
+                this.scope.record_go_use(&key_var);
+            }
+            let after_key = bindings.len();
+            let value_statements = this.lower_irrefutable_pattern_site(
+                PatternSubject::for_value(value_var.clone()),
+                second,
+                None,
+                second_ty,
+            );
+            Renderer.render_lowered_block(
+                &mut bindings,
+                &LoweredBlock {
+                    statements: value_statements,
+                },
+            );
+            if bindings.len() > after_key {
+                this.scope.record_go_use(&value_var);
+            }
+            (bindings, this.lower_block_as_body(body))
+        });
 
         let mut inner = vec![LoweredStatement::RawGo(bindings)];
         inner.extend(lowered_body.statements);
@@ -369,51 +374,51 @@ impl Planner<'_> {
     ) -> (Vec<LoweredStatement>, String, LoweredBlock) {
         let (prologue, iter_expression, single_var) = self.capture_iterable_operand(iterable);
 
-        self.enter_scope();
-        let (header, body_block) = if !pattern_has_bindings(&binding.pattern) {
-            let header = format!("for range {} {{\n", iter_expression);
-            (header, self.lower_block_as_body(body))
-        } else {
-            let item_var = self.fresh_var(Some("item"));
-            let header = if single_var {
-                format!("for {} := range {} {{\n", item_var, iter_expression)
+        let (header, body_block) = self.with_scope(|this| {
+            if !pattern_has_bindings(&binding.pattern) {
+                let header = format!("for range {} {{\n", iter_expression);
+                (header, this.lower_block_as_body(body))
             } else {
-                format!("for _, {} := range {} {{\n", item_var, iter_expression)
-            };
-            self.scope.enter_use_region();
-            let mut bindings = String::new();
-            let binding_statements = self.lower_irrefutable_pattern_site(
-                PatternSubject::for_value(item_var.clone()),
-                &binding.pattern,
-                binding.typed_pattern.as_ref(),
-                &binding.ty,
-            );
-            Renderer.render_lowered_block(
-                &mut bindings,
-                &LoweredBlock {
-                    statements: binding_statements,
-                },
-            );
-            if !bindings.is_empty() {
-                self.scope.record_go_use(&item_var);
+                let item_var = this.fresh_var(Some("item"));
+                let header = if single_var {
+                    format!("for {} := range {} {{\n", item_var, iter_expression)
+                } else {
+                    format!("for _, {} := range {} {{\n", item_var, iter_expression)
+                };
+                let ((bindings, lowered_body), used) = this.capture_go_uses(|this| {
+                    let mut bindings = String::new();
+                    let binding_statements = this.lower_irrefutable_pattern_site(
+                        PatternSubject::for_value(item_var.clone()),
+                        &binding.pattern,
+                        binding.typed_pattern.as_ref(),
+                        &binding.ty,
+                    );
+                    Renderer.render_lowered_block(
+                        &mut bindings,
+                        &LoweredBlock {
+                            statements: binding_statements,
+                        },
+                    );
+                    if !bindings.is_empty() {
+                        this.scope.record_go_use(&item_var);
+                    }
+                    (bindings, this.lower_block_as_body(body))
+                });
+
+                let mut inner = vec![LoweredStatement::RawGo(bindings)];
+                inner.extend(lowered_body.statements);
+                let body_block = LoweredBlock { statements: inner };
+
+                let references_item = used.contains(&item_var);
+
+                let mut statements = Vec::new();
+                if !references_item {
+                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", item_var)));
+                }
+                statements.extend(body_block.statements);
+                (header, LoweredBlock { statements })
             }
-            let lowered_body = self.lower_block_as_body(body);
-            let used = self.scope.exit_use_region();
-
-            let mut inner = vec![LoweredStatement::RawGo(bindings)];
-            inner.extend(lowered_body.statements);
-            let body_block = LoweredBlock { statements: inner };
-
-            let references_item = used.contains(&item_var);
-
-            let mut statements = Vec::new();
-            if !references_item {
-                statements.push(LoweredStatement::RawGo(format!("_ = {}\n", item_var)));
-            }
-            statements.extend(body_block.statements);
-            (header, LoweredBlock { statements })
-        };
-        self.exit_scope();
+        });
         (prologue, header, body_block)
     }
 
@@ -473,23 +478,23 @@ impl Planner<'_> {
             start_expression = var;
         }
 
-        self.enter_scope();
-        let loop_var = self.bind_loop_pattern(&binding.pattern, Some("_i"));
-        let header = match end_expression {
-            Some(end_expression) => {
-                let operator = if *inclusive { "<=" } else { "<" };
-                format!(
-                    "for {} := {}; {} {} {}; {}++ {{\n",
-                    loop_var, start_expression, loop_var, operator, end_expression, loop_var
-                )
-            }
-            None => format!(
-                "for {} := {}; ; {}++ {{\n",
-                loop_var, start_expression, loop_var
-            ),
-        };
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
+        let (header, lowered_body) = self.with_scope(|this| {
+            let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+            let header = match end_expression {
+                Some(end_expression) => {
+                    let operator = if *inclusive { "<=" } else { "<" };
+                    format!(
+                        "for {} := {}; {} {} {}; {}++ {{\n",
+                        loop_var, start_expression, loop_var, operator, end_expression, loop_var
+                    )
+                }
+                None => format!(
+                    "for {} := {}; ; {}++ {{\n",
+                    loop_var, start_expression, loop_var
+                ),
+            };
+            (header, this.lower_block_as_body(body))
+        });
         (prologue, header, lowered_body)
     }
 

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,5 +1,4 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::abi::callable::{CallableReturnAbi, PayloadLayout};
 use crate::abi::transition;
 use crate::context::expression::ExpressionContext;
@@ -289,7 +288,7 @@ impl Planner<'_> {
                 let body = LoweredBlock {
                     statements: vec![self.lower_statement(expression)],
                 };
-                (!Renderer.renders_empty(&body)).then_some(body)
+                (!body.renders_empty()).then_some(body)
             };
             return ReturnStatementPlan {
                 form: ReturnForm::Unit { side_effect },
@@ -485,13 +484,7 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
-            let ok_arg = if matches!(
-                shape,
-                CallableReturnAbi::Result {
-                    bare_error: true,
-                    ..
-                }
-            ) {
+            let ok_arg = if matches!(shape, CallableReturnAbi::BareError) {
                 if !args.is_empty() {
                     let (setup, _) = self
                         .lower_composite_value(&args[0], ExpressionContext::value())

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -1,5 +1,4 @@
 use crate::Planner;
-use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::{
@@ -7,7 +6,8 @@ use crate::patterns::sites::{
     unwrap_some_typed_pattern,
 };
 use crate::plan::bodies::{
-    ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan, SelectStatementPlan,
+    ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan,
+    SelectStatementPlan,
 };
 use crate::plan::placement::unreachable_panic_if_needed;
 use crate::plan::values::{GoExpression, ValuePlan};
@@ -35,7 +35,6 @@ enum PreparedSelectArm<'a> {
         typed_pattern: Option<&'a TypedPattern>,
         body: &'a Expression,
         channel: String,
-        retry_on_close: bool,
         element_ty: Type,
     },
     Send {
@@ -70,9 +69,7 @@ impl Planner<'_> {
             .iter()
             .any(|arm| matches!(arm, PreparedSelectArm::Default { .. }));
 
-        self.enter_scope();
-        let arm_plans = self.lower_select_arms(prep, place);
-        self.exit_scope();
+        let arm_plans = self.with_scope(|this| this.lower_select_arms(prep, place));
 
         let all_arms_diverge =
             !arm_plans.is_empty() && arm_plans.iter().all(|arm| arm.body().ends_with_diverge());
@@ -108,14 +105,13 @@ impl Planner<'_> {
                     typed_pattern,
                     body,
                     channel,
-                    retry_on_close,
                     element_ty,
                 } => {
                     let receiver_ctx = SelectReceiveContext {
                         channel: &channel,
                         body,
                         default_body,
-                        retry_var: retry_on_close.then_some(channel.as_str()),
+                        retry_var: binding.is_some_pattern().then_some(channel.as_str()),
                         element_ty,
                         place,
                     };
@@ -168,23 +164,20 @@ impl Planner<'_> {
                     let channel_has_call = channel.evaluation.effect.has_call();
                     let (channel_setup, ch) = channel.into_parts();
                     setup.extend(channel_setup);
-                    let (channel, retry_on_close) = if binding.is_some_pattern() && needs_retry_loop
-                    {
-                        (self.hoist_tmp_value_statement(setup, "ch", &ch), true)
+                    let channel = if binding.is_some_pattern() {
+                        self.hoist_tmp_value_statement(setup, "ch", &ch)
                     } else {
-                        let ch = if needs_retry_loop && channel_has_call {
+                        if needs_retry_loop && channel_has_call {
                             self.hoist_tmp_value_statement(setup, "ch", &ch)
                         } else {
                             ch
-                        };
-                        (ch, false)
+                        }
                     };
                     PreparedSelectArm::Receive {
                         binding,
                         typed_pattern: typed_pattern.as_ref(),
                         body,
                         channel,
-                        retry_on_close,
                         element_ty: receive_expression.get_type().ok_type(),
                     }
                 }
@@ -249,7 +242,7 @@ impl Planner<'_> {
         // statements (e.g. a discard `let _`) render to empty text even when the
         // IR is structurally non-empty.
         let body_block = self.lower_block_to_place(ctx.body, ctx.place);
-        let body_empty = Renderer.renders_empty(&body_block);
+        let body_empty = body_block.renders_empty();
         let else_block = self.build_ok_else_block(ctx);
         let has_else = else_block.is_some();
 
@@ -289,10 +282,7 @@ impl Planner<'_> {
             return Some(LoweredBlock {
                 statements: vec![
                     LoweredStatement::RawGo(format!("{} = nil\n", retry_var)),
-                    LoweredStatement::Continue {
-                        target: None,
-                        label: None,
-                    },
+                    LoweredStatement::Continue(LoopTransfer::Unlabeled),
                 ],
             });
         }
@@ -302,40 +292,41 @@ impl Planner<'_> {
     }
 
     /// `case v, ok := <-ch:` plus an `if ok { ... } else { ... }` body.
-    fn lower_ok_guard(
+    fn lower_ok_guard<F>(
         &mut self,
-        receiver_var: &str,
+        prepare_receiver: F,
         inner_pattern: Option<(&Pattern, Option<&TypedPattern>)>,
         ctx: &SelectReceiveContext,
-    ) -> SelectArmPlan {
-        let ok_var = self.fresh_ok_var();
-        let receive_vars = format!("{}, {}", receiver_var, ok_var);
-        self.scope.enter_use_region();
-        let body_statements = if let Some((pattern, typed)) = inner_pattern {
-            self.lower_select_receive_pattern_site(
-                TypedSubject {
-                    var: receiver_var,
-                    ty: &ctx.element_ty,
-                },
-                AnnotatedPattern { pattern, typed },
-                ctx.body,
-                ctx.default_body,
-                ctx.place,
-            )
-        } else {
-            self.lower_block_to_place(ctx.body, ctx.place).statements
-        };
-        let used = self.scope.exit_use_region();
-        let body_holder = LoweredBlock {
-            statements: body_statements,
-        };
-        let mut then_statements: Vec<LoweredStatement> = Vec::new();
-        let references_receiver = used.contains(receiver_var);
-        if !references_receiver {
-            then_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", receiver_var)));
-        }
-        then_statements.extend(body_holder.statements);
-        self.scope.pop_binding_frame();
+    ) -> SelectArmPlan
+    where
+        F: FnOnce(&mut Self) -> String,
+    {
+        let (receiver_var, ok_var, then_statements) = self.with_binding_frame(|this| {
+            let receiver_var = prepare_receiver(this);
+            let ok_var = this.fresh_ok_var();
+            let (body_statements, used) = this.capture_go_uses(|this| {
+                if let Some((pattern, typed)) = inner_pattern {
+                    this.lower_select_receive_pattern_site(
+                        TypedSubject {
+                            var: &receiver_var,
+                            ty: &ctx.element_ty,
+                        },
+                        AnnotatedPattern { pattern, typed },
+                        ctx.body,
+                        ctx.default_body,
+                        ctx.place,
+                    )
+                } else {
+                    this.lower_block_to_place(ctx.body, ctx.place).statements
+                }
+            });
+            let mut then_statements: Vec<LoweredStatement> = Vec::new();
+            if !used.contains(&receiver_var) {
+                then_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", receiver_var)));
+            }
+            then_statements.extend(body_statements);
+            (receiver_var, ok_var, then_statements)
+        });
 
         let else_arm = match self.build_ok_else_block(ctx) {
             Some(body) => ElseArm::Else {
@@ -344,6 +335,7 @@ impl Planner<'_> {
             },
             None => ElseArm::None,
         };
+        let receive_vars = format!("{}, {}", receiver_var, ok_var);
         let if_plan = IfPlan {
             condition_setup: Vec::new(),
             condition: ok_var,
@@ -370,7 +362,6 @@ impl Planner<'_> {
         let effective_pattern = unwrap_some_pattern(binding);
         let inner_typed = unwrap_some_typed_pattern(typed_pattern);
 
-        self.scope.push_binding_frame();
         if binding.is_some_pattern() {
             self.lower_receive_arm_with_ok_check(effective_pattern, inner_typed, ctx)
         } else {
@@ -388,16 +379,17 @@ impl Planner<'_> {
         if let Pattern::Identifier { identifier, .. } = effective_pattern
             && let Some(go_name) = self.go_name_for_binding(effective_pattern)
         {
-            let var = self.scope.bind(identifier, go_name);
-            return self.lower_ok_guard(&var, None, ctx);
+            return self.lower_ok_guard(|this| this.scope.bind(identifier, go_name), None, ctx);
         }
         if matches!(
             effective_pattern,
             Pattern::Identifier { .. } | Pattern::WildCard { .. }
         ) {
-            let ok_var = self.fresh_ok_var();
-            let body = self.lower_ok_check(&ok_var, ctx);
-            self.scope.pop_binding_frame();
+            let (ok_var, body) = self.with_binding_frame(|this| {
+                let ok_var = this.fresh_ok_var();
+                let body = this.lower_ok_check(&ok_var, ctx);
+                (ok_var, body)
+            });
             return SelectArmPlan::Receive {
                 receive_vars: Some(format!("_, {}", ok_var)),
                 channel: ctx.channel.to_string(),
@@ -405,7 +397,11 @@ impl Planner<'_> {
             };
         }
         let receiver_var = self.fresh_var(Some("recv"));
-        self.lower_ok_guard(&receiver_var, Some((effective_pattern, inner_typed)), ctx)
+        self.lower_ok_guard(
+            |_| receiver_var,
+            Some((effective_pattern, inner_typed)),
+            ctx,
+        )
     }
 
     /// Plain receive: `case v := <-ch:` then the arm body.
@@ -415,36 +411,37 @@ impl Planner<'_> {
         inner_typed: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
     ) -> SelectArmPlan {
-        let mut body_statements: Vec<LoweredStatement> = Vec::new();
-        let receive_vars = if let Pattern::Identifier { identifier, .. } = effective_pattern
-            && let Some(go_name) = self.go_name_for_binding(effective_pattern)
-        {
-            Some(self.scope.bind(identifier, go_name))
-        } else if matches!(
-            effective_pattern,
-            Pattern::Identifier { .. } | Pattern::WildCard { .. }
-        ) {
-            None
-        } else {
-            let receiver_var = self.fresh_var(Some("recv"));
-            body_statements.extend(self.lower_irrefutable_pattern_site(
-                PatternSubject::for_value(receiver_var.clone()),
+        self.with_binding_frame(|this| {
+            let mut body_statements: Vec<LoweredStatement> = Vec::new();
+            let receive_vars = if let Pattern::Identifier { identifier, .. } = effective_pattern
+                && let Some(go_name) = this.go_name_for_binding(effective_pattern)
+            {
+                Some(this.scope.bind(identifier, go_name))
+            } else if matches!(
                 effective_pattern,
-                inner_typed,
-                &ctx.element_ty,
-            ));
-            Some(receiver_var)
-        };
-        let block = self.lower_block_to_place(ctx.body, ctx.place);
-        self.scope.pop_binding_frame();
-        body_statements.extend(block.statements);
-        SelectArmPlan::Receive {
-            receive_vars,
-            channel: ctx.channel.to_string(),
-            body: LoweredBlock {
-                statements: body_statements,
-            },
-        }
+                Pattern::Identifier { .. } | Pattern::WildCard { .. }
+            ) {
+                None
+            } else {
+                let receiver_var = this.fresh_var(Some("recv"));
+                body_statements.extend(this.lower_irrefutable_pattern_site(
+                    PatternSubject::for_value(receiver_var.clone()),
+                    effective_pattern,
+                    inner_typed,
+                    &ctx.element_ty,
+                ));
+                Some(receiver_var)
+            };
+            let block = this.lower_block_to_place(ctx.body, ctx.place);
+            body_statements.extend(block.statements);
+            SelectArmPlan::Receive {
+                receive_vars,
+                channel: ctx.channel.to_string(),
+                body: LoweredBlock {
+                    statements: body_statements,
+                },
+            }
+        })
     }
 
     fn prepare_send_arm(
@@ -521,79 +518,68 @@ impl Planner<'_> {
         element_ty: &syntax::types::Type,
         place: &PlacePlan,
     ) -> SelectArmPlan {
-        self.scope.push_binding_frame();
+        self.with_binding_frame(|this| {
+            let (receiver_var_pattern, some_arm) = match_arms
+                .iter()
+                .find_map(|arm| {
+                    if let Pattern::EnumVariant {
+                        identifier, fields, ..
+                    } = &arm.pattern
+                        && go_name::unqualified_name(identifier) == "Some"
+                        && fields.len() == 1
+                    {
+                        Some((&fields[0], arm))
+                    } else {
+                        None
+                    }
+                })
+                .expect("MatchReceive must have Some arm");
 
-        let (receiver_var_pattern, some_arm) = match_arms
-            .iter()
-            .find_map(|arm| {
-                if let Pattern::EnumVariant {
-                    identifier, fields, ..
-                } = &arm.pattern
-                    && go_name::unqualified_name(identifier) == "Some"
-                    && fields.len() == 1
-                {
-                    Some((&fields[0], arm))
-                } else {
-                    None
+            let (case_var, needs_receiver_destructure) =
+                this.classify_receive_var_pattern(receiver_var_pattern);
+            let ok_var = this.fresh_ok_var();
+
+            let (arms_plan, used) = this.capture_go_uses(|this| {
+                let some_block = this.lower_receive_some_arm(
+                    some_arm,
+                    match_arms,
+                    receiver_var_pattern,
+                    &case_var,
+                    needs_receiver_destructure,
+                    element_ty,
+                    place,
+                );
+                let none_block = this.capture_scoped_block(|this| {
+                    sites::lower_none_arm_body(this, match_arms, place)
+                });
+
+                let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
+                if arms_plan.is_some() {
+                    this.scope.record_go_use(&ok_var);
                 }
-            })
-            .expect("MatchReceive must have Some arm");
+                arms_plan
+            });
 
-        let (case_var, needs_receiver_destructure) =
-            self.classify_receive_var_pattern(receiver_var_pattern);
-
-        let ok_var = self.fresh_ok_var();
-
-        self.scope.enter_use_region();
-        let some_block = self.lower_receive_some_arm(
-            some_arm,
-            match_arms,
-            receiver_var_pattern,
-            &case_var,
-            needs_receiver_destructure,
-            element_ty,
-            place,
-        );
-        let none_block =
-            self.capture_scoped_block(|this| sites::lower_none_arm_body(this, match_arms, place));
-
-        let arms_plan = build_receive_arms_plan(&ok_var, some_block, none_block);
-        if arms_plan.is_some() {
-            self.scope.record_go_use(&ok_var);
-        }
-        let used = self.scope.exit_use_region();
-
-        // Compose the receive-arms body as a structured `if ok { ... } else
-        // { ... }` plan so usage of `case_var` and `ok_var` can be checked
-        // structurally before deciding whether to emit per-var discards.
-        let body_block = LoweredBlock {
-            statements: match arms_plan {
-                Some(plan) => vec![LoweredStatement::If(plan)],
-                None => Vec::new(),
-            },
-        };
-
-        self.scope.pop_binding_frame();
-
-        // Per-var discards (emitted when the body does not reference the var)
-        // precede the structured body inside the `case x, ok := <-ch:` arm.
-        let mut body_statements: Vec<LoweredStatement> = Vec::new();
-        let references_ok = used.contains(&ok_var);
-        if !references_ok {
-            body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", ok_var)));
-        }
-        let references_case = used.contains(&case_var);
-        if case_var != "_" && !references_case {
-            body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", case_var)));
-        }
-        body_statements.extend(body_block.statements);
-        SelectArmPlan::Receive {
-            receive_vars: Some(format!("{}, {}", case_var, ok_var)),
-            channel: channel.to_string(),
-            body: LoweredBlock {
-                statements: body_statements,
-            },
-        }
+            // Per-var discards (emitted when the body does not reference the var)
+            // precede the structured body inside the `case x, ok := <-ch:` arm.
+            let mut body_statements: Vec<LoweredStatement> = Vec::new();
+            if !used.contains(&ok_var) {
+                body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", ok_var)));
+            }
+            if case_var != "_" && !used.contains(&case_var) {
+                body_statements.push(LoweredStatement::RawGo(format!("_ = {}\n", case_var)));
+            }
+            if let Some(plan) = arms_plan {
+                body_statements.push(LoweredStatement::If(plan));
+            }
+            SelectArmPlan::Receive {
+                receive_vars: Some(format!("{}, {}", case_var, ok_var)),
+                channel: channel.to_string(),
+                body: LoweredBlock {
+                    statements: body_statements,
+                },
+            }
+        })
     }
 
     /// Lower the Some arm body (with payload destructure) so the caller can

--- a/crates/emit/src/control_flow/targets.rs
+++ b/crates/emit/src/control_flow/targets.rs
@@ -1,39 +1,37 @@
 use crate::plan::bodies::{
-    AssignForm, BreakValueDisposition, CompoundKind, ElseArm, ExpressionStatementForm, IfPlan,
-    LetForm, LoopId, LoopPlan, LoweredBlock, LoweredStatement, ReturnForm,
+    AssignForm, BreakValuePlan, CompoundKind, ElseArm, ExpressionStatementForm, IfPlan, LetForm,
+    LoopId, LoopKind, LoopTransfer, LoweredBlock, LoweredStatement, ReturnForm,
 };
 use crate::plan::values::ValuePlan;
 
-#[derive(Clone, Copy, Default)]
-struct Interception {
-    break_transfer: bool,
-    continue_transfer: bool,
+#[derive(Clone, Copy)]
+enum Interception {
+    None,
+    Break,
+    All,
 }
 
 impl Interception {
-    fn all() -> Self {
-        Self {
-            break_transfer: true,
-            continue_transfer: true,
-        }
+    fn intercepts_break(self) -> bool {
+        !matches!(self, Interception::None)
     }
 
-    fn breakable(self) -> Self {
-        Self {
-            break_transfer: true,
-            ..self
+    fn intercepts_continue(self) -> bool {
+        matches!(self, Interception::All)
+    }
+
+    fn with_break(self) -> Self {
+        match self {
+            Interception::None => Interception::Break,
+            Interception::Break | Interception::All => self,
         }
     }
 }
 
-pub(crate) fn legalize_source_loop(plan: &mut LoopPlan) {
-    let Some(target) = plan.target else {
-        return;
-    };
-    debug_assert!(plan.label.is_none());
+pub(crate) fn legalize_source_loop(body: &mut LoweredBlock, target: LoopId) -> Option<String> {
     let mut legalizer = Legalizer::new(target);
-    legalizer.walk_block(&mut plan.body, Interception::default());
-    plan.label = legalizer.label;
+    legalizer.walk_block(body, Interception::None);
+    legalizer.label
 }
 
 struct Legalizer {
@@ -63,23 +61,22 @@ impl Legalizer {
         self.walk_statements(&mut value.setup, interception);
     }
 
-    fn resolve_transfer(
-        &mut self,
-        transfer_target: Option<LoopId>,
-        resolved_label: &mut Option<String>,
-        intercepted: bool,
-    ) {
-        if transfer_target != Some(self.target) {
+    fn resolve_transfer(&mut self, transfer: &mut LoopTransfer, intercepted: bool) {
+        let LoopTransfer::Source(target) = transfer else {
+            return;
+        };
+        if *target != self.target {
             return;
         }
+
         if intercepted {
             let label_number = self.target.0 + 1;
             let label = self
                 .label
                 .get_or_insert_with(|| format!("loop_{label_number}"));
-            *resolved_label = Some(label.clone());
+            *transfer = LoopTransfer::Labeled(label.clone());
         } else {
-            *resolved_label = None;
+            *transfer = LoopTransfer::Unlabeled;
         }
     }
 
@@ -88,16 +85,16 @@ impl Legalizer {
             LoweredStatement::If(plan) => self.walk_if(plan, interception),
             LoweredStatement::Loop(plan) => {
                 self.walk_statements(&mut plan.prologue, interception);
-                if plan.target.is_none() {
-                    self.walk_block(&mut plan.body, Interception::all());
+                if matches!(&plan.kind, LoopKind::Generated { .. }) {
+                    self.walk_block(&mut plan.body, Interception::All);
                 }
             }
             LoweredStatement::Block(body) => self.walk_block(body, interception),
-            LoweredStatement::Break { target, label } => {
-                self.resolve_transfer(*target, label, interception.break_transfer)
+            LoweredStatement::Break(target) => {
+                self.resolve_transfer(target, interception.intercepts_break())
             }
-            LoweredStatement::Continue { target, label } => {
-                self.resolve_transfer(*target, label, interception.continue_transfer)
+            LoweredStatement::Continue(target) => {
+                self.resolve_transfer(target, interception.intercepts_continue())
             }
             LoweredStatement::Const(plan) => self.walk_value(&mut plan.value, interception),
             LoweredStatement::Return(plan) => match &mut plan.form {
@@ -112,16 +109,13 @@ impl Legalizer {
                 }
                 ReturnForm::Multi { .. } => {}
             },
-            LoweredStatement::BreakValue(plan) => {
-                self.walk_value(&mut plan.value, interception);
-                if !matches!(&plan.disposition, BreakValueDisposition::Diverged) {
-                    self.resolve_transfer(
-                        plan.target,
-                        &mut plan.label,
-                        interception.break_transfer,
-                    );
+            LoweredStatement::BreakValue(plan) => match plan {
+                BreakValuePlan::Diverged { value } => self.walk_value(value, interception),
+                BreakValuePlan::Transfer { value, target, .. } => {
+                    self.walk_value(value, interception);
+                    self.resolve_transfer(target, interception.intercepts_break());
                 }
-            }
+            },
             LoweredStatement::Let(plan) => {
                 if let LetForm::Never {
                     declaration: Some(declaration),
@@ -165,9 +159,9 @@ impl Legalizer {
             LoweredStatement::Select(plan) => {
                 self.walk_statements(&mut plan.setup, interception);
                 let arm_interception = if plan.retry_loop {
-                    Interception::all()
+                    Interception::All
                 } else {
-                    interception.breakable()
+                    interception.with_break()
                 };
                 for arm in &mut plan.arms {
                     self.walk_block(arm.body_mut(), arm_interception);
@@ -175,7 +169,7 @@ impl Legalizer {
                 self.walk_statements(&mut plan.postlude, interception);
             }
             LoweredStatement::Switch(plan) => {
-                let case_interception = interception.breakable();
+                let case_interception = interception.with_break();
                 for case in &mut plan.cases {
                     self.walk_block(&mut case.body, case_interception);
                 }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -205,8 +205,8 @@ impl Planner<'_> {
 
         let enum_name = layout.enum_name.clone();
         let generics = layout.generics.clone();
+        let func_name = go_name::enum_make_function(&enum_name, &variant.name);
         let go_type_name = go_name::escape_type_name(&enum_name);
-        let func_name = format!("Make{}{}", go_type_name, variant.name);
         let tag_constant = variant.tag_constant.clone();
 
         let (fields, params): (Vec<_>, Vec<_>) = variant

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -45,11 +45,9 @@ impl Planner<'_> {
         should_return: bool,
         return_ctx: &ReturnContext,
     ) {
-        self.push_const_frame();
-        self.push_return_ctx(return_ctx.clone());
-        self.emit_function_body_inner(output, body, should_return);
-        self.pop_return_ctx();
-        self.pop_const_frame();
+        self.with_function_body_context(return_ctx.clone(), |this| {
+            this.emit_function_body_inner(output, body, should_return);
+        });
     }
 
     fn emit_function_body_inner(
@@ -69,63 +67,54 @@ impl Planner<'_> {
         ty: &Type,
         ctx: ExpressionContext<'_>,
     ) -> String {
-        let frame = self.scope.enter_isolated_function();
+        self.with_fresh_scope(|this| {
+            let (mut param_pairs, destructure_bindings) = this.build_lambda_param_pairs(params);
 
-        let (mut param_pairs, destructure_bindings) = self.build_lambda_param_pairs(params);
+            let handle = params
+                .iter()
+                .position(|p| is_test_context_ty(&p.ty))
+                .map(|index| {
+                    if param_pairs[index].0 == "_" {
+                        let name = this.fresh_var(Some("lisetteSub"));
+                        this.declare(&name);
+                        param_pairs[index].0 = name.clone();
+                        name
+                    } else {
+                        param_pairs[index].0.clone()
+                    }
+                });
 
-        // A `t.run` subtest closure binds its own handle. Name a discarded `|_|`
-        // so `assert` targets the subtest, not the enclosing test.
-        let handle = params
-            .iter()
-            .position(|p| is_test_context_ty(&p.ty))
-            .map(|index| {
-                if param_pairs[index].0 == "_" {
-                    let name = self.fresh_var(Some("lisetteSub"));
-                    self.declare(&name);
-                    param_pairs[index].0 = name.clone();
-                    name
-                } else {
-                    param_pairs[index].0.clone()
-                }
+            let recover = handle.as_ref().map(|name| {
+                this.require_testkit();
+                let span = body.get_span();
+                format!(
+                    "defer {name}.Recover({}, {}, {})\n",
+                    span.file_id,
+                    span.byte_offset,
+                    span.byte_offset + span.byte_length,
+                )
             });
-        if let Some(name) = handle.clone() {
-            self.push_test_handle(name);
-        }
 
-        let recover = handle.as_ref().map(|name| {
-            self.require_testkit();
-            let span = body.get_span();
+            let return_info = this.lambda_return_info(ty, ctx);
+            let mut body_string = this.with_test_handle(handle, |this| {
+                this.emit_lambda_body_with_deferred(
+                    body,
+                    &destructure_bindings,
+                    &return_info.ctx,
+                    return_info.has_return,
+                )
+            });
+            if let Some(recover) = recover {
+                body_string.insert_str(0, &recover);
+            }
+
             format!(
-                "defer {name}.Recover({}, {}, {})\n",
-                span.file_id,
-                span.byte_offset,
-                span.byte_offset + span.byte_length,
+                "func({}){} {{\n{}}}",
+                group_params(&param_pairs),
+                return_info.ty_string,
+                body_string
             )
-        });
-
-        let return_info = self.lambda_return_info(ty, ctx);
-        let mut body_string = self.emit_lambda_body_with_deferred(
-            body,
-            &destructure_bindings,
-            &return_info.ctx,
-            return_info.has_return,
-        );
-        if let Some(recover) = recover {
-            body_string.insert_str(0, &recover);
-        }
-
-        if handle.is_some() {
-            self.pop_test_handle();
-        }
-
-        self.scope.exit_isolated_function(frame);
-
-        format!(
-            "func({}){} {{\n{}}}",
-            group_params(&param_pairs),
-            return_info.ty_string,
-            body_string
-        )
+        })
     }
 
     fn build_lambda_param_pairs<'a>(
@@ -334,18 +323,14 @@ impl Planner<'_> {
                         .then(|| this.go_name_for_binding(&param.pattern))
                         .flatten()
                 });
-                if let Some(name) = test_handle.clone() {
-                    this.push_test_handle(name);
-                }
-                this.emit_function_body_with_deferred_patterns(
-                    &mut body,
-                    function_definition,
-                    deferred_patterns,
-                    &return_ctx,
-                );
-                if test_handle.is_some() {
-                    this.pop_test_handle();
-                }
+                this.with_test_handle(test_handle, |this| {
+                    this.emit_function_body_with_deferred_patterns(
+                        &mut body,
+                        function_definition,
+                        deferred_patterns,
+                        &return_ctx,
+                    );
+                });
                 signature
             },
         );
@@ -520,8 +505,6 @@ impl Planner<'_> {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        let saved = std::mem::take(&mut self.function_state);
-        self.function_state.set_generic_context(generic_context);
         let bounded_generics: HashSet<&str> = match resolved_signature_generics {
             Some(generics) => generics
                 .iter()
@@ -534,16 +517,26 @@ impl Planner<'_> {
                 .map(|generic| generic.name.as_str())
                 .collect(),
         };
-        for param in params.iter() {
-            if param.ty.is_ref()
-                && let Some(inner) = param.ty.inner()
-                && let Type::Parameter(name) = &inner
-                && bounded_generics.contains(name.as_str())
-            {
-                self.function_state
-                    .record_absorbed_ref_generic(name.to_string());
-            }
-        }
+        let absorbed_ref_generics = params
+            .iter()
+            .filter_map(|param| {
+                if !param.ty.is_ref() {
+                    return None;
+                }
+                let inner = param.ty.inner()?;
+                let Type::Parameter(name) = inner else {
+                    return None;
+                };
+                bounded_generics
+                    .contains(name.as_str())
+                    .then(|| name.to_string())
+            })
+            .collect();
+        let state = crate::state::module_state::FunctionEmissionState::for_function(
+            generic_context,
+            absorbed_ref_generics,
+        );
+        let saved = std::mem::replace(&mut self.function_state, state);
         let result = f(self);
         self.function_state = saved;
         result

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -1,5 +1,5 @@
 use crate::Planner;
-use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::transition::render_lowered_result_return;
 use crate::names::go_name;
 use crate::names::go_name::GO_IMPORT_PREFIX;
@@ -269,16 +269,12 @@ impl Planner<'_> {
         hints: &[String],
     ) -> CallableReturnAbi {
         let base = self.callable_return_abi(return_ty);
-        if let CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Nullable,
-            payload,
-        } = base
+        if matches!(base, CallableReturnAbi::Option(OptionReturnAbi::Nullable))
             && hints.iter().any(|h| h == "comma_ok")
         {
-            return CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
-                payload,
-            };
+            return CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
+                payload: PayloadLayout::Packed,
+            });
         }
         base
     }
@@ -296,7 +292,7 @@ impl Planner<'_> {
             return name.to_string();
         }
 
-        let index = self.adapter_registry.next_index();
+        let index = self.adapter_registry.allocate_index();
         let mut base_name = adapter_type_name(&plan, index);
         while self.is_declared(&base_name) {
             base_name.push('_');
@@ -353,48 +349,47 @@ impl Planner<'_> {
         generic_context: &[(EcoString, Vec<Type>)],
         method: &AdapterMethod,
     ) {
-        self.enter_scope();
+        self.with_scope(|this| {
+            for (name, _) in generic_context {
+                let go_name = this.generic_go_name(name).into_owned();
+                this.declare(&go_name);
+            }
+            let receiver_name = this.declare_adapter_method_binding("a".to_string());
+            let param_names: Vec<String> = (0..method.param_types.len())
+                .map(|i| this.declare_adapter_method_binding(format!("arg{}", i)))
+                .collect();
 
-        for (name, _) in generic_context {
-            let go_name = self.generic_go_name(name).into_owned();
-            self.declare(&go_name);
-        }
-        let receiver_name = self.declare_adapter_method_binding("a".to_string());
-        let param_names: Vec<String> = (0..method.param_types.len())
-            .map(|i| self.declare_adapter_method_binding(format!("arg{}", i)))
-            .collect();
+            let params_str = param_names
+                .iter()
+                .zip(method.param_types.iter())
+                .map(|(n, t)| format!("{} {}", n, this.go_type_string(t)))
+                .collect::<Vec<_>>()
+                .join(", ");
 
-        let params_str = param_names
-            .iter()
-            .zip(method.param_types.iter())
-            .map(|(n, t)| format!("{} {}", n, self.go_type_string(t)))
-            .collect::<Vec<_>>()
-            .join(", ");
+            let go_method_name = if this.method_needs_export(&method.name) {
+                go_name::snake_to_camel(&method.name)
+            } else {
+                go_name::escape_keyword(&method.name).into_owned()
+            };
+            let inner_call = format!(
+                "{}.inner.{}({})",
+                receiver_name,
+                go_method_name,
+                param_names.join(", ")
+            );
 
-        let go_method_name = if self.method_needs_export(&method.name) {
-            go_name::snake_to_camel(&method.name)
-        } else {
-            go_name::escape_keyword(&method.name).into_owned()
-        };
-        let inner_call = format!(
-            "{}.inner.{}({})",
-            receiver_name,
-            go_method_name,
-            param_names.join(", ")
-        );
-
-        let (go_ret, body) = self.build_adapter_body(method, &inner_call);
-        write_method_header(
-            declaration,
-            &receiver_name,
-            adapter_name,
-            &go_method_name,
-            &params_str,
-            &go_ret,
-        );
-        declaration.push_str(&body);
-        write_line!(declaration, "}}");
-        self.exit_scope();
+            let (go_ret, body) = this.build_adapter_body(method, &inner_call);
+            write_method_header(
+                declaration,
+                &receiver_name,
+                adapter_name,
+                &go_method_name,
+                &params_str,
+                &go_ret,
+            );
+            declaration.push_str(&body);
+            write_line!(declaration, "}}");
+        });
     }
 
     fn declare_adapter_method_binding(&mut self, preferred: String) -> String {
@@ -640,9 +635,9 @@ fn adapter_uses_type_parameter(
 fn abi_matches_type(abi: &CallableReturnAbi, peeled: &Type) -> bool {
     match abi {
         CallableReturnAbi::Tagged | CallableReturnAbi::Direct => true,
-        CallableReturnAbi::Result { .. } => peeled.is_result(),
+        CallableReturnAbi::BareError | CallableReturnAbi::Result { .. } => peeled.is_result(),
         CallableReturnAbi::Partial { .. } => peeled.is_partial(),
-        CallableReturnAbi::Option { .. } => peeled.is_option(),
+        CallableReturnAbi::Option(_) => peeled.is_option(),
         CallableReturnAbi::Tuple { .. } => peeled.tuple_arity().is_some_and(|arity| arity >= 2),
     }
 }

--- a/crates/emit/src/definitions/tags.rs
+++ b/crates/emit/src/definitions/tags.rs
@@ -1,37 +1,94 @@
 use syntax::ast::{Attribute, AttributeArg, StructFieldDefinition};
 use syntax::attributes::{is_serialization_key, struct_attribute_forces_field_export};
 
-#[derive(Default)]
 pub(super) struct TagConfig {
     key: String,
+    value: TagValue,
+}
+
+enum TagValue {
+    Structured(StructuredTag),
+    Raw(String),
+}
+
+#[derive(Default)]
+struct StructuredTag {
     name_override: Option<String>,
     case_transform: Option<CaseTransform>,
-    omitempty: bool,
+    omitempty: Option<bool>,
     skip: bool,
     string_encoding: bool,
-    raw_value: Option<String>,
 }
 
 impl TagConfig {
+    fn structured(key: String) -> Self {
+        Self {
+            key,
+            value: TagValue::Structured(StructuredTag::default()),
+        }
+    }
+
+    fn raw(key: String, value: String) -> Self {
+        Self {
+            key,
+            value: TagValue::Raw(value),
+        }
+    }
+
+    fn settings(&self) -> Option<&StructuredTag> {
+        match &self.value {
+            TagValue::Structured(settings) => Some(settings),
+            TagValue::Raw(_) => None,
+        }
+    }
+
+    fn settings_mut(&mut self) -> Option<&mut StructuredTag> {
+        match &mut self.value {
+            TagValue::Structured(settings) => Some(settings),
+            TagValue::Raw(_) => None,
+        }
+    }
+
     fn merge_from(&mut self, other: TagConfig) {
-        if other.case_transform.is_some() {
-            self.case_transform = other.case_transform;
+        debug_assert_eq!(self.key, other.key);
+        match other.value {
+            TagValue::Raw(raw) => self.value = TagValue::Raw(raw),
+            TagValue::Structured(other) => {
+                let Some(current) = self.settings_mut() else {
+                    return;
+                };
+                if other.case_transform.is_some() {
+                    current.case_transform = other.case_transform;
+                }
+                if other.omitempty.is_some() {
+                    current.omitempty = other.omitempty;
+                }
+                current.skip |= other.skip;
+                current.string_encoding |= other.string_encoding;
+                if other.name_override.is_some() {
+                    current.name_override = other.name_override;
+                }
+            }
         }
-        if other.omitempty {
-            self.omitempty = true;
+    }
+}
+
+impl StructuredTag {
+    /// Apply options shared by struct-level and field-level tag attributes.
+    fn apply_common_arg(&mut self, arg: &AttributeArg) -> bool {
+        match arg {
+            AttributeArg::Flag(flag) => match flag.as_str() {
+                "snake_case" => self.case_transform = Some(CaseTransform::SnakeCase),
+                "camel_case" => self.case_transform = Some(CaseTransform::CamelCase),
+                "omitempty" => self.omitempty = Some(true),
+                _ => return false,
+            },
+            AttributeArg::NegatedFlag(flag) if flag == "omitempty" => {
+                self.omitempty = Some(false);
+            }
+            _ => return false,
         }
-        if other.skip {
-            self.skip = true;
-        }
-        if other.string_encoding {
-            self.string_encoding = true;
-        }
-        if other.name_override.is_some() {
-            self.name_override = other.name_override;
-        }
-        if other.raw_value.is_some() {
-            self.raw_value = other.raw_value;
-        }
+        true
     }
 }
 
@@ -66,7 +123,9 @@ pub(super) fn interpret_field_attributes(
 
     for mut default in struct_defaults {
         if !configs.iter().any(|c| c.key == default.key) {
-            default.name_override = None;
+            if let Some(settings) = default.settings_mut() {
+                settings.name_override = None;
+            }
             configs.push(default);
         }
     }
@@ -84,26 +143,13 @@ fn interpret_struct_attribute(attribute: &Attribute) -> Option<TagConfig> {
         return interpret_struct_tag_attribute(attribute);
     }
 
-    let mut config = TagConfig {
-        key: key.clone(),
-        ..Default::default()
-    };
+    let mut config = TagConfig::structured(key.clone());
 
     for arg in &attribute.args {
-        match arg {
-            AttributeArg::Flag(flag) => match flag.as_str() {
-                "snake_case" => config.case_transform = Some(CaseTransform::SnakeCase),
-                "camel_case" => config.case_transform = Some(CaseTransform::CamelCase),
-                "omitempty" => config.omitempty = true,
-                _ => {}
-            },
-            AttributeArg::NegatedFlag(flag) => {
-                if flag == "omitempty" {
-                    config.omitempty = false;
-                }
-            }
-            _ => {}
-        }
+        let _ = config
+            .settings_mut()
+            .expect("structured tag config")
+            .apply_common_arg(arg);
     }
 
     Some(config)
@@ -118,26 +164,13 @@ fn interpret_struct_tag_attribute(attribute: &Attribute) -> Option<TagConfig> {
         return None;
     };
 
-    let mut config = TagConfig {
-        key: key.clone(),
-        ..Default::default()
-    };
+    let mut config = TagConfig::structured(key.clone());
 
     for arg in attribute.args.iter().skip(1) {
-        match arg {
-            AttributeArg::Flag(flag) => match flag.as_str() {
-                "snake_case" => config.case_transform = Some(CaseTransform::SnakeCase),
-                "camel_case" => config.case_transform = Some(CaseTransform::CamelCase),
-                "omitempty" => config.omitempty = true,
-                _ => {}
-            },
-            AttributeArg::NegatedFlag(flag) => {
-                if flag == "omitempty" {
-                    config.omitempty = false;
-                }
-            }
-            _ => {}
-        }
+        let _ = config
+            .settings_mut()
+            .expect("structured tag config")
+            .apply_common_arg(arg);
     }
 
     Some(config)
@@ -157,41 +190,38 @@ fn interpret_field_attribute(
         return None;
     }
 
-    let mut config = struct_defaults
+    let mut config = TagConfig::structured(key.clone());
+    if let Some(default) = struct_defaults
         .iter()
-        .find(|c| c.key == *key)
-        .map(|c| TagConfig {
-            key: c.key.clone(),
-            case_transform: c.case_transform,
-            omitempty: c.omitempty,
-            ..Default::default()
-        })
-        .unwrap_or_else(|| TagConfig {
-            key: key.clone(),
-            ..Default::default()
-        });
+        .find(|config| config.key == *key)
+        .and_then(TagConfig::settings)
+    {
+        let settings = config.settings_mut().expect("structured tag config");
+        settings.case_transform = default.case_transform;
+        settings.omitempty = default.omitempty;
+    }
 
     for arg in &attribute.args {
+        if let AttributeArg::Raw(raw) = arg {
+            config.value = TagValue::Raw(raw.clone());
+            continue;
+        }
+        let Some(settings) = config.settings_mut() else {
+            continue;
+        };
+        if settings.apply_common_arg(arg) {
+            continue;
+        }
         match arg {
             AttributeArg::Flag(flag) => match flag.as_str() {
-                "snake_case" => config.case_transform = Some(CaseTransform::SnakeCase),
-                "camel_case" => config.case_transform = Some(CaseTransform::CamelCase),
-                "omitempty" => config.omitempty = true,
-                "skip" => config.skip = true,
-                "string" => config.string_encoding = true,
+                "skip" => settings.skip = true,
+                "string" => settings.string_encoding = true,
                 _ => {}
             },
-            AttributeArg::NegatedFlag(flag) => {
-                if flag == "omitempty" {
-                    config.omitempty = false;
-                }
-            }
             AttributeArg::String(name) => {
-                config.name_override = Some(name.clone());
+                settings.name_override = Some(name.clone());
             }
-            AttributeArg::Raw(raw) => {
-                config.raw_value = Some(raw.clone());
-            }
+            AttributeArg::NegatedFlag(_) | AttributeArg::Raw(_) => {}
         }
     }
 
@@ -213,35 +243,23 @@ fn interpret_tag_attribute(attribute: &Attribute) -> Option<TagConfig> {
                 .filter(|k| !k.is_empty())
                 .unwrap_or("tag")
                 .to_string();
-            Some(TagConfig {
-                key,
-                raw_value: Some(raw.clone()),
-                ..Default::default()
-            })
+            Some(TagConfig::raw(key, raw.clone()))
         }
 
         AttributeArg::String(key) => {
-            let mut config = TagConfig {
-                key: key.clone(),
-                ..Default::default()
-            };
+            let mut config = TagConfig::structured(key.clone());
 
             for (i, arg) in attribute.args.iter().enumerate().skip(1) {
+                let settings = config.settings_mut().expect("structured tag config");
+                if settings.apply_common_arg(arg) {
+                    continue;
+                }
                 match arg {
                     AttributeArg::String(name) if i == 1 => {
-                        config.name_override = Some(name.clone());
+                        settings.name_override = Some(name.clone());
                     }
-                    AttributeArg::Flag(flag) => match flag.as_str() {
-                        "snake_case" => config.case_transform = Some(CaseTransform::SnakeCase),
-                        "camel_case" => config.case_transform = Some(CaseTransform::CamelCase),
-                        "omitempty" => config.omitempty = true,
-                        "skip" => config.skip = true,
-                        _ => {}
-                    },
-                    AttributeArg::NegatedFlag(flag) => {
-                        if flag == "omitempty" {
-                            config.omitempty = false;
-                        }
+                    AttributeArg::Flag(flag) if flag == "skip" => {
+                        settings.skip = true;
                     }
                     _ => {}
                 }
@@ -279,7 +297,7 @@ pub(super) fn format_tag_string(
 }
 
 fn tag_sort_key(config: &TagConfig) -> (u8, &str) {
-    if config.raw_value.is_some() {
+    if matches!(&config.value, TagValue::Raw(_)) {
         return (3, &config.key);
     }
 
@@ -291,33 +309,36 @@ fn tag_sort_key(config: &TagConfig) -> (u8, &str) {
 }
 
 fn format_single_tag(field_name: &str, config: &TagConfig, is_option: bool) -> Option<String> {
-    if let Some(ref raw) = config.raw_value {
-        let key_prefix = format!("{}:", config.key);
-        if raw.starts_with(&key_prefix) {
-            return Some(raw.clone());
+    let settings = match &config.value {
+        TagValue::Raw(raw) => {
+            let key_prefix = format!("{}:", config.key);
+            if raw.starts_with(&key_prefix) {
+                return Some(raw.clone());
+            }
+            return Some(format!("{}:{}", config.key, raw));
         }
-        return Some(format!("{}:{}", config.key, raw));
-    }
+        TagValue::Structured(settings) => settings,
+    };
 
-    if config.skip {
+    if settings.skip {
         return Some(format!("{}:\"-\"", config.key));
     }
 
-    let name = if let Some(ref override_name) = config.name_override {
+    let name = if let Some(ref override_name) = settings.name_override {
         override_name.clone()
     } else {
-        apply_case_transform(field_name, config.case_transform)
+        apply_case_transform(field_name, settings.case_transform)
     };
 
     let mut options = Vec::new();
-    if config.omitempty {
+    if settings.omitempty == Some(true) {
         options.push(if is_option && config.key == "json" {
             "omitzero"
         } else {
             "omitempty"
         });
     }
-    if config.string_encoding {
+    if settings.string_encoding {
         options.push("string");
     }
 

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -56,10 +56,7 @@ impl Planner<'_> {
             return None;
         };
 
-        let enum_name = unqualified_name(enum_id);
-        let constructor_key = format!("{}.{}", enum_name, variant_name);
-
-        let make_fn_name = self.facts.make_function_name(&constructor_key)?.to_string();
+        let make_fn_name = self.facts.make_function_name(enum_id, variant_name)?;
 
         let enum_module = self.facts.module_for_qualified_name(enum_id)?;
         let needs_qualifier = !self.facts.is_current_module(enum_module);
@@ -116,9 +113,7 @@ impl Planner<'_> {
             return None;
         }
 
-        let enum_name = unqualified_name(enum_id);
-        let key = format!("{}.{}", enum_name, variant_name);
-        let make_fn = self.facts.make_function_name(&key)?.to_string();
+        let make_fn = self.facts.make_function_name(enum_id, variant_name)?;
         let type_args = self.format_type_args(params);
 
         if is_prelude {

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -100,31 +100,18 @@ impl Planner<'_> {
             return IdentifierKind::PublicFunction { capitalized };
         }
 
-        let mut make_fn = self.facts.make_function_name(&name);
-
-        if make_fn.is_none() {
-            let enum_id = match ty {
-                Type::Function(f) => {
-                    if let Type::Nominal { id, .. } = f.return_type.as_ref() {
-                        Some(id.as_str())
-                    } else {
-                        None
-                    }
-                }
+        let enum_id = match ty {
+            Type::Function(f) => match f.return_type.as_ref() {
                 Type::Nominal { id, .. } => Some(id.as_str()),
                 _ => None,
-            };
+            },
+            Type::Nominal { id, .. } => Some(id.as_str()),
+            _ => None,
+        };
+        let make_fn =
+            enum_id.and_then(|id| self.facts.make_function_name(id, unqualified_name(value)));
 
-            if let Some(id) = enum_id {
-                let enum_name = unqualified_name(id);
-                let qualified = format!("{}.{}", enum_name, value);
-                make_fn = self.facts.make_function_name(&qualified);
-            }
-        }
-
-        if let Some(make_fn_value) = make_fn {
-            let name = make_fn_value.to_string();
-
+        if let Some(name) = make_fn {
             match ty {
                 Type::Nominal { params, .. } => {
                     let type_args = match ctx.expected_slot_type() {
@@ -150,8 +137,7 @@ impl Planner<'_> {
             }
         }
 
-        let resolved = make_fn.map(str::to_string).unwrap_or(name);
-        IdentifierKind::Regular { name: resolved }
+        IdentifierKind::Regular { name }
     }
 
     /// Type args for a constructor function reference (e.g. `MakeFoo[T]` used as a value).

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -53,10 +53,7 @@ impl Planner<'_> {
                 let mut setup = Vec::new();
                 let value = if self.go_fn_needs_lowered_tuple_adapter(expression, abi, ctx) {
                     self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression)
-                } else if let CallableReturnAbi::Option {
-                    encoding: OptionReturnAbi::Sentinel(value),
-                    ..
-                } = abi
+                } else if let CallableReturnAbi::Option(OptionReturnAbi::Sentinel(value)) = abi
                     && !ctx.forces_tagged_go_function()
                 {
                     self.emit_go_fn_sentinel_adapter(&mut setup, expression, *value)
@@ -217,13 +214,11 @@ impl Planner<'_> {
             (
                 CallableReturnAbi::Result {
                     payload: PayloadLayout::Flattened,
-                    ..
                 } | CallableReturnAbi::Partial {
                     payload: PayloadLayout::Flattened,
                 },
                 CallableReturnAbi::Result {
                     payload: PayloadLayout::Packed,
-                    ..
                 } | CallableReturnAbi::Partial {
                     payload: PayloadLayout::Packed,
                 }

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -34,7 +34,6 @@ pub use output::imports;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
@@ -45,6 +44,7 @@ use names::packages::{PackageRequirements, PackageUse};
 use plan::ModulePlan;
 use plan::bodies::{LoopId, LoweredBlock, LoweredStatement};
 use state::adapter_registry::AdapterRegistry;
+use state::bindings::BindingSnapshot;
 use state::file_namespace::FileNamespace;
 use state::module_state::{FunctionEmissionState, ModuleState};
 use state::scope::ScopeState;
@@ -62,30 +62,21 @@ pub struct EmitOptions {
     pub emit_tests: bool,
 }
 
-#[derive(Default)]
 pub(crate) struct GlobalEmitData {
     go_abi_catalog: GoAbiCatalog,
     exported_method_names: HashSet<String>,
-    make_function_names: HashMap<String, String>,
 }
 
 impl GlobalEmitData {
     fn compute(definitions: &HashMap<Symbol, Definition>) -> Self {
         let mut globals = GlobalEmitData {
             go_abi_catalog: GoAbiCatalog::from_definitions(definitions),
-            ..GlobalEmitData::default()
+            exported_method_names: HashSet::default(),
         };
-
-        for prelude_type in PreludeType::enum_types() {
-            for (constructor, make_fn) in prelude_type.make_function_entries() {
-                globals.make_function_names.insert(constructor, make_fn);
-            }
-        }
 
         for (key, definition) in definitions.iter() {
             let is_go = go_name::is_go_import(key);
             globals.register_exported_methods(key, definition, is_go);
-            globals.register_enum_make_functions(definition);
         }
 
         globals
@@ -116,33 +107,6 @@ impl GlobalEmitData {
             self.exported_method_names.insert("to_string".to_string());
         }
     }
-
-    fn register_enum_make_functions(&mut self, definition: &Definition) {
-        if let Definition {
-            name: Some(name),
-            body: DefinitionBody::Enum { variants, .. },
-            ..
-        } = definition
-            && PreludeType::from_name(name).is_none()
-        {
-            for (constructor, make_fn) in user_enum_make_function_entries(name, variants) {
-                self.make_function_names.insert(constructor, make_fn);
-            }
-        }
-    }
-}
-
-/// Make-function name registry entries for a user-declared enum.
-fn user_enum_make_function_entries<'a>(
-    name: &'a str,
-    variants: &'a [syntax::ast::EnumVariant],
-) -> impl Iterator<Item = (String, String)> + 'a {
-    let go_type_name = go_name::escape_type_name(name).into_owned();
-    variants.iter().map(move |variant| {
-        let constructor = format!("{}.{}", name, variant.name);
-        let make_fn = format!("Make{}{}", go_type_name, variant.name);
-        (constructor, make_fn)
-    })
 }
 
 pub(crate) fn classify_go_return_type(
@@ -165,34 +129,27 @@ pub(crate) fn classify_go_return_type(
         return Some(CallableReturnAbi::Partial { payload: payload() });
     }
     if return_ty.is_result() {
-        return Some(CallableReturnAbi::Result {
-            bare_error: return_ty.ok_type().is_unit(),
-            payload: payload(),
+        return Some(if return_ty.ok_type().is_unit() {
+            CallableReturnAbi::BareError
+        } else {
+            CallableReturnAbi::Result { payload: payload() }
         });
     }
     if return_ty.is_option() {
         if let Some(value) = sentinel_hint(go_hints) {
-            return Some(CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::Sentinel(value),
-                payload: PayloadLayout::Packed,
-            });
+            return Some(CallableReturnAbi::Option(OptionReturnAbi::Sentinel(value)));
         }
         if !is_nullable_option(definitions, return_ty) {
-            return Some(CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
+            return Some(CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
                 payload: payload(),
-            });
+            }));
         }
         if go_hints.iter().any(|s| s == "comma_ok") {
-            return Some(CallableReturnAbi::Option {
-                encoding: OptionReturnAbi::CommaOk,
+            return Some(CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
                 payload: payload(),
-            });
+            }));
         }
-        return Some(CallableReturnAbi::Option {
-            encoding: OptionReturnAbi::Nullable,
-            payload: PayloadLayout::Packed,
-        });
+        return Some(CallableReturnAbi::Option(OptionReturnAbi::Nullable));
     }
     if let Some(arity) = return_ty.tuple_arity()
         && arity >= 2
@@ -314,7 +271,7 @@ impl<'a> Planner<'a> {
 
     /// Append this file's newly-synthesized adapter declarations to `source`.
     fn drain_file_emission_into(&mut self, source: &mut OutputCollector) {
-        for adapter_declaration in self.adapter_registry.flush_new_declarations() {
+        for adapter_declaration in self.adapter_registry.drain_declarations() {
             source.collect_with_blank(adapter_declaration);
         }
     }
@@ -427,12 +384,11 @@ impl<'a> Planner<'a> {
         }
     }
 
-    fn push_loop(&mut self, result_var: impl Into<String>) {
+    fn with_loop<R>(&mut self, result_var: impl Into<String>, f: impl FnOnce(&mut Self) -> R) -> R {
         self.scope.push_loop(result_var.into());
-    }
-
-    fn pop_loop(&mut self) {
+        let result = f(self);
         self.scope.pop_loop();
+        result
     }
 
     fn current_loop_result_var(&self) -> Option<&str> {
@@ -446,20 +402,22 @@ impl<'a> Planner<'a> {
     /// Push the enclosing function/lambda/try/recover return context. This
     /// scope stack is the single source of truth for return-context lowering;
     /// all readers consult it via [`Planner::return_ctx`].
-    fn push_return_ctx(&mut self, ctx: ReturnContext) {
-        self.scope.push_return_ctx(Rc::new(ctx));
-    }
-
-    fn pop_return_ctx(&mut self) {
+    fn with_return_context<R>(&mut self, ctx: ReturnContext, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.scope.push_return_ctx(ctx);
+        let result = f(self);
         self.scope.pop_return_ctx();
+        result
     }
 
-    fn push_test_handle(&mut self, name: String) {
-        self.scope.push_test_handle(name);
-    }
-
-    fn pop_test_handle(&mut self) {
-        self.scope.pop_test_handle();
+    fn with_test_handle<R>(&mut self, name: Option<String>, f: impl FnOnce(&mut Self) -> R) -> R {
+        if let Some(name) = name {
+            self.scope.push_test_handle(name);
+            let result = f(self);
+            self.scope.pop_test_handle();
+            result
+        } else {
+            f(self)
+        }
     }
 
     fn current_test_handle(&self) -> Option<String> {
@@ -471,10 +429,10 @@ impl<'a> Planner<'a> {
     /// `ReturnContext::None` outside any function body (e.g. module-level
     /// collection). This is the single source of truth for return-context
     /// lowering.
-    fn return_ctx(&self) -> Rc<ReturnContext> {
+    fn return_ctx(&self) -> ReturnContext {
         self.scope
             .current_return_ctx()
-            .unwrap_or_else(|| Rc::new(ReturnContext::None))
+            .unwrap_or(ReturnContext::None)
     }
 
     /// `true` if this is a new declaration in the current block (use `:=`),
@@ -518,17 +476,13 @@ impl<'a> Planner<'a> {
     }
 
     /// Run `f` inside a fresh scope to build a `LoweredBlock`, returning `None`
-    /// when it renders empty.
+    /// when its IR emits no output.
     fn capture_scoped_block<F>(&mut self, f: F) -> Option<LoweredBlock>
     where
         F: FnOnce(&mut Self) -> LoweredBlock,
     {
-        self.enter_scope();
-        let block = f(self);
-        self.exit_scope();
-        let mut buffer = String::new();
-        Renderer.render_lowered_block(&mut buffer, &block);
-        (!buffer.is_empty()).then_some(block)
+        let block = self.with_scope(f);
+        (!block.renders_empty()).then_some(block)
     }
 
     fn enter_scope(&mut self) {
@@ -539,16 +493,62 @@ impl<'a> Planner<'a> {
         self.scope.exit_block();
     }
 
+    fn with_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.enter_scope();
+        let result = f(self);
+        self.exit_scope();
+        result
+    }
+
+    fn with_binding_frame<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.scope.push_binding_frame();
+        let result = f(self);
+        self.scope.pop_binding_frame();
+        result
+    }
+
+    fn with_assign_target<R>(&mut self, target: &str, f: impl FnOnce(&mut Self) -> R) -> R {
+        let newly_active = self.scope.activate_assign_target(target);
+        let result = f(self);
+        if newly_active {
+            self.scope.deactivate_assign_target(target);
+        }
+        result
+    }
+
+    fn with_binding_snapshot<R>(
+        &mut self,
+        snapshot: BindingSnapshot,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let current = self.scope.replace_binding_snapshot(snapshot);
+        let result = f(self);
+        let _ = self.scope.replace_binding_snapshot(current);
+        result
+    }
+
+    fn capture_go_uses<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> (R, HashSet<String>) {
+        self.scope.enter_use_region();
+        let result = f(self);
+        let uses = self.scope.exit_use_region();
+        (result, uses)
+    }
+
     fn fresh_var(&mut self, hint: Option<&str>) -> String {
         self.scope.fresh_go_name(hint)
     }
 
-    fn push_const_frame(&mut self) {
+    fn with_function_body_context<R>(
+        &mut self,
+        return_ctx: ReturnContext,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
         self.scope.push_const_frame();
-    }
-
-    fn pop_const_frame(&mut self) {
+        self.scope.push_return_ctx(return_ctx);
+        let result = f(self);
+        self.scope.pop_return_ctx();
         self.scope.pop_const_frame();
+        result
     }
 
     fn record_go_const(&mut self, go_identifier: String) {
@@ -588,8 +588,6 @@ impl<'a> Planner<'a> {
         let mut output_files = Vec::new();
 
         for (i, (file, file_plan)) in files.iter().zip(file_plans).enumerate() {
-            debug_assert_eq!(file.id, file_plan.file_id, "plan/file order mismatch");
-
             *self.namespace.borrow_mut() = Some(file_plan.namespace);
             let mut source = OutputCollector::new();
 
@@ -621,7 +619,7 @@ impl<'a> Planner<'a> {
                 diagnostics.append(&mut collision_diagnostics);
             }
             output_files.push(OutputFile {
-                name: file_plan.output_name.clone(),
+                name: file.go_filename(),
                 imports,
                 source: rendered_source,
                 package_name: package_name.clone(),

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -186,6 +186,10 @@ pub(crate) fn enum_tag_constant(enum_name: &str, variant_name: &str) -> String {
     }
 }
 
+pub(crate) fn enum_make_function(enum_name: &str, variant_name: &str) -> String {
+    format!("Make{}{}", escape_type_name(enum_name), variant_name)
+}
+
 /// Go builtins re-exposed by the Lisette prelude under the same name. The
 /// `prelude_function_shadowed` diagnostic forbids user code from declaring
 /// identifiers with these names, so the emitter need not escape them.

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -1,5 +1,5 @@
 use crate::Planner;
-use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
+use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
 use crate::patterns::decision_tree::{Check, PatternBinding, PatternInfo, render_condition};
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::placement::simple_assign;
@@ -110,6 +110,7 @@ pub(crate) fn tree_binding_statements(
     bindings: &[PatternBinding],
     subject_var: &str,
     consumers: &[&syntax::ast::Expression],
+    inline_blockers: &[&syntax::ast::Expression],
 ) -> Vec<(String, Option<BindingValue>)> {
     let mut installed_inlines = Vec::new();
     for binding in bindings {
@@ -122,6 +123,7 @@ pub(crate) fn tree_binding_statements(
 
         if !consumers.is_empty()
             && analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline
+            && !region_blocks_inline(inline_blockers.iter().copied(), &binding.lisette_name)
         {
             let previous = planner
                 .scope
@@ -182,6 +184,28 @@ pub(crate) fn drop_inline_overlays(
             }
         }
     }
+}
+
+pub(crate) fn with_tree_bindings<R>(
+    planner: &mut Planner,
+    statements: &mut Vec<LoweredStatement>,
+    bindings: &[PatternBinding],
+    subject_var: &str,
+    consumers: &[&syntax::ast::Expression],
+    inline_blockers: &[&syntax::ast::Expression],
+    f: impl FnOnce(&mut Planner, &mut Vec<LoweredStatement>) -> R,
+) -> R {
+    let overlays = tree_binding_statements(
+        planner,
+        statements,
+        bindings,
+        subject_var,
+        consumers,
+        inline_blockers,
+    );
+    let result = f(planner, statements);
+    drop_inline_overlays(planner, &overlays);
+    result
 }
 
 /// Push `name = subject.path` leaves for or-pattern alternatives whose

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -57,9 +57,9 @@ impl Planner<'_> {
         let (subject_var, declaration) =
             self.lower_match_subject_var(&mut statements, subject, arms);
 
-        self.scope.enter_use_region();
-        let block = self.lower_match_tree(arms, subject_var.clone(), subject_ty, place);
-        let used_set = self.scope.exit_use_region();
+        let (block, used_set) = self.capture_go_uses(|this| {
+            this.lower_match_tree(arms, subject_var.clone(), subject_ty, place)
+        });
         let used = used_set.contains(&subject_var);
 
         match declaration {
@@ -107,7 +107,10 @@ impl Planner<'_> {
         let shape = plan.resolved.abi.result.clone();
         let nil_guard = match &plan.resolved.origin {
             CallableOrigin::GoInterop
-                if matches!(plan.resolved.abi.result, CallableReturnAbi::Result { .. }) =>
+                if matches!(
+                    plan.resolved.abi.result,
+                    CallableReturnAbi::BareError | CallableReturnAbi::Result { .. }
+                ) =>
             {
                 let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
                 if matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
@@ -124,7 +127,11 @@ impl Planner<'_> {
             CallableOrigin::GoInterop => return None,
             _ => None,
         };
-        matches!(shape, CallableReturnAbi::Result { .. }).then_some(FusedShape { shape, nil_guard })
+        matches!(
+            shape,
+            CallableReturnAbi::BareError | CallableReturnAbi::Result { .. }
+        )
+        .then_some(FusedShape { shape, nil_guard })
     }
 
     /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
@@ -149,13 +156,8 @@ impl Planner<'_> {
         let ok_name = ok_binding.filter(|n| *n != "_");
         let err_name = err_binding.filter(|n| *n != "_");
 
-        let need_val = matches!(
-            shape,
-            CallableReturnAbi::Result {
-                bare_error: false,
-                ..
-            }
-        ) && (ok_name.is_some() || nil_guard.is_some());
+        let need_val = matches!(shape, CallableReturnAbi::Result { .. })
+            && (ok_name.is_some() || nil_guard.is_some());
         let val_var = need_val.then(|| {
             let v = self.fresh_var(Some("ret"));
             self.declare(&v);
@@ -170,16 +172,12 @@ impl Planner<'_> {
         let bind_line = match &val_var {
             Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
             None => match shape {
-                CallableReturnAbi::Result {
-                    bare_error: false, ..
-                } => format!("_, {} := {}\n", err_var, call_str),
-                CallableReturnAbi::Result {
-                    bare_error: true, ..
-                } => format!("{} := {}\n", err_var, call_str),
+                CallableReturnAbi::Result { .. } => format!("_, {} := {}\n", err_var, call_str),
+                CallableReturnAbi::BareError => format!("{} := {}\n", err_var, call_str),
                 CallableReturnAbi::Tagged
                 | CallableReturnAbi::Direct
                 | CallableReturnAbi::Partial { .. }
-                | CallableReturnAbi::Option { .. }
+                | CallableReturnAbi::Option(_)
                 | CallableReturnAbi::Tuple { .. } => unreachable!("rejected above"),
             },
         };
@@ -344,36 +342,35 @@ impl Planner<'_> {
         body: &Expression,
         place: &PlacePlan,
     ) -> (LoweredBlock, bool) {
-        self.scope.push_binding_frame();
-        let bound: Vec<Option<(String, String)>> = bindings
-            .iter()
-            .map(|binding| {
-                binding.map(|(name, value)| {
-                    let go_name = self.scope.bind(name, name);
-                    self.declare(&go_name);
-                    (go_name, value.to_string())
+        self.with_binding_frame(|this| {
+            let bound: Vec<Option<(String, String)>> = bindings
+                .iter()
+                .map(|binding| {
+                    binding.map(|(name, value)| {
+                        let go_name = this.scope.bind(name, name);
+                        this.declare(&go_name);
+                        (go_name, value.to_string())
+                    })
                 })
-            })
-            .collect();
-        self.scope.enter_use_region();
-        let body_block = self.lower_block_to_place(body, place);
-        let used = self.scope.exit_use_region();
-        let mut statements = Vec::new();
-        let mut any_referenced = false;
-        for (go_name, value) in bound.iter().flatten() {
-            statements.push(LoweredStatement::TempBind {
-                name: go_name.clone(),
-                value: value.clone(),
-            });
-            if used.contains(go_name) {
-                any_referenced = true;
-            } else {
-                statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
+                .collect();
+            let (body_block, used) =
+                this.capture_go_uses(|this| this.lower_block_to_place(body, place));
+            let mut statements = Vec::new();
+            let mut any_referenced = false;
+            for (go_name, value) in bound.iter().flatten() {
+                statements.push(LoweredStatement::TempBind {
+                    name: go_name.clone(),
+                    value: value.clone(),
+                });
+                if used.contains(go_name) {
+                    any_referenced = true;
+                } else {
+                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
+                }
             }
-        }
-        statements.extend(body_block.statements);
-        self.scope.pop_binding_frame();
-        (LoweredBlock { statements }, any_referenced)
+            statements.extend(body_block.statements);
+            (LoweredBlock { statements }, any_referenced)
+        })
     }
 
     fn lower_match_subject_var(
@@ -533,16 +530,14 @@ fn ok_arm_payload_is_omitted(arm: &MatchArm, shape: &CallableReturnAbi) -> bool 
         return false;
     };
     match shape {
-        CallableReturnAbi::Result {
-            bare_error: true, ..
-        } => fields.is_empty() || matches!(fields.as_slice(), [Pattern::Unit { .. }]),
+        CallableReturnAbi::BareError => {
+            fields.is_empty() || matches!(fields.as_slice(), [Pattern::Unit { .. }])
+        }
         CallableReturnAbi::Tagged
         | CallableReturnAbi::Direct
-        | CallableReturnAbi::Result {
-            bare_error: false, ..
-        }
+        | CallableReturnAbi::Result { .. }
         | CallableReturnAbi::Partial { .. }
-        | CallableReturnAbi::Option { .. }
+        | CallableReturnAbi::Option(_)
         | CallableReturnAbi::Tuple { .. } => false,
     }
 }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -10,10 +10,12 @@ use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::binding_emit::{
     apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
-    drop_inline_overlays, tree_assignment_statements, tree_binding_statements,
+    tree_assignment_statements, tree_binding_statements, with_tree_bindings,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
-use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::bodies::{
+    ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
+};
 use crate::state::bindings::BindingValue;
 use crate::utils::wrap_if_struct_literal;
 use crate::write_line;
@@ -146,11 +148,12 @@ impl Planner<'_> {
         let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
         self.require_packages(&info.packages);
 
-        let mut body = Vec::new();
-        self.scope.enter_use_region();
-        let effective = apply_root_assertion(self, &mut body, &info, resolved.var());
-        tree_binding_statements(self, &mut body, &info.bindings, &effective, &[]);
-        let used = self.scope.exit_use_region();
+        let (body, used) = self.capture_go_uses(|this| {
+            let mut body = Vec::new();
+            let effective = apply_root_assertion(this, &mut body, &info, resolved.var());
+            tree_binding_statements(this, &mut body, &info.bindings, &effective, &[], &[]);
+            body
+        });
         let body_block = LoweredBlock { statements: body };
 
         let references = used.contains(resolved.var());
@@ -211,13 +214,13 @@ impl Planner<'_> {
             ty: &value_ty,
         };
 
-        self.scope.enter_use_region();
-        let body = if matches!(ap.pattern, Pattern::Or { .. }) {
-            self.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
-        } else {
-            self.lower_let_else_single_pattern(ap, subject, fail)
-        };
-        let used = self.scope.exit_use_region();
+        let (body, used) = self.capture_go_uses(|this| {
+            if matches!(ap.pattern, Pattern::Or { .. }) {
+                this.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
+            } else {
+                this.lower_let_else_single_pattern(ap, subject, fail)
+            }
+        });
         let body_block = LoweredBlock { statements: body };
 
         let references = used.contains(resolved.var());
@@ -302,13 +305,21 @@ impl Planner<'_> {
             apply_refutable_root_assertion(self, &mut loop_body, &info, &subject_var);
         let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
 
-        self.enter_scope();
-        let mut then_body: Vec<LoweredStatement> = Vec::new();
-        if !matches!(pattern, Pattern::Or { .. }) {
-            tree_binding_statements(self, &mut then_body, &info.bindings, &effective, &[body]);
-        }
-        then_body.extend(self.lower_block_as_body(body).statements);
-        self.exit_scope();
+        let then_body = self.with_scope(|this| {
+            let mut then_body: Vec<LoweredStatement> = Vec::new();
+            if !matches!(pattern, Pattern::Or { .. }) {
+                tree_binding_statements(
+                    this,
+                    &mut then_body,
+                    &info.bindings,
+                    &effective,
+                    &[body],
+                    &[],
+                );
+            }
+            then_body.extend(this.lower_block_as_body(body).statements);
+            then_body
+        });
 
         loop_body.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -318,10 +329,10 @@ impl Planner<'_> {
             },
             else_arm: ElseArm::Else {
                 body: LoweredBlock {
-                    statements: vec![LoweredStatement::Break {
-                        target: self.current_loop_id(),
-                        label: None,
-                    }],
+                    statements: vec![LoweredStatement::Break(
+                        self.current_loop_id()
+                            .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
+                    )],
                 },
                 inline: false,
             },
@@ -391,6 +402,7 @@ impl Planner<'_> {
                 &info.bindings,
                 &effective_subject,
                 &[],
+                &[],
             );
             return statements;
         }
@@ -422,6 +434,7 @@ impl Planner<'_> {
             &info.bindings,
             &effective_subject,
             &[],
+            &[],
         );
         statements
     }
@@ -444,7 +457,6 @@ impl Planner<'_> {
         let pre_let_snapshot = self.scope.binding_snapshot();
         let mut statements = Vec::new();
         self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty, typed);
-        let post_declaration_snapshot = self.scope.binding_snapshot();
 
         let mut asserts = Vec::new();
         let alts =
@@ -502,13 +514,9 @@ impl Planner<'_> {
                     statements: assigns,
                 }
             }
-            None => {
-                self.scope.restore_binding_snapshot(pre_let_snapshot);
-                let fail_lowered = self.lower_refutable_fail(fail, subject_var);
-                self.scope
-                    .restore_binding_snapshot(post_declaration_snapshot);
-                fail_lowered
-            }
+            None => self.with_binding_snapshot(pre_let_snapshot, |this| {
+                this.lower_refutable_fail(fail, subject_var)
+            }),
         };
 
         statements.push(assemble_if_else_chain(pieces, terminal));
@@ -590,22 +598,30 @@ impl Planner<'_> {
             let (effective, ok_var) = &hoisted[i];
             let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
 
-            self.enter_scope();
-            let mut branch = Vec::new();
-            let overlays =
-                tree_binding_statements(self, &mut branch, &info.bindings, effective, &[body]);
-            branch.extend(self.lower_block_as_body(body).statements);
-            drop_inline_overlays(self, &overlays);
-            self.exit_scope();
+            let branch = self.with_scope(|this| {
+                let mut branch = Vec::new();
+                with_tree_bindings(
+                    this,
+                    &mut branch,
+                    &info.bindings,
+                    effective,
+                    &[body],
+                    &[],
+                    |this, branch| {
+                        branch.extend(this.lower_block_as_body(body).statements);
+                    },
+                );
+                branch
+            });
 
             pieces.push((condition, LoweredBlock { statements: branch }));
         }
 
         let terminal = LoweredBlock {
-            statements: vec![LoweredStatement::Break {
-                target: self.current_loop_id(),
-                label: None,
-            }],
+            statements: vec![LoweredStatement::Break(
+                self.current_loop_id()
+                    .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
+            )],
         };
         statements.push(assemble_if_else_chain(pieces, terminal));
     }
@@ -659,9 +675,18 @@ impl Planner<'_> {
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if info.checks.is_empty() && ok_var.is_none() {
-            tree_binding_statements(self, &mut statements, &info.bindings, &effective, &[body]);
-            let block = self.lower_block_to_place(body, place);
-            statements.extend(block.statements);
+            with_tree_bindings(
+                self,
+                &mut statements,
+                &info.bindings,
+                &effective,
+                &[body],
+                &[],
+                |this, statements| {
+                    let block = this.lower_block_to_place(body, place);
+                    statements.extend(block.statements);
+                },
+            );
             return statements;
         }
 
@@ -670,11 +695,18 @@ impl Planner<'_> {
         }
         let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
         let mut then_body = Vec::new();
-        let overlays =
-            tree_binding_statements(self, &mut then_body, &info.bindings, &effective, &[body]);
-        let block = self.lower_block_to_place(body, place);
-        then_body.extend(block.statements);
-        drop_inline_overlays(self, &overlays);
+        with_tree_bindings(
+            self,
+            &mut then_body,
+            &info.bindings,
+            &effective,
+            &[body],
+            &[],
+            |this, then_body| {
+                let block = this.lower_block_to_place(body, place);
+                then_body.extend(block.statements);
+            },
+        );
         let else_arm = match failure(self) {
             Some(body) => ElseArm::Else {
                 body,

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -2,21 +2,19 @@ use syntax::ast::{Expression, MatchArm};
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::{is_catchall_pattern, is_unconditional_catchall};
-use crate::patterns::binding_emit::drop_inline_overlays;
+use crate::patterns::binding_emit::{drop_inline_overlays, tree_binding_statements};
 use crate::patterns::decision_tree::{
     ChainTest, Decision, PatternBinding, SwitchBranch, SwitchKind as PatternSwitchKind,
     SwitchShape, compile_expanded_arms, decision_is_exhaustive, expand_or_patterns,
     render_condition, tree_has_unguarded_terminal,
 };
 use crate::plan::bodies::{
-    ElseArm, IfPlan, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan, SwitchCasePlan,
-    SwitchKind, SwitchStatementPlan,
+    ElseArm, IfPlan, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
+    SwitchCasePlan, SwitchKind, SwitchStatementPlan,
 };
 use crate::plan::placement::unreachable_panic_if_needed;
-use crate::state::bindings::{BindingValue, InlineExpr};
 use crate::utils::wrap_if_struct_literal;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -138,6 +136,27 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         result
     }
 
+    fn with_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.planner.enter_scope();
+        let result = f(self);
+        self.planner.exit_scope();
+        result
+    }
+
+    fn with_optional_scope<R>(&mut self, scoped: bool, f: impl FnOnce(&mut Self) -> R) -> R {
+        if scoped { self.with_scope(f) } else { f(self) }
+    }
+
+    fn capture_go_uses<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> (R, rustc_hash::FxHashSet<String>) {
+        self.planner.scope.enter_use_region();
+        let result = f(self);
+        let uses = self.planner.scope.exit_use_region();
+        (result, uses)
+    }
+
     fn render_single_catchall(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
@@ -150,14 +169,15 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             .pattern_has_binding_collisions(&self.arms[arm_index].pattern);
         let arm_body = &*self.arms[arm_index].expression;
 
-        self.planner.enter_scope();
-        let mut inner: Vec<LoweredStatement> = Vec::new();
-        let inlines = self.emit_bindings(&mut inner, bindings, &[arm_body], None);
-        self.emit_arm_body(&mut inner, arm_index, place);
-        drop_inline_overlays(self.planner, &inlines);
-        let needs_block =
-            self.planner.scope.current_block_declared_nonempty() || pattern_has_collisions;
-        self.planner.exit_scope();
+        let (inner, needs_block) = self.with_scope(|this| {
+            let mut inner: Vec<LoweredStatement> = Vec::new();
+            this.with_bindings(&mut inner, bindings, &[arm_body], None, |this, inner| {
+                this.emit_arm_body(inner, arm_index, place)
+            });
+            let needs_block =
+                this.planner.scope.current_block_declared_nonempty() || pattern_has_collisions;
+            (inner, needs_block)
+        });
 
         if needs_block {
             statements.push(LoweredStatement::Block(LoweredBlock { statements: inner }));
@@ -195,9 +215,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 bindings,
             } => {
                 let arm_body = &*self.arms[*arm_index].expression;
-                let inlines = self.emit_bindings(statements, bindings, &[arm_body], None);
-                self.emit_arm_body(statements, *arm_index, place);
-                drop_inline_overlays(self.planner, &inlines);
+                self.with_bindings(
+                    statements,
+                    bindings,
+                    &[arm_body],
+                    None,
+                    |this, statements| this.emit_arm_body(statements, *arm_index, place),
+                );
             }
             Decision::Chain { tests, fallback } => {
                 self.lower_chain_branch(statements, tests, fallback, place);
@@ -244,10 +268,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             } else {
                 &chain_ctx
             };
-            self.planner.enter_scope();
-            let mut body: Vec<LoweredStatement> = Vec::new();
-            self.walk(&mut body, &test.decision, walk_ctx);
-            self.planner.exit_scope();
+            let body = self.with_scope(|this| {
+                let mut body: Vec<LoweredStatement> = Vec::new();
+                this.walk(&mut body, &test.decision, walk_ctx);
+                body
+            });
             let body = LoweredBlock { statements: body };
             last_diverges = body.ends_with_diverge();
             branches.push(ChainBranch { condition, body });
@@ -311,15 +336,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let mut body: Vec<LoweredStatement> = Vec::new();
         self.walk(&mut body, tree, &ctx);
         if !unguarded_exit {
-            body.push(LoweredStatement::Break {
-                target: None,
-                label: Some(label.clone()),
-            });
+            body.push(LoweredStatement::Break(LoopTransfer::Labeled(
+                label.clone(),
+            )));
         }
         statements.push(LoweredStatement::Loop(LoopPlan {
             prologue: Vec::new(),
-            target: None,
-            label: Some(label),
+            kind: LoopKind::Generated { label: Some(label) },
             header: "for {\n".to_string(),
             body: LoweredBlock { statements: body },
         }));
@@ -333,18 +356,17 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             } => {
                 let wrap = ctx.leaf_scope_explicit();
                 let arm_body = &*self.arms[*arm_index].expression;
+                let leaf = self.with_optional_scope(wrap, |this| {
+                    let mut leaf: Vec<LoweredStatement> = Vec::new();
+                    this.with_bindings(&mut leaf, bindings, &[arm_body], None, |this, leaf| {
+                        let mut body_statements: Vec<LoweredStatement> = Vec::new();
+                        this.emit_arm_body(&mut body_statements, *arm_index, ctx.arm_place);
+                        let body_diverges = capture_diverge(body_statements, leaf);
+                        apply_leaf_terminator(leaf, ctx, body_diverges);
+                    });
+                    leaf
+                });
                 if wrap {
-                    self.planner.enter_scope();
-                }
-                let mut leaf: Vec<LoweredStatement> = Vec::new();
-                let inlines = self.emit_bindings(&mut leaf, bindings, &[arm_body], None);
-                let mut body_statements: Vec<LoweredStatement> = Vec::new();
-                self.emit_arm_body(&mut body_statements, *arm_index, ctx.arm_place);
-                let body_diverges = capture_diverge(body_statements, &mut leaf);
-                apply_leaf_terminator(&mut leaf, ctx, body_diverges);
-                drop_inline_overlays(self.planner, &inlines);
-                if wrap {
-                    self.planner.exit_scope();
                     statements.push(LoweredStatement::Block(LoweredBlock { statements: leaf }));
                 } else {
                     statements.extend(leaf);
@@ -463,10 +485,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     ) {
         self.planner.scope.record_go_use(&self.current_subject);
         let inner = WalkCtx::switch_case(ctx.arm_place);
-        self.planner.enter_scope();
-        let mut then_statements: Vec<LoweredStatement> = Vec::new();
-        self.walk(&mut then_statements, then_branch, &inner);
-        self.planner.exit_scope();
+        let then_statements = self.with_scope(|this| {
+            let mut then_statements: Vec<LoweredStatement> = Vec::new();
+            this.walk(&mut then_statements, then_branch, &inner);
+            then_statements
+        });
         let then_body = LoweredBlock {
             statements: then_statements,
         };
@@ -492,9 +515,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         ctx: &WalkCtx,
     ) {
         let needs_pre_scope = ctx.leaf_scope_explicit() && !bindings.is_empty();
-        if needs_pre_scope {
-            self.planner.enter_scope();
-        }
         let arm = &self.arms[arm_index];
         let arm_body = &*arm.expression;
         let mut guard_consumers: Vec<&Expression> = Vec::with_capacity(2);
@@ -505,39 +525,42 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
         // Collect the bindings and the guard `if` into one block so a pre-scope
         // can wrap them as a single `LoweredStatement::Block`.
-        let mut guard_statements: Vec<LoweredStatement> = Vec::new();
-        let inlines = self.emit_bindings(
-            &mut guard_statements,
-            bindings,
-            &guard_consumers,
-            Some(failure),
-        );
-        if let Some((condition_setup, condition)) = self.lower_guard_condition(arm_index) {
-            self.planner.enter_scope();
-            let mut success_statements: Vec<LoweredStatement> = Vec::new();
-            self.walk(&mut success_statements, success, &ctx.nested());
-            let then_body = LoweredBlock {
-                statements: success_statements,
-            };
-            let success_diverges = then_body.ends_with_diverge();
-            self.planner.exit_scope();
-            drop_inline_overlays(self.planner, &inlines);
-            let else_arm = if ctx.role == WalkRole::SwitchCase {
-                self.lower_else_or_flat(failure, ctx, success_diverges)
-            } else {
-                ElseArm::None
-            };
-            guard_statements.push(LoweredStatement::If(IfPlan {
-                condition_setup,
-                condition,
-                then_body,
-                else_arm,
-            }));
-        } else {
-            drop_inline_overlays(self.planner, &inlines);
-        }
+        let guard_statements = self.with_optional_scope(needs_pre_scope, |this| {
+            let mut guard_statements: Vec<LoweredStatement> = Vec::new();
+            let guarded = this.with_bindings(
+                &mut guard_statements,
+                bindings,
+                &guard_consumers,
+                Some(failure),
+                |this, _| {
+                    let (condition_setup, condition) = this.lower_guard_condition(arm_index)?;
+                    let then_body = this.with_scope(|this| {
+                        let mut success_statements: Vec<LoweredStatement> = Vec::new();
+                        this.walk(&mut success_statements, success, &ctx.nested());
+                        LoweredBlock {
+                            statements: success_statements,
+                        }
+                    });
+                    Some((condition_setup, condition, then_body))
+                },
+            );
+            if let Some((condition_setup, condition, then_body)) = guarded {
+                let success_diverges = then_body.ends_with_diverge();
+                let else_arm = if ctx.role == WalkRole::SwitchCase {
+                    this.lower_else_or_flat(failure, ctx, success_diverges)
+                } else {
+                    ElseArm::None
+                };
+                guard_statements.push(LoweredStatement::If(IfPlan {
+                    condition_setup,
+                    condition,
+                    then_body,
+                    else_arm,
+                }));
+            }
+            guard_statements
+        });
         if needs_pre_scope {
-            self.planner.exit_scope();
             statements.push(LoweredStatement::Block(LoweredBlock {
                 statements: guard_statements,
             }));
@@ -570,10 +593,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 inline: true,
             };
         }
-        self.planner.enter_scope();
-        let mut body: Vec<LoweredStatement> = Vec::new();
-        self.walk(&mut body, decision, ctx);
-        self.planner.exit_scope();
+        let body = self.with_scope(|this| {
+            let mut body: Vec<LoweredStatement> = Vec::new();
+            this.walk(&mut body, decision, ctx);
+            body
+        });
         ElseArm::Else {
             body: LoweredBlock { statements: body },
             inline: false,
@@ -616,13 +640,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         place: &PlacePlan,
     ) -> SwitchStatementPlan {
         let (regular, default) = split_with_default_lift(branches, fallback);
-        self.planner.scope.enter_use_region();
-        let (case_plans, default_block) = self.with_subject(base.clone(), |tree_planner| {
-            let case_plans = tree_planner.lower_switch_cases(regular, place);
-            let default_block = tree_planner.lower_switch_default(default, place);
-            (case_plans, default_block)
+        let ((case_plans, default_block), used) = self.capture_go_uses(|this| {
+            this.with_subject(base.clone(), |this| {
+                let case_plans = this.lower_switch_cases(regular, place);
+                let default_block = this.lower_switch_default(default, place);
+                (case_plans, default_block)
+            })
         });
-        let used = self.planner.scope.exit_use_region();
 
         // Keep the `base :=` type-switch binding only when a case references it;
         // Go rejects an unused `:= base` assignment otherwise.
@@ -648,10 +672,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let ctx = WalkCtx::switch_case(place);
         let mut case_plans = Vec::with_capacity(branches.len());
         for branch in branches {
-            let mut body: Vec<LoweredStatement> = Vec::new();
-            self.planner.enter_scope();
-            self.walk(&mut body, &branch.decision, &ctx);
-            self.planner.exit_scope();
+            let body = self.with_scope(|this| {
+                let mut body: Vec<LoweredStatement> = Vec::new();
+                this.walk(&mut body, &branch.decision, &ctx);
+                body
+            });
             case_plans.push(SwitchCasePlan {
                 labels: branch.case_label.clone(),
                 body: LoweredBlock { statements: body },
@@ -669,10 +694,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     ) -> Option<LoweredBlock> {
         let default_decision = default?;
         let ctx = WalkCtx::switch_case(place);
-        let mut body: Vec<LoweredStatement> = Vec::new();
-        self.planner.enter_scope();
-        self.walk(&mut body, default_decision, &ctx);
-        self.planner.exit_scope();
+        let body = self.with_scope(|this| {
+            let mut body: Vec<LoweredStatement> = Vec::new();
+            this.walk(&mut body, default_decision, &ctx);
+            body
+        });
         (!body.is_empty()).then_some(LoweredBlock { statements: body })
     }
 
@@ -721,14 +747,15 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             return;
         }
 
-        self.planner.enter_scope();
-        let mut body: Vec<LoweredStatement> = Vec::new();
-        if bindings_are_hoistable(tests, indices) {
-            self.emit_chain_group_hoisted(&mut body, indices, tests, ctx);
-        } else {
-            self.emit_chain_group_per_test(&mut body, indices, tests, ctx);
-        }
-        self.planner.exit_scope();
+        let body = self.with_scope(|this| {
+            let mut body: Vec<LoweredStatement> = Vec::new();
+            if bindings_are_hoistable(tests, indices) {
+                this.emit_chain_group_hoisted(&mut body, indices, tests, ctx);
+            } else {
+                this.emit_chain_group_per_test(&mut body, indices, tests, ctx);
+            }
+            body
+        });
 
         let body = LoweredBlock { statements: body };
         let first_condition = &conditions[indices[0]];
@@ -753,7 +780,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         tests: &[ChainTest],
         ctx: &WalkCtx,
     ) {
-        let mut inlines: Vec<(String, Option<BindingValue>)> = Vec::new();
         if let Some(&ref_index) = indices
             .iter()
             .find(|&&index| !decision_top_bindings(&tests[index].decision).is_empty())
@@ -775,13 +801,27 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     consumers.push(&arm.expression);
                 }
             }
-            inlines = self.emit_bindings(
+            self.with_bindings(
                 statements,
                 decision_top_bindings(&tests[ref_index].decision),
                 &consumers,
                 None,
+                |this, statements| {
+                    this.emit_chain_group_bodies(statements, indices, tests, ctx);
+                },
             );
+        } else {
+            self.emit_chain_group_bodies(statements, indices, tests, ctx);
         }
+    }
+
+    fn emit_chain_group_bodies(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        indices: &[usize],
+        tests: &[ChainTest],
+        ctx: &WalkCtx,
+    ) {
         for &test_index in indices {
             match &tests[test_index].decision {
                 Decision::Success { arm_index, .. } => {
@@ -794,13 +834,14 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     if let Some((condition_setup, condition)) =
                         self.lower_guard_condition(*arm_index)
                     {
-                        self.planner.enter_scope();
-                        let mut arm_body: Vec<LoweredStatement> = Vec::new();
-                        self.emit_arm_body(&mut arm_body, *arm_index, ctx.arm_place);
-                        let mut then_body: Vec<LoweredStatement> = Vec::new();
-                        let body_diverges = capture_diverge(arm_body, &mut then_body);
-                        apply_leaf_terminator(&mut then_body, ctx, body_diverges);
-                        self.planner.exit_scope();
+                        let then_body = self.with_scope(|this| {
+                            let mut arm_body: Vec<LoweredStatement> = Vec::new();
+                            this.emit_arm_body(&mut arm_body, *arm_index, ctx.arm_place);
+                            let mut then_body: Vec<LoweredStatement> = Vec::new();
+                            let body_diverges = capture_diverge(arm_body, &mut then_body);
+                            apply_leaf_terminator(&mut then_body, ctx, body_diverges);
+                            then_body
+                        });
                         statements.push(LoweredStatement::If(IfPlan {
                             condition_setup,
                             condition,
@@ -814,7 +855,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 _ => self.walk(statements, &tests[test_index].decision, ctx),
             }
         }
-        drop_inline_overlays(self.planner, &inlines);
     }
 
     fn emit_chain_group_per_test(
@@ -829,10 +869,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             let needs_wrapper =
                 !is_last_in_group && !decision_top_bindings(&tests[test_index].decision).is_empty();
             if needs_wrapper {
-                self.planner.enter_scope();
-                let mut wrapped: Vec<LoweredStatement> = Vec::new();
-                self.walk(&mut wrapped, &tests[test_index].decision, ctx);
-                self.planner.exit_scope();
+                let wrapped = self.with_scope(|this| {
+                    let mut wrapped: Vec<LoweredStatement> = Vec::new();
+                    this.walk(&mut wrapped, &tests[test_index].decision, ctx);
+                    wrapped
+                });
                 statements.push(LoweredStatement::Block(LoweredBlock {
                     statements: wrapped,
                 }));
@@ -850,7 +891,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         bindings: &[PatternBinding],
         consumers: &[&Expression],
         failure_blocker: Option<&Decision>,
-    ) -> Vec<(String, Option<BindingValue>)> {
+    ) -> Vec<(String, Option<crate::state::bindings::BindingValue>)> {
         let failure_trees: Vec<&Expression> = match failure_blocker {
             Some(failure) => {
                 let mut reached: Vec<usize> = Vec::new();
@@ -868,84 +909,28 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             None => Vec::new(),
         };
 
-        let mut installed_inlines: Vec<(String, Option<BindingValue>)> = Vec::new();
-        for binding in bindings {
-            let Some(ref go_name) = binding.go_name else {
-                self.planner.scope.bind(&binding.lisette_name, "");
-                continue;
-            };
-
-            let previous = self
-                .planner
-                .scope
-                .resolve_identifier_binding(&binding.lisette_name)
-                .cloned();
-            if self.try_inline_binding(binding, consumers, &failure_trees) {
-                installed_inlines.push((binding.lisette_name.clone(), previous));
-                continue;
-            }
-
-            let access_expression = binding.path.render(&self.current_subject);
-            self.planner.scope.record_go_use(&self.current_subject);
-            if self.planner.scope.has_binding_for_go_name(go_name) {
-                let fresh = self.planner.fresh_var(Some(&binding.lisette_name));
-                self.planner.scope.bind(&binding.lisette_name, &fresh);
-                self.planner.try_declare(&fresh);
-                statements.push(LoweredStatement::RawGo(format!(
-                    "{} := {}\n",
-                    fresh, access_expression
-                )));
-            } else {
-                let name = self
-                    .planner
-                    .scope
-                    .bind(&binding.lisette_name, go_name.clone());
-                if self.planner.try_declare(&name) {
-                    statements.push(LoweredStatement::RawGo(format!(
-                        "{} := {}\n",
-                        name, access_expression
-                    )));
-                } else {
-                    let fresh = self.planner.fresh_var(Some(&binding.lisette_name));
-                    self.planner.scope.bind(&binding.lisette_name, &fresh);
-                    self.planner.try_declare(&fresh);
-                    statements.push(LoweredStatement::RawGo(format!(
-                        "{} := {}\n",
-                        fresh, access_expression
-                    )));
-                }
-            }
-        }
-        installed_inlines
+        tree_binding_statements(
+            self.planner,
+            statements,
+            bindings,
+            &self.current_subject,
+            consumers,
+            &failure_trees,
+        )
     }
 
-    fn try_inline_binding(
+    fn with_bindings<R>(
         &mut self,
-        binding: &PatternBinding,
+        statements: &mut Vec<LoweredStatement>,
+        bindings: &[PatternBinding],
         consumers: &[&Expression],
-        failure_trees: &[&Expression],
-    ) -> bool {
-        if consumers.is_empty() {
-            return false;
-        }
-        if analyze_inline_candidate(&binding.lisette_name, consumers) != InlineDecision::Inline {
-            return false;
-        }
-        if !failure_trees.is_empty()
-            && region_blocks_inline(failure_trees.iter().copied(), &binding.lisette_name)
-        {
-            return false;
-        }
-        let composable_access = binding.path.render_composable(&self.current_subject);
-        self.planner.scope.bind_inline_expr(
-            &binding.lisette_name,
-            InlineExpr::new(
-                composable_access,
-                vec![self.current_subject.clone()],
-                binding.path.contains_deferred_evaluation(),
-            ),
-        );
-        true
+        failure_blocker: Option<&Decision>,
+        f: impl FnOnce(&mut Self, &mut Vec<LoweredStatement>) -> R,
+    ) -> R {
+        let overlays = self.emit_bindings(statements, bindings, consumers, failure_blocker);
+        let result = f(self, statements);
+        drop_inline_overlays(self.planner, &overlays);
+        result
     }
 
     fn emit_arm_body(
@@ -1159,9 +1144,8 @@ fn apply_leaf_terminator(
     if let Some(label) = ctx.break_label
         && !body_diverges
     {
-        statements.push(LoweredStatement::Break {
-            target: None,
-            label: Some(label.to_string()),
-        });
+        statements.push(LoweredStatement::Break(LoopTransfer::Labeled(
+            label.to_string(),
+        )));
     }
 }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -29,6 +29,12 @@ pub(crate) struct LoweredBlock {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct LoopId(pub(crate) u32);
 
+pub(crate) enum LoopTransfer {
+    Unlabeled,
+    Source(LoopId),
+    Labeled(String),
+}
+
 pub(crate) fn directed(directive: String, stmt: LoweredStatement) -> LoweredStatement {
     if directive.is_empty() {
         stmt
@@ -44,14 +50,8 @@ pub(crate) enum LoweredStatement {
     If(IfPlan),
     Loop(LoopPlan),
     Block(LoweredBlock),
-    Break {
-        target: Option<LoopId>,
-        label: Option<String>,
-    },
-    Continue {
-        target: Option<LoopId>,
-        label: Option<String>,
-    },
+    Break(LoopTransfer),
+    Continue(LoopTransfer),
     Const(ConstPlan),
     Return(ReturnStatementPlan),
     BreakValue(BreakValuePlan),
@@ -133,22 +133,21 @@ pub(crate) enum ReturnForm {
     },
 }
 
-/// `break value` statement. `disposition` decides how the value text
-/// reaches the loop-result slot (or is discarded); a trailing `break`
-/// terminates unless the value already diverged.
-pub(crate) struct BreakValuePlan {
-    pub(crate) value: ValuePlan,
-    pub(crate) disposition: BreakValueDisposition,
-    pub(crate) target: Option<LoopId>,
-    pub(crate) label: Option<String>,
+/// A `break value` statement. A diverged value terminates on its own; all
+/// other values carry the action and transfer needed to finish the break.
+pub(crate) enum BreakValuePlan {
+    Diverged {
+        value: ValuePlan,
+    },
+    Transfer {
+        value: ValuePlan,
+        action: BreakValueAction,
+        target: LoopTransfer,
+    },
 }
 
-/// What to do with the value of a `break value` statement after its setup
-/// has run.
-pub(crate) enum BreakValueDisposition {
-    /// The value diverged (empty `Propagate`); no further code is emitted
-    /// and the `break` is skipped because the value already terminates.
-    Diverged,
+/// What to do with a non-diverging `break value` after its setup has run.
+pub(crate) enum BreakValueAction {
     /// Inside a loop with a result slot, when the value is a unit-typed
     /// call: emit `<value>` as a side-effect statement (skipped if value
     /// text is empty), then `<result_var> = struct{}{}`, then break.
@@ -387,13 +386,26 @@ pub(crate) struct WhileLetPlan {
 
 /// A statement-position loop. `prologue` is pre-loop setup (a for-loop's
 /// iterable capture); `header` is the rendered Go loop opener through the body's
-/// opening brace; `label` is the optional break/continue label.
+/// opening brace; its kind records whether transfers inside it can target an
+/// enclosing source loop.
 pub(crate) struct LoopPlan {
     pub(crate) prologue: Vec<LoweredStatement>,
-    pub(crate) target: Option<LoopId>,
-    pub(crate) label: Option<String>,
+    pub(crate) kind: LoopKind,
     pub(crate) header: String,
     pub(crate) body: LoweredBlock,
+}
+
+pub(crate) enum LoopKind {
+    Source { label: Option<String> },
+    Generated { label: Option<String> },
+}
+
+impl LoopKind {
+    pub(crate) fn label(&self) -> Option<&str> {
+        match self {
+            LoopKind::Source { label } | LoopKind::Generated { label } => label.as_deref(),
+        }
+    }
 }
 
 pub(crate) struct IfPlan {
@@ -429,16 +441,84 @@ impl LoweredBlock {
     pub(crate) fn is_empty(&self) -> bool {
         self.statements.is_empty()
     }
+
+    pub(crate) fn renders_empty(&self) -> bool {
+        self.statements
+            .iter()
+            .all(|statement| !statement.emits_output())
+    }
 }
 
 impl LoweredStatement {
+    fn emits_output(&self) -> bool {
+        match self {
+            LoweredStatement::If(_)
+            | LoweredStatement::Loop(_)
+            | LoweredStatement::Block(_)
+            | LoweredStatement::Break(_)
+            | LoweredStatement::Continue(_)
+            | LoweredStatement::Const(_)
+            | LoweredStatement::Select(_)
+            | LoweredStatement::Switch(_)
+            | LoweredStatement::TempBind { .. }
+            | LoweredStatement::VarDecl { .. }
+            | LoweredStatement::ClosureBind { .. }
+            | LoweredStatement::UnreachablePanic => true,
+            LoweredStatement::Return(plan) => match &plan.form {
+                ReturnForm::LoweredAbi { body } | ReturnForm::Wrapped { body } => {
+                    !body.renders_empty()
+                }
+                ReturnForm::Plain { .. } | ReturnForm::Unit { .. } | ReturnForm::Multi { .. } => {
+                    true
+                }
+            },
+            LoweredStatement::BreakValue(plan) => match plan {
+                BreakValuePlan::Diverged { value } => {
+                    value.setup.iter().any(LoweredStatement::emits_output)
+                }
+                BreakValuePlan::Transfer { .. } => true,
+            },
+            LoweredStatement::Let(plan) => {
+                matches!(
+                    &plan.form,
+                    LetForm::Never {
+                        declaration: Some(_),
+                        ..
+                    }
+                ) || !plan.form.body().renders_empty()
+            }
+            LoweredStatement::Assign(plan) => match &plan.form {
+                AssignForm::Compound { .. } | AssignForm::Simple { .. } => true,
+                AssignForm::Discard { body } | AssignForm::NeverTyped { body } => {
+                    !body.renders_empty()
+                }
+            },
+            LoweredStatement::Expression(plan) => match &plan.form {
+                ExpressionStatementForm::Async { value } => {
+                    !value.is_empty() || value.setup.iter().any(LoweredStatement::emits_output)
+                }
+                ExpressionStatementForm::AsyncBlock { .. } => true,
+                ExpressionStatementForm::Propagate { body }
+                | ExpressionStatementForm::Discard { body } => !body.renders_empty(),
+            },
+            LoweredStatement::Match(plan) => !plan.body.renders_empty(),
+            LoweredStatement::WhileLet(plan) => !plan.body.renders_empty(),
+            LoweredStatement::Directed { directive, inner } => {
+                !directive.is_empty() || inner.emits_output()
+            }
+            LoweredStatement::RawGo(code) | LoweredStatement::DivergingRawGo(code) => {
+                !code.is_empty()
+            }
+        }
+    }
+
     fn ends_with_diverge(&self) -> bool {
         match self {
             LoweredStatement::If(plan) => plan.ends_with_diverge(),
             LoweredStatement::Loop(_) | LoweredStatement::Block(_) | LoweredStatement::Const(_) => {
                 false
             }
-            LoweredStatement::Break { .. } | LoweredStatement::Continue { .. } => true,
+            LoweredStatement::Break(_) | LoweredStatement::Continue(_) => true,
             LoweredStatement::Return(_) => true,
             LoweredStatement::BreakValue(_) => true,
             LoweredStatement::Let(plan) => plan.form.body().ends_with_diverge(),

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -20,14 +20,18 @@ pub(crate) struct CallPlan<'a> {
 /// Canonical identity, signatures, and physical ABI for one callable.
 #[derive(Debug)]
 pub(crate) struct ResolvedCallee<'a> {
-    pub(crate) id: Option<String>,
     pub(crate) origin: CallableOrigin,
     pub(crate) definition: Option<&'a Definition>,
     pub(crate) instantiated: Type,
-    pub(crate) declared: Option<Type>,
     pub(crate) receiver_offset: usize,
     pub(crate) abi: CallableAbi,
     pub(crate) is_prelude_dispatch: bool,
+}
+
+impl ResolvedCallee<'_> {
+    pub(crate) fn declared_type(&self) -> Option<&Type> {
+        self.definition.map(|definition| &definition.ty)
+    }
 }
 
 /// AST-level `CallKind` plus emit-side classification.
@@ -195,13 +199,12 @@ impl<'a> Planner<'a> {
         arg_count: usize,
     ) -> ResolvedCallee<'a> {
         let (id, definition) = self.resolve_callee_definition(function);
-        let declared = definition.map(|definition| definition.ty.clone());
         let instantiated = self
             .facts
             .resolve_to_function_type(function.get_type().unwrap_forall())
             .unwrap_or_else(|| function.get_type().unwrap_forall().clone());
-        let declared_params = declared
-            .as_ref()
+        let declared_params = definition
+            .map(|definition| &definition.ty)
             .and_then(|ty| ty.unwrap_forall().get_function_params());
         let receiver_offset =
             declared_params.map_or(0, |params| params.len().saturating_sub(arg_count));
@@ -225,8 +228,8 @@ impl<'a> Planner<'a> {
                 }),
         };
         let return_type = instantiated.get_function_ret().unwrap_or(&Type::Never);
-        let declared_return = declared
-            .as_ref()
+        let declared_return = definition
+            .map(|definition| &definition.ty)
             .and_then(|ty| ty.unwrap_forall().get_function_ret());
         let catalog_return = matches!(origin, CallableOrigin::GoInterop)
             .then(|| {
@@ -261,11 +264,9 @@ impl<'a> Planner<'a> {
             );
 
         ResolvedCallee {
-            id,
             origin,
             definition,
             instantiated,
-            declared,
             receiver_offset,
             abi: CallableAbi {
                 params,

--- a/crates/emit/src/plan/invariants.rs
+++ b/crates/emit/src/plan/invariants.rs
@@ -19,7 +19,7 @@ fn walk_statement(statement: &LoweredStatement, issues: &mut Vec<String>, path: 
         LoweredStatement::If(plan) => walk_if(plan, issues, &format!("{}/If", path)),
         LoweredStatement::Loop(plan) => walk_loop(plan, issues, &format!("{}/Loop", path)),
         LoweredStatement::Block(body) => walk_block(body, issues, &format!("{}/Block", path)),
-        LoweredStatement::Break { .. } | LoweredStatement::Continue { .. } => {}
+        LoweredStatement::Break(_) | LoweredStatement::Continue(_) => {}
         LoweredStatement::Directed { inner, .. } => {
             walk_statement(inner, issues, &format!("{}/Directed", path))
         }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -7,8 +7,9 @@ use crate::control_flow::targets::legalize_source_loop;
 use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
 use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
 use crate::plan::bodies::{
-    ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopPlan, LoweredBlock,
-    LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan, directed,
+    ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopKind, LoopPlan,
+    LoopTransfer, LoweredBlock, LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan,
+    directed,
 };
 use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
 use crate::plan::values::ValuePlan;
@@ -122,9 +123,9 @@ impl Planner<'_> {
             unreachable!("plan_loop_as_operand_temp called on non-Loop expression");
         };
         let (result_var, declaration) = self.operand_temp_declaration(ty);
-        self.push_loop(result_var.clone());
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body);
-        self.pop_loop();
+        let plan = self.with_loop(result_var.clone(), |this| {
+            this.lower_loop_with_header("for {\n".to_string(), body)
+        });
         ValuePlan::name(
             vec![declaration, LoweredStatement::Loop(plan)],
             result_var,
@@ -227,32 +228,21 @@ impl Planner<'_> {
                 let plan = self.lower_while(condition, body);
                 self.directed_at(expression, LoweredStatement::Loop(plan))
             }
-            Expression::Block { .. } => {
-                self.enter_scope();
-                let body = self.lower_block_as_body(expression);
-                self.exit_scope();
-                LoweredStatement::Block(body)
-            }
+            Expression::Block { .. } => LoweredStatement::Block(
+                self.with_scope(|this| this.lower_block_as_body(expression)),
+            ),
             Expression::For { .. } => self.lower_for_statement(expression),
             Expression::Continue { .. } => {
-                let target = self.current_loop_id();
-                self.directed_at(
-                    expression,
-                    LoweredStatement::Continue {
-                        target,
-                        label: None,
-                    },
-                )
+                let target = self
+                    .current_loop_id()
+                    .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source);
+                self.directed_at(expression, LoweredStatement::Continue(target))
             }
             Expression::Break { value: None, .. } => {
-                let target = self.current_loop_id();
-                self.directed_at(
-                    expression,
-                    LoweredStatement::Break {
-                        target,
-                        label: None,
-                    },
-                )
+                let target = self
+                    .current_loop_id()
+                    .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source);
+                self.directed_at(expression, LoweredStatement::Break(target))
             }
             Expression::Break {
                 value: Some(value), ..
@@ -641,17 +631,16 @@ impl Planner<'_> {
             unreachable!("lower_while_let_statement requires a WhileLet expression");
         };
         let directive = self.maybe_line_directive(&expression.get_span());
-        self.push_loop("_");
-        let body = self.lower_while_let(pattern, typed_pattern.as_ref(), scrutinee, body);
-        self.pop_loop();
+        let body = self.with_loop("_", |this| {
+            this.lower_while_let(pattern, typed_pattern.as_ref(), scrutinee, body)
+        });
         directed(directive, LoweredStatement::WhileLet(WhileLetPlan { body }))
     }
 
     fn lower_infinite_loop(&mut self, body: &Expression) -> LoopPlan {
-        self.push_loop("_");
-        let plan = self.lower_loop_with_header("for {\n".to_string(), body);
-        self.pop_loop();
-        plan
+        self.with_loop("_", |this| {
+            this.lower_loop_with_header("for {\n".to_string(), body)
+        })
     }
 
     fn lower_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, String) {
@@ -660,35 +649,30 @@ impl Planner<'_> {
     }
 
     fn lower_while(&mut self, condition: &Expression, body: &Expression) -> LoopPlan {
-        self.push_loop("_");
-        let (setup, rendered) = self.lower_condition(condition);
-        let header = if !setup.is_empty() {
-            // Condition produced setup statements (temps); they must re-run each
-            // iteration, so move everything inside the loop.
-            let setup_text = Renderer.render_setup(&setup);
-            format!("for {{\n{}if !({}) {{ break }}\n", setup_text, rendered)
-        } else if matches!(
-            condition.unwrap_parens(),
-            Expression::Literal {
-                literal: Literal::Boolean(true),
-                ..
-            }
-        ) {
-            "for {\n".to_string()
-        } else {
-            format!("for {} {{\n", wrap_if_struct_literal(rendered))
-        };
-        let plan = self.lower_loop_with_header(header, body);
-        self.pop_loop();
-        plan
+        self.with_loop("_", |this| {
+            let (setup, rendered) = this.lower_condition(condition);
+            let header = if !setup.is_empty() {
+                let setup_text = Renderer.render_setup(&setup);
+                format!("for {{\n{}if !({}) {{ break }}\n", setup_text, rendered)
+            } else if matches!(
+                condition.unwrap_parens(),
+                Expression::Literal {
+                    literal: Literal::Boolean(true),
+                    ..
+                }
+            ) {
+                "for {\n".to_string()
+            } else {
+                format!("for {} {{\n", wrap_if_struct_literal(rendered))
+            };
+            this.lower_loop_with_header(header, body)
+        })
     }
 
-    /// Shared loop lowering once the header is known. Caller owns
-    /// `push_loop`/`pop_loop`.
+    /// Shared loop lowering once the header is known. The caller must have an
+    /// active loop context.
     pub(crate) fn lower_loop_with_header(&mut self, header: String, body: &Expression) -> LoopPlan {
-        self.enter_scope();
-        let lowered_body = self.lower_block_as_body(body);
-        self.exit_scope();
+        let lowered_body = self.with_scope(|this| this.lower_block_as_body(body));
         self.build_source_loop(Vec::new(), header, lowered_body)
     }
 
@@ -696,20 +680,18 @@ impl Planner<'_> {
         &mut self,
         prologue: Vec<LoweredStatement>,
         header: String,
-        body: LoweredBlock,
+        mut body: LoweredBlock,
     ) -> LoopPlan {
-        let mut plan = LoopPlan {
+        let target = self
+            .current_loop_id()
+            .expect("source loop plan requires an active loop context");
+        let label = legalize_source_loop(&mut body, target);
+        LoopPlan {
             prologue,
-            target: Some(
-                self.current_loop_id()
-                    .expect("source loop plan requires an active loop context"),
-            ),
-            label: None,
+            kind: LoopKind::Source { label },
             header,
             body,
-        };
-        legalize_source_loop(&mut plan);
-        plan
+        }
     }
 
     /// Lower a branch arm body in statement position (`PlacePlan::Statement`).
@@ -950,9 +932,7 @@ impl Planner<'_> {
         let (condition_setup, condition_string) = self.lower_condition(condition);
         let condition = wrap_if_struct_literal(condition_string);
 
-        self.enter_scope();
-        let then_body = self.lower_block_to_place(consequence, place);
-        self.exit_scope();
+        let then_body = self.with_scope(|this| this.lower_block_to_place(consequence, place));
 
         let preceding_diverges = then_body.ends_with_diverge();
         let else_arm = self.lower_else_chain(alternative, preceding_diverges, place);
@@ -995,23 +975,24 @@ impl Planner<'_> {
             // that also wraps the recursion. Plain else-if uses a single scope
             // around the body and recurses outside it.
             if !condition_setup.is_empty() {
-                self.enter_scope();
-                self.enter_scope();
-                let then_body = self.lower_block_to_place(consequence, place);
-                self.exit_scope();
-                let inner =
-                    self.lower_else_chain(next_alternative, then_body.ends_with_diverge(), place);
-                self.exit_scope();
-                ElseArm::ElseIf(Box::new(IfPlan {
-                    condition_setup,
-                    condition,
-                    then_body,
-                    else_arm: inner,
-                }))
+                self.with_scope(|this| {
+                    let then_body =
+                        this.with_scope(|this| this.lower_block_to_place(consequence, place));
+                    let inner = this.lower_else_chain(
+                        next_alternative,
+                        then_body.ends_with_diverge(),
+                        place,
+                    );
+                    ElseArm::ElseIf(Box::new(IfPlan {
+                        condition_setup,
+                        condition,
+                        then_body,
+                        else_arm: inner,
+                    }))
+                })
             } else {
-                self.enter_scope();
-                let then_body = self.lower_block_to_place(consequence, place);
-                self.exit_scope();
+                let then_body =
+                    self.with_scope(|this| this.lower_block_to_place(consequence, place));
                 let inner =
                     self.lower_else_chain(next_alternative, then_body.ends_with_diverge(), place);
                 ElseArm::ElseIf(Box::new(IfPlan {
@@ -1022,14 +1003,11 @@ impl Planner<'_> {
                 }))
             }
         } else if preceding_diverges {
-            self.scope.push_binding_frame();
-            let body = self.lower_block_to_place(alternative, place);
-            self.scope.pop_binding_frame();
+            let body =
+                self.with_binding_frame(|this| this.lower_block_to_place(alternative, place));
             ElseArm::Else { body, inline: true }
         } else {
-            self.enter_scope();
-            let body = self.lower_block_to_place(alternative, place);
-            self.exit_scope();
+            let body = self.with_scope(|this| this.lower_block_to_place(alternative, place));
             ElseArm::Else {
                 body,
                 inline: false,

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -21,8 +21,6 @@ pub(crate) struct ModulePlan {
 }
 
 pub(crate) struct FilePlan {
-    pub(crate) file_id: u32,
-    pub(crate) output_name: String,
     pub(crate) make_functions: Vec<MakeFunctionPlan>,
     pub(crate) namespace: FileNamespace,
 }
@@ -36,8 +34,8 @@ impl Planner<'_> {
     /// Run module-level collection and fix per-file identity before any item
     /// is rendered.
     pub(crate) fn build_module_plan(&mut self, files: &[&File], module_id: &str) -> ModulePlan {
-        self.facts.set_current_module(module_id);
-        self.collect_local_method_facts(files);
+        debug_assert_eq!(self.facts.current_module(), module_id);
+        self.collect_user_to_string_facts(files);
         self.collect_escape_remap(files);
         self.collect_generic_renames(files);
         let collision_diagnostics = self.detect_name_collisions(files);
@@ -53,8 +51,6 @@ impl Planner<'_> {
         let file_plans = files
             .iter()
             .map(|file| FilePlan {
-                file_id: file.id,
-                output_name: file.go_filename(),
                 make_functions: make_functions_by_file.remove(&file.id).unwrap_or_default(),
                 namespace: FileNamespace::build(
                     file,

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -5,8 +5,8 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::plan::bodies::{
-    AssignForm, AssignPlan, BreakValueDisposition, BreakValuePlan, LoweredBlock, LoweredStatement,
-    PlacePlan,
+    AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, LoopTransfer, LoweredBlock,
+    LoweredStatement, PlacePlan,
 };
 use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
@@ -264,9 +264,9 @@ impl Planner<'_> {
         }
 
         if let Expression::Loop { body, .. } = expression {
-            self.push_loop(var);
-            let plan = self.lower_loop_with_header("for {\n".to_string(), body);
-            self.pop_loop();
+            let plan = self.with_loop(var, |this| {
+                this.lower_loop_with_header("for {\n".to_string(), body)
+            });
             return vec![LoweredStatement::Loop(plan)];
         }
 
@@ -397,43 +397,34 @@ impl Planner<'_> {
             std::slice::from_ref(expression)
         };
 
-        self.enter_block_scope(is_block, has_go_braces);
-
-        let mut statements = Vec::new();
-        if let Some((last, rest)) = items.split_last() {
-            let is_new_target = self.scope.try_acquire_assign_target(var);
-            for item in rest {
-                statements.push(self.lower_statement(item));
-            }
-            statements.extend(self.lower_assign_tail(last, var, target_ty));
-            if is_new_target {
-                self.scope.release_assign_target(var);
-            }
-        }
-
-        self.exit_block_scope(is_block, has_go_braces);
-        statements
+        self.with_block_scope(is_block, has_go_braces, |this| {
+            let Some((last, rest)) = items.split_last() else {
+                return Vec::new();
+            };
+            this.with_assign_target(var, |this| {
+                let mut statements = Vec::new();
+                for item in rest {
+                    statements.push(this.lower_statement(item));
+                }
+                statements.extend(this.lower_assign_tail(last, var, target_ty));
+                statements
+            })
+        })
     }
 
-    fn enter_block_scope(&mut self, is_block: bool, has_go_braces: bool) {
+    fn with_block_scope<R>(
+        &mut self,
+        is_block: bool,
+        has_go_braces: bool,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
         if !is_block {
-            return;
+            return f(self);
         }
         if has_go_braces {
-            self.enter_scope();
+            self.with_scope(f)
         } else {
-            self.scope.push_binding_frame();
-        }
-    }
-
-    fn exit_block_scope(&mut self, is_block: bool, has_go_braces: bool) {
-        if !is_block {
-            return;
-        }
-        if has_go_braces {
-            self.exit_scope();
-        } else {
-            self.scope.pop_binding_frame();
+            self.with_binding_frame(f)
         }
     }
 
@@ -662,22 +653,26 @@ impl Planner<'_> {
         let value = self.plan_value(val, ExpressionContext::value());
         let value_is_empty = value.is_empty();
         let is_propagate_diverged = value_is_empty && matches!(val, Expression::Propagate { .. });
-        let disposition = if is_propagate_diverged {
-            BreakValueDisposition::Diverged
-        } else if let Some(result_var) = self.current_loop_result_var().map(str::to_string) {
+        if is_propagate_diverged {
+            return BreakValuePlan::Diverged { value };
+        }
+
+        let action = if let Some(result_var) = self.current_loop_result_var().map(str::to_string) {
             if is_unit_call(val) {
-                BreakValueDisposition::UnitCallIntoResult { result_var }
+                BreakValueAction::UnitCallIntoResult { result_var }
             } else {
-                BreakValueDisposition::AssignToResult { result_var }
+                BreakValueAction::AssignToResult { result_var }
             }
         } else {
-            BreakValueDisposition::Discard
+            BreakValueAction::Discard
         };
-        BreakValuePlan {
+        let target = self
+            .current_loop_id()
+            .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source);
+        BreakValuePlan::Transfer {
             value,
-            disposition,
-            target: self.current_loop_id(),
-            label: None,
+            action,
+            target,
         }
     }
 }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -1,7 +1,7 @@
 use crate::plan::bodies::{
-    AssignForm, AssignPlan, BreakValueDisposition, BreakValuePlan, CompoundKind, ConstPlan,
-    ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LetForm, LetPlan, LoopPlan,
-    LoweredBlock, LoweredStatement, ReturnForm, ReturnStatementPlan, SelectArmPlan,
+    AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, CompoundKind, ConstPlan, ElseArm,
+    ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LetForm, LetPlan, LoopPlan,
+    LoopTransfer, LoweredBlock, LoweredStatement, ReturnForm, ReturnStatementPlan, SelectArmPlan,
     SelectStatementPlan, SwitchKind, SwitchStatementPlan,
 };
 #[cfg(debug_assertions)]
@@ -33,16 +33,6 @@ impl Renderer {
         for statement in &block.statements {
             self.render_statement(output, statement);
         }
-    }
-
-    /// True when `block` renders to no output. Some structurally non-empty
-    /// statements (e.g. a side-effect-free discard `let _`) render empty, so
-    /// callers that gate scaffolding on emptiness query this rather than
-    /// `LoweredBlock::is_empty`.
-    pub(crate) fn renders_empty(&self, block: &LoweredBlock) -> bool {
-        let mut buffer = String::new();
-        self.render_lowered_block(&mut buffer, block);
-        buffer.is_empty()
     }
 
     /// Render a `select` statement: optional retry-loop framing around the
@@ -132,14 +122,8 @@ impl Renderer {
                 self.render_lowered_block(output, body);
                 output.push_str("}\n");
             }
-            LoweredStatement::Break { label, .. } => match label {
-                Some(label) => write_line!(output, "break {}", label),
-                None => output.push_str("break\n"),
-            },
-            LoweredStatement::Continue { label, .. } => match label {
-                Some(label) => write_line!(output, "continue {}", label),
-                None => output.push_str("continue\n"),
-            },
+            LoweredStatement::Break(target) => self.render_transfer(output, "break", target),
+            LoweredStatement::Continue(target) => self.render_transfer(output, "continue", target),
             LoweredStatement::Const(plan) => {
                 self.render_const_declaration(output, plan);
             }
@@ -324,34 +308,49 @@ impl Renderer {
         }
     }
 
-    /// Render a `BreakValuePlan`: flush the value's setup, apply the
-    /// disposition (assign to result slot / unit-call side effect + unit
-    /// assign / discard / no-op when diverged), then emit `break [label]`
-    /// (skipped when diverged).
-    fn render_break_value(&self, output: &mut String, plan: &BreakValuePlan) {
-        let value_text = self.render_value(output, &plan.value);
-        match &plan.disposition {
-            BreakValueDisposition::Diverged => return,
-            BreakValueDisposition::UnitCallIntoResult { result_var } => {
-                if !value_text.is_empty() {
-                    write_line!(output, "{}", value_text);
-                }
-                write_line!(output, "{} = struct{{}}{{}}", result_var);
-            }
-            BreakValueDisposition::AssignToResult { result_var } => {
-                if !value_text.is_empty() {
-                    write_line!(output, "{} = {}", result_var, value_text);
-                }
-            }
-            BreakValueDisposition::Discard => {
-                if !value_text.is_empty() {
-                    write_line!(output, "_ = {}", value_text);
-                }
+    fn render_transfer(&self, output: &mut String, keyword: &str, target: &LoopTransfer) {
+        match target {
+            LoopTransfer::Unlabeled => write_line!(output, "{}", keyword),
+            LoopTransfer::Labeled(label) => write_line!(output, "{} {}", keyword, label),
+            LoopTransfer::Source(target) => {
+                unreachable!(
+                    "source loop transfer must be legalized before rendering: {keyword} {target:?}"
+                )
             }
         }
-        match &plan.label {
-            Some(label) => write_line!(output, "break {}", label),
-            None => output.push_str("break\n"),
+    }
+
+    fn render_break_value(&self, output: &mut String, plan: &BreakValuePlan) {
+        match plan {
+            BreakValuePlan::Diverged { value } => {
+                self.render_value(output, value);
+            }
+            BreakValuePlan::Transfer {
+                value,
+                action,
+                target,
+            } => {
+                let value_text = self.render_value(output, value);
+                match action {
+                    BreakValueAction::UnitCallIntoResult { result_var } => {
+                        if !value_text.is_empty() {
+                            write_line!(output, "{}", value_text);
+                        }
+                        write_line!(output, "{} = struct{{}}{{}}", result_var);
+                    }
+                    BreakValueAction::AssignToResult { result_var } => {
+                        if !value_text.is_empty() {
+                            write_line!(output, "{} = {}", result_var, value_text);
+                        }
+                    }
+                    BreakValueAction::Discard => {
+                        if !value_text.is_empty() {
+                            write_line!(output, "_ = {}", value_text);
+                        }
+                    }
+                }
+                self.render_transfer(output, "break", target);
+            }
         }
     }
 
@@ -374,7 +373,7 @@ impl Renderer {
 
     fn render_loop(&self, output: &mut String, plan: &LoopPlan) {
         output.push_str(&self.render_setup(&plan.prologue));
-        if let Some(label) = &plan.label {
+        if let Some(label) = plan.kind.label() {
             write_line!(output, "{}:", label);
         }
         output.push_str(&plan.header);

--- a/crates/emit/src/state/adapter_registry.rs
+++ b/crates/emit/src/state/adapter_registry.rs
@@ -4,8 +4,8 @@ use rustc_hash::FxHashMap as HashMap;
 #[derive(Default)]
 pub(crate) struct AdapterRegistry {
     synthesized: HashMap<(EcoString, EcoString), String>,
-    declarations: Vec<String>,
-    emitted_count: usize,
+    pending_declarations: Vec<String>,
+    next_index: usize,
 }
 
 impl AdapterRegistry {
@@ -13,8 +13,10 @@ impl AdapterRegistry {
         self.synthesized.get(key).map(String::as_str)
     }
 
-    pub(crate) fn next_index(&self) -> usize {
-        self.declarations.len()
+    pub(crate) fn allocate_index(&mut self) -> usize {
+        let index = self.next_index;
+        self.next_index += 1;
+        index
     }
 
     pub(crate) fn insert(
@@ -24,16 +26,14 @@ impl AdapterRegistry {
         declaration: String,
     ) {
         self.synthesized.insert(key, name);
-        self.declarations.push(declaration);
+        self.pending_declarations.push(declaration);
     }
 
     pub(crate) fn push_declaration(&mut self, declaration: String) {
-        self.declarations.push(declaration);
+        self.pending_declarations.push(declaration);
     }
 
-    pub(crate) fn flush_new_declarations(&mut self) -> Vec<String> {
-        let new_declarations = self.declarations[self.emitted_count..].to_vec();
-        self.emitted_count = self.declarations.len();
-        new_declarations
+    pub(crate) fn drain_declarations(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_declarations)
     }
 }

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -42,6 +42,8 @@ pub(crate) enum BindingValue {
     InlineExpr(InlineExpr),
 }
 
+pub(crate) struct BindingSnapshot(HashMap<String, BindingValue>);
+
 impl BindingValue {
     pub(crate) fn as_go_name(&self) -> Option<&str> {
         match self {
@@ -51,10 +53,16 @@ impl BindingValue {
     }
 }
 
-#[derive(Default)]
 pub(crate) struct Bindings {
-    map: HashMap<String, BindingValue>,
-    stack: Vec<HashMap<String, BindingValue>>,
+    frames: Vec<HashMap<String, BindingValue>>,
+}
+
+impl Default for Bindings {
+    fn default() -> Self {
+        Self {
+            frames: vec![HashMap::default()],
+        }
+    }
 }
 
 impl Bindings {
@@ -63,8 +71,8 @@ impl Bindings {
     }
 
     pub(crate) fn reset(&mut self) {
-        self.map.clear();
-        self.stack.clear();
+        self.frames.truncate(1);
+        self.current_mut().clear();
     }
 
     pub(crate) fn bind_go_name(
@@ -73,50 +81,61 @@ impl Bindings {
         value: impl Into<String>,
     ) -> String {
         let go_value = escape_reserved(&value.into()).into_owned();
-        self.map
+        self.current_mut()
             .insert(key.into(), BindingValue::GoName(go_value.clone()));
         go_value
     }
 
     pub(crate) fn bind_inline_expr(&mut self, key: impl Into<String>, expression_text: InlineExpr) {
-        self.map
+        self.current_mut()
             .insert(key.into(), BindingValue::InlineExpr(expression_text));
     }
 
     pub(crate) fn get(&self, name: &str) -> Option<&BindingValue> {
-        self.map.get(name)
+        self.current().get(name)
     }
 
     pub(crate) fn get_go_name(&self, name: &str) -> Option<&str> {
-        self.map.get(name).and_then(BindingValue::as_go_name)
+        self.current().get(name).and_then(BindingValue::as_go_name)
     }
 
     pub(crate) fn has_go_name(&self, go_name: &str) -> bool {
-        self.map
+        self.current()
             .values()
             .filter_map(BindingValue::as_go_name)
             .any(|v| v == go_name)
     }
 
     pub(crate) fn save(&mut self) {
-        self.stack.push(self.map.clone());
+        self.frames.push(self.current().clone());
     }
 
     pub(crate) fn restore(&mut self) {
-        if let Some(saved) = self.stack.pop() {
-            self.map = saved;
-        }
+        assert!(self.frames.len() > 1, "cannot pop the base binding frame");
+        let _ = self.frames.pop();
     }
 
-    pub(crate) fn snapshot(&self) -> HashMap<String, BindingValue> {
-        self.map.clone()
+    pub(crate) fn snapshot(&self) -> BindingSnapshot {
+        BindingSnapshot(self.current().clone())
     }
 
-    pub(crate) fn restore_snapshot(&mut self, snapshot: HashMap<String, BindingValue>) {
-        self.map = snapshot;
+    pub(crate) fn replace_snapshot(&mut self, snapshot: BindingSnapshot) -> BindingSnapshot {
+        BindingSnapshot(std::mem::replace(self.current_mut(), snapshot.0))
     }
 
     pub(crate) fn remove(&mut self, key: &str) {
-        self.map.remove(key);
+        self.current_mut().remove(key);
+    }
+
+    fn current(&self) -> &HashMap<String, BindingValue> {
+        self.frames
+            .last()
+            .expect("bindings always retain a base frame")
+    }
+
+    fn current_mut(&mut self) -> &mut HashMap<String, BindingValue> {
+        self.frames
+            .last_mut()
+            .expect("bindings always retain a base frame")
     }
 }

--- a/crates/emit/src/state/file_namespace.rs
+++ b/crates/emit/src/state/file_namespace.rs
@@ -1,5 +1,8 @@
+use std::rc::Rc;
+
 use rustc_hash::FxHashMap as HashMap;
 
+use crate::EnumLayout;
 use crate::names::packages::{PackageRequirements, PackageUse};
 use crate::output::imports::{ImportBuilder, ImportPlan};
 use diagnostics::LisetteDiagnostic;
@@ -8,9 +11,8 @@ use syntax::ast::ImportAlias;
 use syntax::program::File;
 
 pub(crate) struct FileNamespace {
-    file_id: u32,
-    module_aliases: HashMap<String, String>,
-    reverse_aliases: HashMap<String, String>,
+    module_aliases: Vec<(String, String)>,
+    enum_layouts: HashMap<String, Rc<EnumLayout>>,
     imports: ImportPlan,
     requirements: PackageRequirements,
 }
@@ -22,8 +24,7 @@ impl FileNamespace {
         unused_imports: &rustc_hash::FxHashSet<EcoString>,
         go_package_names: &HashMap<String, String>,
     ) -> Self {
-        let mut module_aliases = HashMap::default();
-        let mut reverse_aliases = HashMap::default();
+        let mut module_aliases = Vec::new();
         for import in file.imports() {
             if matches!(import.alias, Some(ImportAlias::Blank(_))) {
                 continue;
@@ -31,29 +32,37 @@ impl FileNamespace {
             let Some(alias) = import.effective_alias(go_package_names) else {
                 continue;
             };
-            module_aliases.insert(import.name.to_string(), alias.clone());
-            reverse_aliases.insert(alias, import.name.to_string());
+            module_aliases.push((import.name.to_string(), alias));
         }
 
         Self {
-            file_id: file.id,
             module_aliases,
-            reverse_aliases,
+            enum_layouts: HashMap::default(),
             imports: ImportPlan::build(file, go_module, unused_imports, go_package_names),
             requirements: PackageRequirements::default(),
         }
     }
 
-    pub(crate) fn file_id(&self) -> u32 {
-        self.file_id
+    pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<Rc<EnumLayout>> {
+        self.enum_layouts.get(enum_id).cloned()
+    }
+
+    pub(crate) fn record_enum_layout(&mut self, enum_id: String, layout: Rc<EnumLayout>) {
+        self.enum_layouts.insert(enum_id, layout);
     }
 
     pub(crate) fn module_alias(&self, module: &str) -> Option<&str> {
-        self.module_aliases.get(module).map(String::as_str)
+        self.module_aliases
+            .iter()
+            .rev()
+            .find_map(|(candidate, alias)| (candidate == module).then_some(alias.as_str()))
     }
 
     pub(crate) fn module_for_alias(&self, alias: &str) -> Option<&str> {
-        self.reverse_aliases.get(alias).map(String::as_str)
+        self.module_aliases
+            .iter()
+            .rev()
+            .find_map(|(module, candidate)| (candidate == alias).then_some(module.as_str()))
     }
 
     pub(crate) fn reference(&mut self, package: PackageUse) -> String {

--- a/crates/emit/src/state/module_state.rs
+++ b/crates/emit/src/state/module_state.rs
@@ -1,47 +1,16 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use ecow::EcoString;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::types::Type;
 
-use crate::EnumLayout;
-
 #[derive(Default)]
 pub(crate) struct ModuleState {
-    enum_layouts: RefCell<HashMap<u32, HashMap<String, Rc<EnumLayout>>>>,
-    exported_method_names: HashSet<String>,
     user_to_string_types: HashSet<String>,
     escape_remap: HashMap<String, String>,
     generic_renames: HashMap<String, String>,
 }
 
 impl ModuleState {
-    pub(crate) fn record_enum_layout(&self, file_id: u32, enum_id: String, layout: EnumLayout) {
-        self.enum_layouts
-            .borrow_mut()
-            .entry(file_id)
-            .or_default()
-            .insert(enum_id, Rc::new(layout));
-    }
-
-    pub(crate) fn enum_layout(&self, file_id: u32, enum_id: &str) -> Option<Rc<EnumLayout>> {
-        self.enum_layouts
-            .borrow()
-            .get(&file_id)?
-            .get(enum_id)
-            .cloned()
-    }
-
-    pub(crate) fn record_exported_method_name(&mut self, name: impl Into<String>) {
-        self.exported_method_names.insert(name.into());
-    }
-
-    pub(crate) fn has_local_exported_method_name(&self, name: &str) -> bool {
-        self.exported_method_names.contains(name)
-    }
-
     pub(crate) fn record_user_to_string_type(&mut self, type_name: impl Into<String>) {
         self.user_to_string_types.insert(type_name.into());
     }
@@ -84,16 +53,18 @@ pub(crate) struct FunctionEmissionState {
 }
 
 impl FunctionEmissionState {
+    pub(crate) fn for_function(
+        generic_context: &[(EcoString, Vec<Type>)],
+        absorbed_ref_generics: HashSet<String>,
+    ) -> Self {
+        Self {
+            absorbed_ref_generics,
+            generic_context: generic_context.to_vec(),
+        }
+    }
+
     pub(crate) fn is_absorbed_ref_generic(&self, name: &str) -> bool {
         self.absorbed_ref_generics.contains(name)
-    }
-
-    pub(crate) fn record_absorbed_ref_generic(&mut self, name: impl Into<String>) {
-        self.absorbed_ref_generics.insert(name.into());
-    }
-
-    pub(crate) fn set_generic_context(&mut self, context: &[(EcoString, Vec<Type>)]) {
-        self.generic_context = context.to_vec();
     }
 
     pub(crate) fn generic_context(&self) -> &[(EcoString, Vec<Type>)] {

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -1,13 +1,11 @@
-use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
-use std::rc::Rc;
 
 use crate::Bindings;
 use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::escape_reserved;
 use crate::plan::bodies::LoopId;
-use crate::state::bindings::{BindingValue, InlineExpr};
+use crate::state::bindings::{BindingSnapshot, BindingValue, InlineExpr};
 
 pub(crate) struct ScopeState {
     next_var: usize,
@@ -15,9 +13,8 @@ pub(crate) struct ScopeState {
     bindings: Bindings,
     declared: Vec<HashSet<String>>,
     type_param_go_names: HashSet<String>,
-    scope_depth: usize,
     loop_stack: Vec<LoopContext>,
-    return_ctx_stack: Vec<Rc<ReturnContext>>,
+    return_ctx_stack: Vec<ReturnContext>,
     test_handle_stack: Vec<String>,
     assign_targets: HashSet<String>,
     go_const_bindings: Vec<HashSet<String>>,
@@ -25,13 +22,8 @@ pub(crate) struct ScopeState {
     use_frames: Vec<HashSet<String>>,
 }
 
-pub(crate) struct BindingSnapshot {
-    inner: HashMap<String, BindingValue>,
-}
-
 pub(crate) struct IsolatedFunctionFrame {
     declared: Vec<HashSet<String>>,
-    scope_depth: usize,
 }
 
 impl ScopeState {
@@ -42,7 +34,6 @@ impl ScopeState {
             bindings: Bindings::new(),
             declared: vec![HashSet::default()],
             type_param_go_names: HashSet::default(),
-            scope_depth: 0,
             loop_stack: Vec::new(),
             return_ctx_stack: Vec::new(),
             test_handle_stack: Vec::new(),
@@ -58,7 +49,10 @@ impl ScopeState {
 
     /// Pop and return the region's uses, merging them into the enclosing region.
     pub(crate) fn exit_use_region(&mut self) -> HashSet<String> {
-        let frame = self.use_frames.pop().unwrap_or_default();
+        let frame = self
+            .use_frames
+            .pop()
+            .expect("a use region must be entered before it is exited");
         if let Some(parent) = self.use_frames.last_mut() {
             parent.extend(frame.iter().cloned());
         }
@@ -132,25 +126,28 @@ impl ScopeState {
     }
 
     pub(crate) fn binding_snapshot(&self) -> BindingSnapshot {
-        BindingSnapshot {
-            inner: self.bindings.snapshot(),
-        }
+        self.bindings.snapshot()
     }
 
-    pub(crate) fn restore_binding_snapshot(&mut self, snapshot: BindingSnapshot) {
-        self.bindings.restore_snapshot(snapshot.inner);
+    pub(crate) fn replace_binding_snapshot(
+        &mut self,
+        snapshot: BindingSnapshot,
+    ) -> BindingSnapshot {
+        self.bindings.replace_snapshot(snapshot)
     }
 
     pub(crate) fn declare_go_name(&mut self, go_name: &str) {
-        if let Some(current) = self.declared.last_mut() {
-            current.insert(go_name.to_string());
-        }
+        self.declared
+            .last_mut()
+            .expect("scope state always retains a declaration frame")
+            .insert(go_name.to_string());
     }
 
     pub(crate) fn try_declare_go_name(&mut self, go_name: &str) -> bool {
-        let Some(current) = self.declared.last_mut() else {
-            return true;
-        };
+        let current = self
+            .declared
+            .last_mut()
+            .expect("scope state always retains a declaration frame");
         if current.contains(go_name) {
             false
         } else {
@@ -168,14 +165,12 @@ impl ScopeState {
     }
 
     pub(crate) fn enter_block(&mut self) {
-        self.scope_depth += 1;
         self.bindings.save();
         self.declared.push(HashSet::default());
         self.go_const_bindings.push(HashSet::default());
     }
 
     pub(crate) fn exit_block(&mut self) {
-        self.scope_depth = self.scope_depth.saturating_sub(1);
         self.bindings.restore();
         pop_keep_base(&mut self.declared);
         pop_keep_base(&mut self.go_const_bindings);
@@ -184,10 +179,8 @@ impl ScopeState {
     pub(crate) fn enter_isolated_function(&mut self) -> IsolatedFunctionFrame {
         let saved = IsolatedFunctionFrame {
             declared: std::mem::take(&mut self.declared),
-            scope_depth: self.scope_depth,
         };
         self.declared = vec![self.type_param_go_names.clone()];
-        self.scope_depth = 0;
         self.bindings.save();
         saved
     }
@@ -195,7 +188,6 @@ impl ScopeState {
     pub(crate) fn exit_isolated_function(&mut self, frame: IsolatedFunctionFrame) {
         self.bindings.restore();
         self.declared = frame.declared;
-        self.scope_depth = frame.scope_depth;
     }
 
     pub(crate) fn fresh_go_name(&mut self, hint: Option<&str>) -> String {
@@ -226,15 +218,19 @@ impl ScopeState {
     }
 
     pub(crate) fn pop_loop(&mut self) {
-        self.loop_stack.pop();
+        self.loop_stack
+            .pop()
+            .expect("a loop context must be pushed before it is popped");
     }
 
-    pub(crate) fn push_return_ctx(&mut self, ctx: Rc<ReturnContext>) {
+    pub(crate) fn push_return_ctx(&mut self, ctx: ReturnContext) {
         self.return_ctx_stack.push(ctx);
     }
 
     pub(crate) fn pop_return_ctx(&mut self) {
-        self.return_ctx_stack.pop();
+        self.return_ctx_stack
+            .pop()
+            .expect("a return context must be pushed before it is popped");
     }
 
     pub(crate) fn push_test_handle(&mut self, name: String) {
@@ -242,14 +238,16 @@ impl ScopeState {
     }
 
     pub(crate) fn pop_test_handle(&mut self) {
-        self.test_handle_stack.pop();
+        self.test_handle_stack
+            .pop()
+            .expect("a test handle must be pushed before it is popped");
     }
 
     pub(crate) fn current_test_handle(&self) -> Option<&str> {
         self.test_handle_stack.last().map(String::as_str)
     }
 
-    pub(crate) fn current_return_ctx(&self) -> Option<Rc<ReturnContext>> {
+    pub(crate) fn current_return_ctx(&self) -> Option<ReturnContext> {
         self.return_ctx_stack.last().cloned()
     }
 
@@ -261,11 +259,11 @@ impl ScopeState {
         self.loop_stack.last().map(|context| context.id)
     }
 
-    pub(crate) fn try_acquire_assign_target(&mut self, var: &str) -> bool {
+    pub(crate) fn activate_assign_target(&mut self, var: &str) -> bool {
         self.assign_targets.insert(var.to_string())
     }
 
-    pub(crate) fn release_assign_target(&mut self, var: &str) {
+    pub(crate) fn deactivate_assign_target(&mut self, var: &str) {
         self.assign_targets.remove(var);
     }
 
@@ -282,9 +280,10 @@ impl ScopeState {
     }
 
     pub(crate) fn record_go_const_binding(&mut self, go_identifier: String) {
-        if let Some(top) = self.go_const_bindings.last_mut() {
-            top.insert(go_identifier);
-        }
+        self.go_const_bindings
+            .last_mut()
+            .expect("scope state always retains a const frame")
+            .insert(go_identifier);
     }
 
     pub(crate) fn is_go_const_binding(&self, go_identifier: &str) -> bool {
@@ -295,7 +294,6 @@ impl ScopeState {
 }
 
 fn pop_keep_base<T>(stack: &mut Vec<T>) {
-    if stack.len() > 1 {
-        stack.pop();
-    }
+    assert!(stack.len() > 1, "cannot pop a stack's base frame");
+    let _ = stack.pop();
 }

--- a/crates/emit/src/types/prelude.rs
+++ b/crates/emit/src/types/prelude.rs
@@ -13,25 +13,21 @@ pub(crate) enum PreludeType {
     PanicValue,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct VariantInfo {
-    name: &'static str,
-}
-
 impl PreludeType {
+    const ALL: [Self; 9] = [
+        Self::Option,
+        Self::Result,
+        Self::Partial,
+        Self::Range,
+        Self::RangeInclusive,
+        Self::RangeFrom,
+        Self::RangeTo,
+        Self::RangeToInclusive,
+        Self::PanicValue,
+    ];
+
     pub(crate) fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "Option" => Some(Self::Option),
-            "Result" => Some(Self::Result),
-            "Partial" => Some(Self::Partial),
-            "Range" => Some(Self::Range),
-            "RangeInclusive" => Some(Self::RangeInclusive),
-            "RangeFrom" => Some(Self::RangeFrom),
-            "RangeTo" => Some(Self::RangeTo),
-            "RangeToInclusive" => Some(Self::RangeToInclusive),
-            "PanicValue" => Some(Self::PanicValue),
-            _ => None,
-        }
+        Self::ALL.into_iter().find(|ty| ty.go_name() == name)
     }
 
     pub(crate) fn emit_type(&self, type_args: &[String]) -> String {
@@ -56,39 +52,5 @@ impl PreludeType {
             Self::RangeToInclusive => "RangeToInclusive",
             Self::PanicValue => "PanicValue",
         }
-    }
-
-    fn variants(&self) -> Option<&'static [VariantInfo]> {
-        match self {
-            Self::Option => Some(&[VariantInfo { name: "Some" }, VariantInfo { name: "None" }]),
-            Self::Result => Some(&[VariantInfo { name: "Ok" }, VariantInfo { name: "Err" }]),
-            Self::Partial => Some(&[
-                VariantInfo { name: "Ok" },
-                VariantInfo { name: "Err" },
-                VariantInfo { name: "Both" },
-            ]),
-            Self::Range
-            | Self::RangeInclusive
-            | Self::RangeFrom
-            | Self::RangeTo
-            | Self::RangeToInclusive
-            | Self::PanicValue => None,
-        }
-    }
-
-    fn make_function_name(&self, variant: &str) -> String {
-        format!("prelude.Make{}{}", self.go_name(), variant)
-    }
-
-    pub(crate) fn enum_types() -> &'static [PreludeType] {
-        &[Self::Option, Self::Result, Self::Partial]
-    }
-
-    pub(crate) fn make_function_entries(&self) -> impl Iterator<Item = (String, String)> + '_ {
-        self.variants().into_iter().flatten().map(move |v| {
-            let constructor = format!("{}.{}", self.go_name(), v.name);
-            let make_fn = self.make_function_name(v.name);
-            (constructor, make_fn)
-        })
     }
 }

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -5753,6 +5753,61 @@ fn main() {
 }
 
 #[test]
+fn adapter_declarations_drain_to_the_file_that_synthesizes_them() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "types.lis",
+        r#"
+struct Entry { value: int }
+
+interface Cache {
+  #[go(comma_ok)]
+  fn get() -> Option<Ref<Entry>>
+}
+
+fn consume(_cache: Cache) {}
+
+struct First {}
+
+impl First {
+  fn get(self) -> Option<Ref<Entry>> { None }
+}
+
+struct Second {}
+
+impl Second {
+  fn get(self) -> Option<Ref<Entry>> { None }
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "first.lis",
+        r#"
+fn adapt_first() {
+  consume(First {} as Cache)
+}
+"#,
+    );
+
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  adapt_first()
+  consume(Second {} as Cache)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn inherited_comma_ok_hint_propagates_to_child_iface_cast() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/adapter_declarations_drain_to_the_file_that_synthesizes_them.snap
+++ b/tests/spec/build/snapshots/adapter_declarations_drain_to_the_file_that_synthesizes_them.snap
@@ -1,0 +1,74 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === first.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func adapt_first() {
+	consume(_lisAdapter_First_Cache_1{inner: First{}})
+}
+
+type _lisAdapter_First_Cache_1 struct {
+	inner First
+}
+
+func (a _lisAdapter_First_Cache_1) get() (*Entry, bool) {
+	raw_1 := a.inner.get()
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}
+
+
+// === main.go ===
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func main() {
+	adapt_first()
+	consume(_lisAdapter_Second_Cache_0{inner: Second{}})
+}
+
+type _lisAdapter_Second_Cache_0 struct {
+	inner Second
+}
+
+func (a _lisAdapter_Second_Cache_0) get() (*Entry, bool) {
+	raw_1 := a.inner.get()
+	option_2 := lisette.OptionFromNilable[*Entry](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal, true
+	}
+	return nil, false
+}
+
+
+// === types.go ===
+package main
+
+type Entry struct {
+	value int
+}
+
+type Cache interface {
+	get() (*Entry, bool)
+}
+
+func consume(_ Cache) {}
+
+type First struct{}
+
+func (f First) get() *Entry {
+	return nil
+}
+
+type Second struct{}
+
+func (s Second) get() *Entry {
+	return nil
+}

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -777,6 +777,26 @@ fn main() {
 }
 
 #[test]
+fn select_receive_bindings_are_scoped_per_arm_and_after_select() {
+    let input = r#"
+fn test() -> int {
+  let value = 40
+  let first = Channel.new<int>()
+  let outbound = Channel.new<int>()
+
+  let selected = select {
+    let Some(value) = first.receive() => value,
+    outbound.send(1) => value + 1,
+    _ => value + 2,
+  }
+
+  selected + value
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn select_send_channel_expression_hoisted() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/later_struct_tag_attribute_can_disable_omitempty.snap
+++ b/tests/spec/emit/snapshots/later_struct_tag_attribute_can_disable_omitempty.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[json(omitempty)]
+  #[json(!omitempty)]
+  struct User {
+    id: int,
+  }
+---
+package main
+
+type User struct {
+	Id int `json:"id"`
+}

--- a/tests/spec/emit/snapshots/select_receive_bindings_are_scoped_per_arm_and_after_select.snap
+++ b/tests/spec/emit/snapshots/select_receive_bindings_are_scoped_per_arm_and_after_select.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/concurrency.rs
+description: |
+  
+  fn test() -> int {
+    let value = 40
+    let first = Channel.new<int>()
+    let outbound = Channel.new<int>()
+  
+    let selected = select {
+      let Some(value) = first.receive() => value,
+      outbound.send(1) => value + 1,
+      _ => value + 2,
+    }
+  
+    selected + value
+  }
+---
+package main
+
+func test() int {
+	value := 40
+	first := make(chan int)
+	outbound := make(chan int)
+	var selected int
+	ch_1 := first
+	for {
+		select {
+		case value, ok := <-ch_1:
+			if ok {
+				selected = value
+			} else {
+				ch_1 = nil
+				continue
+			}
+		case outbound <- 1:
+			selected = value + 1
+		default:
+			selected = value + 2
+		}
+		break
+	}
+	return selected + value
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2446,6 +2446,18 @@ struct User {
 }
 
 #[test]
+fn later_struct_tag_attribute_can_disable_omitempty() {
+    let input = r#"
+#[json(omitempty)]
+#[json(!omitempty)]
+struct User {
+  id: int,
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn struct_with_snake_case_oauth() {
     let input = r#"
 #[json(snake_case)]


### PR DESCRIPTION
Remodels emission around explicit state representations, removing synchronized fields and manual scope protocols. Also fixes tag override semantics and removes render-during-lowering checks.