### PR TITLE
refactor: emit idiomatic Go for chains, errors, and key-only loops

### DIFF
--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -16,7 +16,7 @@ use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee}
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
-use crate::utils::reads_mutable_operand;
+use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
@@ -47,6 +47,16 @@ fn find_go_string_literal_close(s: &str) -> Option<usize> {
         }
     }
     None
+}
+
+fn is_errors_new_callee(function: &Expression) -> bool {
+    let Expression::DotAccess {
+        expression, member, ..
+    } = function
+    else {
+        return false;
+    };
+    member == "New" && expression.get_type().as_import_namespace() == Some("go:errors")
 }
 
 fn lowers_to_bare_sprintf(expression: &Expression) -> bool {
@@ -146,6 +156,12 @@ impl<'a> Planner<'a> {
             .resolved_types()
             .expect("emission requires checked call type arguments");
 
+        if let Some(plan) =
+            self.collapse_errors_new_format_arg(function, args, spread, expression_ctx)
+        {
+            return plan;
+        }
+
         if let Some(go_name) = self.get_callee_go_name(function).map(str::to_string) {
             let arg_ctx = match (expression_ctx.retired_receiver(), args.len()) {
                 (Some(retired), 1) if self.callee_lowers_to_type_construction(function) => {
@@ -216,11 +232,12 @@ impl<'a> Planner<'a> {
         let args_effect = sequenced_args.effect;
         let (args_setup, args_strings) = sequenced_args.into_rendered();
 
+        let delayed_after_arg_setup = !args_setup.is_empty() && reads_mutable_operand(function);
+        let racing_inline_arg_calls =
+            args_effect.has_effectful_call() && reads_unsequenced_mutable_operand(function);
         let callee_needs_pin = setup.is_empty()
             && type_args_string.is_empty()
-            && reads_mutable_operand(function)
-            && (!args_setup.is_empty()
-                || (!matches!(function, Expression::Call { .. }) && args_effect.has_call()));
+            && (delayed_after_arg_setup || racing_inline_arg_calls);
         if callee_needs_pin {
             function_string =
                 self.hoist_tmp_value_statement(&mut setup, "callee", &function_string);
@@ -252,6 +269,54 @@ impl<'a> Planner<'a> {
                 effect,
             )
         }
+    }
+
+    /// Emit `errors.New(f"...")` as `fmt.Errorf(...)`: compiler-built format strings
+    /// cannot contain `%w`, and bypassing the callee drops an unused `errors` import.
+    fn collapse_errors_new_format_arg(
+        &mut self,
+        function: &Expression,
+        args: &[Expression],
+        spread: Option<&Expression>,
+        expression_ctx: ExpressionContext<'_>,
+    ) -> Option<ValuePlan> {
+        if spread.is_some() || !is_errors_new_callee(function) {
+            return None;
+        }
+        let [argument] = args else {
+            return None;
+        };
+        let Expression::Literal {
+            literal: Literal::FormatString(parts),
+            ..
+        } = argument.unwrap_parens()
+        else {
+            return None;
+        };
+        if !self.format_string_lowers_to_sprintf(parts) {
+            return None;
+        }
+        let staged = self.stage_operand(argument, ExpressionContext::value());
+        let mut sequenced =
+            self.sequence_values(vec![staged], expression_ctx.capture_boundary(), "_arg");
+        let effect = self.regular_call_effect(function, sequenced.effect);
+        let value = sequenced
+            .values
+            .pop()
+            .expect("sequenced exactly one argument");
+        let call = match value {
+            GoExpression::Call { callee, arguments } if callee.rendered() == "fmt.Sprintf" => {
+                GoExpression::call(GoExpression::opaque("fmt.Errorf".to_string()), arguments)
+            }
+            captured => {
+                let qualifier = self.require_module_import("go:errors");
+                GoExpression::call(
+                    GoExpression::opaque(format!("{}.New", qualifier)),
+                    vec![captured],
+                )
+            }
+        };
+        Some(ValuePlan::plain_call(sequenced.setup, call, effect))
     }
 
     fn regular_call_effect(

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -275,6 +275,9 @@ impl Planner<'_> {
             || self.go_name_for_binding(second).is_none();
         let header = if first_is_discard && second_is_discard {
             format!("for range {} {{\n", iter_expression)
+        } else if second_is_discard {
+            let key = self.bind_loop_pattern(first, None);
+            format!("for {} := range {} {{\n", key, iter_expression)
         } else {
             let key = self.bind_loop_pattern(first, None);
             let value = self.bind_loop_pattern(second, None);

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -182,6 +182,19 @@ impl Planner<'_> {
             effect,
         )
     }
+
+    pub(crate) fn format_string_lowers_to_sprintf(&self, parts: &[FormatStringPart]) -> bool {
+        let has_interpolation = parts
+            .iter()
+            .any(|p| matches!(p, FormatStringPart::Expression(_)));
+        if !has_interpolation {
+            return false;
+        }
+        let [FormatStringPart::Expression(solo)] = parts else {
+            return true;
+        };
+        format_verb_for(&self.facts.peel_alias(&solo.get_type())) == "%c"
+    }
 }
 
 /// The `fmt` printf verb for interpolating a value of alias-peeled `ty` into

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -137,3 +137,27 @@ pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {
         _ => false,
     }
 }
+
+pub(crate) fn reads_unsequenced_mutable_operand(expression: &Expression) -> bool {
+    match expression.unwrap_parens() {
+        Expression::Call { .. } => false,
+        Expression::IndexedAccess { .. } => true,
+        Expression::Unary {
+            operator: UnaryOperator::Deref,
+            ..
+        } => true,
+        Expression::DotAccess {
+            expression,
+            dot_access_kind,
+            ..
+        } => match dot_access_kind {
+            Some(
+                DotAccessKind::StructField { .. }
+                | DotAccessKind::TupleStructField { .. }
+                | DotAccessKind::TupleElement,
+            ) => true,
+            _ => reads_unsequenced_mutable_operand(expression),
+        },
+        _ => false,
+    }
+}

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -522,6 +522,20 @@ fn test(m: Map<string, int>) -> int {
 }
 
 #[test]
+fn for_loop_tuple_pattern_map_discard_value() {
+    let input = r#"
+fn test(m: Map<string, int>) -> Slice<string> {
+  let mut keys: Slice<string> = []
+  for (key, _) in m {
+    keys = keys.append(key)
+  }
+  keys
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_loop_iter_seq_single_value() {
     let input = r#"
 import "go:maps"

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1165,6 +1165,116 @@ fn main() {
 }
 
 #[test]
+fn chained_callee_call_arg_stays_inline() {
+    let input = r#"
+struct O {}
+
+impl O {
+  fn a(self, num: int) -> O { self }
+  fn b(self, num: int) -> O { self }
+  fn c(self) {}
+}
+
+fn one() -> int { 1 }
+
+fn main() {
+  let o = O {}
+  o.a(1).b(one()).c()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn chained_callee_constructor_args_stay_inline() {
+    let input = r#"
+struct O {}
+struct P(int)
+
+enum Color {
+  Red(int),
+  Blue,
+}
+
+impl O {
+  fn p(self, p: P) -> O { self }
+  fn col(self, c: Color) -> O { self }
+  fn c(self) {}
+}
+
+fn main() {
+  let o = O {}
+  o.p(P(2)).col(Color.Red(3)).col(Color.Blue).c()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn errors_new_format_string_collapses_to_errorf() {
+    let input = r#"
+import "go:errors"
+
+fn fail(line: string) -> error {
+  errors.New(f"malformed line: {line}")
+}
+
+fn percent(rate: int) -> error {
+  errors.New(f"{rate}% failed")
+}
+
+fn main() {
+  let _ = fail("x")
+  let _ = percent(3)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn errors_new_non_sprintf_args_stay() {
+    let input = r#"
+import "go:errors"
+
+fn plain() -> error {
+  errors.New("plain message")
+}
+
+fn no_interpolation() -> error {
+  errors.New(f"nothing to fill in")
+}
+
+fn solo(msg: string) -> error {
+  errors.New(f"{msg}")
+}
+
+fn main() {
+  let _ = plain()
+  let _ = no_interpolation()
+  let _ = solo("y")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn indexed_callee_pure_constructor_arg_not_captured() {
+    let input = r#"
+struct P(int)
+fn f0(p: P) -> int { 0 }
+fn f1(p: P) -> int { 1 }
+
+fn main() {
+  let fs = [f0, f1]
+  let i = 0
+  let r = fs[i](P(2))
+  let _ = r
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn index_access_eval_order_captured() {
     let input = r#"
 fn bump(i: Ref<int>) -> int {

--- a/tests/spec/emit/snapshots/chained_callee_call_arg_stays_inline.snap
+++ b/tests/spec/emit/snapshots/chained_callee_call_arg_stays_inline.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct O {}
+  
+  impl O {
+    fn a(self, num: int) -> O { self }
+    fn b(self, num: int) -> O { self }
+    fn c(self) {}
+  }
+  
+  fn one() -> int { 1 }
+  
+  fn main() {
+    let o = O {}
+    o.a(1).b(one()).c()
+  }
+---
+package main
+
+type O struct{}
+
+func (o O) a(_ int) O {
+	return o
+}
+
+func (o O) b(_ int) O {
+	return o
+}
+
+func (o O) c() {}
+
+func one() int {
+	return 1
+}
+
+func main() {
+	o := O{}
+	o.a(1).b(one()).c()
+}

--- a/tests/spec/emit/snapshots/chained_callee_constructor_args_stay_inline.snap
+++ b/tests/spec/emit/snapshots/chained_callee_constructor_args_stay_inline.snap
@@ -1,0 +1,63 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct O {}
+  struct P(int)
+  
+  enum Color {
+    Red(int),
+    Blue,
+  }
+  
+  impl O {
+    fn p(self, p: P) -> O { self }
+    fn col(self, c: Color) -> O { self }
+    fn c(self) {}
+  }
+  
+  fn main() {
+    let o = O {}
+    o.p(P(2)).col(Color.Red(3)).col(Color.Blue).c()
+  }
+---
+package main
+
+func MakeColorRed(arg0 int) Color {
+	return Color{Tag: ColorRed, Red: arg0}
+}
+
+func MakeColorBlue() Color {
+	return Color{Tag: ColorBlue}
+}
+
+type O struct{}
+
+type P int
+
+type ColorTag int
+
+const (
+	ColorRed ColorTag = iota
+	ColorBlue
+)
+
+type Color struct {
+	Tag ColorTag
+	Red int
+}
+
+func (o O) p(_ P) O {
+	return o
+}
+
+func (o O) col(_ Color) O {
+	return o
+}
+
+func (o O) c() {}
+
+func main() {
+	o := O{}
+	o.p(P(2)).col(MakeColorRed(3)).col(MakeColorBlue()).c()
+}

--- a/tests/spec/emit/snapshots/errors_new_format_string_collapses_to_errorf.snap
+++ b/tests/spec/emit/snapshots/errors_new_format_string_collapses_to_errorf.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:errors"
+  
+  fn fail(line: string) -> error {
+    errors.New(f"malformed line: {line}")
+  }
+  
+  fn percent(rate: int) -> error {
+    errors.New(f"{rate}% failed")
+  }
+  
+  fn main() {
+    let _ = fail("x")
+    let _ = percent(3)
+  }
+---
+package main
+
+import "fmt"
+
+func fail(line string) error {
+	return fmt.Errorf("malformed line: %s", line)
+}
+
+func percent(rate int) error {
+	return fmt.Errorf("%d%% failed", rate)
+}
+
+func main() {
+	_ = fail("x")
+	_ = percent(3)
+}

--- a/tests/spec/emit/snapshots/errors_new_non_sprintf_args_stay.snap
+++ b/tests/spec/emit/snapshots/errors_new_non_sprintf_args_stay.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:errors"
+  
+  fn plain() -> error {
+    errors.New("plain message")
+  }
+  
+  fn no_interpolation() -> error {
+    errors.New(f"nothing to fill in")
+  }
+  
+  fn solo(msg: string) -> error {
+    errors.New(f"{msg}")
+  }
+  
+  fn main() {
+    let _ = plain()
+    let _ = no_interpolation()
+    let _ = solo("y")
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func plain() error {
+	return errors.New("plain message")
+}
+
+func noInterpolation() error {
+	return errors.New("nothing to fill in")
+}
+
+func solo(msg string) error {
+	return errors.New(fmt.Sprint(msg))
+}
+
+func main() {
+	_ = plain()
+	_ = noInterpolation()
+	_ = solo("y")
+}

--- a/tests/spec/emit/snapshots/for_loop_tuple_pattern_map_discard_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_tuple_pattern_map_discard_value.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(m: Map<string, int>) -> Slice<string> {
+    let mut keys: Slice<string> = []
+    for (key, _) in m {
+      keys = keys.append(key)
+    }
+    keys
+  }
+---
+package main
+
+func test(m map[string]int) []string {
+	keys := []string{}
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/tests/spec/emit/snapshots/indexed_callee_pure_constructor_arg_not_captured.snap
+++ b/tests/spec/emit/snapshots/indexed_callee_pure_constructor_arg_not_captured.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct P(int)
+  fn f0(p: P) -> int { 0 }
+  fn f1(p: P) -> int { 1 }
+  
+  fn main() {
+    let fs = [f0, f1]
+    let i = 0
+    let r = fs[i](P(2))
+    let _ = r
+  }
+---
+package main
+
+type P int
+
+func f0(_ P) int {
+	return 0
+}
+
+func f1(_ P) int {
+	return 1
+}
+
+func main() {
+	fs := []func(P) int{f0, f1}
+	i := 0
+	r := fs[i](P(2))
+	_ = r
+}

--- a/tests/spec/emit/snapshots/slice_make_fills_elements_without_go_zero.snap
+++ b/tests/spec/emit/snapshots/slice_make_fills_elements_without_go_zero.snap
@@ -27,11 +27,9 @@ func main() {
 		}
 		return s
 	}()
-	callee_1 := lisette.SliceGet(maps_, 0).UnwrapOr
-	first := callee_1(make(map[string]int))
+	first := lisette.SliceGet(maps_, 0).UnwrapOr(make(map[string]int))
 	first["k"] = 1
-	callee_2 := lisette.SliceGet(maps_, 1).UnwrapOr
-	second := callee_2(make(map[string]int))
+	second := lisette.SliceGet(maps_, 1).UnwrapOr(make(map[string]int))
 	if len(first) != 1 {
 		panic("expected a writable empty map element")
 	}


### PR DESCRIPTION
- Chained method calls no longer split in two when an arg contains a call or constructor. Reported in #1101.
- `errors.New(f"...")` now emits `fmt.Errorf("...", args)` instead of `errors.New(fmt.Sprintf("...", args))`.
- `for (key, _) in m` now emits `for key := range m` instead of `for key, _ := range m`.
