### PR TITLE
refactor: polish arithmetic, type name, and interface diagnostics

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -193,10 +193,34 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
             ));
     }
 
-    LisetteDiagnostic::error("Type not found")
+    let diagnostic = LisetteDiagnostic::error("Type not found")
         .with_resolve_code("type_not_found")
-        .with_span_label(&name_span, "type not found in scope")
-        .with_help("Define or import this type")
+        .with_span_label(&name_span, "type not found in scope");
+
+    match foreign_type_alias(simple_name) {
+        Some(suggestion) => diagnostic.with_help(format!("Did you mean `{}`?", suggestion)),
+        None => diagnostic.with_help("Define or import this type"),
+    }
+}
+
+fn foreign_type_alias(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "float" | "double" | "f64" => "float64",
+        "f32" => "float32",
+        "i8" => "int8",
+        "i16" => "int16",
+        "i32" => "int32",
+        "i64" => "int64",
+        "u8" => "uint8",
+        "u16" => "uint16",
+        "u32" => "uint32",
+        "u64" => "uint64",
+        "usize" | "isize" => "int",
+        "str" | "String" => "string",
+        "Vec" => "Slice",
+        "HashMap" => "Map",
+        _ => return None,
+    })
 }
 
 pub fn value_in_type_position(
@@ -2022,8 +2046,16 @@ pub fn type_conversion_arity(
 pub struct InterfaceViolation {
     pub interface_name: String,
     pub parent_of: Option<String>,
-    pub missing: Vec<(String, Type)>,
+    pub missing: Vec<MissingMethod>,
     pub incompatible: Vec<(String, Type, Type)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MissingMethod {
+    pub name: String,
+    pub signature: Type,
+    /// A private method that would satisfy this requirement if it were `pub`.
+    pub private_candidate: Option<String>,
 }
 
 pub fn sealed_interface_not_satisfiable(
@@ -2071,7 +2103,16 @@ pub fn interface_not_implemented(
             let methods: Vec<String> = violation
                 .missing
                 .iter()
-                .map(|(name, sig)| format!("  - {}: {}", name, sig))
+                .flat_map(|method| {
+                    let mut lines = vec![format!("  - {}: {}", method.name, method.signature)];
+                    if let Some(private_name) = &method.private_candidate {
+                        lines.push(format!(
+                            "    (add `pub` to the private method `{}` to satisfy this)",
+                            private_name
+                        ));
+                    }
+                    lines
+                })
                 .collect();
             missing_sections.push((header.clone(), methods));
         }
@@ -2380,10 +2421,10 @@ fn operator_verb(operator: &BinaryOperator) -> &'static str {
 fn operator_help(op: &BinaryOperator) -> &'static str {
     match op {
         BinaryOperator::Addition => "requires both operands to have the same type",
-        BinaryOperator::Subtraction
-        | BinaryOperator::Multiplication
-        | BinaryOperator::Division
-        | BinaryOperator::Remainder
+        BinaryOperator::Subtraction | BinaryOperator::Multiplication | BinaryOperator::Division => {
+            "requires both operands to have the same numeric type"
+        }
+        BinaryOperator::Remainder
         | BinaryOperator::BitwiseAnd
         | BinaryOperator::BitwiseOr
         | BinaryOperator::BitwiseXor

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -1,6 +1,6 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
-use diagnostics::infer::InterfaceViolation;
+use diagnostics::infer::{InterfaceViolation, MissingMethod};
 use syntax::ast::Span;
 use syntax::program::{DefinitionBody, Interface, MethodSignatures};
 use syntax::types::{GO_IMPORT_PREFIX, SubstitutionMap, Type, substitute};
@@ -139,12 +139,15 @@ impl InferCtx<'_> {
             return Ok(());
         }
 
+        let resolved = ty.resolve_in(&self.env);
         if let Some(sealed) = violations.iter().find(|v| {
             v.missing
                 .iter()
-                .any(|(name, _)| crate::checker::sealing::is_unexported_key(name))
+                .any(|method| crate::checker::sealing::is_unexported_key(&method.name))
         }) {
-            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            let type_name = resolved
+                .get_name()
+                .map_or_else(|| resolved.to_string(), str::to_owned);
             self.sink
                 .push(diagnostics::infer::sealed_interface_not_satisfiable(
                     &sealed.interface_name,
@@ -153,7 +156,6 @@ impl InferCtx<'_> {
                 ));
             return Err(violations);
         }
-        let resolved = ty.resolve_in(&self.env);
         let wrapper = if resolved.is_result() {
             Some(diagnostics::infer::WrapperKind::Result)
         } else if resolved.is_option() {
@@ -172,7 +174,9 @@ impl InferCtx<'_> {
                     *span,
                 ));
         } else if builtin_receiver {
-            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            let type_name = resolved
+                .get_name()
+                .map_or_else(|| resolved.to_string(), str::to_owned);
             self.sink
                 .push(diagnostics::infer::builtin_type_cannot_implement_interface(
                     &interface.name,
@@ -180,7 +184,9 @@ impl InferCtx<'_> {
                     *span,
                 ));
         } else {
-            let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+            let type_name = resolved
+                .get_name()
+                .map_or_else(|| resolved.to_string(), str::to_owned);
             self.sink
                 .push(diagnostics::infer::interface_not_implemented(
                     &interface.name,
@@ -500,7 +506,7 @@ impl InferCtx<'_> {
             .zip(type_args.iter().cloned())
             .collect();
 
-        let mut missing: Vec<(String, Type)> = Vec::new();
+        let mut missing: Vec<MissingMethod> = Vec::new();
         let mut incompatible: Vec<(String, Type, Type)> = Vec::new();
 
         let resolved_receiver = store.deep_resolve_alias(&ty.strip_refs().resolve_in(&self.env));
@@ -551,11 +557,27 @@ impl InferCtx<'_> {
                             ),
                         );
                     }
-                    missing.push((method_name.to_string(), method_ty.clone()));
+                    missing.push(MissingMethod {
+                        name: method_name.to_string(),
+                        signature: method_ty.clone(),
+                        private_candidate: None,
+                    });
                     continue;
                 }
                 SelectedMethod::Missing => {
-                    missing.push((method_name.to_string(), method_ty.clone()));
+                    let private_candidate = self.private_method_hint(
+                        ty,
+                        &symbol_methods,
+                        interface_qualified_id,
+                        method_name.as_str(),
+                        method_ty,
+                        &map,
+                    );
+                    missing.push(MissingMethod {
+                        name: method_name.to_string(),
+                        signature: method_ty.clone(),
+                        private_candidate,
+                    });
                     continue;
                 }
             };
