### PR TITLE
feat: add LSP restart command and label-first diagnostics

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -321,6 +321,12 @@ impl LisetteDiagnostic {
         &self.message
     }
 
+    pub fn plain_label(&self) -> Option<&str> {
+        self.labels
+            .iter()
+            .find_map(|span| span.label().filter(|text| !text.is_empty()))
+    }
+
     pub fn plain_help(&self) -> Option<&str> {
         self.help.as_deref()
     }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -278,13 +278,16 @@ pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Di
             DiagnosticSeverity::WARNING
         }),
         message: {
-            let mut msg = d.plain_message().to_string();
+            let mut msg = match d.plain_label() {
+                Some(label) => label.to_string(),
+                None => d.plain_message().to_string(),
+            };
             if let Some(help) = d.plain_help() {
-                msg.push_str(". ");
+                msg.push_str(" · ");
                 msg.push_str(help);
             }
             if let Some(note) = d.plain_note() {
-                msg.push_str(". ");
+                msg.push_str(" · ");
                 msg.push_str(note);
             }
             msg

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -13113,7 +13113,12 @@ async fn library_main_function_is_not_flagged() {
     let diags = client.await_diagnostics().await;
     let bad: Vec<_> = diags
         .iter()
-        .filter(|d| d.message.contains("main signature"))
+        .filter(|d| {
+            d.code
+                == Some(NumberOrString::String(
+                    "infer.invalid_main_signature".to_string(),
+                ))
+        })
         .collect();
     assert!(
         bad.is_empty(),
@@ -13143,9 +13148,16 @@ async fn creating_main_lis_flips_a_library_to_a_binary() {
         .to_string();
     client.open(&uri, content).await;
 
+    let is_main_signature = |d: &Diagnostic| {
+        d.code
+            == Some(NumberOrString::String(
+                "infer.invalid_main_signature".to_string(),
+            ))
+    };
+
     let diags = client.await_diagnostics().await;
     assert!(
-        !diags.iter().any(|d| d.message.contains("main signature")),
+        !diags.iter().any(is_main_signature),
         "library `main` should not be flagged: {diags:?}"
     );
 
@@ -13154,7 +13166,7 @@ async fn creating_main_lis_flips_a_library_to_a_binary() {
 
     let diags = client.await_diagnostics().await;
     assert!(
-        diags.iter().any(|d| d.message.contains("main signature")),
+        diags.iter().any(is_main_signature),
         "after `src/main.lis` appears the project is a binary: {diags:?}"
     );
     client.shutdown().await;

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -14,6 +14,13 @@
   "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "lisette.restartServer",
+        "title": "Restart Server",
+        "category": "Lisette"
+      }
+    ],
     "languages": [
       {
         "id": "lisette",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { type ExtensionContext, window, workspace } from "vscode";
+import { type ExtensionContext, commands, window, workspace } from "vscode";
 import {
   LanguageClient,
   type LanguageClientOptions,
@@ -8,7 +8,7 @@ import {
 
 let client: LanguageClient | undefined;
 
-export async function activate(context: ExtensionContext) {
+async function startClient() {
   const config = workspace.getConfiguration("lisette");
   const command: string = config.get("serverPath") || "lis";
 
@@ -35,6 +35,17 @@ export async function activate(context: ExtensionContext) {
       `Failed to find the Lisette language server. Install it with "cargo install lisette" or configure "lisette.serverPath" in VS Code settings to point to your binary.`,
     );
   }
+}
+
+export async function activate(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand("lisette.restartServer", async () => {
+      await client?.stop();
+      await startClient();
+    }),
+  );
+
+  await startClient();
 }
 
 export async function deactivate() {


### PR DESCRIPTION
- Adds a `Lisette: Restart Server` command to the VS Code extension, to restart the LSP server without reloading the window.
- Editor diagnostics now lead with the span label rather than the generic heading, and join help and note with a middot.