### PR TITLE
fix: bound AST depth for long operator chains

### DIFF
--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -46,11 +46,17 @@ impl<'source> Parser<'source> {
             }
 
             if self.at_range() && RANGE_PREC > min_prec {
+                if !self.enter_recursion() {
+                    break;
+                }
                 lhs = self.parse_range(Some(lhs.into()), start);
                 continue;
             }
 
             if self.current_token().kind == As && CAST_PREC > min_prec {
+                if !self.enter_recursion() {
+                    break;
+                }
                 self.next();
                 let target_type = self.parse_annotation();
                 lhs = ast::Expression::Cast {
@@ -72,6 +78,9 @@ impl<'source> Parser<'source> {
             if let Some(prec) = self.binary_operator_precedence(self.current_token().kind)
                 && prec > min_prec
             {
+                if !self.enter_recursion() {
+                    break;
+                }
                 let operator = self.parse_binary_operator();
                 let rhs = self.pratt_parse(prec);
                 lhs = ast::Expression::Binary {
@@ -480,5 +489,50 @@ fn format_annotation(ann: &ast::Annotation) -> std::string::String {
             text.clone().unwrap_or_else(|| value.to_string())
         }
         ast::Annotation::Unknown | ast::Annotation::Opaque { .. } => "_".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::Expression;
+    use crate::parse::{MAX_DEPTH, Parser};
+
+    fn depth(expression: &Expression) -> u32 {
+        1 + expression
+            .children()
+            .into_iter()
+            .map(depth)
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn parse_bounded(source: &str) -> u32 {
+        let result = Parser::lex_and_parse_file(source, 0);
+        assert!(result.failed(), "expected a nesting error");
+        result.ast.iter().map(depth).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn long_pipeline_chain_stays_shallow() {
+        let source = format!("pub const x = a{}", " |> f".repeat(500));
+        assert!(parse_bounded(&source) <= MAX_DEPTH);
+    }
+
+    #[test]
+    fn long_binary_chain_stays_shallow() {
+        let source = format!("pub const x: int = 1{}", " + 1".repeat(500));
+        assert!(parse_bounded(&source) <= MAX_DEPTH);
+    }
+
+    #[test]
+    fn long_cast_chain_stays_shallow() {
+        let source = format!("pub const x = 1{}", " as int".repeat(500));
+        assert!(parse_bounded(&source) <= MAX_DEPTH);
+    }
+
+    #[test]
+    fn long_range_chain_stays_shallow() {
+        let source = format!("pub const x = 1{}", "..2".repeat(500));
+        assert!(parse_bounded(&source) <= MAX_DEPTH);
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lisette-deps"
-version = "0.4.2"
+version = "0.9.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.4.2"
+version = "0.9.0"
 dependencies = [
  "lisette-syntax",
  "miette",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.4.2"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -217,11 +217,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.4.2"
+version = "0.9.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.4.2"
+version = "0.9.0"
 dependencies = [
  "ecow",
  "rustc-hash",


### PR DESCRIPTION
Long chains of `|>`, binary, `as`, or `..` operators aborted the compiler with a stack overflow.

```rs
const x = value |> f |> f |> f // ... repeated >100 times
```

These chains now error out with `too deeply nested` at the same 64-level limit that already bounds parens, nested calls, and `.a.b.c` chains.

Fix #1102