@@ -580,7 +602,11 @@ impl InferCtx<'_> {
             }
 
             if !signature.receiver_pinned {
-                missing.push((method_name.to_string(), method_ty.clone()));
+                missing.push(MissingMethod {
+                    name: method_name.to_string(),
+                    signature: method_ty.clone(),
+                    private_candidate: None,
+                });
             } else if !signature.matched {
                 incompatible.push((
                     method_name.to_string(),
@@ -653,6 +679,39 @@ impl InferCtx<'_> {
             Some((name, method)) => SelectedMethod::Found(name.clone(), method.clone()),
             None => SelectedMethod::Missing,
         }
+    }
+
+    fn private_method_hint(
+        &mut self,
+        ty: &Type,
+        symbol_methods: &MethodSignatures,
+        interface_qualified_id: &str,
+        method_name: &str,
+        method_ty: &Type,
+        map: &SubstitutionMap,
+    ) -> Option<String> {
+        let interface_is_public = self
+            .store
+            .get_definition(interface_qualified_id)
+            .is_some_and(|d| d.visibility.is_public());
+        let (impl_name, impl_method) = syntax::go_names::conformance_method_if_public(
+            symbol_methods,
+            interface_qualified_id,
+            interface_is_public,
+            method_name,
+            &|name| self.conformance_candidate(ty, name),
+        )?;
+        let impl_name = impl_name.to_string();
+        let impl_method = impl_method.clone();
+        let signature = self.check_method_signature(
+            ty,
+            interface_qualified_id,
+            method_name,
+            method_ty,
+            &impl_method,
+            map,
+        );
+        (signature.receiver_pinned && signature.matched).then_some(impl_name)
     }
 
     fn check_method_signature(

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -230,6 +230,29 @@ pub fn conformance_method<'a>(
     if interface_matches_by_source_name(interface_id, interface_is_public) {
         return methods.get_key_value(method_name);
     }
+    select_by_emitted_name(methods, interface_id, method_name, candidate, false)
+}
+
+pub fn conformance_method_if_public<'a>(
+    methods: &'a MethodSignatures,
+    interface_id: &str,
+    interface_is_public: bool,
+    method_name: &str,
+    candidate: &dyn Fn(&str) -> ConformanceCandidate,
+) -> Option<(&'a EcoString, &'a Type)> {
+    if interface_matches_by_source_name(interface_id, interface_is_public) {
+        return None;
+    }
+    select_by_emitted_name(methods, interface_id, method_name, candidate, true)
+}
+
+fn select_by_emitted_name<'a>(
+    methods: &'a MethodSignatures,
+    interface_id: &str,
+    method_name: &str,
+    candidate: &dyn Fn(&str) -> ConformanceCandidate,
+    as_if_public: bool,
+) -> Option<(&'a EcoString, &'a Type)> {
     let want = if interface_id.starts_with(GO_IMPORT_PREFIX) {
         Cow::Borrowed(method_name)
     } else {
@@ -242,7 +265,10 @@ pub fn conformance_method<'a>(
         if info.shadowed {
             continue;
         }
-        let emitted = if info.exported {
+        if as_if_public && (info.exported || exact) {
+            continue;
+        }
+        let emitted = if info.exported || as_if_public {
             Cow::Owned(snake_to_camel(name))
         } else {
             Cow::Owned(snake_to_lower_camel(name))
@@ -431,6 +457,28 @@ mod tests {
         methods.insert("Read".into(), Type::Error);
         let via_source = conformance_method(&methods, "go:io", true, "Read", &UNEXPORTED);
         assert_eq!(via_source.map(|(name, _)| name.as_str()), Some("Read"));
+    }
+
+    #[test]
+    fn conformance_method_if_public_finds_private_near_misses() {
+        let mut methods = MethodSignatures::default();
+        methods.insert("write".into(), Type::Error);
+
+        let private_hit =
+            conformance_method_if_public(&methods, "go:io", true, "Write", &UNEXPORTED);
+        assert_eq!(private_hit.map(|(name, _)| name.as_str()), Some("write"));
+
+        let already_exported =
+            conformance_method_if_public(&methods, "go:io", true, "Write", &exported_at(0));
+        assert_eq!(already_exported, None);
+
+        let exact_name =
+            conformance_method_if_public(&methods, "main.W", true, "write", &UNEXPORTED);
+        assert_eq!(exact_name, None);
+
+        let source_matched =
+            conformance_method_if_public(&methods, "main.W", false, "write", &UNEXPORTED);
+        assert_eq!(source_matched, None);
     }
 
     #[test]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2687,6 +2687,24 @@ fn test() {
 }
 
 #[test]
+fn infer_type_not_found_float_suggests_float64() {
+    let input = r#"
+struct Circle { radius: float }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_not_found_vec_suggests_slice() {
+    let input = r#"
+fn test(items: Vec<int>) -> int {
+  0
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_type_not_found_struct_bound() {
     let input = r#"
 struct Foo<T: Undefined> {}
@@ -3585,6 +3603,16 @@ fn test() {
 }
 
 #[test]
+fn infer_division_int_float_mismatch() {
+    let input = r#"
+fn half(n: int) -> float64 {
+  n / 2.0
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_comparison_type_mismatch() {
     let input = r#"
 fn test() {
@@ -3858,6 +3886,63 @@ impl Ctx {
 fn test() {
   let c = Ctx {}
   c.fatal(c.read())
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_not_implemented_ref_argument_resolves() {
+    let input = r#"
+import "go:fmt"
+
+struct Sink {}
+
+fn main() {
+  let mut sink = Sink {}
+  fmt.Fprintf(&sink, "x")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_missing_method_private_candidate_hint() {
+    let input = r#"
+import "go:fmt"
+
+struct Shouter { written: Slice<byte> }
+
+impl Shouter {
+  fn write(self: Ref<Shouter>, p: Slice<byte>) -> Partial<int, error> {
+    Partial.Ok(p.length())
+  }
+}
+
+fn main() {
+  let mut shouter = Shouter { written: [] }
+  fmt.Fprintf(&shouter, "x")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_missing_method_private_candidate_wrong_signature() {
+    let input = r#"
+import "go:fmt"
+
+struct Shouter {}
+
+impl Shouter {
+  fn write(self: Ref<Shouter>, p: string) -> Partial<int, error> {
+    Partial.Ok(p.length())
+  }
+}
+
+fn main() {
+  let mut shouter = Shouter {}
+  fmt.Fprintf(&shouter, "x")
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_division_int_float_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_division_int_float_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:3:3]
+ 2 │ fn half(n: int) -> float64 {
+ 3 │   n / 2.0
+   ·   ───┬───
+   ·      ╰── cannot divide `int` and `float64`
+ 4 │ }
+   ╰────
+  help: The `/` operator requires both operands to have the same numeric type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_hint.snap
+++ b/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_hint.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:14:15]
+ 13 │   let mut shouter = Shouter { written: [] }
+ 14 │   fmt.Fprintf(&shouter, "x")
+    ·               ────┬───
+    ·                   ╰── `Shouter` does not implement `Writer`
+ 15 │ }
+    ╰────
+  help: Missing methods:
+          From `Writer`
+            - Write: fn (Slice<byte>) -> Partial<int, error>
+              (add `pub` to the private method `write` to satisfy this)
+        code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_wrong_signature.snap
+++ b/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_wrong_signature.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:14:15]
+ 13 │   let mut shouter = Shouter {}
+ 14 │   fmt.Fprintf(&shouter, "x")
+    ·               ────┬───
+    ·                   ╰── `Shouter` does not implement `Writer`
+ 15 │ }
+    ╰────
+  help: Missing methods:
+          From `Writer`
+            - Write: fn (Slice<byte>) -> Partial<int, error>
+        code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_not_implemented_ref_argument_resolves.snap
+++ b/tests/ui/errors/snapshots/infer_interface_not_implemented_ref_argument_resolves.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Interface not implemented
+   ╭─[test.lis:8:15]
+ 7 │   let mut sink = Sink {}
+ 8 │   fmt.Fprintf(&sink, "x")
+   ·               ──┬──
+   ·                 ╰── `Sink` does not implement `Writer`
+ 9 │ }
+   ╰────
+  help: Missing methods:
+          From `Writer`
+            - Write: fn (Slice<byte>) -> Partial<int, error>
+        code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_type_not_found_float_suggests_float64.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_float_suggests_float64.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type not found
+   ╭─[test.lis:2:25]
+ 1 │ 
+ 2 │ struct Circle { radius: float }
+   ·                         ──┬──
+   ·                           ╰── type not found in scope
+   ╰────
+  help: Did you mean `float64`? · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_vec_suggests_slice.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_vec_suggests_slice.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type not found
+   ╭─[test.lis:2:16]
+ 1 │ 
+ 2 │ fn test(items: Vec<int>) -> int {
+   ·                ─┬─
+   ·                 ╰── type not found in scope
+ 3 │   0
+   ╰────
+  help: Did you mean `Slice`? · code: [resolve.type_not_found]


### PR DESCRIPTION
- The help for mixed-operand `-`, `*`, and `/` now says the operands must share a numeric type. It used to claim an int was required, which is wrong for float operands.
- `Type not found` now suggests the Lis spelling for common type names from other languages: `float` and `double` suggest `float64`, `i32` suggests `int32`, `Vec` suggests `Slice`, `HashMap` suggests `Map`, etc.
- `Interface not implemented` now renders the resolved arg type - it was leaking the internal type var e.g. `Ref<A>`.
- When a private method has the exact name and sig an interface requires, the missing-method list now points to the visibility issue: "(add `pub` to the private method `write` to satisfy this)"
