### PR TITLE
refactor: encode more invariants in type system

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -134,14 +134,13 @@ fn generics_to_string(generics: &[Generic]) -> String {
             generics
                 .iter()
                 .map(|g| {
-                    if g.bounds.is_empty() {
+                    if g.bound_count() == 0 {
                         g.name.to_string()
                     } else {
                         format!(
                             "{}: {}",
                             g.name,
-                            g.bounds
-                                .iter()
+                            g.bounds()
                                 .map(annotation_to_string)
                                 .collect::<Vec<_>>()
                                 .join(" + ")

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -119,11 +119,11 @@ pub fn compile(
     let emit_stamps = analyze_output.emit_stamps;
     let unreachable_modules = analyze_output.unreachable_modules;
 
-    let user_file_count: usize = semantic_result
-        .modules
+    let user_file_count = semantic_result
+        .files
         .values()
-        .map(|module| module.file_ids.len())
-        .sum();
+        .filter(|file| !file.is_d_lis())
+        .count();
 
     let sources: HashMap<u32, SourceInfo> = semantic_result
         .files
@@ -142,7 +142,14 @@ pub fn compile(
     let failed = semantic_result.failed();
     let mut errors = semantic_result.errors.clone();
     let mut lints = semantic_result.lints.clone();
-    let live_modules: Vec<String> = semantic_result.modules.keys().cloned().collect();
+    let mut live_modules: Vec<String> = semantic_result
+        .files
+        .values()
+        .filter(|file| !file.is_d_lis())
+        .map(|file| file.module_id.clone())
+        .collect();
+    live_modules.sort_unstable();
+    live_modules.dedup();
     let test_index = semantic_result.test_index.clone();
 
     if !unreachable_modules.is_empty() && !config.emit_tests {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2008,12 +2008,13 @@ pub fn not_callable(
     ty: &Type,
     callee_name: Option<&str>,
     arg_name: Option<&str>,
+    has_underlying_type: bool,
     span: Span,
 ) -> LisetteDiagnostic {
     let type_name = ty.get_name();
     let is_type_call = matches!((callee_name, type_name), (Some(c), Some(t)) if c == t);
-    let is_cast_target = ty.get_underlying().is_some()
-        || type_name.is_some_and(|n| SimpleKind::from_name(n).is_some());
+    let is_cast_target =
+        has_underlying_type || type_name.is_some_and(|n| SimpleKind::from_name(n).is_some());
 
     let help = if is_type_call && is_cast_target {
         let subject = arg_name.unwrap_or("value");
@@ -2818,7 +2819,20 @@ pub fn continue_in_defer_block(span: Span) -> LisetteDiagnostic {
         .with_help("Remove the `continue`, or move it inside a loop within the `defer` block")
 }
 
-pub fn invalid_cast(source_ty: &Type, target_ty: &Type, span: Span) -> LisetteDiagnostic {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidCastKind {
+    Complex,
+    RuneToByte,
+    ByteToString,
+    Other,
+}
+
+pub fn invalid_cast(
+    source_ty: &Type,
+    target_ty: &Type,
+    kind: InvalidCastKind,
+    span: Span,
+) -> LisetteDiagnostic {
     let same_constructor_with_unresolved = source_ty
         .get_qualified_id()
         .zip(target_ty.get_qualified_id())
@@ -2832,11 +2846,11 @@ pub fn invalid_cast(source_ty: &Type, target_ty: &Type, span: Span) -> LisetteDi
         )
     } else if source_ty.is_string() {
         "Strings cannot be cast to numbers and require explicit conversion. Use `strconv.Atoi()` to parse.".into()
-    } else if source_ty.is_complex() || target_ty.is_complex() {
+    } else if kind == InvalidCastKind::Complex {
         "Complex numbers cannot be cast directly. Use `real(c)` or `imaginary(c)` to extract components.".into()
-    } else if source_ty.has_underlying_rune() && target_ty.has_underlying_byte() {
+    } else if kind == InvalidCastKind::RuneToByte {
         "rune (int32) is wider than byte (uint8) and may not fit. Use an intermediate variable to cast via int first: `let n = r as int; n as byte`".into()
-    } else if source_ty.has_underlying_byte() && target_ty.is_string() {
+    } else if kind == InvalidCastKind::ByteToString {
         "A byte has two readings as a string. Use `[b] as string` to preserve the byte (may be invalid UTF-8), or cast through a rune to encode as a codepoint: `let r = b as rune; r as string`".into()
     } else {
         "Casts are supported between numeric types, between string and byte/rune slices, from rune to string, and from concrete types to interfaces.".into()

--- a/crates/diagnostics/src/result.rs
+++ b/crates/diagnostics/src/result.rs
@@ -3,20 +3,16 @@ use std::path::PathBuf;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ParseError;
-use syntax::ast::Span;
 use syntax::program::{
-    Definition, EmitInput, EqualityIndex, File, ModuleInfo, MutationInfo, ResolvedDefinitions,
-    TestIndex, UnusedInfo,
+    Definition, EmitInput, EqualityIndex, File, MutationInfo, TestIndex, UnusedInfo,
 };
-use syntax::types::{Symbol, Type};
+use syntax::types::Symbol;
 
 use crate::LisetteDiagnostic;
 
 pub struct SemanticResult {
     pub files: HashMap<u32, File>,
     pub definitions: HashMap<Symbol, Definition>,
-    pub const_names: HashSet<Symbol>,
-    pub modules: HashMap<String, ModuleInfo>,
     pub errors: Vec<LisetteDiagnostic>,
     pub lints: Vec<LisetteDiagnostic>,
     pub entry_module_id: String,
@@ -32,9 +28,6 @@ pub struct SemanticResult {
     pub typedef_paths: HashMap<u32, PathBuf>,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
-    /// Resolved type for each generic-bound annotation, keyed by span.
-    pub bound_types: HashMap<Span, Type>,
-    pub resolved_definitions: ResolvedDefinitions,
 }
 
 impl SemanticResult {
@@ -42,8 +35,6 @@ impl SemanticResult {
         Self {
             files: HashMap::default(),
             definitions: HashMap::default(),
-            const_names: HashSet::default(),
-            modules: HashMap::default(),
             errors: errors.into_iter().map(Into::into).collect(),
             lints: vec![],
             entry_module_id: entry_module_id.to_string(),
@@ -56,8 +47,6 @@ impl SemanticResult {
             typedef_paths: HashMap::default(),
             go_package_names: HashMap::default(),
             go_module_ids: HashSet::default(),
-            bound_types: HashMap::default(),
-            resolved_definitions: HashMap::default(),
         }
     }
 
@@ -69,8 +58,6 @@ impl SemanticResult {
         EmitInput {
             files: self.files,
             definitions: self.definitions,
-            const_names: self.const_names,
-            modules: self.modules,
             entry_module_id: self.entry_module_id,
             unused: self.unused,
             mutations: self.mutations,
@@ -80,8 +67,6 @@ impl SemanticResult {
             test_index: self.test_index,
             go_package_names: self.go_package_names,
             go_module_ids: self.go_module_ids,
-            bound_types: self.bound_types,
-            resolved_definitions: self.resolved_definitions,
         }
     }
 }

--- a/crates/emit/src/abi/catalog.rs
+++ b/crates/emit/src/abi/catalog.rs
@@ -34,7 +34,7 @@ impl GoAbiCatalog {
                 continue;
             }
             catalog.register_callable(definitions, qualified_name, definition);
-            catalog.register_fields(qualified_name, definition);
+            catalog.register_fields(definitions, qualified_name, definition);
         }
         catalog
     }
@@ -78,12 +78,18 @@ impl GoAbiCatalog {
             .params
             .iter()
             .map(|parameter| GoSlotDescriptor {
-                origin: SlotOrigin::go_parameter(&parameter.ty),
+                origin: SlotOrigin::go_parameter(syntax::types::resolves_to_unknown(
+                    &parameter.ty,
+                    |id| definitions.get(id),
+                )),
                 declared_type: parameter.ty.clone(),
             })
             .collect();
         let return_slot = GoSlotDescriptor {
-            origin: SlotOrigin::go_return(&function.return_type),
+            origin: SlotOrigin::go_return(syntax::types::resolves_to_unknown(
+                &function.return_type,
+                |id| definitions.get(id),
+            )),
             declared_type: (*function.return_type).clone(),
         };
         let return_abi =
@@ -98,7 +104,12 @@ impl GoAbiCatalog {
         );
     }
 
-    fn register_fields(&mut self, qualified_name: &str, definition: &Definition) {
+    fn register_fields(
+        &mut self,
+        definitions: &HashMap<Symbol, Definition>,
+        qualified_name: &str,
+        definition: &Definition,
+    ) {
         let DefinitionBody::Struct { fields, .. } = &definition.body else {
             return;
         };
@@ -107,7 +118,10 @@ impl GoAbiCatalog {
             slots.insert(
                 field.name.to_string(),
                 GoSlotDescriptor {
-                    origin: SlotOrigin::go_field(&field.ty),
+                    origin: SlotOrigin::go_field(syntax::types::resolves_to_unknown(
+                        &field.ty,
+                        |id| definitions.get(id),
+                    )),
                     declared_type: field.ty.clone(),
                 },
             );

--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -13,24 +13,20 @@ pub(crate) enum SlotOrigin {
 }
 
 impl SlotOrigin {
-    pub(crate) fn go_parameter(ty: &Type) -> Self {
-        Self::go_slot(Self::GoParameter, ty)
+    pub(crate) fn go_parameter(is_any: bool) -> Self {
+        Self::go_slot(Self::GoParameter, is_any)
     }
 
-    pub(crate) fn go_return(ty: &Type) -> Self {
-        Self::go_slot(Self::GoReturn, ty)
+    pub(crate) fn go_return(is_any: bool) -> Self {
+        Self::go_slot(Self::GoReturn, is_any)
     }
 
-    pub(crate) fn go_field(ty: &Type) -> Self {
-        Self::go_slot(Self::GoField, ty)
+    pub(crate) fn go_field(is_any: bool) -> Self {
+        Self::go_slot(Self::GoField, is_any)
     }
 
-    fn go_slot(origin: Self, ty: &Type) -> Self {
-        if ty.resolves_to_unknown() {
-            Self::GoAny
-        } else {
-            origin
-        }
+    fn go_slot(origin: Self, is_any: bool) -> Self {
+        if is_any { Self::GoAny } else { origin }
     }
 
     fn nested(self) -> Self {
@@ -370,10 +366,13 @@ impl Planner<'_> {
         declaration: Option<&Type>,
     ) -> ValueLayout {
         let resolved_declaration = declaration.map(|ty| self.facts.peel_alias(ty));
-        if resolved_declaration
-            .as_ref()
-            .is_some_and(is_opaque_layout_hint)
-        {
+        if resolved_declaration.as_ref().is_some_and(|ty| {
+            self.facts.resolves_to_unknown(ty)
+                || matches!(
+                    ty.unwrap_forall(),
+                    Type::Parameter(_) | Type::Var { .. } | Type::ReceiverPlaceholder
+                )
+        }) {
             return self.value_layout_with_hint(ty, SlotOrigin::Lisette, None);
         }
 
@@ -591,14 +590,6 @@ fn optional_layouts_match(left: Option<&ValueLayout>, right: Option<&ValueLayout
         (None, None) => true,
         _ => false,
     }
-}
-
-fn is_opaque_layout_hint(ty: &Type) -> bool {
-    ty.resolves_to_unknown()
-        || matches!(
-            ty.unwrap_forall(),
-            Type::Parameter(_) | Type::Var { .. } | Type::ReceiverPlaceholder
-        )
 }
 
 fn compound_hint(

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -8,7 +8,7 @@ use crate::Planner;
 use crate::names::go_name::PRELUDE_ERROR_ID;
 use crate::types::go_type::GoType;
 use callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
-use syntax::ast::Expression;
+use syntax::ast::{Expression, IdentifierResolution};
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -189,6 +189,9 @@ pub(crate) fn is_tagged_shape_fn_value(expression: &Expression) -> bool {
     }
     matches!(
         inner,
-        Expression::Identifier { qualified: Some(q), .. } if q.starts_with("prelude.")
+        Expression::Identifier {
+            resolution: IdentifierResolution::Definition(q),
+            ..
+        } if q.starts_with("prelude.")
     )
 }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -5,8 +5,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{BindingId, Pattern, RestPattern, Span};
 use syntax::program::{
-    Definition, DefinitionBody, EqualityIndex, ModuleId, MutationInfo, ResolvedDefinitions,
-    TestIndex, UnusedInfo,
+    Definition, DefinitionBody, EqualityIndex, ModuleId, MutationInfo, TestIndex, UnusedInfo,
 };
 use syntax::types::{Symbol, Type};
 
@@ -19,7 +18,6 @@ use crate::{EmitOptions, GlobalEmitData};
 
 pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) definitions: &'a HashMap<Symbol, Definition>,
-    pub(crate) const_names: &'a HashSet<Symbol>,
     pub(crate) unused: &'a UnusedInfo,
     pub(crate) mutations: &'a MutationInfo,
     pub(crate) ufcs_methods: &'a HashSet<(String, String)>,
@@ -33,13 +31,11 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) options: EmitOptions,
     pub(crate) line_indexes: Arc<HashMap<u32, LineIndex>>,
     pub(crate) globals: Arc<GlobalEmitData>,
-    pub(crate) resolved_definitions: &'a ResolvedDefinitions,
     pub(crate) current_module: ModuleId,
 }
 
 pub(crate) struct EmitFacts<'a> {
     definitions: &'a HashMap<Symbol, Definition>,
-    const_names: &'a HashSet<Symbol>,
     unused: &'a UnusedInfo,
     mutations: &'a MutationInfo,
     ufcs_methods: &'a HashSet<(String, String)>,
@@ -53,7 +49,6 @@ pub(crate) struct EmitFacts<'a> {
     options: EmitOptions,
     line_indexes: Arc<HashMap<u32, LineIndex>>,
     globals: Arc<GlobalEmitData>,
-    pub(crate) resolved_definitions: &'a ResolvedDefinitions,
     current_module: ModuleId,
 }
 
@@ -61,7 +56,6 @@ impl<'a> EmitFacts<'a> {
     pub(crate) fn new(config: EmitFactsConfig<'a>) -> Self {
         Self {
             definitions: config.definitions,
-            const_names: config.const_names,
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
@@ -75,7 +69,6 @@ impl<'a> EmitFacts<'a> {
             options: config.options,
             line_indexes: config.line_indexes,
             globals: config.globals,
-            resolved_definitions: config.resolved_definitions,
             current_module: config.current_module,
         }
     }
@@ -92,7 +85,8 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn is_const(&self, qualified_name: &str) -> bool {
-        self.const_names.contains(qualified_name)
+        self.definition(qualified_name)
+            .is_some_and(Definition::is_const)
     }
 
     pub(crate) fn iter_definitions(&self) -> impl Iterator<Item = (&'a Symbol, &'a Definition)> {
@@ -109,6 +103,30 @@ impl<'a> EmitFacts<'a> {
 
     pub(crate) fn peel_alias(&self, ty: &Type) -> Type {
         peel_alias(self.definitions, ty)
+    }
+
+    pub(crate) fn underlying_type(&self, ty: &Type) -> Option<Type> {
+        syntax::types::underlying_type(ty, |id| self.definition(id))
+    }
+
+    pub(crate) fn underlying_simple_kind(&self, ty: &Type) -> Option<syntax::types::SimpleKind> {
+        syntax::types::underlying_simple_kind(ty, |id| self.definition(id))
+    }
+
+    pub(crate) fn underlying_numeric_type(&self, ty: &Type) -> Option<Type> {
+        syntax::types::underlying_numeric_type(ty, |id| self.definition(id))
+    }
+
+    pub(crate) fn is_aliased_numeric_type(&self, ty: &Type) -> bool {
+        syntax::types::is_aliased_numeric_type(ty, |id| self.definition(id))
+    }
+
+    pub(crate) fn resolves_to_unknown(&self, ty: &Type) -> bool {
+        syntax::types::resolves_to_unknown(ty, |id| self.definition(id))
+    }
+
+    pub(crate) fn contains_unknown(&self, ty: &Type) -> bool {
+        syntax::types::contains_unknown(ty, |id| self.definition(id))
     }
 
     pub(crate) fn strip_and_peel(&self, ty: &Type) -> Type {
@@ -335,19 +353,14 @@ fn as_interface(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Option<
 }
 
 fn resolve_to_function_type(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Option<Type> {
-    fn as_function(ty: &Type) -> Option<Type> {
-        if matches!(ty, Type::Function(_)) {
-            return Some(ty.clone());
-        }
-        ty.get_underlying()
-            .filter(|u| matches!(u, Type::Function(_)))
-            .cloned()
+    let resolved = peel_alias(definitions, ty);
+    if matches!(resolved, Type::Function(_)) {
+        return Some(resolved);
     }
-    as_function(ty).or_else(|| as_function(&peel_alias(definitions, ty)))
+    syntax::types::underlying_type(ty, |id| definitions.get(id))
+        .filter(|underlying| matches!(underlying, Type::Function(_)))
 }
 
 fn peel_alias(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Type {
-    syntax::types::peel_alias(ty, |id| {
-        definitions.get(id).is_some_and(Definition::is_type_alias)
-    })
+    syntax::types::peel_alias(ty, |id| definitions.get(id))
 }

--- a/crates/emit/src/analyze/inline_uses.rs
+++ b/crates/emit/src/analyze/inline_uses.rs
@@ -113,7 +113,6 @@ impl<'a> Walker<'a> {
             }
             Expression::Literal { .. }
             | Expression::Unit { .. }
-            | Expression::NoOp
             | Expression::Break { value: None, .. }
             | Expression::Continue { .. } => {}
 
@@ -155,11 +154,11 @@ impl<'a> Walker<'a> {
             Expression::Let {
                 binding,
                 value,
-                else_block,
+                mode,
                 ..
             } => {
                 self.walk(value);
-                if let Some(else_b) = else_block {
+                if let Some(else_b) = mode.else_block() {
                     self.walk(else_b);
                 }
                 if pattern_binds_name(&binding.pattern, self.name) {
@@ -275,12 +274,22 @@ impl<'a> Walker<'a> {
                 self.enclosure_depth -= 1;
             }
 
-            Expression::Lambda { params, body, .. } | Expression::Function { params, body, .. } => {
+            Expression::Lambda { params, body, .. } => {
                 self.enclosure_depth += 1;
                 let shadowed = params
                     .iter()
                     .any(|p| pattern_binds_name(&p.pattern, self.name));
                 self.with_shadow(shadowed, |w| w.walk(body));
+                self.enclosure_depth -= 1;
+            }
+            Expression::Function { params, body, .. } => {
+                self.enclosure_depth += 1;
+                let shadowed = params
+                    .iter()
+                    .any(|p| pattern_binds_name(&p.pattern, self.name));
+                if let Some(body) = body.definition() {
+                    self.with_shadow(shadowed, |w| w.walk(body));
+                }
                 self.enclosure_depth -= 1;
             }
             Expression::Task { expression, .. } | Expression::Defer { expression, .. } => {
@@ -308,7 +317,11 @@ impl<'a> Walker<'a> {
             }
 
             // Block-local `Const`/`Function` shadowing is applied in `walk_block`.
-            Expression::Const { expression, .. } => self.walk(expression),
+            Expression::Const { expression, .. } => {
+                if let Some(value) = expression.value() {
+                    self.walk(value);
+                }
+            }
             Expression::VariableDeclaration { .. } => {}
 
             Expression::ImplBlock { methods, .. } => {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -164,16 +164,15 @@ impl Planner<'_> {
     }
 
     pub(crate) fn peel_alias_id(&self, id: &str) -> String {
-        syntax::types::peel_alias_id(id, |current| {
-            let definition = self.facts.definition(current)?;
-            if !matches!(definition.body, DefinitionBody::TypeAlias { .. }) {
-                return None;
-            }
-            let Type::Nominal { id: next, .. } = definition.ty.unwrap_forall() else {
-                return None;
-            };
-            Some(next.to_string())
-        })
+        let nominal = Type::Nominal {
+            id: id.into(),
+            params: Vec::new(),
+        };
+        self.facts
+            .peel_alias(&nominal)
+            .get_qualified_id()
+            .unwrap_or(id)
+            .to_string()
     }
 
     pub(crate) fn as_enum(&self, ty: &Type) -> Option<String> {
@@ -189,7 +188,7 @@ impl Planner<'_> {
             return false;
         }
         let inner = ty.ok_type();
-        if inner.contains_unknown() || inner.has_name("any") {
+        if self.facts.contains_unknown(&inner) || inner.has_name("any") {
             return false;
         }
         !self.facts.is_nilable_go_type(&inner)

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::expressions::access::struct_call::emit_struct_literal;
 use crate::names::generics::extract_type_mapping;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use std::borrow::Cow;
 
 use super::NativeCallContext;
@@ -14,11 +14,10 @@ use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
-use syntax::ast::{Expression, StructKind};
+use syntax::ast::{Expression, ResolvedCallTypeArguments, StructKind};
 use syntax::program::{CallKind, Definition, DefinitionBody};
 use syntax::types::{
-    CompoundKind, FunctionParameter, SimpleKind, SubstitutionMap, Symbol, Type,
-    build_substitution_map, substitute,
+    CompoundKind, FunctionParameter, SimpleKind, Type, build_substitution_map, substitute,
 };
 
 struct TupleStructTarget {
@@ -63,27 +62,7 @@ impl Planner<'_> {
         if self.is_function_alias(ty) {
             return true;
         }
-        let mut current = ty.clone();
-        let mut seen: HashSet<Symbol> = HashSet::default();
-        while let Type::Nominal { id, params, .. } = &current {
-            if !seen.insert(id.clone()) {
-                break;
-            }
-            let Some(definition) = self.facts.definition(id.as_str()) else {
-                break;
-            };
-            if !matches!(definition.body, DefinitionBody::TypeAlias { .. }) {
-                break;
-            }
-            let definition_ty = &definition.ty;
-            let (vars, body) = match definition_ty {
-                Type::Forall { vars, body } => (vars.clone(), body.as_ref().clone()),
-                other => (vec![], other.clone()),
-            };
-            let map: SubstitutionMap = vars.iter().cloned().zip(params.iter().cloned()).collect();
-            current = substitute(&body, &map);
-        }
-        let Some(numeric) = current.underlying_numeric_type() else {
+        let Some(numeric) = self.facts.underlying_numeric_type(ty) else {
             return false;
         };
         let Some(kind) = numeric.as_simple() else {
@@ -110,7 +89,7 @@ impl Planner<'_> {
     fn resolve_element_type(
         &mut self,
         function: &Expression,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         call_ty: Option<&Type>,
     ) -> String {
         let element = self.resolve_element_lisette_type(function, type_args, call_ty);
@@ -120,7 +99,7 @@ impl Planner<'_> {
     fn resolve_element_lisette_type<'t>(
         &self,
         function: &Expression,
-        type_args: &'t [Type],
+        type_args: ResolvedCallTypeArguments<'t>,
         call_ty: Option<&'t Type>,
     ) -> Cow<'t, Type> {
         if let Some(first) = type_args.first() {
@@ -140,7 +119,7 @@ impl Planner<'_> {
     fn resolve_map_types(
         &mut self,
         function: &Expression,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         call_ty: Option<&Type>,
     ) -> (String, String) {
         if type_args.len() >= 2 {
@@ -315,7 +294,7 @@ impl Planner<'_> {
             return None;
         };
         let function = callee.unwrap_parens();
-        let spread = (**spread).as_ref();
+        let spread = spread.as_deref();
         let resolved_type_args = type_arguments
             .resolved_types()
             .expect("emission requires checked call type arguments");
@@ -367,7 +346,7 @@ impl Planner<'_> {
             unreachable!("lower_call requires a Call expression");
         };
         let function = callee.unwrap_parens();
-        let spread = (**spread).as_ref();
+        let spread = spread.as_deref();
         let resolved_type_args = type_arguments
             .resolved_types()
             .expect("emission requires checked call type arguments");
@@ -625,7 +604,7 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         args: &[Expression],
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
     ) -> (Vec<LoweredStatement>, String) {
         let target_ty = if !type_args.is_empty() {
             self.go_type_string(&type_args[0])

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -7,14 +7,14 @@ mod ufcs;
 
 use crate::plan::values::CaptureBoundary;
 use crate::types::native::NativeGoType;
-use syntax::ast::Expression;
+use syntax::ast::{Expression, ResolvedCallTypeArguments};
 use syntax::types::Type;
 
 pub(super) struct NativeCallContext<'a> {
     pub function: &'a Expression,
     pub args: &'a [Expression],
     pub spread: Option<&'a Expression>,
-    pub resolved_type_args: &'a [Type],
+    pub resolved_type_args: ResolvedCallTypeArguments<'a>,
     pub call_ty: Option<&'a Type>,
     pub native_type: &'a NativeGoType,
     pub method: &'a str,

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -500,7 +500,7 @@ impl Planner<'_> {
             let receiver_ty = expression.get_type();
             self.format_type_args_with_receiver(&receiver_ty, ctx.resolved_type_args)
         } else {
-            self.format_type_args(ctx.resolved_type_args)
+            self.format_resolved_type_args(ctx.resolved_type_args)
         };
         NativeCallResult::new(
             setup,
@@ -593,11 +593,11 @@ impl Planner<'_> {
             } => true,
             Expression::DotAccess {
                 expression: base,
-                dot_access_kind,
+                resolution,
                 ..
             } => {
                 if matches!(
-                    dot_access_kind,
+                    resolution.kind(),
                     Some(DotAccessKind::TupleStructField { is_newtype: true })
                 ) {
                     return false;
@@ -701,7 +701,8 @@ impl Planner<'_> {
             all_stages.len() - 1
         });
 
-        let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(1));
+        let combine =
+            plan_variadic_spread(&self.facts, ctx.function, ctx.spread).map(|p| p.combine(1));
         let mut sequenced = self.sequence_values(all_stages, ctx.capture_boundary, "_arg");
         if let Some(spread_index) = spread_index {
             self.finalize_spread_stage(&mut sequenced.values, spread_index, false, combine);
@@ -814,7 +815,7 @@ impl Planner<'_> {
             ctx.native_type.method_prefix(),
             go_name::snake_to_camel(ctx.method)
         );
-        let type_args_string = self.format_type_args(ctx.resolved_type_args);
+        let type_args_string = self.format_resolved_type_args(ctx.resolved_type_args);
         NativeCallResult::new(
             setup,
             format!(
@@ -867,7 +868,8 @@ impl Planner<'_> {
             stages.push(stage);
             stages.len() - 1
         });
-        let combine = plan_variadic_spread(ctx.function, ctx.spread).map(|p| p.combine(0));
+        let combine =
+            plan_variadic_spread(&self.facts, ctx.function, ctx.spread).map(|p| p.combine(0));
         let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "_arg");
         if let Some(spread_index) = spread_index {
             self.finalize_spread_stage(&mut sequenced.values, spread_index, false, combine);
@@ -936,8 +938,8 @@ impl Planner<'_> {
         }
 
         let arg_ty = arg.get_type();
-        let range_kind = peel_to_range_type(&arg_ty)
-            .and_then(|t| t.get_name())
+        let range_kind = peel_to_range_type(&arg_ty, |id| self.facts.definition(id))
+            .and_then(|ty| ty.get_name().map(str::to_owned))
             .expect("substring arg should resolve to a known range type");
         let receiver_staged = self.stage_operand(receiver_expr, ExpressionContext::value());
         let range_staged = self.stage_or_capture(arg, "range");
@@ -949,7 +951,7 @@ impl Planner<'_> {
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (setup, values) = sequenced.into_rendered();
-        let (start, end) = range_var_bounds(&values[1], range_kind);
+        let (start, end) = range_var_bounds(&values[1], &range_kind);
         NativeCallResult::new(
             setup,
             format_substring_call(&deref(&values[0]), start.as_deref(), end.as_deref()),

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -18,7 +18,7 @@ use crate::plan::values::{
 };
 use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
 use crate::write_line;
-use syntax::ast::{Expression, Literal};
+use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::types::Type;
 
 struct CallArgsContext<'plan, 'facts> {
@@ -151,7 +151,7 @@ impl<'a> Planner<'a> {
             unreachable!("lower_regular_call requires a Call expression");
         };
         let function = callee.unwrap_parens();
-        let spread = (**spread).as_ref();
+        let spread = spread.as_deref();
         let resolved_type_args = type_arguments
             .resolved_types()
             .expect("emission requires checked call type arguments");
@@ -173,7 +173,7 @@ impl<'a> Planner<'a> {
                 .iter()
                 .map(|a| self.stage_operand(a, arg_ctx))
                 .collect();
-            let wrap_to_any = spread_needs_any_wrap(function, spread);
+            let wrap_to_any = spread_needs_any_wrap(&self.facts, function, spread);
             let combine = call_plan.variadic_combine(0);
             let sequenced = self.sequence_with_spread_values(
                 stages,
@@ -220,7 +220,7 @@ impl<'a> Planner<'a> {
         let args_ctx = CallArgsContext {
             plan: call_plan,
             spread,
-            wrap_spread_to_any: spread_needs_any_wrap(function, spread),
+            wrap_spread_to_any: spread_needs_any_wrap(&self.facts, function, spread),
             combine_variadic: call_plan.variadic_combine(0),
             capture_boundary: expression_ctx.capture_boundary(),
             retired_receiver: (args.len() == 1
@@ -374,7 +374,7 @@ impl<'a> Planner<'a> {
         &mut self,
         function: &Expression,
         callee: &ResolvedCallee<'_>,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         call_ty: Option<&Type>,
         arg_shape: CallArgShape,
         function_string: &mut String,
@@ -394,7 +394,7 @@ impl<'a> Planner<'a> {
                 .unwrap_or_default();
         }
 
-        let mut type_args_string = self.format_type_args(type_args);
+        let mut type_args_string = self.format_resolved_type_args(type_args);
 
         let slot_ty = ctx.expected_slot_type();
 
@@ -512,7 +512,7 @@ impl<'a> Planner<'a> {
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
-                let arg_ctx = direct_arg_emit_ctx(Some(target), true);
+                let arg_ctx = direct_arg_emit_ctx(&self.facts, Some(target), true);
                 let argument = self.lower_composite_value(arg, arg_ctx);
                 argument.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
                     let lowered = self.emit_lower_arg_to_tagged(setup, &value, target);
@@ -574,7 +574,7 @@ impl<'a> Planner<'a> {
         declared_param_ty: Option<&Type>,
     ) -> ValuePlan {
         let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
-        let mut arg_ctx = direct_arg_emit_ctx(effective_param_ty, suppress);
+        let mut arg_ctx = direct_arg_emit_ctx(&self.facts, effective_param_ty, suppress);
         if let Some(retired) = ctx.retired_receiver {
             arg_ctx = arg_ctx.with_retired_receiver(retired);
         }
@@ -983,20 +983,27 @@ fn varargs_inner_or_self(ty: &Type) -> Type {
     }
 }
 
-fn spread_needs_any_wrap(function: &Expression, spread: Option<&Expression>) -> bool {
+fn spread_needs_any_wrap(
+    facts: &crate::EmitFacts<'_>,
+    function: &Expression,
+    spread: Option<&Expression>,
+) -> bool {
     let Some(spread_expr) = spread else {
         return false;
     };
-    let Some(variadic_element) = function.get_type().unwrap_forall().is_variadic() else {
+    let Some(function_ty) = facts.resolve_to_function_type(&function.get_type()) else {
         return false;
     };
-    if !variadic_element.is_unknown() {
+    let Some(variadic_element) = function_ty.is_variadic() else {
+        return false;
+    };
+    if !facts.resolves_to_unknown(&variadic_element) {
         return false;
     }
     spread_expr
         .get_type()
         .inner()
-        .is_some_and(|t| !t.is_unknown())
+        .is_some_and(|ty| !facts.resolves_to_unknown(&ty))
 }
 
 fn would_suppress_tagged_go(callee: &ResolvedCallee<'_>, declared_param_ty: Option<&Type>) -> bool {
@@ -1007,11 +1014,12 @@ fn would_suppress_tagged_go(callee: &ResolvedCallee<'_>, declared_param_ty: Opti
 /// Compute the `ExpressionContext` for emitting a Direct or TaggedGoLowering
 /// argument's underlying value via `emit_composite_value`.
 fn direct_arg_emit_ctx<'b>(
+    facts: &crate::EmitFacts<'_>,
     effective_param_ty: Option<&'b Type>,
     suppress: bool,
 ) -> ExpressionContext<'b> {
     let unwrapped = effective_param_ty.map(|p| p.unwrap_forall());
-    let flows_to_unknown = unwrapped.is_some_and(|p| p.resolves_to_unknown());
+    let flows_to_unknown = unwrapped.is_some_and(|ty| facts.resolves_to_unknown(ty));
     ExpressionContext::value()
         .with_forced_tagged_go_function(suppress)
         .with_unknown_argument_target(flows_to_unknown)

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -11,7 +11,7 @@ use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, ResolvedCallee};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::types::native::NativeGoType;
-use syntax::ast::{Expression, Literal};
+use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
 
@@ -22,7 +22,7 @@ impl Planner<'_> {
         function: &Expression,
         callee: &ResolvedCallee<'_>,
         receiver_ty: &Type,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         arg_shape: CallArgShape,
     ) -> Option<String> {
         let definition_ty = callee.declared_type()?;
@@ -91,20 +91,21 @@ impl Planner<'_> {
         &mut self,
         function: &Expression,
         args: &[Expression],
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         spread: Option<&Expression>,
         call_plan: &CallPlan<'_>,
     ) -> ValuePlan {
         let Expression::DotAccess {
             expression: receiver,
             member,
-            receiver_coercion: coercion,
+            resolution,
             ..
         } = function
         else {
             unreachable!("lower_ufcs_call called on non-DotAccess");
         };
 
+        let coercion = resolution.receiver_coercion();
         let receiver_ty = self.facts.strip_and_peel(&receiver.get_type());
         let Type::Nominal {
             id: qualified_name, ..
@@ -120,7 +121,7 @@ impl Planner<'_> {
                 args,
                 spread,
                 &call_plan.resolved,
-                *coercion,
+                coercion,
             );
         let receiver_arg = match coercion {
             Some(ReceiverCoercion::AutoDeref) => format!("*{receiver_arg}"),
@@ -218,7 +219,7 @@ impl Planner<'_> {
                 param.map(|param| &param.instantiated),
             ));
         }
-        let combine = plan_variadic_spread(function, spread).map(|p| p.combine(1));
+        let combine = plan_variadic_spread(&self.facts, function, spread).map(|p| p.combine(1));
 
         let sequenced = self.sequence_args_with_spread_adapter_values(
             all_stages,
@@ -270,7 +271,7 @@ impl Planner<'_> {
         receiver_ty: &Type,
         qualified_name: &str,
         member: &str,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
         arg_shape: CallArgShape,
     ) -> String {
         let type_args_string = self
@@ -331,7 +332,7 @@ impl Planner<'_> {
             .map(|a| self.stage_composite(a, ExpressionContext::value()))
             .collect();
 
-        let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
+        let combine = plan_variadic_spread(&self.facts, function, spread).map(|p| p.combine(0));
         let sequenced = self.sequence_with_spread_values(
             stages,
             spread,

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -226,7 +226,7 @@ impl Planner<'_> {
             }
             return statements;
         }
-        if item_ty.is_unit() || item_ty.is_variable() {
+        if item_ty.is_unit() || item_ty.is_ignored() || item_ty.is_variable() {
             return vec![
                 self.lower_statement(last),
                 self.lower_zero_return(fallible.ok_ty()),
@@ -262,9 +262,9 @@ fn resolve_fallible_block_type(
     });
     let base = Fallible::from_type(ty);
     let needs_return_context = tail_is_never
-        || base
-            .as_ref()
-            .is_some_and(|f| f.ok_ty().is_variable() || f.ok_ty().is_never());
+        || base.as_ref().is_some_and(|f| {
+            f.ok_ty().is_variable() || f.ok_ty().is_placeholder() || f.ok_ty().is_never()
+        });
     if !needs_return_context {
         return ty.clone();
     }

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -316,7 +316,6 @@ impl Planner<'_> {
             let key_statements = this.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(key_var.clone()),
                 first,
-                None,
                 first_ty,
             );
             Renderer.render_lowered_block(
@@ -332,7 +331,6 @@ impl Planner<'_> {
             let value_statements = this.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(value_var.clone()),
                 second,
-                None,
                 second_ty,
             );
             Renderer.render_lowered_block(
@@ -393,7 +391,6 @@ impl Planner<'_> {
                     let binding_statements = this.lower_irrefutable_pattern_site(
                         PatternSubject::for_value(item_var.clone()),
                         &binding.pattern,
-                        binding.typed_pattern.as_ref(),
                         &binding.ty,
                     );
                     Renderer.render_lowered_block(

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -3,7 +3,6 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::{
     self, AnnotatedPattern, PatternSubject, TypedSubject, unwrap_some_pattern,
-    unwrap_some_typed_pattern,
 };
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan,
@@ -11,7 +10,7 @@ use crate::plan::bodies::{
 };
 use crate::plan::placement::unreachable_panic_if_needed;
 use crate::plan::values::{GoExpression, ValuePlan};
-use syntax::ast::{Expression, MatchArm, Pattern, SelectArm, SelectArmPattern, TypedPattern};
+use syntax::ast::{Expression, MatchArm, Pattern, SelectArm, SelectArmPattern};
 use syntax::program::{ChannelOperation, channel_operation};
 use syntax::types::Type;
 
@@ -32,7 +31,6 @@ struct SelectReceiveContext<'a> {
 enum PreparedSelectArm<'a> {
     Receive {
         binding: &'a Pattern,
-        typed_pattern: Option<&'a TypedPattern>,
         body: &'a Expression,
         channel: String,
         element_ty: Type,
@@ -102,7 +100,6 @@ impl Planner<'_> {
             let plan = match arm {
                 PreparedSelectArm::Receive {
                     binding,
-                    typed_pattern,
                     body,
                     channel,
                     element_ty,
@@ -115,7 +112,7 @@ impl Planner<'_> {
                         element_ty,
                         place,
                     };
-                    self.lower_receive_arm(binding, typed_pattern, &receiver_ctx)
+                    self.lower_receive_arm(binding, &receiver_ctx)
                 }
                 PreparedSelectArm::Send { body, operation } => {
                     self.lower_send_arm(&operation, body, place)
@@ -156,7 +153,6 @@ impl Planner<'_> {
                 SelectArmPattern::Receive {
                     receive_expression,
                     binding,
-                    typed_pattern,
                     body,
                     ..
                 } => {
@@ -175,7 +171,6 @@ impl Planner<'_> {
                     };
                     PreparedSelectArm::Receive {
                         binding,
-                        typed_pattern: typed_pattern.as_ref(),
                         body,
                         channel,
                         element_ty: receive_expression.get_type().ok_type(),
@@ -295,7 +290,7 @@ impl Planner<'_> {
     fn lower_ok_guard<F>(
         &mut self,
         prepare_receiver: F,
-        inner_pattern: Option<(&Pattern, Option<&TypedPattern>)>,
+        inner_pattern: Option<&Pattern>,
         ctx: &SelectReceiveContext,
     ) -> SelectArmPlan
     where
@@ -305,13 +300,13 @@ impl Planner<'_> {
             let receiver_var = prepare_receiver(this);
             let ok_var = this.fresh_ok_var();
             let (body_statements, used) = this.capture_go_uses(|this| {
-                if let Some((pattern, typed)) = inner_pattern {
+                if let Some(pattern) = inner_pattern {
                     this.lower_select_receive_pattern_site(
                         TypedSubject {
                             var: &receiver_var,
                             ty: &ctx.element_ty,
                         },
-                        AnnotatedPattern { pattern, typed },
+                        AnnotatedPattern { pattern },
                         ctx.body,
                         ctx.default_body,
                         ctx.place,
@@ -356,16 +351,14 @@ impl Planner<'_> {
     fn lower_receive_arm(
         &mut self,
         binding: &Pattern,
-        typed_pattern: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
     ) -> SelectArmPlan {
         let effective_pattern = unwrap_some_pattern(binding);
-        let inner_typed = unwrap_some_typed_pattern(typed_pattern);
 
         if binding.is_some_pattern() {
-            self.lower_receive_arm_with_ok_check(effective_pattern, inner_typed, ctx)
+            self.lower_receive_arm_with_ok_check(effective_pattern, ctx)
         } else {
-            self.lower_receive_arm_simple(effective_pattern, inner_typed, ctx)
+            self.lower_receive_arm_simple(effective_pattern, ctx)
         }
     }
 
@@ -373,7 +366,6 @@ impl Planner<'_> {
     fn lower_receive_arm_with_ok_check(
         &mut self,
         effective_pattern: &Pattern,
-        inner_typed: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
     ) -> SelectArmPlan {
         if let Pattern::Identifier { identifier, .. } = effective_pattern
@@ -397,18 +389,13 @@ impl Planner<'_> {
             };
         }
         let receiver_var = self.fresh_var(Some("recv"));
-        self.lower_ok_guard(
-            |_| receiver_var,
-            Some((effective_pattern, inner_typed)),
-            ctx,
-        )
+        self.lower_ok_guard(|_| receiver_var, Some(effective_pattern), ctx)
     }
 
     /// Plain receive: `case v := <-ch:` then the arm body.
     fn lower_receive_arm_simple(
         &mut self,
         effective_pattern: &Pattern,
-        inner_typed: Option<&TypedPattern>,
         ctx: &SelectReceiveContext,
     ) -> SelectArmPlan {
         self.with_binding_frame(|this| {
@@ -427,7 +414,6 @@ impl Planner<'_> {
                 body_statements.extend(this.lower_irrefutable_pattern_site(
                     PatternSubject::for_value(receiver_var.clone()),
                     effective_pattern,
-                    inner_typed,
                     &ctx.element_ty,
                 ));
                 Some(receiver_var)
@@ -599,7 +585,6 @@ impl Planner<'_> {
             if !needs_receiver_destructure {
                 return this.lower_block_to_place(&some_arm.expression, place);
             }
-            let inner_typed = unwrap_some_typed_pattern(some_arm.typed_pattern.as_ref());
             LoweredBlock {
                 statements: this.lower_select_match_receive_some_site(
                     TypedSubject {
@@ -608,7 +593,6 @@ impl Planner<'_> {
                     },
                     AnnotatedPattern {
                         pattern: receiver_var_pattern,
-                        typed: inner_typed,
                     },
                     &some_arm.expression,
                     match_arms,

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -248,7 +248,6 @@ impl Planner<'_> {
                 .iter()
                 .map(|g| Type::Parameter(g.name.clone()))
                 .collect(),
-            underlying_ty: None,
         };
 
         let return_type = self.go_type_string(&return_type);

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -12,12 +12,12 @@ use crate::types::native::NativeGoType;
 use crate::utils::{group_params, receiver_name};
 use syntax::EcoString;
 use syntax::ast::{
-    Annotation, Binding, Expression, FunctionDefinitionView, Generic, Pattern, Span, TypedPattern,
+    Annotation, Binding, Expression, FunctionDefinitionView, Generic, Pattern, Span,
 };
 use syntax::types::{Type, build_substitution_map, substitute};
 
-/// Owned param-destructure record: temp var, pattern, typed pattern, param type.
-type DeferredParamDestructure = (String, Pattern, Option<TypedPattern>, Type);
+/// Owned param-destructure record: temp var, pattern, param type.
+type DeferredParamDestructure = (String, Pattern, Type);
 
 pub(crate) fn is_test_context_ty(ty: &Type) -> bool {
     let stripped = ty.strip_refs();
@@ -29,7 +29,7 @@ pub(crate) fn is_test_context_ty(ty: &Type) -> bool {
 
 /// Borrowed lambda param-destructure record. Lambdas keep references to the
 /// caller's `params` slice since they cannot outlive emission scope.
-type LambdaParamDestructure<'a> = (String, &'a Pattern, Option<&'a TypedPattern>, &'a Type);
+type LambdaParamDestructure<'a> = (String, &'a Pattern, &'a Type);
 
 struct LambdaReturnInfo {
     ty_string: String,
@@ -137,12 +137,7 @@ impl Planner<'_> {
                 } else {
                     let temp_name = self.fresh_var(Some("arg"));
                     self.declare(&temp_name);
-                    destructure_bindings.push((
-                        temp_name.clone(),
-                        &p.pattern,
-                        p.typed_pattern.as_ref(),
-                        &p.ty,
-                    ));
+                    destructure_bindings.push((temp_name.clone(), &p.pattern, &p.ty));
                     temp_name
                 };
                 (name, self.go_type_string(&p.ty))
@@ -160,6 +155,7 @@ impl Planner<'_> {
         let has_return = matches!(ty, Type::Function(f)
             if !(f.return_type.is_unit()
                 || f.return_type.is_variable()
+                || f.return_type.is_placeholder()
                 || (argument_flows_to_unknown && f.return_type.is_never())));
 
         let ctx = match ty {
@@ -203,11 +199,10 @@ impl Planner<'_> {
         should_return: bool,
     ) -> String {
         let mut body_string = String::new();
-        for (temp_name, pattern, typed, param_ty) in destructure_bindings {
+        for (temp_name, pattern, param_ty) in destructure_bindings {
             let statements = self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(temp_name.clone()),
                 pattern,
-                *typed,
                 param_ty,
             );
             Renderer.render_lowered_block(&mut body_string, &LoweredBlock { statements });
@@ -255,7 +250,7 @@ impl Planner<'_> {
         is_public: bool,
         resolved_generic_bounds: Option<&[(EcoString, Vec<Type>)]>,
     ) -> String {
-        if matches!(function_definition.body, Expression::NoOp) {
+        if function_definition.body.is_none() {
             return String::new();
         }
 
@@ -387,16 +382,22 @@ impl Planner<'_> {
         return_ctx: &ReturnContext,
     ) {
         let should_return = !function_definition.return_type.is_unit();
-        for (var_name, pattern, typed, param_ty) in deferred_patterns {
+        for (var_name, pattern, param_ty) in deferred_patterns {
             let statements = self.lower_irrefutable_pattern_site(
                 PatternSubject::for_value(var_name),
                 &pattern,
-                typed.as_ref(),
                 &param_ty,
             );
             Renderer.render_lowered_block(body, &LoweredBlock { statements });
         }
-        self.emit_function_body(body, function_definition.body, should_return, return_ctx);
+        self.emit_function_body(
+            body,
+            function_definition
+                .body
+                .expect("declarations return before function body emission"),
+            should_return,
+            return_ctx,
+        );
     }
 
     fn emit_receiver_part(
@@ -455,11 +456,14 @@ impl Planner<'_> {
         if let Some(resolved) = resolved_generic_bounds {
             context.extend_from_slice(resolved);
         } else {
-            context.extend(
-                function_generics
-                    .iter()
-                    .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone())),
-            );
+            context.extend(function_generics.iter().map(|generic| {
+                let bounds = generic
+                    .resolved_bounds()
+                    .expect("generic bounds must be resolved before emission")
+                    .cloned()
+                    .collect();
+                (generic.name.clone(), bounds)
+            }));
         }
         context
     }
@@ -485,8 +489,8 @@ impl Planner<'_> {
                     return None;
                 };
                 let bounds = generic
-                    .resolved_bounds
-                    .iter()
+                    .resolved_bounds()
+                    .expect("generic bounds must be resolved before emission")
                     .map(|bound| substitute(bound, &substitution))
                     .collect();
                 Some((name.clone(), bounds))
@@ -513,7 +517,13 @@ impl Planner<'_> {
                 .collect(),
             None => signature_generics
                 .iter()
-                .filter(|generic| !generic.resolved_bounds.is_empty())
+                .filter(|generic| {
+                    generic
+                        .resolved_bounds()
+                        .expect("generic bounds must be resolved before emission")
+                        .next()
+                        .is_some()
+                })
                 .map(|generic| generic.name.as_str())
                 .collect(),
         };
@@ -561,12 +571,7 @@ impl Planner<'_> {
                 _ => {
                     let var = self.fresh_var(Some("arg"));
                     self.declare(&var);
-                    deferred_patterns.push((
-                        var.clone(),
-                        param.pattern.clone(),
-                        param.typed_pattern.clone(),
-                        param.ty.clone(),
-                    ));
+                    deferred_patterns.push((var.clone(), param.pattern.clone(), param.ty.clone()));
                     var
                 }
             };
@@ -651,9 +656,8 @@ fn change_go_builtin_methods(
             span: Span::dummy(),
         },
         annotation: Some(Annotation::Unknown),
-        typed_pattern: None,
         ty: receiver_type,
-        mutable: false,
+        mut_span: None,
     };
 
     let mut params = Vec::with_capacity(function_definition.params.len() + 1);

--- a/crates/emit/src/definitions/impls.rs
+++ b/crates/emit/src/definitions/impls.rs
@@ -123,18 +123,21 @@ impl Planner<'_> {
             .zip(ctx.generics)
             .map(|(receiver_generic, impl_generic)| {
                 let bounds = receiver_generic
-                    .resolved_bounds
-                    .iter()
+                    .resolved_bounds()
+                    .expect("generic bounds must be resolved before emission")
                     .map(|bound| substitute(bound, &substitution))
                     .collect();
                 (impl_generic.name.clone(), bounds)
             })
             .collect::<Vec<_>>();
-        generic_bounds.extend(
-            method_generics
-                .iter()
-                .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone())),
-        );
+        generic_bounds.extend(method_generics.iter().map(|generic| {
+            let bounds = generic
+                .resolved_bounds()
+                .expect("generic bounds must be resolved before emission")
+                .cloned()
+                .collect();
+            (generic.name.clone(), bounds)
+        }));
         Some(generic_bounds)
     }
 }

--- a/crates/emit/src/definitions/interfaces.rs
+++ b/crates/emit/src/definitions/interfaces.rs
@@ -93,22 +93,10 @@ fn bound_references_interface(annotation: &Annotation, interface_name: &str) -> 
 fn strip_self_referential_bounds(generics: &[Generic], interface_name: &str) -> Vec<Generic> {
     generics
         .iter()
-        .map(|g| Generic {
-            name: g.name.clone(),
-            bounds: g
-                .bounds
-                .iter()
-                .filter(|ann| !bound_references_interface(ann, interface_name))
-                .cloned()
-                .collect(),
-            resolved_bounds: g
-                .bounds
-                .iter()
-                .zip(&g.resolved_bounds)
-                .filter(|(ann, _)| !bound_references_interface(ann, interface_name))
-                .map(|(_, ty)| ty.clone())
-                .collect(),
-            span: g.span,
+        .cloned()
+        .map(|mut generic| {
+            generic.retain_bounds(|bound| !bound_references_interface(bound, interface_name));
+            generic
         })
         .collect()
 }

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -231,7 +231,7 @@ impl Planner<'_> {
         }
 
         let tag_configs = interpret_field_attributes(f, struct_attrs);
-        let is_option = is_option_type(&f.ty);
+        let is_option = self.facts.peel_alias(&f.ty).is_option();
         let tag_string = format_tag_string(&f.name, &tag_configs, is_option);
 
         let field_name = struct_field_go_name(f, struct_attrs);
@@ -399,11 +399,7 @@ impl Planner<'_> {
         self.facts
             .definition(qualified.as_str())
             .is_some_and(|definition| {
-                definition.is_pointer_backed_newtype(|id| {
-                    self.facts
-                        .definition(id)
-                        .is_some_and(Definition::is_type_alias)
-                })
+                definition.is_pointer_backed_newtype(|id| self.facts.definition(id))
             })
     }
 
@@ -527,15 +523,6 @@ pub(crate) fn stringer_verb(is_function: bool) -> &'static str {
 
 pub(crate) fn debug_verb(is_function: bool) -> &'static str {
     if is_function { "%p" } else { "%s" }
-}
-
-fn is_option_type(ty: &Type) -> bool {
-    match ty {
-        Type::Nominal { underlying_ty, .. } => {
-            ty.is_option() || underlying_ty.as_deref().is_some_and(is_option_type)
-        }
-        _ => false,
-    }
 }
 
 fn emit_to_string_method(name: &str, receiver_generics: &str, method_name: &str) -> String {

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -15,33 +15,22 @@ impl Planner<'_> {
         generics: &[Generic],
         ty: &Type,
     ) -> String {
-        let is_fn_alias;
-        let underlying = match ty {
-            Type::Forall { body, .. } => match body.as_ref() {
-                Type::Nominal {
-                    underlying_ty: Some(inner),
-                    ..
-                } if matches!(inner.as_ref(), Type::Function(_)) => {
-                    is_fn_alias = true;
-                    inner.as_ref()
-                }
-                other => {
-                    is_fn_alias = false;
-                    other
-                }
-            },
-            Type::Nominal {
-                underlying_ty: Some(inner),
-                ..
-            } if matches!(inner.as_ref(), Type::Function(_)) => {
-                is_fn_alias = true;
-                inner.as_ref()
-            }
-            _ => {
-                is_fn_alias = false;
-                ty
-            }
-        };
+        let params: Vec<Type> = generics
+            .iter()
+            .map(|generic| Type::Parameter(generic.name.clone()))
+            .collect();
+        let declared_target = self
+            .facts
+            .definition(&self.facts.qualified_current(name))
+            .and_then(|definition| definition.instantiate_alias_target(&params));
+        let function_target = declared_target
+            .as_ref()
+            .and_then(|target| self.facts.resolve_to_function_type(target));
+        let is_fn_alias = function_target.is_some();
+        let underlying = function_target
+            .as_ref()
+            .or(declared_target.as_ref())
+            .unwrap_or(ty);
         let ty_string = self.go_type_string(underlying);
 
         if let Type::Nominal { id, .. } = underlying

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -22,15 +22,14 @@ impl Planner<'_> {
             expression,
             member,
             ty: result_ty,
-            dot_access_kind,
-            receiver_coercion,
+            resolution,
             ..
         } = dot_access
         else {
             unreachable!("plan_dot_access requires a DotAccess expression");
         };
-        let dot_access_kind = *dot_access_kind;
-        let receiver_coercion = *receiver_coercion;
+        let dot_access_kind = resolution.kind();
+        let receiver_coercion = resolution.receiver_coercion();
 
         if let Some(s) =
             self.try_emit_pre_receiver_dot(expression, member, result_ty, dot_access_kind, ctx)

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -30,7 +30,9 @@ impl Planner<'_> {
         // Range-typed variable as index (e.g. `items[r]` where `r: Range<int>`,
         // or `r: Prefix` where `type Prefix = RangeTo<int>`).
         let index_ty = index.get_type();
-        if let Some(range_kind) = peel_to_range_type(&index_ty).and_then(|t| t.get_name()) {
+        if let Some(range_kind) = peel_to_range_type(&index_ty, |id| self.facts.definition(id))
+            .and_then(|ty| ty.get_name().map(str::to_owned))
+        {
             let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
             if base_staged.evaluation.effect.has_call() {
                 self.pin_staged(&mut base_staged, "_base");
@@ -44,7 +46,7 @@ impl Planner<'_> {
             let effect = sequenced.effect;
             let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
             let (setup, values) = sequenced.into_rendered();
-            let value = emit_range_var_slice(&values[0], &values[1], range_kind, needs_cap);
+            let value = emit_range_var_slice(&values[0], &values[1], &range_kind, needs_cap);
             return ValuePlan::computed(
                 setup,
                 GoExpression::opaque_with_deferred_evaluation(value, contains_deferred_evaluation),

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -275,7 +275,10 @@ impl Planner<'_> {
                 Some(DefinitionBody::Struct { .. })
             ) || matches!(
                 self.facts.definition(id).map(|d| &d.body),
-                Some(DefinitionBody::TypeAlias { annotation, .. }) if annotation.is_opaque()
+                Some(DefinitionBody::TypeAlias {
+                    alias: syntax::program::AliasKind::Opaque(_),
+                    ..
+                })
             ));
         if is_struct_like {
             format!("{}{{}}", go_ty)
@@ -373,8 +376,8 @@ impl Planner<'_> {
                 .collect();
             return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
         }
-        if let Some(underlying) = ty.get_underlying() {
-            return self.lisette_zero(underlying);
+        if let Some(underlying) = self.facts.underlying_type(ty) {
+            return self.lisette_zero(&underlying);
         }
         format!("{}{{}}", self.go_type_string(ty))
     }

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
 use crate::Renderer;
+use crate::analyze::facts::EmitFacts;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -41,7 +42,7 @@ impl Planner<'_> {
             ty: right_expression.get_type(),
         };
 
-        if let Some(emit_info) = is_casting_needed(operator, &left, &right) {
+        if let Some(emit_info) = is_casting_needed(&self.facts, operator, &left, &right) {
             return self.plan_numeric_binary_with_casts(
                 operator,
                 left_expression,
@@ -233,7 +234,7 @@ impl Planner<'_> {
             ..
         } = target
             && let Some(flipped) = flip_comparison(cmp)
-            && flip_preserves_nan(cmp, left, right)
+            && flip_preserves_nan(&self.facts, cmp, left, right)
         {
             let plan = self.plan_binary(&flipped, left, right, ctx);
             return if preserve_parens {
@@ -299,15 +300,19 @@ impl Planner<'_> {
     }
 }
 
-fn flip_preserves_nan(operator: &BinaryOperator, left: &Expression, right: &Expression) -> bool {
+fn flip_preserves_nan(
+    facts: &EmitFacts<'_>,
+    operator: &BinaryOperator,
+    left: &Expression,
+    right: &Expression,
+) -> bool {
     matches!(operator, BinaryOperator::Equal | BinaryOperator::NotEqual)
-        || (is_non_float(left) && is_non_float(right))
+        || (is_non_float(facts, left) && is_non_float(facts, right))
 }
 
-fn is_non_float(expression: &Expression) -> bool {
-    expression
-        .get_type()
-        .underlying_simple_kind()
+fn is_non_float(facts: &EmitFacts<'_>, expression: &Expression) -> bool {
+    facts
+        .underlying_simple_kind(&expression.get_type())
         .is_some_and(|kind| !kind.is_float())
 }
 
@@ -472,9 +477,9 @@ fn is_numeric_binary_op(operator: &BinaryOperator) -> bool {
 /// Common underlying numeric type when both operands lower to the same
 /// numeric family; `None` if either operand is non-numeric or the two
 /// numeric families differ.
-fn matching_underlying_numeric(left: &Type, right: &Type) -> Option<Type> {
-    let left_underlying = left.underlying_numeric_type()?;
-    let right_underlying = right.underlying_numeric_type()?;
+fn matching_underlying_numeric(facts: &EmitFacts<'_>, left: &Type, right: &Type) -> Option<Type> {
+    let left_underlying = facts.underlying_numeric_type(left)?;
+    let right_underlying = facts.underlying_numeric_type(right)?;
     if left_underlying.numeric_family()? != right_underlying.numeric_family()? {
         return None;
     }
@@ -492,6 +497,7 @@ fn cast_unless_literal(is_literal: bool, target: &Type) -> Option<Type> {
 /// Go requires explicit casts when mixing aliased numeric types with
 /// their underlying types.
 fn is_casting_needed(
+    facts: &EmitFacts<'_>,
     operator: &BinaryOperator,
     left: &BinaryOperand<'_>,
     right: &BinaryOperand<'_>,
@@ -500,10 +506,10 @@ fn is_casting_needed(
         return None;
     }
 
-    matching_underlying_numeric(&left.ty, &right.ty)?;
+    matching_underlying_numeric(facts, &left.ty, &right.ty)?;
 
-    let left_is_aliased = left.ty.is_aliased_numeric_type();
-    let right_is_aliased = right.ty.is_aliased_numeric_type();
+    let left_is_aliased = facts.is_aliased_numeric_type(&left.ty);
+    let right_is_aliased = facts.is_aliased_numeric_type(&right.ty);
 
     if left.ty == right.ty {
         return None;

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -8,7 +8,7 @@ use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, Stability, ValuePlan,
 };
-use syntax::ast::Expression;
+use syntax::ast::{Expression, IdentifierResolution};
 use syntax::types::{FunctionParameter, Type};
 
 /// Folds `f(leading, spread...)` into `f(append([]T{leading}, spread...)...)` — Go rejects the former.
@@ -131,12 +131,10 @@ impl Planner<'_> {
     pub(crate) fn is_unmutated_identifier(&self, expression: &Expression) -> bool {
         match expression {
             Expression::Identifier {
-                binding_id: Some(id),
+                resolution: IdentifierResolution::Binding(id),
                 ..
             } => !self.facts.is_mutated(*id),
-            Expression::Identifier {
-                binding_id: None, ..
-            } => true,
+            Expression::Identifier { .. } => true,
             _ => false,
         }
     }
@@ -146,12 +144,10 @@ impl Planner<'_> {
     pub(crate) fn identifier_immune_to_calls(&self, expression: &Expression) -> bool {
         match expression {
             Expression::Identifier {
-                binding_id: Some(id),
+                resolution: IdentifierResolution::Binding(id),
                 ..
             } => !self.facts.is_alias_mutated(*id),
-            Expression::Identifier {
-                binding_id: None, ..
-            } => true,
+            Expression::Identifier { .. } => true,
             _ => false,
         }
     }

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -95,6 +95,9 @@ impl Planner<'_> {
                 ty,
                 ..
             } => {
+                let Some(expression) = expression.value() else {
+                    return String::new();
+                };
                 let doc_comment = emit_doc(doc);
                 let code = self.emit_const(identifier, expression, ty);
                 format!("{}{}", doc_comment, code)
@@ -165,13 +168,11 @@ impl Planner<'_> {
                 span: function.name_span,
             },
             annotation: None,
-            typed_pattern: None,
             ty: Type::Nominal {
                 id: Symbol::from_parts(go_name::TEST_PRELUDE_MODULE, "TestContext"),
                 params: vec![],
-                underlying_ty: None,
             },
-            mutable: false,
+            mut_span: None,
         }])
     }
 }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -238,10 +238,10 @@ impl Planner<'_> {
             Expression::Identifier {
                 value,
                 ty,
-                qualified,
+                resolution,
                 ..
             } => {
-                let go_expression = self.emit_identifier(value, qualified.as_deref(), ty, ctx);
+                let go_expression = self.emit_identifier(value, resolution.definition(), ty, ctx);
                 let stable_across_calls = self.identifier_immune_to_calls(expression);
                 let plan =
                     ValuePlan::from_identifier_expression(go_expression, stable_across_calls);
@@ -268,13 +268,15 @@ impl Planner<'_> {
             Expression::Call { ty, .. } => self.lower_call_value(expression, ty, ctx),
             Expression::RawGo { text } => ValuePlan::opaque(text.clone()),
             Expression::Unit { .. } => ValuePlan::opaque("struct{}{}".to_string()),
-            Expression::NoOp => ValuePlan::opaque(String::new()),
             Expression::Lambda {
                 params, body, ty, ..
-            }
-            | Expression::Function {
-                params, body, ty, ..
             } => ValuePlan::opaque(self.emit_lambda(params, body, ty, ctx)),
+            Expression::Function {
+                params, body, ty, ..
+            } => match body.definition() {
+                Some(body) => ValuePlan::opaque(self.emit_lambda(params, body, ty, ctx)),
+                None => ValuePlan::opaque(String::new()),
+            },
             Expression::IfLet { ty, .. }
             | Expression::Match { ty, .. }
             | Expression::Select { ty, .. }
@@ -417,15 +419,16 @@ impl Planner<'_> {
     }
 
     fn shift_pin_go_type(&self, expression: &Expression, target_ty: &Type) -> Option<String> {
-        let target_is_float = target_ty
-            .underlying_simple_kind()
+        let target_is_float = self
+            .facts
+            .underlying_simple_kind(target_ty)
             .is_some_and(|kind| kind.is_float());
         if !target_is_float || !self.contains_untyped_constant_shift(expression) {
             return None;
         }
         let source_ty = expression.get_type();
-        source_ty
-            .underlying_simple_kind()
+        self.facts
+            .underlying_simple_kind(&source_ty)
             .is_some_and(|kind| kind.integer_range().is_some())
             .then(|| self.go_type_string(&source_ty))
     }

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -50,8 +50,7 @@ use state::module_state::{FunctionEmissionState, ModuleState};
 use state::scope::ScopeState;
 use syntax::ast::Span;
 use syntax::program::{
-    Definition, DefinitionBody, EmitInput, EqualityIndex, File, ModuleId, MutationInfo,
-    ResolvedDefinitions, TestIndex, UnusedInfo,
+    Definition, DefinitionBody, EmitInput, EqualityIndex, File, MutationInfo, TestIndex, UnusedInfo,
 };
 use syntax::types::{Symbol, Type};
 use types::go_type::GoType;
@@ -174,7 +173,6 @@ fn sentinel_hint(hints: &[String]) -> Option<i64> {
 
 pub struct TestEmitConfig<'a> {
     pub definitions: &'a HashMap<Symbol, Definition>,
-    pub const_names: &'a HashSet<Symbol>,
     pub module_id: &'a str,
     pub go_module: &'a str,
     pub unused: &'a UnusedInfo,
@@ -184,7 +182,6 @@ pub struct TestEmitConfig<'a> {
     pub test_index: &'a TestIndex,
     pub go_package_names: &'a HashMap<String, String>,
     pub go_module_ids: &'a HashSet<String>,
-    pub resolved_definitions: &'a ResolvedDefinitions,
 }
 
 pub struct Planner<'a> {
@@ -311,23 +308,31 @@ impl<'a> Planner<'a> {
             globals: Arc::new(GlobalEmitData::compute(&analysis.definitions)),
         };
 
-        let mut work: Vec<(&ModuleId, &syntax::program::ModuleInfo)> = analysis
-            .modules
-            .iter()
-            .filter(|(id, _)| !analysis.cached_modules.contains(*id))
-            .collect();
-        work.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        let mut files_by_module: HashMap<&str, Vec<&File>> = HashMap::default();
+        for file in analysis.files.values().filter(|file| !file.is_d_lis()) {
+            if !analysis.cached_modules.contains(&file.module_id) {
+                files_by_module
+                    .entry(file.module_id.as_str())
+                    .or_default()
+                    .push(file);
+            }
+        }
+        for files in files_by_module.values_mut() {
+            files.sort_unstable_by_key(|file| file.id);
+        }
+        let mut work: Vec<_> = files_by_module.into_iter().collect();
+        work.sort_unstable_by_key(|(module_id, _)| *module_id);
 
         const PARALLEL_THRESHOLD: usize = 4;
 
-        let emit_one = |&(module_id, module_info): &(&ModuleId, &syntax::program::ModuleInfo)| {
+        let emit_one = |(module_id, files): &(&str, Vec<&File>)| {
             emit_module(
                 analysis,
                 go_module,
                 entry_package_name,
                 &shared,
                 module_id,
-                module_info,
+                files,
             )
         };
 
@@ -356,7 +361,6 @@ impl<'a> Planner<'a> {
         let globals = Arc::new(GlobalEmitData::compute(config.definitions));
         let facts = EmitFacts::new(EmitFactsConfig {
             definitions: config.definitions,
-            const_names: config.const_names,
             unused: config.unused,
             mutations: config.mutations,
             ufcs_methods: config.ufcs_methods,
@@ -364,7 +368,6 @@ impl<'a> Planner<'a> {
             test_index: config.test_index,
             go_package_names: config.go_package_names,
             go_module_ids: config.go_module_ids,
-            resolved_definitions: config.resolved_definitions,
             entry_module: config.module_id.to_string(),
             entry_package_name: "main",
             go_module: config.go_module.to_string(),
@@ -651,11 +654,10 @@ fn emit_module<'a>(
     entry_package_name: &'a str,
     shared_emit_ctx: &SharedEmitContext,
     module_id: &str,
-    module_info: &syntax::program::ModuleInfo,
+    files: &[&'a File],
 ) -> Vec<OutputFile> {
     let facts = EmitFacts::new(EmitFactsConfig {
         definitions: &analysis.definitions,
-        const_names: &analysis.const_names,
         unused: &analysis.unused,
         mutations: &analysis.mutations,
         ufcs_methods: &analysis.ufcs_methods,
@@ -663,7 +665,6 @@ fn emit_module<'a>(
         test_index: &analysis.test_index,
         go_package_names: &analysis.go_package_names,
         go_module_ids: &analysis.go_module_ids,
-        resolved_definitions: &analysis.resolved_definitions,
         entry_module: analysis.entry_module_id.to_string(),
         entry_package_name,
         go_module: go_module.to_string(),
@@ -674,21 +675,11 @@ fn emit_module<'a>(
     });
     let mut planner: Planner<'a> = Planner::new(facts);
 
-    let files: Vec<_> = module_info
-        .file_ids
-        .iter()
-        .filter_map(|fid| analysis.files.get(fid))
-        .collect();
-
-    if files.is_empty() {
-        return Vec::new();
-    }
-
-    let mut module_output = planner.emit_files(&files, module_id);
+    let mut module_output = planner.emit_files(files, module_id);
 
     if module_id != analysis.entry_module_id.as_str() {
         for file in &mut module_output {
-            file.name = format!("{}/{}", module_info.path, file.name);
+            file.name = format!("{}/{}", module_id, file.name);
         }
     }
 

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -51,7 +51,14 @@ impl Planner<'_> {
     pub(crate) fn generics_to_string(&mut self, generics: &[Generic]) -> String {
         let resolved_generics = generics
             .iter()
-            .map(|generic| (generic.name.clone(), generic.resolved_bounds.clone()))
+            .map(|generic| {
+                let bounds = generic
+                    .resolved_bounds()
+                    .expect("generic bounds must be resolved before emission")
+                    .cloned()
+                    .collect();
+                (generic.name.clone(), bounds)
+            })
             .collect::<Vec<_>>();
         self.resolved_generics_to_string(&resolved_generics)
     }

--- a/crates/emit/src/patterns/binding_decls.rs
+++ b/crates/emit/src/patterns/binding_decls.rs
@@ -1,7 +1,8 @@
 use syntax::EcoString;
 use syntax::ast::{
-    EnumFieldDefinition, Generic, Literal, Pattern, RestPattern, StructFieldDefinition,
-    StructFieldPattern, StructKind, TypedPattern, VariantFields,
+    ConstructorPatternResolution, EnumFieldDefinition, Generic, Literal, Pattern,
+    RecordPatternResolution, RestPattern, SequencePatternResolution, StructFieldDefinition,
+    StructFieldPattern,
 };
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Type, unqualified_name};
@@ -40,14 +41,6 @@ impl FieldDef for EnumFieldDefinition {
     }
     fn ty(&self) -> &Type {
         &self.ty
-    }
-}
-
-/// `Unit` variants yield an empty slice so callers handle all shapes uniformly.
-fn variant_fields_slice(fields: &VariantFields) -> &[EnumFieldDefinition] {
-    match fields {
-        VariantFields::Unit => &[],
-        VariantFields::Tuple(f) | VariantFields::Struct(f) => f,
     }
 }
 
@@ -161,49 +154,50 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         pattern: &Pattern,
         ty: &Type,
-        typed: Option<&TypedPattern>,
     ) {
         match pattern {
             Pattern::Identifier { identifier, .. } => {
                 self.declare_pattern_var(statements, pattern, identifier, ty);
             }
             Pattern::Tuple { elements, .. } => {
-                self.lower_tuple_pattern_declarations(statements, elements, ty, typed);
+                self.lower_tuple_pattern_declarations(statements, elements, ty);
             }
             Pattern::Struct {
-                fields, identifier, ..
+                fields,
+                resolution,
+                ty,
+                ..
             } => {
-                self.lower_struct_pattern_declarations(statements, fields, identifier, ty, typed);
+                self.lower_struct_pattern_declarations(statements, fields, resolution, ty);
             }
             Pattern::EnumVariant {
                 fields,
-                identifier,
-                ty: pattern_ty,
+                resolution,
+                ty,
                 ..
             } => {
-                self.lower_enum_variant_pattern_declarations(
-                    statements, fields, identifier, pattern_ty, ty, typed,
-                );
+                self.lower_enum_variant_pattern_declarations(statements, fields, resolution, ty);
             }
-            Pattern::Slice { prefix, rest, .. } => {
-                self.lower_slice_pattern_declarations(statements, prefix, rest, ty, typed);
+            Pattern::Slice {
+                prefix,
+                rest,
+                resolution,
+                ..
+            } => {
+                self.lower_slice_pattern_declarations(statements, prefix, rest, ty, resolution);
             }
             Pattern::Or { patterns, .. } => {
                 let Some(first) = patterns.first() else {
                     return;
                 };
-                let alt = match typed {
-                    Some(TypedPattern::Or { alternatives }) => alternatives.first(),
-                    _ => None,
-                };
-                self.lower_binding_declarations_with_type(statements, first, ty, alt);
+                self.lower_binding_declarations_with_type(statements, first, ty);
             }
             p @ Pattern::AsBinding {
                 pattern: inner,
                 name,
                 ..
             } => {
-                self.lower_binding_declarations_with_type(statements, inner, ty, typed);
+                self.lower_binding_declarations_with_type(statements, inner, ty);
                 self.declare_pattern_var(statements, p, name, ty);
             }
             Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => {}
@@ -254,49 +248,35 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         elements: &[Pattern],
         resolved: &Type,
-        typed: Option<&TypedPattern>,
     ) {
-        let typed_elements: &[TypedPattern] = match typed {
-            Some(TypedPattern::Tuple { elements: te, .. }) => te.as_slice(),
-            _ => &[],
-        };
         let types: &[Type] = match resolved {
             Type::Nominal { params, .. } => params,
             Type::Tuple(elements) => elements,
             _ => return,
         };
-        for (i, (element, element_ty)) in elements.iter().zip(types.iter()).enumerate() {
-            self.lower_binding_declarations_with_type(
-                statements,
-                element,
-                element_ty,
-                typed_elements.get(i),
-            );
+        for (element, element_ty) in elements.iter().zip(types) {
+            self.lower_binding_declarations_with_type(statements, element, element_ty);
         }
     }
 
-    /// Recurse into named struct-pattern fields (plain struct or enum's
-    /// struct variant, resolved via the typed pattern or definitions table).
+    /// Recurse into named fields using the definition selected by inference.
     fn lower_struct_pattern_declarations(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         fields: &[StructFieldPattern],
-        identifier: &EcoString,
-        resolved: &Type,
-        typed: Option<&TypedPattern>,
+        resolution: &RecordPatternResolution,
+        ty: &Type,
     ) {
-        match typed {
-            Some(TypedPattern::Struct {
-                struct_name,
-                struct_fields,
-                pattern_fields,
-                ..
-            }) => {
-                let Type::Nominal { params, .. } = resolved else {
-                    return;
-                };
+        let params = self.pattern_type_args(ty);
+        match resolution {
+            RecordPatternResolution::Struct { struct_name } => {
                 let Some(Definition {
-                    body: DefinitionBody::Struct { generics, .. },
+                    body:
+                        DefinitionBody::Struct {
+                            generics,
+                            fields: struct_fields,
+                            ..
+                        },
                     ..
                 }) = self.facts.definition(struct_name.as_str())
                 else {
@@ -306,263 +286,153 @@ impl Planner<'_> {
                     statements,
                     fields,
                     struct_fields,
-                    GenericArgs { generics, params },
-                    Some(pattern_fields),
+                    GenericArgs {
+                        generics,
+                        params: &params,
+                    },
                 );
             }
-            Some(TypedPattern::EnumStructVariant {
+            RecordPatternResolution::EnumVariant {
                 enum_name,
-                variant_fields,
-                pattern_fields,
-                ..
-            }) => {
-                let Type::Nominal { params, .. } = resolved else {
-                    return;
-                };
+                variant_name,
+            } => {
                 let Some(Definition {
-                    body: DefinitionBody::Enum { generics, .. },
+                    body:
+                        DefinitionBody::Enum {
+                            generics, variants, ..
+                        },
                     ..
                 }) = self.facts.definition(enum_name.as_str())
+                else {
+                    return;
+                };
+                let Some(variant) = variants
+                    .iter()
+                    .find(|variant| variant.name == unqualified_name(variant_name))
                 else {
                     return;
                 };
                 self.recurse_named_fields(
                     statements,
                     fields,
-                    variant_fields,
-                    GenericArgs { generics, params },
-                    Some(pattern_fields),
+                    variant.fields.as_slice(),
+                    GenericArgs {
+                        generics,
+                        params: &params,
+                    },
                 );
             }
-            _ => self.lower_struct_pattern_fallback(statements, fields, identifier, resolved),
+            RecordPatternResolution::Unresolved => {}
         }
     }
 
-    /// Untyped struct-pattern fallback via the definitions table.
-    fn lower_struct_pattern_fallback(
+    /// Recurse into positional constructor fields using their inferred types.
+    fn lower_enum_variant_pattern_declarations(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        fields: &[StructFieldPattern],
-        identifier: &EcoString,
-        resolved: &Type,
+        fields: &[Pattern],
+        resolution: &ConstructorPatternResolution,
+        ty: &Type,
     ) {
-        let Type::Nominal { id, params, .. } = resolved else {
+        let ConstructorPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } = resolution
+        else {
             return;
         };
-        match self.facts.definition(id.as_str()).map(|d| &d.body) {
-            Some(DefinitionBody::Struct {
-                fields: field_definitions,
+        let params = self.pattern_type_args(ty);
+        let Some(definition) = self.facts.definition(enum_name) else {
+            return;
+        };
+        match &definition.body {
+            DefinitionBody::Struct {
+                fields: definitions,
                 generics,
                 ..
-            }) => {
-                self.recurse_named_fields(
+            } => self.recurse_positional_fields(
+                statements,
+                fields,
+                definitions,
+                GenericArgs {
+                    generics,
+                    params: &params,
+                },
+            ),
+            DefinitionBody::Enum {
+                variants, generics, ..
+            } => {
+                let Some(variant) = variants
+                    .iter()
+                    .find(|variant| variant.name == unqualified_name(variant_name))
+                else {
+                    return;
+                };
+                self.recurse_positional_fields(
                     statements,
                     fields,
-                    field_definitions,
-                    GenericArgs { generics, params },
-                    None,
+                    variant.fields.as_slice(),
+                    GenericArgs {
+                        generics,
+                        params: &params,
+                    },
                 );
-            }
-            Some(DefinitionBody::Enum {
-                variants, generics, ..
-            }) => {
-                let variant_name = unqualified_name(identifier);
-                if let Some(variant) = variants.iter().find(|v| v.name == variant_name) {
-                    self.recurse_named_fields(
-                        statements,
-                        fields,
-                        variant_fields_slice(&variant.fields),
-                        GenericArgs { generics, params },
-                        None,
-                    );
-                }
             }
             _ => {}
         }
     }
 
-    /// Recurse into positional enum-variant fields (tuple-struct matches
-    /// route through the struct definition).
-    #[allow(clippy::too_many_arguments)]
-    fn lower_enum_variant_pattern_declarations(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        fields: &[Pattern],
-        identifier: &EcoString,
-        pattern_ty: &Type,
-        resolved: &Type,
-        typed: Option<&TypedPattern>,
-    ) {
-        if self.is_tuple_struct_type(pattern_ty) {
-            self.lower_tuple_struct_variant_declarations(statements, fields, resolved, typed);
-            return;
+    fn pattern_type_args(&self, ty: &Type) -> Vec<Type> {
+        match self.facts.peel_alias(ty) {
+            Type::Nominal { params, .. } => params,
+            _ => vec![],
         }
-
-        let typed_fields = match typed {
-            Some(TypedPattern::EnumVariant { fields: tf, .. }) => Some(tf.as_slice()),
-            _ => None,
-        };
-
-        if let Some(TypedPattern::EnumVariant {
-            enum_name,
-            variant_fields,
-            ..
-        }) = typed
-        {
-            let Type::Nominal { params, .. } = resolved else {
-                return;
-            };
-            let Some(Definition {
-                body: DefinitionBody::Enum { generics, .. },
-                ..
-            }) = self.facts.definition(enum_name.as_str())
-            else {
-                return;
-            };
-            self.recurse_positional_fields(
-                statements,
-                fields,
-                variant_fields,
-                GenericArgs { generics, params },
-                typed_fields,
-            );
-            return;
-        }
-
-        let Type::Nominal { id, params, .. } = resolved else {
-            return;
-        };
-        let Some(Definition {
-            body: DefinitionBody::Enum {
-                variants, generics, ..
-            },
-            ..
-        }) = self.facts.definition(id.as_str())
-        else {
-            return;
-        };
-        let variant_name = unqualified_name(identifier);
-        let Some(variant) = variants.iter().find(|v| v.name == variant_name) else {
-            return;
-        };
-        self.recurse_positional_fields(
-            statements,
-            fields,
-            variant_fields_slice(&variant.fields),
-            GenericArgs { generics, params },
-            None,
-        );
     }
 
-    /// Newtype-tuple-struct match via the struct's own positional fields.
-    fn lower_tuple_struct_variant_declarations(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        fields: &[Pattern],
-        resolved: &Type,
-        typed: Option<&TypedPattern>,
-    ) {
-        let Type::Nominal { id, params, .. } = resolved else {
-            return;
-        };
-        let Some(Definition {
-            body:
-                DefinitionBody::Struct {
-                    fields: field_definitions,
-                    generics,
-                    kind: StructKind::Tuple,
-                    ..
-                },
-            ..
-        }) = self.facts.definition(id.as_str())
-        else {
-            return;
-        };
-        let typed_fields = match typed {
-            Some(TypedPattern::EnumVariant { fields: tf, .. }) => Some(tf.as_slice()),
-            _ => None,
-        };
-        self.recurse_positional_fields(
-            statements,
-            fields,
-            field_definitions,
-            GenericArgs { generics, params },
-            typed_fields,
-        );
-    }
-
-    /// Recurse into a slice pattern's prefix and bind any rest variable.
+    /// Recurse into a sequence prefix and bind any rest variable.
     fn lower_slice_pattern_declarations(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         prefix: &[Pattern],
         rest: &RestPattern,
         resolved: &Type,
-        typed: Option<&TypedPattern>,
+        resolution: &SequencePatternResolution,
     ) {
-        let (element_ty, typed_prefix): (Type, Option<&[TypedPattern]>) = match typed {
-            Some(TypedPattern::Slice {
-                prefix: tp,
+        let (element_type, array_length) = match resolution {
+            SequencePatternResolution::Slice { element_type } => (element_type, None),
+            SequencePatternResolution::Array {
                 element_type,
-                ..
-            })
-            | Some(TypedPattern::Array {
-                prefix: tp,
-                element_type,
-                ..
-            }) => (element_type.clone(), Some(tp.as_slice())),
-            _ => {
-                if let Type::Array { element, .. } = resolved {
-                    (element.as_ref().clone(), None)
-                } else {
-                    let Type::Nominal { params, .. } = resolved else {
-                        return;
-                    };
-                    let Some(element) = params.first().cloned() else {
-                        return;
-                    };
-                    (element, None)
-                }
-            }
+                length,
+            } => (element_type, Some(*length)),
+            SequencePatternResolution::Unresolved => return,
         };
 
-        for (i, element) in prefix.iter().enumerate() {
-            let typed_child = typed_prefix.and_then(|tp| tp.get(i));
-            self.lower_binding_declarations_with_type(
-                statements,
-                element,
-                &element_ty,
-                typed_child,
-            );
+        for element in prefix {
+            self.lower_binding_declarations_with_type(statements, element, element_type);
         }
 
         if let RestPattern::Bind { name, .. } = rest
             && let Some(go_name) = self.go_name_for_rest_binding(rest)
         {
-            let rest_ty = match typed {
-                Some(TypedPattern::Array {
-                    length,
-                    element_type,
-                    ..
-                }) => Type::Array {
+            let rest_ty = if let Some(length) = array_length {
+                Type::Array {
                     length: length.saturating_sub(prefix.len() as u64),
                     element: Box::new(element_type.clone()),
-                },
-                _ => resolved.clone(),
+                }
+            } else {
+                resolved.clone()
             };
             self.declare_var_declaration(statements, name, go_name, &rest_ty);
         }
     }
 
-    /// For each named field, resolve its type against the enclosing generics
-    /// and recurse with the matching typed child.
+    /// For each named field, resolve its type against the enclosing generics.
     fn recurse_named_fields<F: FieldDef>(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         patterns: &[StructFieldPattern],
         definitions: &[F],
         generic_args: GenericArgs,
-        typed_pf: Option<&[(EcoString, TypedPattern)]>,
     ) {
         let GenericArgs { generics, params } = generic_args;
         for pattern in patterns {
@@ -570,34 +440,21 @@ impl Planner<'_> {
                 continue;
             };
             let field_ty = generics::resolve_field_type(generics, params, definition.ty());
-            let typed_child = typed_pf.and_then(|pf| {
-                pf.iter()
-                    .find(|(n, _)| n == &pattern.name)
-                    .map(|(_, tp)| tp)
-            });
-            self.lower_binding_declarations_with_type(
-                statements,
-                &pattern.value,
-                &field_ty,
-                typed_child,
-            );
+            self.lower_binding_declarations_with_type(statements, &pattern.value, &field_ty);
         }
     }
 
-    /// Zip positional pattern slots with definition slots and recurse.
     fn recurse_positional_fields<F: FieldDef>(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         patterns: &[Pattern],
         definitions: &[F],
         generic_args: GenericArgs,
-        typed_fields: Option<&[TypedPattern]>,
     ) {
         let GenericArgs { generics, params } = generic_args;
-        for (i, (pattern, definition)) in patterns.iter().zip(definitions.iter()).enumerate() {
+        for (pattern, definition) in patterns.iter().zip(definitions) {
             let field_ty = generics::resolve_field_type(generics, params, definition.ty());
-            let typed_child = typed_fields.and_then(|tf| tf.get(i));
-            self.lower_binding_declarations_with_type(statements, pattern, &field_ty, typed_child);
+            self.lower_binding_declarations_with_type(statements, pattern, &field_ty);
         }
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -2,14 +2,16 @@ use crate::patterns::binding_decls::pattern_has_bindings;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{
-    EnumFieldDefinition, MatchArm, Pattern, RestPattern, StructFieldPattern, TypedPattern,
+    ConstructorPatternResolution, EnumFieldDefinition, MatchArm, Pattern, RecordPatternResolution,
+    RestPattern, SequencePatternResolution, StructFieldPattern,
 };
 use syntax::parse::TUPLE_FIELDS;
+use syntax::program::DefinitionBody;
 use syntax::types::{Type, unqualified_name};
 
 use crate::Planner;
-use crate::names::go_name;
 use crate::names::packages::PackageRequirements;
+use crate::names::{generics, go_name};
 use crate::patterns::binding_decls::emit_pattern_literal;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -749,7 +751,6 @@ fn collect_checks_and_bindings(
     planner: &Planner,
     path: &AccessPath,
     pattern: &Pattern,
-    typed: Option<&TypedPattern>,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) {
@@ -773,23 +774,28 @@ fn collect_checks_and_bindings(
         }
 
         Pattern::EnumVariant { .. } => {
-            collect_enum_variant_checks(planner, path, pattern, typed, path_ty, collector);
+            collect_enum_variant_checks(planner, path, pattern, path_ty, collector);
         }
 
         Pattern::Struct { .. } => {
-            collect_struct_checks(planner, path, pattern, typed, path_ty, collector);
+            collect_struct_checks(planner, path, pattern, path_ty, collector);
         }
 
         Pattern::Tuple { elements, .. } => {
-            collect_tuple_checks(planner, path, elements, typed, path_ty, collector);
+            collect_tuple_checks(planner, path, elements, path_ty, collector);
         }
 
-        Pattern::Slice { prefix, rest, .. } => {
-            collect_slice_checks(planner, path, prefix, rest, typed, collector);
+        Pattern::Slice {
+            prefix,
+            rest,
+            resolution,
+            ..
+        } => {
+            collect_slice_checks(planner, path, prefix, rest, resolution, collector);
         }
 
         Pattern::Or { patterns, .. } => {
-            collect_or_pattern_checks(planner, path, patterns, typed, pattern, path_ty, collector);
+            collect_or_pattern_checks(planner, path, patterns, pattern, path_ty, collector);
         }
 
         p @ Pattern::AsBinding {
@@ -797,7 +803,7 @@ fn collect_checks_and_bindings(
             name,
             ..
         } => {
-            collect_checks_and_bindings(planner, path, inner, typed, path_ty, collector);
+            collect_checks_and_bindings(planner, path, inner, path_ty, collector);
             let go_name = planner.go_name_for_binding(p);
             collector.bindings.push(PatternBinding {
                 lisette_name: name.to_string(),
@@ -812,15 +818,9 @@ fn collect_tuple_checks(
     planner: &Planner,
     path: &AccessPath,
     elements: &[Pattern],
-    typed: Option<&TypedPattern>,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) {
-    let typed_elements: Vec<Option<&TypedPattern>> = match typed {
-        Some(TypedPattern::Tuple { elements: te, .. }) => te.iter().map(Some).collect(),
-        _ => vec![None; elements.len()],
-    };
-
     let stripped_path_ty = path_ty.map(Type::strip_refs);
     let element_tys: Option<&[Type]> = match &stripped_path_ty {
         Some(Type::Tuple(tys)) => Some(tys.as_slice()),
@@ -834,7 +834,6 @@ fn collect_tuple_checks(
             planner,
             &field_path,
             element,
-            typed_elements.get(i).copied().flatten(),
             element_tys.and_then(|tys| tys.get(i)),
             collector,
         );
@@ -846,15 +845,14 @@ fn collect_slice_checks(
     path: &AccessPath,
     prefix: &[Pattern],
     rest: &RestPattern,
-    typed: Option<&TypedPattern>,
+    resolution: &SequencePatternResolution,
     collector: &mut PatternCollector,
 ) {
-    let array_info = match typed {
-        Some(TypedPattern::Array {
+    let array_info = match resolution {
+        SequencePatternResolution::Array {
             length,
             element_type,
-            ..
-        }) => Some((*length, element_type.clone())),
+        } => Some((*length, element_type)),
         _ => None,
     };
 
@@ -872,26 +870,15 @@ fn collect_slice_checks(
         }
     }
 
-    let typed_prefix: Vec<Option<&TypedPattern>> = match typed {
-        Some(TypedPattern::Slice {
-            prefix: tp_prefix, ..
-        })
-        | Some(TypedPattern::Array {
-            prefix: tp_prefix, ..
-        }) => tp_prefix.iter().map(Some).collect(),
-        _ => vec![None; prefix.len()],
+    let element_type = match resolution {
+        SequencePatternResolution::Slice { element_type }
+        | SequencePatternResolution::Array { element_type, .. } => Some(element_type),
+        SequencePatternResolution::Unresolved => None,
     };
 
     for (i, element) in prefix.iter().enumerate() {
         let element_path = path.push(PathSegment::Index(i));
-        collect_checks_and_bindings(
-            planner,
-            &element_path,
-            element,
-            typed_prefix.get(i).copied().flatten(),
-            None,
-            collector,
-        );
+        collect_checks_and_bindings(planner, &element_path, element, element_type, collector);
     }
 
     if let RestPattern::Bind { name, .. } = rest {
@@ -901,7 +888,7 @@ fn collect_slice_checks(
                 let sub_length = length.saturating_sub(prefix.len() as u64);
                 let sub_ty = Type::Array {
                     length: sub_length,
-                    element: Box::new(element_type.clone()),
+                    element: Box::new((*element_type).clone()),
                 };
                 PathSegment::ArraySliceFrom {
                     offset: prefix.len(),
@@ -924,25 +911,17 @@ fn collect_or_pattern_checks(
     planner: &Planner,
     path: &AccessPath,
     patterns: &[Pattern],
-    typed: Option<&TypedPattern>,
     pattern: &Pattern,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) {
     let has_bindings = pattern_has_bindings(pattern);
     if !has_bindings {
-        let typed_alternatives: Vec<Option<&TypedPattern>> = match typed {
-            Some(TypedPattern::Or { alternatives }) => alternatives.iter().map(Some).collect(),
-            _ => vec![None; patterns.len()],
-        };
-
         let alt_collectors: Vec<PatternCollector> = patterns
             .iter()
-            .enumerate()
-            .map(|(i, p)| {
+            .map(|p| {
                 let mut alt_collector = PatternCollector::new();
-                let tc = typed_alternatives.get(i).copied().flatten();
-                collect_checks_and_bindings(planner, path, p, tc, path_ty, &mut alt_collector);
+                collect_checks_and_bindings(planner, path, p, path_ty, &mut alt_collector);
                 alt_collector
             })
             .collect();
@@ -968,7 +947,7 @@ fn compute_struct_field_path(
     field: &StructFieldPattern,
     ty: &Type,
     enum_info: Option<&(String, String)>,
-    typed_variant_fields: Option<&[syntax::ast::EnumFieldDefinition]>,
+    variant_fields: Option<&[EnumFieldDefinition]>,
 ) -> AccessPath {
     let go_field_name = if let Some((enum_id, variant_name)) = enum_info {
         planner
@@ -991,7 +970,7 @@ fn compute_struct_field_path(
         && let Some(field_index) =
             planner.get_enum_struct_field_index(ty, variant_name, &field.name)
     {
-        let is_source_ref = typed_variant_fields
+        let is_source_ref = variant_fields
             .and_then(|vf| vf.get(field_index).map(|f| f.ty.is_ref()))
             .unwrap_or_else(|| planner.is_enum_field_source_ref(ty, variant_name, field_index));
         let is_auto_pointer =
@@ -1038,13 +1017,13 @@ fn collect_enum_variant_checks(
     planner: &Planner,
     path: &AccessPath,
     pattern: &Pattern,
-    typed: Option<&TypedPattern>,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) {
     let Pattern::EnumVariant {
         identifier,
         fields,
+        resolution,
         ty,
         ..
     } = pattern
@@ -1054,26 +1033,60 @@ fn collect_enum_variant_checks(
 
     // A const pattern is a value comparison against a named constant, emitted
     // as a Go `case` expression rather than an enum tag or newtype destructure.
-    if let Some(TypedPattern::Const { qualified_name, .. }) = typed {
+    if let ConstructorPatternResolution::Const { qualified_name, .. } = resolution {
         collect_const_pattern_check(planner, path, qualified_name, collector);
         return;
     }
 
-    let (typed_children, typed_variant_fields) = match typed {
-        Some(TypedPattern::EnumVariant {
-            fields: tf,
-            variant_fields: vf,
-            ..
-        }) => (tf.iter().map(Some).collect::<Vec<_>>(), Some(vf.as_slice())),
-        _ => (vec![None; fields.len()], None),
+    let ConstructorPatternResolution::EnumVariant {
+        enum_name,
+        variant_name,
+    } = resolution
+    else {
+        return;
+    };
+    let params = pattern_type_args(planner, ty);
+    let Some(definition) = planner.facts.definition(enum_name) else {
+        return;
+    };
+    let (variant_fields, field_types): (&[EnumFieldDefinition], Vec<Type>) = match &definition.body
+    {
+        DefinitionBody::Struct {
+            fields, generics, ..
+        } => (
+            &[],
+            fields
+                .iter()
+                .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
+                .collect(),
+        ),
+        DefinitionBody::Enum {
+            variants, generics, ..
+        } => {
+            let Some(variant) = variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))
+            else {
+                return;
+            };
+            (
+                variant.fields.as_slice(),
+                variant
+                    .fields
+                    .iter()
+                    .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
+                    .collect(),
+            )
+        }
+        _ => return,
     };
 
     let variant_data = EnumVariantData {
         identifier,
         fields,
         ty,
-        typed_children: &typed_children,
-        typed_variant_fields,
+        variant_fields,
+        field_types: &field_types,
     };
 
     if planner.is_tuple_struct_type(ty) {
@@ -1082,7 +1095,7 @@ fn collect_enum_variant_checks(
         if planner.is_newtype_struct(ty) {
             collect_newtype_checks(planner, &child_path, &variant_data, collector);
         } else {
-            collect_tuple_struct_checks(planner, &child_path, fields, &typed_children, collector);
+            collect_tuple_struct_checks(planner, &child_path, fields, &field_types, collector);
         }
         return;
     }
@@ -1165,8 +1178,7 @@ fn collect_newtype_checks(
             planner,
             &field_path,
             field,
-            variant.typed_children.first().copied().flatten(),
-            None,
+            variant.field_types.first(),
             collector,
         );
     }
@@ -1177,19 +1189,12 @@ fn collect_tuple_struct_checks(
     planner: &Planner,
     path: &AccessPath,
     fields: &[Pattern],
-    typed_children: &[Option<&TypedPattern>],
+    field_types: &[Type],
     collector: &mut PatternCollector,
 ) {
     for (i, field) in fields.iter().enumerate() {
         let field_path = path.push(PathSegment::Field(format!("F{}", i)));
-        collect_checks_and_bindings(
-            planner,
-            &field_path,
-            field,
-            typed_children.get(i).copied().flatten(),
-            None,
-            collector,
-        );
+        collect_checks_and_bindings(planner, &field_path, field, field_types.get(i), collector);
     }
 }
 
@@ -1197,8 +1202,8 @@ struct EnumVariantData<'a> {
     identifier: &'a str,
     fields: &'a [Pattern],
     ty: &'a Type,
-    typed_children: &'a [Option<&'a TypedPattern>],
-    typed_variant_fields: Option<&'a [syntax::ast::EnumFieldDefinition]>,
+    variant_fields: &'a [EnumFieldDefinition],
+    field_types: &'a [Type],
 }
 
 fn enum_module_of<'a>(planner: &Planner<'a>, ty: &'a Type) -> &'a str {
@@ -1245,8 +1250,9 @@ fn collect_tagged_enum_checks(
         let field_name = planner.get_enum_tuple_field_name(variant.ty, variant_name, i);
 
         let is_source_ref = variant
-            .typed_variant_fields
-            .and_then(|vf| vf.get(i).map(|f| f.ty.is_ref()))
+            .variant_fields
+            .get(i)
+            .map(|f| f.ty.is_ref())
             .unwrap_or_else(|| planner.is_enum_field_source_ref(variant.ty, variant_name, i));
         let is_auto_pointer =
             planner.is_enum_field_pointer(variant.ty, variant_name, i) && !is_source_ref;
@@ -1273,8 +1279,7 @@ fn collect_tagged_enum_checks(
                 planner,
                 &field_path,
                 field,
-                variant.typed_children.get(i).copied().flatten(),
-                None,
+                variant.field_types.get(i),
                 collector,
             );
         }
@@ -1284,28 +1289,17 @@ fn collect_tagged_enum_checks(
 /// Collect checks and bindings for a struct pattern (plain struct or enum struct variant).
 /// Detect whether a struct pattern is actually an enum struct variant,
 /// returning `(enum_id, variant_name)` if so.
-fn detect_enum_info(
-    planner: &Planner,
-    ty: &Type,
-    identifier: &str,
-    typed: Option<&TypedPattern>,
-) -> Option<(String, String)> {
-    match typed {
-        Some(TypedPattern::EnumStructVariant {
-            variant_name: vn, ..
-        }) => {
-            let variant_name_str = unqualified_name(vn);
-            let id = planner.as_enum(ty).unwrap_or_else(|| {
-                vn.rsplit_once('.')
-                    .map_or(vn.to_string(), |(e, _)| e.to_string())
-            });
-            Some((id, variant_name_str.to_string()))
-        }
-        Some(TypedPattern::Struct { .. }) => None,
-        _ => planner.as_enum(ty).map(|id| {
-            let variant_name_str = unqualified_name(identifier);
-            (id, variant_name_str.to_string())
-        }),
+fn detect_enum_info(resolution: &RecordPatternResolution) -> Option<(String, String)> {
+    match resolution {
+        RecordPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+            ..
+        } => Some((
+            enum_name.to_string(),
+            unqualified_name(variant_name).to_string(),
+        )),
+        RecordPatternResolution::Struct { .. } | RecordPatternResolution::Unresolved => None,
     }
 }
 
@@ -1313,7 +1307,6 @@ fn collect_struct_checks(
     planner: &Planner,
     path: &AccessPath,
     pattern: &Pattern,
-    typed: Option<&TypedPattern>,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) {
@@ -1321,33 +1314,33 @@ fn collect_struct_checks(
         fields,
         ty,
         identifier,
+        resolution,
         ..
     } = pattern
     else {
         return;
     };
 
-    let (enum_info, child_path) =
-        resolve_struct_child_path(planner, path, ty, identifier, typed, path_ty, collector);
-    let types = StructPatternTypes::build(typed);
+    let (enum_info, child_path) = resolve_struct_child_path(
+        planner, path, ty, identifier, resolution, path_ty, collector,
+    );
+    let variant_fields = record_variant_fields(planner, resolution);
 
     for field in fields {
-        let typed_child = types.lookup_typed_child(&field.name);
         let field_path = compute_struct_field_path(
             planner,
             &child_path,
             field,
             ty,
             enum_info.as_ref(),
-            types.typed_variant_fields,
+            variant_fields,
         );
-        let field_ty = types.lookup_field_ty(&field.name);
+        let field_ty = record_field_type(planner, resolution, ty, &field.name);
         collect_checks_and_bindings(
             planner,
             &field_path,
             &field.value,
-            typed_child,
-            field_ty,
+            field_ty.as_ref(),
             collector,
         );
     }
@@ -1363,14 +1356,14 @@ fn resolve_struct_child_path(
     path: &AccessPath,
     ty: &Type,
     identifier: &str,
-    typed: Option<&TypedPattern>,
+    resolution: &RecordPatternResolution,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) -> (Option<(String, String)>, AccessPath) {
     if let Some(asserted) = interface_assert_child_path(planner, path, ty, path_ty, collector) {
         return (None, asserted);
     }
-    let enum_info = detect_enum_info(planner, ty, identifier, typed);
+    let enum_info = detect_enum_info(resolution);
     if enum_info.is_some() {
         let enum_module = enum_module_of(planner, ty);
         let alias = if planner.facts.is_foreign_module(enum_module) {
@@ -1396,63 +1389,68 @@ fn resolve_struct_child_path(
     (enum_info, path.clone())
 }
 
-/// Per-call typed-pattern lookups for a struct pattern. Built once so the
-/// per-field loop can do `O(1)` lookups instead of three parallel matches.
-struct StructPatternTypes<'a> {
-    typed_fields_map: Option<Vec<(&'a str, Option<&'a TypedPattern>)>>,
-    typed_variant_fields: Option<&'a [EnumFieldDefinition]>,
-    field_tys: Vec<(&'a str, &'a Type)>,
+fn pattern_type_args(planner: &Planner, ty: &Type) -> Vec<Type> {
+    match planner.facts.peel_alias(ty) {
+        Type::Nominal { params, .. } => params,
+        _ => vec![],
+    }
 }
 
-impl<'a> StructPatternTypes<'a> {
-    fn build(typed: Option<&'a TypedPattern>) -> Self {
-        let typed_fields_map = match typed {
-            Some(TypedPattern::Struct { pattern_fields, .. })
-            | Some(TypedPattern::EnumStructVariant { pattern_fields, .. }) => Some(
-                pattern_fields
-                    .iter()
-                    .map(|(name, tp)| (name.as_str(), Some(tp)))
-                    .collect(),
-            ),
-            _ => None,
-        };
-        let typed_variant_fields = match typed {
-            Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => {
-                Some(variant_fields.as_slice())
-            }
-            _ => None,
-        };
-        let field_tys: Vec<(&str, &Type)> = match typed {
-            Some(TypedPattern::Struct { struct_fields, .. }) => struct_fields
+fn record_variant_fields<'a>(
+    planner: &'a Planner,
+    resolution: &RecordPatternResolution,
+) -> Option<&'a [EnumFieldDefinition]> {
+    let RecordPatternResolution::EnumVariant {
+        enum_name,
+        variant_name,
+    } = resolution
+    else {
+        return None;
+    };
+    let DefinitionBody::Enum { variants, .. } = &planner.facts.definition(enum_name)?.body else {
+        return None;
+    };
+    variants
+        .iter()
+        .find(|variant| variant.name == unqualified_name(variant_name))
+        .map(|variant| variant.fields.as_slice())
+}
+
+fn record_field_type(
+    planner: &Planner,
+    resolution: &RecordPatternResolution,
+    pattern_ty: &Type,
+    field_name: &str,
+) -> Option<Type> {
+    let params = pattern_type_args(planner, pattern_ty);
+    match resolution {
+        RecordPatternResolution::Struct { struct_name } => {
+            let DefinitionBody::Struct {
+                fields, generics, ..
+            } = &planner.facts.definition(struct_name)?.body
+            else {
+                return None;
+            };
+            fields
                 .iter()
-                .map(|f| (f.name.as_str(), &f.ty))
-                .collect(),
-            Some(TypedPattern::EnumStructVariant { variant_fields, .. }) => variant_fields
-                .iter()
-                .map(|f| (f.name.as_str(), &f.ty))
-                .collect(),
-            _ => Vec::new(),
-        };
-        Self {
-            typed_fields_map,
-            typed_variant_fields,
-            field_tys,
+                .find(|field| field.name == field_name)
+                .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
         }
-    }
-
-    fn lookup_typed_child(&self, field_name: &str) -> Option<&'a TypedPattern> {
-        self.typed_fields_map
-            .as_ref()?
-            .iter()
-            .find(|(name, _)| *name == field_name)
-            .and_then(|(_, tp)| *tp)
-    }
-
-    fn lookup_field_ty(&self, field_name: &str) -> Option<&'a Type> {
-        self.field_tys
-            .iter()
-            .find(|(name, _)| *name == field_name)
-            .map(|(_, ty)| *ty)
+        RecordPatternResolution::EnumVariant { .. } => {
+            let fields = record_variant_fields(planner, resolution)?;
+            let RecordPatternResolution::EnumVariant { enum_name, .. } = resolution else {
+                unreachable!()
+            };
+            let DefinitionBody::Enum { generics, .. } = &planner.facts.definition(enum_name)?.body
+            else {
+                return None;
+            };
+            fields
+                .iter()
+                .find(|field| field.name == field_name)
+                .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
+        }
+        RecordPatternResolution::Unresolved => None,
     }
 }
 
@@ -1467,17 +1465,10 @@ pub(super) fn expand_or_patterns<'a>(arms: &'a [MatchArm]) -> Vec<ExpandedArm<'a
         if let Pattern::Or { patterns, .. } = &arm.pattern
             && pattern_has_bindings(&arm.pattern)
         {
-            let typed_alternatives: Vec<Option<&TypedPattern>> =
-                if let Some(TypedPattern::Or { alternatives }) = &arm.typed_pattern {
-                    alternatives.iter().map(Some).collect()
-                } else {
-                    vec![None; patterns.len()]
-                };
-            for (j, alt) in patterns.iter().enumerate() {
+            for alt in patterns {
                 result.push(ExpandedArm {
                     arm_index: i,
                     pattern: alt,
-                    typed_pattern: typed_alternatives.get(j).copied().flatten(),
                     has_guard: arm.has_guard(),
                 });
             }
@@ -1486,7 +1477,6 @@ pub(super) fn expand_or_patterns<'a>(arms: &'a [MatchArm]) -> Vec<ExpandedArm<'a
         result.push(ExpandedArm {
             arm_index: i,
             pattern: &arm.pattern,
-            typed_pattern: arm.typed_pattern.as_ref(),
             has_guard: arm.has_guard(),
         });
     }
@@ -1497,7 +1487,6 @@ pub(super) fn expand_or_patterns<'a>(arms: &'a [MatchArm]) -> Vec<ExpandedArm<'a
 pub(super) struct ExpandedArm<'a> {
     pub arm_index: usize,
     pub pattern: &'a Pattern,
-    pub typed_pattern: Option<&'a TypedPattern>,
     pub has_guard: bool,
 }
 
@@ -1552,7 +1541,7 @@ pub(super) fn compile_expanded_arms<'a>(
     let arm_infos: Vec<ArmInfo> = expanded
         .iter()
         .map(|ea| {
-            let info = collect_pattern_info(planner, ea.pattern, ea.typed_pattern, subject_ty);
+            let info = collect_pattern_info(planner, ea.pattern, subject_ty);
             packages.extend(&info.packages);
             ArmInfo {
                 arm_index: ea.arm_index,
@@ -1607,7 +1596,6 @@ pub(super) fn compile_expanded_arms<'a>(
 pub(crate) fn collect_pattern_info(
     planner: &Planner,
     pattern: &Pattern,
-    typed: Option<&TypedPattern>,
     subject_ty: &Type,
 ) -> PatternInfo {
     let mut collector = PatternCollector::new();
@@ -1615,7 +1603,6 @@ pub(crate) fn collect_pattern_info(
         planner,
         &AccessPath::root(),
         pattern,
-        typed,
         Some(subject_ty),
         &mut collector,
     );

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -1,7 +1,7 @@
 use crate::patterns::binding_decls::pattern_has_bindings;
 use std::borrow::Cow;
 
-use syntax::ast::{Expression, MatchArm, Pattern, Span, TypedPattern};
+use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::Type;
 
 use crate::Planner;
@@ -23,7 +23,6 @@ use crate::write_line;
 #[derive(Clone, Copy)]
 pub(crate) struct AnnotatedPattern<'a> {
     pub(crate) pattern: &'a Pattern,
-    pub(crate) typed: Option<&'a TypedPattern>,
 }
 
 #[derive(Clone, Copy)]
@@ -140,12 +139,11 @@ impl Planner<'_> {
         &mut self,
         subject: PatternSubject<'_>,
         pattern: &Pattern,
-        typed: Option<&TypedPattern>,
         subject_ty: &Type,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         let resolved = self.resolve_pattern_subject(&mut statements, subject);
-        let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
+        let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
 
         let (body, used) = self.capture_go_uses(|this| {
@@ -263,7 +261,6 @@ impl Planner<'_> {
     pub(crate) fn lower_while_let(
         &mut self,
         pattern: &Pattern,
-        typed: Option<&TypedPattern>,
         scrutinee: &Expression,
         body: &Expression,
     ) -> LoweredBlock {
@@ -298,7 +295,7 @@ impl Planner<'_> {
             };
         }
 
-        let info = decision_tree::collect_pattern_info(self, pattern, typed, &scrutinee_ty);
+        let info = decision_tree::collect_pattern_info(self, pattern, &scrutinee_ty);
         self.require_packages(&info.packages);
         let mut loop_body = subject_setup;
         let (effective, ok_var) =
@@ -383,12 +380,12 @@ impl Planner<'_> {
         subject: TypedSubject,
         fail: RefutableFail,
     ) -> Vec<LoweredStatement> {
-        let AnnotatedPattern { pattern, typed } = ap;
+        let AnnotatedPattern { pattern } = ap;
         let TypedSubject {
             var: subject_var,
             ty: subject_ty,
         } = subject;
-        let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
+        let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
 
         let mut statements = Vec::new();
@@ -446,7 +443,7 @@ impl Planner<'_> {
         subject: TypedSubject,
         fail: RefutableFail,
     ) -> Vec<LoweredStatement> {
-        let AnnotatedPattern { pattern, typed } = ap;
+        let AnnotatedPattern { pattern } = ap;
         let TypedSubject {
             var: subject_var,
             ty: subject_ty,
@@ -456,7 +453,7 @@ impl Planner<'_> {
         };
         let pre_let_snapshot = self.scope.binding_snapshot();
         let mut statements = Vec::new();
-        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty, typed);
+        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty);
 
         let mut asserts = Vec::new();
         let alts =
@@ -532,7 +529,7 @@ impl Planner<'_> {
     ) -> LetElseAlternatives<'s> {
         let collected: Vec<PatternInfo> = patterns
             .iter()
-            .map(|alt| decision_tree::collect_pattern_info(self, alt, None, subject_ty))
+            .map(|alt| decision_tree::collect_pattern_info(self, alt, subject_ty))
             .collect();
         for info in &collected {
             self.require_packages(&info.packages);
@@ -568,7 +565,7 @@ impl Planner<'_> {
         } = subject;
         let mut alternatives: Vec<_> = patterns
             .iter()
-            .map(|alt| decision_tree::collect_pattern_info(self, alt, None, subject_ty))
+            .map(|alt| decision_tree::collect_pattern_info(self, alt, subject_ty))
             .collect();
         for info in &alternatives {
             self.require_packages(&info.packages);
@@ -663,12 +660,12 @@ impl Planner<'_> {
         place: &PlacePlan,
         failure: impl FnOnce(&mut Planner) -> Option<LoweredBlock>,
     ) -> Vec<LoweredStatement> {
-        let AnnotatedPattern { pattern, typed } = ap;
+        let AnnotatedPattern { pattern } = ap;
         let TypedSubject {
             var: subject_var,
             ty: subject_ty,
         } = subject;
-        let info = decision_tree::collect_pattern_info(self, pattern, typed, subject_ty);
+        let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
         let mut statements = Vec::new();
         let (effective, ok_var) =
@@ -757,20 +754,6 @@ pub(crate) fn unwrap_some_pattern(pattern: &Pattern) -> &Pattern {
         return &fields[0];
     }
     pattern
-}
-
-pub(crate) fn unwrap_some_typed_pattern(typed: Option<&TypedPattern>) -> Option<&TypedPattern> {
-    if let Some(TypedPattern::EnumVariant {
-        variant_name,
-        fields,
-        ..
-    }) = typed
-        && variant_name == "Some"
-        && fields.len() == 1
-    {
-        return Some(&fields[0]);
-    }
-    None
 }
 
 fn peel_as_binding(pattern: &Pattern) -> &Pattern {

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -3,7 +3,7 @@ use crate::abi::callable::{AbiTransition, CallableAbi, CallableParamAbi, Callabl
 use crate::abi::layout::SlotOrigin;
 use crate::expressions::staging::VariadicCombine;
 use crate::types::native::NativeGoType;
-use syntax::ast::Expression;
+use syntax::ast::{Expression, IdentifierResolution};
 use syntax::program::{CallKind, Definition, NativeTypeKind, resolved_definition};
 use syntax::types::{FunctionParameter, Type};
 
@@ -126,7 +126,7 @@ impl<'a> Planner<'a> {
         };
 
         let function = callee.unwrap_parens();
-        let variadic = plan_variadic_spread(function, (**spread).as_ref());
+        let variadic = plan_variadic_spread(&self.facts, function, spread.as_deref());
 
         let go_return = self.resolve_go_call_abi(expression);
 
@@ -238,7 +238,10 @@ impl<'a> Planner<'a> {
             })
             .flatten();
         let return_origin = if matches!(origin, CallableOrigin::GoInterop) {
-            catalog_return.map_or_else(|| SlotOrigin::go_return(return_type), |slot| slot.origin)
+            catalog_return.map_or_else(
+                || SlotOrigin::go_return(self.facts.resolves_to_unknown(return_type)),
+                |slot| slot.origin,
+            )
         } else {
             SlotOrigin::Lisette
         };
@@ -300,7 +303,7 @@ impl<'a> Planner<'a> {
         &self,
         function: &Expression,
     ) -> (Option<String>, Option<&'a Definition>) {
-        let id = resolved_definition(function, self.facts.resolved_definitions).map(str::to_string);
+        let id = resolved_definition(function).map(str::to_string);
         let definition = id
             .as_deref()
             .and_then(|definition| self.facts.definition(definition));
@@ -353,7 +356,7 @@ impl<'a> Planner<'a> {
             return None;
         };
         let inner = callee.unwrap_parens();
-        let callee_definition = resolved_definition(callee, self.facts.resolved_definitions);
+        let callee_definition = resolved_definition(callee);
         if callee_definition.is_some_and(|definition| definition.starts_with("go:")) {
             return None;
         }
@@ -367,7 +370,10 @@ impl<'a> Planner<'a> {
                 || receiver_is_prelude_type(&receiver_type)
                 || matches!(
                     &**receiver,
-                    Expression::Identifier { qualified: Some(definition), .. }
+                    Expression::Identifier {
+                        resolution: IdentifierResolution::Definition(definition),
+                        ..
+                    }
                         if definition.starts_with("prelude.")
                 )
             {
@@ -410,7 +416,7 @@ impl<'a> Planner<'a> {
         callee: &Expression,
         return_ty: &Type,
     ) -> Option<CallableReturnAbi> {
-        let qualified_name = resolved_definition(callee, self.facts.resolved_definitions)?;
+        let qualified_name = resolved_definition(callee)?;
         if !qualified_name.starts_with("go:") {
             return None;
         }
@@ -426,8 +432,7 @@ impl<'a> Planner<'a> {
     }
 
     fn is_go_callable(&self, expression: &Expression) -> bool {
-        resolved_definition(expression, self.facts.resolved_definitions)
-            .is_some_and(|definition| definition.starts_with("go:"))
+        resolved_definition(expression).is_some_and(|definition| definition.starts_with("go:"))
     }
 }
 
@@ -467,7 +472,11 @@ fn build_param_abi(
             let origin = catalog_slot.map_or_else(
                 || {
                     if matches!(callable_origin, CallableOrigin::GoInterop) {
-                        SlotOrigin::go_parameter(declared.as_ref().unwrap_or(&instantiated.ty))
+                        SlotOrigin::go_parameter(
+                            planner
+                                .facts
+                                .resolves_to_unknown(declared.as_ref().unwrap_or(&instantiated.ty)),
+                        )
                     } else {
                         SlotOrigin::Lisette
                     }
@@ -501,14 +510,14 @@ fn build_param_abi(
 /// Plan a variadic spread: present when the callee accepts a variadic
 /// parameter and the call supplies a trailing spread argument.
 pub(crate) fn plan_variadic_spread(
+    facts: &crate::EmitFacts<'_>,
     function: &Expression,
     spread: Option<&Expression>,
 ) -> Option<VariadicSpreadPlan> {
     spread?;
-    let fn_ty = function.get_type();
-    let unwrapped = fn_ty.unwrap_forall();
-    let element_ty = unwrapped.is_variadic()?;
-    let fixed_in_signature = unwrapped.get_function_params()?.len().saturating_sub(1);
+    let function_ty = facts.resolve_to_function_type(&function.get_type())?;
+    let element_ty = function_ty.is_variadic()?;
+    let fixed_in_signature = function_ty.get_function_params()?.len().saturating_sub(1);
     Some(VariadicSpreadPlan {
         element_ty,
         fixed_in_signature,

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -14,12 +14,11 @@ use crate::plan::bodies::{
 use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
 use crate::plan::values::ValuePlan;
 use crate::utils::wrap_if_struct_literal;
-use syntax::ast::{BinaryOperator, Expression, Literal, MatchArm, Pattern, TypedPattern};
+use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, Literal, MatchArm, Pattern};
 use syntax::types::Type;
 
 fn if_let_match_arms(
     pattern: &Pattern,
-    typed_pattern: &Option<TypedPattern>,
     consequence: &Expression,
     alternative: &Expression,
 ) -> Vec<MatchArm> {
@@ -27,7 +26,6 @@ fn if_let_match_arms(
         MatchArm {
             pattern: pattern.clone(),
             guard: None,
-            typed_pattern: typed_pattern.clone(),
             expression: Box::new(consequence.clone()),
         },
         MatchArm {
@@ -35,7 +33,6 @@ fn if_let_match_arms(
                 span: alternative.get_span(),
             },
             guard: None,
-            typed_pattern: None,
             expression: Box::new(alternative.clone()),
         },
     ]
@@ -256,6 +253,9 @@ impl Planner<'_> {
                 ty,
                 ..
             } => {
+                let Some(value) = value.value() else {
+                    return LoweredStatement::Block(LoweredBlock { statements: vec![] });
+                };
                 let plan = self.build_const_plan(identifier, value, ty);
                 self.directed_at(expression, LoweredStatement::Const(plan))
             }
@@ -268,16 +268,15 @@ impl Planner<'_> {
             Expression::Let {
                 binding,
                 value,
-                else_block,
-                assert,
+                mode,
                 ..
             } => {
                 let plan = self.build_let_plan(
                     binding,
                     value,
-                    else_block.as_deref(),
-                    binding.mutable,
-                    *assert,
+                    mode.else_block(),
+                    binding.is_mutable(),
+                    mode.is_assert(),
                 );
                 self.directed_at(expression, LoweredStatement::Let(plan))
             }
@@ -295,10 +294,9 @@ impl Planner<'_> {
                 scrutinee,
                 consequence,
                 alternative,
-                typed_pattern,
                 ..
             } => {
-                let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
+                let arms = if_let_match_arms(pattern, consequence, alternative);
                 let body = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Statement);
                 self.directed_at(
                     expression,
@@ -626,7 +624,6 @@ impl Planner<'_> {
     fn lower_while_let_statement(&mut self, expression: &Expression) -> LoweredStatement {
         let Expression::WhileLet {
             pattern,
-            typed_pattern,
             scrutinee,
             body,
             ..
@@ -635,9 +632,7 @@ impl Planner<'_> {
             unreachable!("lower_while_let_statement requires a WhileLet expression");
         };
         let directive = self.maybe_line_directive(&expression.get_span());
-        let body = self.with_loop("_", |this| {
-            this.lower_while_let(pattern, typed_pattern.as_ref(), scrutinee, body)
-        });
+        let body = self.with_loop("_", |this| this.lower_while_let(pattern, scrutinee, body));
         directed(directive, LoweredStatement::WhileLet(WhileLetPlan { body }))
     }
 
@@ -737,10 +732,9 @@ impl Planner<'_> {
                 scrutinee,
                 consequence,
                 alternative,
-                typed_pattern,
                 ..
             } => {
-                let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
+                let arms = if_let_match_arms(pattern, consequence, alternative);
                 self.lower_match_to_block(scrutinee, &arms, place)
             }
             Expression::Match { subject, arms, .. } => {
@@ -847,13 +841,12 @@ impl Planner<'_> {
                 scrutinee,
                 consequence,
                 alternative,
-                typed_pattern,
                 ..
             } => {
                 if !directive.is_empty() {
                     statements.push(LoweredStatement::RawGo(directive));
                 }
-                let arms = if_let_match_arms(pattern, typed_pattern, consequence, alternative);
+                let arms = if_let_match_arms(pattern, consequence, alternative);
                 let block = self.lower_match_to_block(scrutinee, &arms, &PlacePlan::Return);
                 statements.extend(block.statements);
             }
@@ -1042,8 +1035,7 @@ fn temp_identifier(name: &str, original: &Expression) -> Expression {
         value: name.into(),
         ty: original.get_type(),
         span: original.get_span(),
-        binding_id: None,
-        qualified: None,
+        resolution: IdentifierResolution::Unresolved,
     }
 }
 

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -90,13 +90,13 @@ pub(crate) fn try_elide_tail_let(items: &[Expression]) -> Option<(&Expression, &
     let Expression::Let {
         binding,
         value,
-        else_block,
+        mode,
         ..
     } = penultimate
     else {
         return None;
     };
-    if else_block.is_some() || binding.mutable {
+    if mode.else_block().is_some() || binding.is_mutable() {
         return None;
     }
     let syntax::ast::Pattern::Identifier { identifier, .. } = &binding.pattern else {
@@ -201,7 +201,11 @@ impl Planner<'_> {
         }
 
         let value_ty = value.get_type();
-        if value_ty.is_unit() || value_ty.is_variable() || value_ty.is_never() {
+        if value_ty.is_unit()
+            || value_ty.is_variable()
+            || value_ty.is_placeholder()
+            || value_ty.is_never()
+        {
             let staged = self.stage_operand(value, ExpressionContext::value());
             let (mut statements, staged_value) = staged.into_parts();
             if !staged_value.is_empty() {
@@ -517,7 +521,7 @@ impl Planner<'_> {
             is_lvalue_chain(unwrapped) && !self.contains_newtype_access(unwrapped);
 
         let (value, mut statements) = if receiver_is_lvalue {
-            let arguments = self.lower_growth_args(func, args, (**spread).as_ref());
+            let arguments = self.lower_growth_args(func, args, spread.as_deref());
             let mut capture: Vec<LoweredStatement> = Vec::new();
             let receiver_lv =
                 self.emit_left_value_capturing(&mut capture, unwrapped, Some(&arguments));
@@ -576,7 +580,7 @@ impl Planner<'_> {
             .iter()
             .map(|a| self.stage_composite(a, ExpressionContext::value()))
             .collect();
-        let combine = plan_variadic_spread(function, spread).map(|p| p.combine(0));
+        let combine = plan_variadic_spread(&self.facts, function, spread).map(|p| p.combine(0));
         let sequenced = self.sequence_with_spread_values(
             stages,
             spread,
@@ -619,7 +623,10 @@ impl Planner<'_> {
         ty: &Type,
     ) -> ValuePlan {
         if let Expression::Block { items, .. } = expression {
-            if ty.is_never() || ty.is_unit() || matches!(ty, Type::Var { .. } | Type::Forall { .. })
+            if ty.is_never()
+                || ty.is_unit()
+                || ty.is_placeholder()
+                || matches!(ty, Type::Var { .. } | Type::Forall { .. })
             {
                 return ValuePlan::computed(
                     self.lower_block_as_body(expression).statements,

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -7,7 +7,7 @@ use crate::names::go_name;
 use crate::plan::bodies::{AssignForm, AssignPlan, CompoundKind, LoweredBlock, LoweredStatement};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::bindings::BindingValue;
-use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
+use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
@@ -472,11 +472,11 @@ pub(crate) fn lvalues_match(a: &Expression, b: &Expression) -> bool {
     match (a, b) {
         (
             Expression::Identifier {
-                binding_id: Some(id_a),
+                resolution: IdentifierResolution::Binding(id_a),
                 ..
             },
             Expression::Identifier {
-                binding_id: Some(id_b),
+                resolution: IdentifierResolution::Binding(id_b),
                 ..
             },
         ) => id_a == id_b,

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -31,7 +31,7 @@ fn needs_explicit_type_declaration(
             return true;
         }
     }
-    if is_fn_alias_nominal(binding_ty) {
+    if planner.is_function_alias(binding_ty) {
         let value_ty = value.get_type();
         if matches!(value_ty.unwrap_forall(), Type::Function(_)) {
             return true;
@@ -61,17 +61,6 @@ fn unwrap_unary_negation(expression: &Expression) -> &Expression {
     }
 }
 
-fn is_fn_alias_nominal(ty: &Type) -> bool {
-    let Type::Nominal {
-        underlying_ty: Some(inner),
-        ..
-    } = ty.unwrap_forall()
-    else {
-        return false;
-    };
-    matches!(inner.unwrap_forall(), Type::Function(_))
-}
-
 /// Pick the Go type for a `let` binding's `var X T` temp. Diverging values
 /// use the binding type so dead `return x` paths still typecheck; branching
 /// values that produce tuples widen slots to match the assignment site.
@@ -87,7 +76,7 @@ fn resolve_let_temp_declaration_ty(
         return binding_ty.clone();
     }
     let base = if value_ty.is_unit() || value_ty.is_never() {
-        if !binding_ty.is_unit() && !binding_ty.is_variable() {
+        if !binding_ty.is_unit() && !binding_ty.is_variable() && !binding_ty.is_placeholder() {
             binding_ty.clone()
         } else {
             value_ty
@@ -350,14 +339,15 @@ impl Planner<'_> {
         }
         let return_ctx = self.return_ctx();
         let resolved_ty = resolve_let_temp_declaration_ty(self, value, binding_ty);
-        let has_variable_ok_ty = matches!(
+        let needs_context = |ty: &Type| ty.is_variable() || ty.is_placeholder();
+        let has_contextual_ok_ty = matches!(
             value,
             Expression::TryBlock { .. } | Expression::RecoverBlock { .. }
-        ) && !resolved_ty.is_variable()
-            && resolved_ty.ok_type().is_variable();
+        ) && !needs_context(&resolved_ty)
+            && needs_context(&resolved_ty.ok_type());
 
-        let var_ty = if has_variable_ok_ty {
-            if !binding_ty.is_variable() && !binding_ty.ok_type().is_variable() {
+        let var_ty = if has_contextual_ok_ty {
+            if !needs_context(binding_ty) && !needs_context(&binding_ty.ok_type()) {
                 self.go_type_string(binding_ty)
             } else if let Some(ctx_ty) = return_ctx.ty().cloned() {
                 if Fallible::from_type(&ctx_ty).is_some() {
@@ -447,7 +437,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
             LetKind::Refutable => {
                 let ap = AnnotatedPattern {
                     pattern: &self.binding.pattern,
-                    typed: self.binding.typed_pattern.as_ref(),
                 };
                 let statements = if self.assert {
                     let span = self.binding.pattern.get_span();
@@ -486,7 +475,6 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                 let statements = self.planner.lower_irrefutable_pattern_site(
                     PatternSubject::expression(self.value, &self.binding.pattern, None),
                     &self.binding.pattern,
-                    self.binding.typed_pattern.as_ref(),
                     &value_ty,
                 );
                 LetForm::ComplexPattern {

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -5,6 +5,7 @@ use crate::names::go_name;
 use crate::names::packages::{PackageRequirements, PackageUse};
 use crate::types::native::NativeGoType;
 use crate::types::prelude::PreludeType;
+use syntax::ast::ResolvedCallTypeArguments;
 use syntax::program::DefinitionBody;
 use syntax::types::{CompoundKind, FunctionParameter, SimpleKind, Type};
 
@@ -70,7 +71,7 @@ impl Planner<'_> {
             }
             Type::Compound { kind, args } => self.emit_compound(*kind, args, ty),
             Type::Function(f) => self.emit_function_type(&f.params, &f.return_type),
-            Type::Var { .. } => GoType::new("any"),
+            Type::Var { .. } | Type::Uninferred | Type::Ignored => GoType::new("any"),
             Type::Forall { .. } => GoType::new("any"),
             Type::Parameter(name) => GoType::new(self.generic_go_name(name).into_owned()),
             Type::Never => GoType::new("struct{}"),
@@ -132,10 +133,24 @@ impl Planner<'_> {
     }
 
     pub(crate) fn format_type_args(&mut self, params: &[Type]) -> String {
-        if params.is_empty() {
+        self.format_type_arg_iter(params)
+    }
+
+    pub(crate) fn format_resolved_type_args(
+        &mut self,
+        params: ResolvedCallTypeArguments<'_>,
+    ) -> String {
+        self.format_type_arg_iter(params.iter())
+    }
+
+    fn format_type_arg_iter<'t>(&mut self, params: impl IntoIterator<Item = &'t Type>) -> String {
+        let args: Vec<String> = params
+            .into_iter()
+            .map(|param| self.go_type_string(param))
+            .collect();
+        if args.is_empty() {
             return String::new();
         }
-        let args: Vec<String> = params.iter().map(|p| self.go_type_string(p)).collect();
         format!("[{}]", args.join(", "))
     }
 
@@ -368,7 +383,7 @@ impl Planner<'_> {
     pub(crate) fn format_type_args_with_receiver(
         &mut self,
         receiver_ty: &Type,
-        type_args: &[Type],
+        type_args: ResolvedCallTypeArguments<'_>,
     ) -> String {
         let mut go_type_strs = Vec::new();
         if let Some(params) = receiver_ty.get_type_params() {
@@ -377,11 +392,11 @@ impl Planner<'_> {
                 go_type_strs.push(self.go_type_string(param));
             }
         }
-        for ta in type_args {
+        for ta in type_args.iter() {
             go_type_strs.push(self.go_type_string(ta));
         }
         if go_type_strs.is_empty() {
-            self.format_type_args(type_args)
+            String::new()
         } else {
             format!("[{}]", go_type_strs.join(", "))
         }

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -124,9 +124,9 @@ pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {
         } => true,
         Expression::DotAccess {
             expression,
-            dot_access_kind,
+            resolution,
             ..
-        } => match dot_access_kind {
+        } => match resolution.kind() {
             Some(
                 DotAccessKind::StructField { .. }
                 | DotAccessKind::TupleStructField { .. }
@@ -148,9 +148,9 @@ pub(crate) fn reads_unsequenced_mutable_operand(expression: &Expression) -> bool
         } => true,
         Expression::DotAccess {
             expression,
-            dot_access_kind,
+            resolution,
             ..
-        } => match dot_access_kind {
+        } => match resolution.kind() {
             Some(
                 DotAccessKind::StructField { .. }
                 | DotAccessKind::TupleStructField { .. }

--- a/crates/format/src/formatter/expression.rs
+++ b/crates/format/src/formatter/expression.rs
@@ -4,8 +4,9 @@ use crate::INDENT_WIDTH;
 use crate::comments::prepend_comments;
 use crate::lindig::{Document, concat, flex_break, join, strict_break};
 use syntax::ast::{
-    Annotation, BinaryOperator, Binding, Expression, FormatStringPart, Literal, MatchArm, Pattern,
-    SelectArm, SelectArmPattern, Span, StructFieldAssignment, StructSpread, UnaryOperator,
+    Annotation, BinaryOperator, Binding, CallTypeArguments, Expression, FormatStringPart, Literal,
+    MatchArm, Pattern, SelectArm, SelectArmPattern, Span, StructFieldAssignment, StructSpread,
+    UnaryOperator,
 };
 
 impl<'a> Formatter<'a> {
@@ -25,7 +26,6 @@ impl<'a> Formatter<'a> {
                 }
             }
             Expression::Continue { .. } => Document::str("continue"),
-            Expression::NoOp => Document::Sequence(vec![]),
 
             Expression::Paren { expression, .. } => Document::str("(")
                 .append(self.expression(expression))
@@ -36,10 +36,9 @@ impl<'a> Formatter<'a> {
             Expression::Let {
                 binding,
                 value,
-                else_block,
-                assert,
+                mode,
                 ..
-            } => self.let_(binding, value, else_block.as_deref(), *assert),
+            } => self.let_(binding, value, mode.else_block(), mode.is_assert()),
 
             Expression::Return { expression, .. } => self.return_(expression),
 
@@ -84,7 +83,7 @@ impl<'a> Formatter<'a> {
                 spread,
                 type_arguments,
                 ..
-            } => self.call(expression, args, spread, type_arguments.annotations()),
+            } => self.call(expression, args, spread, type_arguments),
 
             Expression::DotAccess {
                 expression, member, ..
@@ -392,7 +391,6 @@ impl<'a> Formatter<'a> {
     pub(super) fn as_block(&mut self, expression: &'a Expression) -> Document<'a> {
         match expression {
             Expression::Block { items, span, .. } => self.block(items, span),
-            Expression::NoOp => Document::Sequence(vec![]),
             _ => Document::str("{ ")
                 .append(self.expression(expression))
                 .append(" }"),
@@ -414,7 +412,6 @@ impl<'a> Formatter<'a> {
                 }
                 self.block(items, span)
             }
-            Expression::NoOp => Document::Sequence(vec![]),
             _ => {
                 let expression = self.expression(expression);
                 Document::str("{")
@@ -600,8 +597,8 @@ impl<'a> Formatter<'a> {
         &mut self,
         callee: &'a Expression,
         args: &'a [Expression],
-        spread: &'a Option<Expression>,
-        raw_type_args: &'a [Annotation],
+        spread: &'a Option<Box<Expression>>,
+        type_arguments: &'a CallTypeArguments,
     ) -> Document<'a> {
         if let Expression::DotAccess {
             expression: inner,
@@ -617,7 +614,7 @@ impl<'a> Formatter<'a> {
                 member_start,
                 args,
                 spread,
-                raw_type_args,
+                type_arguments,
             });
             if chain_segments.len() >= 2 {
                 return self.format_method_chain(root, &chain_segments);
@@ -638,15 +635,15 @@ impl<'a> Formatter<'a> {
 
         let head = self
             .expression(callee)
-            .append(Self::format_type_args(raw_type_args));
+            .append(Self::format_type_args(type_arguments));
         self.format_call_with_head(head, args, spread)
     }
 
-    fn format_type_args(type_args: &'a [Annotation]) -> Document<'a> {
-        if type_args.is_empty() {
+    fn format_type_args(type_arguments: &'a CallTypeArguments) -> Document<'a> {
+        if type_arguments.is_empty() {
             Document::Sequence(vec![])
         } else {
-            let types: Vec<_> = type_args.iter().map(Self::annotation).collect();
+            let types: Vec<_> = type_arguments.annotations().map(Self::annotation).collect();
             Document::str("<")
                 .append(join(types, Document::str(", ")))
                 .append(">")
@@ -657,7 +654,7 @@ impl<'a> Formatter<'a> {
         &mut self,
         head: Document<'a>,
         args: &'a [Expression],
-        spread: &'a Option<Expression>,
+        spread: &'a Option<Box<Expression>>,
     ) -> Document<'a> {
         if args.is_empty() && spread.is_none() {
             return head.append("()");
@@ -761,7 +758,7 @@ impl<'a> Formatter<'a> {
                 let comments = self.comments.take_comments_before(seg.member_start);
                 let head = Document::str(".")
                     .append(seg.member)
-                    .append(Self::format_type_args(seg.raw_type_args));
+                    .append(Self::format_type_args(seg.type_arguments));
                 let call_doc = strict_break("", "")
                     .append(self.format_call_with_head(head, seg.args, seg.spread));
                 match comments {
@@ -1069,8 +1066,8 @@ struct MethodChainSegment<'a> {
     member: &'a str,
     member_start: u32,
     args: &'a [Expression],
-    spread: &'a Option<Expression>,
-    raw_type_args: &'a [Annotation],
+    spread: &'a Option<Box<Expression>>,
+    type_arguments: &'a CallTypeArguments,
 }
 
 fn collect_method_chain(expression: &Expression) -> (&Expression, Vec<MethodChainSegment<'_>>) {
@@ -1100,7 +1097,7 @@ fn collect_method_chain(expression: &Expression) -> (&Expression, Vec<MethodChai
             member_start,
             args,
             spread,
-            raw_type_args: type_arguments.annotations(),
+            type_arguments,
         });
         current = inner;
     }

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -3,8 +3,8 @@ use super::sequence::SiblingEntry;
 use crate::INDENT_WIDTH;
 use crate::lindig::{Document, join, strict_break};
 use syntax::ast::{
-    Annotation, Attribute, AttributeArg, Binding, EnumVariant, Expression, Generic,
-    ParentInterface, Span, StructFieldDefinition, StructKind, VariantFields,
+    Annotation, Attribute, AttributeArg, Binding, ConstInitializer, EnumVariant, Expression,
+    FunctionBody, Generic, ParentInterface, Span, StructFieldDefinition, StructKind, VariantFields,
 };
 
 impl<'a> Formatter<'a> {
@@ -14,7 +14,7 @@ impl<'a> Formatter<'a> {
         generics: &'a [Generic],
         params: &'a [Binding],
         return_annotation: &'a Annotation,
-        body: &'a Expression,
+        body: &'a FunctionBody,
     ) -> Document<'a> {
         let generics_doc = Self::generics(generics);
 
@@ -35,10 +35,9 @@ impl<'a> Formatter<'a> {
             .append(return_doc)
             .group();
 
-        if matches!(body, Expression::NoOp) {
-            signature
-        } else {
-            signature.append(" ").append(self.as_block(body))
+        match body.definition() {
+            None => signature,
+            Some(body) => signature.append(" ").append(self.as_block(body)),
         }
     }
 
@@ -456,7 +455,7 @@ impl<'a> Formatter<'a> {
         &mut self,
         name: &'a str,
         annotation: Option<&'a Annotation>,
-        value: &'a Expression,
+        value: &'a ConstInitializer,
     ) -> Document<'a> {
         let type_doc = match annotation {
             Some(ann) => Document::str(": ").append(Self::annotation(ann)),
@@ -465,16 +464,15 @@ impl<'a> Formatter<'a> {
 
         let declaration = Document::str("const ").append(name).append(type_doc);
 
-        if matches!(value, Expression::NoOp) {
-            declaration
-        } else {
-            declaration.append(" = ").append(self.expression(value))
+        match value.value() {
+            None => declaration,
+            Some(value) => declaration.append(" = ").append(self.expression(value)),
         }
     }
 
     pub(super) fn binding(&mut self, binding: &'a Binding) -> Document<'a> {
         self.with_leading_comments(binding.pattern.get_span().byte_offset, |s| {
-            let pattern_doc = if binding.mutable {
+            let pattern_doc = if binding.is_mutable() {
                 Document::str("mut ").append(s.pattern(&binding.pattern))
             } else {
                 s.pattern(&binding.pattern)
@@ -548,10 +546,10 @@ impl<'a> Formatter<'a> {
         let generics_docs: Vec<_> = generics
             .iter()
             .map(|g| {
-                if g.bounds.is_empty() {
+                if g.bound_count() == 0 {
                     Document::string(g.name.to_string())
                 } else {
-                    let bounds: Vec<_> = g.bounds.iter().map(Self::annotation).collect();
+                    let bounds: Vec<_> = g.bounds().map(Self::annotation).collect();
                     Document::string(g.name.to_string())
                         .append(": ")
                         .append(join(bounds, Document::str(" + ")))

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -19,17 +19,14 @@ use crate::snapshot::AnalysisSnapshot;
 use crate::state::{CachedSnapshot, SharedState};
 
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
-pub(crate) fn type_name(ty: &Type) -> Option<String> {
-    match ty {
-        Type::Nominal {
-            underlying_ty: Some(u),
-            ..
-        } => type_name(u),
+pub(crate) fn type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String> {
+    let resolved = syntax::types::peel_alias(ty, |id| snapshot.definitions().get(id));
+    match &resolved {
         Type::Nominal { id, .. } => Some(id.to_string()),
         Type::Compound {
             kind: CompoundKind::Ref,
             args,
-        } => args.first().and_then(type_name),
+        } => args.first().and_then(|ty| type_name(ty, snapshot)),
         Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
         Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
         Type::Array { .. } => Some("prelude.Array".to_string()),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 use tower_lsp::lsp_types::*;
 
-use syntax::ast::Expression;
+use syntax::ast::{Expression, IdentifierResolution};
 use syntax::attributes::{AttributeInfo, AttributeTarget, attributes_for};
 use syntax::lex::{Lexer, Token, TokenKind as Tk};
 use syntax::program::DefinitionBody;
@@ -60,18 +60,18 @@ pub(crate) fn definition_to_completion_kind(
 }
 
 /// Extract the element type from an array, slice, or map.
-fn element_type_name(ty: &Type) -> Option<String> {
+fn element_type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String> {
     use syntax::types::CompoundKind;
 
     if let Type::Array { element, .. } = ty {
-        return type_name(element);
+        return type_name(element, snapshot);
     }
 
     match ty.as_compound()? {
         (CompoundKind::Slice | CompoundKind::EnumeratedSlice, args) => {
-            args.first().and_then(type_name)
+            args.first().and_then(|ty| type_name(ty, snapshot))
         }
-        (CompoundKind::Map, args) => args.get(1).and_then(type_name),
+        (CompoundKind::Map, args) => args.get(1).and_then(|ty| type_name(ty, snapshot)),
         _ => None,
     }
 }
@@ -127,7 +127,8 @@ pub(crate) fn resolve_variable_type(
     let ty = if let Some(t) = borrowed_ty {
         t
     } else {
-        let (t, _) = crate::hover::get_hover_type_and_span(expression, binding.span.byte_offset);
+        let (t, _) =
+            crate::hover::get_hover_type_and_span(snapshot, expression, binding.span.byte_offset);
         owned_ty = t;
         &owned_ty
     };
@@ -136,9 +137,9 @@ pub(crate) fn resolve_variable_type(
     let ty = &resolved[0];
 
     if indexed {
-        element_type_name(ty)
+        element_type_name(ty, snapshot)
     } else {
-        type_name(ty)
+        type_name(ty, snapshot)
     }
 }
 
@@ -168,12 +169,12 @@ pub(crate) fn detect_dot_context(
         if !matches!(
             get_root_expression(expression),
             Expression::Identifier {
-                binding_id: None,
+                resolution,
                 ..
-            }
+            } if !matches!(resolution, IdentifierResolution::Binding(_))
         ) {
             let ty = expression.get_type();
-            return type_name(&ty).map(DotContext::Instance);
+            return type_name(&ty, snapshot).map(DotContext::Instance);
         }
         return None;
     }
@@ -190,7 +191,7 @@ pub(crate) fn detect_dot_context(
     }
 
     let ty = expression.get_type();
-    if let Some(type_id) = type_name(&ty) {
+    if let Some(type_id) = type_name(&ty, snapshot) {
         return Some(DotContext::Instance(type_id));
     }
 
@@ -240,7 +241,7 @@ pub(crate) fn get_instance_completions(
                 definition.body,
                 syntax::program::DefinitionBody::Value { .. }
             )
-            && is_instance_method(&definition.ty, type_id)
+            && is_instance_method(&definition.ty, type_id, snapshot)
             && (same_module || definition.visibility.is_public())
         {
             items.push(CompletionItem {
@@ -432,7 +433,7 @@ pub(crate) fn get_type_completions(
         if let Some(method_name) = qname.strip_prefix(method_prefix.as_str())
             && !method_name.contains('.')
             && matches!(definition.body, DefinitionBody::Value { .. })
-            && !is_instance_method(&definition.ty, method_id)
+            && !is_instance_method(&definition.ty, method_id, snapshot)
             && (same_module || definition.visibility.is_public())
             && !items.iter().any(|i| i.label == method_name)
         {
@@ -469,13 +470,19 @@ fn enum_variant_items(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<Vec<
 /// Returns the target id of a non-generic alias.
 fn alias_target(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<String> {
     let def = snapshot.definitions().get(type_id)?;
-    let DefinitionBody::TypeAlias { generics, .. } = &def.body else {
+    let DefinitionBody::TypeAlias {
+        generics,
+        alias: syntax::program::AliasKind::Transparent { .. },
+        ..
+    } = &def.body
+    else {
         return None;
     };
     if !generics.is_empty() {
         return None;
     }
-    let target = match &def.ty {
+    let target = syntax::types::peel_alias(&def.ty, |id| snapshot.definitions().get(id));
+    let target = match target {
         Type::Nominal { id, .. } => id.to_string(),
         Type::Simple(kind) => format!("prelude.{}", kind.leaf_name()),
         Type::Compound { kind, .. } => format!("prelude.{}", kind.leaf_name()),
@@ -484,14 +491,18 @@ fn alias_target(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<String> {
     (target != type_id).then_some(target)
 }
 
-fn is_instance_method(ty: &syntax::types::Type, type_id: &str) -> bool {
+fn is_instance_method(
+    ty: &syntax::types::Type,
+    type_id: &str,
+    snapshot: &AnalysisSnapshot,
+) -> bool {
     let func_ty = match ty {
         syntax::types::Type::Forall { body, .. } => body,
         other => other,
     };
     match func_ty {
         syntax::types::Type::Function(f) if !f.params.is_empty() => {
-            type_name(&f.params[0].ty).is_some_and(|name| name == type_id)
+            type_name(&f.params[0].ty, snapshot).is_some_and(|name| name == type_id)
         }
         _ => false,
     }

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -1,7 +1,9 @@
 use rustc_hash::FxHashMap;
 use syntax::ast::{
-    Annotation, Expression, MatchArm, Pattern, Span, StructFieldPattern, TypedPattern,
+    Annotation, ConstructorPatternResolution, Expression, IdentifierResolution, MatchArm, Pattern,
+    RecordPatternResolution, Span, StructFieldPattern,
 };
+use syntax::program::DefinitionBody;
 use syntax::types::unqualified_name;
 
 use crate::analysis::find_module_by_alias;
@@ -47,7 +49,7 @@ pub(crate) fn resolve_struct_call_field(
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<syntax::ast::Span> {
-    let type_id = type_name(ty);
+    let type_id = type_name(ty, snapshot);
 
     field_assignments
         .iter()
@@ -112,7 +114,7 @@ pub(crate) fn resolve_dot_access_definition(
     };
 
     let resolve_by_type = || {
-        type_name(&expression.get_type()).and_then(|type_id| {
+        type_name(&expression.get_type(), snapshot).and_then(|type_id| {
             let name = format!("{}.{}", type_id, member);
             try_lookup(&name).or_else(|| find_struct_field_span(&type_id, member, snapshot))
         })
@@ -127,7 +129,7 @@ pub(crate) fn resolve_dot_access_definition(
         if matches!(
             root_expression,
             Expression::Identifier {
-                binding_id: Some(_),
+                resolution: IdentifierResolution::Binding(_),
                 ..
             }
         ) {
@@ -147,10 +149,9 @@ pub(crate) fn resolve_dot_access_definition(
             try_lookup(&dotted_path)
         }
     } else if let Expression::Identifier {
-        value,
-        binding_id: None,
-        ..
+        value, resolution, ..
     } = expression.unwrap_parens()
+        && !matches!(resolution, IdentifierResolution::Binding(_))
     {
         if let Some(module_name) =
             find_module_by_alias(file, value.as_str(), &snapshot.result.go_package_names)
@@ -352,21 +353,13 @@ pub(crate) fn resolve_match_pattern_definition(
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<syntax::ast::Span> {
-    arms.iter().find_map(|arm| {
-        resolve_enum_in_pattern(
-            &arm.pattern,
-            arm.typed_pattern.as_ref(),
-            offset,
-            file,
-            snapshot,
-        )
-    })
+    arms.iter()
+        .find_map(|arm| resolve_enum_in_pattern(&arm.pattern, offset, file, snapshot))
 }
 
 /// Resolve an enum variant in a single pattern (used by match, if-let, while-let).
 pub(crate) fn resolve_enum_in_pattern(
     pattern: &Pattern,
-    typed_pattern: Option<&TypedPattern>,
     offset: u32,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
@@ -377,20 +370,16 @@ pub(crate) fn resolve_enum_in_pattern(
 
     match pattern {
         Pattern::EnumVariant {
-            identifier, fields, ..
+            identifier,
+            fields,
+            resolution,
+            ..
         } => {
-            let typed_fields = match typed_pattern {
-                Some(TypedPattern::EnumVariant { fields: tf, .. }) => Some(tf.as_slice()),
-                _ => None,
-            };
             let mut offset_in_field = false;
-            for (i, field) in fields.iter().enumerate() {
+            for field in fields {
                 if offset_in_span(offset, &field.get_span()) {
                     offset_in_field = true;
-                    let child_typed = typed_fields.and_then(|tf| tf.get(i));
-                    if let Some(result) =
-                        resolve_enum_in_pattern(field, child_typed, offset, file, snapshot)
-                    {
+                    if let Some(result) = resolve_enum_in_pattern(field, offset, file, snapshot) {
                         return Some(result);
                     }
                 }
@@ -399,19 +388,12 @@ pub(crate) fn resolve_enum_in_pattern(
                 return None;
             }
 
-            match typed_pattern {
-                Some(
-                    TypedPattern::EnumVariant {
-                        enum_name,
-                        variant_name,
-                        ..
-                    }
-                    | TypedPattern::EnumStructVariant {
-                        enum_name,
-                        variant_name,
-                        ..
-                    },
-                ) => {
+            match resolution {
+                ConstructorPatternResolution::EnumVariant {
+                    enum_name,
+                    variant_name,
+                    ..
+                } => {
                     let variant_last = unqualified_name(variant_name);
                     let qualified = format!("{}.{}", enum_name, variant_last);
                     snapshot
@@ -419,67 +401,51 @@ pub(crate) fn resolve_enum_in_pattern(
                         .get(qualified.as_str())
                         .and_then(|d| d.name_span)
                 }
-                Some(TypedPattern::Const { qualified_name, .. }) => snapshot
+                ConstructorPatternResolution::Const { qualified_name, .. } => snapshot
                     .definitions()
                     .get(qualified_name.as_str())
                     .and_then(|d| d.name_span),
-                _ => lookup_definition_span(identifier, file, snapshot),
+                ConstructorPatternResolution::Unresolved => {
+                    lookup_definition_span(identifier, file, snapshot)
+                }
             }
         }
 
-        Pattern::Or { patterns, .. } => {
-            let alternatives = match typed_pattern {
-                Some(TypedPattern::Or { alternatives, .. }) => Some(alternatives.as_slice()),
-                _ => None,
-            };
-            patterns.iter().enumerate().find_map(|(i, pat)| {
-                let child_typed = alternatives.and_then(|a| a.get(i));
-                resolve_enum_in_pattern(pat, child_typed, offset, file, snapshot)
-            })
-        }
+        Pattern::Or { patterns, .. }
+        | Pattern::Tuple {
+            elements: patterns, ..
+        } => patterns
+            .iter()
+            .find_map(|pattern| resolve_enum_in_pattern(pattern, offset, file, snapshot)),
 
         Pattern::Struct {
             identifier,
             fields,
             span,
+            resolution,
             ..
         } => {
             if let Some(field) = fields
                 .iter()
-                .find(|f| offset_in_span(offset, &f.value.get_span()))
-                && let Some(TypedPattern::Struct { struct_fields, .. }) = typed_pattern
-                && let Some(sf) = struct_fields.iter().find(|sf| sf.name == field.name)
+                .find(|field| offset_in_span(offset, &field.value.get_span()))
             {
-                return Some(sf.name_span);
+                if let Some(result) = resolve_enum_in_pattern(&field.value, offset, file, snapshot)
+                {
+                    return Some(result);
+                }
+                let definition_span = record_pattern_field_span(snapshot, resolution, &field.name);
+                if is_shorthand_field(field, *span, snapshot) {
+                    return definition_span;
+                }
+                return None;
             }
-            if let Some(TypedPattern::EnumStructVariant {
+
+            if let RecordPatternResolution::EnumVariant {
                 enum_name,
                 variant_name,
-                variant_fields,
-                pattern_fields,
                 ..
-            }) = typed_pattern
+            } = resolution
             {
-                if let Some(field) = fields
-                    .iter()
-                    .find(|f| offset_in_span(offset, &f.value.get_span()))
-                {
-                    let child_typed = pattern_fields
-                        .iter()
-                        .find(|(name, _)| name == &field.name)
-                        .map(|(_, t)| t);
-                    if let Some(result) =
-                        resolve_enum_in_pattern(&field.value, child_typed, offset, file, snapshot)
-                    {
-                        return Some(result);
-                    }
-                    if is_shorthand_field(field, *span, snapshot)
-                        && let Some(vf) = variant_fields.iter().find(|vf| vf.name == field.name)
-                    {
-                        return Some(vf.name_span);
-                    }
-                    return None;
-                }
                 if !offset_in_variant_token_span(*span, offset, snapshot) {
                     return None;
                 }
@@ -493,22 +459,53 @@ pub(crate) fn resolve_enum_in_pattern(
             lookup_definition_span(identifier, file, snapshot)
         }
 
-        Pattern::Tuple { elements, .. } => {
-            let typed_elements = match typed_pattern {
-                Some(TypedPattern::Tuple { elements: te, .. }) => Some(te.as_slice()),
-                _ => None,
-            };
-            elements.iter().enumerate().find_map(|(i, pat)| {
-                let child_typed = typed_elements.and_then(|te| te.get(i));
-                resolve_enum_in_pattern(pat, child_typed, offset, file, snapshot)
-            })
-        }
+        Pattern::Slice { prefix, .. } => prefix
+            .iter()
+            .find_map(|pattern| resolve_enum_in_pattern(pattern, offset, file, snapshot)),
 
         Pattern::AsBinding { pattern, .. } => {
-            resolve_enum_in_pattern(pattern, typed_pattern, offset, file, snapshot)
+            resolve_enum_in_pattern(pattern, offset, file, snapshot)
         }
 
         _ => None,
+    }
+}
+
+fn record_pattern_field_span(
+    snapshot: &AnalysisSnapshot,
+    resolution: &RecordPatternResolution,
+    field_name: &str,
+) -> Option<Span> {
+    match resolution {
+        RecordPatternResolution::Struct { struct_name } => {
+            let DefinitionBody::Struct { fields, .. } =
+                &snapshot.definitions().get(struct_name.as_str())?.body
+            else {
+                return None;
+            };
+            fields
+                .iter()
+                .find(|field| field.name == field_name)
+                .map(|field| field.name_span)
+        }
+        RecordPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } => {
+            let DefinitionBody::Enum { variants, .. } =
+                &snapshot.definitions().get(enum_name.as_str())?.body
+            else {
+                return None;
+            };
+            variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))?
+                .fields
+                .iter()
+                .find(|field| field.name == field_name)
+                .map(|field| field.name_span)
+        }
+        RecordPatternResolution::Unresolved => None,
     }
 }
 
@@ -538,7 +535,7 @@ pub(crate) fn resolve_definition_span(
             let expression = find_expression_at(&file.items, offset)?;
             match expression {
                 Expression::Identifier {
-                    binding_id: Some(id),
+                    resolution: IdentifierResolution::Binding(id),
                     ..
                 } => snapshot.facts().bindings.get(id).map(|b| b.span),
 

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Annotation, Expression, Span};
+use syntax::ast::{Annotation, Expression, IdentifierResolution, Span};
 use syntax::program::{Definition, DefinitionBody};
 
 use crate::analysis::find_module_by_alias;
@@ -25,7 +25,10 @@ pub(crate) fn resolve_declaration_hover(
         }
         let qualified = format!("{}.{}", file.module_id, name);
         let definition = snapshot.definitions().get(qualified.as_str())?;
-        Some((definition.ty.clone(), name_span))
+        let ty = definition
+            .instantiate_alias_target(&[])
+            .unwrap_or_else(|| definition.ty.clone());
+        Some((ty, name_span))
     };
 
     match expression {
@@ -145,31 +148,28 @@ fn lookup_type_by_name(
 
 /// Extract the type and span for hover display at the given offset within an expression.
 pub(crate) fn get_hover_type_and_span(
+    snapshot: &AnalysisSnapshot,
     expression: &Expression,
     offset: u32,
 ) -> (syntax::types::Type, Span) {
     fn get_binding_type(
+        snapshot: &AnalysisSnapshot,
         binding: &syntax::ast::Binding,
         offset: u32,
     ) -> Option<(syntax::types::Type, Span)> {
-        get_pattern_element_type(
-            &binding.pattern,
-            binding.typed_pattern.as_ref(),
-            &binding.ty,
-            offset,
-        )
+        get_pattern_element_type(snapshot, &binding.pattern, &binding.ty, offset)
     }
 
     match expression {
         Expression::Let { binding, .. } | Expression::For { binding, .. } => {
-            if let Some(result) = get_binding_type(binding, offset) {
+            if let Some(result) = get_binding_type(snapshot, binding, offset) {
                 return result;
             }
         }
 
         Expression::Function { params, .. } | Expression::Lambda { params, .. } => {
             for param in params {
-                if let Some(result) = get_binding_type(param, offset) {
+                if let Some(result) = get_binding_type(snapshot, param, offset) {
                     return result;
                 }
             }
@@ -177,30 +177,21 @@ pub(crate) fn get_hover_type_and_span(
 
         Expression::Match { subject, arms, .. } => {
             for arm in arms {
-                if let Some(result) = get_pattern_element_type(
-                    &arm.pattern,
-                    arm.typed_pattern.as_ref(),
-                    &subject.get_type(),
-                    offset,
-                ) {
+                if let Some(result) =
+                    get_pattern_element_type(snapshot, &arm.pattern, &subject.get_type(), offset)
+                {
                     return result;
                 }
             }
         }
 
         Expression::IfLet {
-            pattern,
-            scrutinee,
-            typed_pattern,
-            ..
+            pattern, scrutinee, ..
         } => {
             if offset_in_span(offset, &pattern.get_span()) {
-                if let Some(result) = get_pattern_element_type(
-                    pattern,
-                    typed_pattern.as_ref(),
-                    &scrutinee.get_type(),
-                    offset,
-                ) {
+                if let Some(result) =
+                    get_pattern_element_type(snapshot, pattern, &scrutinee.get_type(), offset)
+                {
                     return result;
                 }
                 let ty = pattern.get_type().unwrap_or_else(|| scrutinee.get_type());
@@ -209,18 +200,12 @@ pub(crate) fn get_hover_type_and_span(
         }
 
         Expression::WhileLet {
-            pattern,
-            scrutinee,
-            typed_pattern,
-            ..
+            pattern, scrutinee, ..
         } => {
             if offset_in_span(offset, &pattern.get_span()) {
-                if let Some(result) = get_pattern_element_type(
-                    pattern,
-                    typed_pattern.as_ref(),
-                    &scrutinee.get_type(),
-                    offset,
-                ) {
+                if let Some(result) =
+                    get_pattern_element_type(snapshot, pattern, &scrutinee.get_type(), offset)
+                {
                     return result;
                 }
                 let ty = pattern.get_type().unwrap_or_else(|| scrutinee.get_type());
@@ -300,7 +285,7 @@ fn resolve_dot_access_doc(
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<String> {
-    if let Some(type_id) = type_name(&expression.get_type()) {
+    if let Some(type_id) = type_name(&expression.get_type(), snapshot) {
         let qualified = format!("{}.{}", type_id, member);
         if let Some(def) = snapshot.definitions().get(qualified.as_str())
             && let Some(doc) = &def.doc
@@ -312,10 +297,8 @@ fn resolve_dot_access_doc(
     let root = get_root_expression(expression);
     let alias = match root.unwrap_parens() {
         Expression::Identifier {
-            value,
-            binding_id: None,
-            ..
-        } => value.as_str(),
+            value, resolution, ..
+        } if !matches!(resolution, IdentifierResolution::Binding(_)) => value.as_str(),
         _ => return None,
     };
 
@@ -352,7 +335,7 @@ pub(crate) fn get_hover_doc(
 
     match expression {
         Expression::Identifier {
-            qualified: Some(qname),
+            resolution: IdentifierResolution::Definition(qname),
             ..
         } => {
             let definition = snapshot.definitions().get(qname.as_str())?;
@@ -376,7 +359,7 @@ pub(crate) fn get_hover_doc(
             ty,
             ..
         } => {
-            let type_id = type_name(ty)?;
+            let type_id = type_name(ty, snapshot)?;
 
             if let Some(fa) = field_assignments
                 .iter()
@@ -404,18 +387,8 @@ pub(crate) fn get_hover_doc(
             find_doc_at_definition_span(span, snapshot)
         }
 
-        Expression::IfLet {
-            pattern,
-            typed_pattern,
-            ..
-        }
-        | Expression::WhileLet {
-            pattern,
-            typed_pattern,
-            ..
-        } => {
-            let span =
-                resolve_enum_in_pattern(pattern, typed_pattern.as_ref(), offset, file, snapshot)?;
+        Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
+            let span = resolve_enum_in_pattern(pattern, offset, file, snapshot)?;
             find_doc_at_definition_span(span, snapshot)
         }
 

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,24 +1,27 @@
-use syntax::ast::{Annotation, Binding, Expression, Pattern, RestPattern, Span, TypedPattern};
+use syntax::ast::{Annotation, Binding, Expression, Pattern, RestPattern, Span};
 use syntax::types::Type;
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel};
 
 use crate::patterns::get_pattern_element_type;
 use crate::position::LineIndex;
+use crate::snapshot::AnalysisSnapshot;
 
 /// Inlay hints for `items` within the range.
 pub(crate) fn collect(
+    snapshot: &AnalysisSnapshot,
     items: &[Expression],
     range: (u32, u32),
     line_index: &LineIndex,
 ) -> Vec<InlayHint> {
     let mut hints = Vec::new();
     for item in items {
-        walk(item, range, line_index, &mut hints);
+        walk(snapshot, item, range, line_index, &mut hints);
     }
     hints
 }
 
 fn walk(
+    snapshot: &AnalysisSnapshot,
     expression: &Expression,
     range: (u32, u32),
     line_index: &LineIndex,
@@ -36,32 +39,19 @@ fn walk(
         Expression::Match { subject, arms, .. } => {
             let fallback = subject.get_type();
             for arm in arms {
-                pattern_hints(
-                    &arm.pattern,
-                    arm.typed_pattern.as_ref(),
-                    &fallback,
-                    range,
-                    line_index,
-                    hints,
-                );
+                pattern_hints(snapshot, &arm.pattern, &fallback, range, line_index, hints);
             }
         }
 
         Expression::IfLet {
-            pattern,
-            scrutinee,
-            typed_pattern,
-            ..
+            pattern, scrutinee, ..
         }
         | Expression::WhileLet {
-            pattern,
-            scrutinee,
-            typed_pattern,
-            ..
+            pattern, scrutinee, ..
         } => {
             pattern_hints(
+                snapshot,
                 pattern,
-                typed_pattern.as_ref(),
                 &scrutinee.get_type(),
                 range,
                 line_index,
@@ -95,7 +85,7 @@ fn walk(
     }
 
     for child in expression.children() {
-        walk(child, range, line_index, hints);
+        walk(snapshot, child, range, line_index, hints);
     }
 }
 
@@ -117,8 +107,8 @@ fn binding_type_hint(
 }
 
 fn pattern_hints(
+    snapshot: &AnalysisSnapshot,
     pattern: &Pattern,
-    typed_pattern: Option<&TypedPattern>,
     fallback: &Type,
     range: (u32, u32),
     line_index: &LineIndex,
@@ -128,7 +118,7 @@ fn pattern_hints(
     collect_identifier_spans(pattern, &mut spans);
     for span in spans {
         if let Some((ty, name_span)) =
-            get_pattern_element_type(pattern, typed_pattern, fallback, span.byte_offset)
+            get_pattern_element_type(snapshot, pattern, fallback, span.byte_offset)
         {
             let at = name_span.byte_offset + name_span.byte_length;
             push_type_hint(at, &ty, range, line_index, hints);
@@ -187,7 +177,8 @@ fn lambda_hints(
         && !matches!(body, Expression::Lambda { .. })
         && let Some(ret) = ty.get_function_ret()
         && !ret.is_unit()
-        && !ret.is_type_var()
+        && !ret.is_variable()
+        && !ret.is_placeholder()
         && !ret.is_error()
     {
         let at = leftmost_offset(body);
@@ -214,7 +205,7 @@ fn push_type_hint(
     line_index: &LineIndex,
     hints: &mut Vec<InlayHint>,
 ) {
-    if ty.is_type_var() || ty.is_error() {
+    if ty.is_variable() || ty.is_placeholder() || ty.is_error() {
         return;
     }
     if at >= range.0 && at < range.1 {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -16,6 +16,7 @@ mod state;
 mod traversal;
 mod validation;
 
+use syntax::ast::IdentifierResolution;
 use tower_lsp::LanguageServer;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -227,9 +228,9 @@ impl LanguageServer for Backend {
         };
 
         let (ty, span) = hover::resolve_declaration_hover(expression, offset, file, &snapshot)
-            .unwrap_or_else(|| hover::get_hover_type_and_span(expression, offset));
+            .unwrap_or_else(|| hover::get_hover_type_and_span(&snapshot, expression, offset));
 
-        if ty.is_type_var() || ty.is_error() {
+        if ty.is_variable() || ty.is_placeholder() || ty.is_error() {
             return Ok(None);
         }
 
@@ -277,6 +278,7 @@ impl LanguageServer for Backend {
             .unwrap_or(eof);
 
         Ok(Some(inlay_hints::collect(
+            &snapshot,
             &file.items,
             (start, end),
             line_index,
@@ -322,13 +324,13 @@ impl LanguageServer for Backend {
 
         let definition_span = match expression {
             syntax::ast::Expression::Identifier {
-                binding_id: Some(id),
+                resolution: IdentifierResolution::Binding(id),
                 ..
             } => snapshot.facts().bindings.get(id).map(|b| b.span),
 
             syntax::ast::Expression::Identifier {
                 value,
-                qualified: Some(qname),
+                resolution: IdentifierResolution::Definition(qname),
                 span: id_span,
                 ..
             } => {
@@ -440,18 +442,12 @@ impl LanguageServer for Backend {
                     .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
             }
 
-            syntax::ast::Expression::IfLet {
-                pattern,
-                typed_pattern,
-                ..
+            syntax::ast::Expression::IfLet { pattern, .. }
+            | syntax::ast::Expression::WhileLet { pattern, .. } => {
+                resolve_enum_in_pattern(pattern, offset, file, &snapshot)
+                    .or_else(&find_binding)
+                    .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
             }
-            | syntax::ast::Expression::WhileLet {
-                pattern,
-                typed_pattern,
-                ..
-            } => resolve_enum_in_pattern(pattern, typed_pattern.as_ref(), offset, file, &snapshot)
-                .or_else(&find_binding)
-                .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot)),
 
             _ => find_binding()
                 .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot)),
@@ -642,7 +638,7 @@ impl LanguageServer for Backend {
             offset,
             |expression| match expression {
                 syntax::ast::Expression::Identifier {
-                    qualified: Some(qname),
+                    resolution: IdentifierResolution::Definition(qname),
                     ..
                 } => snapshot
                     .definitions()
@@ -661,23 +657,11 @@ impl LanguageServer for Backend {
                         .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
                 }
 
-                syntax::ast::Expression::IfLet {
-                    pattern,
-                    typed_pattern,
-                    ..
+                syntax::ast::Expression::IfLet { pattern, .. }
+                | syntax::ast::Expression::WhileLet { pattern, .. } => {
+                    resolve_enum_in_pattern(pattern, offset, file, &snapshot)
+                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
                 }
-                | syntax::ast::Expression::WhileLet {
-                    pattern,
-                    typed_pattern,
-                    ..
-                } => resolve_enum_in_pattern(
-                    pattern,
-                    typed_pattern.as_ref(),
-                    offset,
-                    file,
-                    &snapshot,
-                )
-                .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot)),
 
                 _ => resolve_word_at_offset(&file.source, offset, file, &snapshot),
             },
@@ -787,7 +771,7 @@ impl LanguageServer for Backend {
             && let Some(fa) = field_assignments
                 .iter()
                 .find(|fa| offset_in_span(offset, &fa.name_span))
-            && type_name(ty)
+            && type_name(ty, &snapshot)
                 .and_then(|type_id| find_struct_field_span(&type_id, &fa.name, &snapshot))
                 .is_some()
         {
@@ -800,7 +784,7 @@ impl LanguageServer for Backend {
         match expression {
             syntax::ast::Expression::Identifier {
                 value,
-                binding_id: Some(id),
+                resolution: IdentifierResolution::Binding(id),
                 span,
                 ..
             } => {
@@ -818,7 +802,7 @@ impl LanguageServer for Backend {
 
             syntax::ast::Expression::Identifier {
                 value,
-                qualified: Some(qname),
+                resolution: IdentifierResolution::Definition(qname),
                 span,
                 ..
             } => {
@@ -959,23 +943,10 @@ impl LanguageServer for Backend {
                 Ok(None)
             }
 
-            syntax::ast::Expression::IfLet {
-                pattern,
-                typed_pattern,
-                ..
-            }
-            | syntax::ast::Expression::WhileLet {
-                pattern,
-                typed_pattern,
-                ..
-            } => {
-                if let Some(def_span) = resolve_enum_in_pattern(
-                    pattern,
-                    typed_pattern.as_ref(),
-                    offset,
-                    file,
-                    &snapshot,
-                ) && !is_generated_typedef_span(&snapshot, &def_span)
+            syntax::ast::Expression::IfLet { pattern, .. }
+            | syntax::ast::Expression::WhileLet { pattern, .. } => {
+                if let Some(def_span) = resolve_enum_in_pattern(pattern, offset, file, &snapshot)
+                    && !is_generated_typedef_span(&snapshot, &def_span)
                     && let Some((word, start, end)) = word_at_offset(&file.source, offset)
                 {
                     let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
@@ -1037,7 +1008,7 @@ impl LanguageServer for Backend {
             offset,
             |expression| match expression {
                 syntax::ast::Expression::Identifier {
-                    qualified: Some(qname),
+                    resolution: IdentifierResolution::Definition(qname),
                     ..
                 } => {
                     if validation::check_rename_guards(qname.as_str()).is_err() {
@@ -1061,23 +1032,11 @@ impl LanguageServer for Backend {
                         .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
                 }
 
-                syntax::ast::Expression::IfLet {
-                    pattern,
-                    typed_pattern,
-                    ..
+                syntax::ast::Expression::IfLet { pattern, .. }
+                | syntax::ast::Expression::WhileLet { pattern, .. } => {
+                    resolve_enum_in_pattern(pattern, offset, file, &snapshot)
+                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
                 }
-                | syntax::ast::Expression::WhileLet {
-                    pattern,
-                    typed_pattern,
-                    ..
-                } => resolve_enum_in_pattern(
-                    pattern,
-                    typed_pattern.as_ref(),
-                    offset,
-                    file,
-                    &snapshot,
-                )
-                .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot)),
 
                 _ => resolve_word_at_offset(&file.source, offset, file, &snapshot),
             },
@@ -1311,7 +1270,7 @@ impl LanguageServer for Backend {
 
         // In a struct literal's field-name position, offer the unassigned fields.
         if let Some((name, ty, assigned)) = detect_struct_literal_field_context(file, offset)
-            && let Some(type_id) = type_name(ty)
+            && let Some(type_id) = type_name(ty, &snapshot)
         {
             let same_module = id_is_in_module(&type_id, &file.module_id);
             let items = get_struct_literal_completions(

--- a/crates/lsp/src/patterns.rs
+++ b/crates/lsp/src/patterns.rs
@@ -1,12 +1,18 @@
 //! Pattern-to-type resolution shared by hover and inlay hints.
 
-use syntax::ast::{Pattern, RestPattern, Span, TypedPattern};
-use syntax::types::{CompoundKind, Type};
+use syntax::ast::{
+    ConstructorPatternResolution, Pattern, RecordPatternResolution, RestPattern,
+    SequencePatternResolution, Span,
+};
+use syntax::program::DefinitionBody;
+use syntax::types::{CompoundKind, Type, build_substitution_map, substitute, unqualified_name};
+
+use crate::snapshot::AnalysisSnapshot;
 
 /// Resolve the type and span of the pattern element at `offset`.
 pub(crate) fn get_pattern_element_type(
+    snapshot: &AnalysisSnapshot,
     pattern: &Pattern,
-    typed_pattern: Option<&TypedPattern>,
     fallback_ty: &Type,
     offset: u32,
 ) -> Option<(Type, Span)> {
@@ -15,133 +21,83 @@ pub(crate) fn get_pattern_element_type(
         return None;
     }
 
-    match (pattern, typed_pattern) {
-        (Pattern::Identifier { .. }, _) => Some((fallback_ty.clone(), span)),
+    match pattern {
+        Pattern::Identifier { .. } => Some((fallback_ty.clone(), span)),
 
-        (Pattern::Tuple { elements, .. }, typed) => {
-            // Element types come from decomposing the tuple type; the typed sub-pattern
-            // only carries deeper structure.
-            let typed_elements = match typed {
-                Some(TypedPattern::Tuple { elements, .. }) => Some(elements),
-                _ => None,
-            };
+        Pattern::Tuple { elements, .. } => {
             let type_elements = match fallback_ty {
                 Type::Tuple(elems) => elems,
                 _ => return None,
             };
-            elements.iter().enumerate().find_map(|(i, elem)| {
+            elements.iter().enumerate().find_map(|(i, element)| {
                 let elem_ty = type_elements.get(i)?;
-                let typed_elem = typed_elements.and_then(|te| te.get(i));
-                get_pattern_element_type(elem, typed_elem, elem_ty, offset)
+                get_pattern_element_type(snapshot, element, elem_ty, offset)
             })
         }
 
-        (
-            Pattern::EnumVariant { fields, .. },
-            Some(TypedPattern::EnumVariant {
-                fields: typed_fields,
-                field_types,
-                ..
-            }),
-        ) => fields
-            .iter()
-            .enumerate()
-            .find_map(|(i, field)| {
-                let field_ty = field_types.get(i).unwrap_or(fallback_ty);
-                get_pattern_element_type(field, typed_fields.get(i), field_ty, offset)
-            })
-            .or_else(|| Some((fallback_ty.clone(), span))),
-
-        (
-            Pattern::EnumVariant { fields, .. },
-            Some(TypedPattern::EnumStructVariant { variant_fields, .. }),
-        ) => fields
-            .iter()
-            .enumerate()
-            .find_map(|(i, field)| {
-                let field_ty = variant_fields.get(i).map(|f| &f.ty).unwrap_or(fallback_ty);
-                get_pattern_element_type(field, None, field_ty, offset)
-            })
-            .or_else(|| Some((fallback_ty.clone(), span))),
-
-        (Pattern::EnumVariant { .. }, _) => Some((fallback_ty.clone(), span)),
-
-        (Pattern::Struct { fields, .. }, Some(typed)) => {
-            let (field_defs, pattern_fields): (Vec<_>, _) = match typed {
-                TypedPattern::Struct {
-                    struct_fields,
-                    pattern_fields,
-                    ..
-                } => (
-                    struct_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
-                    pattern_fields,
-                ),
-                TypedPattern::EnumStructVariant {
-                    variant_fields,
-                    pattern_fields,
-                    ..
-                } => (
-                    variant_fields.iter().map(|f| (&f.name, &f.ty)).collect(),
-                    pattern_fields,
-                ),
-                _ => return None,
-            };
-
-            fields.iter().find_map(|field| {
-                let field_ty = field_defs
-                    .iter()
-                    .find(|(name, _)| *name == &field.name)
-                    .map(|(_, ty)| *ty)
-                    .unwrap_or(fallback_ty);
-                let typed_field = pattern_fields
-                    .iter()
-                    .find(|(name, _)| name == &field.name)
-                    .map(|(_, tp)| tp);
-                get_pattern_element_type(&field.value, typed_field, field_ty, offset)
-            })
-        }
-
-        (
-            Pattern::Slice {
-                prefix,
-                rest,
-                element_ty,
-                ..
-            },
-            typed,
-        ) => {
-            let (elem_type, typed_prefix) = match typed {
-                Some(TypedPattern::Slice {
-                    element_type,
-                    prefix: typed_prefix,
-                    ..
+        Pattern::EnumVariant {
+            fields,
+            resolution,
+            ty,
+            ..
+        } => {
+            let field_types = constructor_field_types(snapshot, resolution, ty);
+            fields
+                .iter()
+                .enumerate()
+                .find_map(|(i, field)| {
+                    let field_ty = field_types.get(i).unwrap_or(fallback_ty);
+                    get_pattern_element_type(snapshot, field, field_ty, offset)
                 })
-                | Some(TypedPattern::Array {
+                .or_else(|| Some((fallback_ty.clone(), span)))
+        }
+
+        Pattern::Struct {
+            fields,
+            resolution,
+            ty,
+            ..
+        } => fields.iter().find_map(|field| {
+            let field_ty = record_field_type(snapshot, resolution, ty, &field.name);
+            get_pattern_element_type(
+                snapshot,
+                &field.value,
+                field_ty.as_ref().unwrap_or(fallback_ty),
+                offset,
+            )
+        }),
+
+        Pattern::Slice {
+            prefix,
+            rest,
+            resolution,
+            ..
+        } => {
+            let (element_type, array_length) = match resolution {
+                SequencePatternResolution::Slice { element_type } => (element_type, None),
+                SequencePatternResolution::Array {
                     element_type,
-                    prefix: typed_prefix,
-                    ..
-                }) => (element_type, Some(typed_prefix)),
-                _ => (element_ty, None),
+                    length,
+                } => (element_type, Some(*length)),
+                SequencePatternResolution::Unresolved => return None,
             };
 
             prefix
                 .iter()
-                .enumerate()
-                .find_map(|(i, elem)| {
-                    let typed_elem = typed_prefix.and_then(|tp| tp.get(i));
-                    get_pattern_element_type(elem, typed_elem, elem_type, offset)
+                .find_map(|element| {
+                    get_pattern_element_type(snapshot, element, element_type, offset)
                 })
                 .or_else(|| {
                     if let RestPattern::Bind { span, .. } = rest
                         && offset >= span.byte_offset
                         && offset < span.byte_offset + span.byte_length
                     {
-                        let rest_ty = match typed {
-                            Some(TypedPattern::Array { length, .. }) => Type::Array {
+                        let rest_ty = match array_length {
+                            Some(length) => Type::Array {
                                 length: length.saturating_sub(prefix.len() as u64),
-                                element: Box::new(elem_type.clone()),
+                                element: Box::new(element_type.clone()),
                             },
-                            _ => Type::compound(CompoundKind::Slice, vec![elem_type.clone()]),
+                            None => Type::compound(CompoundKind::Slice, vec![element_type.clone()]),
                         };
                         Some((rest_ty, *span))
                     } else {
@@ -150,20 +106,15 @@ pub(crate) fn get_pattern_element_type(
                 })
         }
 
-        (Pattern::Or { patterns, .. }, Some(TypedPattern::Or { alternatives, .. })) => {
-            patterns.iter().enumerate().find_map(|(i, alt)| {
-                get_pattern_element_type(alt, alternatives.get(i), fallback_ty, offset)
-            })
-        }
+        Pattern::Or { patterns, .. } => patterns.iter().find_map(|alternative| {
+            get_pattern_element_type(snapshot, alternative, fallback_ty, offset)
+        }),
 
-        (
-            Pattern::AsBinding {
-                pattern: inner,
-                name,
-                ..
-            },
-            _,
-        ) => get_pattern_element_type(inner, typed_pattern, fallback_ty, offset).or_else(|| {
+        Pattern::AsBinding {
+            pattern: inner,
+            name,
+            ..
+        } => get_pattern_element_type(snapshot, inner, fallback_ty, offset).or_else(|| {
             let binding_ty = inner.get_type().unwrap_or_else(|| fallback_ty.clone());
             let name_span = Span::new(
                 span.file_id,
@@ -173,10 +124,108 @@ pub(crate) fn get_pattern_element_type(
             Some((binding_ty, name_span))
         }),
 
-        (Pattern::Literal { .. }, _) | (Pattern::WildCard { .. }, _) => {
+        Pattern::Literal { .. } | Pattern::WildCard { .. } | Pattern::Unit { .. } => {
             Some((fallback_ty.clone(), span))
         }
+    }
+}
 
-        _ => None,
+fn pattern_type_args(snapshot: &AnalysisSnapshot, ty: &Type) -> Vec<Type> {
+    match syntax::types::peel_alias(ty, |id| snapshot.definitions().get(id)) {
+        Type::Nominal { params, .. } => params,
+        _ => vec![],
+    }
+}
+
+fn constructor_field_types(
+    snapshot: &AnalysisSnapshot,
+    resolution: &ConstructorPatternResolution,
+    ty: &Type,
+) -> Vec<Type> {
+    let ConstructorPatternResolution::EnumVariant {
+        enum_name,
+        variant_name,
+    } = resolution
+    else {
+        return vec![];
+    };
+    let params = pattern_type_args(snapshot, ty);
+    let Some(definition) = snapshot.definitions().get(enum_name.as_str()) else {
+        return vec![];
+    };
+    match &definition.body {
+        DefinitionBody::Struct {
+            fields, generics, ..
+        } => {
+            let substitution = build_substitution_map(generics, &params);
+            fields
+                .iter()
+                .map(|field| substitute(&field.ty, &substitution))
+                .collect()
+        }
+        DefinitionBody::Enum {
+            variants, generics, ..
+        } => {
+            let Some(variant) = variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))
+            else {
+                return vec![];
+            };
+            let substitution = build_substitution_map(generics, &params);
+            variant
+                .fields
+                .iter()
+                .map(|field| substitute(&field.ty, &substitution))
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
+fn record_field_type(
+    snapshot: &AnalysisSnapshot,
+    resolution: &RecordPatternResolution,
+    pattern_ty: &Type,
+    field_name: &str,
+) -> Option<Type> {
+    let params = pattern_type_args(snapshot, pattern_ty);
+    match resolution {
+        RecordPatternResolution::Struct { struct_name } => {
+            let DefinitionBody::Struct {
+                fields, generics, ..
+            } = &snapshot.definitions().get(struct_name.as_str())?.body
+            else {
+                return None;
+            };
+            let field = fields.iter().find(|field| field.name == field_name)?;
+            Some(substitute(
+                &field.ty,
+                &build_substitution_map(generics, &params),
+            ))
+        }
+        RecordPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } => {
+            let DefinitionBody::Enum {
+                variants, generics, ..
+            } = &snapshot.definitions().get(enum_name.as_str())?.body
+            else {
+                return None;
+            };
+            let variant = variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))?;
+            let field = variant
+                .fields
+                .iter()
+                .find(|field| field.name == field_name)?;
+            Some(substitute(
+                &field.ty,
+                &build_substitution_map(generics, &params),
+            ))
+        }
+        RecordPatternResolution::Unresolved => None,
     }
 }

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::SemanticResult;
-use syntax::program::{ModuleInfo, MutationInfo, UnusedInfo};
+use syntax::program::{MutationInfo, UnusedInfo};
 
 use semantics::cache::{EmitStamp, compute_emit_artifact_hash, save_module_cache};
 use semantics::facts::Facts;
@@ -100,8 +100,6 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
 
     let mut files = HashMap::default();
     let mut definitions = HashMap::default();
-    let mut const_names = HashSet::default();
-    let mut modules = HashMap::default();
 
     let go_module_ids: HashSet<String> = store
         .modules
@@ -110,41 +108,25 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         .cloned()
         .collect();
 
-    for (mod_id, module) in store.modules {
+    for (_, module) in store.modules {
         // Worker views are gone by now, so this unwraps without cloning.
         let module = Arc::try_unwrap(module).unwrap_or_else(|shared| (*shared).clone());
         let is_internal = module.is_internal();
-
-        const_names.extend(module.const_names);
         definitions.extend(module.definitions);
 
-        // Internal modules (prelude, **nominal, go:...) stay out of `modules`
-        // so emit and lints skip them; their typedef files still join `files`
-        // so the LSP can map typedef file IDs to URIs for go-to-definition.
+        // Internal typedef files remain available so the LSP can map their IDs
+        // to URIs for go-to-definition. Source files identify their own module.
         if is_internal {
-            files.extend(module.typedefs);
+            files.extend(module.files.into_iter().filter(|(_, file)| file.is_d_lis()));
             continue;
         }
 
-        modules.insert(
-            mod_id,
-            ModuleInfo {
-                file_ids: module.files.keys().copied().collect(),
-                typedef_ids: module.typedefs.keys().copied().collect(),
-                id: module.id.clone(),
-                path: module.id,
-            },
-        );
-
         files.extend(module.files);
-        files.extend(module.typedefs);
     }
 
     let result = SemanticResult {
         files,
         definitions,
-        const_names,
-        modules,
         errors,
         lints,
         entry_module_id: ENTRY_MODULE_ID.to_string(),
@@ -157,8 +139,6 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         typedef_paths: store.typedef_paths,
         go_package_names: store.go_package_names,
         go_module_ids,
-        bound_types: std::mem::take(&mut facts.bound_types),
-        resolved_definitions: std::mem::take(&mut facts.resolved_definitions),
     };
 
     AnalyzeOutput {

--- a/crates/passes/src/passes/checks/cast_nan_to_int.rs
+++ b/crates/passes/src/passes/checks/cast_nan_to_int.rs
@@ -15,7 +15,7 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    let Some(kind) = ty.underlying_simple_kind() else {
+    let Some(kind) = ctx.store.underlying_simple_kind(ty) else {
         return;
     };
     if !(kind.is_signed_int() || kind.is_unsigned_int() || kind == SimpleKind::Uintptr) {

--- a/crates/passes/src/passes/checks/empty_select_default.rs
+++ b/crates/passes/src/passes/checks/empty_select_default.rs
@@ -20,7 +20,12 @@ fn visit_expression(expression: &Expression, in_loop: bool, sink: &LocalSink) {
     }
 
     match expression {
-        Expression::Function { body, .. } | Expression::Lambda { body, .. } => {
+        Expression::Function { body, .. } => {
+            if let Some(body) = body.definition() {
+                visit_expression(body, false, sink);
+            }
+        }
+        Expression::Lambda { body, .. } => {
             visit_expression(body, false, sink);
         }
         Expression::Task {

--- a/crates/passes/src/passes/checks/enum_variant_value.rs
+++ b/crates/passes/src/passes/checks/enum_variant_value.rs
@@ -1,5 +1,5 @@
 use diagnostics::LocalSink;
-use syntax::ast::{Expression, Span};
+use syntax::ast::{Expression, IdentifierResolution, Span};
 use syntax::types::{Type, unqualified_name};
 
 use crate::passes::walk::NodeCtx;
@@ -8,7 +8,7 @@ use semantics::store::Store;
 pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     match expression {
         Expression::Identifier {
-            qualified: Some(qualified),
+            resolution: IdentifierResolution::Definition(qualified),
             value,
             span,
             ..

--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -131,7 +131,13 @@ fn check_constrained_return_type(
         let available = generics
             .iter()
             .find(|generic| generic.name == *param_name)
-            .map(|generic| generic.resolved_bounds.clone())
+            .map(|generic| {
+                generic
+                    .resolved_bounds()
+                    .expect("generic bounds must be resolved before checks")
+                    .cloned()
+                    .collect()
+            })
             .unwrap_or_else(|| enclosing_parameter_bounds(store, enclosing, param_name));
         if !bound_implied(store, &available, &applied.required) {
             sink.push(
@@ -158,7 +164,13 @@ fn enclosing_parameter_bounds(
         .generics
         .iter()
         .find(|generic| generic.name == parameter)
-        .map_or_else(Vec::new, |generic| generic.resolved_bounds.clone());
+        .map_or_else(Vec::new, |generic| {
+            generic
+                .resolved_bounds()
+                .expect("generic bounds must be resolved before checks")
+                .cloned()
+                .collect()
+        });
     if let Some(receiver) = context.receiver {
         available.extend(
             type_obligations(store, receiver)

--- a/crates/passes/src/passes/checks/instantiation_cycle.rs
+++ b/crates/passes/src/passes/checks/instantiation_cycle.rs
@@ -5,7 +5,7 @@
 use diagnostics::LocalSink;
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use syntax::ast::{Binding, Expression, Pattern, Span};
+use syntax::ast::{Binding, Expression, IdentifierResolution, Pattern, Span};
 use syntax::program::DotAccessKind;
 use syntax::types::{CompoundKind, FunctionType, Symbol, Type};
 
@@ -80,7 +80,7 @@ fn collect_generic_targets(store: &Store) -> Targets<'_> {
     let mut targets = Targets::default();
     for module_id in module_ids {
         let module = &store.modules[module_id];
-        let mut files: Vec<_> = module.files.values().collect();
+        let mut files: Vec<_> = module.source_files().collect();
         files.sort_unstable_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
         for file in files {
             for item in &file.items {
@@ -93,6 +93,9 @@ fn collect_generic_targets(store: &Store) -> Targets<'_> {
                         body,
                         ..
                     } if !generics.is_empty() => {
+                        let Some(body) = body.definition() else {
+                            continue;
+                        };
                         let index = targets.add(GenericTarget {
                             name,
                             vars: generics.iter().map(|g| &g.name).collect(),
@@ -155,6 +158,9 @@ fn collect_method<'a>(
     if vars.is_empty() {
         return;
     }
+    let Some(body) = body.definition() else {
+        return;
+    };
     let (declared_self, declared_params) = split_self_param(params);
     let receiver_id = declared_self.and_then(receiver_type_id).unwrap_or_else(|| {
         Symbol::from_parts(module_id, receiver_name)
@@ -273,7 +279,7 @@ impl<'a> EdgeCollector<'_, 'a> {
     fn process_reference(&mut self, reference: &'a Expression, span: Span) {
         match reference {
             Expression::Identifier {
-                qualified: Some(qualified),
+                resolution: IdentifierResolution::Definition(qualified),
                 ty,
                 ..
             } => {
@@ -287,9 +293,9 @@ impl<'a> EdgeCollector<'_, 'a> {
                 expression: base,
                 member,
                 ty,
-                dot_access_kind,
+                resolution,
                 ..
-            } => self.process_method_reference(base, member, ty, dot_access_kind, span),
+            } => self.process_method_reference(base, member, ty, resolution.kind(), span),
             _ => {}
         }
     }
@@ -299,7 +305,7 @@ impl<'a> EdgeCollector<'_, 'a> {
         base: &'a Expression,
         member: &EcoString,
         ty: &'a Type,
-        dot_access_kind: &Option<DotAccessKind>,
+        dot_access_kind: Option<DotAccessKind>,
         span: Span,
     ) {
         let is_instance = match dot_access_kind {
@@ -311,7 +317,7 @@ impl<'a> EdgeCollector<'_, 'a> {
         let base_ty = base.get_type();
         let receiver_id = receiver_type_id(&base_ty).or_else(|| match base {
             Expression::Identifier {
-                qualified: Some(qualified),
+                resolution: IdentifierResolution::Definition(qualified),
                 ..
             } => Some(qualified.clone()),
             _ => None,
@@ -442,8 +448,8 @@ fn same_shape(declared: &Type, actual: &Type) -> bool {
 }
 
 /// Child positions matched pairwise between the declared and instantiated
-/// sides. Excludes `Nominal.underlying_ty`, which can be present on only one
-/// side.
+/// sides. A nominal occurrence contains only its type arguments; its alias
+/// target lives in the definition store and is not part of this shape.
 fn structural_children(ty: &Type) -> Vec<&Type> {
     match ty {
         Type::Compound { args, .. } => args.iter().collect(),

--- a/crates/passes/src/passes/checks/interpolation_stringer.rs
+++ b/crates/passes/src/passes/checks/interpolation_stringer.rs
@@ -106,9 +106,5 @@ fn has_stringer(
 }
 
 fn is_pointer_newtype(definition: &Definition, store: &Store) -> bool {
-    definition.is_pointer_backed_newtype(|id| {
-        store
-            .get_definition(id)
-            .is_some_and(Definition::is_type_alias)
-    })
+    definition.is_pointer_backed_newtype(|id| store.get_definition(id))
 }

--- a/crates/passes/src/passes/checks/irrefutable_patterns.rs
+++ b/crates/passes/src/passes/checks/irrefutable_patterns.rs
@@ -22,14 +22,9 @@ use syntax::ast::{Binding, Expression, Pattern, SelectArm, SelectArmPattern};
 pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     let sink = ctx.sink;
     match expression {
-        Expression::Let {
-            binding,
-            else_block,
-            assert,
-            ..
-        } => {
+        Expression::Let { binding, mode, .. } => {
             reject_as_binding(&binding.pattern, sink);
-            if else_block.is_none() && !assert {
+            if mode.else_block().is_none() && !mode.is_assert() {
                 check_binding_pattern(&binding.pattern, sink);
             } else {
                 check_literal_only(&binding.pattern, sink);

--- a/crates/passes/src/passes/checks/json_methods.rs
+++ b/crates/passes/src/passes/checks/json_methods.rs
@@ -15,8 +15,7 @@ pub(crate) fn run_module(module_id: &str, store: &Store, sink: &LocalSink) {
     };
 
     let json_enums: HashSet<&str> = module
-        .files
-        .values()
+        .source_files()
         .flat_map(|file| file.items.iter())
         .filter_map(|item| match item {
             Expression::Enum {
@@ -30,7 +29,7 @@ pub(crate) fn run_module(module_id: &str, store: &Store, sink: &LocalSink) {
         return;
     }
 
-    for item in module.files.values().flat_map(|file| file.items.iter()) {
+    for item in module.source_files().flat_map(|file| file.items.iter()) {
         let Expression::ImplBlock { ty, methods, .. } = item else {
             continue;
         };

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -63,7 +63,7 @@ pub(crate) fn run_all(
         .modules
         .values()
         .map(Arc::as_ref)
-        .flat_map(|m| m.files.values().map(move |f| (m, f)))
+        .flat_map(|module| module.source_files().map(move |file| (module, file)))
         .collect();
     work.sort_unstable_by(|a, b| {
         a.0.id
@@ -140,8 +140,6 @@ fn run_file_checks(
         is_d_lis: file.is_d_lis(),
         sink,
         claimed_spans: Default::default(),
-        function_role: Default::default(),
-        pattern_role: Default::default(),
     };
     node_walk::run(&file.items, &ctx);
     interpolation_stringer::run(&file.items, store, ufcs_methods, sink);

--- a/crates/passes/src/passes/checks/nan_comparison.rs
+++ b/crates/passes/src/passes/checks/nan_comparison.rs
@@ -25,12 +25,12 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
     }
 }
 
-pub(super) fn is_math_nan_call(expression: &Expression, ctx: &NodeCtx) -> bool {
+pub(super) fn is_math_nan_call(expression: &Expression, _ctx: &NodeCtx) -> bool {
     let Expression::Call {
         expression: callee, ..
     } = expression
     else {
         return false;
     };
-    resolved_definition(callee, &ctx.facts.resolved_definitions) == Some("go:math.NaN")
+    resolved_definition(callee) == Some("go:math.NaN")
 }

--- a/crates/passes/src/passes/checks/node_walk.rs
+++ b/crates/passes/src/passes/checks/node_walk.rs
@@ -1,9 +1,8 @@
-use std::sync::LazyLock;
+use syntax::ast::{Expression, Pattern};
 
-use syntax::ast::Expression;
-use syntax::ast::ExpressionKind::*;
-
-use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
+use crate::passes::walk::{
+    FunctionRole, NodeCtx, PatternRole, apply_expression_checks, walk_nodes,
+};
 
 use super::{
     cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop,
@@ -13,59 +12,60 @@ use super::{
     unchanging_loop_condition,
 };
 
-static NODE_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
-    CheckTable::new(
-        &[
-            (nan_comparison::check, &[Binary]),
-            (min_max::check, &[Call]),
-            (cast_nan_to_int::check, &[Cast]),
-            (impossible_comparison::check, &[Binary]),
-            (empty_range::check, &[Range]),
-            (empty_infinite_loop::check, &[Loop]),
-            (oversized_shift::check, &[Binary]),
-            (repeated_if_condition::check, &[If]),
-            (index_out_of_bounds::check, &[IndexedAccess]),
-            (decimal_file_mode::check, &[Literal]),
-            (
-                duplicate_bindings::check,
-                &[Let, For, IfLet, WhileLet, Match, Select, Function, Lambda],
-            ),
-            (
-                irrefutable_patterns::check,
-                &[Let, For, Function, Lambda, Select],
-            ),
-            (receivers::check, &[ImplBlock]),
-            (stringer_signature::check, &[ImplBlock]),
-            (
-                pub_type_export::check,
-                &[Struct, Enum, TypeAlias, Interface],
-            ),
-            (
-                temp_producing::check,
-                &[
-                    Call,
-                    StructCall,
-                    Binary,
-                    Unary,
-                    Reference,
-                    Cast,
-                    If,
-                    While,
-                    IndexedAccess,
-                    Range,
-                    Literal,
-                ],
-            ),
-            (map_key::check, &[Let, TypeAlias, Call]),
-            (newtype::check, &[Assignment, Reference]),
-            (enum_variant_value::check, &[Identifier, DotAccess]),
-            (unchanging_loop_condition::check, &[While]),
-            (const_naming::check, &[Const]),
-        ],
-        &[],
-    )
-});
+fn run_expression_checks(expression: &Expression, ctx: &NodeCtx<'_>, _role: FunctionRole<'_>) {
+    apply_expression_checks!(
+        expression,
+        ctx,
+        (nan_comparison::check, &[Binary]),
+        (min_max::check, &[Call]),
+        (cast_nan_to_int::check, &[Cast]),
+        (impossible_comparison::check, &[Binary]),
+        (empty_range::check, &[Range]),
+        (empty_infinite_loop::check, &[Loop]),
+        (oversized_shift::check, &[Binary]),
+        (repeated_if_condition::check, &[If]),
+        (index_out_of_bounds::check, &[IndexedAccess]),
+        (decimal_file_mode::check, &[Literal]),
+        (
+            duplicate_bindings::check,
+            &[Let, For, IfLet, WhileLet, Match, Select, Function, Lambda],
+        ),
+        (
+            irrefutable_patterns::check,
+            &[Let, For, Function, Lambda, Select],
+        ),
+        (receivers::check, &[ImplBlock]),
+        (stringer_signature::check, &[ImplBlock]),
+        (
+            pub_type_export::check,
+            &[Struct, Enum, TypeAlias, Interface],
+        ),
+        (
+            temp_producing::check,
+            &[
+                Call,
+                StructCall,
+                Binary,
+                Unary,
+                Reference,
+                Cast,
+                If,
+                While,
+                IndexedAccess,
+                Range,
+                Literal,
+            ],
+        ),
+        (map_key::check, &[Let, TypeAlias, Call]),
+        (newtype::check, &[Assignment, Reference]),
+        (enum_variant_value::check, &[Identifier, DotAccess]),
+        (unchanging_loop_condition::check, &[While]),
+        (const_naming::check, &[Const]),
+    );
+}
+
+fn ignore_patterns(_: &Pattern, _: &NodeCtx<'_>, _: PatternRole) {}
 
 pub(crate) fn run<'a>(items: &'a [Expression], ctx: &NodeCtx<'a>) {
-    walk_nodes(items, ctx, &NODE_CHECKS);
+    walk_nodes(items, ctx, run_expression_checks, ignore_patterns);
 }

--- a/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
@@ -42,7 +42,9 @@ fn type_key(ty: &Type) -> String {
         }
         Type::Array { length, element } => format!("[{}]{}", length, type_key(element)),
         Type::Function(_) => "fn".to_string(),
-        Type::Var { .. } | Type::Parameter(_) | Type::Error => "param".to_string(),
+        Type::Var { .. } | Type::Uninferred | Type::Ignored | Type::Parameter(_) | Type::Error => {
+            "param".to_string()
+        }
         Type::Forall { body, .. } => type_key(body),
         Type::ImportNamespace(m) => format!("<import:{}>", m),
         Type::ReceiverPlaceholder => "<receiver>".to_string(),
@@ -62,7 +64,7 @@ pub fn is_inhabited(ty: &Type, store: &Store, cache: &InhabitanceCache) -> bool 
     match ty {
         Type::Never => return false,
         Type::Function(_) => return true,
-        Type::Var { .. } | Type::Parameter(_) => return true,
+        Type::Var { .. } | Type::Uninferred | Type::Ignored | Type::Parameter(_) => return true,
         _ => {}
     }
 
@@ -135,9 +137,14 @@ fn check_constructor_inhabited(
             })
         }
 
-        DefinitionBody::TypeAlias { generics, .. } => {
+        DefinitionBody::TypeAlias {
+            generics, alias, ..
+        } => {
+            let syntax::program::AliasKind::Transparent { target, .. } = alias else {
+                return true;
+            };
             let map = build_substitution_map(generics, params);
-            let target_ty = substitute(&definition.ty, &map);
+            let target_ty = substitute(target, &map);
 
             if is_self_referential_alias(id, &target_ty) {
                 return true;

--- a/crates/passes/src/passes/checks/pattern_analysis/mod.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/mod.rs
@@ -11,7 +11,7 @@ use crate::passes::is_trivial_expression;
 pub use inhabitance::InhabitanceCache;
 pub use inhabitance::is_inhabited;
 pub use maranget::check_exhaustiveness;
-pub use normalize::{NormalizationContext, normalize_typed_pattern};
+pub use normalize::{NormalizationContext, normalize_pattern};
 pub use types::*;
 pub use witness::format_witness;
 
@@ -23,7 +23,7 @@ use std::cell::RefCell;
 use diagnostics::{IssueKind, LocalSink, PatternIssue};
 use semantics::context::AnalysisContext;
 use semantics::store::Store;
-use syntax::ast::{Expression, Literal, Pattern, SelectArmPattern, Span, TypedPattern};
+use syntax::ast::{Expression, Literal, Pattern, SelectArmPattern, Span};
 use syntax::types::Type;
 
 use maranget::is_useful;
@@ -86,15 +86,17 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
 
         Expression::Function { params, body, .. } => {
             for param in params {
-                if !check_refutability(&param.pattern, param.typed_pattern.as_ref(), ctx, sink) {
+                if !check_refutability(&param.pattern, ctx, sink) {
                     return;
                 }
             }
-            check(body, ctx, sink);
+            if let Some(body) = body.definition() {
+                check(body, ctx, sink);
+            }
         }
         Expression::Lambda { params, body, .. } => {
             for param in params {
-                if !check_refutability(&param.pattern, param.typed_pattern.as_ref(), ctx, sink) {
+                if !check_refutability(&param.pattern, ctx, sink) {
                     return;
                 }
             }
@@ -116,28 +118,22 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
         Expression::Let {
             binding,
             value,
-            else_block,
-            assert,
+            mode,
             ..
         } => {
             check(value, ctx, sink);
-            let typed_pattern = &binding.typed_pattern;
 
-            if let Some(else_expression) = else_block {
+            if let Some(else_expression) = mode.else_block() {
                 check(else_expression, ctx, sink);
 
-                if let Some(tp) = typed_pattern
-                    && is_pattern_irrefutable(tp, ctx.store)
-                {
+                if is_pattern_irrefutable(&binding.pattern, ctx.store) {
                     ctx.add_issue(binding.pattern.get_span(), IssueKind::RedundantLetElse);
                 }
-            } else if *assert {
-                if let Some(tp) = typed_pattern
-                    && is_pattern_irrefutable(tp, ctx.store)
-                {
+            } else if mode.is_assert() {
+                if is_pattern_irrefutable(&binding.pattern, ctx.store) {
                     ctx.add_issue(binding.pattern.get_span(), IssueKind::RedundantLetAssert);
                 }
-            } else if !check_refutability(&binding.pattern, typed_pattern.as_ref(), ctx, sink) {
+            } else if !check_refutability(&binding.pattern, ctx, sink) {
             }
         }
 
@@ -174,12 +170,11 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
             scrutinee,
             consequence,
             alternative,
-            typed_pattern,
             else_span,
             ..
         } => {
             check(scrutinee, ctx, sink);
-            check_if_let(pattern, typed_pattern, alternative, *else_span, ctx);
+            check_if_let(pattern, alternative, *else_span, ctx);
             check(consequence, ctx, sink);
             check(alternative, ctx, sink);
         }
@@ -267,7 +262,11 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
 
         Expression::Paren { expression, .. } => check(expression, ctx, sink),
         Expression::Unary { expression, .. } => check(expression, ctx, sink),
-        Expression::Const { expression, .. } => check(expression, ctx, sink),
+        Expression::Const { expression, .. } => {
+            if let Some(value) = expression.value() {
+                check(value, ctx, sink);
+            }
+        }
         Expression::Reference { expression, .. } => check(expression, ctx, sink),
         Expression::IndexedAccess {
             expression, index, ..
@@ -289,15 +288,12 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
             pattern,
             scrutinee,
             body,
-            typed_pattern,
             ..
         } => {
             check(scrutinee, ctx, sink);
             check(body, ctx, sink);
 
-            if let Some(tp) = typed_pattern
-                && is_pattern_irrefutable(tp, ctx.store)
-            {
+            if is_pattern_irrefutable(pattern, ctx.store) {
                 sink.push(diagnostics::pattern::irrefutable_while_let(
                     pattern.get_span(),
                 ));
@@ -310,7 +306,7 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
             body,
             ..
         } => {
-            if !check_refutability(&binding.pattern, binding.typed_pattern.as_ref(), ctx, sink) {
+            if !check_refutability(&binding.pattern, ctx, sink) {
                 return;
             }
             check(iterable, ctx, sink);
@@ -380,7 +376,6 @@ pub fn check(expression: &Expression, ctx: &PatternAnalysisContext, sink: &Local
             }
         }
         Expression::Continue { .. } => {}
-        Expression::NoOp => {}
     }
 }
 
@@ -473,21 +468,16 @@ fn check_redundancy_with_guards(
 
 fn check_if_let(
     pattern: &Pattern,
-    typed_pattern: &Option<TypedPattern>,
     alternative: &Expression,
     else_span: Option<Span>,
     ctx: &PatternAnalysisContext,
 ) {
-    let Some(tp) = typed_pattern else {
-        return;
-    };
-
     // Suppress lints for patterns that already have or-pattern binding errors.
     if ctx.or_pattern_error_spans.contains(&pattern.get_span()) {
         return;
     }
 
-    if is_pattern_irrefutable(tp, ctx.store) {
+    if is_pattern_irrefutable(pattern, ctx.store) {
         ctx.add_issue(pattern.get_span(), IssueKind::RedundantIfLet);
 
         if let Some(else_span) = else_span
@@ -504,27 +494,14 @@ fn check_if_let(
 }
 
 /// Returns true if pattern is irrefutable, false if an error was pushed to sink.
-fn check_refutability(
-    pattern: &Pattern,
-    typed_pattern: Option<&TypedPattern>,
-    ctx: &PatternAnalysisContext,
-    sink: &LocalSink,
-) -> bool {
-    let Some(typed_pattern) = typed_pattern else {
-        return true;
-    };
-
-    if matches!(typed_pattern, TypedPattern::Or { .. }) {
+fn check_refutability(pattern: &Pattern, ctx: &PatternAnalysisContext, sink: &LocalSink) -> bool {
+    if matches!(pattern, Pattern::Or { .. }) {
         return true;
     }
 
     let mut unions = HashMap::default();
     let norm_ctx = ctx.normalize_context();
-    let row = vec![normalize_typed_pattern(
-        typed_pattern,
-        &mut unions,
-        &norm_ctx,
-    )];
+    let row = vec![normalize_pattern(pattern, &mut unions, &norm_ctx)];
 
     if let Err(witnesses) = check_exhaustiveness(&[row], &unions) {
         let witness = witnesses.first().expect("witnesses not empty");
@@ -547,7 +524,7 @@ fn check_refutability(
     true
 }
 
-pub fn is_pattern_irrefutable(typed_pattern: &TypedPattern, store: &Store) -> bool {
+pub fn is_pattern_irrefutable(pattern: &Pattern, store: &Store) -> bool {
     let cache = InhabitanceCache::new();
     let norm_ctx = NormalizationContext {
         store,
@@ -557,17 +534,13 @@ pub fn is_pattern_irrefutable(typed_pattern: &TypedPattern, store: &Store) -> bo
 
     let mut unions = HashMap::default();
 
-    let rows: Vec<Row> = if let TypedPattern::Or { alternatives } = typed_pattern {
-        alternatives
+    let rows: Vec<Row> = if let Pattern::Or { patterns, .. } = pattern {
+        patterns
             .iter()
-            .map(|alt| vec![normalize_typed_pattern(alt, &mut unions, &norm_ctx)])
+            .map(|alt| vec![normalize_pattern(alt, &mut unions, &norm_ctx)])
             .collect()
     } else {
-        vec![vec![normalize_typed_pattern(
-            typed_pattern,
-            &mut unions,
-            &norm_ctx,
-        )]]
+        vec![vec![normalize_pattern(pattern, &mut unions, &norm_ctx)]]
     };
 
     check_exhaustiveness(&rows, &unions).is_ok()

--- a/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
@@ -1,7 +1,10 @@
 use semantics::store::Store;
-use syntax::ast::{Literal, MatchArm, TypedPattern};
+use syntax::ast::{
+    ConstructorPatternResolution, Literal, MatchArm, Pattern, RecordPatternResolution,
+    SequencePatternResolution,
+};
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{SubstitutionMap, Type, build_substitution_map, substitute, unqualified_name};
+use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
 
 use super::NormalizedPattern::Wildcard;
 use super::inhabitance::{InhabitanceCache, is_inhabited, is_variant_inhabited};
@@ -21,20 +24,11 @@ fn make_type_key(name: &str, type_args: &[Type]) -> String {
     }
 }
 
-/// Map a definition's generics to a pattern's type args, so a field declared
-/// `T` resolves to its concrete type at this position. Empty for non-generics.
-fn field_substitution_map(
-    ctx: &NormalizationContext,
-    type_name: &str,
-    type_args: &[Type],
-) -> SubstitutionMap {
-    let generics = match ctx.store.get_definition(type_name).map(|d| &d.body) {
-        Some(DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. }) => {
-            generics.as_slice()
-        }
-        _ => &[],
-    };
-    build_substitution_map(generics, type_args)
+fn pattern_type_args(ctx: &NormalizationContext, ty: &Type) -> Vec<Type> {
+    match ctx.store.peel_alias(ty) {
+        Type::Nominal { params, .. } => params,
+        _ => vec![],
+    }
 }
 
 pub struct NormalizationContext<'a> {
@@ -120,31 +114,26 @@ pub fn normalize_arm(
     unions: &mut UnionTable,
     ctx: &NormalizationContext,
 ) -> Vec<Row> {
-    let typed_pattern = arm
-        .typed_pattern
-        .as_ref()
-        .expect("typed pattern should be populated during inference");
-
-    match typed_pattern {
-        TypedPattern::Or { alternatives } => alternatives
+    match &arm.pattern {
+        Pattern::Or { patterns, .. } => patterns
             .iter()
-            .map(|alt| vec![normalize_typed_pattern(alt, unions, ctx)])
+            .map(|alt| vec![normalize_pattern(alt, unions, ctx)])
             .collect(),
-        _ => {
-            vec![vec![normalize_typed_pattern(typed_pattern, unions, ctx)]]
-        }
+        pattern => vec![vec![normalize_pattern(pattern, unions, ctx)]],
     }
 }
 
-pub fn normalize_typed_pattern(
-    typed_pattern: &TypedPattern,
+pub fn normalize_pattern(
+    pattern: &Pattern,
     unions: &mut UnionTable,
     ctx: &NormalizationContext,
 ) -> NormalizedPattern {
-    match typed_pattern {
-        TypedPattern::Wildcard => Wildcard,
+    match pattern {
+        Pattern::Identifier { .. } | Pattern::WildCard { .. } | Pattern::Unit { .. } => Wildcard,
 
-        TypedPattern::Literal(literal) => {
+        Pattern::AsBinding { pattern, .. } => normalize_pattern(pattern, unions, ctx),
+
+        Pattern::Literal { literal, .. } => {
             if let Literal::Boolean(b) = literal {
                 return normalize_boolean(*b, unions);
             }
@@ -152,129 +141,186 @@ pub fn normalize_typed_pattern(
             NormalizedPattern::Literal(literal.clone())
         }
 
-        TypedPattern::Const {
-            qualified_name,
-            value,
-            ..
-        } => match value {
-            Some(Literal::Boolean(b)) => normalize_boolean(*b, unions),
-            Some(literal) => NormalizedPattern::Literal(literal.clone()),
-            None => NormalizedPattern::OpaqueConst(qualified_name.to_string()),
-        },
-
-        TypedPattern::EnumVariant {
-            enum_name,
-            variant_name,
+        Pattern::EnumVariant {
             fields,
-            type_args,
-            field_types,
+            rest,
+            resolution,
+            ty,
             ..
-        } => {
-            let patterns: Vec<NormalizedPattern> = fields
-                .iter()
-                .enumerate()
-                .map(|(i, f)| {
-                    let child = ctx.at_position(field_types.get(i).cloned());
-                    normalize_typed_pattern(f, unions, &child)
-                })
-                .collect();
-
-            let enum_def = ctx.store.get_definition(enum_name);
-
-            if let Some(Definition {
-                body:
-                    DefinitionBody::Struct {
-                        fields: struct_fields,
-                        ..
-                    },
-                ..
-            }) = enum_def
-            {
-                let arity = struct_fields.len();
-                let mut args = patterns.clone();
-                while args.len() < arity {
-                    args.push(Wildcard);
-                }
-                if let Some(normalized) =
-                    try_normalize_interface_implementer(ctx, enum_name, arity, args, unions)
-                {
-                    return normalized;
-                }
-            }
-
-            let type_name = make_type_key(enum_name, type_args);
-            let enum_body = enum_def.map(|d| &d.body);
-
-            // Tuple struct / newtype tags are the bare type name (like record
-            // structs); enum variants are `Type.Variant`.
-            let is_struct_def = matches!(enum_body, Some(DefinitionBody::Struct { .. }));
-            let tag = if is_struct_def {
-                enum_name.to_string()
-            } else {
-                format!("{}.{}", enum_name, unqualified_name(variant_name))
-            };
-
-            if unions.get(&type_name).is_none() {
-                let alternatives = match enum_body {
+        } => match resolution {
+            ConstructorPatternResolution::Unresolved => Wildcard,
+            ConstructorPatternResolution::Const {
+                qualified_name,
+                value,
+            } => match value {
+                Some(Literal::Boolean(b)) => normalize_boolean(*b, unions),
+                Some(literal) => NormalizedPattern::Literal(literal.clone()),
+                None => NormalizedPattern::OpaqueConst(qualified_name.to_string()),
+            },
+            ConstructorPatternResolution::EnumVariant {
+                enum_name,
+                variant_name,
+            } => {
+                let type_args = pattern_type_args(ctx, ty);
+                let enum_def = ctx.store.get_definition(enum_name);
+                let field_types = match enum_def.map(|definition| &definition.body) {
+                    Some(DefinitionBody::Struct {
+                        fields, generics, ..
+                    }) => {
+                        let substitution = build_substitution_map(generics, &type_args);
+                        fields
+                            .iter()
+                            .map(|field| substitute(&field.ty, &substitution))
+                            .collect::<Vec<_>>()
+                    }
                     Some(DefinitionBody::Enum {
                         variants, generics, ..
-                    }) => variants
-                        .iter()
-                        .filter(|v| {
-                            is_variant_inhabited(v, type_args, generics, ctx.store, ctx.cache)
-                        })
-                        .map(|v| Constructor {
-                            tag_id: format!("{}.{}", enum_name, v.name),
-                            arity: v.fields.len(),
-                        })
-                        .collect(),
-                    Some(DefinitionBody::Struct {
-                        fields: struct_fields,
-                        generics,
-                        ..
-                    }) if super::inhabitance::is_struct_inhabited(
-                        struct_fields,
-                        type_args,
-                        generics,
-                        ctx.store,
-                        ctx.cache,
-                    ) =>
-                    {
-                        vec![Constructor {
-                            tag_id: tag.clone(),
-                            arity: struct_fields.len(),
-                        }]
+                    }) => {
+                        let Some(variant) = variants
+                            .iter()
+                            .find(|variant| variant.name == unqualified_name(variant_name))
+                        else {
+                            return Wildcard;
+                        };
+                        let substitution = build_substitution_map(generics, &type_args);
+                        variant
+                            .fields
+                            .iter()
+                            .map(|field| substitute(&field.ty, &substitution))
+                            .collect()
                     }
-                    _ => vec![],
+                    _ => return Wildcard,
+                };
+                let patterns: Vec<NormalizedPattern> = fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| {
+                        let child = ctx.at_position(field_types.get(i).cloned());
+                        normalize_pattern(f, unions, &child)
+                    })
+                    .collect();
+
+                let mut patterns = patterns;
+                if *rest && patterns.len() < field_types.len() {
+                    patterns.resize(field_types.len(), Wildcard);
+                }
+
+                if let Some(Definition {
+                    body:
+                        DefinitionBody::Struct {
+                            fields: struct_fields,
+                            ..
+                        },
+                    ..
+                }) = enum_def
+                {
+                    let arity = struct_fields.len();
+                    let mut args = patterns.clone();
+                    while args.len() < arity {
+                        args.push(Wildcard);
+                    }
+                    if let Some(normalized) =
+                        try_normalize_interface_implementer(ctx, enum_name, arity, args, unions)
+                    {
+                        return normalized;
+                    }
+                }
+
+                let type_name = make_type_key(enum_name, &type_args);
+                let enum_body = enum_def.map(|d| &d.body);
+
+                // Tuple struct / newtype tags are the bare type name (like record
+                // structs); enum variants are `Type.Variant`.
+                let is_struct_def = matches!(enum_body, Some(DefinitionBody::Struct { .. }));
+                let tag = if is_struct_def {
+                    enum_name.to_string()
+                } else {
+                    format!("{}.{}", enum_name, unqualified_name(variant_name))
                 };
 
-                unions.insert(type_name.clone(), alternatives);
-            }
+                if unions.get(&type_name).is_none() {
+                    let alternatives = match enum_body {
+                        Some(DefinitionBody::Enum {
+                            variants, generics, ..
+                        }) => variants
+                            .iter()
+                            .filter(|v| {
+                                is_variant_inhabited(v, &type_args, generics, ctx.store, ctx.cache)
+                            })
+                            .map(|v| Constructor {
+                                tag_id: format!("{}.{}", enum_name, v.name),
+                                arity: v.fields.len(),
+                            })
+                            .collect(),
+                        Some(DefinitionBody::Struct {
+                            fields: struct_fields,
+                            generics,
+                            ..
+                        }) if super::inhabitance::is_struct_inhabited(
+                            struct_fields,
+                            &type_args,
+                            generics,
+                            ctx.store,
+                            ctx.cache,
+                        ) =>
+                        {
+                            vec![Constructor {
+                                tag_id: tag.clone(),
+                                arity: struct_fields.len(),
+                            }]
+                        }
+                        _ => vec![],
+                    };
 
-            NormalizedPattern::Constructor {
-                type_name,
-                tag,
-                args: patterns,
-            }
-        }
+                    unions.insert(type_name.clone(), alternatives);
+                }
 
-        TypedPattern::EnumStructVariant {
-            enum_name,
-            variant_name,
-            variant_fields,
-            pattern_fields,
-            type_args,
+                NormalizedPattern::Constructor {
+                    type_name,
+                    tag,
+                    args: patterns,
+                }
+            }
+        },
+
+        Pattern::Struct {
+            fields,
+            ty,
+            resolution:
+                RecordPatternResolution::EnumVariant {
+                    enum_name,
+                    variant_name,
+                },
+            ..
         } => {
-            let substitution = field_substitution_map(ctx, enum_name, type_args);
-            let patterns = variant_fields
+            let type_args = pattern_type_args(ctx, ty);
+            let Some(Definition {
+                body:
+                    DefinitionBody::Enum {
+                        variants, generics, ..
+                    },
+                ..
+            }) = ctx.store.get_definition(enum_name)
+            else {
+                return Wildcard;
+            };
+            let Some(variant) = variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))
+            else {
+                return Wildcard;
+            };
+            let substitution = build_substitution_map(generics, &type_args);
+            let patterns = variant
+                .fields
                 .iter()
                 .map(|f| {
-                    pattern_fields
+                    fields
                         .iter()
-                        .find_map(|(name, pattern)| {
-                            if *name == f.name {
+                        .find_map(|field| {
+                            if field.name == f.name {
                                 let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
-                                Some(normalize_typed_pattern(pattern, unions, &child))
+                                Some(normalize_pattern(&field.value, unions, &child))
                             } else {
                                 None
                             }
@@ -283,24 +329,17 @@ pub fn normalize_typed_pattern(
                 })
                 .collect();
 
-            let type_name = make_type_key(enum_name, type_args);
+            let type_name = make_type_key(enum_name, &type_args);
 
             if unions.get(&type_name).is_none() {
-                let alternatives = match ctx.store.get_definition(enum_name).map(|d| &d.body) {
-                    Some(DefinitionBody::Enum {
-                        variants, generics, ..
-                    }) => variants
-                        .iter()
-                        .filter(|v| {
-                            is_variant_inhabited(v, type_args, generics, ctx.store, ctx.cache)
-                        })
-                        .map(|v| Constructor {
-                            tag_id: format!("{}.{}", enum_name, v.name),
-                            arity: v.fields.len(),
-                        })
-                        .collect(),
-                    _ => vec![],
-                };
+                let alternatives = variants
+                    .iter()
+                    .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, ctx.cache))
+                    .map(|v| Constructor {
+                        tag_id: format!("{}.{}", enum_name, v.name),
+                        arity: v.fields.len(),
+                    })
+                    .collect();
 
                 unions.insert(type_name.clone(), alternatives);
             }
@@ -315,22 +354,35 @@ pub fn normalize_typed_pattern(
             }
         }
 
-        TypedPattern::Struct {
-            struct_name,
-            struct_fields,
-            pattern_fields,
-            type_args,
+        Pattern::Struct {
+            fields,
+            ty,
+            resolution: RecordPatternResolution::Struct { struct_name },
+            ..
         } => {
-            let substitution = field_substitution_map(ctx, struct_name, type_args);
+            let type_args = pattern_type_args(ctx, ty);
+            let Some(Definition {
+                body:
+                    DefinitionBody::Struct {
+                        fields: struct_fields,
+                        generics,
+                        ..
+                    },
+                ..
+            }) = ctx.store.get_definition(struct_name)
+            else {
+                return Wildcard;
+            };
+            let substitution = build_substitution_map(generics, &type_args);
             let patterns: Vec<NormalizedPattern> = struct_fields
                 .iter()
                 .map(|f| {
-                    pattern_fields
+                    fields
                         .iter()
-                        .find_map(|(name, pattern)| {
-                            if *name == f.name {
+                        .find_map(|field| {
+                            if field.name == f.name {
                                 let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
-                                Some(normalize_typed_pattern(pattern, unions, &child))
+                                Some(normalize_pattern(&field.value, unions, &child))
                             } else {
                                 None
                             }
@@ -349,21 +401,16 @@ pub fn normalize_typed_pattern(
                 return normalized;
             }
 
-            let type_name = make_type_key(struct_name, type_args);
+            let type_name = make_type_key(struct_name, &type_args);
 
             if unions.get(&type_name).is_none() {
-                let is_inhabited = ctx
-                    .store
-                    .get_definition(struct_name)
-                    .map(|definition| match &definition.body {
-                        DefinitionBody::Struct {
-                            generics, fields, ..
-                        } => super::inhabitance::is_struct_inhabited(
-                            fields, type_args, generics, ctx.store, ctx.cache,
-                        ),
-                        _ => true,
-                    })
-                    .unwrap_or(true);
+                let is_inhabited = super::inhabitance::is_struct_inhabited(
+                    struct_fields,
+                    &type_args,
+                    generics,
+                    ctx.store,
+                    ctx.cache,
+                );
 
                 if is_inhabited {
                     let constructor = Constructor {
@@ -383,22 +430,36 @@ pub fn normalize_typed_pattern(
             }
         }
 
-        TypedPattern::Slice {
-            prefix,
-            has_rest,
-            element_type,
-        } => normalize_slice(prefix, *has_rest, element_type, unions, ctx),
+        Pattern::Struct {
+            resolution: RecordPatternResolution::Unresolved,
+            ..
+        } => Wildcard,
 
-        TypedPattern::Array {
+        Pattern::Slice {
             prefix,
-            element_type,
-            length,
+            rest,
+            resolution: SequencePatternResolution::Slice { element_type },
+            ..
+        } => normalize_slice(prefix, rest.is_present(), element_type, unions, ctx),
+
+        Pattern::Slice {
+            prefix,
+            resolution:
+                SequencePatternResolution::Array {
+                    element_type,
+                    length,
+                },
             ..
         } => normalize_array(prefix, element_type, *length, unions, ctx),
 
-        TypedPattern::Tuple { arity, elements } => normalize_tuple(elements, *arity, unions, ctx),
+        Pattern::Slice {
+            resolution: SequencePatternResolution::Unresolved,
+            ..
+        } => Wildcard,
 
-        TypedPattern::Or { .. } => {
+        Pattern::Tuple { elements, .. } => normalize_tuple(elements, unions, ctx),
+
+        Pattern::Or { .. } => {
             unreachable!("Or-pattern should be handled by normalize_arm")
         }
     }
@@ -417,7 +478,7 @@ pub fn normalize_typed_pattern(
 /// - [a, ..rest] → NonEmptySlice(a, Wildcard)
 /// - [..] → Wildcard (matches any slice)
 fn normalize_slice(
-    prefix: &[TypedPattern],
+    prefix: &[Pattern],
     has_rest: bool,
     element_type: &Type,
     unions: &mut UnionTable,
@@ -467,7 +528,7 @@ fn normalize_slice(
     let element_ctx = ctx.at_position(Some(element_type.clone()));
     let mut result = tail;
     for element in prefix.iter().rev() {
-        let head = normalize_typed_pattern(element, unions, &element_ctx);
+        let head = normalize_pattern(element, unions, &element_ctx);
         result = NormalizedPattern::Constructor {
             type_name: type_name.clone(),
             tag: "NonEmptySlice".to_string(),
@@ -479,11 +540,11 @@ fn normalize_slice(
 }
 
 fn normalize_tuple(
-    elements: &[TypedPattern],
-    arity: usize,
+    elements: &[Pattern],
     unions: &mut UnionTable,
     ctx: &NormalizationContext,
 ) -> NormalizedPattern {
+    let arity = elements.len();
     let type_name = format!("Tuple{}", arity);
 
     if unions.get(&type_name).is_none() {
@@ -504,7 +565,7 @@ fn normalize_tuple(
         .enumerate()
         .map(|(i, e)| {
             let child = ctx.at_position(element_types.as_ref().and_then(|ts| ts.get(i).cloned()));
-            normalize_typed_pattern(e, unions, &child)
+            normalize_pattern(e, unions, &child)
         })
         .collect();
 
@@ -516,7 +577,7 @@ fn normalize_tuple(
 }
 
 fn normalize_array(
-    prefix: &[TypedPattern],
+    prefix: &[Pattern],
     element_type: &Type,
     length: u64,
     unions: &mut UnionTable,
@@ -561,7 +622,7 @@ fn normalize_array(
     };
 
     let element_ctx = ctx.at_position(Some(element_type.clone()));
-    let head = normalize_typed_pattern(first, unions, &element_ctx);
+    let head = normalize_pattern(first, unions, &element_ctx);
     let tail = normalize_array(rest, element_type, length - 1, unions, ctx);
 
     NormalizedPattern::Constructor {

--- a/crates/passes/src/passes/checks/temp_producing.rs
+++ b/crates/passes/src/passes/checks/temp_producing.rs
@@ -80,12 +80,12 @@ fn has_auto_address_on_call(expression: &Expression) -> bool {
     if let Expression::Call { expression, .. } = expression
         && let Expression::DotAccess {
             expression: receiver,
-            receiver_coercion,
+            resolution,
             ..
         } = expression.unwrap_parens()
     {
         if matches!(receiver.unwrap_parens(), Expression::Call { .. })
-            && *receiver_coercion == Some(ReceiverCoercion::AutoAddress)
+            && resolution.receiver_coercion() == Some(ReceiverCoercion::AutoAddress)
         {
             return true;
         }

--- a/crates/passes/src/passes/checks/unchanging_loop_condition.rs
+++ b/crates/passes/src/passes/checks/unchanging_loop_condition.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap as HashMap;
-use syntax::ast::{BindingId, Expression, UnaryOperator};
+use syntax::ast::{BindingId, Expression, IdentifierResolution, UnaryOperator};
 
 use crate::passes::walk::NodeCtx;
 use semantics::facts::BindingFact;
@@ -42,7 +42,7 @@ fn is_invariant(
 ) -> bool {
     match expression {
         Expression::Identifier {
-            binding_id: Some(id),
+            resolution: IdentifierResolution::Binding(id),
             ..
         } => match bindings.get(id) {
             Some(fact) if !fact.mutation.happened() => {

--- a/crates/passes/src/passes/comparison.rs
+++ b/crates/passes/src/passes/comparison.rs
@@ -1,4 +1,5 @@
-use syntax::ast::{BinaryOperator, Expression, UnaryOperator};
+use semantics::store::Store;
+use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
 use syntax::types::SimpleKind;
 
 /// A value bound: `(value, inclusive)`, or `None` for an open side.
@@ -22,7 +23,7 @@ pub(crate) struct MaskComparison {
 /// Decomposes a masked integer comparison; `None` unless `m` and `c` are in-range
 /// integer literals and `m != 0` (zero masks belong to `redundant_operation`).
 /// A negative `m` is valid only for the equality reasoning.
-pub(crate) fn mask_comparison(expression: &Expression) -> Option<MaskComparison> {
+pub(crate) fn mask_comparison(expression: &Expression, store: &Store) -> Option<MaskComparison> {
     use BinaryOperator::*;
     let Expression::Binary {
         operator,
@@ -73,7 +74,7 @@ pub(crate) fn mask_comparison(expression: &Expression) -> Option<MaskComparison>
         _ => return None,
     };
 
-    let kind = mask_expr.get_type().underlying_simple_kind()?;
+    let kind = store.underlying_simple_kind(&mask_expr.get_type())?;
     if !kind.is_ordered() {
         return None;
     }
@@ -284,8 +285,7 @@ pub(crate) fn prelude_min_max(expression: &Expression) -> Option<MinMaxCall<'_>>
         return None;
     }
     let Expression::Identifier {
-        binding_id: None,
-        qualified: Some(qualified),
+        resolution: IdentifierResolution::Definition(qualified),
         ..
     } = callee.unwrap_parens()
     else {

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -116,7 +116,7 @@ mod tests {
         Type::Compound {
             kind: CompoundKind::Slice,
             args: vec![Type::Var {
-                id: TypeVarId(id),
+                id: TypeVarId::new(id),
                 hint: Some("T".into()),
             }],
         }

--- a/crates/passes/src/passes/fact_producers/generics.rs
+++ b/crates/passes/src/passes/fact_producers/generics.rs
@@ -33,7 +33,9 @@ fn visit_expression(expression: &Expression, local: &mut ProducedFacts) {
             if !generics.is_empty() {
                 let mut still_missing: HashSet<EcoString> =
                     generics.iter().map(|g| g.name.clone()).collect();
-                body_remove_found_type_names(body, &mut still_missing);
+                if let Some(body) = body.definition() {
+                    body_remove_found_type_names(body, &mut still_missing);
+                }
                 let found_in_body: HashSet<EcoString> = generics
                     .iter()
                     .map(|g| g.name.clone())
@@ -70,7 +72,7 @@ fn check_unused_type_parameters(
     }
     return_type.remove_found_type_names(&mut remaining);
     for generic in generics {
-        for bound in &generic.bounds {
+        for bound in generic.bounds() {
             annotation_remove_names(bound, &mut remaining);
         }
     }
@@ -94,7 +96,7 @@ fn check_type_params_only_in_bound(
     found_in_body: &HashSet<EcoString>,
     local: &mut ProducedFacts,
 ) {
-    if generics.iter().all(|g| g.bounds.is_empty()) {
+    if generics.iter().all(|generic| generic.bound_count() == 0) {
         return;
     }
 
@@ -130,7 +132,7 @@ fn collect_type_params_only_in_bound(
 
     let mut unseen_anywhere = unseen_outside_bound_rhs.clone();
     for generic in generics {
-        for bound in &generic.bounds {
+        for bound in generic.bounds() {
             annotation_remove_names(bound, &mut unseen_anywhere);
         }
     }
@@ -153,6 +155,7 @@ fn body_remove_found_type_names(expression: &Expression, names: &mut HashSet<Eco
             for ty in type_arguments
                 .resolved_types()
                 .expect("generic fact production requires checked call type arguments")
+                .iter()
             {
                 ty.remove_found_type_names(names);
             }

--- a/crates/passes/src/passes/fact_producers/mod.rs
+++ b/crates/passes/src/passes/fact_producers/mod.rs
@@ -79,7 +79,7 @@ pub(crate) fn run_all(analysis: &AnalysisContext) -> ProducedFacts {
         .modules
         .values()
         .map(Arc::as_ref)
-        .flat_map(|m| m.files.values().map(move |f| (m, f)))
+        .flat_map(|module| module.source_files().map(move |file| (module, file)))
         .collect();
     work.sort_unstable_by(|a, b| {
         a.0.id

--- a/crates/passes/src/passes/fact_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/fact_producers/unused_expressions.rs
@@ -45,6 +45,9 @@ fn visit_expression(
             return_annotation,
             ..
         } => {
+            let Some(body) = body.definition() else {
+                return;
+            };
             let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
             let body_ty = body.get_type();
             let tail_is_discarded = is_implicit_return
@@ -395,7 +398,12 @@ fn emit_unused_expression(
         Some(UnusedExpressionKind::Option)
     } else if ty.is_partial() {
         Some(UnusedExpressionKind::Partial)
-    } else if !ty.is_unit() && !ty.is_variable() && !ty.is_never() && !ty.is_error() {
+    } else if !ty.is_unit()
+        && !ty.is_variable()
+        && !ty.is_placeholder()
+        && !ty.is_never()
+        && !ty.is_error()
+    {
         Some(UnusedExpressionKind::Value)
     } else {
         None
@@ -429,7 +437,6 @@ fn is_statement_only(expression: &Expression) -> bool {
             | Expression::VariableDeclaration { .. }
             | Expression::ModuleImport { .. }
             | Expression::RawGo { .. }
-            | Expression::NoOp
     )
 }
 
@@ -454,11 +461,11 @@ fn callee_allowed_lints(expression: &Expression, module_id: &str, store: &Store)
     };
 
     if let Expression::Identifier {
-        value, qualified, ..
+        value, resolution, ..
     } = callee.as_ref()
     {
-        if let Some(q) = qualified
-            && let Some(definition) = store.get_definition(q.as_str())
+        if let Some(q) = resolution.definition()
+            && let Some(definition) = store.get_definition(q)
         {
             return definition.allowed_lints().to_vec();
         }

--- a/crates/passes/src/passes/lints/ast_walk/checks/almost_swapped.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/almost_swapped.rs
@@ -1,5 +1,5 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BindingId, Expression};
+use syntax::ast::{BindingId, Expression, IdentifierResolution};
 use syntax::types::Type;
 
 pub fn check_almost_swapped(expression: &Expression, ctx: &NodeCtx) {
@@ -69,7 +69,7 @@ struct Variable<'a> {
 
 fn variable(expression: &Expression) -> Option<Variable<'_>> {
     if let Expression::Identifier {
-        binding_id: Some(id),
+        resolution: IdentifierResolution::Binding(id),
         ty,
         value,
         ..

--- a/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/append_to_zero_filled.rs
@@ -1,6 +1,6 @@
 use super::helpers::{is_bare_identifier, is_zero_literal};
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BindingId, Expression, Literal, Pattern, Span};
+use syntax::ast::{BindingId, Expression, IdentifierResolution, Literal, Pattern, Span};
 use syntax::program::{CallKind, NativeTypeKind};
 
 pub fn check_append_to_zero_filled(expression: &Expression, ctx: &NodeCtx) {
@@ -213,6 +213,9 @@ fn growing_append_receiver(expression: &Expression) -> Option<&Expression> {
 fn is_binding(expression: &Expression, binding_id: BindingId) -> bool {
     matches!(
         expression.unwrap_parens(),
-        Expression::Identifier { binding_id: Some(id), .. } if *id == binding_id
+        Expression::Identifier {
+            resolution: IdentifierResolution::Binding(id),
+            ..
+        } if *id == binding_id
     )
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/bad_bit_mask.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/bad_bit_mask.rs
@@ -6,7 +6,7 @@ pub fn check_bad_bit_mask(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary { span, .. } = expression else {
         return;
     };
-    let Some(mask) = mask_comparison(expression) else {
+    let Some(mask) = mask_comparison(expression, ctx.store) else {
         return;
     };
     let Some(always_true) = constant_result(&mask) else {

--- a/crates/passes/src/passes/lints/ast_walk/checks/discarded_unit_binding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/discarded_unit_binding.rs
@@ -1,15 +1,14 @@
 use crate::passes::lints::span_edit::statement_deletion;
 use crate::passes::walk::NodeCtx;
 use diagnostics::{Edit, Fix};
-use syntax::ast::{Expression, Pattern, Span};
+use syntax::ast::{Expression, LetMode, Pattern, Span};
 
 /// Flags `let _ = expr` where `expr` has unit type, so the discard binds nothing.
 pub fn check_discarded_unit_binding(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Let {
         binding,
         value,
-        else_block: None,
-        assert: false,
+        mode: LetMode::Plain,
         span,
         ..
     } = expression

--- a/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
@@ -39,7 +39,7 @@ pub fn check_double_comparison(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let both_non_float = is_known_non_float(left_lhs) && is_known_non_float(left_rhs);
+    let both_non_float = is_known_non_float(left_lhs, ctx) && is_known_non_float(left_rhs, ctx);
     let Some(combined) = combine(*operator, left_op, right_op, both_non_float) else {
         return;
     };
@@ -60,10 +60,9 @@ pub fn check_double_comparison(expression: &Expression, ctx: &NodeCtx) {
 
 /// True only when the operand's type is known to have a non-float underlying
 /// kind. An unknown kind (e.g. an unbounded type parameter) is possibly-float.
-fn is_known_non_float(expression: &Expression) -> bool {
-    expression
-        .get_type()
-        .underlying_simple_kind()
+fn is_known_non_float(expression: &Expression, ctx: &NodeCtx<'_>) -> bool {
+    ctx.store
+        .underlying_simple_kind(&expression.get_type())
         .is_some_and(|kind| !kind.is_float())
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/equal_operands.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/equal_operands.rs
@@ -38,7 +38,7 @@ pub fn check_equal_operands(expression: &Expression, ctx: &NodeCtx) {
     if signed_integer_literal(left).is_some() || !is_side_effect_free(left) {
         return;
     }
-    if !is_integer_operand(&left.get_type(), bitwise) {
+    if !is_integer_operand(&left.get_type(), bitwise, ctx) {
         return;
     }
 
@@ -48,9 +48,10 @@ pub fn check_equal_operands(expression: &Expression, ctx: &NodeCtx) {
 /// Bitwise ops also accept a direct `uintptr` (per the checker's
 /// `is_integer_type`), but not a `uintptr` alias/newtype, so that exception is
 /// gated on `as_simple` rather than the underlying kind.
-fn is_integer_operand(ty: &Type, bitwise: bool) -> bool {
-    if ty
-        .underlying_simple_kind()
+fn is_integer_operand(ty: &Type, bitwise: bool, ctx: &NodeCtx<'_>) -> bool {
+    if ctx
+        .store
+        .underlying_simple_kind(ty)
         .is_some_and(|kind| kind.is_signed_int() || kind.is_unsigned_int())
     {
         return true;

--- a/crates/passes/src/passes/lints/ast_walk/checks/exit_after_defer.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/exit_after_defer.rs
@@ -3,7 +3,13 @@ use syntax::ast::Expression;
 
 pub fn check_exit_after_defer(expression: &Expression, ctx: &NodeCtx) {
     let body = match expression {
-        Expression::Function { body, .. } | Expression::Lambda { body, .. } => body,
+        Expression::Function { body, .. } => {
+            let Some(body) = body.definition() else {
+                return;
+            };
+            body
+        }
+        Expression::Lambda { body, .. } => body.as_ref(),
         _ => return,
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/float_cmp.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/float_cmp.rs
@@ -46,7 +46,7 @@ pub fn check_float_cmp(expression: &Expression, ctx: &NodeCtx) {
     ctx.sink.push(diagnostics::lint::float_cmp(span, is_equal));
 }
 
-fn is_exact_operand(expression: &Expression, ctx: &NodeCtx) -> bool {
+fn is_exact_operand(expression: &Expression, _ctx: &NodeCtx) -> bool {
     if is_float_zero(expression) {
         return true;
     }
@@ -57,7 +57,7 @@ fn is_exact_operand(expression: &Expression, ctx: &NodeCtx) -> bool {
         return false;
     };
     matches!(
-        resolved_definition(callee, &ctx.facts.resolved_definitions),
+        resolved_definition(callee),
         Some("go:math.NaN" | "go:math.Inf")
     )
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
@@ -44,18 +44,9 @@ pub(super) fn struct_field_names(
 
 pub(super) fn is_float_operand(store: &Store, expression: &Expression) -> bool {
     let resolved = store.deep_resolve_alias(&expression.get_type());
-    if let Some(kind) = resolved.underlying_simple_kind() {
-        return kind.is_float();
-    }
-    if let Type::Nominal { id, .. } = &resolved
-        && let Some(definition) = store.get_definition(id.as_str())
-    {
-        return definition
-            .ty
-            .underlying_simple_kind()
-            .is_some_and(SimpleKind::is_float);
-    }
-    false
+    store
+        .underlying_simple_kind(&resolved)
+        .is_some_and(SimpleKind::is_float)
 }
 
 pub(super) fn is_zero_literal(expression: &Expression) -> bool {
@@ -177,7 +168,7 @@ pub(super) fn expression_is_pure(expression: &Expression, store: &Store) -> bool
             right,
             ..
         } => {
-            binary_operator_cannot_panic(*operator, left, right)
+            binary_operator_cannot_panic(*operator, left, right, store)
                 && expression_is_pure(left, store)
                 && expression_is_pure(right, store)
         }
@@ -198,6 +189,7 @@ fn binary_operator_cannot_panic(
     operator: BinaryOperator,
     left: &Expression,
     right: &Expression,
+    store: &Store,
 ) -> bool {
     match operator {
         BinaryOperator::Division
@@ -205,8 +197,8 @@ fn binary_operator_cannot_panic(
         | BinaryOperator::ShiftLeft
         | BinaryOperator::ShiftRight => false,
         BinaryOperator::Equal | BinaryOperator::NotEqual => {
-            left.get_type().underlying_simple_kind().is_some()
-                && right.get_type().underlying_simple_kind().is_some()
+            store.underlying_simple_kind(&left.get_type()).is_some()
+                && store.underlying_simple_kind(&right.get_type()).is_some()
         }
         _ => true,
     }

--- a/crates/passes/src/passes/lints/ast_walk/checks/ineffective_bit_mask.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/ineffective_bit_mask.rs
@@ -6,7 +6,7 @@ pub fn check_ineffective_bit_mask(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary { span, .. } = expression else {
         return;
     };
-    let Some(mask) = mask_comparison(expression) else {
+    let Some(mask) = mask_comparison(expression, ctx.store) else {
         return;
     };
     if mask.mask_op != MaskOp::Or || !is_ineffective(&mask) {

--- a/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
@@ -16,7 +16,7 @@ pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Let {
         binding,
         value: bound_value,
-        else_block: None,
+        mode,
         span,
         ..
     } = binding_statement
@@ -24,7 +24,11 @@ pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    if binding.mutable {
+    if mode.else_block().is_some() {
+        return;
+    }
+
+    if binding.is_mutable() {
         return;
     }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/lost_cancel.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/lost_cancel.rs
@@ -35,10 +35,10 @@ fn check_slot(pattern: &Pattern, ty: &Type, ctx: &NodeCtx) {
                 }
             }
         }
-        Pattern::WildCard { span } if contains_cancel_func(ty) => {
+        Pattern::WildCard { span } if contains_cancel_func(ty, ctx) => {
             ctx.sink.push(diagnostics::lint::lost_cancel(span));
         }
-        Pattern::Identifier { span, .. } if contains_cancel_func(ty) => {
+        Pattern::Identifier { span, .. } if contains_cancel_func(ty, ctx) => {
             if ctx
                 .facts
                 .bindings
@@ -54,10 +54,13 @@ fn check_slot(pattern: &Pattern, ty: &Type, ctx: &NodeCtx) {
 
 /// Whether `ty` is, or transitively contains through tuples and type aliases, a
 /// cancel func.
-fn contains_cancel_func(ty: &Type) -> bool {
+fn contains_cancel_func(ty: &Type, ctx: &NodeCtx<'_>) -> bool {
     is_cancel_func(ty)
-        || matches!(ty, Type::Tuple(elements) if elements.iter().any(contains_cancel_func))
-        || ty.get_underlying().is_some_and(contains_cancel_func)
+        || matches!(ty, Type::Tuple(elements) if elements.iter().any(|ty| contains_cancel_func(ty, ctx)))
+        || ctx
+            .store
+            .underlying_type(ty)
+            .is_some_and(|underlying| contains_cancel_func(&underlying, ctx))
 }
 
 fn is_cancel_func(ty: &Type) -> bool {

--- a/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
@@ -1,8 +1,12 @@
 use crate::passes::lints::span_edit::match_arm_deletion;
 use crate::passes::walk::NodeCtx;
 use diagnostics::{Edit, Fix};
-use ecow::EcoString;
-use syntax::ast::{Expression, Literal, MatchArm, TypedPattern, collect_pattern_bindings};
+use semantics::store::Store;
+use syntax::ast::{
+    ConstructorPatternResolution, Expression, Literal, MatchArm, Pattern, RecordPatternResolution,
+    StructFieldPattern, collect_pattern_bindings,
+};
+use syntax::program::DefinitionBody;
 use syntax::types::unqualified_name;
 
 use super::helpers::{expressions_equivalent, is_empty_block};
@@ -26,12 +30,10 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
     }
 
     for (index, later) in arms.iter().enumerate().skip(1) {
-        if !is_mergeable(later) {
+        if !is_mergeable(later, ctx.store) {
             continue;
         }
-        let Some(later_pattern) = later.typed_pattern.as_ref() else {
-            continue;
-        };
+        let later_pattern = &later.pattern;
         // Each arm between, and the earlier arm itself, must provably not match the
         // later value, or the merge reroutes it. Guards are opaque here, so an
         // overlapping guarded arm still blocks the merge.
@@ -39,7 +41,7 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
             .iter()
             .enumerate()
             .find_map(|(earlier_index, earlier)| {
-                let safe = is_mergeable(earlier)
+                let safe = is_mergeable(earlier, ctx.store)
                     && expressions_equivalent(&earlier.expression, &later.expression)
                     && disjoint_from_later(earlier, later_pattern)
                     && arms[earlier_index + 1..index]
@@ -76,87 +78,160 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
     }
 }
 
-fn is_mergeable(arm: &MatchArm) -> bool {
+fn is_mergeable(arm: &MatchArm, store: &Store) -> bool {
     !arm.has_guard()
         && !is_empty_block(&arm.expression)
-        // On the surface pattern: the typed form erases an `as` binding, and only a
-        // binding-free value arm can join an `|` merge.
+        // Only a binding-free value arm can join an `|` merge.
         && collect_pattern_bindings(&arm.pattern).is_empty()
-        && arm.typed_pattern.as_ref().is_some_and(is_singleton_typed)
+        && is_singleton_pattern(&arm.pattern, store)
 }
 
-fn disjoint_from_later(arm: &MatchArm, later_pattern: &TypedPattern) -> bool {
-    arm.typed_pattern
-        .as_ref()
-        .is_some_and(|pattern| typed_patterns_disjoint(pattern, later_pattern))
+fn disjoint_from_later(arm: &MatchArm, later_pattern: &Pattern) -> bool {
+    patterns_disjoint(&arm.pattern, later_pattern)
 }
 
-fn is_singleton_typed(pattern: &TypedPattern) -> bool {
+fn is_singleton_pattern(pattern: &Pattern, store: &Store) -> bool {
     match pattern {
-        TypedPattern::Literal(_) | TypedPattern::Const { .. } => true,
-        TypedPattern::EnumVariant { fields, .. } => fields.iter().all(is_singleton_typed),
-        TypedPattern::EnumStructVariant {
-            variant_fields,
-            pattern_fields,
+        Pattern::Literal { .. } => true,
+        Pattern::EnumVariant {
+            resolution: ConstructorPatternResolution::Const { .. },
             ..
-        } => {
-            pattern_fields.len() == variant_fields.len()
-                && pattern_fields.iter().all(|(_, p)| is_singleton_typed(p))
+        } => true,
+        Pattern::EnumVariant {
+            fields, resolution, ..
+        } => constructor_arity(resolution, store).is_some_and(|arity| {
+            fields.len() == arity
+                && fields
+                    .iter()
+                    .all(|field| is_singleton_pattern(field, store))
+        }),
+        Pattern::Struct {
+            fields, resolution, ..
+        } => record_arity(resolution, store).is_some_and(|arity| {
+            fields.len() == arity
+                && fields
+                    .iter()
+                    .all(|field| is_singleton_pattern(&field.value, store))
+        }),
+        Pattern::Tuple { elements, .. } => elements
+            .iter()
+            .all(|element| is_singleton_pattern(element, store)),
+        Pattern::AsBinding { pattern, .. } => is_singleton_pattern(pattern, store),
+        Pattern::Unit { .. }
+        | Pattern::Identifier { .. }
+        | Pattern::WildCard { .. }
+        | Pattern::Slice { .. }
+        | Pattern::Or { .. } => false,
+    }
+}
+
+fn constructor_arity(resolution: &ConstructorPatternResolution, store: &Store) -> Option<usize> {
+    let ConstructorPatternResolution::EnumVariant {
+        enum_name,
+        variant_name,
+    } = resolution
+    else {
+        return None;
+    };
+    match &store.get_definition(enum_name)?.body {
+        DefinitionBody::Struct { fields, .. } => Some(fields.len()),
+        DefinitionBody::Enum { variants, .. } => variants
+            .iter()
+            .find(|variant| variant.name == unqualified_name(variant_name))
+            .map(|variant| variant.fields.len()),
+        _ => None,
+    }
+}
+
+fn record_arity(resolution: &RecordPatternResolution, store: &Store) -> Option<usize> {
+    match resolution {
+        RecordPatternResolution::Struct { struct_name } => {
+            match &store.get_definition(struct_name)?.body {
+                DefinitionBody::Struct { fields, .. } => Some(fields.len()),
+                _ => None,
+            }
         }
-        TypedPattern::Struct {
-            struct_fields,
-            pattern_fields,
-            ..
-        } => {
-            pattern_fields.len() == struct_fields.len()
-                && pattern_fields.iter().all(|(_, p)| is_singleton_typed(p))
-        }
-        TypedPattern::Tuple { elements, .. } => elements.iter().all(is_singleton_typed),
-        TypedPattern::Wildcard
-        | TypedPattern::Slice { .. }
-        | TypedPattern::Array { .. }
-        | TypedPattern::Or { .. } => false,
+        RecordPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } => match &store.get_definition(enum_name)?.body {
+            DefinitionBody::Enum { variants, .. } => variants
+                .iter()
+                .find(|variant| variant.name == unqualified_name(variant_name))
+                .map(|variant| variant.fields.len()),
+            _ => None,
+        },
+        RecordPatternResolution::Unresolved => None,
     }
 }
 
 // Conservative: `false` unless disjointness is proven. A const is a value
 // comparison (compare folded values, never names). An enum variant is a
 // constructor (distinct names are disjoint).
-fn typed_patterns_disjoint(a: &TypedPattern, b: &TypedPattern) -> bool {
-    use TypedPattern as T;
+fn patterns_disjoint(a: &Pattern, b: &Pattern) -> bool {
+    use Pattern as P;
     match (a, b) {
-        (T::Literal(la), T::Literal(lb)) => distinct_literals(la, lb),
+        (P::AsBinding { pattern, .. }, other) | (other, P::AsBinding { pattern, .. }) => {
+            patterns_disjoint(pattern, other)
+        }
+        (P::Literal { literal: la, .. }, P::Literal { literal: lb, .. }) => {
+            distinct_literals(la, lb)
+        }
         (
-            T::Const {
-                value: Some(la), ..
+            P::EnumVariant {
+                resolution:
+                    ConstructorPatternResolution::Const {
+                        value: Some(la), ..
+                    },
+                ..
             },
-            T::Const {
-                value: Some(lb), ..
+            P::EnumVariant {
+                resolution:
+                    ConstructorPatternResolution::Const {
+                        value: Some(lb), ..
+                    },
+                ..
             },
         ) => distinct_literals(la, lb),
         (
-            T::Const {
-                value: Some(cv), ..
+            P::EnumVariant {
+                resolution:
+                    ConstructorPatternResolution::Const {
+                        value: Some(cv), ..
+                    },
+                ..
             },
-            T::Literal(lv),
+            P::Literal { literal: lv, .. },
         )
         | (
-            T::Literal(lv),
-            T::Const {
-                value: Some(cv), ..
+            P::Literal { literal: lv, .. },
+            P::EnumVariant {
+                resolution:
+                    ConstructorPatternResolution::Const {
+                        value: Some(cv), ..
+                    },
+                ..
             },
         ) => distinct_literals(cv, lv),
         (
-            T::EnumVariant {
-                enum_name: ea,
-                variant_name: va,
+            P::EnumVariant {
                 fields: fa,
+                resolution:
+                    ConstructorPatternResolution::EnumVariant {
+                        enum_name: ea,
+                        variant_name: va,
+                        ..
+                    },
                 ..
             },
-            T::EnumVariant {
-                enum_name: eb,
-                variant_name: vb,
+            P::EnumVariant {
                 fields: fb,
+                resolution:
+                    ConstructorPatternResolution::EnumVariant {
+                        enum_name: eb,
+                        variant_name: vb,
+                        ..
+                    },
                 ..
             },
         ) => {
@@ -165,22 +240,27 @@ fn typed_patterns_disjoint(a: &TypedPattern, b: &TypedPattern) -> bool {
             ea == eb
                 && (unqualified_name(va) != unqualified_name(vb)
                     || (fa.len() == fb.len()
-                        && fa
-                            .iter()
-                            .zip(fb)
-                            .any(|(x, y)| typed_patterns_disjoint(x, y))))
+                        && fa.iter().zip(fb).any(|(x, y)| patterns_disjoint(x, y))))
         }
         (
-            T::EnumStructVariant {
-                enum_name: ea,
-                variant_name: va,
-                pattern_fields: fa,
+            P::Struct {
+                fields: fa,
+                resolution:
+                    RecordPatternResolution::EnumVariant {
+                        enum_name: ea,
+                        variant_name: va,
+                        ..
+                    },
                 ..
             },
-            T::EnumStructVariant {
-                enum_name: eb,
-                variant_name: vb,
-                pattern_fields: fb,
+            P::Struct {
+                fields: fb,
+                resolution:
+                    RecordPatternResolution::EnumVariant {
+                        enum_name: eb,
+                        variant_name: vb,
+                        ..
+                    },
                 ..
             },
         ) => {
@@ -188,32 +268,29 @@ fn typed_patterns_disjoint(a: &TypedPattern, b: &TypedPattern) -> bool {
                 && (unqualified_name(va) != unqualified_name(vb) || struct_fields_disjoint(fa, fb))
         }
         (
-            T::Struct {
-                pattern_fields: fa, ..
+            P::Struct {
+                fields: fa,
+                resolution: RecordPatternResolution::Struct { .. },
+                ..
             },
-            T::Struct {
-                pattern_fields: fb, ..
+            P::Struct {
+                fields: fb,
+                resolution: RecordPatternResolution::Struct { .. },
+                ..
             },
         ) => struct_fields_disjoint(fa, fb),
-        (T::Tuple { elements: ea, .. }, T::Tuple { elements: eb, .. }) => {
-            ea.len() == eb.len()
-                && ea
-                    .iter()
-                    .zip(eb)
-                    .any(|(x, y)| typed_patterns_disjoint(x, y))
+        (P::Tuple { elements: ea, .. }, P::Tuple { elements: eb, .. }) => {
+            ea.len() == eb.len() && ea.iter().zip(eb).any(|(x, y)| patterns_disjoint(x, y))
         }
         _ => false,
     }
 }
 
-fn struct_fields_disjoint(
-    a: &[(EcoString, TypedPattern)],
-    b: &[(EcoString, TypedPattern)],
-) -> bool {
-    a.iter().any(|(name, ap)| {
+fn struct_fields_disjoint(a: &[StructFieldPattern], b: &[StructFieldPattern]) -> bool {
+    a.iter().any(|field| {
         b.iter()
-            .find(|(other, _)| other == name)
-            .is_some_and(|(_, bp)| typed_patterns_disjoint(ap, bp))
+            .find(|other| other.name == field.name)
+            .is_some_and(|other| patterns_disjoint(&field.value, &other.value))
     })
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
@@ -6,7 +6,11 @@ use crate::passes::walk::{FunctionRole, NodeCtx, PatternRole};
 
 use super::helpers::first_param_is_self;
 
-pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
+pub fn check_expression_naming<'a>(
+    expression: &Expression,
+    ctx: &NodeCtx<'a>,
+    role: FunctionRole<'a>,
+) {
     let sink = ctx.sink;
     let is_d_lis = ctx.is_d_lis;
     match expression {
@@ -115,7 +119,7 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
             visibility,
             ..
         } => {
-            let exempt = go_method_name_exempt(ctx, params, *visibility, name);
+            let exempt = go_method_name_exempt(ctx, role, params, *visibility, name);
             if !is_d_lis && !exempt {
                 check_snake_case(name, name_span, "non_snake_case_function", sink);
             }
@@ -135,7 +139,7 @@ pub fn check_expression_naming(expression: &Expression, ctx: &NodeCtx) {
     }
 }
 
-pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
+pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx, role: PatternRole) {
     if ctx.is_d_lis {
         return;
     }
@@ -150,7 +154,7 @@ pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
         } => (name, span),
         _ => return,
     };
-    let code = match ctx.pattern_role.get() {
+    let code = match role {
         PatternRole::Parameter => "non_snake_case_parameter",
         PatternRole::Binding => "non_snake_case_variable",
     };
@@ -161,11 +165,12 @@ pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx) {
 /// its exported Go name or break interface conformance (matched by source name).
 fn go_method_name_exempt(
     ctx: &NodeCtx,
+    role: FunctionRole<'_>,
     params: &[Binding],
     visibility: Visibility,
     name: &str,
 ) -> bool {
-    let (is_method, public, impl_type) = match ctx.function_role.get() {
+    let (is_method, public, impl_type) = match role {
         FunctionRole::InterfaceMethod { public } => (true, public, None),
         FunctionRole::ImplMethod { type_name } => (
             first_param_is_self(params),

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
@@ -6,7 +6,11 @@ use super::helpers::{span_text, wrapped_single_arg};
 
 pub fn check_needless_question_mark(expression: &Expression, ctx: &NodeCtx) {
     match expression {
-        Expression::Function { body, .. } => flag_tail(body, ctx),
+        Expression::Function { body, .. } => {
+            if let Some(body) = body.definition() {
+                flag_tail(body, ctx);
+            }
+        }
         Expression::Return {
             expression: value, ..
         } => flag_needless(value, ctx),

--- a/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
@@ -46,9 +46,9 @@ pub fn check_neg_multiply(expression: &Expression, ctx: &NodeCtx) {
     }
 
     // `-operand` is only well-typed (and only checker-accepted) for signed or float.
-    if !inner
-        .get_type()
-        .underlying_simple_kind()
+    if !ctx
+        .store
+        .underlying_simple_kind(&inner.get_type())
         .is_some_and(|kind| kind.is_signed_int() || kind.is_float())
     {
         return;

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
@@ -1,5 +1,5 @@
 use diagnostics::{Edit, Fix};
-use syntax::ast::{Expression, Pattern};
+use syntax::ast::{Expression, IdentifierResolution, Pattern};
 use syntax::program::{CallKind, DotAccessKind};
 
 use super::helpers::lambda_is_annotated;
@@ -88,14 +88,14 @@ fn hoistable_callee(callee: &Expression, params: &[&str], facts: &Facts) -> Opti
     }
     match callee {
         Expression::Identifier {
-            value, binding_id, ..
+            value, resolution, ..
         } => {
             if params.contains(&value.as_str()) {
                 return None;
             }
             // A reassignable capture is read lazily by the closure but bound
             // eagerly as a bare reference, so hoisting it would change behavior.
-            if let Some(id) = binding_id {
+            if let IdentifierResolution::Binding(id) = resolution {
                 match facts.bindings.get(id) {
                     Some(binding) if !binding.kind.is_mutable() => {}
                     _ => return None,
@@ -106,9 +106,9 @@ fn hoistable_callee(callee: &Expression, params: &[&str], facts: &Facts) -> Opti
         Expression::DotAccess {
             expression: base,
             member,
-            dot_access_kind: Some(DotAccessKind::ModuleMember),
+            resolution,
             ..
-        } => {
+        } if resolution.kind() == Some(DotAccessKind::ModuleMember) => {
             let Expression::Identifier { value: base, .. } = base.unwrap_parens() else {
                 return None;
             };

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_field_names.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_field_names.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, Span, StructFieldAssignment};
+use syntax::ast::{Expression, IdentifierResolution, Span, StructFieldAssignment};
 
 use super::helpers::struct_field_names;
 use crate::passes::walk::NodeCtx;
@@ -47,8 +47,7 @@ fn redundant_field(assignment: &StructFieldAssignment) -> Option<Span> {
     let Expression::Identifier {
         value,
         span,
-        binding_id,
-        qualified,
+        resolution,
         ..
     } = assignment.value.as_ref()
     else {
@@ -57,7 +56,7 @@ fn redundant_field(assignment: &StructFieldAssignment) -> Option<Span> {
     if value != &assignment.name {
         return None;
     }
-    if binding_id.is_none() && qualified.is_none() {
+    if matches!(resolution, IdentifierResolution::Unresolved) {
         return None;
     }
     if span.byte_offset == assignment.name_span.byte_offset {

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
@@ -1,14 +1,14 @@
 use crate::passes::lints::span_edit::statement_deletion;
 use crate::passes::walk::NodeCtx;
 use diagnostics::{Edit, Fix};
-use syntax::ast::{Expression, Pattern};
+use syntax::ast::{Expression, IdentifierResolution, Pattern};
 
 /// Flags `let x = x`, an immutable rebinding of a variable to itself.
 pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Let {
         binding,
         value,
-        else_block: None,
+        mode,
         span,
         ..
     } = expression
@@ -16,7 +16,11 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    if binding.mutable {
+    if mode.else_block().is_some() {
+        return;
+    }
+
+    if binding.is_mutable() {
         return;
     }
 
@@ -35,7 +39,7 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
 
     let Expression::Identifier {
         value: rhs_name,
-        binding_id: Some(outer_id),
+        resolution: IdentifierResolution::Binding(outer_id),
         ..
     } = value.unwrap_parens()
     else {

--- a/crates/passes/src/passes/lints/ast_walk/checks/type_limit_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/type_limit_comparison.rs
@@ -34,7 +34,9 @@ pub fn check_type_limit_comparison(expression: &Expression, ctx: &NodeCtx) {
             _ => return,
         };
 
-    let Some((floor, ceil)) = fixed_width_bounds(value.get_type().underlying_simple_kind()) else {
+    let Some((floor, ceil)) =
+        fixed_width_bounds(ctx.store.underlying_simple_kind(&value.get_type()))
+    else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
@@ -38,7 +38,7 @@ pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
     let replacement = if then_value {
         span_text(ctx.source, condition).map(|text| as_tight_operand(text, condition))
     } else {
-        negated_condition(ctx.source, condition)
+        negated_condition(ctx.source, condition, ctx)
     };
     if let Some(replacement) = replacement {
         diagnostic = diagnostic.with_fix(Fix::new(
@@ -50,7 +50,7 @@ pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
 }
 
 /// Source text negating `condition`: flip a comparison operator, else prefix `!`.
-fn negated_condition(source: &str, condition: &Expression) -> Option<String> {
+fn negated_condition(source: &str, condition: &Expression, ctx: &NodeCtx<'_>) -> Option<String> {
     if let Expression::Binary {
         operator,
         left,
@@ -58,7 +58,7 @@ fn negated_condition(source: &str, condition: &Expression) -> Option<String> {
         ..
     } = condition
         && let Some(negated) = negate_comparison(*operator)
-        && flip_preserves_nan(*operator, left, right)
+        && flip_preserves_nan(*operator, left, right, ctx)
     {
         let lhs = span_text(source, left)?;
         let rhs = span_text(source, right)?;
@@ -69,15 +69,19 @@ fn negated_condition(source: &str, condition: &Expression) -> Option<String> {
 }
 
 // Ordered flips are not NaN-safe (`!(a < b)` is not `a >= b`), only `==`/`!=` are.
-fn flip_preserves_nan(operator: BinaryOperator, left: &Expression, right: &Expression) -> bool {
+fn flip_preserves_nan(
+    operator: BinaryOperator,
+    left: &Expression,
+    right: &Expression,
+    ctx: &NodeCtx<'_>,
+) -> bool {
     matches!(operator, BinaryOperator::Equal | BinaryOperator::NotEqual)
-        || (is_non_float(left) && is_non_float(right))
+        || (is_non_float(left, ctx) && is_non_float(right, ctx))
 }
 
-fn is_non_float(expression: &Expression) -> bool {
-    expression
-        .get_type()
-        .underlying_simple_kind()
+fn is_non_float(expression: &Expression, ctx: &NodeCtx<'_>) -> bool {
+    ctx.store
+        .underlying_simple_kind(&expression.get_type())
         .is_some_and(|kind| !kind.is_float())
 }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_range_loop.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_range_loop.rs
@@ -1,14 +1,22 @@
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BindingId, Expression};
+use syntax::ast::{BindingId, Expression, IdentifierResolution, Pattern};
 
 pub fn check_unnecessary_range_loop(expression: &Expression, ctx: &NodeCtx) {
     let Expression::For {
+        binding,
         iterable,
         body,
-        binding_id: Some(index_id),
         ..
     } = expression
     else {
+        return;
+    };
+    let binding_span = match &binding.pattern {
+        Pattern::Identifier { span, .. } => *span,
+        Pattern::AsBinding { name_span, .. } => *name_span,
+        _ => return,
+    };
+    let Some(index_id) = ctx.facts.binding_id_at(binding_span) else {
         return;
     };
     let Expression::Range {
@@ -29,7 +37,7 @@ pub fn check_unnecessary_range_loop(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let mut walk = Walk {
-        index_id: *index_id,
+        index_id,
         collection_id,
         found: false,
         blocked: false,
@@ -67,7 +75,7 @@ fn length_receiver(expression: &Expression) -> Option<(&str, BindingId)> {
     }
     let Expression::Identifier {
         value,
-        binding_id: Some(binding_id),
+        resolution: IdentifierResolution::Binding(binding_id),
         ..
     } = receiver.unwrap_parens()
     else {

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_return.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_return.rs
@@ -7,6 +7,9 @@ pub fn check_unnecessary_return(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Function { body, .. } = expression else {
         return;
     };
+    let Some(body) = body.definition() else {
+        return;
+    };
 
     flag_tail_returns(body, ctx.sink);
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unsigned_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unsigned_comparison.rs
@@ -27,10 +27,22 @@ pub fn check_unsigned_comparison(expression: &Expression, ctx: &NodeCtx) {
         is_zero_literal(left.unwrap_parens()),
         is_zero_literal(right.unwrap_parens()),
     ) {
-        (true, false) if right.get_type().underlying_is_unsigned_int() => {
+        (true, false)
+            if ctx
+                .store
+                .underlying_simple_kind(&right.get_type())
+                .is_some_and(|kind| kind.is_unsigned_int()) =>
+        {
             flip_comparison(*operator)
         }
-        (false, true) if left.get_type().underlying_is_unsigned_int() => *operator,
+        (false, true)
+            if ctx
+                .store
+                .underlying_simple_kind(&left.get_type())
+                .is_some_and(|kind| kind.is_unsigned_int()) =>
+        {
+            *operator
+        }
         _ => return,
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/waitgroup_add_in_task.rs
@@ -1,11 +1,17 @@
 use crate::passes::walk::NodeCtx;
 use rustc_hash::FxHashSet;
-use syntax::ast::{BindingId, Expression, Literal, Span, UnaryOperator};
+use syntax::ast::{BindingId, Expression, IdentifierResolution, Literal, Span, UnaryOperator};
 use syntax::types::Type;
 
 pub fn check_waitgroup_add_in_task(expression: &Expression, ctx: &NodeCtx) {
     let body = match expression {
-        Expression::Function { body, .. } | Expression::Lambda { body, .. } => body,
+        Expression::Function { body, .. } => {
+            let Some(body) = body.definition() else {
+                return;
+            };
+            body
+        }
+        Expression::Lambda { body, .. } => body.as_ref(),
         _ => return,
     };
 
@@ -82,7 +88,7 @@ fn waitgroup_method(callee: &Expression) -> Option<(&str, BindingId)> {
         return None;
     };
     let Expression::Identifier {
-        binding_id: Some(binding),
+        resolution: IdentifierResolution::Binding(binding),
         ..
     } = receiver.unwrap_parens()
     else {

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -3,17 +3,19 @@ pub(crate) mod casing;
 mod checks;
 mod deprecation;
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use crate::passes::PARALLEL_THRESHOLD;
-use crate::passes::walk::{CheckTable, NodeCtx, walk_nodes};
+use crate::passes::walk::{
+    FunctionRole, NodeCtx, PatternRole, apply_expression_checks, apply_pattern_checks, walk_nodes,
+};
 use diagnostics::{LisetteDiagnostic, LocalSink};
 use rayon::prelude::*;
 use rustc_hash::FxHashMap as HashMap;
 use semantics::context::AnalysisContext;
 use semantics::facts::{Facts, Usage};
 use semantics::store::Store;
-use syntax::ast::Span;
+use syntax::ast::{Expression, Pattern, Span};
 use syntax::program::Module;
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
@@ -56,148 +58,153 @@ use checks::{
     check_wildcard_in_or_patterns,
 };
 
-static LINT_CHECKS: LazyLock<CheckTable> = LazyLock::new(|| {
-    use syntax::ast::ExpressionKind::*;
-    use syntax::ast::PatternKind;
+fn run_expression_checks(expression: &Expression, ctx: &NodeCtx<'_>, role: FunctionRole<'_>) {
+    apply_expression_checks!(
+        expression,
+        ctx,
+        (check_double_negation, &[Unary]),
+        (check_self_comparison, &[Binary]),
+        (check_float_cmp, &[Binary]),
+        (check_float_equality_without_abs, &[Binary]),
+        (check_redundant_comparison, &[Binary]),
+        (check_double_comparison, &[Binary]),
+        (check_bad_bit_mask, &[Binary]),
+        (check_ineffective_bit_mask, &[Binary]),
+        (check_equal_operands, &[Binary]),
+        (check_unsigned_comparison, &[Binary]),
+        (check_type_limit_comparison, &[Binary]),
+        (check_non_negative_comparison, &[Binary]),
+        (check_goos_goarch_comparison, &[Binary]),
+        (check_redundant_operation, &[Binary]),
+        (check_integer_division_to_zero, &[Binary]),
+        (check_self_assignment, &[Assignment]),
+        (check_manual_compound_assignment, &[Assignment]),
+        (check_misrefactored_assign_op, &[Assignment]),
+        (check_neg_multiply, &[Binary]),
+        (check_manual_bytes_equal, &[Binary]),
+        (check_manual_rotate, &[Binary]),
+        (check_manual_replace_all, &[Call]),
+        (check_needless_splitn, &[Call]),
+        (check_redundant_sprintf, &[Call]),
+        (check_manual_equal_fold, &[Binary]),
+        (check_manual_find, &[Call]),
+        (check_manual_contains, &[Call]),
+        (check_unnecessary_first_then_check, &[Call]),
+        (check_unnecessary_min_or_max, &[Call]),
+        (check_manual_is_empty, &[Binary]),
+        (check_bool_literal_comparison, &[Binary]),
+        (check_identical_if_branches, &[If]),
+        (check_collapsible_if, &[If]),
+        (check_collapsible_else_if, &[If]),
+        (check_needless_bool_assign, &[If]),
+        // Must precede `match_as_if_let`: it claims the span that one cedes on,
+        // and checks run in listed order per node.
+        (check_collapsible_match, &[Match, IfLet]),
+        (check_identical_match_arms, &[Match]),
+        (check_match_same_arms, &[Match]),
+        (check_redundant_guards, &[Match]),
+        (check_loop_runs_once, &[Loop, While, WhileLet, For]),
+        (check_regexp_in_loop, &[Loop, While, WhileLet, For]),
+        (check_single_element_loop, &[For]),
+        (check_while_let_loop, &[Loop]),
+        (check_empty_match_arm, &[Match]),
+        (check_excess_parens_on_condition, &[If, IfLet, While, Match]),
+        (check_match_literal_collection, &[Match]),
+        (check_match_on_bool, &[Match]),
+        (check_match_single_binding, &[Match]),
+        (check_negated_equality, &[Unary]),
+        (check_let_and_return, &[Block]),
+        (check_almost_swapped, &[Block, TryBlock, RecoverBlock]),
+        (check_append_to_zero_filled, &[Block, Call]),
+        (check_unnecessary_bool, &[If]),
+        (check_unnecessary_range_loop, &[For]),
+        (check_unnecessary_return, &[Function]),
+        (check_match_as_if_let, &[Match]),
+        (check_single_arm_select, &[Select]),
+        (check_redundant_slice_bounds, &[IndexedAccess]),
+        (check_redundant_pattern_matching, &[Match]),
+        (check_equatable_if_let, &[IfLet]),
+        (check_manual_map, &[Match]),
+        (check_manual_map_or, &[Match]),
+        (check_manual_filter, &[Match]),
+        (check_manual_ok_or, &[Match]),
+        (check_manual_ok_err, &[Match]),
+        (check_needless_match, &[Match]),
+        (check_manual_time_since, &[Call]),
+        (check_manual_time_until, &[Call]),
+        (check_map_unwrap_or, &[Call]),
+        (check_bind_instead_of_map, &[Call]),
+        (check_map_flatten, &[Call]),
+        (check_map_identity, &[Call]),
+        (check_unnecessary_map_on_constructor, &[Call]),
+        (check_map_or_none, &[Call]),
+        (check_or_fn_call, &[Call]),
+        (check_unnecessary_lazy_evaluations, &[Call]),
+        (check_manual_option_zip, &[Call]),
+        (check_needless_question_mark, &[Function, Return]),
+        (check_manual_unwrap_or, &[Match]),
+        (check_uninterpolated_fstring, &[Literal]),
+        (check_nested_fstring, &[Literal]),
+        (check_redundant_fstring_conversion, &[Literal]),
+        (check_unnecessary_raw_string_expression, &[Literal]),
+        (check_invisible_in_string_expression, &[Literal]),
+        (check_verbose_failure_propagation, &[Match, IfLet]),
+        (check_dup_arg, &[Call]),
+        (check_duplicate_cutset, &[Call]),
+        (check_waitgroup_add_in_task, &[Function, Lambda]),
+        (check_exit_after_defer, &[Function, Lambda]),
+        (check_struct_attributes, &[Struct]),
+        (check_attributes, &[Function]),
+        (check_enum_attributes, &[Enum]),
+        (check_duplicate_logical_operand, &[Binary]),
+        (check_negated_logical_operand, &[Binary]),
+    );
+    if matches!(
+        expression,
+        Expression::Struct { .. }
+            | Expression::Enum { .. }
+            | Expression::TypeAlias { .. }
+            | Expression::Interface { .. }
+            | Expression::Function { .. }
+            | Expression::ImplBlock { .. }
+    ) {
+        check_expression_naming(expression, ctx, role);
+    }
+    apply_expression_checks!(
+        expression,
+        ctx,
+        (check_enum_variant_names, &[Enum]),
+        (check_self_named_constructors, &[ImplBlock]),
+        (check_replaceable_with_autofill, &[StructCall]),
+        (check_redundant_field_names, &[StructCall]),
+        (check_needless_update, &[StructCall]),
+        (check_lost_query_mutation, &[Call]),
+        (check_lost_cancel, &[Let]),
+        (check_redundant_rebinding, &[Let]),
+        (check_discarded_unit_binding, &[Let]),
+        (check_redundant_closure, &[Lambda]),
+        (check_redundant_closure_call, &[Call]),
+        (check_redundant_else, &[Block]),
+        (check_out_of_domain_value, &[Literal, Unary, Call]),
+    );
+}
 
-    CheckTable::new(
-        &[
-            (check_double_negation, &[Unary]),
-            (check_self_comparison, &[Binary]),
-            (check_float_cmp, &[Binary]),
-            (check_float_equality_without_abs, &[Binary]),
-            (check_redundant_comparison, &[Binary]),
-            (check_double_comparison, &[Binary]),
-            (check_bad_bit_mask, &[Binary]),
-            (check_ineffective_bit_mask, &[Binary]),
-            (check_equal_operands, &[Binary]),
-            (check_unsigned_comparison, &[Binary]),
-            (check_type_limit_comparison, &[Binary]),
-            (check_non_negative_comparison, &[Binary]),
-            (check_goos_goarch_comparison, &[Binary]),
-            (check_redundant_operation, &[Binary]),
-            (check_integer_division_to_zero, &[Binary]),
-            (check_self_assignment, &[Assignment]),
-            (check_manual_compound_assignment, &[Assignment]),
-            (check_misrefactored_assign_op, &[Assignment]),
-            (check_neg_multiply, &[Binary]),
-            (check_manual_bytes_equal, &[Binary]),
-            (check_manual_rotate, &[Binary]),
-            (check_manual_replace_all, &[Call]),
-            (check_needless_splitn, &[Call]),
-            (check_redundant_sprintf, &[Call]),
-            (check_manual_equal_fold, &[Binary]),
-            (check_manual_find, &[Call]),
-            (check_manual_contains, &[Call]),
-            (check_unnecessary_first_then_check, &[Call]),
-            (check_unnecessary_min_or_max, &[Call]),
-            (check_manual_is_empty, &[Binary]),
-            (check_bool_literal_comparison, &[Binary]),
-            (check_identical_if_branches, &[If]),
-            (check_collapsible_if, &[If]),
-            (check_collapsible_else_if, &[If]),
-            (check_needless_bool_assign, &[If]),
-            // Must precede `match_as_if_let`: it claims the span that one cedes on,
-            // and checks run in table order per node.
-            (check_collapsible_match, &[Match, IfLet]),
-            (check_identical_match_arms, &[Match]),
-            (check_match_same_arms, &[Match]),
-            (check_redundant_guards, &[Match]),
-            (check_loop_runs_once, &[Loop, While, WhileLet, For]),
-            (check_regexp_in_loop, &[Loop, While, WhileLet, For]),
-            (check_single_element_loop, &[For]),
-            (check_while_let_loop, &[Loop]),
-            (check_empty_match_arm, &[Match]),
-            (check_excess_parens_on_condition, &[If, IfLet, While, Match]),
-            (check_match_literal_collection, &[Match]),
-            (check_match_on_bool, &[Match]),
-            (check_match_single_binding, &[Match]),
-            (check_negated_equality, &[Unary]),
-            (check_let_and_return, &[Block]),
-            (check_almost_swapped, &[Block, TryBlock, RecoverBlock]),
-            (check_append_to_zero_filled, &[Block, Call]),
-            (check_unnecessary_bool, &[If]),
-            (check_unnecessary_range_loop, &[For]),
-            (check_unnecessary_return, &[Function]),
-            (check_match_as_if_let, &[Match]),
-            (check_single_arm_select, &[Select]),
-            (check_redundant_slice_bounds, &[IndexedAccess]),
-            (check_redundant_pattern_matching, &[Match]),
-            (check_equatable_if_let, &[IfLet]),
-            (check_manual_map, &[Match]),
-            (check_manual_map_or, &[Match]),
-            (check_manual_filter, &[Match]),
-            (check_manual_ok_or, &[Match]),
-            (check_manual_ok_err, &[Match]),
-            (check_needless_match, &[Match]),
-            (check_manual_time_since, &[Call]),
-            (check_manual_time_until, &[Call]),
-            (check_map_unwrap_or, &[Call]),
-            (check_bind_instead_of_map, &[Call]),
-            (check_map_flatten, &[Call]),
-            (check_map_identity, &[Call]),
-            (check_unnecessary_map_on_constructor, &[Call]),
-            (check_map_or_none, &[Call]),
-            (check_or_fn_call, &[Call]),
-            (check_unnecessary_lazy_evaluations, &[Call]),
-            (check_manual_option_zip, &[Call]),
-            (check_needless_question_mark, &[Function, Return]),
-            (check_manual_unwrap_or, &[Match]),
-            (check_uninterpolated_fstring, &[Literal]),
-            (check_nested_fstring, &[Literal]),
-            (check_redundant_fstring_conversion, &[Literal]),
-            (check_unnecessary_raw_string_expression, &[Literal]),
-            (check_invisible_in_string_expression, &[Literal]),
-            (check_verbose_failure_propagation, &[Match, IfLet]),
-            (check_dup_arg, &[Call]),
-            (check_duplicate_cutset, &[Call]),
-            (check_waitgroup_add_in_task, &[Function, Lambda]),
-            (check_exit_after_defer, &[Function, Lambda]),
-            (check_struct_attributes, &[Struct]),
-            (check_attributes, &[Function]),
-            (check_enum_attributes, &[Enum]),
-            (check_duplicate_logical_operand, &[Binary]),
-            (check_negated_logical_operand, &[Binary]),
-            (
-                check_expression_naming,
-                &[Struct, Enum, TypeAlias, Interface, Function, ImplBlock],
-            ),
-            (check_enum_variant_names, &[Enum]),
-            (check_self_named_constructors, &[ImplBlock]),
-            (check_replaceable_with_autofill, &[StructCall]),
-            (check_redundant_field_names, &[StructCall]),
-            (check_needless_update, &[StructCall]),
-            (check_lost_query_mutation, &[Call]),
-            (check_lost_cancel, &[Let]),
-            (check_redundant_rebinding, &[Let]),
-            (check_discarded_unit_binding, &[Let]),
-            (check_redundant_closure, &[Lambda]),
-            (check_redundant_closure_call, &[Call]),
-            (check_redundant_else, &[Block]),
-            (check_out_of_domain_value, &[Literal, Unary, Call]),
-        ],
-        &[
-            (
-                check_rest_only_pattern,
-                &[PatternKind::Slice, PatternKind::Or],
-            ),
-            (check_wildcard_in_or_patterns, &[PatternKind::Or]),
-            (
-                check_unnecessary_raw_string_pattern,
-                &[PatternKind::Literal],
-            ),
-            (check_invisible_in_string_pattern, &[PatternKind::Literal]),
-            (
-                check_pattern_naming,
-                &[
-                    PatternKind::Identifier,
-                    PatternKind::AsBinding,
-                    PatternKind::Slice,
-                ],
-            ),
-        ],
-    )
-});
+fn run_pattern_checks(pattern: &Pattern, ctx: &NodeCtx<'_>, role: PatternRole) {
+    apply_pattern_checks!(
+        pattern,
+        ctx,
+        (check_rest_only_pattern, &[Slice, Or],),
+        (check_wildcard_in_or_patterns, &[Or]),
+        (check_unnecessary_raw_string_pattern, &[Literal],),
+        (check_invisible_in_string_pattern, &[Literal]),
+    );
+    if matches!(
+        pattern,
+        Pattern::Identifier { .. } | Pattern::AsBinding { .. } | Pattern::Slice { .. }
+    ) {
+        check_pattern_naming(pattern, ctx, role);
+    }
+}
 
 pub(crate) fn run(analysis: &AnalysisContext, facts: &Facts) -> Vec<LisetteDiagnostic> {
     let store = analysis.store;
@@ -255,7 +262,7 @@ fn run_module(
     deprecated: &HashMap<Span, String>,
     usages_by_file: &HashMap<u32, Vec<&Usage>>,
 ) {
-    for (file_id, file) in &module.files {
+    for (file_id, file) in module.source_file_entries() {
         let file_sink = LocalSink::new();
         let ctx = NodeCtx {
             store,
@@ -266,10 +273,8 @@ fn run_module(
             is_d_lis: file.is_d_lis(),
             sink: &file_sink,
             claimed_spans: Default::default(),
-            function_role: Default::default(),
-            pattern_role: Default::default(),
         };
-        walk_nodes(&file.items, &ctx, &LINT_CHECKS);
+        walk_nodes(&file.items, &ctx, run_expression_checks, run_pattern_checks);
 
         if let Some(usages) = usages_by_file.get(file_id) {
             deprecation::sweep(usages, deprecated, &file_sink);

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -105,7 +105,7 @@ pub(crate) fn run(
 fn source_by_file<'a>(analysis: &AnalysisContext<'a>) -> HashMap<u32, &'a str> {
     let mut sources = HashMap::default();
     for module in analysis.store.modules.values() {
-        for (file_id, file) in &module.files {
+        for (file_id, file) in module.source_file_entries() {
             sources.insert(*file_id, file.source.as_str());
         }
     }

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -3,8 +3,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use semantics::checker::promotion::{self, MemberKind, Resolution};
 use semantics::store::Store;
 use syntax::ast::{
-    Annotation, Attribute, Binding, Expression, Generic, ImportAlias, Pattern, SelectArm,
-    SelectArmPattern, StructSpread,
+    Annotation, Attribute, Binding, CallTypeArguments, Expression, Generic, ImportAlias, Pattern,
+    SelectArm, SelectArmPattern, StructSpread,
 };
 use syntax::program::File;
 use syntax::program::{DefinitionBody, DotAccessKind, EqualityIndex, Module};
@@ -21,7 +21,7 @@ impl<'a> AliasMap<'a> {
     pub fn build(files: &HashMap<u32, File>, store: &'a Store) -> Self {
         let mut aliases = HashMap::default();
 
-        for file in files.values() {
+        for file in files.values().filter(|file| !file.is_d_lis()) {
             for import in file.imports() {
                 if matches!(import.alias, Some(ImportAlias::Blank(_))) {
                     continue;
@@ -46,28 +46,10 @@ impl<'a> AliasMap<'a> {
     fn is_import_alias(&self, name: &str) -> bool {
         self.aliases.contains_key(name)
     }
-
-    fn is_type_alias(&self, id: &Symbol) -> bool {
-        self.store
-            .get_definition(id.as_str())
-            .is_some_and(|def| def.is_type_alias())
-    }
 }
 
 fn deref_for_keying(ty: &Type, aliases: &AliasMap) -> Type {
-    let mut current = ty.strip_refs();
-    while let Type::Nominal {
-        id,
-        underlying_ty: Some(underlying),
-        ..
-    } = &current
-    {
-        if !aliases.is_type_alias(id) {
-            break;
-        }
-        current = underlying.strip_refs();
-    }
-    current
+    aliases.store.peel_refs_and_aliases(ty).0
 }
 
 pub(super) fn walk_expression(
@@ -94,7 +76,7 @@ pub(super) fn walk_expression(
                 callee,
                 args,
                 spread,
-                type_arguments.annotations(),
+                type_arguments,
                 graph,
                 alias_map,
                 ctx,
@@ -108,7 +90,7 @@ pub(super) fn walk_expression(
         Expression::DotAccess {
             expression,
             member,
-            dot_access_kind,
+            resolution,
             ..
         } => {
             walk_expression(module, expression, graph, alias_map, ctx);
@@ -118,7 +100,7 @@ pub(super) fn walk_expression(
             }
             mark_promoted_field_read(&receiver_ty, member, graph, alias_map);
             if let Some(from) = ctx
-                && is_method_access(dot_access_kind)
+                && is_method_access(resolution.kind())
                 && credits_local_method(&expression.get_type(), module, alias_map)
             {
                 let to = method_node(member, &expression.get_type(), alias_map);
@@ -146,7 +128,7 @@ pub(super) fn walk_expression(
                 generics,
                 params,
                 return_annotation,
-                body,
+                body.definition(),
                 graph,
                 alias_map,
                 &fn_ctx,
@@ -165,7 +147,9 @@ pub(super) fn walk_expression(
             if let Some(ann) = annotation {
                 walk_annotation(module, ann, graph, alias_map, &const_ctx);
             }
-            walk_expression(module, expression, graph, alias_map, Some(&const_ctx));
+            if let Some(value) = expression.value() {
+                walk_expression(module, value, graph, alias_map, Some(&const_ctx));
+            }
         }
 
         Expression::Enum {
@@ -196,7 +180,7 @@ pub(super) fn walk_expression(
         } => {
             let struct_ctx = ModuleItemId::new(name);
             for g in generics {
-                for bound in &g.bounds {
+                for bound in g.bounds() {
                     walk_annotation(module, bound, graph, alias_map, &struct_ctx);
                 }
             }
@@ -252,7 +236,7 @@ pub(super) fn walk_expression(
         Expression::Let {
             binding,
             value,
-            else_block,
+            mode,
             ..
         } => {
             walk_pattern(module, &binding.pattern, graph, alias_map, ctx);
@@ -267,7 +251,7 @@ pub(super) fn walk_expression(
                 );
             }
             walk_expression(module, value, graph, alias_map, ctx);
-            if let Some(eb) = else_block {
+            if let Some(eb) = mode.else_block() {
                 walk_expression(module, eb, graph, alias_map, ctx);
             }
         }
@@ -285,7 +269,7 @@ pub(super) fn walk_expression(
             let impl_id = ModuleItemId::new(receiver_name);
             let impl_context = ctx.unwrap_or(&impl_id);
             for g in generics {
-                for bound in &g.bounds {
+                for bound in g.bounds() {
                     walk_annotation(module, bound, graph, alias_map, impl_context);
                 }
             }
@@ -305,7 +289,7 @@ pub(super) fn walk_expression(
                         generics,
                         params,
                         return_annotation,
-                        body,
+                        body.definition(),
                         graph,
                         alias_map,
                         &method_ctx,
@@ -419,8 +403,8 @@ fn walk_call(
     module: &Module,
     callee: &Expression,
     args: &[Expression],
-    spread: &Option<Expression>,
-    type_args: &[Annotation],
+    spread: &Option<Box<Expression>>,
+    type_arguments: &CallTypeArguments,
     graph: &mut ReferenceGraph,
     alias_map: &AliasMap,
     ctx: Option<&ModuleItemId>,
@@ -451,7 +435,7 @@ fn walk_call(
         walk_expression(module, spread_expr, graph, alias_map, ctx);
     }
     if let Some(from) = ctx {
-        for type_arg in type_args {
+        for type_arg in type_arguments.annotations() {
             walk_annotation(module, type_arg, graph, alias_map, from);
         }
     }
@@ -732,6 +716,8 @@ fn walk_type(
         Type::Array { element, .. } => walk_type(module, element, graph, alias_map, from),
         Type::Simple(_)
         | Type::Var { .. }
+        | Type::Uninferred
+        | Type::Ignored
         | Type::Parameter(_)
         | Type::Never
         | Type::Error
@@ -780,7 +766,7 @@ fn mark_constructor_pattern(
     }
 }
 
-fn is_method_access(kind: &Option<DotAccessKind>) -> bool {
+fn is_method_access(kind: Option<DotAccessKind>) -> bool {
     matches!(
         kind,
         Some(
@@ -797,13 +783,13 @@ fn walk_callable_body(
     generics: &[Generic],
     params: &[Binding],
     return_annotation: &Annotation,
-    body: &Expression,
+    body: Option<&Expression>,
     graph: &mut ReferenceGraph,
     alias_map: &AliasMap,
     fn_ctx: &ModuleItemId,
 ) {
     for g in generics {
-        for bound in &g.bounds {
+        for bound in g.bounds() {
             walk_annotation(module, bound, graph, alias_map, fn_ctx);
         }
     }
@@ -819,7 +805,9 @@ fn walk_callable_body(
         );
     }
     walk_annotation(module, return_annotation, graph, alias_map, fn_ctx);
-    walk_expression(module, body, graph, alias_map, Some(fn_ctx));
+    if let Some(body) = body {
+        walk_expression(module, body, graph, alias_map, Some(fn_ctx));
+    }
 }
 
 /// The graph node for a `member` method call on `receiver_ty`, resolving the receiver to
@@ -849,11 +837,19 @@ fn has_equality_attr(attributes: &[Attribute]) -> bool {
 pub(super) fn equals_targets(
     ty: &Type,
     module: &Module,
+    store: &Store,
     index: &EqualityIndex,
     out: &mut Vec<ModuleItemId>,
 ) {
     let mut current = ty.clone();
-    while let Some(next) = current.get_underlying().cloned() {
+    let mut seen = HashSet::default();
+    while let Type::Nominal { id, .. } = &current {
+        if !seen.insert(id.clone()) {
+            break;
+        }
+        let Some(next) = store.underlying_type(&current) else {
+            break;
+        };
         current = next;
     }
     match &current {
@@ -862,7 +858,7 @@ pub(super) fn equals_targets(
             args,
         } => {
             if let Some(element) = args.first() {
-                equals_targets(element, module, index, out);
+                equals_targets(element, module, store, index, out);
             }
         }
         Type::Compound {
@@ -870,7 +866,7 @@ pub(super) fn equals_targets(
             args,
         } => {
             if let Some(value) = args.get(1) {
-                equals_targets(value, module, index, out);
+                equals_targets(value, module, store, index, out);
             }
         }
         Type::Nominal { id, .. } => {

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -112,8 +112,7 @@ fn apply_ref_lints(
     let mut diagnostics = result.diagnostics;
     if !diagnostics.is_empty() {
         let allows: Vec<_> = module
-            .files
-            .values()
+            .source_files()
             .flat_map(|file| super::suppression::collect_declaration_allows(&file.items))
             .collect();
         diagnostics = super::suppression::filter_unused_allowed(diagnostics, &allows);
@@ -144,7 +143,7 @@ fn run_ref_lints(
     );
 
     let alias_map = AliasMap::build(files, store);
-    for file in files.values() {
+    for file in files.values().filter(|file| !file.is_d_lis()) {
         for item in &file.items {
             walk_expression(module, item, &mut graph, &alias_map, None);
         }
@@ -155,6 +154,7 @@ fn run_ref_lints(
         equals_targets(
             &receiver_ty.strip_refs(),
             module,
+            store,
             equality_index,
             &mut targets,
         );
@@ -168,7 +168,7 @@ fn run_ref_lints(
             continue;
         }
         let mut targets = Vec::new();
-        equals_targets(&field_ty, module, equality_index, &mut targets);
+        equals_targets(&field_ty, module, store, equality_index, &mut targets);
         for to in targets {
             graph.mark_as_used(to);
         }
@@ -240,7 +240,7 @@ fn collect_items(
     equality_index: &EqualityIndex,
     graph: &mut ReferenceGraph,
 ) {
-    for file in files.values() {
+    for file in files.values().filter(|file| !file.is_d_lis()) {
         for item in &file.items {
             match item {
                 Expression::ModuleImport {

--- a/crates/passes/src/passes/lints/ref_graph/visibility_constraints.rs
+++ b/crates/passes/src/passes/lints/ref_graph/visibility_constraints.rs
@@ -21,8 +21,7 @@ pub fn check_visibility_constraints(
             .next_back()
             .unwrap_or(qualified_name);
 
-        let annotation = find_function_annotation(files, item_name)
-            .or_else(|| find_function_annotation(&module.typedefs, item_name));
+        let annotation = find_function_annotation(files, item_name);
 
         let mut ctx = LeakCtx {
             module,
@@ -127,6 +126,8 @@ impl LeakCtx<'_> {
             }
             Type::Simple(_)
             | Type::Var { .. }
+            | Type::Uninferred
+            | Type::Ignored
             | Type::Parameter(_)
             | Type::Never
             | Type::Error

--- a/crates/passes/src/passes/walk.rs
+++ b/crates/passes/src/passes/walk.rs
@@ -1,10 +1,8 @@
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 
 use diagnostics::LocalSink;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use syntax::ast::{
-    Expression, ExpressionKind, Pattern, PatternKind, RestPattern, SelectArmPattern, Span,
-};
+use syntax::ast::{Expression, Pattern, RestPattern, SelectArmPattern, Span};
 use syntax::program::File;
 
 use semantics::facts::Facts;
@@ -21,8 +19,6 @@ pub(crate) struct NodeCtx<'a> {
     /// Node spans already claimed by an enclosing node, so a check does not also
     /// judge them standalone (e.g. the nested `&&` of an outer comparison chain).
     pub claimed_spans: RefCell<HashSet<Span>>,
-    pub function_role: Cell<FunctionRole<'a>>,
-    pub pattern_role: Cell<PatternRole>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -44,54 +40,46 @@ pub enum FunctionRole<'a> {
     Free,
 }
 
-pub(crate) type NodeCheck = fn(&Expression, &NodeCtx);
-pub(crate) type PatternCheck = fn(&Pattern, &NodeCtx);
-
-pub(crate) struct CheckTable {
-    expression_buckets: [Vec<NodeCheck>; ExpressionKind::COUNT],
-    pattern_buckets: [Vec<PatternCheck>; PatternKind::COUNT],
+macro_rules! apply_expression_checks {
+    ($expression:expr, $ctx:expr, $(($check:path, &[$($kind:ident),+ $(,)?] $(,)?)),* $(,)?) => {
+        $(
+            if matches!($expression, $(syntax::ast::Expression::$kind { .. })|+) {
+                $check($expression, $ctx);
+            }
+        )*
+    };
 }
 
-impl CheckTable {
-    pub(crate) fn new(
-        expression_checks: &[(NodeCheck, &[ExpressionKind])],
-        pattern_checks: &[(PatternCheck, &[PatternKind])],
-    ) -> Self {
-        let mut expression_buckets: [Vec<NodeCheck>; ExpressionKind::COUNT] =
-            std::array::from_fn(|_| Vec::new());
-        for (check, kinds) in expression_checks {
-            for kind in *kinds {
-                expression_buckets[*kind as usize].push(*check);
+pub(crate) use apply_expression_checks;
+
+macro_rules! apply_pattern_checks {
+    ($pattern:expr, $ctx:expr, $(($check:path, &[$($kind:ident),+ $(,)?] $(,)?)),* $(,)?) => {
+        $(
+            if matches!($pattern, $(syntax::ast::Pattern::$kind { .. })|+) {
+                $check($pattern, $ctx);
             }
-        }
-        let mut pattern_buckets: [Vec<PatternCheck>; PatternKind::COUNT] =
-            std::array::from_fn(|_| Vec::new());
-        for (check, kinds) in pattern_checks {
-            for kind in *kinds {
-                pattern_buckets[*kind as usize].push(*check);
-            }
-        }
-        Self {
-            expression_buckets,
-            pattern_buckets,
-        }
-    }
+        )*
+    };
 }
 
-pub(crate) fn walk_nodes<'a>(ast: &'a [Expression], ctx: &NodeCtx<'a>, checks: &CheckTable) {
+pub(crate) use apply_pattern_checks;
+
+pub(crate) fn walk_nodes<'a, E, P>(
+    ast: &'a [Expression],
+    ctx: &NodeCtx<'a>,
+    expression_checks: E,
+    pattern_checks: P,
+) where
+    E: Fn(&Expression, &NodeCtx<'a>, FunctionRole<'a>),
+    P: Fn(&Pattern, &NodeCtx<'a>, PatternRole),
+{
     visit_ast(
         ast,
         &mut |expression, role| {
-            ctx.function_role.set(role);
-            for check in &checks.expression_buckets[expression.kind() as usize] {
-                check(expression, ctx);
-            }
+            expression_checks(expression, ctx, role);
         },
         &mut |pattern, role| {
-            ctx.pattern_role.set(role);
-            for check in &checks.pattern_buckets[pattern.kind() as usize] {
-                check(pattern, ctx);
-            }
+            pattern_checks(pattern, ctx, role);
         },
     );
 }

--- a/crates/semantics/src/cache/bounds.rs
+++ b/crates/semantics/src/cache/bounds.rs
@@ -61,7 +61,6 @@ fn restore_module_bounds(
     let sources: Vec<(u32, String)> = module
         .files
         .values()
-        .chain(module.typedefs.values())
         .filter(|file| file.items.is_empty() && !file.is_test())
         .map(|file| (file.id, file.source.clone()))
         .collect();
@@ -219,5 +218,5 @@ fn file_context_kind(module_id: &str) -> FileContextKind {
 }
 
 fn needs_restoration(generic: &Generic) -> bool {
-    generic.bounds.len() != generic.resolved_bounds.len()
+    !generic.bounds_are_resolved()
 }

--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -65,10 +65,9 @@ pub(crate) fn save_go_stdlib_cache(store: &Store, go_module_ids: &[String], targ
             .definitions
             .iter()
             .map(|(name, definition)| {
-                let is_const = module.const_names.contains(name);
                 (
                     name.to_string(),
-                    CachedDefinition::from_definition(definition, is_const, &empty_file_map),
+                    CachedDefinition::from_definition(definition, &empty_file_map),
                 )
             })
             .collect();
@@ -149,10 +148,9 @@ fn register_cached_go_module(
     if let (Some(go_pkg), Some(source)) = (go_pkg, source) {
         let file_id = store.new_file_id();
         let filename = format!("{}.d.lis", go_pkg.replace('/', "_"));
-        store.store_file(
-            module_id,
-            File::new_cached(module_id, &filename, &filename, source, file_id),
-        );
+        store.store_file(File::new_cached(
+            module_id, &filename, &filename, source, file_id,
+        ));
         if let Some(path) = deps::stdlib_typedef_path(target, go_pkg) {
             store.typedef_paths.insert(file_id, path);
         }

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -299,11 +299,7 @@ pub fn save_module_cache(
         return Err(io::Error::other("module not found in store"));
     };
 
-    let mut all_files: Vec<_> = module
-        .files
-        .values()
-        .chain(module.typedefs.values())
-        .collect();
+    let mut all_files: Vec<_> = module.files.values().collect();
     all_files.sort_by_key(|f| &f.name);
 
     let file_id_to_index: HashMap<u32, u32> = all_files
@@ -358,10 +354,9 @@ fn extract_public_definitions(
         .filter(|(_, definition)| definition.visibility.is_public())
         .filter(|(_, definition)| !store.is_test_definition(definition))
         .map(|(name, definition)| {
-            let is_const = module.const_names.contains(name);
             (
                 name.to_string(),
-                CachedDefinition::from_definition(definition, is_const, file_id_to_index),
+                CachedDefinition::from_definition(definition, file_id_to_index),
             )
         })
         .collect()
@@ -398,11 +393,7 @@ pub(crate) fn build_cached_module(
             &cached_file.source,
             file_id,
         );
-        if file.is_d_lis() {
-            module.typedefs.insert(file_id, file);
-        } else {
-            module.files.insert(file_id, file);
-        }
+        module.files.insert(file_id, file);
     }
 
     for (qualified_name, cached_definition) in cached.definitions {
@@ -616,44 +607,45 @@ mod tests {
     }
 
     #[test]
-    fn build_cached_module_restores_const_names() {
+    fn build_cached_module_preserves_constant_kind() {
         use syntax::ast::Literal;
-        use syntax::program::{Definition, DefinitionBody, Visibility};
+        use syntax::program::{Definition, DefinitionBody, ValueKind, Visibility};
 
-        let make_value = |const_value: Option<Literal>| Definition {
+        let make_value = |kind| Definition {
             visibility: Visibility::Public,
             ty: Type::Nominal {
                 id: Symbol::from_raw("int"),
                 params: vec![],
-                underlying_ty: None,
             },
             name: None,
             name_span: None,
             doc: None,
             body: DefinitionBody::Value {
+                kind,
                 allowed_lints: vec![],
                 go_hints: vec![],
                 go_name: None,
                 go_type_param_recipe: None,
-                const_value,
             },
         };
 
         let empty_files = HashMap::default();
-        let const_def = make_value(Some(Literal::Integer {
-            value: 5,
-            text: None,
-        }));
-        let var_def = make_value(None);
+        let const_def = make_value(ValueKind::Constant {
+            value: Some(Literal::Integer {
+                value: 5,
+                text: None,
+            }),
+        });
+        let var_def = make_value(ValueKind::Runtime);
 
         let mut definitions = HashMap::default();
         definitions.insert(
             "mymod.MAX".to_string(),
-            CachedDefinition::from_definition(&const_def, true, &empty_files),
+            CachedDefinition::from_definition(&const_def, &empty_files),
         );
         definitions.insert(
             "mymod.counter".to_string(),
-            CachedDefinition::from_definition(&var_def, false, &empty_files),
+            CachedDefinition::from_definition(&var_def, &empty_files),
         );
 
         let interface = ModuleInterface {
@@ -677,8 +669,8 @@ mod tests {
             &DisplayPathBase::new(Path::new("/project/src")),
         );
 
-        assert!(built.module.const_names.contains("mymod.MAX"));
-        assert!(!built.module.const_names.contains("mymod.counter"));
+        assert!(built.module.definitions["mymod.MAX"].is_const());
+        assert!(!built.module.definitions["mymod.counter"].is_const());
     }
 
     #[test]
@@ -687,14 +679,13 @@ mod tests {
         use syntax::program::{Attributes, Definition, DefinitionBody, TypeAttribute, Visibility};
 
         let mut attributes = Attributes::default();
-        attributes.insert(TypeAttribute::Serialized, ());
+        attributes.insert(TypeAttribute::Serialized);
 
         let struct_def = Definition {
             visibility: Visibility::Public,
             ty: Type::Nominal {
                 id: Symbol::from_raw("dep.Inner"),
                 params: vec![],
-                underlying_ty: None,
             },
             name: Some("Inner".into()),
             name_span: None,
@@ -710,7 +701,7 @@ mod tests {
         };
 
         let empty_files = HashMap::default();
-        let cached = CachedDefinition::from_definition(&struct_def, false, &empty_files);
+        let cached = CachedDefinition::from_definition(&struct_def, &empty_files);
         let bytes = bincode::serialize(&cached).unwrap();
         let restored: CachedDefinition = bincode::deserialize(&bytes).unwrap();
 
@@ -750,7 +741,6 @@ mod tests {
                 Type::Nominal {
                     id: Symbol::from_raw("int"),
                     params: vec![],
-                    underlying_ty: None,
                 },
                 false,
             )],
@@ -758,7 +748,6 @@ mod tests {
             Box::new(Type::Nominal {
                 id: Symbol::from_raw("main.MyType"),
                 params: vec![Type::Tuple(vec![Type::Never])],
-                underlying_ty: None,
             }),
         );
 

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -52,10 +52,9 @@ pub(crate) fn save_prelude_cache(store: &Store) {
         .definitions
         .iter()
         .map(|(name, definition)| {
-            let is_const = module.const_names.contains(name);
             (
                 name.to_string(),
-                CachedDefinition::from_definition(definition, is_const, &file_id_to_index),
+                CachedDefinition::from_definition(definition, &file_id_to_index),
             )
         })
         .collect();
@@ -76,18 +75,15 @@ pub(crate) fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
     // Register the prelude file for file_id → module_id mapping (needed by diagnostics).
     // Items are empty since we're loading definitions from cache.
     use syntax::program::File;
-    store.store_file(
-        PRELUDE_MODULE_ID,
-        File {
-            id: PRELUDE_FILE_ID,
-            module_id: PRELUDE_MODULE_ID.to_string(),
-            name: "prelude.d.lis".to_string(),
-            display_path: "prelude.d.lis".to_string(),
-            source: stdlib::LIS_PRELUDE_SOURCE.to_string(),
-            items: vec![],
-            file_comment: None,
-        },
-    );
+    store.store_file(File {
+        id: PRELUDE_FILE_ID,
+        module_id: PRELUDE_MODULE_ID.to_string(),
+        name: "prelude.d.lis".to_string(),
+        display_path: "prelude.d.lis".to_string(),
+        source: stdlib::LIS_PRELUDE_SOURCE.to_string(),
+        items: vec![],
+        file_comment: None,
+    });
 
     let file_ids: &[u32] = &[PRELUDE_FILE_ID];
     let module = store

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -6,7 +6,8 @@ use syntax::ast::{
     Annotation, AttributeArg, Generic, Span, StructKind, Visibility as FieldVisibility,
 };
 use syntax::program::{
-    Attributes, Definition, DefinitionBody, Interface, MethodSignatures, Module, Visibility,
+    AliasKind, Attributes, Definition, DefinitionBody, Interface, MethodSignatures, Module,
+    ValueKind, Visibility,
 };
 use syntax::types::{Symbol, Type};
 
@@ -49,18 +50,17 @@ impl CachedGeneric {
     fn from_generic(generic: &Generic, file_id_to_index: &HashMap<u32, u32>) -> Self {
         Self {
             name: generic.name.clone(),
-            bounds: generic.bounds.clone(),
+            bounds: generic.bounds().cloned().collect(),
             span: CachedSpan::from_span(&generic.span, file_id_to_index),
         }
     }
 
     fn to_generic(&self, file_ids: &[u32]) -> Generic {
-        Generic {
-            name: self.name.clone(),
-            bounds: self.bounds.clone(),
-            resolved_bounds: vec![],
-            span: self.span.to_span(file_ids),
-        }
+        Generic::new(
+            self.name.clone(),
+            self.bounds.clone(),
+            self.span.to_span(file_ids),
+        )
     }
 }
 
@@ -324,7 +324,12 @@ pub struct CachedDefinition {
     name_span: Option<CachedSpan>,
     doc: Option<String>,
     pub body: CachedDefinitionBody,
-    is_const: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum CachedValueKind {
+    Runtime,
+    Constant { value: Option<CachedLiteral> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -332,7 +337,7 @@ pub enum CachedDefinitionBody {
     TypeAlias {
         generics: Vec<CachedGeneric>,
         methods: MethodSignatures,
-        is_opaque: bool,
+        alias: CachedAliasKind,
         attributes: Attributes,
     },
     Enum {
@@ -353,12 +358,18 @@ pub enum CachedDefinitionBody {
         definition: CachedInterface,
     },
     Value {
+        kind: CachedValueKind,
         allowed_lints: Vec<String>,
         go_hints: Vec<String>,
         go_name: Option<String>,
         go_type_param_recipe: Option<String>,
-        const_value: Option<CachedLiteral>,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum CachedAliasKind {
+    Opaque,
+    Transparent(Type),
 }
 
 impl CachedDefinition {
@@ -366,7 +377,6 @@ impl CachedDefinition {
     /// Only call this for public definitions that should be cached.
     pub(crate) fn from_definition(
         definition: &Definition,
-        is_const: bool,
         file_id_to_index: &HashMap<u32, u32>,
     ) -> Self {
         let Definition {
@@ -380,7 +390,7 @@ impl CachedDefinition {
         let body = match body {
             DefinitionBody::TypeAlias {
                 generics,
-                annotation,
+                alias,
                 methods,
                 attributes,
             } => CachedDefinitionBody::TypeAlias {
@@ -389,7 +399,12 @@ impl CachedDefinition {
                     .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
                     .collect(),
                 methods: methods.clone(),
-                is_opaque: annotation.is_opaque(),
+                alias: match alias {
+                    AliasKind::Opaque(_) => CachedAliasKind::Opaque,
+                    AliasKind::Transparent { target, .. } => {
+                        CachedAliasKind::Transparent(target.clone())
+                    }
+                },
                 attributes: attributes.clone(),
             },
             DefinitionBody::Enum {
@@ -434,17 +449,22 @@ impl CachedDefinition {
                 definition: CachedInterface::from_interface(definition, file_id_to_index),
             },
             DefinitionBody::Value {
+                kind,
                 allowed_lints,
                 go_hints,
                 go_name,
                 go_type_param_recipe,
-                const_value,
             } => CachedDefinitionBody::Value {
+                kind: match kind {
+                    ValueKind::Runtime => CachedValueKind::Runtime,
+                    ValueKind::Constant { value } => CachedValueKind::Constant {
+                        value: value.as_ref().map(CachedLiteral::from_literal),
+                    },
+                },
                 allowed_lints: allowed_lints.clone(),
                 go_hints: go_hints.clone(),
                 go_name: go_name.clone(),
                 go_type_param_recipe: go_type_param_recipe.clone(),
-                const_value: const_value.as_ref().map(CachedLiteral::from_literal),
             },
         };
         CachedDefinition {
@@ -453,7 +473,6 @@ impl CachedDefinition {
             name_span: name_span.map(|s| CachedSpan::from_span(&s, file_id_to_index)),
             doc: doc.clone(),
             body,
-            is_const,
         }
     }
 
@@ -463,9 +482,6 @@ impl CachedDefinition {
         qualified_name: Symbol,
         file_ids: &[u32],
     ) {
-        if self.is_const {
-            module.const_names.insert(qualified_name.clone());
-        }
         let definition = self.to_definition(file_ids);
         module.definitions.insert(qualified_name, definition);
     }
@@ -475,16 +491,18 @@ impl CachedDefinition {
             CachedDefinitionBody::TypeAlias {
                 generics,
                 methods,
-                is_opaque,
+                alias,
                 attributes,
             } => DefinitionBody::TypeAlias {
                 generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
-                annotation: if *is_opaque {
-                    Annotation::Opaque {
+                alias: match alias {
+                    CachedAliasKind::Opaque => AliasKind::Opaque(Annotation::Opaque {
                         span: Span::dummy(),
-                    }
-                } else {
-                    Annotation::Unknown
+                    }),
+                    CachedAliasKind::Transparent(target) => AliasKind::Transparent {
+                        annotation: Annotation::Unknown,
+                        target: target.clone(),
+                    },
                 },
                 methods: methods.clone(),
                 attributes: attributes.clone(),
@@ -519,17 +537,22 @@ impl CachedDefinition {
                 definition: definition.to_interface(file_ids),
             },
             CachedDefinitionBody::Value {
+                kind,
                 allowed_lints,
                 go_hints,
                 go_name,
                 go_type_param_recipe,
-                const_value,
             } => DefinitionBody::Value {
+                kind: match kind {
+                    CachedValueKind::Runtime => ValueKind::Runtime,
+                    CachedValueKind::Constant { value } => ValueKind::Constant {
+                        value: value.as_ref().map(CachedLiteral::to_literal),
+                    },
+                },
                 allowed_lints: allowed_lints.clone(),
                 go_hints: go_hints.clone(),
                 go_name: go_name.clone(),
                 go_type_param_recipe: go_type_param_recipe.clone(),
-                const_value: const_value.as_ref().map(CachedLiteral::to_literal),
             },
         };
         Definition {

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -8,7 +8,8 @@
 
 use syntax::ast::{
     Binding, EnumFieldDefinition, Expression, FormatStringPart, Literal, Pattern, SelectArm,
-    SelectArmPattern, StructFieldDefinition, StructSpread, TypedPattern, VariantFields,
+    SelectArmPattern, SequencePatternResolution, StructFieldDefinition, StructSpread,
+    VariantFields,
 };
 use syntax::types::Type;
 
@@ -27,16 +28,10 @@ impl<'a> FreezeFolder<'a> {
 
     fn normalize_ref_aliases(&self, ty: &Type) -> Type {
         match ty {
-            Type::Nominal {
-                id,
-                params,
-                underlying_ty,
-            } => {
-                if underlying_ty.is_some() {
-                    let peeled = self.store.peel_alias(ty);
-                    if peeled.is_ref() {
-                        return self.normalize_ref_aliases(&peeled);
-                    }
+            Type::Nominal { id, params } => {
+                let peeled = self.store.peel_alias(ty);
+                if peeled.is_ref() {
+                    return self.normalize_ref_aliases(&peeled);
                 }
                 Type::Nominal {
                     id: id.clone(),
@@ -44,7 +39,6 @@ impl<'a> FreezeFolder<'a> {
                         .iter()
                         .map(|p| self.normalize_ref_aliases(p))
                         .collect(),
-                    underlying_ty: underlying_ty.clone(),
                 }
             }
             Type::Compound { kind, args } => Type::Compound {
@@ -173,9 +167,6 @@ impl<'a> FreezeFolder<'a> {
                 self.freeze_expr(subject.as_mut());
                 for arm in arms {
                     self.freeze_pattern(&mut arm.pattern);
-                    if let Some(tp) = &mut arm.typed_pattern {
-                        self.freeze_typed_pattern(tp);
-                    }
                     self.freeze_expr(arm.expression.as_mut());
                     if let Some(guard) = &mut arm.guard {
                         self.freeze_expr(guard.as_mut());
@@ -183,12 +174,10 @@ impl<'a> FreezeFolder<'a> {
                 }
             }
 
-            Expression::Let {
-                value, else_block, ..
-            } => {
+            Expression::Let { value, mode, .. } => {
                 self.freeze_expr(value.as_mut());
-                if let Some(else_block) = else_block {
-                    self.freeze_expr(else_block.as_mut());
+                if let Some(else_block) = mode.else_block_mut() {
+                    self.freeze_expr(else_block);
                 }
             }
 
@@ -201,9 +190,14 @@ impl<'a> FreezeFolder<'a> {
             | Expression::Task { expression, .. }
             | Expression::Defer { expression, .. }
             | Expression::Assert { expression, .. }
-            | Expression::Cast { expression, .. }
-            | Expression::Const { expression, .. } => {
+            | Expression::Cast { expression, .. } => {
                 self.freeze_expr(expression.as_mut());
+            }
+
+            Expression::Const { expression, .. } => {
+                if let Some(value) = expression.value_mut() {
+                    self.freeze_expr(value);
+                }
             }
 
             Expression::IndexedAccess {
@@ -231,9 +225,13 @@ impl<'a> FreezeFolder<'a> {
                 }
             }
 
-            Expression::Function { body, .. }
-            | Expression::Lambda { body, .. }
-            | Expression::Loop { body, .. } => {
+            Expression::Function { body, .. } => {
+                if let Some(body) = body.definition_mut() {
+                    self.freeze_expr(body);
+                }
+            }
+
+            Expression::Lambda { body, .. } | Expression::Loop { body, .. } => {
                 self.freeze_expr(body.as_mut());
             }
 
@@ -304,8 +302,7 @@ impl<'a> FreezeFolder<'a> {
             | Expression::Break { value: None, .. }
             | Expression::Continue { .. }
             | Expression::Unit { .. }
-            | Expression::RawGo { .. }
-            | Expression::NoOp => {}
+            | Expression::RawGo { .. } => {}
         }
     }
 
@@ -313,14 +310,10 @@ impl<'a> FreezeFolder<'a> {
         match &mut arm.pattern {
             SelectArmPattern::Receive {
                 binding,
-                typed_pattern,
                 receive_expression,
                 body,
             } => {
                 self.freeze_pattern(binding);
-                if let Some(tp) = typed_pattern {
-                    self.freeze_typed_pattern(tp);
-                }
                 self.freeze_expr(receive_expression.as_mut());
                 self.freeze_expr(body.as_mut());
             }
@@ -338,9 +331,6 @@ impl<'a> FreezeFolder<'a> {
                 self.freeze_expr(receive_expression.as_mut());
                 for arm in arms {
                     self.freeze_pattern(&mut arm.pattern);
-                    if let Some(tp) = &mut arm.typed_pattern {
-                        self.freeze_typed_pattern(tp);
-                    }
                     self.freeze_expr(arm.expression.as_mut());
                     if let Some(guard) = &mut arm.guard {
                         self.freeze_expr(guard.as_mut());
@@ -399,9 +389,6 @@ impl<'a> FreezeFolder<'a> {
     fn freeze_binding(&self, binding: &mut Binding) {
         self.freeze_ty(&mut binding.ty);
         self.freeze_pattern(&mut binding.pattern);
-        if let Some(tp) = &mut binding.typed_pattern {
-            self.freeze_typed_pattern(tp);
-        }
     }
 
     fn freeze_pattern(&self, pattern: &mut Pattern) {
@@ -420,11 +407,17 @@ impl<'a> FreezeFolder<'a> {
                 }
             }
             Pattern::Slice {
-                element_ty, prefix, ..
+                prefix, resolution, ..
             } => {
-                self.freeze_ty(element_ty);
                 for p in prefix {
                     self.freeze_pattern(p);
+                }
+                match resolution {
+                    SequencePatternResolution::Slice { element_type }
+                    | SequencePatternResolution::Array { element_type, .. } => {
+                        self.freeze_ty(element_type);
+                    }
+                    SequencePatternResolution::Unresolved => {}
                 }
             }
             Pattern::Tuple { elements, .. } => {
@@ -439,95 +432,6 @@ impl<'a> FreezeFolder<'a> {
             }
             Pattern::AsBinding { pattern, .. } => self.freeze_pattern(pattern),
             Pattern::WildCard { .. } | Pattern::Identifier { .. } => {}
-        }
-    }
-
-    fn freeze_typed_pattern(&self, tp: &mut TypedPattern) {
-        match tp {
-            TypedPattern::Wildcard | TypedPattern::Literal(_) => {}
-            TypedPattern::Const { ty, .. } => self.freeze_ty(ty),
-            TypedPattern::EnumVariant {
-                type_args,
-                field_types,
-                fields,
-                variant_fields,
-                ..
-            } => {
-                for t in type_args {
-                    self.freeze_ty(t);
-                }
-                for t in field_types.iter_mut() {
-                    self.freeze_ty(t);
-                }
-                for f in fields {
-                    self.freeze_typed_pattern(f);
-                }
-                for vf in variant_fields {
-                    self.freeze_ty(&mut vf.ty);
-                }
-            }
-            TypedPattern::EnumStructVariant {
-                type_args,
-                pattern_fields,
-                variant_fields,
-                ..
-            } => {
-                for t in type_args {
-                    self.freeze_ty(t);
-                }
-                for (_, f) in pattern_fields {
-                    self.freeze_typed_pattern(f);
-                }
-                for vf in variant_fields {
-                    self.freeze_ty(&mut vf.ty);
-                }
-            }
-            TypedPattern::Struct {
-                type_args,
-                pattern_fields,
-                struct_fields,
-                ..
-            } => {
-                for t in type_args {
-                    self.freeze_ty(t);
-                }
-                for (_, f) in pattern_fields {
-                    self.freeze_typed_pattern(f);
-                }
-                for sf in struct_fields {
-                    self.freeze_ty(&mut sf.ty);
-                }
-            }
-            TypedPattern::Slice {
-                element_type,
-                prefix,
-                ..
-            } => {
-                self.freeze_ty(element_type);
-                for p in prefix {
-                    self.freeze_typed_pattern(p);
-                }
-            }
-            TypedPattern::Array {
-                element_type,
-                prefix,
-                ..
-            } => {
-                self.freeze_ty(element_type);
-                for p in prefix {
-                    self.freeze_typed_pattern(p);
-                }
-            }
-            TypedPattern::Tuple { elements, .. } => {
-                for e in elements {
-                    self.freeze_typed_pattern(e);
-                }
-            }
-            TypedPattern::Or { alternatives } => {
-                for a in alternatives {
-                    self.freeze_typed_pattern(a);
-                }
-            }
         }
     }
 
@@ -610,32 +514,17 @@ impl<'a> FreezeFolder<'a> {
                 self.freeze_binding(binding);
             }
 
-            Expression::IfLet {
-                ty,
-                pattern,
-                typed_pattern,
-                ..
-            } => {
+            Expression::IfLet { ty, pattern, .. } => {
                 self.freeze_ty(ty);
                 self.freeze_pattern(pattern);
-                if let Some(tp) = typed_pattern {
-                    self.freeze_typed_pattern(tp);
-                }
             }
 
             Expression::For { binding, .. } => {
                 self.freeze_binding(binding);
             }
 
-            Expression::WhileLet {
-                pattern,
-                typed_pattern,
-                ..
-            } => {
+            Expression::WhileLet { pattern, .. } => {
                 self.freeze_pattern(pattern);
-                if let Some(tp) = typed_pattern {
-                    self.freeze_typed_pattern(tp);
-                }
             }
 
             Expression::Struct { fields, .. } => {
@@ -670,8 +559,7 @@ impl<'a> FreezeFolder<'a> {
             | Expression::Break { .. }
             | Expression::Continue { .. }
             | Expression::ModuleImport { .. }
-            | Expression::RawGo { .. }
-            | Expression::NoOp => {}
+            | Expression::RawGo { .. } => {}
         }
     }
 }

--- a/crates/semantics/src/checker/infer/addressability.rs
+++ b/crates/semantics/src/checker/infer/addressability.rs
@@ -3,10 +3,12 @@ use syntax::types::peel_to_range_type;
 
 use crate::checker::EnvResolve;
 use crate::checker::TypeEnv;
+use crate::store::Store;
 
 pub(crate) fn check_is_non_addressable(
     expression: &Expression,
     env: &TypeEnv,
+    store: &Store,
 ) -> Option<&'static str> {
     match expression {
         Expression::Identifier { .. } => None,
@@ -18,14 +20,14 @@ pub(crate) fn check_is_non_addressable(
             if is_non_addressable_origin {
                 Some("field access on non-addressable value")
             } else {
-                check_is_non_addressable(expression, env)
+                check_is_non_addressable(expression, env, store)
             }
         }
         Expression::IndexedAccess {
             expression, index, ..
         } => {
             let is_range_index = matches!(index.unwrap_parens(), Expression::Range { .. })
-                || peel_to_range_type(&index.get_type()).is_some();
+                || peel_to_range_type(&index.get_type(), |id| store.get_definition(id)).is_some();
             if is_range_index {
                 return Some("sub-slice expression");
             }
@@ -41,7 +43,7 @@ pub(crate) fn check_is_non_addressable(
             if matches!(expression.unwrap_parens(), Expression::Call { .. }) {
                 Some("index access on function call")
             } else {
-                check_is_non_addressable(expression, env)
+                check_is_non_addressable(expression, env, store)
             }
         }
         Expression::Unary {
@@ -49,7 +51,7 @@ pub(crate) fn check_is_non_addressable(
             ..
         } => None,
         Expression::StructCall { .. } => None,
-        Expression::Paren { expression, .. } => check_is_non_addressable(expression, env),
+        Expression::Paren { expression, .. } => check_is_non_addressable(expression, env, store),
         Expression::Call { .. } => None,
         Expression::Literal { .. } => Some("literal"),
         Expression::Binary { .. } => Some("binary expression"),
@@ -69,6 +71,7 @@ pub(crate) fn check_is_non_addressable(
 pub(crate) fn check_non_addressable_assignment_target(
     expression: &Expression,
     env: &TypeEnv,
+    store: &Store,
 ) -> Option<&'static str> {
     match expression.unwrap_parens() {
         Expression::Identifier { .. } => None,
@@ -78,15 +81,15 @@ pub(crate) fn check_non_addressable_assignment_target(
             {
                 None
             } else {
-                check_non_addressable_assignment_target(expression, env)
+                check_non_addressable_assignment_target(expression, env, store)
             }
         }
         Expression::IndexedAccess {
             expression: base, ..
         } => {
             if base.get_type().resolve_in(env).get_name() == Some("Array") {
-                check_is_non_addressable(base, env)
-                    .or_else(|| check_non_addressable_assignment_target(base, env))
+                check_is_non_addressable(base, env, store)
+                    .or_else(|| check_non_addressable_assignment_target(base, env, store))
             } else {
                 None
             }

--- a/crates/semantics/src/checker/infer/carry_mut.rs
+++ b/crates/semantics/src/checker/infer/carry_mut.rs
@@ -120,6 +120,8 @@ fn can_carry_mutation(
         Type::Forall { body, .. } => can_carry_mutation(body, env, store, visited),
         Type::Function(_)
         | Type::Var { .. }
+        | Type::Uninferred
+        | Type::Ignored
         | Type::Parameter(_)
         | Type::Simple(_)
         | Type::Never

--- a/crates/semantics/src/checker/infer/expressions/aliasing.rs
+++ b/crates/semantics/src/checker/infer/expressions/aliasing.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, Literal, Span, UnaryOperator};
+use syntax::ast::{Expression, IdentifierResolution, Literal, Span, UnaryOperator};
 use syntax::program::{CallKind, DefinitionBody};
 use syntax::types::Type;
 
@@ -125,7 +125,7 @@ impl InferCtx<'_> {
     fn alias_leaf(&self, place: &Expression, via_clone: bool, span: Span) -> Option<AliasFinding> {
         let Expression::Identifier {
             value,
-            binding_id: Some(root_id),
+            resolution: IdentifierResolution::Binding(root_id),
             ..
         } = place_root(place)?
         else {
@@ -154,7 +154,7 @@ impl InferCtx<'_> {
             source: render_place(place),
             span,
             kind,
-            addressable: check_is_non_addressable(place, &self.env).is_none(),
+            addressable: check_is_non_addressable(place, &self.env, self.store).is_none(),
         })
     }
 

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -65,7 +65,7 @@ impl InferCtx<'_> {
         let store = self.store;
         let ty = if let Some(annotation) = &annotation {
             let ty = self.convert_to_type(store, annotation, &span);
-            if self.is_lis(store) && ty.contains_unknown() {
+            if self.is_lis(store) && store.contains_unknown(&ty) {
                 self.sink
                     .push(diagnostics::infer::unknown_in_const_annotation(
                         annotation.get_span(),
@@ -79,29 +79,31 @@ impl InferCtx<'_> {
                 .unwrap_or_else(|| self.new_type_var())
         };
 
-        let new_expression = self.infer_expression(*expression, &ty);
-
-        match self.classify_const_init(&new_expression) {
-            None => {}
-            Some(ConstInitReject::NotSimple) => {
-                self.sink
-                    .push(diagnostics::infer::const_requires_simple_expression(
-                        new_expression.get_span(),
-                    ));
+        let new_expression = expression.map_value(|expression| {
+            let expression = self.infer_expression(expression, &ty);
+            match self.classify_const_init(&expression) {
+                None => {}
+                Some(ConstInitReject::NotSimple) => {
+                    self.sink
+                        .push(diagnostics::infer::const_requires_simple_expression(
+                            expression.get_span(),
+                        ));
+                }
+                Some(ConstInitReject::Composite) => {
+                    self.sink
+                        .push(diagnostics::infer::const_disallows_composite(
+                            expression.get_span(),
+                        ));
+                }
             }
-            Some(ConstInitReject::Composite) => {
-                self.sink
-                    .push(diagnostics::infer::const_disallows_composite(
-                        new_expression.get_span(),
-                    ));
-            }
-        }
+            expression
+        });
 
         Expression::Const {
             doc,
             identifier,
             identifier_span,
-            expression: new_expression.into(),
+            expression: new_expression,
             annotation,
             ty,
             span,
@@ -117,10 +119,7 @@ impl InferCtx<'_> {
         let Expression::Let {
             binding,
             value,
-            mut_span,
-            else_block,
-            else_span,
-            assert,
+            mode,
             span,
             ..
         } = expression
@@ -128,13 +127,14 @@ impl InferCtx<'_> {
             unreachable!("infer_let_binding called with non-Let expression");
         };
         let binding = *binding;
-        let mutable = binding.mutable;
+        let mutable = binding.is_mutable();
+        let mut_span = binding.mut_span;
         let store = self.store;
         let has_annotation = binding.annotation.is_some();
         let binding_name = binding.pattern.get_identifier();
         let pattern_span = binding.pattern.get_span();
 
-        if assert && !self.scopes.has_test_handle() {
+        if mode.is_assert() && !self.scopes.has_test_handle() {
             self.sink
                 .push(diagnostics::infer::assert_without_test_context(
                     pattern_span,
@@ -151,33 +151,29 @@ impl InferCtx<'_> {
         let new_value = self.with_value_context(|s| s.infer_expression(*value, &ty));
         self.scopes.set_let_binding_rhs(prior_let_rhs);
 
-        let new_else_block = if let Some(else_expression) = else_block {
+        let new_mode = mode.map_else(|else_expression, else_span| {
             let else_ty = self.new_type_var();
-            let new_else = self.infer_expression(*else_expression, &else_ty);
+            let new_else = self.infer_expression(else_expression, &else_ty);
 
             let resolved_else_ty = else_ty.resolve_in(&self.env);
             if new_else.diverges().is_none() && !resolved_else_ty.is_never() {
-                let error_span = else_span.expect("let-else must have else_span");
                 self.sink
-                    .push(diagnostics::infer::let_else_must_diverge(error_span));
+                    .push(diagnostics::infer::let_else_must_diverge(else_span));
             }
             let never_ty = self.type_never();
             self.unify(&else_ty, &never_ty, &span);
 
-            Some(Box::new(new_else))
-        } else {
-            None
-        };
+            new_else
+        });
 
-        let (inferred_pattern, typed_pattern) =
+        let inferred_pattern =
             self.infer_pattern(binding.pattern, ty.clone(), BindingKind::Let { mutable });
 
         let new_binding = Binding {
             pattern: inferred_pattern,
             annotation: binding.annotation,
-            typed_pattern: Some(typed_pattern),
             ty: ty.clone(),
-            mutable,
+            mut_span,
         };
 
         if !has_annotation
@@ -237,10 +233,7 @@ impl InferCtx<'_> {
         Expression::Let {
             binding: Box::new(new_binding),
             value: new_value.into(),
-            mut_span,
-            else_block: new_else_block,
-            else_span,
-            assert,
+            mode: new_mode,
             ty: self.type_unit(),
             span,
         }

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -101,11 +101,11 @@ fn check_not_comparable_impl(
         return (!definite_only).then_some("interface values");
     }
 
-    if let Some(underlying) = ty.get_underlying() {
+    if let Some(underlying) = store.underlying_type(ty) {
         return check_not_comparable_impl(
             env,
             store,
-            underlying,
+            &underlying,
             visiting,
             definite_only,
             comparable_parameter,
@@ -339,7 +339,7 @@ fn is_opaque_go_handle(store: &Store, ty: &Type) -> bool {
         && matches!(
             &definition.body,
             DefinitionBody::TypeAlias {
-                annotation: Annotation::Opaque { .. },
+                alias: syntax::program::AliasKind::Opaque(Annotation::Opaque { .. }),
                 ..
             }
         )

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::facts::BranchSubsumption;
 use syntax::ast::BindingKind;
-use syntax::ast::{Binding, BindingId, Expression, MatchArm, Pattern, Span};
+use syntax::ast::{Binding, Expression, MatchArm, Pattern, Span};
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
@@ -162,7 +162,7 @@ impl InferCtx<'_> {
                 self.sink
                     .push(diagnostics::infer::cannot_match_on_functions(*span));
             }
-            Type::Var { .. } => {
+            Type::Var { .. } | Type::Uninferred | Type::Ignored => {
                 self.sink
                     .push(diagnostics::infer::cannot_match_on_unconstrained_type(
                         *span,
@@ -214,7 +214,11 @@ impl InferCtx<'_> {
     fn infer_condition(&mut self, condition: Expression, span: &Span) -> Expression {
         let cond_ty = self.new_type_var();
         let inferred = self.infer_expression(condition, &cond_ty);
-        if cond_ty.resolve_in(&self.env).underlying_simple_kind() != Some(SimpleKind::Bool) {
+        if self
+            .store
+            .underlying_simple_kind(&cond_ty.resolve_in(&self.env))
+            != Some(SimpleKind::Bool)
+        {
             let bool_ty = self.type_bool();
             self.unify(&bool_ty, &cond_ty, span);
         }
@@ -324,7 +328,6 @@ impl InferCtx<'_> {
             scrutinee,
             consequence,
             alternative,
-            typed_pattern,
             else_span,
             span,
             ..
@@ -337,7 +340,6 @@ impl InferCtx<'_> {
             MatchArm {
                 pattern,
                 guard: None,
-                typed_pattern,
                 expression: consequence,
             },
             MatchArm {
@@ -345,7 +347,6 @@ impl InferCtx<'_> {
                     span: alternative.get_span(),
                 },
                 guard: None,
-                typed_pattern: None,
                 expression: alternative,
             },
         ];
@@ -367,7 +368,6 @@ impl InferCtx<'_> {
             scrutinee: new_scrutinee.into(),
             consequence: pattern_arm.expression,
             alternative: wildcard_arm.expression,
-            typed_pattern: pattern_arm.typed_pattern,
             else_span,
             ty: result_ty,
             span,
@@ -415,8 +415,7 @@ impl InferCtx<'_> {
                 self.scopes.push();
 
                 let pattern_ty = subject_ty.resolve_in(&self.env);
-                let (new_pattern, typed_pattern) =
-                    self.infer_pattern(a.pattern, pattern_ty, arm_kind);
+                let new_pattern = self.infer_pattern(a.pattern, pattern_ty, arm_kind);
 
                 let new_guard = a
                     .guard
@@ -437,7 +436,6 @@ impl InferCtx<'_> {
                 MatchArm {
                     pattern: new_pattern,
                     guard: new_guard,
-                    typed_pattern: Some(typed_pattern),
                     expression: Box::new(new_expression),
                 }
             })
@@ -538,7 +536,7 @@ impl InferCtx<'_> {
         );
 
         self.scopes.push();
-        let (new_pattern, typed_pattern) = self.infer_pattern(
+        let new_pattern = self.infer_pattern(
             pattern,
             scrutinee_ty.resolve_in(&self.env),
             BindingKind::WhileLet,
@@ -553,7 +551,6 @@ impl InferCtx<'_> {
             pattern: new_pattern,
             scrutinee: new_scrutinee.into(),
             body: new_body.into(),
-            typed_pattern: Some(typed_pattern),
             span,
         }
     }
@@ -693,7 +690,7 @@ impl InferCtx<'_> {
         // Push a new scope so the loop variable doesn't shadow outer bindings
         self.scopes.push();
 
-        let (inferred_pattern, typed_pattern) = self.infer_pattern(
+        let inferred_pattern = self.infer_pattern(
             binding.pattern,
             element_ty.clone(),
             BindingKind::Let { mutable: false },
@@ -702,15 +699,9 @@ impl InferCtx<'_> {
         let new_binding = Binding {
             pattern: inferred_pattern,
             annotation: binding.annotation,
-            typed_pattern: Some(typed_pattern),
             ty: element_ty.clone(),
-            mutable: false,
+            mut_span: None,
         };
-
-        let binding_id: Option<BindingId> = new_binding
-            .pattern
-            .get_identifier()
-            .and_then(|name| self.scopes.lookup_binding_id(&name));
 
         // When iterating over types that yield multiple values (`Map`, `EnumeratedSlice`),
         // Go's `range` returns multiple values, so the binding must be a tuple literal.
@@ -738,7 +729,6 @@ impl InferCtx<'_> {
             iterable: new_iterable.into(),
             body: new_body.into(),
             span,
-            binding_id,
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/definitions.rs
+++ b/crates/semantics/src/checker/infer/expressions/definitions.rs
@@ -94,7 +94,7 @@ impl InferCtx<'_> {
             body:
                 DefinitionBody::TypeAlias {
                     generics: definition_generics,
-                    annotation: definition_annotation,
+                    alias,
                     ..
                 },
             ..
@@ -108,7 +108,7 @@ impl InferCtx<'_> {
                     .expect("type alias definition has a name"),
                 name_span,
                 generics: definition_generics.clone(),
-                annotation: definition_annotation.clone(),
+                annotation: alias.annotation().clone(),
                 ty: definition_ty.clone(),
                 visibility,
                 span,

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::checker::EnvResolve;
 use ecow::EcoString;
-use syntax::ast::{Expression, Span, StructKind};
+use syntax::ast::{Expression, IdentifierResolution, Span, StructKind};
 use syntax::program::{
-    Definition, DefinitionBody, DotAccessKind, NativeTypeKind, ReceiverCoercion,
+    Definition, DefinitionBody, DotAccessResolution, NativeTypeKind, ReceiverCoercion,
 };
 use syntax::types::{Symbol, Type, substitute, unqualified_name};
 
@@ -45,8 +45,7 @@ impl InferCtx<'_> {
                     member,
                     ty: expected_ty.clone(),
                     span,
-                    dot_access_kind: None,
-                    receiver_coercion: None,
+                    resolution: DotAccessResolution::Unresolved,
                 };
             }
         }
@@ -59,40 +58,35 @@ impl InferCtx<'_> {
         if let Some(root) = expression.root_identifier()
             && let Some(qualified_root) = self.lookup_qualified_name(store, root)
             && let Some(def) = store.get_definition(&qualified_root)
-            && matches!(def.body, DefinitionBody::TypeAlias { .. })
+            && let DefinitionBody::TypeAlias { generics, .. } = &def.body
+            && !generics.is_empty()
         {
-            let alias_ty = &def.ty;
-            let underlying = alias_ty.unwrap_forall();
-            let is_generic = matches!(alias_ty, Type::Forall { .. })
-                || matches!(underlying, Type::Nominal { params, .. } if !params.is_empty());
-            if is_generic {
-                if qualified_root == "prelude.Ref" {
-                    self.sink.push(diagnostics::infer::ref_qualifier(
-                        &member,
-                        expression.get_span(),
-                    ));
+            if qualified_root == "prelude.Ref" {
+                self.sink.push(diagnostics::infer::ref_qualifier(
+                    &member,
+                    expression.get_span(),
+                ));
+            } else {
+                let target = store.peel_alias(&def.ty);
+                let type_name = if let Type::Nominal { id, .. } = &target {
+                    unqualified_name(id).to_string()
                 } else {
-                    let type_name = if let Type::Nominal { id, .. } = underlying {
-                        unqualified_name(id).to_string()
-                    } else {
-                        "the original type".to_string()
-                    };
-                    self.sink.push(diagnostics::infer::type_alias_as_qualifier(
-                        root,
-                        &type_name,
-                        &member,
-                        expression.get_span(),
-                    ));
-                }
-                return Expression::DotAccess {
-                    expression,
-                    member,
-                    ty: expected_ty.clone(),
-                    span,
-                    dot_access_kind: None,
-                    receiver_coercion: None,
+                    "the original type".to_string()
                 };
+                self.sink.push(diagnostics::infer::type_alias_as_qualifier(
+                    root,
+                    &type_name,
+                    &member,
+                    expression.get_span(),
+                ));
             }
+            return Expression::DotAccess {
+                expression,
+                member,
+                ty: expected_ty.clone(),
+                span,
+                resolution: DotAccessResolution::Unresolved,
+            };
         }
 
         self.infer_dot_access(expression, member, span, expected_ty)
@@ -135,8 +129,7 @@ impl InferCtx<'_> {
                 value: path.into(),
                 ty: Type::uninferred(),
                 span,
-                binding_id: None,
-                qualified: None,
+                resolution: IdentifierResolution::Unresolved,
             },
             expected_ty,
         ))
@@ -145,13 +138,14 @@ impl InferCtx<'_> {
     fn nongeneric_alias_target(&self, qualified_root: &str) -> Option<String> {
         let store = self.store;
         let definition = store.get_definition(qualified_root)?;
-        let DefinitionBody::TypeAlias { .. } = &definition.body else {
+        let DefinitionBody::TypeAlias { generics, .. } = &definition.body else {
             return None;
         };
-        match definition.ty.unwrap_forall() {
-            Type::Nominal { id, params, .. }
-                if params.is_empty() && id.as_str() != qualified_root =>
-            {
+        if !generics.is_empty() {
+            return None;
+        }
+        match store.peel_alias(&definition.ty) {
+            Type::Nominal { id, params } if params.is_empty() && id.as_str() != qualified_root => {
                 Some(id.to_string())
             }
             Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
@@ -187,19 +181,13 @@ struct DotAccessResolutionArgs<'a> {
 }
 
 impl DotAccessResolutionArgs<'_> {
-    fn build_dot_access(
-        &self,
-        ty: Type,
-        kind: Option<DotAccessKind>,
-        receiver_coercion: Option<ReceiverCoercion>,
-    ) -> Expression {
+    fn build_dot_access(&self, ty: Type, resolution: DotAccessResolution) -> Expression {
         Expression::DotAccess {
             expression: self.expression.clone().into(),
             member: self.member_name.into(),
             ty,
             span: *self.span,
-            dot_access_kind: kind,
-            receiver_coercion,
+            resolution,
         }
     }
 }
@@ -240,14 +228,14 @@ impl InferCtx<'_> {
 
         if resolved_expression_ty.is_error() {
             self.unify(expected_ty, &Type::Error, &span);
-            return args.build_dot_access(Type::Error, None, None);
+            return args.build_dot_access(Type::Error, DotAccessResolution::Unresolved);
         }
 
         if resolved_expression_ty.is_variable() {
             self.sink
                 .push(diagnostics::infer::unresolved_receiver_type(&member, span));
             self.unify(expected_ty, &Type::Error, &span);
-            return args.build_dot_access(Type::Error, None, None);
+            return args.build_dot_access(Type::Error, DotAccessResolution::Unresolved);
         }
 
         let resolved = self
@@ -259,7 +247,7 @@ impl InferCtx<'_> {
             .or_else(|| self.as_instance_method(&args))
             .or_else(|| self.as_static_method(&args));
 
-        if let Some((expression, _kind)) = resolved {
+        if let Some(expression) = resolved {
             if matches!(member.as_str(), "append" | "reserve")
                 && resolved_expression_ty.is_ref()
                 && args.deref_ty.has_name("Slice")
@@ -301,13 +289,14 @@ impl InferCtx<'_> {
                 span,
             ));
             self.unify(expected_ty, &Type::Error, &span);
-            return args.build_dot_access(Type::Error, None, None);
+            return args.build_dot_access(Type::Error, DotAccessResolution::Unresolved);
         }
 
+        let display_ty = self.store.peel_alias(&resolved_expression_ty);
         let available_members = self.get_available_member_names(&resolved_expression_ty);
-        let unwrap_hint = self.compute_unwrap_hint(&resolved_expression_ty, &member);
+        let unwrap_hint = self.compute_unwrap_hint(&display_ty, &member);
         self.sink.push(diagnostics::infer::member_not_found(
-            &resolved_expression_ty,
+            &display_ty,
             &member,
             span,
             if available_members.is_empty() {
@@ -319,7 +308,7 @@ impl InferCtx<'_> {
             self.scopes.is_callee_context(),
         ));
 
-        args.build_dot_access(Type::Error, None, None)
+        args.build_dot_access(Type::Error, DotAccessResolution::Unresolved)
     }
 
     /// Whether a type's owning module is foreign (not current, prelude, or Go stdlib).
@@ -336,8 +325,7 @@ impl InferCtx<'_> {
         let store = self.store;
         match expression {
             Expression::Identifier {
-                binding_id: None,
-                qualified: Some(qname),
+                resolution: IdentifierResolution::Definition(qname),
                 ..
             } => store
                 .get_definition(qname)
@@ -364,10 +352,11 @@ impl InferCtx<'_> {
         let Type::Nominal { id, .. } = deref_ty.strip_refs() else {
             return false;
         };
-        !self
-            .store
-            .get_own_methods(id.as_str())
-            .is_some_and(|methods| methods.contains_key(member))
+        promotion::has_direct_embed(self.store, deref_ty)
+            && !self
+                .store
+                .get_own_methods(id.as_str())
+                .is_some_and(|methods| methods.contains_key(member))
     }
 
     fn get_available_member_names(&mut self, ty: &Type) -> Vec<String> {
@@ -426,45 +415,21 @@ impl InferCtx<'_> {
         self.get_all_methods(store, &deref_ty).contains_key(member)
     }
 
-    fn as_struct_field(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_struct_field(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
         let Type::Nominal { .. } = &args.deref_ty else {
             return None;
         };
 
         let qualified_name = args.deref_ty.get_qualified_name();
-
-        let struct_name = {
-            let mut name = qualified_name.clone();
-            let mut seen = Vec::new();
-            loop {
-                if seen.contains(&name) {
-                    break;
-                }
-                seen.push(name.clone());
-                let new_name = match store.get_definition(&name) {
-                    Some(Definition {
-                        ty,
-                        body: DefinitionBody::TypeAlias { .. },
-                        ..
-                    }) => {
-                        if let Type::Nominal { id, .. } = ty.unwrap_forall()
-                            && id.as_str() != name.as_str()
-                        {
-                            id.clone()
-                        } else {
-                            break;
-                        }
-                    }
-                    _ => break,
-                };
-                name = new_name;
-            }
-            name
+        let resolved_struct_ty = store.peel_alias(&args.deref_ty);
+        let Type::Nominal {
+            id: struct_name, ..
+        } = &resolved_struct_ty
+        else {
+            return None;
         };
+        let struct_name = struct_name.clone();
 
         let Some(Definition {
             ty: struct_type,
@@ -523,19 +488,16 @@ impl InferCtx<'_> {
         self.unify(args.expected_ty, &field_ty, args.span);
 
         let is_exported = field_is_pub || is_cross_module;
-        let kind = if struct_kind == StructKind::Tuple {
-            DotAccessKind::TupleStructField { is_newtype }
+        let resolution = if struct_kind == StructKind::Tuple {
+            DotAccessResolution::TupleStructField { is_newtype }
         } else {
-            DotAccessKind::StructField { is_exported }
+            DotAccessResolution::StructField { is_exported }
         };
 
-        Some((args.build_dot_access(field_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(field_ty, resolution))
     }
 
-    fn as_promoted_field(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_promoted_field(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
         if !matches!(args.deref_ty, Type::Nominal { .. })
             || !promotion::has_direct_embed(store, &args.deref_ty)
@@ -577,16 +539,15 @@ impl InferCtx<'_> {
 
         self.unify(args.expected_ty, &field_ty, args.span);
 
-        let kind = DotAccessKind::StructField {
-            is_exported: visibility.is_public() || is_cross_module,
-        };
-        Some((args.build_dot_access(field_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(
+            field_ty,
+            DotAccessResolution::StructField {
+                is_exported: visibility.is_public() || is_cross_module,
+            },
+        ))
     }
 
-    fn as_tuple_element(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_tuple_element(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let index: usize = args.member_name.parse().ok()?;
 
         let peeled = self.store.peel_alias(&args.deref_ty);
@@ -601,14 +562,10 @@ impl InferCtx<'_> {
         let element_ty = elements[index].clone();
         self.unify(args.expected_ty, &element_ty, args.span);
 
-        let kind = DotAccessKind::TupleElement;
-        Some((args.build_dot_access(element_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(element_ty, DotAccessResolution::TupleElement))
     }
 
-    fn as_module_member(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_module_member(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
         let type_name = args.deref_ty.get_name()?;
         let namespace_id = args.deref_ty.as_import_namespace();
@@ -632,8 +589,6 @@ impl InferCtx<'_> {
         let module_id = module_id.to_string();
         let module_ty = Type::ImportNamespace(module_id.clone().into());
 
-        let kind = DotAccessKind::ModuleMember;
-
         let Some(member_type) = module_fields
             .iter()
             .find(|f| f.name == args.member_name)
@@ -645,7 +600,10 @@ impl InferCtx<'_> {
                     &module_id,
                     *args.span,
                 ));
-            return Some((args.build_dot_access(Type::Error, Some(kind), None), kind));
+            return Some(args.build_dot_access(
+                Type::Error,
+                DotAccessResolution::ModuleMember { definition: None },
+            ));
         };
 
         let resolved_definition = Symbol::from_parts(&module_id, args.member_name);
@@ -757,17 +715,15 @@ impl InferCtx<'_> {
             self.register_function_value_obligations(&display_name, &member_ty, *args.span);
         }
 
-        self.facts
-            .resolved_definitions
-            .insert(*args.span, resolved_definition);
-
-        Some((args.build_dot_access(member_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(
+            member_ty,
+            DotAccessResolution::ModuleMember {
+                definition: Some(resolved_definition),
+            },
+        ))
     }
 
-    fn as_instance_method(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_instance_method(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
 
         // Array methods live on the size-erased prelude `Array` impl, reached via
@@ -808,24 +764,19 @@ impl InferCtx<'_> {
             (method_ty, is_exported, resolved_definition)
         };
 
-        let kind = DotAccessKind::InstanceMethod { is_exported };
-
-        if let Some(resolved_definition) = resolved_definition.as_ref() {
-            self.facts
-                .resolved_definitions
-                .insert(*args.span, resolved_definition.clone());
-        }
-
         let (mut method_ty, _) = self.instantiate(&method_ty);
 
         if !matches!(method_ty, Type::Function(_)) {
             return None;
         }
 
-        if let Some((expression, value_kind)) =
-            self.as_method_value(args, &mut method_ty, is_exported)
-        {
-            return Some((expression, value_kind));
+        if let Some(expression) = self.as_method_value(
+            args,
+            &mut method_ty,
+            is_exported,
+            resolved_definition.clone(),
+        ) {
+            return Some(expression);
         }
 
         if self.scopes.is_callee_context() && self.is_type_level_receiver(args.expression) {
@@ -853,9 +804,13 @@ impl InferCtx<'_> {
 
         self.unify(args.expected_ty, &method_ty, args.span);
 
-        Some((
-            args.build_dot_access(method_ty, Some(kind), receiver_coercion),
-            kind,
+        Some(args.build_dot_access(
+            method_ty,
+            DotAccessResolution::InstanceMethod {
+                is_exported,
+                receiver_coercion,
+                definition: resolved_definition,
+            },
         ))
     }
 
@@ -863,7 +818,7 @@ impl InferCtx<'_> {
         &mut self,
         args: &DotAccessResolutionArgs,
         method_ty: &Type,
-    ) -> Option<(Expression, DotAccessKind)> {
+    ) -> Option<Expression> {
         let Resolution::Found(member) =
             promotion::resolve_selector(self.store, &args.deref_ty, args.member_name)
         else {
@@ -894,16 +849,15 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::private_method_expression(*args.span));
         }
 
-        let kind = DotAccessKind::InstanceMethodValue {
-            is_exported,
-            is_pointer_receiver,
-        };
-
         self.unify(args.expected_ty, &method_ty, args.span);
-        self.facts
-            .resolved_definitions
-            .insert(*args.span, resolved_definition);
-        Some((args.build_dot_access(method_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(
+            method_ty,
+            DotAccessResolution::InstanceMethodValue {
+                is_exported,
+                is_pointer_receiver,
+                definition: Some(resolved_definition),
+            },
+        ))
     }
 
     fn promoted_method_is_exported(&self, declaring_type: &Symbol, member_name: &str) -> bool {
@@ -1015,7 +969,8 @@ impl InferCtx<'_> {
         args: &DotAccessResolutionArgs,
         method_ty: &mut Type,
         is_exported: bool,
-    ) -> Option<(Expression, DotAccessKind)> {
+        resolved_definition: Option<Symbol>,
+    ) -> Option<Expression> {
         let Type::Function(f) = &*method_ty else {
             return None;
         };
@@ -1041,14 +996,13 @@ impl InferCtx<'_> {
         self.unify(args.expected_ty, method_ty, args.span);
 
         let is_pointer_receiver = matches!(method_ty, Type::Function(f) if !f.params.is_empty() && f.params[0].ty.resolve_in(&self.env).is_ref());
-        let value_kind = DotAccessKind::InstanceMethodValue {
-            is_exported,
-            is_pointer_receiver,
-        };
-
-        Some((
-            args.build_dot_access(method_ty.clone(), Some(value_kind), None),
-            value_kind,
+        Some(args.build_dot_access(
+            method_ty.clone(),
+            DotAccessResolution::InstanceMethodValue {
+                is_exported,
+                is_pointer_receiver,
+                definition: resolved_definition,
+            },
         ))
     }
 
@@ -1076,7 +1030,9 @@ impl InferCtx<'_> {
         match (receiver_is_ref, actual_is_ref) {
             (true, false) => {
                 // Method expects Ref<T>, have T → auto-address
-                if let Some(kind) = check_is_non_addressable(receiver_expression, &self.env) {
+                if let Some(kind) =
+                    check_is_non_addressable(receiver_expression, &self.env, self.store)
+                {
                     self.sink
                         .push(diagnostics::infer::cannot_auto_address_receiver(
                             kind,
@@ -1183,30 +1139,23 @@ impl InferCtx<'_> {
         }
     }
 
-    fn as_enum_variant(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_enum_variant(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
-        let id = match &args.deref_ty {
-            Type::Nominal { id, .. } => id.clone(),
-            Type::Function(f) => {
-                if let Type::Nominal { id, .. } = f.return_type.as_ref() {
-                    id.clone()
-                } else {
-                    return None;
-                }
-            }
+        let receiver_ty = match &args.deref_ty {
+            Type::Nominal { .. } => args.deref_ty.clone(),
+            Type::Function(f) => f.return_type.as_ref().clone(),
             _ => return None,
+        };
+        let Type::Nominal { id, .. } = store.peel_alias(&receiver_ty) else {
+            return None;
         };
 
         let definition = store.get_definition(&id)?;
 
-        let (is_enum_variant, kind) = match &definition.body {
-            DefinitionBody::Enum { variants, .. } => (
-                variants.iter().any(|v| v.name == args.member_name),
-                DotAccessKind::EnumVariant,
-            ),
+        let is_enum_variant = match &definition.body {
+            DefinitionBody::Enum { variants, .. } => {
+                variants.iter().any(|v| v.name == args.member_name)
+            }
             _ => return None,
         };
 
@@ -1241,51 +1190,44 @@ impl InferCtx<'_> {
 
         let (variant_ty, _) = self.instantiate(&variant_ty);
         self.unify(args.expected_ty, &variant_ty, args.span);
-        self.facts
-            .resolved_definitions
-            .insert(*args.span, variant_qualified_name);
-
-        Some((args.build_dot_access(variant_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(
+            variant_ty,
+            DotAccessResolution::EnumVariant {
+                definition: variant_qualified_name,
+            },
+        ))
     }
 
-    fn as_static_method(
-        &mut self,
-        args: &DotAccessResolutionArgs,
-    ) -> Option<(Expression, DotAccessKind)> {
+    fn as_static_method(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
         let id = match &args.deref_ty {
             Type::Function(f) => {
-                if let Type::Nominal { id, .. } = f.return_type.as_ref() {
-                    id.clone()
+                if let Type::Nominal { id, .. } = store.peel_alias(&f.return_type) {
+                    id
                 } else {
                     return None;
                 }
             }
-            Type::Nominal { id, .. } => {
-                // For enums with Constructor type, we need to distinguish between:
-                // - Type access (e.g., `module.Color.default()`) - ALLOW
-                // - Value access (e.g., `c.new()` where c is a Color value) - REJECT
-                //
-                // Type access comes through DotAccess on a module import.
-                // Value access comes through an Identifier or other expression.
-                if let Some(def) = store.get_definition(id)
-                    && matches!(def.body, DefinitionBody::Enum { .. })
-                {
-                    // Check if expression is a module member access (type-level access)
-                    let is_type_access = matches!(
-                        args.expression,
-                        Expression::DotAccess { expression, .. }
-                            if expression.get_type().resolve_in(&self.env).as_import_namespace().is_some()
-                    );
-                    if !is_type_access {
-                        return None;
+            ty => match store.peel_alias(ty) {
+                Type::Nominal { id, .. } => {
+                    if let Some(def) = store.get_definition(&id)
+                        && matches!(def.body, DefinitionBody::Enum { .. })
+                    {
+                        let is_type_access = matches!(
+                            args.expression,
+                            Expression::DotAccess { expression, .. }
+                                if expression.get_type().resolve_in(&self.env).as_import_namespace().is_some()
+                        );
+                        if !is_type_access {
+                            return None;
+                        }
                     }
+                    id
                 }
-                id.clone()
-            }
-            Type::Simple(kind) => Symbol::from_parts("prelude", kind.leaf_name()),
-            Type::Compound { kind, .. } => Symbol::from_parts("prelude", kind.leaf_name()),
-            _ => return None,
+                Type::Simple(kind) => Symbol::from_parts("prelude", kind.leaf_name()),
+                Type::Compound { kind, .. } => Symbol::from_parts("prelude", kind.leaf_name()),
+                _ => return None,
+            },
         };
 
         if self
@@ -1351,12 +1293,13 @@ impl InferCtx<'_> {
         let type_module = store.module_for_qualified_name(&id).unwrap_or(&id);
         let is_cross_module = type_module != self.cursor.module_id;
         let is_exported = is_public || is_cross_module;
-        let kind = DotAccessKind::StaticMethod { is_exported };
-        self.facts
-            .resolved_definitions
-            .insert(*args.span, method_qualified_name);
-
-        Some((args.build_dot_access(method_ty, Some(kind), None), kind))
+        Some(args.build_dot_access(
+            method_ty,
+            DotAccessResolution::StaticMethod {
+                is_exported,
+                definition: method_qualified_name,
+            },
+        ))
     }
 
     fn is_dot_access_exported(&self, deref_ty: &Type, member_name: &str) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1,7 +1,8 @@
 use crate::checker::{EnvResolve, resolved_generic_bounds};
 use ecow::EcoString;
 use syntax::ast::{
-    Annotation, Binding, Expression, Literal, Pattern, Span, StructKind, UnaryOperator,
+    Annotation, Binding, Expression, IdentifierResolution, Literal, Pattern, Span, StructKind,
+    UnaryOperator,
 };
 use syntax::ast::{BindingKind, CallTypeArguments};
 use syntax::program::{CallKind, Definition, DefinitionBody, NativeTypeKind};
@@ -24,7 +25,7 @@ struct TypeConversionCall {
     target_ty: Type,
     underlying_fn: Type,
     args: Vec<Expression>,
-    spread: Box<Option<Expression>>,
+    spread: Option<Box<Expression>>,
     type_arguments: CallTypeArguments,
     span: Span,
 }
@@ -152,7 +153,11 @@ impl InferCtx<'_> {
         let bounds = resolved_generic_bounds(&generics);
 
         let resolved_expected = expected_ty.resolve_in(&self.env);
-        let expected_params = resolved_expected.get_function_params().unwrap_or_default();
+        let expected_function = store.resolve_to_function_type(&resolved_expected);
+        let expected_params = expected_function
+            .as_ref()
+            .and_then(Type::get_function_params)
+            .unwrap_or_default();
         let is_test = attributes.iter().any(|a| a.name == "test");
         let params = normalize_test_params(params, is_test);
         let new_params = self.infer_function_params(params, expected_params, true);
@@ -182,7 +187,7 @@ impl InferCtx<'_> {
                     FunctionParameter::named(
                         param.ty.clone(),
                         param.pattern.get_identifier(),
-                        param.mutable,
+                        param.is_mutable(),
                     )
                 })
                 .collect(),
@@ -199,7 +204,9 @@ impl InferCtx<'_> {
             return_ty.clone()
         };
 
-        let new_body = self.infer_function_body(body, &body_ty, &return_annotation, &return_ty);
+        let new_body = body.map_definition(|body| {
+            self.infer_function_body(Box::new(body), &body_ty, &return_annotation, &return_ty)
+        });
 
         self.check_deferred_map_key_bounds(store);
 
@@ -229,7 +236,7 @@ impl InferCtx<'_> {
             return_annotation,
             return_type: return_ty,
             visibility,
-            body: new_body.into(),
+            body: new_body,
             ty: fn_ty,
             span,
         }
@@ -249,7 +256,11 @@ impl InferCtx<'_> {
         // Resolve type variables so that a Go function alias bound via speculative
         // unification (e.g. T = tea.Cmd) is visible as its underlying function shape.
         let resolved_expected = expected_ty.resolve_in(&self.env);
-        let expected_params = resolved_expected.get_function_params().unwrap_or_default();
+        let expected_function = store.resolve_to_function_type(&resolved_expected);
+        let expected_params = expected_function
+            .as_ref()
+            .and_then(Type::get_function_params)
+            .unwrap_or_default();
         let new_params = self.infer_function_params(params, expected_params, false);
 
         if new_params
@@ -277,7 +288,7 @@ impl InferCtx<'_> {
                     FunctionParameter::named(
                         param.ty.clone(),
                         param.pattern.get_identifier(),
-                        param.mutable,
+                        param.is_mutable(),
                     )
                 })
                 .collect(),
@@ -350,12 +361,12 @@ impl InferCtx<'_> {
                 .map(|arg| self.with_value_context(|s| s.infer_expression(arg, &Type::Error)))
                 .collect();
             let new_spread = spread
-                .map(|s| self.with_value_context(|state| state.infer_expression(s, &Type::Error)));
+                .map(|s| self.with_value_context(|state| state.infer_expression(*s, &Type::Error)));
             return Expression::Call {
                 expression,
                 args: new_args,
-                spread: Box::new(new_spread),
-                type_arguments: CallTypeArguments::resolved(type_args, Vec::new()),
+                spread: new_spread.map(Box::new),
+                type_arguments: CallTypeArguments::checked_without_types(type_args),
                 ty: Type::Error,
                 span,
                 call_kind: None,
@@ -411,7 +422,7 @@ impl InferCtx<'_> {
             let resolved_expected = expected_ty.resolve_in(&self.env);
             if !resolved_expected.is_variable()
                 && (self.is_enum_type(store, &return_ty.resolve_in(&self.env))
-                    || !resolved_expected.contains_unknown())
+                    || !store.contains_unknown(&resolved_expected))
             {
                 let peeled = store.deep_resolve_alias(&resolved_expected);
                 let _ = self.speculatively(|this| {
@@ -447,7 +458,7 @@ impl InferCtx<'_> {
             .resolve_in(&self.env)
             .is_error();
 
-        let new_spread = (*spread).map(|spread_expr| match &variadic {
+        let new_spread = spread.map(|spread_expr| match &variadic {
             Some(variadic) => {
                 let expected = if variadic.ty.is_unknown() {
                     let var = self.new_type_var();
@@ -456,7 +467,7 @@ impl InferCtx<'_> {
                     self.type_slice(variadic.ty.clone())
                 };
                 let inferred =
-                    self.with_value_context(|s| s.infer_expression(spread_expr, &expected));
+                    self.with_value_context(|s| s.infer_expression(*spread_expr, &expected));
                 if variadic.mutable {
                     let callee_label = callee_label(&callee_expression);
                     self.check_arg_against_mut_param(&inferred, &variadic.ty, &callee_label);
@@ -468,19 +479,16 @@ impl InferCtx<'_> {
                     self.sink
                         .push(diagnostics::infer::spread_on_non_variadic(span));
                 }
-                self.with_value_context(|s| s.infer_expression(spread_expr, &Type::Error))
+                self.with_value_context(|s| s.infer_expression(*spread_expr, &Type::Error))
             }
         });
 
-        // Bridge multi-hop aliases by re-resolving the expected type through
-        // the store before the final unify (forward-declared intermediates
-        // leave gaps in the cached `underlying_ty` chain).
         let resolved_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
         let expected_is_map = matches!(
             resolved_expected.as_compound(),
             Some((CompoundKind::Map, _))
         );
-        self.unify(&resolved_expected, &return_ty, &span);
+        self.unify(expected_ty, &return_ty, &span);
         self.unify_trait_bounds(&bounds, &parameters, &new_args, &span);
 
         let resolved_return = store.deep_resolve_alias(&return_ty.resolve_in(&self.env));
@@ -582,7 +590,7 @@ impl InferCtx<'_> {
         Expression::Call {
             expression: callee_expression.into(),
             args: new_args,
-            spread: Box::new(new_spread),
+            spread: new_spread.map(Box::new),
             type_arguments,
             ty: call_ty,
             span,
@@ -715,15 +723,14 @@ impl InferCtx<'_> {
             value: "Array.new".into(),
             ty: callee_ty,
             span: callee.get_span(),
-            binding_id: None,
-            qualified: None,
+            resolution: IdentifierResolution::Unresolved,
         };
 
         Expression::Call {
             expression: callee_expression.into(),
             args: new_args,
-            spread: Box::new(None),
-            type_arguments: CallTypeArguments::resolved(type_args, Vec::new()),
+            spread: None,
+            type_arguments: CallTypeArguments::checked_without_types(type_args),
             ty: array_ty,
             span,
             call_kind: Some(CallKind::NativeConstructor(NativeTypeKind::Array)),
@@ -838,7 +845,7 @@ impl InferCtx<'_> {
         let is_method_only_arity =
             receiver_generics_count > 0 && type_args.len() == method_only_count;
 
-        let mut resolved_args: Vec<Type> = Vec::new();
+        let mut resolved_args: Vec<(Annotation, Type)> = Vec::new();
         let mut instantiated = if is_method_only_arity {
             let mut map: SubstitutionMap = SubstitutionMap::default();
             for var in &vars[..receiver_generics_count] {
@@ -846,7 +853,7 @@ impl InferCtx<'_> {
             }
             for (var, ann) in vars[receiver_generics_count..].iter().zip(type_args.iter()) {
                 let arg_ty = self.convert_to_type(store, ann, span);
-                resolved_args.push(arg_ty.clone());
+                resolved_args.push((ann.clone(), arg_ty.clone()));
                 map.insert(var.clone(), arg_ty);
             }
             substitute(body, &map)
@@ -859,10 +866,14 @@ impl InferCtx<'_> {
 
         if !is_full_arity && !is_method_only_arity {
             let vars_as_str: Vec<String> = vars.iter().map(|s| s.to_string()).collect();
+            let resolved_types = resolved_args
+                .iter()
+                .map(|(_, ty)| ty.clone())
+                .collect::<Vec<_>>();
             self.sink.push(diagnostics::infer::generics_arity_mismatch(
                 &vars_as_str,
                 type_args,
-                &resolved_args,
+                &resolved_types,
                 *span,
             ));
         }
@@ -906,10 +917,7 @@ impl InferCtx<'_> {
         }
         self.unify(&instantiated, &callee_ty, span);
 
-        (
-            instantiated,
-            CallTypeArguments::resolved(type_args.to_vec(), resolved_args),
-        )
+        (instantiated, CallTypeArguments::resolved(resolved_args))
     }
 
     fn extract_call_signature(
@@ -921,7 +929,8 @@ impl InferCtx<'_> {
         let arg_count = args.len();
         let callee_ty = callee_ty.resolve_in(&self.env);
         let bounds = callee_ty.get_bounds().to_vec();
-        let is_variadic = callee_ty.is_variadic();
+        let function_ty = self.store.resolve_to_function_type(&callee_ty);
+        let is_variadic = function_ty.as_ref().and_then(Type::is_variadic);
 
         let (parameters, variadic, declared_parameter_count, return_type) =
             match self.extract_function_type(&callee_ty) {
@@ -953,10 +962,10 @@ impl InferCtx<'_> {
                 None => {
                     let callee_name = match callee_expression.unwrap_parens() {
                         Expression::Identifier {
-                            value,
-                            binding_id: None,
-                            ..
-                        } => Some(value.as_str()),
+                            value, resolution, ..
+                        } if !matches!(resolution, IdentifierResolution::Binding(_)) => {
+                            Some(value.as_str())
+                        }
                         _ => None,
                     };
                     let arg_name = if args.len() == 1 {
@@ -971,6 +980,7 @@ impl InferCtx<'_> {
                         &callee_ty,
                         callee_name,
                         arg_name,
+                        self.store.underlying_type(&callee_ty).is_some(),
                         callee_expression.get_span(),
                     ));
                     let parameters = (0..arg_count)
@@ -990,7 +1000,6 @@ impl InferCtx<'_> {
     }
 
     fn extract_function_type(&self, ty: &Type) -> Option<(Vec<FunctionParameter>, Type)> {
-        let store = self.store;
         let fn_type = |ty: &Type| -> Option<(Vec<FunctionParameter>, Type)> {
             if let Type::Function(f) = ty {
                 Some((f.params.clone(), (*f.return_type).clone()))
@@ -999,69 +1008,28 @@ impl InferCtx<'_> {
             }
         };
 
-        if let result @ Some(_) = fn_type(ty) {
-            return result;
-        }
-
-        if let Type::Nominal {
-            underlying_ty: Some(underlying),
-            ..
-        } = ty
-            && let result @ Some(_) = fn_type(underlying)
-        {
-            return result;
-        }
-
-        if let Type::Nominal { id, params, .. } = ty
-            && let Some(def) = store.get_definition(id)
-            && matches!(def.body, DefinitionBody::TypeAlias { .. })
-        {
-            let alias_ty = &def.ty;
-            let concrete_alias_ty = match alias_ty {
-                Type::Forall { vars, body } => {
-                    let map: SubstitutionMap =
-                        vars.iter().cloned().zip(params.iter().cloned()).collect();
-                    substitute(body, &map)
-                }
-                other => other.clone(),
-            };
-            let resolved = concrete_alias_ty.resolve_in(&self.env);
-            if let Type::Nominal {
-                underlying_ty: Some(underlying),
-                ..
-            } = &resolved
-            {
-                return fn_type(underlying);
-            }
-        }
-
-        None
+        fn_type(ty).or_else(|| {
+            self.store
+                .resolve_to_function_type(ty)
+                .and_then(|resolved| fn_type(&resolved))
+        })
     }
 
     fn try_as_type_conversion(&self, callee: &Expression, callee_ty: &Type) -> Option<Type> {
         let store = self.store;
-        let Type::Nominal {
-            id,
-            underlying_ty: Some(underlying),
-            ..
-        } = callee_ty
-        else {
+        let Type::Nominal { id, params } = callee_ty else {
             return None;
         };
-
-        if !matches!(underlying.as_ref(), Type::Function(_)) {
-            return None;
-        }
-
-        if !matches!(
-            store.get_definition(id).map(|d| &d.body),
-            Some(DefinitionBody::TypeAlias { .. })
-        ) {
+        let definition = store.get_definition(id)?;
+        let underlying = definition.instantiate_alias_target(params)?;
+        if !matches!(underlying, Type::Function(_)) {
             return None;
         }
 
         let is_bare_type_name = match callee.unwrap_parens() {
-            Expression::Identifier { binding_id, .. } => binding_id.is_none(),
+            Expression::Identifier { resolution, .. } => {
+                !matches!(resolution, IdentifierResolution::Binding(_))
+            }
             Expression::DotAccess {
                 expression: base, ..
             } => base
@@ -1076,7 +1044,7 @@ impl InferCtx<'_> {
             return None;
         }
 
-        Some(underlying.as_ref().clone())
+        Some(underlying)
     }
 
     fn infer_type_conversion_call(
@@ -1093,10 +1061,10 @@ impl InferCtx<'_> {
             type_arguments,
             span,
         } = call;
-        if let Some(spread_expr) = *spread {
+        if let Some(spread_expr) = spread {
             self.sink
                 .push(diagnostics::infer::spread_on_non_variadic(span));
-            self.with_value_context(|s| s.infer_expression(spread_expr, &Type::Error));
+            self.with_value_context(|s| s.infer_expression(*spread_expr, &Type::Error));
         }
 
         if args.len() != 1 {
@@ -1116,7 +1084,7 @@ impl InferCtx<'_> {
             return Expression::Call {
                 expression: callee_expression.into(),
                 args: new_args,
-                spread: Box::new(None),
+                spread: None,
                 type_arguments,
                 ty: Type::Error,
                 span,
@@ -1132,7 +1100,7 @@ impl InferCtx<'_> {
         Expression::Call {
             expression: callee_expression.into(),
             args: vec![new_arg],
-            spread: Box::new(None),
+            spread: None,
             type_arguments,
             ty: named_ty,
             span,
@@ -1351,20 +1319,18 @@ impl InferCtx<'_> {
                         .unwrap_or_else(|| self.new_type_var())
                 });
 
-                let (new_pattern, typed_pattern) = self.infer_pattern(
+                let mutable = binding.is_mutable();
+                let new_pattern = self.infer_pattern(
                     binding.pattern,
                     binding_ty.clone(),
-                    BindingKind::Parameter {
-                        mutable: binding.mutable,
-                    },
+                    BindingKind::Parameter { mutable },
                 );
 
                 Binding {
                     pattern: new_pattern,
                     annotation: binding.annotation,
-                    typed_pattern: Some(typed_pattern),
                     ty: binding_ty,
-                    mutable: binding.mutable,
+                    mut_span: binding.mut_span,
                 }
             })
             .collect()
@@ -1380,14 +1346,8 @@ impl InferCtx<'_> {
         let store = self.store;
         match annotation {
             Annotation::Unknown => {
-                if let Type::Function(f) = expected_ty {
-                    (*f.return_type).clone()
-                } else if let Type::Nominal {
-                    underlying_ty: Some(inner),
-                    ..
-                } = expected_ty
-                    && let Type::Function(f) = inner.as_ref()
-                {
+                let expected_function = store.resolve_to_function_type(expected_ty);
+                if let Type::Function(f) = expected_function.as_ref().unwrap_or(expected_ty) {
                     (*f.return_type).clone()
                 } else {
                     default_for_unknown
@@ -1490,13 +1450,12 @@ impl InferCtx<'_> {
             .and_then(|definition| match &definition.body {
                 DefinitionBody::Struct { methods, .. } => methods.get(method).cloned(),
                 DefinitionBody::Enum { methods, .. } => methods.get(method).cloned(),
-                DefinitionBody::TypeAlias { methods, .. } => {
-                    let alias_ty = &definition.ty;
+                DefinitionBody::TypeAlias { alias, methods, .. } => {
                     methods.get(method).cloned().or_else(|| {
                         // Follow the alias to its underlying type.
-                        let underlying = match alias_ty {
-                            Type::Forall { body, .. } => body.as_ref(),
-                            other => other,
+                        let underlying = match alias {
+                            syntax::program::AliasKind::Transparent { target, .. } => target,
+                            syntax::program::AliasKind::Opaque(_) => return None,
                         };
                         let underlying_key: Option<String> = match underlying {
                             Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
@@ -1708,7 +1667,7 @@ impl InferCtx<'_> {
         let arg_span = arg.get_span();
         let int_ty = self.type_int();
 
-        if let Some(peeled) = peel_to_range_type(&arg_ty) {
+        if let Some(peeled) = peel_to_range_type(&arg_ty, |id| self.store.get_definition(id)) {
             if let Some(inner) = peeled.get_type_params().and_then(|p| p.first()) {
                 self.unify(&int_ty, inner, &arg_span);
             }

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -77,7 +77,10 @@ impl InferCtx<'_> {
         // Handle a stored range used as an index (e.g. `let r = 2..5; items[r]`).
         // Inline ranges are caught by `index.is_range()` above. Strings are
         // rejected; slices return a sub-slice.
-        match (peel_to_range_type(&resolved_index_ty), type_name) {
+        match (
+            peel_to_range_type(&resolved_index_ty, |id| store.get_definition(id)),
+            type_name,
+        ) {
             (Some(_), "string") => {
                 let receiver = collection_expression.root_identifier().unwrap_or("s");
                 let full_span = collection_expression.get_span().merge(span);

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -260,14 +260,14 @@ fn fstring_inner_needs_parens(expression: &Expression) -> bool {
 }
 
 fn numeric_adapt_target(ty: &Type, store: &Store) -> Option<Type> {
-    store.deep_resolve_alias(ty).literal_adaptation_target()
+    store.literal_adaptation_target(ty)
 }
 
 fn adapts_to_named_type(ty: &Type, store: &Store, kind: SimpleKind) -> bool {
     let peeled = store.deep_resolve_alias(ty);
     matches!(&peeled, Type::Nominal { id, .. }
         if store.is_nominal_defined_type(id.as_str())
-            && peeled.underlying_simple_kind() == Some(kind))
+            && store.underlying_simple_kind(&peeled) == Some(kind))
 }
 
 fn char_literal_codepoint(s: &str) -> Option<u64> {

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -288,7 +288,6 @@ impl InferCtx<'_> {
             Expression::Break { value, span } => self.infer_break(value, span, is_subexpression),
             Expression::Continue { span } => self.infer_continue(span, is_subexpression),
             Expression::RawGo { text } => Expression::RawGo { text },
-            Expression::NoOp => Expression::NoOp,
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -40,8 +40,10 @@ impl InferCtx<'_> {
         let propagate_to_operand = {
             let resolved = expected_ty.resolve_in(&self.env);
             match operator {
-                Negative => resolved.is_numeric() || resolved.has_underlying_numeric_type(),
-                Not => resolved.underlying_simple_kind() == Some(SimpleKind::Bool),
+                Negative => {
+                    resolved.is_numeric() || self.store.has_underlying_numeric_type(&resolved)
+                }
+                Not => self.store.underlying_simple_kind(&resolved) == Some(SimpleKind::Bool),
                 _ => false,
             }
         };
@@ -66,7 +68,8 @@ impl InferCtx<'_> {
         let expression_ty = match operator {
             Negative => {
                 let resolved = operand_expected_ty.resolve_in(&self.env);
-                if resolved.is_numeric() || resolved.underlying_numeric_type().is_some() {
+                if resolved.is_numeric() || self.store.underlying_numeric_type(&resolved).is_some()
+                {
                     let is_literal = is_numeric_literal(&new_expression);
                     if resolved.is_unsigned_int() && !is_literal {
                         let type_name = resolved.get_name().unwrap_or_default();
@@ -86,7 +89,7 @@ impl InferCtx<'_> {
             Not => {
                 let resolved = operand_expected_ty.resolve_in(&self.env);
                 if !resolved.is_boolean()
-                    && resolved.underlying_simple_kind() == Some(SimpleKind::Bool)
+                    && self.store.underlying_simple_kind(&resolved) == Some(SimpleKind::Bool)
                 {
                     operand_expected_ty.clone()
                 } else {
@@ -99,7 +102,7 @@ impl InferCtx<'_> {
                 let resolved = operand_expected_ty.resolve_in(&self.env);
                 if resolved.is_error()
                     || matches!(resolved, Type::Var { .. })
-                    || is_integer_type(&resolved, &self.env)
+                    || is_integer_type(&resolved, &self.env, self.store)
                 {
                     operand_expected_ty.clone()
                 } else {
@@ -183,7 +186,7 @@ impl InferCtx<'_> {
         let new_right_operand = self.with_value_context(|s| {
             if is_right_literal {
                 let left_resolved = left.ty.resolve_in(&s.env);
-                if literal_can_adapt_to(&right_literal_kind, &left_resolved) {
+                if literal_can_adapt_to(&right_literal_kind, &left_resolved, self.store) {
                     let _ = s.try_unify(&right_operand_ty, &left_resolved, &span);
                 }
             }
@@ -222,7 +225,7 @@ impl InferCtx<'_> {
                 // can guide the literal's type adaptation.
                 let right = s.infer_expression(*right_operand, &right_operand_ty);
                 let right_resolved = right_operand_ty.resolve_in(&s.env);
-                if literal_can_adapt_to(&left_literal_kind, &right_resolved) {
+                if literal_can_adapt_to(&left_literal_kind, &right_resolved, self.store) {
                     let _ = s.try_unify(&left_operand_ty, &right_resolved, &span);
                 }
                 let left = s.infer_expression(*left_operand, &left_operand_ty);
@@ -231,7 +234,7 @@ impl InferCtx<'_> {
                 let left = s.infer_expression(*left_operand, &left_operand_ty);
                 if is_right_literal {
                     let left_resolved = left_operand_ty.resolve_in(&s.env);
-                    if literal_can_adapt_to(&right_literal_kind, &left_resolved) {
+                    if literal_can_adapt_to(&right_literal_kind, &left_resolved, self.store) {
                         let _ = s.try_unify(&right_operand_ty, &left_resolved, &span);
                     }
                 }
@@ -317,11 +320,13 @@ impl InferCtx<'_> {
                     span,
                 ) {
                     let same_aliased_numeric = resolved_left_operand == resolved_right_operand
-                        && resolved_left_operand.is_aliased_numeric_type();
+                        && self.store.is_aliased_numeric_type(&resolved_left_operand);
 
                     let different_but_compatible = resolved_left_operand != resolved_right_operand
-                        && resolved_left_operand
-                            .is_numeric_compatible_with(&resolved_right_operand);
+                        && self.store.is_numeric_compatible_with(
+                            &resolved_left_operand,
+                            &resolved_right_operand,
+                        );
 
                     if !same_aliased_numeric && !different_but_compatible {
                         self.unify_binary_operands(
@@ -350,8 +355,10 @@ impl InferCtx<'_> {
                     span,
                 ) {
                     left_operand_ty.clone()
-                } else if resolved_left_operand.underlying_simple_kind() == Some(SimpleKind::Bool)
-                    || resolved_right_operand.underlying_simple_kind() == Some(SimpleKind::Bool)
+                } else if self.store.underlying_simple_kind(&resolved_left_operand)
+                    == Some(SimpleKind::Bool)
+                    || self.store.underlying_simple_kind(&resolved_right_operand)
+                        == Some(SimpleKind::Bool)
                 {
                     self.unify_binary_operands(operator, left_operand_ty, right_operand_ty, &span);
                     left_operand_ty.clone()
@@ -376,14 +383,17 @@ impl InferCtx<'_> {
                 }
 
                 let same_aliased_numeric = resolved_left_operand == resolved_right_operand
-                    && resolved_left_operand.is_aliased_numeric_type();
+                    && self.store.is_aliased_numeric_type(&resolved_left_operand);
 
                 let different_but_compatible = resolved_left_operand != resolved_right_operand
-                    && resolved_left_operand.is_numeric_compatible_with(&resolved_right_operand);
+                    && self.store.is_numeric_compatible_with(
+                        &resolved_left_operand,
+                        &resolved_right_operand,
+                    );
 
                 if (same_aliased_numeric || different_but_compatible)
-                    && resolved_left_operand.is_orderable()
-                    && resolved_right_operand.is_orderable()
+                    && self.store.is_orderable(&resolved_left_operand)
+                    && self.store.is_orderable(&resolved_right_operand)
                 {
                     self.type_bool()
                 } else {
@@ -412,8 +422,9 @@ impl InferCtx<'_> {
                 ) {
                     left_operand_ty.clone()
                 } else {
-                    let is_string_like =
-                        |t: &Type| t.underlying_simple_kind() == Some(SimpleKind::String);
+                    let is_string_like = |ty: &Type| {
+                        self.store.underlying_simple_kind(ty) == Some(SimpleKind::String)
+                    };
                     let numeric_ok = if !is_string_like(&resolved_left_operand)
                         && !is_string_like(&resolved_right_operand)
                     {
@@ -556,7 +567,7 @@ impl InferCtx<'_> {
         if matches!(resolved_ty, Type::Var { .. } | Type::Error) {
             return true;
         }
-        if !is_integer_type(&resolved_ty, &self.env) {
+        if !is_integer_type(&resolved_ty, &self.env, self.store) {
             self.sink.push(diagnostics::infer::not_integer_for_binary(
                 operator,
                 &resolved_ty,
@@ -582,7 +593,7 @@ impl InferCtx<'_> {
             return;
         }
 
-        if !resolved_ty.is_orderable() {
+        if !self.store.is_orderable(&resolved_ty) {
             self.sink
                 .push(diagnostics::infer::not_orderable(&resolved_ty, *span));
         }
@@ -620,8 +631,8 @@ impl InferCtx<'_> {
         let right_is_defined_type = is_nominal_defined_type(right, store);
 
         if left_is_defined_type && right_is_defined_type {
-            let underlying = left
-                .underlying_simple_kind()
+            let underlying = store
+                .underlying_simple_kind(left)
                 .map(Type::Simple)
                 .unwrap_or_else(|| left.clone());
             self.sink.push(diagnostics::infer::incompatible_named_types(
@@ -629,13 +640,13 @@ impl InferCtx<'_> {
                 span,
             ));
             true
-        } else if left_is_defined_type && plain_primitive_of_backing(left, right) {
+        } else if left_is_defined_type && plain_primitive_of_backing(left, right, store) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     right, left, span,
                 ));
             true
-        } else if right_is_defined_type && plain_primitive_of_backing(right, left) {
+        } else if right_is_defined_type && plain_primitive_of_backing(right, left, store) {
             self.sink
                 .push(diagnostics::infer::named_primitive_needs_cast(
                     left, right, span,
@@ -654,8 +665,8 @@ impl InferCtx<'_> {
         span: &Span,
     ) -> Option<Type> {
         let store = self.store;
-        let left_underlying = left_ty.underlying_numeric_type();
-        let right_underlying = right_ty.underlying_numeric_type();
+        let left_underlying = store.underlying_numeric_type(left_ty);
+        let right_underlying = store.underlying_numeric_type(right_ty);
 
         let (left_underlying, right_underlying) = match (left_underlying, right_underlying) {
             (Some(l), Some(r)) => (l, r),
@@ -669,8 +680,8 @@ impl InferCtx<'_> {
             return None;
         }
 
-        let left_is_aliased = left_ty.is_aliased_numeric_type();
-        let right_is_aliased = right_ty.is_aliased_numeric_type();
+        let left_is_aliased = store.is_aliased_numeric_type(left_ty);
+        let right_is_aliased = store.is_aliased_numeric_type(right_ty);
 
         match (left_is_aliased, right_is_aliased) {
             (false, false) => None,
@@ -786,7 +797,7 @@ impl InferCtx<'_> {
 
         self.check_valid_cast(&source_ty, &target_ty, span);
 
-        if is_float_literal(&new_expression) && is_integer_type(&target_ty, &self.env) {
+        if is_float_literal(&new_expression) && is_integer_type(&target_ty, &self.env, self.store) {
             self.sink
                 .push(diagnostics::infer::float_literal_int_cast(span));
         }
@@ -847,7 +858,7 @@ fn is_float_literal(expression: &Expression) -> bool {
     }
 }
 
-fn is_integer_type(ty: &Type, env: &crate::checker::TypeEnv) -> bool {
+fn is_integer_type(ty: &Type, env: &crate::checker::TypeEnv, store: &Store) -> bool {
     let resolved = ty.resolve_in(env);
     let direct_match = matches!(
         resolved.get_name(),
@@ -872,8 +883,8 @@ fn is_integer_type(ty: &Type, env: &crate::checker::TypeEnv) -> bool {
         return true;
     }
 
-    resolved
-        .underlying_numeric_type()
+    store
+        .underlying_numeric_type(&resolved)
         .is_some_and(|underlying| {
             matches!(
                 underlying.get_name(),
@@ -952,14 +963,14 @@ fn literal_kind(expression: &Expression) -> LiteralKind {
     }
 }
 
-fn literal_can_adapt_to(kind: &LiteralKind, target: &Type) -> bool {
+fn literal_can_adapt_to(kind: &LiteralKind, target: &Type, store: &Store) -> bool {
     let named_backed_by = |k: SimpleKind| {
-        matches!(target, Type::Nominal { .. }) && target.underlying_simple_kind() == Some(k)
+        matches!(target, Type::Nominal { .. }) && store.underlying_simple_kind(target) == Some(k)
     };
     match kind {
-        LiteralKind::Integer => target.literal_adaptation_target().is_some(),
-        LiteralKind::Float => target
-            .literal_adaptation_target()
+        LiteralKind::Integer => store.literal_adaptation_target(target).is_some(),
+        LiteralKind::Float => store
+            .literal_adaptation_target(target)
             .is_some_and(|underlying| underlying.is_float()),
         LiteralKind::String => named_backed_by(SimpleKind::String),
         LiteralKind::Boolean => named_backed_by(SimpleKind::Bool),
@@ -971,14 +982,14 @@ fn is_nominal_defined_type(ty: &Type, store: &Store) -> bool {
     matches!(store.deep_resolve_alias(ty), Type::Nominal { id, .. } if store.is_nominal_defined_type(id.as_str()))
 }
 
-fn is_plain_numeric_primitive(ty: &Type) -> bool {
-    ty.is_numeric() && !ty.is_aliased_numeric_type()
+fn is_plain_numeric_primitive(ty: &Type, store: &Store) -> bool {
+    ty.is_numeric() && !store.is_aliased_numeric_type(ty)
 }
 
-fn plain_primitive_of_backing(defined_ty: &Type, other: &Type) -> bool {
-    match defined_ty.underlying_simple_kind() {
+fn plain_primitive_of_backing(defined_ty: &Type, other: &Type, store: &Store) -> bool {
+    match store.underlying_simple_kind(defined_ty) {
         Some(SimpleKind::String) => other.is_string(),
         Some(SimpleKind::Bool) => other.is_boolean(),
-        _ => is_plain_numeric_primitive(other),
+        _ => is_plain_numeric_primitive(other, store),
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -2,8 +2,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::BindingKind;
 use syntax::ast::{
-    EnumFieldDefinition, Expression, Literal, Pattern, RestPattern, Span, StructFieldPattern,
-    TypedPattern, collect_pattern_bindings,
+    ConstructorPatternResolution, EnumFieldDefinition, Expression, Literal, Pattern,
+    RecordPatternResolution, RestPattern, SequencePatternResolution, Span, StructFieldPattern,
+    collect_pattern_bindings,
 };
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{CompoundKind, Type, substitute, unqualified_name};
@@ -19,7 +20,7 @@ impl InferCtx<'_> {
         pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         self.infer_pattern_inner(pattern, expected_ty, kind, false)
     }
 
@@ -29,7 +30,7 @@ impl InferCtx<'_> {
         expected_ty: Type,
         kind: BindingKind,
         is_struct_field: bool,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         let store = self.store;
         match pattern {
             Pattern::Identifier { identifier, span } => {
@@ -44,10 +45,7 @@ impl InferCtx<'_> {
                         shorthand_field: is_struct_field,
                     },
                 );
-                (
-                    Pattern::Identifier { identifier, span },
-                    TypedPattern::Wildcard,
-                )
+                Pattern::Identifier { identifier, span }
             }
 
             Pattern::Literal { literal, ty, span } => {
@@ -56,8 +54,7 @@ impl InferCtx<'_> {
 
                 match inferred_literal {
                     Expression::Literal { literal, ty, span } => {
-                        let typed = TypedPattern::Literal(literal.clone());
-                        (Pattern::Literal { literal, ty, span }, typed)
+                        Pattern::Literal { literal, ty, span }
                     }
                     _ => unreachable!(),
                 }
@@ -84,21 +81,16 @@ impl InferCtx<'_> {
                     }
                 };
 
-                let (inferred_elements, typed_elements): (Vec<_>, Vec<_>) = elements
+                let inferred_elements: Vec<_> = elements
                     .into_iter()
                     .zip(element_types.iter())
                     .map(|(p, ty)| self.infer_pattern_inner(p, ty.clone(), kind, false))
-                    .unzip();
+                    .collect();
 
-                let pattern = Pattern::Tuple {
+                Pattern::Tuple {
                     elements: inferred_elements,
                     span,
-                };
-                let typed = TypedPattern::Tuple {
-                    arity: typed_elements.len(),
-                    elements: typed_elements,
-                };
-                (pattern, typed)
+                }
             }
 
             pattern @ Pattern::EnumVariant { .. } => {
@@ -109,12 +101,12 @@ impl InferCtx<'_> {
                 self.infer_struct_pattern(pattern, expected_ty, kind)
             }
 
-            Pattern::WildCard { span } => (Pattern::WildCard { span }, TypedPattern::Wildcard),
+            Pattern::WildCard { span } => Pattern::WildCard { span },
 
             Pattern::Unit { span, .. } => {
                 let unit_ty = self.type_unit();
                 self.unify(&expected_ty, &unit_ty, &span);
-                (Pattern::Unit { ty: unit_ty, span }, TypedPattern::Wildcard)
+                Pattern::Unit { ty: unit_ty, span }
             }
 
             pattern @ Pattern::Slice { .. } => {
@@ -165,7 +157,7 @@ impl InferCtx<'_> {
                     BindingKind::Parameter { .. } => BindingKind::Parameter { mutable: false },
                     other => other,
                 };
-                let (inner, typed) = self.infer_pattern_inner(
+                let inner = self.infer_pattern_inner(
                     *pattern,
                     expected_ty.clone(),
                     inner_kind,
@@ -181,15 +173,12 @@ impl InferCtx<'_> {
                         shorthand_field: is_struct_field,
                     },
                 );
-                (
-                    Pattern::AsBinding {
-                        pattern: Box::new(inner),
-                        name,
-                        name_span,
-                        span,
-                    },
-                    typed,
-                )
+                Pattern::AsBinding {
+                    pattern: Box::new(inner),
+                    name,
+                    name_span,
+                    span,
+                }
             }
         }
     }
@@ -215,7 +204,7 @@ impl InferCtx<'_> {
         length: u64,
         element_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         let Pattern::Slice {
             prefix, rest, span, ..
         } = pattern
@@ -223,10 +212,10 @@ impl InferCtx<'_> {
             unreachable!("infer_array_pattern called with non-Slice pattern");
         };
         let store = self.store;
-        let (inferred_prefix, typed_prefix): (Vec<_>, Vec<_>) = prefix
+        let inferred_prefix: Vec<_> = prefix
             .into_iter()
             .map(|p| self.infer_pattern_inner(p, element_ty.clone(), kind, false))
-            .unzip();
+            .collect();
 
         let prefix_count = inferred_prefix.len() as u64;
         let arity_ok = if rest.is_present() {
@@ -264,18 +253,15 @@ impl InferCtx<'_> {
             );
         }
 
-        let pattern = Pattern::Slice {
+        Pattern::Slice {
             prefix: inferred_prefix,
-            rest: rest.clone(),
-            element_ty: element_ty.clone(),
+            rest,
+            resolution: SequencePatternResolution::Array {
+                element_type: element_ty,
+                length,
+            },
             span,
-        };
-        let typed = TypedPattern::Array {
-            prefix: typed_prefix,
-            element_type: element_ty,
-            length,
-        };
-        (pattern, typed)
+        }
     }
 
     fn infer_slice_pattern(
@@ -284,7 +270,7 @@ impl InferCtx<'_> {
         resolved_ty: Type,
         expected_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         let Pattern::Slice {
             prefix, rest, span, ..
         } = pattern
@@ -302,10 +288,10 @@ impl InferCtx<'_> {
             }
         };
 
-        let (inferred_prefix, typed_prefix): (Vec<_>, Vec<_>) = prefix
+        let inferred_prefix: Vec<_> = prefix
             .into_iter()
             .map(|p| self.infer_pattern_inner(p, element_ty.clone(), kind, false))
-            .unzip();
+            .collect();
 
         if let RestPattern::Bind { ref name, ref span } = rest {
             let rest_ty = if element_ty.shallow_resolve_in(&self.env).is_error() {
@@ -326,18 +312,14 @@ impl InferCtx<'_> {
             );
         }
 
-        let pattern = Pattern::Slice {
+        Pattern::Slice {
             prefix: inferred_prefix,
-            rest: rest.clone(),
-            element_ty: element_ty.clone(),
+            rest,
+            resolution: SequencePatternResolution::Slice {
+                element_type: element_ty,
+            },
             span,
-        };
-        let typed = TypedPattern::Slice {
-            prefix: typed_prefix,
-            has_rest: rest.is_present(),
-            element_type: element_ty,
-        };
-        (pattern, typed)
+        }
     }
 
     fn infer_enum_variant_pattern(
@@ -345,7 +327,7 @@ impl InferCtx<'_> {
         pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         let Pattern::EnumVariant {
             identifier,
             fields,
@@ -374,7 +356,7 @@ impl InferCtx<'_> {
             ty
         } else if let Some(value_ty) = self.lookup_type(store, &identifier) {
             if matches!(self.instantiate(&value_ty).0, Type::Error) {
-                return (Pattern::WildCard { span }, TypedPattern::Wildcard);
+                return Pattern::WildCard { span };
             }
             let Some(ty) =
                 self.resolve_pattern_constructor(&identifier, &expected_ty, is_bare_name)
@@ -411,7 +393,7 @@ impl InferCtx<'_> {
         let unify_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
         self.unify(&unify_expected, &pattern_ty, &span);
 
-        let (new_fields, mut typed_fields): (Vec<_>, Vec<_>) = fields
+        let new_fields: Vec<_> = fields
             .iter()
             .enumerate()
             .map(|(i, f)| {
@@ -421,13 +403,9 @@ impl InferCtx<'_> {
                     .unwrap_or(Type::Error);
                 self.infer_pattern_inner(f.clone(), param_ty, kind, false)
             })
-            .unzip();
+            .collect();
 
-        if rest {
-            for _ in new_fields.len()..params.len() {
-                typed_fields.push(TypedPattern::Wildcard);
-            }
-        } else if params.len() != new_fields.len() {
+        if !rest && params.len() != new_fields.len() {
             let actual_types: Vec<Type> = new_fields
                 .iter()
                 .map(|p| p.get_type().unwrap_or_else(|| self.new_type_var()))
@@ -442,14 +420,9 @@ impl InferCtx<'_> {
             ));
         }
 
-        let resolved_field_types: Box<[Type]> = params
-            .iter()
-            .map(|param| param.ty.resolve_in(&self.env))
-            .collect();
-
         let resolved_ty = pattern_ty.resolve_in(&self.env);
-        let typed = match &resolved_ty {
-            Type::Nominal { id, params, .. } => {
+        let resolution = match &resolved_ty {
+            Type::Nominal { id, .. } => {
                 let variant_name = unqualified_name(&identifier);
                 let variant_qualified = id.with_segment(variant_name);
                 if let Some(definition_span) =
@@ -458,36 +431,22 @@ impl InferCtx<'_> {
                     self.facts.add_usage(span, definition_span);
                 }
 
-                let variant_fields = store
-                    .variants_of(id)
-                    .and_then(|variants| {
-                        variants
-                            .iter()
-                            .find(|v| v.name == variant_name)
-                            .map(|v| v.fields.iter().cloned().collect())
-                    })
-                    .unwrap_or_default();
-
-                TypedPattern::EnumVariant {
+                ConstructorPatternResolution::EnumVariant {
                     enum_name: id.into(),
                     variant_name: identifier.clone(),
-                    variant_fields,
-                    fields: typed_fields,
-                    type_args: params.clone(),
-                    field_types: resolved_field_types,
                 }
             }
-            _ => TypedPattern::Wildcard,
+            _ => return Pattern::WildCard { span },
         };
 
-        let pattern = Pattern::EnumVariant {
+        Pattern::EnumVariant {
             identifier,
             fields: new_fields,
             rest,
+            resolution,
             ty: pattern_ty,
             span,
-        };
-        (pattern, typed)
+        }
     }
 
     fn resolve_pattern_constructor(
@@ -548,7 +507,7 @@ impl InferCtx<'_> {
         match &definition.body {
             DefinitionBody::Struct { .. } => Some(definition),
             DefinitionBody::TypeAlias { .. } => {
-                let underlying = store.deep_resolve_alias(definition.ty.unwrap_forall());
+                let underlying = store.peel_alias(&definition.ty);
                 let Type::Nominal { id, .. } = underlying else {
                     return None;
                 };
@@ -566,7 +525,7 @@ impl InferCtx<'_> {
         span: Span,
         kind: BindingKind,
         is_bare_name: bool,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         if is_bare_name {
             self.sink
                 .push(diagnostics::infer::uppercase_binding(span, identifier));
@@ -580,7 +539,7 @@ impl InferCtx<'_> {
                     kind.is_match_arm(),
                 ));
         }
-        (Pattern::WildCard { span }, TypedPattern::Wildcard)
+        Pattern::WildCard { span }
     }
 
     fn try_infer_const_pattern(
@@ -590,7 +549,7 @@ impl InferCtx<'_> {
         kind: BindingKind,
         expected_ty: &Type,
         span: Span,
-    ) -> Option<(Pattern, TypedPattern)> {
+    ) -> Option<Pattern> {
         let store = self.store;
         let qualified = self.lookup_qualified_name(store, identifier)?;
         let definition = store.get_definition(&qualified)?;
@@ -617,7 +576,7 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::const_pattern_outside_match_arm(
                     identifier, span,
                 ));
-            return Some((Pattern::WildCard { span }, TypedPattern::Wildcard));
+            return Some(Pattern::WildCard { span });
         }
 
         if matches!(unwrapped_ty, Type::Function(_)) {
@@ -625,7 +584,7 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::const_pattern_not_eligible(
                     identifier, span,
                 ));
-            return Some((Pattern::WildCard { span }, TypedPattern::Wildcard));
+            return Some(Pattern::WildCard { span });
         }
 
         let (const_ty, _) = self.instantiate(definition_ty);
@@ -638,19 +597,17 @@ impl InferCtx<'_> {
         }
 
         let resolved_ty = const_ty.resolve_in(&self.env);
-        let pattern = Pattern::EnumVariant {
+        Some(Pattern::EnumVariant {
             identifier: identifier.into(),
             fields: vec![],
             rest,
-            ty: resolved_ty.clone(),
-            span,
-        };
-        let typed = TypedPattern::Const {
-            qualified_name: qualified,
+            resolution: ConstructorPatternResolution::Const {
+                qualified_name: qualified,
+                value: const_value,
+            },
             ty: resolved_ty,
-            value: const_value,
-        };
-        Some((pattern, typed))
+            span,
+        })
     }
 
     fn infer_struct_pattern(
@@ -658,7 +615,7 @@ impl InferCtx<'_> {
         pattern: Pattern,
         expected_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
+    ) -> Pattern {
         let Pattern::Struct {
             identifier,
             fields,
@@ -687,7 +644,7 @@ impl InferCtx<'_> {
                 .unwrap_or_else(|| {
                     self.sink
                         .push(diagnostics::infer::struct_not_found(identifier, span));
-                    (Pattern::WildCard { span }, TypedPattern::Wildcard)
+                    Pattern::WildCard { span }
                 });
         };
         let Some(Definition {
@@ -705,7 +662,7 @@ impl InferCtx<'_> {
                 .unwrap_or_else(|| {
                     self.sink
                         .push(diagnostics::infer::struct_not_found(identifier, span));
-                    (Pattern::WildCard { span }, TypedPattern::Wildcard)
+                    Pattern::WildCard { span }
                 });
         };
 
@@ -727,7 +684,7 @@ impl InferCtx<'_> {
 
         let available: Vec<String> = struct_fields.iter().map(|f| f.name.to_string()).collect();
 
-        let (new_fields, typed_field_values): (Vec<_>, Vec<_>) = fields
+        let new_fields: Vec<_> = fields
             .iter()
             .map(|field| {
                 let field_definition = struct_fields.iter().find(|x| x.name == field.name);
@@ -764,17 +721,14 @@ impl InferCtx<'_> {
                     &field.value,
                     Pattern::Identifier { identifier, .. } if identifier == &field.name
                 );
-                let (inferred_value, typed_value) =
+                let inferred_value =
                     self.infer_pattern_inner(field.value.clone(), field_ty, kind, is_shorthand);
-                (
-                    StructFieldPattern {
-                        name: field.name.clone(),
-                        value: inferred_value,
-                    },
-                    (field.name.clone(), typed_value),
-                )
+                StructFieldPattern {
+                    name: field.name.clone(),
+                    value: inferred_value,
+                }
             })
-            .unzip();
+            .collect();
 
         if !rest {
             let pattern_field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
@@ -790,24 +744,21 @@ impl InferCtx<'_> {
         }
 
         let resolved_ty = struct_ty.resolve_in(&self.env);
-        let typed = match &resolved_ty {
-            Type::Nominal { id, params, .. } => TypedPattern::Struct {
+        let resolution = match &resolved_ty {
+            Type::Nominal { id, .. } => RecordPatternResolution::Struct {
                 struct_name: id.into(),
-                struct_fields,
-                pattern_fields: typed_field_values,
-                type_args: params.clone(),
             },
-            _ => TypedPattern::Wildcard,
+            _ => return Pattern::WildCard { span },
         };
 
-        let pattern = Pattern::Struct {
+        Pattern::Struct {
             identifier: identifier.clone(),
             fields: new_fields,
             rest,
+            resolution,
             ty: struct_ty,
             span,
-        };
-        (pattern, typed)
+        }
     }
 
     fn infer_or_pattern(
@@ -816,8 +767,8 @@ impl InferCtx<'_> {
         span: Span,
         expected_ty: Type,
         kind: BindingKind,
-    ) -> (Pattern, TypedPattern) {
-        let (first, first_typed) = self.infer_pattern_inner(
+    ) -> Pattern {
+        let first = self.infer_pattern_inner(
             patterns
                 .first()
                 .cloned()
@@ -842,13 +793,11 @@ impl InferCtx<'_> {
             .collect();
 
         let mut inferred = vec![first];
-        let mut typed_alternatives = vec![first_typed];
 
         for pattern in patterns.iter().skip(1) {
             self.scopes.push();
             let checkpoint = self.facts.binding_checkpoint();
-            let (alt, alt_typed) =
-                self.infer_pattern_inner(pattern.clone(), expected_ty.clone(), kind, false);
+            let alt = self.infer_pattern_inner(pattern.clone(), expected_ty.clone(), kind, false);
             let alt_bindings = collect_pattern_bindings(&alt);
             let alt_names: HashSet<&str> =
                 alt_bindings.iter().map(|(name, _)| name.as_str()).collect();
@@ -900,17 +849,12 @@ impl InferCtx<'_> {
             self.scopes.pop();
             self.facts.remove_bindings_from(checkpoint);
             inferred.push(alt);
-            typed_alternatives.push(alt_typed);
         }
 
-        let pattern = Pattern::Or {
+        Pattern::Or {
             patterns: inferred,
             span,
-        };
-        let typed = TypedPattern::Or {
-            alternatives: typed_alternatives,
-        };
-        (pattern, typed)
+        }
     }
 
     fn get_enum_variant_info(&self, ty: &Type) -> Option<(String, Vec<String>)> {
@@ -961,13 +905,7 @@ impl InferCtx<'_> {
         let DefinitionBody::TypeAlias { .. } = &def.body else {
             return None;
         };
-        let alias_ty = &def.ty;
-
-        let underlying = match alias_ty {
-            Type::Forall { body, .. } => body.as_ref().clone(),
-            _ => alias_ty.clone(),
-        };
-        let underlying = store.deep_resolve_alias(&underlying);
+        let underlying = store.peel_alias(&def.ty);
 
         if let Type::Nominal { id: enum_id, .. } = &underlying
             && let Some(variants) = store.variants_of(enum_id.as_str())
@@ -1020,7 +958,7 @@ impl InferCtx<'_> {
         pattern: &Pattern,
         expected_ty: &Type,
         kind: BindingKind,
-    ) -> Option<(Pattern, TypedPattern)> {
+    ) -> Option<Pattern> {
         let Pattern::Struct {
             identifier,
             fields,
@@ -1078,7 +1016,7 @@ impl InferCtx<'_> {
         let variant_fields: Vec<EnumFieldDefinition> = variant.fields.iter().cloned().collect();
         let available: Vec<String> = variant_fields.iter().map(|f| f.name.to_string()).collect();
 
-        let (new_fields, typed_field_values): (Vec<_>, Vec<_>) = fields
+        let new_fields: Vec<_> = fields
             .iter()
             .map(|field| {
                 let field_definition = variant_fields.iter().find(|x| x.name == field.name);
@@ -1101,17 +1039,14 @@ impl InferCtx<'_> {
                     &field.value,
                     Pattern::Identifier { identifier, .. } if identifier == &field.name
                 );
-                let (inferred_value, typed_value) =
+                let inferred_value =
                     self.infer_pattern_inner(field.value.clone(), field_ty, kind, is_shorthand);
-                (
-                    StructFieldPattern {
-                        name: field.name.clone(),
-                        value: inferred_value,
-                    },
-                    (field.name.clone(), typed_value),
-                )
+                StructFieldPattern {
+                    name: field.name.clone(),
+                    value: inferred_value,
+                }
             })
-            .unzip();
+            .collect();
 
         if !rest {
             let pattern_field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
@@ -1126,8 +1061,8 @@ impl InferCtx<'_> {
             }
         }
 
-        let typed = match &resolved_ty {
-            Type::Nominal { id, params, .. } => {
+        let resolution = match &resolved_ty {
+            Type::Nominal { id, .. } => {
                 let variant_qualified = id.with_segment(&variant_name);
                 if let Some(definition_span) =
                     self.get_definition_name_span(store, &variant_qualified)
@@ -1135,25 +1070,22 @@ impl InferCtx<'_> {
                     self.facts.add_usage(*span, definition_span);
                 }
 
-                TypedPattern::EnumStructVariant {
+                RecordPatternResolution::EnumVariant {
                     enum_name: id.into(),
                     variant_name: identifier.into(),
-                    variant_fields,
-                    pattern_fields: typed_field_values,
-                    type_args: params.clone(),
                 }
             }
-            _ => TypedPattern::Wildcard,
+            _ => return None,
         };
 
-        let pattern = Pattern::Struct {
+        Some(Pattern::Struct {
             identifier: identifier.into(),
             fields: new_fields,
             rest,
+            resolution,
             ty: pattern_ty,
             span: *span,
-        };
-        Some((pattern, typed))
+        })
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -1,7 +1,7 @@
 use crate::checker::EnvResolve;
 use syntax::EcoString;
 use syntax::ast::DeadCodeCause;
-use syntax::ast::{BinaryOperator, Expression, Span, UnaryOperator};
+use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, Span, UnaryOperator};
 use syntax::program::DefinitionBody;
 use syntax::types::Type;
 
@@ -68,7 +68,7 @@ fn contains_stored_reference_to(expression: &Expression, var_name: &str) -> bool
                     contains_stored_reference_to(expr, var_name)
                 }
             };
-            args.iter().any(check) || spread.as_ref().as_ref().is_some_and(check)
+            args.iter().any(check) || spread.as_deref().is_some_and(check)
         }
         // Recurse but skip immediately-dereferenced contexts
         Expression::Binary { left, right, .. } => {
@@ -210,14 +210,12 @@ impl InferCtx<'_> {
         self.unify(expected_ty, &ref_ty, &span);
 
         if !is_already_ref {
-            if let Some(kind) = check_is_non_addressable(&new_expression, &self.env) {
+            if let Some(kind) = check_is_non_addressable(&new_expression, &self.env, self.store) {
                 self.sink
                     .push(diagnostics::infer::non_addressable_expression(kind, span));
-            } else if let Expression::Identifier {
-                qualified: Some(qname),
-                ..
-            } = &new_expression
-                && self.is_const_name(store, qname.as_str())
+            } else if let Expression::Identifier { resolution, .. } = &new_expression
+                && let Some(qname) = resolution.definition()
+                && self.is_const_name(store, qname)
             {
                 self.sink
                     .push(diagnostics::infer::non_addressable_const(span));
@@ -345,12 +343,18 @@ impl InferCtx<'_> {
             }
         }
 
+        let resolution = match (binding_id, qualified) {
+            (Some(id), None) => IdentifierResolution::Binding(id),
+            (None, Some(definition)) => IdentifierResolution::Definition(definition),
+            (None, None) => IdentifierResolution::Unresolved,
+            (Some(_), Some(_)) => unreachable!("identifier cannot be local and global"),
+        };
+
         Expression::Identifier {
             value,
             ty: identifier_ty,
             span,
-            binding_id,
-            qualified,
+            resolution,
         }
     }
 
@@ -386,7 +390,9 @@ impl InferCtx<'_> {
             self.scopes.restore_use_context(ctx);
         }
 
-        if let Some(kind) = check_non_addressable_assignment_target(&new_target, &self.env) {
+        if let Some(kind) =
+            check_non_addressable_assignment_target(&new_target, &self.env, self.store)
+        {
             self.sink
                 .push(diagnostics::infer::non_addressable_assignment(kind, span));
         }

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -284,6 +284,11 @@ impl InferCtx<'_> {
         }
 
         let inner_ty = last_item.get_type();
+        let inner_ty = if inner_ty.is_ignored() {
+            self.type_unit()
+        } else {
+            inner_ty
+        };
 
         let block_ty = match carrier {
             TryCarrier::Result => {
@@ -365,6 +370,11 @@ impl InferCtx<'_> {
 
         let last_item = new_items.last().expect("block must have at least one item");
         let result_inner_ty = last_item.get_type();
+        let result_inner_ty = if result_inner_ty.is_ignored() {
+            self.type_unit()
+        } else {
+            result_inner_ty
+        };
 
         let panic_value_ty = self.type_panic_value(store);
         let block_ty = self.type_result(store, result_inner_ty, panic_value_ty);

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -221,7 +221,7 @@ impl InferCtx<'_> {
             }
         }
 
-        let (new_binding, typed_pattern) = self.infer_pattern(
+        let new_binding = self.infer_pattern(
             *binding,
             element_ty.clone(),
             syntax::ast::BindingKind::Let { mutable: false },
@@ -231,7 +231,6 @@ impl InferCtx<'_> {
 
         SelectArmPattern::Receive {
             binding: Box::new(new_binding),
-            typed_pattern: Some(typed_pattern),
             receive_expression: Box::new(new_receive_expression),
             body: Box::new(new_body),
         }
@@ -306,7 +305,7 @@ impl InferCtx<'_> {
             .map(|match_arm| {
                 self.scopes.push();
 
-                let (new_pattern, typed_pattern) = self.infer_pattern(
+                let new_pattern = self.infer_pattern(
                     match_arm.pattern,
                     pattern_ty.clone(),
                     syntax::ast::BindingKind::MatchArm,
@@ -341,7 +340,6 @@ impl InferCtx<'_> {
                 MatchArm {
                     pattern: new_pattern,
                     guard: new_guard,
-                    typed_pattern: Some(typed_pattern),
                     expression: Box::new(new_expression),
                 }
             })

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -111,18 +111,15 @@ impl InferCtx<'_> {
         if let Some(qualified_name) = self.lookup_qualified_name(store, &literal.name)
             && let Some(Definition {
                 ty: alias_ty,
-                body: DefinitionBody::TypeAlias { annotation, .. },
+                body: DefinitionBody::TypeAlias { alias, .. },
                 ..
             }) = store.get_definition(&qualified_name)
         {
             let alias_ty = alias_ty.clone();
-            let is_opaque = annotation.is_opaque();
+            let is_opaque = matches!(alias, syntax::program::AliasKind::Opaque(_));
 
-            let underlying = match &alias_ty {
-                Type::Forall { body, .. } => body.as_ref().clone(),
-                _ => alias_ty.clone(),
-            };
-            if let Type::Nominal { id: struct_id, .. } = &underlying
+            let underlying = (!is_opaque).then(|| store.peel_alias(&alias_ty));
+            if let Some(Type::Nominal { id: struct_id, .. }) = &underlying
                 && let Some(Definition {
                     ty: struct_ty,
                     body:
@@ -139,7 +136,7 @@ impl InferCtx<'_> {
                 let alias_underlying = if matches!(&alias_ty, Type::Forall { .. }) {
                     None
                 } else {
-                    Some(underlying)
+                    underlying
                 };
                 return self.infer_struct_call_for_struct(
                     literal,
@@ -166,16 +163,16 @@ impl InferCtx<'_> {
             && let Some(qualified_name) = self.lookup_qualified_name(store, type_part)
             && let Some(Definition {
                 ty: alias_ty,
-                body: DefinitionBody::TypeAlias { .. },
+                body:
+                    DefinitionBody::TypeAlias {
+                        alias: syntax::program::AliasKind::Transparent { .. },
+                        ..
+                    },
                 ..
             }) = store.get_definition(&qualified_name)
         {
             let alias_ty = alias_ty.clone();
-
-            let underlying = match &alias_ty {
-                Type::Forall { body, .. } => body.as_ref().clone(),
-                _ => alias_ty.clone(),
-            };
+            let underlying = store.peel_alias(&alias_ty);
             let variant_fields = if let Type::Nominal { id: enum_id, .. } = &underlying
                 && let Some(variants) = store.variants_of(enum_id)
                 && let Some(variant) = variants.iter().find(|v| v.name == variant_name)
@@ -188,9 +185,10 @@ impl InferCtx<'_> {
 
             if let Some(variant_fields) = variant_fields {
                 let (instantiated_ty, map) = self.instantiate(&alias_ty);
-                let enum_ty = match instantiated_ty {
+                let instantiated_target = store.peel_alias(&instantiated_ty);
+                let enum_ty = match instantiated_target {
                     Type::Function(f) => (*f.return_type).clone(),
-                    _ => instantiated_ty,
+                    other => other,
                 };
                 return self.infer_struct_call_for_enum_variant(
                     literal,
@@ -275,7 +273,9 @@ impl InferCtx<'_> {
         }
 
         let peeled_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
-        if same_nominal(&peeled_expected, &struct_call_ty) && !peeled_expected.contains_unknown() {
+        if same_nominal(&peeled_expected, &struct_call_ty)
+            && !store.contains_unknown(&peeled_expected)
+        {
             let _ = self.speculatively(|this| {
                 InferCtx::new(this, store).try_unify(&peeled_expected, &struct_call_ty, &span)
             });

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -25,7 +25,11 @@ impl TaskState {
             let module = store
                 .get_module_mut(module_id)
                 .expect("module must exist for inference");
-            std::mem::take(&mut module.files).into_values().collect()
+            let file_ids = module.file_ids().collect::<Vec<_>>();
+            file_ids
+                .into_iter()
+                .filter_map(|file_id| module.files.remove(&file_id))
+                .collect()
         })
     }
 }
@@ -193,7 +197,9 @@ impl InferCtx<'_> {
         let const_ty = if let Some(annotation) = annotation {
             self.convert_to_type(store, annotation, span)
         } else {
-            self.type_from_literal_expression(expression)
+            expression
+                .value()
+                .and_then(|value| self.type_from_literal_expression(value))
                 .unwrap_or_else(|| self.new_type_var())
         };
         self.sink.truncate(before);

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -99,7 +99,9 @@ impl InferCtx<'_> {
         let r2_is_unknown = r2.is_unknown();
 
         match (&r1, &r2) {
-            _ if r1.is_ignored() || r2.is_ignored() => Ok(()),
+            _ if r1.is_ignored() || r2.is_ignored() || r1.is_uninferred() || r2.is_uninferred() => {
+                Ok(())
+            }
             _ if r1.is_receiver_placeholder() || r2.is_receiver_placeholder() => Ok(()),
             _ if self.should_unify_refs(&r1, &r2) => self.unify_refs(&r1, &r2, span),
 
@@ -137,37 +139,28 @@ impl InferCtx<'_> {
             // Go-level aliases for scalar types: byte <-> uint8, rune <-> int32.
             (Type::Simple(k1), Type::Simple(k2)) if simple_kinds_are_go_aliases(*k1, *k2) => Ok(()),
 
-            // Alias follow-through: `type MyFoo = Foo` stores a Nominal with
-            // `Foo` as `underlying_ty`; when unifying against a structural
-            // body, peel to the underlying type.
-            (
-                Nominal {
-                    id,
-                    underlying_ty: Some(underlying),
-                    ..
-                },
-                other,
-            ) if other.is_structural_alias_body() => {
+            (Nominal { id, .. }, other)
+                if other.is_structural_alias_body() && store.underlying_type(&r1).is_some() =>
+            {
                 if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
-                    let u = underlying.as_ref().clone();
+                    let u = store
+                        .underlying_type(&r1)
+                        .expect("guard checked underlying");
                     self.try_unify(&u, &r2, span)
                 }
             }
 
-            (
-                other,
-                Nominal {
-                    id,
-                    underlying_ty: Some(underlying),
-                    ..
-                },
-            ) if other.is_structural_alias_body() => {
+            (other, Nominal { id, .. })
+                if other.is_structural_alias_body() && store.underlying_type(&r2).is_some() =>
+            {
                 if matches!(other, Type::Simple(_)) && store.is_nominal_defined_type(id.as_str()) {
                     Err(UnifyError::TypeMismatch)
                 } else {
-                    let u = underlying.as_ref().clone();
+                    let u = store
+                        .underlying_type(&r2)
+                        .expect("guard checked underlying");
                     self.try_unify(&r1, &u, span)
                 }
             }
@@ -179,7 +172,6 @@ impl InferCtx<'_> {
                 let synth = Type::Nominal {
                     id: format!("prelude.{}", kind.leaf_name()).into(),
                     params: vec![],
-                    underlying_ty: None,
                 };
                 self.try_unify(&synth, &r2, span)
             }
@@ -187,7 +179,6 @@ impl InferCtx<'_> {
                 let synth = Type::Nominal {
                     id: format!("prelude.{}", kind.leaf_name()).into(),
                     params: vec![],
-                    underlying_ty: None,
                 };
                 self.try_unify(&r1, &synth, span)
             }
@@ -195,7 +186,6 @@ impl InferCtx<'_> {
                 let synth = Type::Nominal {
                     id: format!("prelude.{}", kind.leaf_name()).into(),
                     params: args.clone(),
-                    underlying_ty: None,
                 };
                 self.try_unify(&synth, &r2, span)
             }
@@ -203,7 +193,6 @@ impl InferCtx<'_> {
                 let synth = Type::Nominal {
                     id: format!("prelude.{}", kind.leaf_name()).into(),
                     params: args.clone(),
-                    underlying_ty: None,
                 };
                 self.try_unify(&r1, &synth, span)
             }
@@ -266,25 +255,17 @@ impl InferCtx<'_> {
                 }
             }
 
-            (
-                Nominal {
-                    underlying_ty: Some(underlying),
-                    ..
-                },
-                Function(_),
-            ) => {
-                let u = underlying.as_ref().clone();
+            (Nominal { .. }, Function(_)) if store.underlying_type(&r1).is_some() => {
+                let u = store
+                    .underlying_type(&r1)
+                    .expect("guard checked underlying");
                 self.try_unify(&u, &r2, span)
             }
 
-            (
-                Function(_),
-                Nominal {
-                    underlying_ty: Some(underlying),
-                    ..
-                },
-            ) => {
-                let u = underlying.as_ref().clone();
+            (Function(_), Nominal { .. }) if store.underlying_type(&r2).is_some() => {
+                let u = store
+                    .underlying_type(&r2)
+                    .expect("guard checked underlying");
                 self.try_unify(&r1, &u, span)
             }
 
@@ -311,17 +292,12 @@ impl InferCtx<'_> {
     }
 
     fn is_transparent_alias(&self, ty: &Type) -> bool {
-        let Type::Nominal {
-            id,
-            underlying_ty: Some(_),
-            ..
-        } = ty
-        else {
+        let Type::Nominal { id, .. } = ty else {
             return false;
         };
         self.store
             .get_definition(id)
-            .is_some_and(|definition| definition.is_type_alias())
+            .is_some_and(|definition| definition.is_transparent_type_alias())
     }
 
     fn is_interface(&self, ty: &Type) -> bool {
@@ -344,7 +320,7 @@ impl InferCtx<'_> {
     fn collapse_vars_to_error(&mut self, ty: &Type, span: &Span) {
         let resolved = self.env.shallow_resolve(ty);
         match resolved {
-            Type::Var { id, .. } if !id.is_reserved() => {
+            Type::Var { id, .. } => {
                 let _ = self.unify_type_variable(id, &Type::Error, span, false);
             }
             Type::Nominal { params, .. } => {
@@ -382,11 +358,6 @@ impl InferCtx<'_> {
         span: &Span,
         var_on_right: bool,
     ) -> Result<(), UnifyError> {
-        // Reserved sentinel ids (ignored/uninferred) unify silently with
-        // anything. Their binding doesn't go into the env.
-        if id.is_reserved() {
-            return Ok(());
-        }
         match self.env.state(id).clone() {
             VarState::Bound(ty) => {
                 if var_on_right {
@@ -395,7 +366,7 @@ impl InferCtx<'_> {
                     self.try_unify(&ty, other_ty, span)
                 }
             }
-            VarState::Unbound { .. } => {
+            VarState::Unbound => {
                 if self.env.occurs(id, other_ty) {
                     return Err(UnifyError::InfiniteType);
                 }
@@ -424,23 +395,17 @@ impl InferCtx<'_> {
         };
 
         if symbol1 != symbol2 {
-            if let Nominal {
-                underlying_ty: Some(u),
-                ..
-            } = t1
-                && store.get_interface(symbol2).is_none()
+            if store.get_interface(symbol2).is_none()
                 && !store.is_nominal_defined_type(symbol1.as_str())
-                && self.try_unify(u, t2, span).is_ok()
+                && let Some(underlying) = store.underlying_type(t1)
+                && self.try_unify(&underlying, t2, span).is_ok()
             {
                 return Ok(());
             }
-            if let Nominal {
-                underlying_ty: Some(u),
-                ..
-            } = t2
-                && store.get_interface(symbol1).is_none()
+            if store.get_interface(symbol1).is_none()
                 && !store.is_nominal_defined_type(symbol2.as_str())
-                && self.try_unify(t1, u, span).is_ok()
+                && let Some(underlying) = store.underlying_type(t2)
+                && self.try_unify(t1, &underlying, span).is_ok()
             {
                 return Ok(());
             }
@@ -821,28 +786,36 @@ impl InferCtx<'_> {
             return "Wrap the value in a slice literal".to_string();
         }
 
-        if expected.contains_unknown() && !actual.contains_unknown() {
+        if self.store.contains_unknown(expected) && !self.store.contains_unknown(actual) {
             use syntax::types::CompoundKind::{Map, Slice};
             return match expected.as_compound() {
-                Some((Map, args)) if args.get(1).is_some_and(|v| v.resolves_to_unknown()) => {
+                Some((Map, args))
+                    if args
+                        .get(1)
+                        .is_some_and(|ty| self.store.resolves_to_unknown(ty)) =>
+                {
                     format!(
                         "Build the map with `Map.new()` plus indexed assignment: `let mut m: {} = Map.new(); m[k] = v`",
                         expected
                     )
                 }
-                Some((Slice, args)) if args.first().is_some_and(|v| v.resolves_to_unknown()) => {
+                Some((Slice, args))
+                    if args
+                        .first()
+                        .is_some_and(|ty| self.store.resolves_to_unknown(ty)) =>
+                {
                     format!("Annotate the slice literal: `let xs: {} = [v1, v2, ...]`", expected)
                 }
                 _ => "The expected type contains `Unknown`. Produce the value in a context where the expected type provides the `Unknown` slot (annotation, parameter type, struct field, or return position).".to_string(),
             };
         }
 
-        if expected.is_numeric_compatible_with(actual) {
+        if self.store.is_numeric_compatible_with(expected, actual) {
             return format!("Cast with `as`, e.g. `value as {}`", expected);
         }
 
-        if let Some(ret) = function_return_under_nominal(expected)
-            && ret == actual
+        if let Some(Type::Function(function)) = self.store.resolve_to_function_type(expected)
+            && function.return_type.as_ref() == actual
         {
             return "Remove the `()` so that the type matches".to_string();
         }
@@ -891,17 +864,6 @@ fn array_to_slice_help_applies(expected: &Type, actual: &Type) -> bool {
         return false;
     };
     expected_element == element.as_ref()
-}
-
-fn function_return_under_nominal(ty: &Type) -> Option<&Type> {
-    match ty {
-        Type::Function(f) => Some(&f.return_type),
-        Type::Nominal {
-            underlying_ty: Some(u),
-            ..
-        } => function_return_under_nominal(u),
-        _ => None,
-    }
 }
 
 fn are_go_type_aliases(a: &str, b: &str) -> bool {

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -1,6 +1,7 @@
 use crate::checker::EnvResolve;
+use diagnostics::infer::InvalidCastKind;
 use syntax::ast::{Expression, Span};
-use syntax::types::{SimpleKind, Type, peel_alias};
+use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
 
@@ -38,38 +39,42 @@ impl InferCtx<'_> {
             self.sink.push(diagnostics::infer::invalid_cast(
                 raw_source_ty,
                 raw_target_ty,
+                InvalidCastKind::Complex,
                 span,
             ));
             return;
         }
 
-        if source_ty.has_underlying_rune() && target_ty.has_underlying_byte() {
+        if store.has_underlying_rune(&source_ty) && store.has_underlying_byte(&target_ty) {
             self.sink.push(diagnostics::infer::invalid_cast(
                 raw_source_ty,
                 raw_target_ty,
+                InvalidCastKind::RuneToByte,
                 span,
             ));
             return;
         }
 
-        if source_ty.has_underlying_numeric_type() && target_ty.has_underlying_numeric_type() {
+        if store.has_underlying_numeric_type(&source_ty)
+            && store.has_underlying_numeric_type(&target_ty)
+        {
             return;
         }
 
-        if uintptr_scalar_conversion(&source_ty, &target_ty) {
+        if uintptr_scalar_conversion(store, &source_ty, &target_ty) {
             return;
         }
 
-        if peel_alias(&source_ty, |_| true) == peel_alias(&target_ty, |_| true) {
+        if store.peel_alias(&source_ty) == store.peel_alias(&target_ty) {
             return;
         }
 
-        if source_ty.has_underlying_rune() && target_ty.is_string() {
+        if store.has_underlying_rune(&source_ty) && target_ty.is_string() {
             return;
         }
 
-        if (source_ty.is_string() && target_ty.has_byte_or_rune_slice_underlying())
-            || (target_ty.is_string() && source_ty.has_byte_or_rune_slice_underlying())
+        if (source_ty.is_string() && store.has_byte_or_rune_slice_underlying(&target_ty))
+            || (target_ty.is_string() && store.has_byte_or_rune_slice_underlying(&source_ty))
         {
             return;
         }
@@ -78,7 +83,9 @@ impl InferCtx<'_> {
             return;
         }
 
-        if store.peel_alias_deep(&source_ty) == store.peel_alias_deep(&target_ty) {
+        if store.peel_alias_deep(&store.peel_underlying(&source_ty))
+            == store.peel_alias_deep(&store.peel_underlying(&target_ty))
+        {
             return;
         }
 
@@ -96,6 +103,11 @@ impl InferCtx<'_> {
         self.sink.push(diagnostics::infer::invalid_cast(
             raw_source_ty,
             raw_target_ty,
+            if store.has_underlying_byte(&source_ty) && target_ty.is_string() {
+                InvalidCastKind::ByteToString
+            } else {
+                InvalidCastKind::Other
+            },
             span,
         ));
     }
@@ -160,12 +172,13 @@ impl InferCtx<'_> {
     }
 }
 
-fn uintptr_scalar_conversion(source: &Type, target: &Type) -> bool {
+fn uintptr_scalar_conversion(store: &crate::store::Store, source: &Type, target: &Type) -> bool {
     let castable = |ty: &Type| {
-        ty.has_underlying_numeric_type() || ty.underlying_simple_kind() == Some(SimpleKind::Uintptr)
+        store.has_underlying_numeric_type(ty)
+            || store.underlying_simple_kind(ty) == Some(SimpleKind::Uintptr)
     };
-    let either_uintptr = source.underlying_simple_kind() == Some(SimpleKind::Uintptr)
-        || target.underlying_simple_kind() == Some(SimpleKind::Uintptr);
+    let either_uintptr = store.underlying_simple_kind(source) == Some(SimpleKind::Uintptr)
+        || store.underlying_simple_kind(target) == Some(SimpleKind::Uintptr);
     either_uintptr && castable(source) && castable(target)
 }
 

--- a/crates/semantics/src/checker/infer/validation/const_cycles.rs
+++ b/crates/semantics/src/checker/infer/validation/const_cycles.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use ecow::EcoString;
-use syntax::ast::{Expression, Span};
+use syntax::ast::{Expression, IdentifierResolution, Span};
 
 use crate::checker::infer::InferCtx;
 
@@ -13,14 +13,6 @@ struct ConstEntry<'a> {
 
 impl InferCtx<'_> {
     pub fn check_const_cycles(&mut self, items_per_file: &[&[Expression]]) {
-        let store = self.store;
-        let module_const_names_empty = store
-            .get_module(&self.cursor.module_id)
-            .is_some_and(|m| m.const_names.is_empty());
-        if module_const_names_empty {
-            return;
-        }
-
         let mut consts: Vec<ConstEntry<'_>> = Vec::new();
         for items in items_per_file {
             for item in *items {
@@ -30,6 +22,7 @@ impl InferCtx<'_> {
                     expression,
                     ..
                 } = item
+                    && let Some(expression) = expression.value()
                 {
                     consts.push(ConstEntry {
                         name: identifier,
@@ -128,12 +121,12 @@ fn collect_const_refs<'a>(
     out: &mut Vec<&'a EcoString>,
 ) {
     if let Expression::Identifier {
-        value, qualified, ..
+        value,
+        resolution: IdentifierResolution::Unresolved,
+        ..
     } = expression
     {
-        if qualified.is_none()
-            && let Some(&name) = const_names.get(value)
-        {
+        if let Some(&name) = const_names.get(value) {
             out.push(name);
         }
         return;

--- a/crates/semantics/src/checker/infer/validation/references.rs
+++ b/crates/semantics/src/checker/infer/validation/references.rs
@@ -50,7 +50,7 @@ impl InferCtx<'_> {
                 spread,
                 ..
             } => {
-                if let Some(s) = spread.as_ref().as_ref() {
+                if let Some(s) = spread.as_deref() {
                     let mut siblings: Vec<&Expression> = args.iter().collect();
                     siblings.push(s);
                     self.check_sibling_ref_aliasing_refs(&siblings);

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -310,13 +310,13 @@ impl TaskState {
     }
 
     pub fn new_type_var(&mut self) -> Type {
-        let id = self.env.fresh(None);
+        let id = self.env.fresh();
         Type::Var { id, hint: None }
     }
 
     fn new_type_var_with_hint(&mut self, hint: &str) -> Type {
         let hint: EcoString = hint.into();
-        let id = self.env.fresh(Some(hint.clone()));
+        let id = self.env.fresh();
         Type::Var {
             id,
             hint: Some(hint),
@@ -345,7 +345,7 @@ impl TaskState {
                 let map: SubstitutionMap = vars
                     .iter()
                     .map(|name| {
-                        let id = self.env.fresh(Some(name.clone()));
+                        let id = self.env.fresh();
                         let fresh_var = Type::Var {
                             id,
                             hint: Some(name.clone()),
@@ -369,7 +369,7 @@ impl TaskState {
             return false;
         };
 
-        module.typedefs.contains_key(&file_id)
+        module.is_typedef(file_id)
     }
 
     fn is_lis(&self, store: &Store) -> bool {
@@ -410,11 +410,7 @@ impl TaskState {
     ) -> Vec<Generic> {
         let mut resolved = generics.to_vec();
         for generic in &mut resolved {
-            generic.resolved_bounds = generic
-                .bounds
-                .iter()
-                .map(|bound| self.register_bound_annotation(store, bound, span))
-                .collect();
+            generic.resolve_bounds_with(|bound| self.register_bound_annotation(store, bound, span));
         }
         self.record_resolved_generic_bounds(&resolved);
         resolved
@@ -422,7 +418,10 @@ impl TaskState {
 
     fn record_resolved_generic_bounds(&mut self, generics: &[Generic]) {
         for generic in generics {
-            for bound in &generic.resolved_bounds {
+            for bound in generic
+                .resolved_bounds()
+                .expect("generic bounds were resolved before recording")
+            {
                 self.record_generic_bound(&generic.name, bound.clone());
             }
         }
@@ -434,10 +433,7 @@ impl TaskState {
         generics: Vec<Generic>,
         span: &Span,
     ) -> Vec<Generic> {
-        if generics
-            .iter()
-            .all(|generic| generic.bounds.len() == generic.resolved_bounds.len())
-        {
+        if generics.iter().all(Generic::bounds_are_resolved) {
             self.record_resolved_generic_bounds(&generics);
             generics
         } else {
@@ -484,7 +480,7 @@ impl TaskState {
         span: &Span,
     ) -> Type {
         let resolved = self.convert_bound_to_type(store, bound, span);
-        if self.is_lis(store) && resolved.contains_unknown() {
+        if self.is_lis(store) && store.contains_unknown(&resolved) {
             self.sink
                 .push(diagnostics::infer::unknown_in_bound_position(
                     bound.get_span(),
@@ -661,12 +657,8 @@ impl TaskState {
 
         // Type alias to tuple struct should return constructor type.
         if let DefinitionBody::TypeAlias { .. } = &definition.body {
-            let alias_ty = &definition.ty;
-            let underlying = match alias_ty {
-                Type::Forall { body, .. } => body.as_ref(),
-                other => other,
-            };
-            if let Type::Nominal { id, .. } = underlying
+            let underlying = store.peel_alias(&definition.ty);
+            if let Type::Nominal { id, .. } = &underlying
                 && let Some(Definition {
                     body:
                         DefinitionBody::Struct {
@@ -1069,11 +1061,15 @@ pub(crate) fn resolved_generic_bounds(generics: &[Generic]) -> Vec<Bound> {
     generics
         .iter()
         .flat_map(|generic| {
-            generic.resolved_bounds.iter().cloned().map(|ty| Bound {
-                param_name: generic.name.clone(),
-                generic: Type::Parameter(generic.name.clone()),
-                ty,
-            })
+            generic
+                .resolved_bounds()
+                .expect("generic bounds must be resolved before use")
+                .cloned()
+                .map(|ty| Bound {
+                    param_name: generic.name.clone(),
+                    generic: Type::Parameter(generic.name.clone()),
+                    ty,
+                })
         })
         .collect()
 }

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -436,7 +436,6 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_parts(MODULE, name),
             params: vec![],
-            underlying_ty: None,
         }
     }
 
@@ -540,12 +539,7 @@ mod tests {
                 DefinitionBody::Struct {
                     generics: generics
                         .into_iter()
-                        .map(|g| Generic {
-                            name: g.into(),
-                            bounds: vec![],
-                            resolved_bounds: vec![],
-                            span: Span::dummy(),
-                        })
+                        .map(|g| Generic::new(g, vec![], Span::dummy()))
                         .collect(),
                     fields,
                     kind: StructKind::Record,
@@ -591,7 +585,6 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_parts(MODULE, name),
             params: args,
-            underlying_ty: None,
         }
     }
 

--- a/crates/semantics/src/checker/registration/builtins.rs
+++ b/crates/semantics/src/checker/registration/builtins.rs
@@ -75,7 +75,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Result"),
             params: vec![ok_type, error_type],
-            underlying_ty: None,
         }
     }
 
@@ -83,7 +82,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Option"),
             params: vec![some_type],
-            underlying_ty: None,
         }
     }
 
@@ -91,7 +89,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "PanicValue"),
             params: vec![],
-            underlying_ty: None,
         }
     }
 
@@ -99,7 +96,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Range"),
             params: vec![element_type],
-            underlying_ty: None,
         }
     }
 
@@ -107,7 +103,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeInclusive"),
             params: vec![element_type],
-            underlying_ty: None,
         }
     }
 
@@ -115,7 +110,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeFrom"),
             params: vec![element_type],
-            underlying_ty: None,
         }
     }
 
@@ -123,7 +117,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeTo"),
             params: vec![element_type],
-            underlying_ty: None,
         }
     }
 
@@ -131,7 +124,6 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeToInclusive"),
             params: vec![element_type],
-            underlying_ty: None,
         }
     }
 

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -7,7 +7,7 @@ use crate::checker::infer::expressions::comparison::{
 };
 use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span};
-use syntax::program::{Definition, DefinitionBody};
+use syntax::program::DefinitionBody;
 use syntax::types::{
     FunctionParameter, SubstitutionMap, Symbol, Type, substitute, unqualified_name,
 };
@@ -342,30 +342,6 @@ impl TaskState {
                     self.check_map_key_comparable(store, key_ty, *annotation_span);
                 }
 
-                // Preserve alias name in emitter output. Guard against re-wrapping bodies whose
-                // id already matches (function aliases are pre-wrapped by populate_type_alias).
-                let body_differs = match &resolved_ty {
-                    Type::Nominal { id, .. } => id.as_str() != qualified_name.as_str(),
-                    other => other.is_structural_alias_body(),
-                };
-                if body_differs
-                    && let Some(Definition {
-                        body:
-                            DefinitionBody::TypeAlias {
-                                annotation: alias_ann,
-                                ..
-                            },
-                        ..
-                    }) = store.get_definition(&qualified_name)
-                    && !alias_ann.is_opaque()
-                {
-                    return Type::Nominal {
-                        id: qualified_name.into(),
-                        params: concrete_args,
-                        underlying_ty: Some(Box::new(resolved_ty)),
-                    };
-                }
-
                 resolved_ty
             }
 
@@ -420,7 +396,6 @@ impl TaskState {
             return Type::Nominal {
                 id: Symbol::from_parts("prelude", "Array"),
                 params: vec![element],
-                underlying_ty: None,
             };
         }
 
@@ -573,9 +548,9 @@ impl TaskState {
         self.resolve_type_from_prelude(store, type_name)
     }
 
-    /// Substitute the `body` with the resolved `type_args`, returning both the
-    /// substituted type and the resolved args (1:1 with `type_args`) so callers
-    /// can reuse them without re-resolving (which would re-emit diagnostics).
+    /// Substitute the `body` with the resolved `type_args`, keeping each source
+    /// annotation paired with its type so callers can reuse the result without
+    /// re-resolving (which would re-emit diagnostics).
     pub(crate) fn instantiate_from_annotations(
         &mut self,
         store: &Store,
@@ -583,16 +558,21 @@ impl TaskState {
         body: &Type,
         type_args: &[Annotation],
         span: &Span,
-    ) -> (Type, Vec<Type>) {
-        let args: Vec<Type> = type_args
+    ) -> (Type, Vec<(Annotation, Type)>) {
+        let args: Vec<(Annotation, Type)> = type_args
             .iter()
-            .map(|arg_ann| self.convert_to_type(store, arg_ann, span))
+            .map(|annotation| {
+                (
+                    annotation.clone(),
+                    self.convert_to_type(store, annotation, span),
+                )
+            })
             .collect();
 
         let map: SubstitutionMap = generics
             .iter()
             .zip(args.iter())
-            .map(|(name, ty)| (name.clone(), ty.clone()))
+            .map(|(name, (_, ty))| (name.clone(), ty.clone()))
             .collect();
 
         (substitute(body, &map), args)
@@ -659,7 +639,7 @@ impl TaskState {
     pub(super) fn check_map_key_comparable(&mut self, store: &Store, key_ty: &Type, span: Span) {
         let resolved = key_ty.resolve_in(&self.env);
 
-        if self.is_lis(store) && resolved.resolves_to_unknown() {
+        if self.is_lis(store) && store.resolves_to_unknown(&resolved) {
             self.sink.push(diagnostics::infer::unknown_as_map_key(span));
             return;
         }
@@ -698,7 +678,7 @@ impl TaskState {
         for (key, span, check_concrete) in self.scopes.take_deferred_map_key_checks() {
             if check_concrete {
                 let resolved = key.resolve_in(&self.env);
-                if !resolved.resolves_to_unknown() {
+                if !store.resolves_to_unknown(&resolved) {
                     self.check_map_key_comparable(store, &resolved, span);
                 }
             } else {
@@ -758,7 +738,7 @@ impl TaskState {
         if argument.is_variable()
             || matches!(argument, Type::Parameter(_))
             || argument.contains_error()
-            || argument.contains_unknown()
+            || store.contains_unknown(&argument)
         {
             return;
         }
@@ -815,7 +795,7 @@ impl TaskState {
                         .push(diagnostics::infer::not_comparable_bound(span));
                 }
             }
-            BuiltinBound::Ordered if !resolved.satisfies_ordered_constraint() => {
+            BuiltinBound::Ordered if !store.satisfies_ordered_constraint(&resolved) => {
                 self.sink
                     .push(diagnostics::infer::not_orderable_bound(span));
             }

--- a/crates/semantics/src/checker/registration/derived_attributes.rs
+++ b/crates/semantics/src/checker/registration/derived_attributes.rs
@@ -60,7 +60,6 @@ impl TaskState {
             module
                 .files
                 .values()
-                .chain(module.typedefs.values())
                 .flat_map(|file| {
                     collect_derived_attributes(module_id, file.is_d_lis(), &file.items)
                 })

--- a/crates/semantics/src/checker/registration/display.rs
+++ b/crates/semantics/src/checker/registration/display.rs
@@ -48,11 +48,7 @@ impl TaskState {
         let qualified = Symbol::from_parts(&candidate.module_id, name);
         if is_struct
             && let Some(definition) = store.get_definition(qualified.as_str())
-            && definition.is_pointer_backed_newtype(|id| {
-                store
-                    .get_definition(id)
-                    .is_some_and(Definition::is_type_alias)
-            })
+            && definition.is_pointer_backed_newtype(|id| store.get_definition(id))
         {
             self.sink
                 .push(diagnostics::attribute::display_on_pointer_newtype(
@@ -126,11 +122,11 @@ impl TaskState {
                 name_span,
                 doc: None,
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             });
     }

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -236,11 +236,15 @@ impl TaskState {
                     .equality_index
                     .insert_ufcs_lowered(id.to_string(), visibility);
             } else if matches!(classification, UserEquals::ValidReceiver) {
-                store.equality_index.insert_method(
-                    id.to_string(),
-                    visibility,
-                    synthesized.contains(id_str),
-                );
+                if synthesized.contains(id_str) {
+                    store
+                        .equality_index
+                        .insert_synthesized_method(id.to_string(), visibility);
+                } else {
+                    store
+                        .equality_index
+                        .insert_declared_method(id.to_string(), visibility);
+                }
             }
         }
     }
@@ -292,11 +296,11 @@ impl TaskState {
                 name_span,
                 doc: None,
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             });
     }

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -15,7 +15,10 @@ impl TaskState {
         declaration_span: Span,
     ) {
         for generic in own_generics {
-            for bound in &generic.resolved_bounds {
+            for bound in generic
+                .resolved_bounds()
+                .expect("generic bounds were resolved before checking")
+            {
                 self.check_bound_type(store, own_generics, declaration_span, bound, true, false);
             }
         }
@@ -134,7 +137,7 @@ impl TaskState {
             {
                 self.check_builtin_bound_argument(store, &argument, required, declaration_span);
             } else if !argument.contains_error()
-                && !argument.contains_unknown()
+                && !store.contains_unknown(&argument)
                 && !argument.is_variable()
                 && resolved_required
                     .get_qualified_id()
@@ -189,8 +192,8 @@ impl TaskState {
         let generic = own_generics
             .iter()
             .find(|generic| generic.name == parameter_name)?;
-        (!generic.resolved_bounds.iter().any(Type::contains_error))
-            .then(|| generic.resolved_bounds.clone())
+        let bounds = generic.resolved_bounds()?.cloned().collect::<Vec<_>>();
+        (!bounds.iter().any(Type::contains_error)).then_some(bounds)
     }
 }
 

--- a/crates/semantics/src/checker/registration/impl_bounds.rs
+++ b/crates/semantics/src/checker/registration/impl_bounds.rs
@@ -64,7 +64,7 @@ impl TaskState {
         }
         let mut resolved_bounds = impl_bounds.iter();
         for (position, generic) in impl_generics.iter().enumerate() {
-            for annotation in &generic.bounds {
+            for annotation in generic.bounds() {
                 let Some(bound) = resolved_bounds.next() else {
                     return;
                 };

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -97,11 +97,11 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: None,
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             },
         );

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -241,13 +241,13 @@ impl TaskState {
             } else {
                 Visibility::Private
             };
-            let fn_sig = function.to_function_signature();
+            let fn_sig = function.function_definition_view();
             let fn_span = function.get_span();
             let mut fn_ty = self.extract_signature_parts(
                 &*store,
-                &fn_sig.generics,
-                &fn_sig.params,
-                &fn_sig.annotation,
+                fn_sig.generics,
+                fn_sig.params,
+                fn_sig.annotation,
                 &fn_span,
             );
             let qualified_name = format!("{}.{}", type_name, fn_sig.name);
@@ -266,9 +266,9 @@ impl TaskState {
             }
 
             let (method_signature_pairs, method_signature_bounds) =
-                super::function_signature_pairs(&fn_ty, &fn_sig.params, fn_span);
+                super::function_signature_pairs(&fn_ty, fn_sig.params, fn_span);
             self.scopes.push();
-            self.put_in_scope(&fn_sig.generics);
+            self.put_in_scope(fn_sig.generics);
             for bound in &method_signature_bounds {
                 self.record_generic_bound(&bound.param_name, bound.ty.clone());
             }
@@ -280,7 +280,7 @@ impl TaskState {
             let go_hints = extract_attribute_flags(fn_attrs, "go");
             let method_key: EcoString =
                 if is_instance_method && go_hints.iter().any(|h| h == "unexported") {
-                    super::seal_method_key(is_d_lis, fn_attrs, &module_id, &fn_sig.name)
+                    super::seal_method_key(is_d_lis, fn_attrs, &module_id, fn_sig.name)
                 } else {
                     fn_sig.name.clone()
                 };
@@ -313,7 +313,7 @@ impl TaskState {
             self.check_duplicate_method(
                 &*store,
                 &receiver,
-                &fn_sig.name,
+                fn_sig.name,
                 fn_sig.name_span,
                 generics.is_empty(),
             );
@@ -330,11 +330,11 @@ impl TaskState {
                     name_span: Some(fn_sig.name_span),
                     doc: fn_doc,
                     body: DefinitionBody::Value {
+                        kind: syntax::program::ValueKind::Runtime,
                         allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
                         go_hints,
                         go_name: None,
                         go_type_param_recipe: None,
-                        const_value: None,
                     },
                 },
             );
@@ -394,13 +394,13 @@ impl TaskState {
                 } else {
                     (&[][..], None)
                 };
-                let method_sig = fe.to_function_signature();
+                let method_sig = fe.function_definition_view();
                 let method_span = fe.get_span();
                 let fn_ty = self.extract_signature_parts(
                     &*store,
-                    &method_sig.generics,
-                    &method_sig.params,
-                    &method_sig.annotation,
+                    method_sig.generics,
+                    method_sig.params,
+                    method_sig.annotation,
                     &method_span,
                 );
                 let fn_ty = match &fn_ty {
@@ -434,7 +434,7 @@ impl TaskState {
                 self.scopes.push();
                 self.put_in_scope(&generics);
                 self.record_resolved_generic_bounds(&generics);
-                self.put_in_scope(&method_sig.generics);
+                self.put_in_scope(method_sig.generics);
                 for bound in &signature_bounds {
                     self.record_generic_bound(&bound.param_name, bound.ty.clone());
                 }
@@ -444,7 +444,7 @@ impl TaskState {
                 let go_hints = extract_attribute_flags(fn_attrs, "go");
                 if go_hints.iter().any(|h| h == "unexported") {
                     (
-                        super::seal_method_key(is_d_lis, fn_attrs, &module_id, &method_sig.name),
+                        super::seal_method_key(is_d_lis, fn_attrs, &module_id, method_sig.name),
                         fn_ty,
                     )
                 } else {
@@ -456,7 +456,7 @@ impl TaskState {
                         name_span: method_sig.name_span,
                         doc: fn_doc,
                     });
-                    (method_sig.name, fn_ty)
+                    (method_sig.name.clone(), fn_ty)
                 }
             })
             .collect();
@@ -518,11 +518,11 @@ impl TaskState {
                     name_span: Some(method.name_span),
                     doc: method.doc,
                     body: DefinitionBody::Value {
+                        kind: syntax::program::ValueKind::Runtime,
                         allowed_lints: method.allowed_lints,
                         go_hints: method.go_hints,
                         go_name: None,
                         go_type_param_recipe: None,
-                        const_value: None,
                     },
                 },
             );

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -22,9 +22,9 @@ use syntax::ast::{
 };
 use syntax::attributes::struct_attribute_forces_field_export;
 use syntax::program::{
-    Attributes, Definition, DefinitionBody, File, FileImport, TypeAttribute, Visibility,
+    AliasKind, Attributes, Definition, DefinitionBody, File, FileImport, TypeAttribute, Visibility,
 };
-use syntax::types::{Bound, FunctionParameter, Symbol, Type, unqualified_name};
+use syntax::types::{Bound, FunctionParameter, Symbol, Type};
 
 use super::{FileContextKind, TaskState, resolved_generic_bounds};
 use crate::store::Store;
@@ -116,7 +116,7 @@ fn has_serialization_attribute(attributes: &[Attribute]) -> bool {
 fn collect_enum_attributes(attributes: &[Attribute]) -> Attributes {
     let mut map = Attributes::default();
     if has_display_attribute(attributes) {
-        map.insert(TypeAttribute::Display, ());
+        map.insert(TypeAttribute::Display);
     }
     map
 }
@@ -124,19 +124,19 @@ fn collect_enum_attributes(attributes: &[Attribute]) -> Attributes {
 fn collect_struct_attributes(attributes: &[Attribute]) -> Attributes {
     let mut map = Attributes::default();
     if has_display_attribute(attributes) {
-        map.insert(TypeAttribute::Display, ());
+        map.insert(TypeAttribute::Display);
     }
     if has_closed_domain_attribute(attributes) {
-        map.insert(TypeAttribute::ClosedDomain, ());
+        map.insert(TypeAttribute::ClosedDomain);
     }
     if has_anon_struct_attribute(attributes) {
-        map.insert(TypeAttribute::AnonStruct, ());
+        map.insert(TypeAttribute::AnonStruct);
     }
     if has_hidden_embed_attribute(attributes) {
-        map.insert(TypeAttribute::HiddenEmbed, ());
+        map.insert(TypeAttribute::HiddenEmbed);
     }
     if has_serialization_attribute(attributes) {
-        map.insert(TypeAttribute::Serialized, ());
+        map.insert(TypeAttribute::Serialized);
     }
     map
 }
@@ -276,8 +276,6 @@ impl TaskState {
             self.register_file_type_aliases(store, id, *file_id, imports);
         }
 
-        self.settle_module_aliases(store, id);
-
         for (file_id, imports) in &file_data {
             self.register_file_type_bodies(store, id, *file_id, imports);
         }
@@ -308,19 +306,15 @@ impl TaskState {
         let Some(module) = store.get_module_mut(module_id) else {
             return;
         };
-        for file in module
-            .files
-            .values_mut()
-            .chain(module.typedefs.values_mut())
-        {
+        for file in module.files.values_mut() {
             for item in &mut file.items {
                 populate_expression_generic_bounds(item, &self.facts.bound_types);
             }
         }
     }
 
-    /// Fill `resolved_bounds` on each item's generics, mirroring the per-module
-    /// pass. Test harnesses that emit a typed AST directly bypass that pass.
+    /// Resolve each item's generic bounds from the per-module pass results.
+    /// Test harnesses that emit a typed AST directly bypass that pass.
     pub fn populate_item_generic_bounds(&self, items: &mut [Expression]) {
         for item in items {
             populate_expression_generic_bounds(item, &self.facts.bound_types);
@@ -424,7 +418,7 @@ impl TaskState {
         if let Some(path) = cache_path {
             store.typedef_paths.insert(file_id, path);
         }
-        store.store_file(module_id, file);
+        store.store_file(file);
 
         self.with_file_context_mut(
             store,
@@ -453,14 +447,14 @@ impl TaskState {
             .get_module(module_id)
             .expect("module must exist for declaration");
         let mut entries = Vec::new();
-        for file in module.files.values() {
+        for file in module.source_files() {
             entries.extend(self.collect_type_name_entries(
                 &file.items,
                 &Visibility::Private,
                 false,
             ));
         }
-        for file in module.all_typedefs() {
+        for file in module.typedef_files() {
             entries.extend(self.collect_type_name_entries(&file.items, &Visibility::Private, true));
         }
         entries
@@ -490,7 +484,6 @@ impl TaskState {
         module
             .files
             .iter()
-            .chain(module.typedefs.iter())
             .map(|(file_id, f)| (*file_id, f.imports()))
             .collect()
     }
@@ -666,14 +659,12 @@ impl TaskState {
                     Type::Nominal {
                         id: qualified_name.clone(),
                         params: args,
-                        underlying_ty: None,
                     }
                 }
             } else {
                 Type::Nominal {
                     id: qualified_name.clone(),
                     params: args,
-                    underlying_ty: None,
                 }
             };
 
@@ -709,11 +700,11 @@ impl TaskState {
                     name_span: None,
                     doc: None,
                     body: DefinitionBody::Value {
+                        kind: syntax::program::ValueKind::Runtime,
                         allowed_lints: vec![],
                         go_hints: vec![],
                         go_name: None,
                         go_type_param_recipe: None,
-                        const_value: None,
                     },
                 },
             ));
@@ -751,8 +742,6 @@ impl TaskState {
 
     pub(crate) fn register_type_definitions(&mut self, store: &mut Store, items: &[Expression]) {
         self.register_type_aliases(store, items);
-        let module_id = self.cursor.module_id.clone();
-        self.settle_module_aliases(store, &module_id);
         self.register_type_bodies(store, items);
     }
 
@@ -881,7 +870,7 @@ impl TaskState {
             return;
         };
 
-        if body.is_noop() && self.is_lis(&*store) {
+        if body.definition().is_none() && self.is_lis(&*store) {
             self.sink
                 .push(diagnostics::infer::bodyless_function_outside_typedef(*span));
         }
@@ -928,11 +917,11 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: extract_attribute_flags(attributes, "allow"),
                     go_hints: extract_attribute_flags(attributes, "go"),
                     go_name: extract_go_name(attributes),
                     go_type_param_recipe: extract_go_type_param_recipe(attributes),
-                    const_value: None,
                 },
             },
         );
@@ -958,7 +947,7 @@ impl TaskState {
             return;
         };
 
-        let has_value = !expression.is_noop();
+        let has_value = expression.value().is_some();
 
         if !has_value && self.is_lis(&*store) {
             self.sink
@@ -978,7 +967,9 @@ impl TaskState {
         let const_ty = if let Some(annotation) = maybe_annotation {
             self.convert_to_type(store, annotation, span)
         } else {
-            self.type_from_literal_expression(expression)
+            expression
+                .value()
+                .and_then(|value| self.type_from_literal_expression(value))
                 .unwrap_or_else(|| self.new_type_var())
         };
         self.sink.truncate(before);
@@ -994,11 +985,9 @@ impl TaskState {
             ));
         }
 
-        let const_value = canonical_const_literal(expression);
+        let const_value = expression.value().and_then(canonical_const_literal);
 
-        let module = self.current_module_mut(store);
-        module.const_names.insert(qualified_name.clone());
-        module.definitions.insert(
+        self.current_module_mut(store).definitions.insert(
             qualified_name,
             Definition {
                 visibility: item_visibility,
@@ -1007,11 +996,11 @@ impl TaskState {
                 name_span: Some(*identifier_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Constant { value: const_value },
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value,
                 },
             },
         );
@@ -1059,11 +1048,11 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             },
         );
@@ -1151,7 +1140,7 @@ impl TaskState {
             .into_iter()
             .zip(params)
             .map(|(ty, binding)| {
-                FunctionParameter::named(ty, binding.pattern.get_identifier(), binding.mutable)
+                FunctionParameter::named(ty, binding.pattern.get_identifier(), binding.is_mutable())
             })
             .collect();
 
@@ -1178,7 +1167,7 @@ fn declaration_value_position_types(definition: &Definition) -> Vec<(Type, Span)
             .iter()
             .flat_map(|variant| variant_field_types(&variant.fields))
             .collect(),
-        DefinitionBody::TypeAlias { annotation, .. } => alias_body_types(definition, annotation),
+        DefinitionBody::TypeAlias { alias, .. } => alias_body_types(alias),
         _ => Vec::new(),
     }
 }
@@ -1216,17 +1205,13 @@ fn variant_field_types(fields: &VariantFields) -> Vec<(Type, Span)> {
     }
 }
 
-fn alias_body_types(definition: &Definition, annotation: &Annotation) -> Vec<(Type, Span)> {
-    let body = definition.ty.unwrap_forall();
-    if let Type::Nominal { id, .. } = body
-        && definition
-            .name
-            .as_ref()
-            .is_some_and(|name| unqualified_name(id) == name.as_str())
-    {
-        return Vec::new();
+fn alias_body_types(alias: &AliasKind) -> Vec<(Type, Span)> {
+    match alias {
+        AliasKind::Opaque(_) => Vec::new(),
+        AliasKind::Transparent { annotation, target } => {
+            vec![(target.clone(), annotation.get_span())]
+        }
     }
-    vec![(body.clone(), annotation.get_span())]
 }
 
 fn populate_expression_generic_bounds(
@@ -1265,16 +1250,12 @@ fn populate_generic_bounds(
     bound_types: &rustc_hash::FxHashMap<Span, Type>,
 ) {
     for generic in generics {
-        generic.resolved_bounds = generic
-            .bounds
-            .iter()
-            .map(|bound| {
-                bound_types
-                    .get(&bound.get_span())
-                    .cloned()
-                    .unwrap_or(Type::Error)
-            })
-            .collect();
+        generic.resolve_bounds_with(|bound| {
+            bound_types
+                .get(&bound.get_span())
+                .cloned()
+                .unwrap_or(Type::Error)
+        });
     }
 }
 

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -11,7 +11,6 @@ fn test_context_type() -> Type {
     Type::Nominal {
         id: Symbol::from_parts(crate::prelude::TEST_PRELUDE_MODULE_ID, "TestContext"),
         params: vec![],
-        underlying_ty: None,
     }
 }
 
@@ -32,7 +31,7 @@ impl TaskState {
         let module = store.get_module(module_id).expect("module must exist");
         let context_shadowed = module_shadows_test_context(store, module_id);
         let mut records: Vec<TestFunction> = Vec::new();
-        for file in module.files.values().chain(module.typedefs.values()) {
+        for file in module.files.values() {
             let in_test_file = file.is_test();
             for item in &file.items {
                 collect_test_candidates(

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -5,8 +5,8 @@ use syntax::ast::{
     VariantFields,
 };
 use syntax::containment::{EnumPayloads, definition_contains_by_value};
-use syntax::program::{Definition, DefinitionBody, MethodSignatures, Visibility};
-use syntax::types::{Symbol, Type};
+use syntax::program::{AliasKind, Definition, DefinitionBody, MethodSignatures, Visibility};
+use syntax::types::Type;
 
 use super::enum_variant_constructor_type;
 use crate::checker::TaskState;
@@ -98,11 +98,11 @@ impl TaskState {
                 name_span: Some(variant_name_span),
                 doc: variant_doc,
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             };
             module
@@ -314,23 +314,6 @@ impl TaskState {
 
         self.scopes.pop();
 
-        // Single-field non-generic tuple structs (e.g. `struct FileMode(uint32)`) are
-        // emitted as Go type aliases (`type FileMode uint32`). Set underlying_ty so the
-        // type checker allows numeric casts through them.
-        let struct_ty =
-            if *kind == StructKind::Tuple && new_fields.len() == 1 && generics.is_empty() {
-                match struct_ty {
-                    Type::Nominal { id, params, .. } => Type::Nominal {
-                        id,
-                        params,
-                        underlying_ty: Some(Box::new(new_fields[0].ty.clone())),
-                    },
-                    other => other,
-                }
-            } else {
-                struct_ty
-            };
-
         let visibility = self
             .current_module(&*store)
             .definitions
@@ -371,7 +354,7 @@ impl TaskState {
         for definition in module.definitions.values() {
             if definition
                 .name_span
-                .is_some_and(|span| module.typedefs.contains_key(&span.file_id))
+                .is_some_and(|span| module.is_typedef(span.file_id))
             {
                 continue;
             }
@@ -464,7 +447,7 @@ impl TaskState {
             .filter(|(_, definition)| matches!(definition.body, DefinitionBody::Struct { .. }))
             .filter_map(|(qualified_name, definition)| {
                 let span = definition.name_span?;
-                if module.typedefs.contains_key(&span.file_id) {
+                if module.is_typedef(span.file_id) {
                     return None;
                 }
                 Some((qualified_name.as_str(), definition.name.as_deref()?, span))
@@ -484,37 +467,6 @@ impl TaskState {
                 self.sink
                     .push(diagnostics::infer::recursive_type(name, span));
                 flagged.insert(qualified_name.to_string());
-            }
-        }
-    }
-
-    pub(super) fn settle_module_aliases(&self, store: &mut Store, module_id: &str) {
-        if module_id.starts_with("go:") {
-            return;
-        }
-        let Some(module) = store.get_module(module_id) else {
-            return;
-        };
-
-        let updates: Vec<(Symbol, Type)> = module
-            .definitions
-            .iter()
-            .filter(|(_, definition)| matches!(definition.body, DefinitionBody::TypeAlias { .. }))
-            .filter_map(|(name, definition)| {
-                let mut changed = false;
-                let mut in_progress = FxHashSet::default();
-                let filled =
-                    fill_alias_underlyings(&definition.ty, store, &mut changed, &mut in_progress);
-                changed.then(|| (name.clone(), filled))
-            })
-            .collect();
-
-        let Some(module) = store.get_module_mut(module_id) else {
-            return;
-        };
-        for (name, ty) in updates {
-            if let Some(definition) = module.definitions.get_mut(&name) {
-                definition.ty = ty;
             }
         }
     }
@@ -572,14 +524,12 @@ impl TaskState {
                         Type::Nominal {
                             id: qualified_name.clone(),
                             params,
-                            underlying_ty: None,
                         }
                     }
                 } else {
                     Type::Nominal {
                         id: qualified_name.clone(),
                         params,
-                        underlying_ty: None,
                     }
                 };
 
@@ -613,7 +563,7 @@ impl TaskState {
                     doc: doc.clone(),
                     body: DefinitionBody::TypeAlias {
                         generics,
-                        annotation: annotation.clone(),
+                        alias: AliasKind::Opaque(annotation.clone()),
                         methods: Default::default(),
                         attributes: super::collect_struct_attributes(attributes),
                     },
@@ -636,26 +586,20 @@ impl TaskState {
             body_ty
         };
 
-        let body_ty = if is_function_body {
-            let params: Vec<Type> = generics
-                .iter()
-                .map(|g| Type::Parameter(g.name.clone()))
-                .collect();
-            Type::Nominal {
-                id: qualified_name.clone(),
-                params,
-                underlying_ty: Some(Box::new(body_ty)),
-            }
-        } else {
-            body_ty
+        let params: Vec<Type> = generics
+            .iter()
+            .map(|g| Type::Parameter(g.name.clone()))
+            .collect();
+        let alias_reference = Type::Nominal {
+            id: qualified_name.clone(),
+            params,
         };
-
         let alias_ty = if generics.is_empty() {
-            body_ty
+            alias_reference
         } else {
             Type::Forall {
                 vars: generics.iter().map(|g| g.name.clone()).collect(),
-                body: Box::new(body_ty),
+                body: Box::new(alias_reference),
             }
         };
 
@@ -686,7 +630,10 @@ impl TaskState {
                 doc: doc.clone(),
                 body: DefinitionBody::TypeAlias {
                     generics,
-                    annotation: annotation.clone(),
+                    alias: AliasKind::Transparent {
+                        annotation: annotation.clone(),
+                        target: body_ty,
+                    },
                     methods: Default::default(),
                     attributes: super::collect_struct_attributes(attributes),
                 },
@@ -712,14 +659,19 @@ impl TaskState {
             }
             seen.push(name.clone());
 
-            if let Some(def) = store.get_definition(&name)
-                && matches!(def.body, DefinitionBody::TypeAlias { .. })
+            if let Some(Definition {
+                body:
+                    DefinitionBody::TypeAlias {
+                        alias: AliasKind::Transparent { target, .. },
+                        ..
+                    },
+                ..
+            }) = store.get_definition(&name)
             {
-                let body = def.ty.unwrap_forall().clone();
-                if Self::type_contains_name(&body, qualified_name) {
+                if Self::type_contains_name(target, qualified_name) {
                     return true;
                 }
-                Self::collect_type_refs(&body, &mut to_visit);
+                Self::collect_type_refs(target, &mut to_visit);
             }
         }
 
@@ -847,107 +799,9 @@ fn has_selector_surface(store: &Store, ty: &Type) -> bool {
 }
 
 fn is_pointer_backed_newtype(store: &Store, ty: &Type) -> bool {
-    let Type::Nominal { id, .. } = ty else {
-        return false;
-    };
     store
-        .get_type(id.as_str())
-        .and_then(Type::get_underlying)
-        .is_some_and(|underlying| store.deep_resolve_alias(underlying).is_ref())
-}
-
-fn fill_alias_underlyings(
-    ty: &Type,
-    store: &Store,
-    changed: &mut bool,
-    in_progress: &mut FxHashSet<Symbol>,
-) -> Type {
-    match ty {
-        Type::Nominal {
-            id,
-            params,
-            underlying_ty,
-        } => {
-            let params: Vec<Type> = params
-                .iter()
-                .map(|param| fill_alias_underlyings(param, store, changed, in_progress))
-                .collect();
-            let underlying = match underlying_ty {
-                Some(inner) => Some(Box::new(fill_alias_underlyings(
-                    inner,
-                    store,
-                    changed,
-                    in_progress,
-                ))),
-                None if in_progress.contains(id) => None,
-                None => {
-                    let probe = Type::Nominal {
-                        id: id.clone(),
-                        params: params.clone(),
-                        underlying_ty: None,
-                    };
-                    let resolved = store.deep_resolve_alias(&probe);
-                    if resolved.get_qualified_id() == Some(id.as_str()) {
-                        None
-                    } else {
-                        *changed = true;
-                        in_progress.insert(id.clone());
-                        let filled = fill_alias_underlyings(&resolved, store, changed, in_progress);
-                        in_progress.remove(id);
-                        Some(Box::new(filled))
-                    }
-                }
-            };
-            Type::Nominal {
-                id: id.clone(),
-                params,
-                underlying_ty: underlying,
-            }
-        }
-        Type::Compound { kind, args } => Type::Compound {
-            kind: *kind,
-            args: args
-                .iter()
-                .map(|arg| fill_alias_underlyings(arg, store, changed, in_progress))
-                .collect(),
-        },
-        Type::Array { length, element } => Type::Array {
-            length: *length,
-            element: Box::new(fill_alias_underlyings(element, store, changed, in_progress)),
-        },
-        Type::Tuple(elements) => Type::Tuple(
-            elements
-                .iter()
-                .map(|element| fill_alias_underlyings(element, store, changed, in_progress))
-                .collect(),
-        ),
-        Type::Forall { vars, body } => Type::Forall {
-            vars: vars.clone(),
-            body: Box::new(fill_alias_underlyings(body, store, changed, in_progress)),
-        },
-        Type::Function(function) => {
-            let params = function
-                .params
-                .iter()
-                .map(|param| {
-                    param.with_type(fill_alias_underlyings(
-                        &param.ty,
-                        store,
-                        changed,
-                        in_progress,
-                    ))
-                })
-                .collect();
-            let return_type = Box::new(fill_alias_underlyings(
-                &function.return_type,
-                store,
-                changed,
-                in_progress,
-            ));
-            function.rebuild(params, function.bounds.clone(), return_type)
-        }
-        other => other.clone(),
-    }
+        .underlying_type(ty)
+        .is_some_and(|underlying| store.deep_resolve_alias(&underlying).is_ref())
 }
 
 // Mirror the written type's own visibility: peel storage (`Option`/`Ref`), not aliases.

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -9,12 +9,11 @@
 //! innermost log; a successful nested region joins its parent, while a failed
 //! region restores its entries in reverse order.
 
-use ecow::EcoString;
 use syntax::types::{Bound, Type, TypeVarId};
 
 #[derive(Debug, Clone)]
 pub enum VarState {
-    Unbound { hint: Option<EcoString> },
+    Unbound,
     Bound(Type),
 }
 
@@ -38,30 +37,21 @@ impl TypeEnv {
     }
 
     /// Allocate a fresh unbound variable and return its handle.
-    pub(crate) fn fresh(&mut self, hint: Option<EcoString>) -> TypeVarId {
-        let id = TypeVarId(self.entries.len() as u32);
-        self.entries.push(VarState::Unbound { hint });
+    pub(crate) fn fresh(&mut self) -> TypeVarId {
+        let id = TypeVarId::new(self.entries.len() as u32);
+        self.entries.push(VarState::Unbound);
         id
     }
 
     fn slot(id: TypeVarId) -> usize {
-        debug_assert!(
-            !id.is_reserved(),
-            "TypeEnv should not be queried for reserved ids"
-        );
-        id.0 as usize
+        id.index() as usize
     }
 
     pub(crate) fn state(&self, id: TypeVarId) -> &VarState {
         &self.entries[Self::slot(id)]
     }
 
-    /// Bind `id` to `ty`. Reserved sentinel ids (ignored/uninferred) are
-    /// silently accepted: they unify with anything without storing anything.
     pub(crate) fn bind(&mut self, id: TypeVarId, ty: Type) {
-        if id.is_reserved() {
-            return;
-        }
         let slot = Self::slot(id);
         let old = std::mem::replace(&mut self.entries[slot], VarState::Bound(ty));
         if let Some(log) = self.undo_logs.last_mut() {
@@ -75,8 +65,8 @@ impl TypeEnv {
         let mut current = ty.clone();
         loop {
             match &current {
-                Type::Var { id, .. } if !id.is_reserved() => match &self.entries[Self::slot(*id)] {
-                    VarState::Unbound { .. } => return current,
+                Type::Var { id, .. } => match &self.entries[Self::slot(*id)] {
+                    VarState::Unbound => return current,
                     VarState::Bound(bound) => current = bound.clone(),
                 },
                 _ => return current,
@@ -85,8 +75,7 @@ impl TypeEnv {
     }
 
     /// Deep resolve: chase `Type::Var` chains, substitute every bound var with
-    /// its chased value, and recurse into composites. Unbound vars (including
-    /// reserved sentinel ids like `IGNORED`/`UNINFERRED`) are preserved as-is.
+    /// its chased value, and recurse into composites. Unbound vars are preserved as-is.
     /// Used both during inference and as the post-inference freeze pass.
     pub(crate) fn resolve(&self, ty: &Type) -> Type {
         self.resolve_changed(ty).unwrap_or_else(|| ty.clone())
@@ -107,41 +96,25 @@ impl TypeEnv {
     /// is reachable), allocating just the changed spine. `None` means unchanged.
     fn resolve_changed(&self, ty: &Type) -> Option<Type> {
         match ty {
-            Type::Var { id, .. } if !id.is_reserved() => match &self.entries[Self::slot(*id)] {
-                VarState::Unbound { .. } => None,
+            Type::Var { id, .. } => match &self.entries[Self::slot(*id)] {
+                VarState::Unbound => None,
                 VarState::Bound(first) => {
                     let mut cursor = first;
                     loop {
                         match cursor {
-                            Type::Var { id, .. } if !id.is_reserved() => {
-                                match &self.entries[Self::slot(*id)] {
-                                    VarState::Unbound { .. } => return Some(cursor.clone()),
-                                    VarState::Bound(next) => cursor = next,
-                                }
-                            }
+                            Type::Var { id, .. } => match &self.entries[Self::slot(*id)] {
+                                VarState::Unbound => return Some(cursor.clone()),
+                                VarState::Bound(next) => cursor = next,
+                            },
                             _ => return Some(self.resolve(cursor)),
                         }
                     }
                 }
             },
-            Type::Nominal {
-                id,
-                params,
-                underlying_ty,
-            } => {
-                let new_params = self.resolve_slice(params);
-                let new_underlying = underlying_ty
-                    .as_ref()
-                    .and_then(|u| self.resolve_changed(u).map(Box::new));
-                if new_params.is_none() && new_underlying.is_none() {
-                    return None;
-                }
-                Some(Type::Nominal {
+            Type::Nominal { id, params } => {
+                self.resolve_slice(params).map(|params| Type::Nominal {
                     id: id.clone(),
-                    params: new_params.unwrap_or_else(|| params.clone()),
-                    underlying_ty: new_underlying
-                        .map(Some)
-                        .unwrap_or_else(|| underlying_ty.clone()),
+                    params,
                 })
             }
             Type::Compound { kind, args } => self
@@ -244,11 +217,8 @@ impl TypeEnv {
                 if *other == id {
                     return true;
                 }
-                if other.is_reserved() {
-                    return false;
-                }
                 match &self.entries[Self::slot(*other)] {
-                    VarState::Unbound { .. } => false,
+                    VarState::Unbound => false,
                     VarState::Bound(bound) => self.occurs(id, bound),
                 }
             }
@@ -313,7 +283,7 @@ mod tests {
         let mut env = TypeEnv::new();
         const DEPTH: usize = 100_000;
 
-        let ids: Vec<TypeVarId> = (0..DEPTH).map(|_| env.fresh(None)).collect();
+        let ids: Vec<TypeVarId> = (0..DEPTH).map(|_| env.fresh()).collect();
         for pair in ids.windows(2) {
             env.bind(pair[0], var(pair[1]));
         }
@@ -325,8 +295,8 @@ mod tests {
     #[test]
     fn outer_rollback_includes_committed_nested_bindings() {
         let mut env = TypeEnv::new();
-        let outer = env.fresh(None);
-        let inner = env.fresh(None);
+        let outer = env.fresh();
+        let inner = env.fresh();
 
         env.begin_speculation();
         env.bind(outer, Type::Simple(SimpleKind::Int));
@@ -335,7 +305,7 @@ mod tests {
         env.end_speculation(false);
         env.end_speculation(true);
 
-        assert!(matches!(env.state(outer), VarState::Unbound { .. }));
-        assert!(matches!(env.state(inner), VarState::Unbound { .. }));
+        assert!(matches!(env.state(outer), VarState::Unbound));
+        assert!(matches!(env.state(inner), VarState::Unbound));
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use diagnostics::PatternIssue;
 use syntax::EcoString;
 use syntax::ast::{BindingId, BindingKind, DeadCodeCause, Span};
-use syntax::program::{BindingMutation, ResolvedDefinitions, TestFunction};
+use syntax::program::{BindingMutation, TestFunction};
 use syntax::types::Type;
 
 #[derive(Debug, Default)]
@@ -74,10 +74,6 @@ pub struct Facts {
     /// annotation's span. Lets emit render bounds from the resolved type
     /// instead of re-resolving the annotation.
     pub bound_types: HashMap<Span, Type>,
-
-    /// Canonical definition selected for resolved dot accesses, keyed by the
-    /// dot expression's span.
-    pub resolved_definitions: ResolvedDefinitions,
 }
 
 #[derive(Debug, Clone)]
@@ -186,7 +182,6 @@ impl Facts {
             equality_derivations: Vec::new(),
             test_functions: Vec::new(),
             bound_types: HashMap::default(),
-            resolved_definitions: HashMap::default(),
         }
     }
 
@@ -220,6 +215,12 @@ impl Facts {
         if let Some(fact) = self.bindings.get_mut(&id) {
             fact.used = true;
         }
+    }
+
+    pub fn binding_id_at(&self, span: Span) -> Option<BindingId> {
+        self.bindings
+            .iter()
+            .find_map(|(&id, binding)| (binding.span == span).then_some(id))
     }
 
     pub(crate) fn mark_mutated(&mut self, id: BindingId) {
@@ -336,12 +337,10 @@ impl Facts {
             equality_derivations,
             test_functions,
             bound_types,
-            resolved_definitions,
         } = other;
         self.equality_derivations.extend(equality_derivations);
         self.test_functions.extend(test_functions);
         self.bound_types.extend(bound_types);
-        self.resolved_definitions.extend(resolved_definitions);
 
         self.bindings.extend(bindings);
         self.dead_code.extend(dead_code);

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -24,8 +24,8 @@ pub(crate) fn apply_bounds(generics: &[Generic], arguments: &[Type]) -> Vec<Appl
         .flat_map(|(generic, argument)| {
             let substitution = &substitution;
             generic
-                .resolved_bounds
-                .iter()
+                .resolved_bounds()
+                .expect("generic bounds must be resolved before use")
                 .map(move |bound| AppliedGenericBound {
                     parameter_name: generic.name.clone(),
                     argument: argument.clone(),
@@ -160,7 +160,7 @@ impl TaskState {
             let key = (obligation.span, argument.to_string(), required.to_string());
             if !seen.insert(key)
                 || argument.contains_error()
-                || argument.contains_unknown()
+                || store.contains_unknown(&argument)
                 || required.contains_error()
             {
                 continue;
@@ -229,13 +229,12 @@ fn return_type_declares_obligation(
 mod tests {
     use super::*;
     use syntax::ast::{Annotation, Span};
-    use syntax::program::{Definition, DefinitionBody, Visibility};
+    use syntax::program::{AliasKind, Definition, DefinitionBody, Visibility};
 
     fn nominal(id: &str, params: Vec<Type>) -> Type {
         Type::Nominal {
             id: Symbol::from_raw(id),
             params,
-            underlying_ty: None,
         }
     }
 
@@ -253,13 +252,14 @@ mod tests {
             name_span: None,
             doc: None,
             body: DefinitionBody::TypeAlias {
-                generics: vec![Generic {
-                    name: "T".into(),
-                    bounds: vec![],
-                    resolved_bounds: vec![],
-                    span: Span::new(0, 0, 0),
-                }],
-                annotation: Annotation::Unknown,
+                generics: vec![Generic::new("T", vec![], Span::new(0, 0, 0))],
+                alias: AliasKind::Transparent {
+                    annotation: Annotation::Unknown,
+                    target: nominal(
+                        "Option",
+                        vec![nominal("m.A", vec![Type::Parameter("T".into())])],
+                    ),
+                },
                 methods: Default::default(),
                 attributes: Default::default(),
             },

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -197,18 +197,15 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             let file_id = store.new_file_id();
             let result = syntax::build_ast(&content.source, file_id);
             sink.extend_parse_errors(result.errors);
-            store.store_file(
+            store.store_file(File::new(
                 ENTRY_MODULE_ID,
-                File::new(
-                    ENTRY_MODULE_ID,
-                    &filename,
-                    &content.display_path,
-                    &content.source,
-                    result.ast,
-                    result.file_comment,
-                    file_id,
-                ),
-            );
+                &filename,
+                &content.display_path,
+                &content.source,
+                result.ast,
+                result.file_comment,
+                file_id,
+            ));
         }
     }
 
@@ -721,8 +718,8 @@ fn infer_modules(checker: &mut TaskState, store: &mut Store, to_infer: &[String]
         checker.absorb_outputs(outputs);
     }
 
-    for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {
-        store.store_file(&module_id, typed_file);
+    for (_, typed_file) in std::mem::take(&mut checker.typed_files) {
+        store.store_file(typed_file);
     }
 
     checker.check_post_inference_bounds(store);

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -19,18 +19,15 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
     sink.extend_parse_errors(result.errors);
 
     store.mark_visited(PRELUDE_MODULE_ID);
-    store.store_file(
-        PRELUDE_MODULE_ID,
-        File {
-            id: PRELUDE_FILE_ID,
-            module_id: PRELUDE_MODULE_ID.to_string(),
-            name: "prelude.d.lis".to_string(),
-            display_path: "prelude.d.lis".to_string(),
-            source: LIS_PRELUDE_SOURCE.to_string(),
-            items: result.ast,
-            file_comment: None,
-        },
-    );
+    store.store_file(File {
+        id: PRELUDE_FILE_ID,
+        module_id: PRELUDE_MODULE_ID.to_string(),
+        name: "prelude.d.lis".to_string(),
+        display_path: "prelude.d.lis".to_string(),
+        source: LIS_PRELUDE_SOURCE.to_string(),
+        items: result.ast,
+        file_comment: None,
+    });
 
     if let Some(path) = deps::prelude_typedef_path() {
         store.typedef_paths.insert(PRELUDE_FILE_ID, path);
@@ -49,11 +46,11 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         &[],
         FileContextKind::Prelude,
         |checker, store| {
-            for file in module.all_typedefs() {
+            for file in module.typedef_files() {
                 checker.register_type_names(store, &file.items, &Visibility::Public);
             }
 
-            for file in module.all_typedefs() {
+            for file in module.typedef_files() {
                 checker.register_type_definitions(store, &file.items);
                 checker.register_impl_blocks(store, &file.items);
                 checker.register_values(store, &file.items, &Visibility::Public);
@@ -74,18 +71,15 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
 
     store.mark_visited(TEST_PRELUDE_MODULE_ID);
     store.add_module(TEST_PRELUDE_MODULE_ID);
-    store.store_file(
-        TEST_PRELUDE_MODULE_ID,
-        File {
-            id: file_id,
-            module_id: TEST_PRELUDE_MODULE_ID.to_string(),
-            name: "test_prelude.d.lis".to_string(),
-            display_path: "test_prelude.d.lis".to_string(),
-            source: LIS_TEST_PRELUDE_SOURCE.to_string(),
-            items: result.ast,
-            file_comment: None,
-        },
-    );
+    store.store_file(File {
+        id: file_id,
+        module_id: TEST_PRELUDE_MODULE_ID.to_string(),
+        name: "test_prelude.d.lis".to_string(),
+        display_path: "test_prelude.d.lis".to_string(),
+        source: LIS_TEST_PRELUDE_SOURCE.to_string(),
+        items: result.ast,
+        file_comment: None,
+    });
 
     let mut checker = TaskState::with_fresh_allocator();
     let module = store
@@ -100,11 +94,11 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
         &[],
         FileContextKind::TestPrelude,
         |checker, store| {
-            for file in module.all_typedefs() {
+            for file in module.typedef_files() {
                 checker.register_type_names(store, &file.items, &Visibility::Public);
             }
 
-            for file in module.all_typedefs() {
+            for file in module.typedef_files() {
                 checker.register_type_definitions(store, &file.items);
                 checker.register_impl_blocks(store, &file.items);
                 checker.register_values(store, &file.items, &Visibility::Public);

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -184,18 +184,15 @@ impl Store {
         ast: Vec<Expression>,
         file_comment: Option<String>,
     ) {
-        self.store_file(
-            ENTRY_MODULE_ID,
-            File {
-                id: ENTRY_FILE_ID,
-                module_id: ENTRY_MODULE_ID.to_string(),
-                name: filename.to_string(),
-                display_path: display_path.to_string(),
-                source: source.to_string(),
-                items: ast,
-                file_comment,
-            },
-        );
+        self.store_file(File {
+            id: ENTRY_FILE_ID,
+            module_id: ENTRY_MODULE_ID.to_string(),
+            name: filename.to_string(),
+            display_path: display_path.to_string(),
+            source: source.to_string(),
+            items: ast,
+            file_comment,
+        });
     }
 
     pub fn store_module(&mut self, module_id: &str, files: Vec<File>) {
@@ -203,41 +200,32 @@ impl Store {
         self.add_module(module_id);
 
         for file in files {
-            self.store_file(module_id, file);
+            assert_eq!(file.module_id, module_id);
+            self.store_file(file);
         }
     }
 
     /// Stores a file in the module and registers the file_id -> module_id mapping.
-    /// .d.lis files go to `typedefs`, .lis files go to `files`.
-    pub fn store_file(&mut self, module_id: &str, file: File) {
-        self.files.insert(file.id, module_id.to_string());
+    pub fn store_file(&mut self, file: File) {
+        let module_id = file.module_id.clone();
+        self.files.insert(file.id, module_id.clone());
 
         let module = self
-            .get_module_mut(module_id)
+            .get_module_mut(&module_id)
             .expect("module must exist to store file");
-
-        if file.is_d_lis() {
-            module.typedefs.insert(file.id, file);
-        } else {
-            module.files.insert(file.id, file);
-        }
+        module.files.insert(file.id, file);
     }
 
     pub fn get_file(&self, file_id: u32) -> Option<&File> {
         let module_id = self.files.get(&file_id)?;
         let module = self.get_module(module_id)?;
-        module
-            .get_file(file_id)
-            .or_else(|| module.get_typedef_by_id(file_id))
+        module.get_file(file_id)
     }
 
     pub(crate) fn get_file_mut(&mut self, file_id: u32) -> Option<&mut File> {
         let module_id = self.files.get(&file_id)?.clone();
         let module = Arc::make_mut(self.modules.get_mut(&module_id)?);
-        module
-            .files
-            .get_mut(&file_id)
-            .or_else(|| module.typedefs.get_mut(&file_id))
+        module.files.get_mut(&file_id)
     }
 
     pub fn get_module(&self, module_id: &str) -> Option<&Module> {
@@ -325,9 +313,8 @@ impl Store {
     }
 
     pub(crate) fn is_const(&self, qualified_name: &str) -> bool {
-        self.module_for_qualified_name(qualified_name)
-            .and_then(|module_id| self.get_module(module_id))
-            .is_some_and(|module| module.const_names.contains(qualified_name))
+        self.get_definition(qualified_name)
+            .is_some_and(Definition::is_const)
     }
 
     pub fn variants_of(&self, qualified_name: &str) -> Option<&[EnumVariant]> {
@@ -358,7 +345,7 @@ impl Store {
                 // Float domains rely on exact-equality over fragile values and do
                 // not occur in the Go stdlib; they are deliberately not indexed.
                 if definition.is_closed_domain()
-                    && let Some(base) = definition.ty.underlying_simple_kind()
+                    && let Some(base) = self.underlying_simple_kind(&definition.ty)
                     && !base.is_float()
                 {
                     bases.insert(qualified_name.clone(), (base, module.id.clone()));
@@ -456,46 +443,99 @@ impl Store {
     }
 
     pub fn peel_alias(&self, ty: &Type) -> Type {
-        syntax::types::peel_alias(ty, |id| {
-            self.get_definition(id)
-                .is_some_and(Definition::is_type_alias)
-        })
+        syntax::types::peel_alias(ty, |id| self.get_definition(id))
     }
 
-    pub(crate) fn peel_refs_and_aliases(&self, ty: &Type) -> (Type, bool) {
+    pub fn underlying_type(&self, ty: &Type) -> Option<Type> {
+        syntax::types::underlying_type(ty, |id| self.get_definition(id))
+    }
+
+    pub fn peel_underlying(&self, ty: &Type) -> Type {
+        syntax::types::peel_underlying(ty, |id| self.get_definition(id))
+    }
+
+    pub fn underlying_simple_kind(&self, ty: &Type) -> Option<SimpleKind> {
+        syntax::types::underlying_simple_kind(ty, |id| self.get_definition(id))
+    }
+
+    pub fn underlying_numeric_type(&self, ty: &Type) -> Option<Type> {
+        syntax::types::underlying_numeric_type(ty, |id| self.get_definition(id))
+    }
+
+    pub fn literal_adaptation_target(&self, ty: &Type) -> Option<Type> {
+        syntax::types::literal_adaptation_target(ty, |id| self.get_definition(id))
+    }
+
+    pub fn is_numeric_compatible_with(&self, left: &Type, right: &Type) -> bool {
+        syntax::types::is_numeric_compatible_with(left, right, |id| self.get_definition(id))
+    }
+
+    pub fn is_aliased_numeric_type(&self, ty: &Type) -> bool {
+        syntax::types::is_aliased_numeric_type(ty, |id| self.get_definition(id))
+    }
+
+    pub fn has_underlying_numeric_type(&self, ty: &Type) -> bool {
+        self.underlying_numeric_type(ty).is_some()
+    }
+
+    pub fn has_underlying_rune(&self, ty: &Type) -> bool {
+        self.underlying_numeric_type(ty)
+            .is_some_and(|ty| ty.is_rune())
+    }
+
+    pub fn has_underlying_byte(&self, ty: &Type) -> bool {
+        self.underlying_numeric_type(ty)
+            .is_some_and(|ty| ty.is_simple(SimpleKind::Byte) || ty.is_simple(SimpleKind::Uint8))
+    }
+
+    pub fn has_byte_or_rune_slice_underlying(&self, ty: &Type) -> bool {
+        syntax::types::has_byte_or_rune_slice_underlying(ty, |id| self.get_definition(id))
+    }
+
+    pub fn is_orderable(&self, ty: &Type) -> bool {
+        syntax::types::is_orderable(ty, |id| self.get_definition(id))
+    }
+
+    pub fn satisfies_ordered_constraint(&self, ty: &Type) -> bool {
+        syntax::types::satisfies_ordered_constraint(ty, |id| self.get_definition(id))
+    }
+
+    pub fn resolves_to_unknown(&self, ty: &Type) -> bool {
+        syntax::types::resolves_to_unknown(ty, |id| self.get_definition(id))
+    }
+
+    pub fn contains_unknown(&self, ty: &Type) -> bool {
+        syntax::types::contains_unknown(ty, |id| self.get_definition(id))
+    }
+
+    pub fn resolve_to_function_type(&self, ty: &Type) -> Option<Type> {
+        let resolved = self.peel_alias(ty);
+        if matches!(resolved, Type::Function(_)) {
+            return Some(resolved);
+        }
+        self.underlying_type(ty)
+            .filter(|underlying| matches!(underlying, Type::Function(_)))
+    }
+
+    pub fn peel_refs_and_aliases(&self, ty: &Type) -> (Type, bool) {
         let mut current = self.peel_alias(ty);
         let mut behind_ref = false;
+        let mut seen = HashSet::default();
         while current.is_ref() {
             behind_ref = true;
-            current = self.peel_alias(&current.strip_refs());
+            let stripped = current.strip_refs();
+            if let Type::Nominal { id, .. } = stripped.unwrap_forall()
+                && !seen.insert(id.clone())
+            {
+                return (stripped, behind_ref);
+            }
+            current = self.peel_alias(&stripped);
         }
         (current, behind_ref)
     }
 
     pub fn deep_resolve_alias(&self, ty: &Type) -> Type {
-        let mut current = ty.clone();
-        let mut seen: HashSet<Symbol> = HashSet::default();
-        loop {
-            let Type::Nominal { id, params, .. } = &current else {
-                return current;
-            };
-            if !seen.insert(id.clone()) {
-                return current;
-            }
-            let Some(def) = self.get_definition(id.as_str()) else {
-                return current;
-            };
-            if !matches!(def.body, DefinitionBody::TypeAlias { .. }) {
-                return current;
-            }
-            let def_ty = &def.ty;
-            let (vars, body) = match def_ty {
-                Type::Forall { vars, body } => (vars.clone(), body.as_ref().clone()),
-                other => (vec![], other.clone()),
-            };
-            let map: SubstitutionMap = vars.iter().cloned().zip(params.iter().cloned()).collect();
-            current = substitute(&body, &map);
-        }
+        self.peel_alias(ty)
     }
 
     pub(crate) fn peel_alias_deep(&self, ty: &Type) -> Type {
@@ -511,14 +551,9 @@ impl Store {
                 length,
                 element: Box::new(self.peel_alias_deep(&element)),
             },
-            Type::Nominal {
-                id,
-                params,
-                underlying_ty,
-            } => Type::Nominal {
+            Type::Nominal { id, params } => Type::Nominal {
                 id,
                 params: params.iter().map(|p| self.peel_alias_deep(p)).collect(),
-                underlying_ty,
             },
             Type::Function(f) => {
                 let new_params = f
@@ -612,27 +647,10 @@ impl Store {
         if let Some(definition) = self.get_definition(&qualified_name)
             && matches!(definition.body, DefinitionBody::TypeAlias { .. })
         {
-            let alias_ty = &definition.ty;
-            let underlying = match alias_ty {
-                Type::Forall { body, .. } => body.as_ref(),
-                other => other,
-            };
-            let underlying_key = match underlying {
-                Type::Nominal { id, .. } => Some(id.as_str().to_string()),
-                Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
-                Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
-                Type::Array { .. } => Some("prelude.Array".to_string()),
-                _ => None,
-            };
-            // Follow only when the alias body names a different type. For
-            // opaque prelude natives (e.g. `type Map<K, V>`) the body points
-            // to itself — following would loop.
-            if let Some(k) = underlying_key
-                && k != qualified_name.as_str()
-            {
-                let alias_ty = alias_ty.clone();
+            let underlying = self.peel_alias(&stripped);
+            if underlying != stripped {
                 for (name, method_ty) in
-                    self.get_all_methods_recursive(&alias_ty, trait_bounds, visited)
+                    self.get_all_methods_recursive(&underlying, trait_bounds, visited)
                 {
                     methods.entry(name).or_insert(method_ty);
                 }
@@ -687,21 +705,21 @@ fn method_lookup_key(ty: &Type) -> Option<Symbol> {
 #[cfg(test)]
 mod closed_domain_tests {
     use super::*;
-    use syntax::ast::StructKind;
-    use syntax::program::{Attributes, TypeAttribute, Visibility};
+    use syntax::ast::{Annotation, Generic, Span, StructKind};
+    use syntax::program::{AliasKind, Attributes, TypeAttribute, Visibility};
+    use syntax::types::CompoundKind;
 
     fn nominal_int(id: &str) -> Type {
         Type::Nominal {
             id: Symbol::from_raw(id),
             params: vec![],
-            underlying_ty: Some(Box::new(Type::Simple(SimpleKind::Int))),
         }
     }
 
     fn struct_def(ty: Type, closed_domain: bool) -> Definition {
         let mut attributes = Attributes::default();
         if closed_domain {
-            attributes.insert(TypeAttribute::ClosedDomain, ());
+            attributes.insert(TypeAttribute::ClosedDomain);
         }
         Definition {
             visibility: Visibility::Public,
@@ -711,7 +729,16 @@ mod closed_domain_tests {
             doc: None,
             body: DefinitionBody::Struct {
                 generics: vec![],
-                fields: vec![],
+                fields: vec![StructFieldDefinition {
+                    doc: None,
+                    attributes: vec![],
+                    name: "0".into(),
+                    name_span: syntax::ast::Span::dummy(),
+                    annotation: syntax::ast::Annotation::Unknown,
+                    visibility: syntax::ast::Visibility::Private,
+                    ty: Type::Simple(SimpleKind::Int),
+                    embedded: false,
+                }],
                 kind: StructKind::Tuple,
                 methods: Default::default(),
                 constructor: None,
@@ -728,11 +755,13 @@ mod closed_domain_tests {
             name_span: None,
             doc: None,
             body: DefinitionBody::Value {
+                kind: syntax::program::ValueKind::Constant {
+                    value: Some(Literal::Integer { value, text: None }),
+                },
                 allowed_lints: vec![],
                 go_hints: vec![],
                 go_name: None,
                 go_type_param_recipe: None,
-                const_value: Some(Literal::Integer { value, text: None }),
             },
         }
     }
@@ -819,5 +848,102 @@ mod closed_domain_tests {
             .map(|m| m.display_name.as_str())
             .collect();
         assert_eq!(names, vec!["Sunday"]);
+    }
+
+    #[test]
+    fn generic_alias_target_is_instantiated_from_its_definition() {
+        let mut store = Store::new();
+        let generic = Generic::new("T", Vec::new(), Span::dummy());
+        let alias_ref = Type::Nominal {
+            id: Symbol::from_raw("m.Items"),
+            params: vec![Type::Parameter("T".into())],
+        };
+        insert(
+            &mut store,
+            "m",
+            "m.Items",
+            Definition {
+                visibility: Visibility::Public,
+                ty: Type::Forall {
+                    vars: vec!["T".into()],
+                    body: Box::new(alias_ref),
+                },
+                name: Some("Items".into()),
+                name_span: None,
+                doc: None,
+                body: DefinitionBody::TypeAlias {
+                    generics: vec![generic],
+                    alias: AliasKind::Transparent {
+                        annotation: Annotation::Unknown,
+                        target: Type::Compound {
+                            kind: CompoundKind::Slice,
+                            args: vec![Type::Parameter("T".into())],
+                        },
+                    },
+                    methods: Default::default(),
+                    attributes: Default::default(),
+                },
+            },
+        );
+
+        let occurrence = Type::Nominal {
+            id: Symbol::from_raw("m.Items"),
+            params: vec![Type::int()],
+        };
+        let expected = Type::Compound {
+            kind: CompoundKind::Slice,
+            args: vec![Type::int()],
+        };
+
+        assert_eq!(store.underlying_type(&occurrence), Some(expected.clone()));
+        assert_eq!(store.peel_alias(&occurrence), expected);
+    }
+
+    #[test]
+    fn newtype_representation_comes_from_its_definition() {
+        let mut store = Store::new();
+        let occurrence = nominal_int("m.Count");
+        insert(
+            &mut store,
+            "m",
+            "m.Count",
+            struct_def(occurrence.clone(), false),
+        );
+
+        assert_eq!(store.peel_underlying(&occurrence), Type::int());
+    }
+
+    #[test]
+    fn peeling_references_and_aliases_terminates_on_recursive_aliases() {
+        fn recursive_alias(name: &str, target: &str) -> Definition {
+            Definition {
+                visibility: Visibility::Public,
+                ty: nominal_int(name),
+                name: name.rsplit('.').next().map(Into::into),
+                name_span: None,
+                doc: None,
+                body: DefinitionBody::TypeAlias {
+                    generics: vec![],
+                    alias: AliasKind::Transparent {
+                        annotation: Annotation::Unknown,
+                        target: Type::Compound {
+                            kind: CompoundKind::Ref,
+                            args: vec![nominal_int(target)],
+                        },
+                    },
+                    methods: Default::default(),
+                    attributes: Default::default(),
+                },
+            }
+        }
+
+        let mut store = Store::new();
+        insert(&mut store, "m", "m.A", recursive_alias("m.A", "m.B"));
+        insert(&mut store, "m", "m.B", recursive_alias("m.B", "m.A"));
+
+        let (peeled, behind_ref) = store.peel_refs_and_aliases(&nominal_int("m.A"));
+
+        assert!(behind_ref);
+        assert_eq!(peeled, nominal_int("m.B"));
     }
 }

--- a/crates/semantics/src/zero.rs
+++ b/crates/semantics/src/zero.rs
@@ -113,7 +113,11 @@ fn has_zero_seen(
             has_zero_nominal(store, id, params, from_module, ty, visited)
         }
         Type::Forall { body, .. } => has_zero_seen(store, body, from_module, visited),
-        Type::Var { .. } | Type::Parameter(_) | Type::ReceiverPlaceholder => {
+        Type::Var { .. }
+        | Type::Uninferred
+        | Type::Ignored
+        | Type::Parameter(_)
+        | Type::ReceiverPlaceholder => {
             // Conservative: unresolved/abstract types have no known zero.
             Err(NoZero {
                 chain: vec![],
@@ -231,26 +235,17 @@ fn has_zero_nominal_fields(
             }
             Ok(())
         }
-        DefinitionBody::TypeAlias { annotation, .. } => {
-            let alias_ty = &def.ty;
-            if annotation.is_opaque() {
+        DefinitionBody::TypeAlias { alias, .. } => {
+            if matches!(alias, syntax::program::AliasKind::Opaque(_)) {
                 return Err(NoZero {
                     chain: vec![],
                     reason: NoZeroReason::NoZeroForType,
                     leaf_ty: original_ty.clone(),
                 });
             }
-            let underlying = match alias_ty {
-                Type::Forall { body, .. } => body.as_ref().clone(),
-                other => other.clone(),
-            };
-            let underlying = store.peel_alias(&underlying);
-            let map = build_substitution(alias_ty, params);
-            let resolved = if map.is_empty() {
-                underlying
-            } else {
-                substitute(&underlying, &map)
-            };
+            let resolved = def
+                .instantiate_alias_target(params)
+                .expect("transparent alias has a target");
             has_zero_seen(store, &resolved, from_module, visited)
         }
         // Enums and other definitions have no zero unless we add a designated

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1,6 +1,6 @@
 use ecow::EcoString;
 
-use crate::program::{CallKind, DotAccessKind, ReceiverCoercion};
+use crate::program::{CallKind, DotAccessResolution};
 use crate::types::Type;
 
 macro_rules! children {
@@ -26,9 +26,14 @@ pub enum DeadCodeCause {
 pub struct Binding {
     pub pattern: Pattern,
     pub annotation: Option<Annotation>,
-    pub typed_pattern: Option<TypedPattern>,
     pub ty: Type,
-    pub mutable: bool,
+    pub mut_span: Option<Span>,
+}
+
+impl Binding {
+    pub fn is_mutable(&self) -> bool {
+        self.mut_span.is_some()
+    }
 }
 
 impl std::fmt::Debug for Binding {
@@ -36,16 +41,146 @@ impl std::fmt::Debug for Binding {
         let mut s = f.debug_struct("Binding");
         s.field("pattern", &self.pattern);
         s.field("annotation", &self.annotation);
-        s.field("typed_pattern", &self.typed_pattern);
         s.field("ty", &self.ty);
-        if self.mutable {
-            s.field("mutable", &self.mutable);
+        if self.mut_span.is_some() {
+            s.field("mut_span", &self.mut_span);
         }
         s.finish()
     }
 }
 
 pub type BindingId = u32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentifierResolution {
+    Unresolved,
+    Binding(BindingId),
+    Definition(EcoString),
+}
+
+impl IdentifierResolution {
+    pub fn binding_id(&self) -> Option<BindingId> {
+        match self {
+            Self::Binding(id) => Some(*id),
+            Self::Unresolved | Self::Definition(_) => None,
+        }
+    }
+
+    pub fn definition(&self) -> Option<&str> {
+        match self {
+            Self::Definition(definition) => Some(definition),
+            Self::Unresolved | Self::Binding(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LetMode {
+    Plain,
+    Assert,
+    Else {
+        block: Box<Expression>,
+        else_span: Span,
+    },
+    /// Parser recovery for the invalid combination `let assert ... else ...`.
+    InvalidAssertElse {
+        block: Box<Expression>,
+        else_span: Span,
+    },
+}
+
+impl LetMode {
+    pub fn is_assert(&self) -> bool {
+        matches!(self, Self::Assert | Self::InvalidAssertElse { .. })
+    }
+
+    pub fn else_block(&self) -> Option<&Expression> {
+        match self {
+            Self::Else { block, .. } | Self::InvalidAssertElse { block, .. } => Some(block),
+            Self::Plain | Self::Assert => None,
+        }
+    }
+
+    pub fn else_block_mut(&mut self) -> Option<&mut Expression> {
+        match self {
+            Self::Else { block, .. } | Self::InvalidAssertElse { block, .. } => Some(block),
+            Self::Plain | Self::Assert => None,
+        }
+    }
+
+    pub fn map_else(self, map: impl FnOnce(Expression, Span) -> Expression) -> Self {
+        match self {
+            Self::Else { block, else_span } => Self::Else {
+                block: Box::new(map(*block, else_span)),
+                else_span,
+            },
+            Self::InvalidAssertElse { block, else_span } => Self::InvalidAssertElse {
+                block: Box::new(map(*block, else_span)),
+                else_span,
+            },
+            Self::Plain => Self::Plain,
+            Self::Assert => Self::Assert,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FunctionBody {
+    Declaration,
+    Definition(Box<Expression>),
+}
+
+impl FunctionBody {
+    pub fn definition(&self) -> Option<&Expression> {
+        match self {
+            Self::Declaration => None,
+            Self::Definition(body) => Some(body),
+        }
+    }
+
+    pub fn definition_mut(&mut self) -> Option<&mut Expression> {
+        match self {
+            Self::Declaration => None,
+            Self::Definition(body) => Some(body),
+        }
+    }
+
+    pub fn map_definition(self, map: impl FnOnce(Expression) -> Expression) -> Self {
+        match self {
+            Self::Declaration => Self::Declaration,
+            Self::Definition(body) => Self::Definition(Box::new(map(*body))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConstInitializer {
+    Declaration,
+    Value(Box<Expression>),
+}
+
+impl ConstInitializer {
+    pub fn value(&self) -> Option<&Expression> {
+        match self {
+            Self::Declaration => None,
+            Self::Value(value) => Some(value),
+        }
+    }
+
+    pub fn value_mut(&mut self) -> Option<&mut Expression> {
+        match self {
+            Self::Declaration => None,
+            Self::Value(value) => Some(value),
+        }
+    }
+
+    pub fn map_value(self, map: impl FnOnce(Expression) -> Expression) -> Self {
+        match self {
+            Self::Declaration => Self::Declaration,
+            Self::Value(value) => Self::Value(Box::new(map(*value))),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingKind {
@@ -84,7 +219,6 @@ impl BindingKind {
 pub struct MatchArm {
     pub pattern: Pattern,
     pub guard: Option<Box<Expression>>,
-    pub typed_pattern: Option<TypedPattern>,
     pub expression: Box<Expression>,
 }
 
@@ -115,7 +249,6 @@ pub struct SelectArm {
 pub enum SelectArmPattern {
     Receive {
         binding: Box<Pattern>,
-        typed_pattern: Option<TypedPattern>,
         receive_expression: Box<Expression>,
         body: Box<Expression>,
     },
@@ -139,6 +272,38 @@ pub enum RestPattern {
     Bind { name: EcoString, span: Span },
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConstructorPatternResolution {
+    Unresolved,
+    Const {
+        qualified_name: EcoString,
+        value: Option<Literal>,
+    },
+    EnumVariant {
+        enum_name: EcoString,
+        variant_name: EcoString,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordPatternResolution {
+    Unresolved,
+    Struct {
+        struct_name: EcoString,
+    },
+    EnumVariant {
+        enum_name: EcoString,
+        variant_name: EcoString,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SequencePatternResolution {
+    Unresolved,
+    Slice { element_type: Type },
+    Array { element_type: Type, length: u64 },
+}
+
 impl RestPattern {
     pub fn is_present(&self) -> bool {
         !matches!(self, RestPattern::Absent)
@@ -160,6 +325,7 @@ pub enum Pattern {
         identifier: EcoString,
         fields: Vec<Self>,
         rest: bool,
+        resolution: ConstructorPatternResolution,
         ty: Type,
         span: Span,
     },
@@ -167,6 +333,7 @@ pub enum Pattern {
         identifier: EcoString,
         fields: Vec<StructFieldPattern>,
         rest: bool,
+        resolution: RecordPatternResolution,
         ty: Type,
         span: Span,
     },
@@ -184,7 +351,7 @@ pub enum Pattern {
     Slice {
         prefix: Vec<Self>,
         rest: RestPattern,
-        element_ty: Type,
+        resolution: SequencePatternResolution,
         span: Span,
     },
     Or {
@@ -238,42 +405,7 @@ pub fn collect_pattern_bindings(pattern: &Pattern) -> Vec<(String, Span)> {
     }
 }
 
-/// Dataless variant index of [`Pattern`], usable as an array index.
-#[derive(Clone, Copy)]
-pub enum PatternKind {
-    Literal,
-    Unit,
-    EnumVariant,
-    Struct,
-    Tuple,
-    WildCard,
-    Identifier,
-    Slice,
-    Or,
-    AsBinding,
-}
-
-impl PatternKind {
-    // Relies on `AsBinding` staying the last variant.
-    pub const COUNT: usize = PatternKind::AsBinding as usize + 1;
-}
-
 impl Pattern {
-    pub fn kind(&self) -> PatternKind {
-        match self {
-            Pattern::Literal { .. } => PatternKind::Literal,
-            Pattern::Unit { .. } => PatternKind::Unit,
-            Pattern::EnumVariant { .. } => PatternKind::EnumVariant,
-            Pattern::Struct { .. } => PatternKind::Struct,
-            Pattern::Tuple { .. } => PatternKind::Tuple,
-            Pattern::WildCard { .. } => PatternKind::WildCard,
-            Pattern::Identifier { .. } => PatternKind::Identifier,
-            Pattern::Slice { .. } => PatternKind::Slice,
-            Pattern::Or { .. } => PatternKind::Or,
-            Pattern::AsBinding { .. } => PatternKind::AsBinding,
-        }
-    }
-
     pub fn get_span(&self) -> Span {
         match self {
             Pattern::Identifier { span, .. } => *span,
@@ -332,78 +464,15 @@ pub struct StructFieldPattern {
     pub value: Pattern,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum TypedPattern {
-    Wildcard,
-    Literal(Literal),
-    /// A qualified const pattern (e.g. `time.Friday`). A value comparison, not
-    /// an enum constructor: `qualified_name` is the resolved constant, `value`
-    /// is its known case-eligible literal when available.
-    Const {
-        qualified_name: EcoString,
-        ty: Type,
-        value: Option<Literal>,
-    },
-    EnumVariant {
-        enum_name: EcoString,
-        variant_name: EcoString,
-        variant_fields: Vec<EnumFieldDefinition>,
-        fields: Vec<TypedPattern>,
-        type_args: Vec<Type>,
-        field_types: Box<[Type]>,
-    },
-    EnumStructVariant {
-        enum_name: EcoString,
-        variant_name: EcoString,
-        variant_fields: Vec<EnumFieldDefinition>,
-        pattern_fields: Vec<(EcoString, TypedPattern)>,
-        type_args: Vec<Type>,
-    },
-    Struct {
-        struct_name: EcoString,
-        struct_fields: Vec<StructFieldDefinition>,
-        pattern_fields: Vec<(EcoString, TypedPattern)>,
-        type_args: Vec<Type>,
-    },
-    Slice {
-        prefix: Vec<TypedPattern>,
-        has_rest: bool,
-        element_type: Type,
-    },
-    Array {
-        prefix: Vec<TypedPattern>,
-        element_type: Type,
-        length: u64,
-    },
-    Tuple {
-        arity: usize,
-        elements: Vec<TypedPattern>,
-    },
-    Or {
-        alternatives: Vec<TypedPattern>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct FunctionDefinition {
-    pub name: EcoString,
-    pub name_span: Span,
-    pub generics: Vec<Generic>,
-    pub params: Vec<Binding>,
-    body: Box<Expression>,
-    return_type: Type,
-    pub annotation: Annotation,
-    ty: Type,
-}
-
 #[derive(Clone, Copy)]
 pub struct FunctionDefinitionView<'a> {
     pub name: &'a EcoString,
     pub name_span: Span,
     pub generics: &'a [Generic],
     pub params: &'a [Binding],
-    pub body: &'a Expression,
+    pub body: Option<&'a Expression>,
     pub return_type: &'a Type,
+    pub annotation: &'a Annotation,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -428,11 +497,15 @@ impl VariantFields {
         }
     }
 
-    pub fn iter(&self) -> std::slice::Iter<'_, EnumFieldDefinition> {
+    pub fn as_slice(&self) -> &[EnumFieldDefinition] {
         match self {
-            VariantFields::Unit => [].iter(),
-            VariantFields::Tuple(fields) | VariantFields::Struct(fields) => fields.iter(),
+            VariantFields::Unit => &[],
+            VariantFields::Tuple(fields) | VariantFields::Struct(fields) => fields,
         }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, EnumFieldDefinition> {
+        self.as_slice().iter()
     }
 
     pub fn is_struct(&self) -> bool {
@@ -557,10 +630,50 @@ pub struct CallTypeArguments(CallTypeArgumentState);
 enum CallTypeArgumentState {
     None,
     Unresolved(Vec<Annotation>),
-    Resolved {
-        annotations: Vec<Annotation>,
-        types: Vec<Type>,
-    },
+    Resolved(Vec<ResolvedCallTypeArgument>),
+    CheckedWithoutTypes(Vec<Annotation>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+struct ResolvedCallTypeArgument {
+    annotation: Annotation,
+    ty: Type,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedCallTypeArguments<'a> {
+    arguments: &'a [ResolvedCallTypeArgument],
+}
+
+impl<'a> ResolvedCallTypeArguments<'a> {
+    pub fn len(self) -> usize {
+        self.arguments.len()
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.arguments.is_empty()
+    }
+
+    pub fn first(self) -> Option<&'a Type> {
+        self.arguments.first().map(|argument| &argument.ty)
+    }
+
+    pub fn get(self, index: usize) -> Option<&'a Type> {
+        self.arguments.get(index).map(|argument| &argument.ty)
+    }
+
+    pub fn iter(self) -> impl ExactSizeIterator<Item = &'a Type> + Clone {
+        self.arguments.iter().map(|argument| &argument.ty)
+    }
+}
+
+impl std::ops::Index<usize> for ResolvedCallTypeArguments<'_> {
+    type Output = Type;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.arguments[index].ty
+    }
 }
 
 impl std::fmt::Debug for CallTypeArguments {
@@ -570,10 +683,24 @@ impl std::fmt::Debug for CallTypeArguments {
             CallTypeArgumentState::Unresolved(annotations) => {
                 f.debug_tuple("Unresolved").field(annotations).finish()
             }
-            CallTypeArgumentState::Resolved { annotations, types } => f
+            CallTypeArgumentState::Resolved(arguments) => {
+                let annotations = arguments
+                    .iter()
+                    .map(|argument| &argument.annotation)
+                    .collect::<Vec<_>>();
+                let types = arguments
+                    .iter()
+                    .map(|argument| &argument.ty)
+                    .collect::<Vec<_>>();
+                f.debug_struct("Resolved")
+                    .field("annotations", &annotations)
+                    .field("types", &types)
+                    .finish()
+            }
+            CallTypeArgumentState::CheckedWithoutTypes(annotations) => f
                 .debug_struct("Resolved")
                 .field("annotations", annotations)
-                .field("types", types)
+                .field("types", &Vec::<Type>::new())
                 .finish(),
         }
     }
@@ -592,44 +719,66 @@ impl CallTypeArguments {
         }
     }
 
-    pub fn resolved(annotations: Vec<Annotation>, types: Vec<Type>) -> Self {
-        if annotations.is_empty() {
-            assert!(
-                types.is_empty(),
-                "resolved type arguments require source annotations"
-            );
+    pub fn resolved(arguments: impl IntoIterator<Item = (Annotation, Type)>) -> Self {
+        let arguments = arguments
+            .into_iter()
+            .map(|(annotation, ty)| ResolvedCallTypeArgument { annotation, ty })
+            .collect::<Vec<_>>();
+        if arguments.is_empty() {
             Self::none()
         } else {
-            Self(CallTypeArgumentState::Resolved { annotations, types })
+            Self(CallTypeArgumentState::Resolved(arguments))
         }
     }
 
-    pub fn annotations(&self) -> &[Annotation] {
-        match &self.0 {
-            CallTypeArgumentState::None => &[],
+    pub fn checked_without_types(annotations: Vec<Annotation>) -> Self {
+        if annotations.is_empty() {
+            Self::none()
+        } else {
+            Self(CallTypeArgumentState::CheckedWithoutTypes(annotations))
+        }
+    }
+
+    pub fn annotations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &Annotation> + DoubleEndedIterator + Clone {
+        let len = match &self.0 {
+            CallTypeArgumentState::None => 0,
             CallTypeArgumentState::Unresolved(annotations)
-            | CallTypeArgumentState::Resolved { annotations, .. } => annotations,
-        }
+            | CallTypeArgumentState::CheckedWithoutTypes(annotations) => annotations.len(),
+            CallTypeArgumentState::Resolved(arguments) => arguments.len(),
+        };
+        (0..len).map(move |index| match &self.0 {
+            CallTypeArgumentState::None => unreachable!(),
+            CallTypeArgumentState::Unresolved(annotations)
+            | CallTypeArgumentState::CheckedWithoutTypes(annotations) => &annotations[index],
+            CallTypeArgumentState::Resolved(arguments) => &arguments[index].annotation,
+        })
     }
 
-    pub fn resolved_types(&self) -> Option<&[Type]> {
-        match &self.0 {
-            CallTypeArgumentState::None => Some(&[]),
-            CallTypeArgumentState::Unresolved(_) => None,
-            CallTypeArgumentState::Resolved { types, .. } => Some(types),
-        }
+    pub fn resolved_types(&self) -> Option<ResolvedCallTypeArguments<'_>> {
+        let arguments: &[ResolvedCallTypeArgument] = match &self.0 {
+            CallTypeArgumentState::None | CallTypeArgumentState::CheckedWithoutTypes(_) => &[],
+            CallTypeArgumentState::Unresolved(_) => return None,
+            CallTypeArgumentState::Resolved(arguments) => arguments,
+        };
+        Some(ResolvedCallTypeArguments { arguments })
     }
 
     pub fn into_annotations(self) -> Vec<Annotation> {
         match self.0 {
             CallTypeArgumentState::None => Vec::new(),
             CallTypeArgumentState::Unresolved(annotations)
-            | CallTypeArgumentState::Resolved { annotations, .. } => annotations,
+            | CallTypeArgumentState::CheckedWithoutTypes(annotations) => annotations,
+            CallTypeArgumentState::Resolved(arguments) => arguments
+                .into_iter()
+                .map(|argument| argument.annotation)
+                .collect(),
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.annotations().is_empty()
+        matches!(self.0, CallTypeArgumentState::None)
     }
 }
 
@@ -705,12 +854,117 @@ impl Annotation {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Generic {
     pub name: EcoString,
-    pub bounds: Vec<Annotation>,
-    pub resolved_bounds: Vec<Type>,
+    bounds: GenericBounds,
     pub span: Span,
+}
+
+impl std::fmt::Debug for Generic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let bounds = self.bounds().collect::<Vec<_>>();
+        let resolved_bounds = self
+            .resolved_bounds()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        f.debug_struct("Generic")
+            .field("name", &self.name)
+            .field("bounds", &bounds)
+            .field("resolved_bounds", &resolved_bounds)
+            .field("span", &self.span)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum GenericBounds {
+    Unresolved(Vec<Annotation>),
+    Resolved(Vec<ResolvedGenericBound>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ResolvedGenericBound {
+    annotation: Annotation,
+    ty: Type,
+}
+
+impl Generic {
+    pub fn new(name: impl Into<EcoString>, bounds: Vec<Annotation>, span: Span) -> Self {
+        let bounds = if bounds.is_empty() {
+            GenericBounds::Resolved(Vec::new())
+        } else {
+            GenericBounds::Unresolved(bounds)
+        };
+        Self {
+            name: name.into(),
+            bounds,
+            span,
+        }
+    }
+
+    pub fn bounds(&self) -> impl Iterator<Item = &Annotation> + Clone {
+        let unresolved = match &self.bounds {
+            GenericBounds::Unresolved(bounds) => Some(bounds.as_slice()),
+            GenericBounds::Resolved(_) => None,
+        };
+        let resolved = match &self.bounds {
+            GenericBounds::Unresolved(_) => None,
+            GenericBounds::Resolved(bounds) => Some(bounds.as_slice()),
+        };
+        unresolved.into_iter().flatten().chain(
+            resolved
+                .into_iter()
+                .flatten()
+                .map(|bound| &bound.annotation),
+        )
+    }
+
+    pub fn bound_count(&self) -> usize {
+        match &self.bounds {
+            GenericBounds::Unresolved(bounds) => bounds.len(),
+            GenericBounds::Resolved(bounds) => bounds.len(),
+        }
+    }
+
+    pub fn bounds_are_resolved(&self) -> bool {
+        matches!(self.bounds, GenericBounds::Resolved(_))
+    }
+
+    pub fn resolved_bounds(&self) -> Option<impl Iterator<Item = &Type> + Clone> {
+        let GenericBounds::Resolved(bounds) = &self.bounds else {
+            return None;
+        };
+        Some(bounds.iter().map(|bound| &bound.ty))
+    }
+
+    pub fn resolve_bounds_with(&mut self, mut resolve: impl FnMut(&Annotation) -> Type) {
+        let resolved = match &mut self.bounds {
+            GenericBounds::Unresolved(annotations) => annotations
+                .drain(..)
+                .map(|annotation| {
+                    let ty = resolve(&annotation);
+                    ResolvedGenericBound { annotation, ty }
+                })
+                .collect(),
+            GenericBounds::Resolved(bounds) => {
+                for bound in bounds {
+                    bound.ty = resolve(&bound.annotation);
+                }
+                return;
+            }
+        };
+        self.bounds = GenericBounds::Resolved(resolved);
+    }
+
+    pub fn retain_bounds(&mut self, mut keep: impl FnMut(&Annotation) -> bool) {
+        match &mut self.bounds {
+            GenericBounds::Unresolved(bounds) => bounds.retain(&mut keep),
+            GenericBounds::Resolved(bounds) => bounds.retain(|bound| keep(&bound.annotation)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -773,7 +1027,7 @@ pub enum Expression {
         return_annotation: Annotation,
         return_type: Type,
         visibility: Visibility,
-        body: Box<Expression>,
+        body: FunctionBody,
         ty: Type,
         span: Span,
     },
@@ -792,10 +1046,7 @@ pub enum Expression {
     Let {
         binding: Box<Binding>,
         value: Box<Expression>,
-        mut_span: Option<Span>,
-        else_block: Option<Box<Expression>>,
-        else_span: Option<Span>,
-        assert: bool,
+        mode: LetMode,
         ty: Type,
         span: Span,
     },
@@ -803,13 +1054,12 @@ pub enum Expression {
         value: EcoString,
         ty: Type,
         span: Span,
-        binding_id: Option<BindingId>,
-        qualified: Option<EcoString>,
+        resolution: IdentifierResolution,
     },
     Call {
         expression: Box<Expression>,
         args: Vec<Expression>,
-        spread: Box<Option<Expression>>,
+        spread: Option<Box<Expression>>,
         type_arguments: CallTypeArguments,
         ty: Type,
         span: Span,
@@ -827,7 +1077,6 @@ pub enum Expression {
         scrutinee: Box<Expression>,
         consequence: Box<Expression>,
         alternative: Box<Expression>,
-        typed_pattern: Option<TypedPattern>,
         else_span: Option<Span>,
         ty: Type,
         span: Span,
@@ -855,8 +1104,7 @@ pub enum Expression {
         member: EcoString,
         ty: Type,
         span: Span,
-        dot_access_kind: Option<DotAccessKind>,
-        receiver_coercion: Option<ReceiverCoercion>,
+        resolution: DotAccessResolution,
     },
     Assignment {
         target: Box<Expression>,
@@ -917,7 +1165,7 @@ pub enum Expression {
         identifier: EcoString,
         identifier_span: Span,
         annotation: Option<Annotation>,
-        expression: Box<Expression>,
+        expression: ConstInitializer,
         visibility: Visibility,
         ty: Type,
         span: Span,
@@ -948,7 +1196,6 @@ pub enum Expression {
         pattern: Pattern,
         scrutinee: Box<Expression>,
         body: Box<Expression>,
-        typed_pattern: Option<TypedPattern>,
         span: Span,
     },
     For {
@@ -956,7 +1203,6 @@ pub enum Expression {
         iterable: Box<Expression>,
         body: Box<Expression>,
         span: Span,
-        binding_id: Option<BindingId>,
     },
     Break {
         value: Option<Box<Expression>>,
@@ -1062,121 +1308,9 @@ pub enum Expression {
         ty: Type,
         span: Span,
     },
-    NoOp,
-}
-
-/// Dataless variant index of [`Expression`], usable as an array index.
-#[derive(Clone, Copy)]
-pub enum ExpressionKind {
-    Literal,
-    Function,
-    Lambda,
-    Block,
-    Let,
-    Identifier,
-    Call,
-    If,
-    IfLet,
-    Match,
-    Tuple,
-    StructCall,
-    DotAccess,
-    Assignment,
-    Return,
-    Propagate,
-    TryBlock,
-    RecoverBlock,
-    ImplBlock,
-    Binary,
-    Unary,
-    Paren,
-    Const,
-    VariableDeclaration,
-    RawGo,
-    Loop,
-    While,
-    WhileLet,
-    For,
-    Break,
-    Continue,
-    Enum,
-    Struct,
-    TypeAlias,
-    ModuleImport,
-    Reference,
-    Interface,
-    IndexedAccess,
-    Task,
-    Defer,
-    Assert,
-    Select,
-    Unit,
-    Range,
-    Cast,
-    NoOp,
-}
-
-impl ExpressionKind {
-    // Relies on `NoOp` staying the last variant.
-    pub const COUNT: usize = ExpressionKind::NoOp as usize + 1;
 }
 
 impl Expression {
-    pub fn kind(&self) -> ExpressionKind {
-        match self {
-            Expression::Literal { .. } => ExpressionKind::Literal,
-            Expression::Function { .. } => ExpressionKind::Function,
-            Expression::Lambda { .. } => ExpressionKind::Lambda,
-            Expression::Block { .. } => ExpressionKind::Block,
-            Expression::Let { .. } => ExpressionKind::Let,
-            Expression::Identifier { .. } => ExpressionKind::Identifier,
-            Expression::Call { .. } => ExpressionKind::Call,
-            Expression::If { .. } => ExpressionKind::If,
-            Expression::IfLet { .. } => ExpressionKind::IfLet,
-            Expression::Match { .. } => ExpressionKind::Match,
-            Expression::Tuple { .. } => ExpressionKind::Tuple,
-            Expression::StructCall { .. } => ExpressionKind::StructCall,
-            Expression::DotAccess { .. } => ExpressionKind::DotAccess,
-            Expression::Assignment { .. } => ExpressionKind::Assignment,
-            Expression::Return { .. } => ExpressionKind::Return,
-            Expression::Propagate { .. } => ExpressionKind::Propagate,
-            Expression::TryBlock { .. } => ExpressionKind::TryBlock,
-            Expression::RecoverBlock { .. } => ExpressionKind::RecoverBlock,
-            Expression::ImplBlock { .. } => ExpressionKind::ImplBlock,
-            Expression::Binary { .. } => ExpressionKind::Binary,
-            Expression::Unary { .. } => ExpressionKind::Unary,
-            Expression::Paren { .. } => ExpressionKind::Paren,
-            Expression::Const { .. } => ExpressionKind::Const,
-            Expression::VariableDeclaration { .. } => ExpressionKind::VariableDeclaration,
-            Expression::RawGo { .. } => ExpressionKind::RawGo,
-            Expression::Loop { .. } => ExpressionKind::Loop,
-            Expression::While { .. } => ExpressionKind::While,
-            Expression::WhileLet { .. } => ExpressionKind::WhileLet,
-            Expression::For { .. } => ExpressionKind::For,
-            Expression::Break { .. } => ExpressionKind::Break,
-            Expression::Continue { .. } => ExpressionKind::Continue,
-            Expression::Enum { .. } => ExpressionKind::Enum,
-            Expression::Struct { .. } => ExpressionKind::Struct,
-            Expression::TypeAlias { .. } => ExpressionKind::TypeAlias,
-            Expression::ModuleImport { .. } => ExpressionKind::ModuleImport,
-            Expression::Reference { .. } => ExpressionKind::Reference,
-            Expression::Interface { .. } => ExpressionKind::Interface,
-            Expression::IndexedAccess { .. } => ExpressionKind::IndexedAccess,
-            Expression::Task { .. } => ExpressionKind::Task,
-            Expression::Defer { .. } => ExpressionKind::Defer,
-            Expression::Assert { .. } => ExpressionKind::Assert,
-            Expression::Select { .. } => ExpressionKind::Select,
-            Expression::Unit { .. } => ExpressionKind::Unit,
-            Expression::Range { .. } => ExpressionKind::Range,
-            Expression::Cast { .. } => ExpressionKind::Cast,
-            Expression::NoOp => ExpressionKind::NoOp,
-        }
-    }
-
-    pub fn is_noop(&self) -> bool {
-        matches!(self, Expression::NoOp)
-    }
-
     pub(crate) fn is_block(&self) -> bool {
         matches!(self, Expression::Block { .. })
     }
@@ -1217,7 +1351,7 @@ impl Expression {
         )
     }
 
-    pub fn to_function_signature(&self) -> FunctionDefinition {
+    pub fn function_definition_view(&self) -> FunctionDefinitionView<'_> {
         match self {
             Expression::Function {
                 name,
@@ -1226,30 +1360,6 @@ impl Expression {
                 params,
                 return_annotation,
                 return_type,
-                ty,
-                ..
-            } => FunctionDefinition {
-                name: name.clone(),
-                name_span: *name_span,
-                generics: generics.clone(),
-                params: params.clone(),
-                body: Box::new(Expression::NoOp),
-                return_type: return_type.clone(),
-                annotation: return_annotation.clone(),
-                ty: ty.clone(),
-            },
-            _ => panic!("to_function_signature called on non-Function expression"),
-        }
-    }
-
-    pub fn function_definition_view(&self) -> FunctionDefinitionView<'_> {
-        match self {
-            Expression::Function {
-                name,
-                name_span,
-                generics,
-                params,
-                return_type,
                 body,
                 ..
             } => FunctionDefinitionView {
@@ -1257,8 +1367,9 @@ impl Expression {
                 name_span: *name_span,
                 generics,
                 params,
-                body,
+                body: body.definition(),
                 return_type,
+                annotation: return_annotation,
             },
             _ => panic!("function_definition_view called on non-Function expression"),
         }
@@ -1349,7 +1460,6 @@ impl Expression {
             | Self::TypeAlias { .. }
             | Self::ModuleImport { .. }
             | Self::Interface { .. }
-            | Self::NoOp
             | Self::RawGo { .. }
             | Self::While { .. }
             | Self::WhileLet { .. }
@@ -1404,7 +1514,7 @@ impl Expression {
             | Self::Continue { span, .. }
             | Self::Range { span, .. }
             | Self::Cast { span, .. } => *span,
-            Self::NoOp | Self::RawGo { .. } => Span::dummy(),
+            Self::RawGo { .. } => Span::dummy(),
         }
     }
 
@@ -1464,7 +1574,7 @@ impl Expression {
             } => {
                 expression.contains_break()
                     || args.iter().any(Self::contains_break)
-                    || spread.as_ref().as_ref().is_some_and(Self::contains_break)
+                    || spread.as_deref().is_some_and(Self::contains_break)
             }
 
             Expression::Function { .. } | Expression::Lambda { .. } => false,
@@ -1480,9 +1590,9 @@ impl Expression {
 
             Expression::Cast { expression, .. } => expression.contains_break(),
 
-            Expression::Let {
-                value, else_block, ..
-            } => value.contains_break() || else_block.as_ref().is_some_and(|e| e.contains_break()),
+            Expression::Let { value, mode, .. } => {
+                value.contains_break() || mode.else_block().is_some_and(Self::contains_break)
+            }
 
             Expression::Assignment { value, .. } => value.contains_break(),
 
@@ -1581,14 +1691,12 @@ impl Expression {
                     .collect(),
                 _ => Vec::new(),
             },
-            Expression::Function { body, .. } => children![body],
+            Expression::Function { body, .. } => body.definition().into_iter().collect(),
             Expression::Lambda { body, .. } => children![body],
             Expression::Block { items, .. } => items.iter().collect(),
-            Expression::Let {
-                value, else_block, ..
-            } => {
+            Expression::Let { value, mode, .. } => {
                 let mut c = children![value.as_ref()];
-                if let Some(eb) = else_block {
+                if let Some(eb) = mode.else_block() {
                     c.push(eb);
                 }
                 c
@@ -1653,7 +1761,7 @@ impl Expression {
             Expression::Binary { left, right, .. } => children![left, right],
             Expression::Unary { expression, .. } => children![expression],
             Expression::Paren { expression, .. } => children![expression],
-            Expression::Const { expression, .. } => children![expression],
+            Expression::Const { expression, .. } => expression.value().into_iter().collect(),
             Expression::Loop { body, .. } => children![body],
             Expression::While {
                 condition, body, ..
@@ -1732,8 +1840,7 @@ impl Expression {
             | Expression::TypeAlias { .. }
             | Expression::VariableDeclaration { .. }
             | Expression::ModuleImport { .. }
-            | Expression::RawGo { .. }
-            | Expression::NoOp => Vec::new(),
+            | Expression::RawGo { .. } => Vec::new(),
         }
     }
 
@@ -1746,7 +1853,7 @@ impl Expression {
 
     pub fn binding_id(&self) -> Option<BindingId> {
         match self.unwrap_parens() {
-            Expression::Identifier { binding_id, .. } => *binding_id,
+            Expression::Identifier { resolution, .. } => resolution.binding_id(),
             _ => None,
         }
     }

--- a/crates/syntax/src/ast_folder.rs
+++ b/crates/syntax/src/ast_folder.rs
@@ -3,29 +3,21 @@ use crate::ast::{
 };
 
 pub(crate) trait AstFolder {
-    type Error;
-
-    fn fold_module(
-        &mut self,
-        expressions: Vec<Expression>,
-    ) -> Result<Vec<Expression>, Self::Error> {
+    fn fold_module(&mut self, expressions: Vec<Expression>) -> Vec<Expression> {
         expressions
             .into_iter()
             .map(|e| self.fold_expression(e))
             .collect()
     }
 
-    fn fold_expression(&mut self, expression: Expression) -> Result<Expression, Self::Error> {
+    fn fold_expression(&mut self, expression: Expression) -> Expression {
         self.fold_expression_default(expression)
     }
 
-    fn fold_expression_default(
-        &mut self,
-        expression: Expression,
-    ) -> Result<Expression, Self::Error> {
+    fn fold_expression_default(&mut self, expression: Expression) -> Expression {
         use Expression::*;
 
-        Ok(match expression {
+        match expression {
             Binary {
                 operator,
                 left,
@@ -34,8 +26,8 @@ pub(crate) trait AstFolder {
                 span,
             } => Binary {
                 operator,
-                left: Box::new(self.fold_expression(*left)?),
-                right: Box::new(self.fold_expression(*right)?),
+                left: Box::new(self.fold_expression(*left)),
+                right: Box::new(self.fold_expression(*right)),
                 ty,
                 span,
             },
@@ -49,9 +41,9 @@ pub(crate) trait AstFolder {
                 span,
                 call_kind,
             } => Call {
-                expression: Box::new(self.fold_expression(*expression)?),
-                args: self.fold_vec(args)?,
-                spread: Box::new((*spread).map(|e| self.fold_expression(e)).transpose()?),
+                expression: Box::new(self.fold_expression(*expression)),
+                args: self.fold_vec(args),
+                spread: spread.map(|e| Box::new(self.fold_expression(*e))),
                 type_arguments,
                 ty,
                 span,
@@ -59,7 +51,7 @@ pub(crate) trait AstFolder {
             },
 
             Block { items, ty, span } => Block {
-                items: self.fold_vec(items)?,
+                items: self.fold_vec(items),
                 ty,
                 span,
             },
@@ -70,7 +62,7 @@ pub(crate) trait AstFolder {
                 try_keyword_span,
                 span,
             } => TryBlock {
-                items: self.fold_vec(items)?,
+                items: self.fold_vec(items),
                 ty,
                 try_keyword_span,
                 span,
@@ -82,7 +74,7 @@ pub(crate) trait AstFolder {
                 recover_keyword_span,
                 span,
             } => RecoverBlock {
-                items: self.fold_vec(items)?,
+                items: self.fold_vec(items),
                 ty,
                 recover_keyword_span,
                 span,
@@ -95,9 +87,9 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => If {
-                condition: Box::new(self.fold_expression(*condition)?),
-                consequence: Box::new(self.fold_expression(*consequence)?),
-                alternative: Box::new(self.fold_expression(*alternative)?),
+                condition: Box::new(self.fold_expression(*condition)),
+                consequence: Box::new(self.fold_expression(*consequence)),
+                alternative: Box::new(self.fold_expression(*alternative)),
                 ty,
                 span,
             },
@@ -107,16 +99,14 @@ pub(crate) trait AstFolder {
                 scrutinee,
                 consequence,
                 alternative,
-                typed_pattern,
                 else_span,
                 ty,
                 span,
             } => IfLet {
                 pattern,
-                scrutinee: Box::new(self.fold_expression(*scrutinee)?),
-                consequence: Box::new(self.fold_expression(*consequence)?),
-                alternative: Box::new(self.fold_expression(*alternative)?),
-                typed_pattern,
+                scrutinee: Box::new(self.fold_expression(*scrutinee)),
+                consequence: Box::new(self.fold_expression(*consequence)),
+                alternative: Box::new(self.fold_expression(*alternative)),
                 else_span,
                 ty,
                 span,
@@ -128,11 +118,11 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Match {
-                subject: Box::new(self.fold_expression(*subject)?),
+                subject: Box::new(self.fold_expression(*subject)),
                 arms: arms
                     .into_iter()
                     .map(|arm| self.fold_match_arm(arm))
-                    .collect::<Result<_, _>>()?,
+                    .collect(),
                 ty,
                 span,
             },
@@ -140,21 +130,13 @@ pub(crate) trait AstFolder {
             Let {
                 binding,
                 value,
-                mut_span,
-                else_block,
-                else_span,
-                assert,
+                mode,
                 ty,
                 span,
             } => Let {
                 binding,
-                value: Box::new(self.fold_expression(*value)?),
-                mut_span,
-                else_block: else_block
-                    .map(|e| self.fold_expression(*e).map(Box::new))
-                    .transpose()?,
-                else_span,
-                assert,
+                value: Box::new(self.fold_expression(*value)),
+                mode: mode.map_else(|expression, _| self.fold_expression(expression)),
                 ty,
                 span,
             },
@@ -164,7 +146,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Return {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -174,7 +156,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Propagate {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -186,7 +168,7 @@ pub(crate) trait AstFolder {
                 span,
             } => Unary {
                 operator,
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -196,7 +178,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Paren {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -206,15 +188,13 @@ pub(crate) trait AstFolder {
                 member,
                 ty,
                 span,
-                dot_access_kind,
-                receiver_coercion,
+                resolution,
             } => DotAccess {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 member,
                 ty,
                 span,
-                dot_access_kind,
-                receiver_coercion,
+                resolution,
             },
 
             IndexedAccess {
@@ -224,8 +204,8 @@ pub(crate) trait AstFolder {
                 span,
                 from_colon_syntax,
             } => IndexedAccess {
-                expression: Box::new(self.fold_expression(*expression)?),
-                index: Box::new(self.fold_expression(*index)?),
+                expression: Box::new(self.fold_expression(*expression)),
+                index: Box::new(self.fold_expression(*index)),
                 ty,
                 span,
                 from_colon_syntax,
@@ -237,14 +217,14 @@ pub(crate) trait AstFolder {
                 compound_operator,
                 span,
             } => Assignment {
-                target: Box::new(self.fold_expression(*target)?),
-                value: Box::new(self.fold_expression(*value)?),
+                target: Box::new(self.fold_expression(*target)),
+                value: Box::new(self.fold_expression(*value)),
                 compound_operator,
                 span,
             },
 
             Tuple { elements, ty, span } => Tuple {
-                elements: self.fold_vec(elements)?,
+                elements: self.fold_vec(elements),
                 ty,
                 span,
             },
@@ -260,15 +240,13 @@ pub(crate) trait AstFolder {
                 field_assignments: field_assignments
                     .into_iter()
                     .map(|mut f| {
-                        f.value = Box::new(self.fold_expression(*f.value)?);
-                        Ok(f)
+                        f.value = Box::new(self.fold_expression(*f.value));
+                        f
                     })
-                    .collect::<Result<_, Self::Error>>()?,
+                    .collect(),
                 spread: match spread {
                     StructSpread::None => StructSpread::None,
-                    StructSpread::From(e) => {
-                        StructSpread::From(Box::new(self.fold_expression(*e)?))
-                    }
+                    StructSpread::From(e) => StructSpread::From(Box::new(self.fold_expression(*e))),
                     StructSpread::Autofill { span } => StructSpread::Autofill { span },
                 },
                 ty,
@@ -298,7 +276,7 @@ pub(crate) trait AstFolder {
                 return_annotation,
                 return_type,
                 visibility,
-                body: Box::new(self.fold_expression(*body)?),
+                body: body.map_definition(|body| self.fold_expression(body)),
                 ty,
                 span,
             },
@@ -312,7 +290,7 @@ pub(crate) trait AstFolder {
             } => Lambda {
                 params,
                 return_annotation,
-                body: Box::new(self.fold_expression(*body)?),
+                body: Box::new(self.fold_expression(*body)),
                 ty,
                 span,
             },
@@ -322,7 +300,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Reference {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -332,13 +310,11 @@ pub(crate) trait AstFolder {
                 iterable,
                 body,
                 span,
-                binding_id,
             } => For {
                 binding,
-                iterable: Box::new(self.fold_expression(*iterable)?),
-                body: Box::new(self.fold_expression(*body)?),
+                iterable: Box::new(self.fold_expression(*iterable)),
+                body: Box::new(self.fold_expression(*body)),
                 span,
-                binding_id,
             },
 
             While {
@@ -346,8 +322,8 @@ pub(crate) trait AstFolder {
                 body,
                 span,
             } => While {
-                condition: Box::new(self.fold_expression(*condition)?),
-                body: Box::new(self.fold_expression(*body)?),
+                condition: Box::new(self.fold_expression(*condition)),
+                body: Box::new(self.fold_expression(*body)),
                 span,
             },
 
@@ -355,18 +331,16 @@ pub(crate) trait AstFolder {
                 pattern,
                 scrutinee,
                 body,
-                typed_pattern,
                 span,
             } => WhileLet {
                 pattern,
-                scrutinee: Box::new(self.fold_expression(*scrutinee)?),
-                body: Box::new(self.fold_expression(*body)?),
-                typed_pattern,
+                scrutinee: Box::new(self.fold_expression(*scrutinee)),
+                body: Box::new(self.fold_expression(*body)),
                 span,
             },
 
             Loop { body, ty, span } => Loop {
-                body: Box::new(self.fold_expression(*body)?),
+                body: Box::new(self.fold_expression(*body)),
                 ty,
                 span,
             },
@@ -376,7 +350,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Task {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -386,7 +360,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Defer {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -396,7 +370,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Assert {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 ty,
                 span,
             },
@@ -405,7 +379,7 @@ pub(crate) trait AstFolder {
                 arms: arms
                     .into_iter()
                     .map(|arm| self.fold_select_arm(arm))
-                    .collect::<Result<_, _>>()?,
+                    .collect(),
                 ty,
                 span,
             },
@@ -420,7 +394,7 @@ pub(crate) trait AstFolder {
             } => ImplBlock {
                 annotation,
                 receiver_name,
-                methods: self.fold_vec(methods)?,
+                methods: self.fold_vec(methods),
                 generics,
                 ty,
                 span,
@@ -440,7 +414,7 @@ pub(crate) trait AstFolder {
                 identifier,
                 identifier_span,
                 annotation,
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: expression.map_value(|value| self.fold_expression(value)),
                 visibility,
                 ty,
                 span,
@@ -452,17 +426,14 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Cast {
-                expression: Box::new(self.fold_expression(*expression)?),
+                expression: Box::new(self.fold_expression(*expression)),
                 target_type,
                 ty,
                 span,
             },
 
             Break { value, span } => Break {
-                value: match value {
-                    Some(v) => Some(Box::new(self.fold_expression(*v)?)),
-                    None => None,
-                },
+                value: value.map(|value| Box::new(self.fold_expression(*value))),
                 span,
             },
 
@@ -474,14 +445,12 @@ pub(crate) trait AstFolder {
                 let folded_parts = parts
                     .into_iter()
                     .map(|part| match part {
-                        FormatStringPart::Expression(expression) => {
-                            Ok(FormatStringPart::Expression(Box::new(
-                                self.fold_expression(*expression)?,
-                            )))
-                        }
-                        other => Ok(other),
+                        FormatStringPart::Expression(expression) => FormatStringPart::Expression(
+                            Box::new(self.fold_expression(*expression)),
+                        ),
+                        other => other,
                     })
-                    .collect::<Result<Vec<_>, Self::Error>>()?;
+                    .collect();
                 Literal {
                     literal: crate::ast::Literal::FormatString(folded_parts),
                     ty,
@@ -494,7 +463,7 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => {
-                let folded_elements = self.fold_vec(elements)?;
+                let folded_elements = self.fold_vec(elements);
                 Literal {
                     literal: crate::ast::Literal::Slice(folded_elements),
                     ty,
@@ -509,12 +478,8 @@ pub(crate) trait AstFolder {
                 ty,
                 span,
             } => Range {
-                start: start
-                    .map(|e| self.fold_expression(*e).map(Box::new))
-                    .transpose()?,
-                end: end
-                    .map(|e| self.fold_expression(*e).map(Box::new))
-                    .transpose()?,
+                start: start.map(|expression| Box::new(self.fold_expression(*expression))),
+                end: end.map(|expression| Box::new(self.fold_expression(*expression))),
                 inclusive,
                 ty,
                 span,
@@ -530,61 +495,57 @@ pub(crate) trait AstFolder {
             | Interface { .. }
             | Continue { .. }
             | Unit { .. }
-            | RawGo { .. }
-            | NoOp => expression,
-        })
+            | RawGo { .. } => expression,
+        }
     }
 
-    fn fold_vec(&mut self, expressions: Vec<Expression>) -> Result<Vec<Expression>, Self::Error> {
+    fn fold_vec(&mut self, expressions: Vec<Expression>) -> Vec<Expression> {
         expressions
             .into_iter()
             .map(|e| self.fold_expression(e))
             .collect()
     }
 
-    fn fold_match_arm(&mut self, mut arm: MatchArm) -> Result<MatchArm, Self::Error> {
-        arm.expression = Box::new(self.fold_expression(*arm.expression)?);
+    fn fold_match_arm(&mut self, mut arm: MatchArm) -> MatchArm {
+        arm.expression = Box::new(self.fold_expression(*arm.expression));
         arm.guard = arm
             .guard
-            .map(|g| self.fold_expression(*g).map(Box::new))
-            .transpose()?;
-        Ok(arm)
+            .map(|guard| Box::new(self.fold_expression(*guard)));
+        arm
     }
 
-    fn fold_select_arm(&mut self, arm: SelectArm) -> Result<SelectArm, Self::Error> {
+    fn fold_select_arm(&mut self, arm: SelectArm) -> SelectArm {
         let pattern = match arm.pattern {
             SelectArmPattern::Receive {
                 binding,
-                typed_pattern,
                 receive_expression,
                 body,
             } => SelectArmPattern::Receive {
                 binding,
-                typed_pattern,
-                receive_expression: Box::new(self.fold_expression(*receive_expression)?),
-                body: Box::new(self.fold_expression(*body)?),
+                receive_expression: Box::new(self.fold_expression(*receive_expression)),
+                body: Box::new(self.fold_expression(*body)),
             },
             SelectArmPattern::Send {
                 send_expression,
                 body,
             } => SelectArmPattern::Send {
-                send_expression: Box::new(self.fold_expression(*send_expression)?),
-                body: Box::new(self.fold_expression(*body)?),
+                send_expression: Box::new(self.fold_expression(*send_expression)),
+                body: Box::new(self.fold_expression(*body)),
             },
             SelectArmPattern::MatchReceive {
                 receive_expression,
                 arms,
             } => SelectArmPattern::MatchReceive {
-                receive_expression: Box::new(self.fold_expression(*receive_expression)?),
+                receive_expression: Box::new(self.fold_expression(*receive_expression)),
                 arms: arms
                     .into_iter()
                     .map(|arm| self.fold_match_arm(arm))
-                    .collect::<Result<_, _>>()?,
+                    .collect(),
             },
             SelectArmPattern::WildCard { body } => SelectArmPattern::WildCard {
-                body: Box::new(self.fold_expression(*body)?),
+                body: Box::new(self.fold_expression(*body)),
             },
         };
-        Ok(SelectArm { pattern })
+        SelectArm { pattern }
     }
 }

--- a/crates/syntax/src/containment.rs
+++ b/crates/syntax/src/containment.rs
@@ -65,9 +65,7 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         visited: &mut HashSet<String>,
         wrap_checking: &HashSet<(String, usize, usize)>,
     ) -> bool {
-        let peeled = peel_alias(ty, |id| {
-            (self.lookup)(id).is_some_and(Definition::is_type_alias)
-        });
+        let peeled = peel_alias(ty, self.lookup);
         match &peeled {
             Type::Nominal { id, params, .. } => {
                 if is_indirection_type(id.as_str()) {
@@ -181,25 +179,17 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
                             )
                     })
             }
-            DefinitionBody::TypeAlias { .. } => {
-                let Type::Forall { vars, body } = &definition.ty else {
+            DefinitionBody::TypeAlias {
+                generics, alias, ..
+            } => {
+                let Some(generic) = generics.get(position) else {
                     return true;
                 };
-                let Some(name) = vars.get(position) else {
-                    return true;
-                };
-                match body.as_ref() {
-                    Type::Nominal {
-                        id: body_id,
-                        underlying_ty,
-                        ..
-                    } if body_id.as_str() == id => match underlying_ty {
-                        Some(underlying) => {
-                            self.parameter_stored_inline(underlying, name, checking, wrap_checking)
-                        }
-                        None => true,
-                    },
-                    _ => self.parameter_stored_inline(body, name, checking, wrap_checking),
+                match alias {
+                    crate::program::AliasKind::Transparent { target, .. } => {
+                        self.parameter_stored_inline(target, &generic.name, checking, wrap_checking)
+                    }
+                    crate::program::AliasKind::Opaque(_) => true,
                 }
             }
             DefinitionBody::Interface { .. } => false,

--- a/crates/syntax/src/desugar.rs
+++ b/crates/syntax/src/desugar.rs
@@ -23,7 +23,7 @@ pub fn desugar(expressions: Vec<Expression>) -> DesugarResult {
     }
 
     let mut desugarer = Desugarer::new();
-    let ast = desugarer.fold_module(expressions).unwrap(); // Infallible
+    let ast = desugarer.fold_module(expressions);
     DesugarResult {
         ast,
         errors: desugarer.errors,
@@ -58,18 +58,15 @@ impl Desugarer {
 }
 
 impl AstFolder for Desugarer {
-    type Error = std::convert::Infallible;
-
-    fn fold_expression(&mut self, expression: Expression) -> Result<Expression, Self::Error> {
+    fn fold_expression(&mut self, expression: Expression) -> Expression {
         if let Expression::Binary { ref left, .. } = expression
             && matches!(**left, Expression::Binary { .. })
         {
             return self.fold_binary_iterative(expression);
         }
 
-        let expression = self.fold_expression_default(expression)?;
-
-        Ok(self.apply_desugar(expression))
+        let expression = self.fold_expression_default(expression);
+        self.apply_desugar(expression)
     }
 }
 
@@ -85,10 +82,7 @@ impl Desugarer {
         }
     }
 
-    fn fold_binary_iterative(
-        &mut self,
-        expression: Expression,
-    ) -> Result<Expression, std::convert::Infallible> {
+    fn fold_binary_iterative(&mut self, expression: Expression) -> Expression {
         let Expression::Binary {
             operator,
             left,
@@ -115,9 +109,9 @@ impl Desugarer {
             current = *l;
         }
 
-        let mut result = self.fold_expression(current)?;
+        let mut result = self.fold_expression(current);
         while let Some((op, right, t, s)) = stack.pop() {
-            let folded_right = self.fold_expression(*right)?;
+            let folded_right = self.fold_expression(*right);
             let binary = Expression::Binary {
                 operator: op,
                 left: Box::new(result),
@@ -127,7 +121,7 @@ impl Desugarer {
             };
             result = self.apply_desugar(binary);
         }
-        Ok(result)
+        result
     }
 
     fn desugar_pipeline(&mut self, pipeline: Expression) -> Expression {
@@ -145,7 +139,7 @@ impl Desugarer {
             Expression::Identifier { .. } | Expression::DotAccess { .. } => Expression::Call {
                 expression: Box::new(right),
                 args: vec![left],
-                spread: Box::new(None),
+                spread: None,
                 type_arguments: CallTypeArguments::none(),
                 ty: Type::uninferred(),
                 span,

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -41,8 +41,12 @@ impl Type {
 
             Type::Var { id, hint } => match hint {
                 Some(name) => format!("?{}", name),
-                None => format!("?{}", id.as_u32()),
+                None => format!("?{}", id.index()),
             },
+
+            Type::Uninferred => "?uninferred".to_string(),
+
+            Type::Ignored => "?ignored".to_string(),
 
             Type::Function(f) => {
                 let args_formatted = f

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -9,7 +9,6 @@ mod types;
 
 pub struct Lexer<'source> {
     input: &'source str,
-    input_bytes: &'source [u8],
     current_offset: usize,
     file_id: u32,
     errors: Vec<ParseError>,
@@ -21,7 +20,6 @@ impl<'source> Lexer<'source> {
     pub fn new(input: &'source str, file_id: u32) -> Lexer<'source> {
         Lexer {
             input,
-            input_bytes: input.as_bytes(),
             current_offset: 0,
             file_id,
             errors: vec![],
@@ -197,11 +195,11 @@ impl<'source> Lexer<'source> {
 
     #[inline]
     fn current_byte(&self) -> u8 {
-        if self.current_offset < self.input_bytes.len() {
-            self.input_bytes[self.current_offset]
-        } else {
-            0
-        }
+        self.input
+            .as_bytes()
+            .get(self.current_offset)
+            .copied()
+            .unwrap_or(0)
     }
 
     #[inline]
@@ -214,21 +212,17 @@ impl<'source> Lexer<'source> {
 
     #[inline]
     fn peek_byte(&self) -> u8 {
-        if self.current_offset + 1 < self.input_bytes.len() {
-            self.input_bytes[self.current_offset + 1]
-        } else {
-            0
-        }
+        self.input
+            .as_bytes()
+            .get(self.current_offset + 1)
+            .copied()
+            .unwrap_or(0)
     }
 
     #[inline]
     fn peek_byte_at(&self, n: usize) -> u8 {
         let offset = self.current_offset + n;
-        if offset < self.input_bytes.len() {
-            self.input_bytes[offset]
-        } else {
-            0
-        }
+        self.input.as_bytes().get(offset).copied().unwrap_or(0)
     }
 
     #[inline]
@@ -420,8 +414,8 @@ impl<'source> Lexer<'source> {
         // Skip decimal part if preceded by single `.` (e.g., `tuple.0.0` — don't lex `0.0` as float).
         // Don't skip if preceded by `..` (range operator), e.g. `0..1.5` should lex `1.5` as float.
         let preceded_by_dot = start_offset > 0
-            && self.input_bytes[start_offset - 1] == b'.'
-            && !(start_offset > 1 && self.input_bytes[start_offset - 2] == b'.');
+            && self.input.as_bytes()[start_offset - 1] == b'.'
+            && !(start_offset > 1 && self.input.as_bytes()[start_offset - 2] == b'.');
 
         if !preceded_by_dot
             && self.current_byte() == b'.'
@@ -914,11 +908,11 @@ impl<'source> Lexer<'source> {
         if self.current_byte() == b'r' && self.peek_byte() == b'#' {
             let mut hash_count = 0usize;
             let mut probe = self.current_offset + 1;
-            while probe < self.input_bytes.len() && self.input_bytes[probe] == b'#' {
+            while probe < self.input.len() && self.input.as_bytes()[probe] == b'#' {
                 hash_count += 1;
                 probe += 1;
             }
-            if hash_count > 0 && probe < self.input_bytes.len() && self.input_bytes[probe] == b'"' {
+            if hash_count > 0 && probe < self.input.len() && self.input.as_bytes()[probe] == b'"' {
                 let start = self.current_offset;
                 self.skip(1 + hash_count + 1);
                 loop {
@@ -1401,7 +1395,7 @@ impl<'source> Lexer<'source> {
     fn count_consecutive(&self, byte: u8) -> usize {
         let mut count = 0;
         let mut offset = self.current_offset;
-        while offset < self.input_bytes.len() && self.input_bytes[offset] == byte {
+        while offset < self.input.len() && self.input.as_bytes()[offset] == byte {
             count += 1;
             offset += 1;
         }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -13,27 +13,14 @@ pub mod types;
 pub use ecow::EcoString;
 pub use parse::ParseError;
 
-use ast::Expression;
-
-#[derive(Debug)]
-pub struct AstBuildResult {
-    pub ast: Vec<Expression>,
-    pub errors: Vec<ParseError>,
-    pub file_comment: Option<String>,
-}
-
-impl AstBuildResult {
-    pub fn failed(&self) -> bool {
-        !self.errors.is_empty()
-    }
-}
+pub type AstBuildResult = parse::ParseResult;
 
 #[cfg(target_pointer_width = "64")]
 mod size_assertions {
     use std::mem::size_of;
-    const _: () = assert!(size_of::<super::ast::Expression>() == 344);
-    const _: () = assert!(size_of::<super::types::Type>() == 48);
-    const _: () = assert!(size_of::<super::ast::Pattern>() == 120);
+    const _: () = assert!(size_of::<super::ast::Expression>() == 288);
+    const _: () = assert!(size_of::<super::ast::Pattern>() == 152);
+    const _: () = assert!(size_of::<super::types::Type>() == 40);
     const _: () = assert!(size_of::<super::ast::Span>() == 12);
 }
 
@@ -41,7 +28,7 @@ const MAX_SOURCE_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
 
 pub fn build_ast(source: &str, file_id: u32) -> AstBuildResult {
     if source.len() > MAX_SOURCE_BYTES {
-        return AstBuildResult {
+        return parse::ParseResult {
             ast: vec![],
             errors: vec![
                 ParseError::new(
@@ -61,7 +48,7 @@ pub fn build_ast(source: &str, file_id: u32) -> AstBuildResult {
 
     let parse_result = parse::Parser::lex_and_parse_file(source, file_id);
     if parse_result.failed() {
-        return AstBuildResult {
+        return parse::ParseResult {
             ast: vec![],
             errors: parse_result.errors,
             file_comment: None,
@@ -69,7 +56,7 @@ pub fn build_ast(source: &str, file_id: u32) -> AstBuildResult {
     }
 
     let desugar_result = desugar::desugar(parse_result.ast);
-    AstBuildResult {
+    parse::ParseResult {
         ast: desugar_result.ast,
         errors: desugar_result.errors,
         file_comment: parse_result.file_comment,

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -1,19 +1,19 @@
 use super::{MAX_TUPLE_ARITY, ParamMode, Parser};
 use crate::EcoString;
-use crate::ast::{Annotation, Attribute, Expression, Generic, Literal, Span, Visibility};
+use crate::ast::{
+    Annotation, Attribute, Expression, FunctionBody, Generic, Literal, Span, Visibility,
+};
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::types::Type;
 
 impl<'source> Parser<'source> {
     pub(crate) fn parse_annotation(&mut self) -> Annotation {
-        if !self.enter_recursion() {
-            self.resync_on_error();
-            return Annotation::Unknown;
+        if let Some(result) = self.with_recursion(Parser::parse_annotation_inner) {
+            return result;
         }
-        let result = self.parse_annotation_inner();
-        self.leave_recursion();
-        result
+        self.resync_on_error();
+        Annotation::Unknown
     }
 
     fn parse_annotation_inner(&mut self) -> Annotation {
@@ -301,13 +301,9 @@ impl<'source> Parser<'source> {
 
     fn parse_generic(&mut self) -> Generic {
         let start = self.current_token();
-
-        Generic {
-            name: self.read_identifier(),
-            bounds: self.parse_generic_bounds(),
-            resolved_bounds: vec![],
-            span: self.span_from_tokens(start),
-        }
+        let name = self.read_identifier();
+        let bounds = self.parse_generic_bounds();
+        Generic::new(name, bounds, self.span_from_tokens(start))
     }
 
     fn parse_generic_bounds(&mut self) -> Vec<Annotation> {
@@ -385,7 +381,7 @@ impl<'source> Parser<'source> {
             return_annotation: self.parse_function_return_annotation(),
             return_type: Type::uninferred(),
             visibility: Visibility::Private,
-            body: Expression::NoOp.into(),
+            body: FunctionBody::Declaration,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }

--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -9,7 +9,7 @@ impl<'source> Parser<'source> {
 
         self.ensure(Match);
 
-        let subject = self.with_control_flow_header(|p| p.parse_expression());
+        let subject = self.parse_control_flow_header();
 
         self.ensure(LeftCurlyBrace);
 
@@ -72,55 +72,50 @@ impl<'source> Parser<'source> {
         Some(MatchArm {
             pattern,
             guard,
-            typed_pattern: None,
             expression: Box::new(self.parse_assignment()),
         })
     }
 
     pub(super) fn parse_if(&mut self) -> Expression {
         let start = self.current_token();
+        if let Some(result) = self.with_recursion(|parser| {
+            parser.ensure(If);
 
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            self.resync_on_error();
-            return Expression::Unit {
-                ty: Type::uninferred(),
-                span,
+            if parser.is(Let) {
+                return parser.parse_if_let_expression(start);
+            }
+
+            let condition = parser.parse_control_flow_header();
+            let consequence = parser.parse_block_expression();
+
+            let alternative = if parser.advance_if(Else) {
+                if parser.is(If) {
+                    parser.parse_if()
+                } else {
+                    parser.parse_block_expression()
+                }
+            } else {
+                Expression::Unit {
+                    ty: Type::uninferred(),
+                    span: parser.span_from_tokens(start),
+                }
             };
-        }
 
-        self.ensure(If);
-
-        if self.is(Let) {
-            let result = self.parse_if_let_expression(start);
-            self.leave_recursion();
+            Expression::If {
+                ty: Type::uninferred(),
+                condition: condition.into(),
+                consequence: consequence.into(),
+                alternative: alternative.into(),
+                span: parser.span_from_tokens(start),
+            }
+        }) {
             return result;
         }
-
-        let condition = self.with_control_flow_header(|p| p.parse_expression());
-        let consequence = self.parse_block_expression();
-
-        let alternative = if self.advance_if(Else) {
-            if self.is(If) {
-                self.parse_if()
-            } else {
-                self.parse_block_expression()
-            }
-        } else {
-            Expression::Unit {
-                ty: Type::uninferred(),
-                span: self.span_from_tokens(start),
-            }
-        };
-
-        self.leave_recursion();
-
-        Expression::If {
+        let span = self.span_from_token(self.current_token());
+        self.resync_on_error();
+        Expression::Unit {
             ty: Type::uninferred(),
-            condition: condition.into(),
-            consequence: consequence.into(),
-            alternative: alternative.into(),
-            span: self.span_from_tokens(start),
+            span,
         }
     }
 
@@ -129,7 +124,7 @@ impl<'source> Parser<'source> {
 
         let pattern = self.parse_pattern_allowing_or();
         self.ensure(Equal);
-        let scrutinee = self.with_control_flow_header(|p| p.parse_expression());
+        let scrutinee = self.parse_control_flow_header();
         let consequence = self.parse_block_expression();
 
         let (alternative, else_span) = if self.is(Else) {
@@ -157,7 +152,6 @@ impl<'source> Parser<'source> {
             scrutinee: scrutinee.into(),
             consequence: consequence.into(),
             alternative: alternative.into(),
-            typed_pattern: None,
             else_span,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
@@ -263,7 +257,7 @@ impl<'source> Parser<'source> {
 
         self.ensure(In_);
 
-        let iterable = self.with_control_flow_header(|p| p.parse_expression());
+        let iterable = self.parse_control_flow_header();
         let body = self.parse_block_expression();
 
         Expression::For {
@@ -271,7 +265,6 @@ impl<'source> Parser<'source> {
             iterable: iterable.into(),
             body: body.into(),
             span: self.span_from_tokens(start),
-            binding_id: None,
         }
     }
 
@@ -284,7 +277,7 @@ impl<'source> Parser<'source> {
             return self.parse_while_let(start);
         }
 
-        let condition = self.with_control_flow_header(|p| p.parse_expression());
+        let condition = self.parse_control_flow_header();
         let body = self.parse_block_expression();
 
         Expression::While {
@@ -299,14 +292,13 @@ impl<'source> Parser<'source> {
 
         let pattern = self.parse_pattern_allowing_or();
         self.ensure(Equal);
-        let scrutinee = self.with_control_flow_header(|p| p.parse_expression());
+        let scrutinee = self.parse_control_flow_header();
         let body = self.parse_block_expression();
 
         Expression::WhileLet {
             pattern,
             scrutinee: scrutinee.into(),
             body: body.into(),
-            typed_pattern: None,
             span: self.span_from_tokens(start),
         }
     }

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -2,8 +2,9 @@ use ecow::EcoString;
 
 use super::{ParamMode, Parser};
 use crate::ast::{
-    Annotation, Attribute, AttributeArg, EnumFieldDefinition, EnumVariant, Expression, Generic,
-    ParentInterface, Span, StructFieldDefinition, StructKind, VariantFields, Visibility,
+    Annotation, Attribute, AttributeArg, ConstInitializer, EnumFieldDefinition, EnumVariant,
+    Expression, Generic, ParentInterface, Span, StructFieldDefinition, StructKind, VariantFields,
+    Visibility,
 };
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
@@ -619,9 +620,9 @@ impl<'source> Parser<'source> {
         };
 
         let expression = if self.advance_if(Equal) {
-            self.parse_expression()
+            ConstInitializer::Value(Box::new(self.parse_expression()))
         } else {
-            Expression::NoOp
+            ConstInitializer::Declaration
         };
 
         Expression::Const {
@@ -629,7 +630,7 @@ impl<'source> Parser<'source> {
             identifier,
             identifier_span,
             annotation,
-            expression: expression.into(),
+            expression,
             visibility: Visibility::Private,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1,13 +1,15 @@
 use ecow::EcoString;
 
+use super::pratt::ExpressionContext;
 use super::strings::cook_string_contents;
 use super::{MAX_TUPLE_ARITY, ParamMode, ParseError, Parser};
 use crate::ast::{
     Annotation, Attribute, BinaryOperator, Binding, CallTypeArguments, Expression,
-    FormatStringPart, ImportAlias, Literal, SelectArm, SelectArmPattern, Span,
-    StructFieldAssignment, StructSpread, UnaryOperator, Visibility,
+    FormatStringPart, FunctionBody, IdentifierResolution, ImportAlias, LetMode, Literal, SelectArm,
+    SelectArmPattern, Span, StructFieldAssignment, StructSpread, UnaryOperator, Visibility,
 };
 use crate::lex::TokenKind::{self, *};
+use crate::program::DotAccessResolution;
 use crate::types::Type;
 
 #[derive(Clone, Copy)]
@@ -19,20 +21,26 @@ enum GoMakeKind {
 
 impl<'source> Parser<'source> {
     pub(crate) fn parse_expression(&mut self) -> Expression {
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            self.resync_on_error();
-            return Expression::Unit {
-                ty: Type::uninferred(),
-                span,
-            };
-        }
-        let result = self.pratt_parse(0);
-        self.leave_recursion();
-        result
+        self.parse_expression_in(ExpressionContext::Normal)
     }
 
-    pub(crate) fn parse_atomic_expression(&mut self) -> Expression {
+    pub(crate) fn parse_control_flow_header(&mut self) -> Expression {
+        self.parse_expression_in(ExpressionContext::ControlFlowHeader)
+    }
+
+    fn parse_expression_in(&mut self, context: ExpressionContext) -> Expression {
+        if let Some(result) = self.with_recursion(|parser| parser.pratt_parse(0, context)) {
+            return result;
+        }
+        let span = self.span_from_token(self.current_token());
+        self.resync_on_error();
+        Expression::Unit {
+            ty: Type::uninferred(),
+            span,
+        }
+    }
+
+    pub(super) fn parse_atomic_expression(&mut self, context: ExpressionContext) -> Expression {
         if self.keyword_in_value_position() {
             return self.recover_keyword_as_identifier();
         }
@@ -62,7 +70,7 @@ impl<'source> Parser<'source> {
             Return => self.parse_return(false),
             Break => self.parse_break(),
             Continue => self.parse_continue(),
-            DotDot | DotDotEqual => self.parse_range(None, self.current_token()),
+            DotDot | DotDotEqual => self.parse_range(None, self.current_token(), context),
 
             LeftAngleBracket
                 if self.stream.peek_ahead(1).kind == Minus
@@ -89,10 +97,11 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(crate) fn parse_range(
+    pub(super) fn parse_range(
         &mut self,
         start: Option<Box<Expression>>,
         span_start: crate::lex::Token<'source>,
+        context: ExpressionContext,
     ) -> Expression {
         if matches!(start.as_deref(), Some(Expression::Range { .. })) {
             self.track_error("not allowed", "Chained range operators are not supported");
@@ -121,7 +130,7 @@ impl<'source> Parser<'source> {
         }
 
         let end = if has_end {
-            Some(Box::new(self.parse_range_end()))
+            Some(Box::new(self.parse_range_end(context)))
         } else {
             None
         };
@@ -271,8 +280,7 @@ impl<'source> Parser<'source> {
             value: text.into(),
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
-            binding_id: None,
-            qualified: None,
+            resolution: IdentifierResolution::Unresolved,
         }
     }
 
@@ -336,8 +344,7 @@ impl<'source> Parser<'source> {
                     value: field_name.clone(),
                     ty: Type::uninferred(),
                     span: self.span_from_tokens(field_name_token),
-                    binding_id: None,
-                    qualified: None,
+                    resolution: IdentifierResolution::Unresolved,
                 }
             };
 
@@ -412,7 +419,7 @@ impl<'source> Parser<'source> {
         let start_offset = expression.get_span().byte_offset;
 
         if raw_type_args.is_empty()
-            && matches!(&expression, Expression::Identifier { value, qualified: None, .. } if value == "make")
+            && matches!(&expression, Expression::Identifier { value, resolution: IdentifierResolution::Unresolved, .. } if value == "make")
             && let Some(recovered) = self.try_go_make_shim(&expression)
         {
             return recovered;
@@ -424,7 +431,7 @@ impl<'source> Parser<'source> {
             ty: Type::uninferred(),
             expression: expression.into(),
             args,
-            spread: spread.into(),
+            spread: spread.map(Box::new),
             type_arguments: CallTypeArguments::unresolved(raw_type_args),
             span: self.span_from_offset(start_offset),
             call_kind: None,
@@ -610,7 +617,10 @@ impl<'source> Parser<'source> {
         let body = if self.is(LeftCurlyBrace) {
             self.parse_block_expression()
         } else {
-            Expression::NoOp
+            Expression::Unit {
+                ty: Type::uninferred(),
+                span: self.span_from_tokens(start),
+            }
         };
 
         Expression::Lambda {
@@ -800,50 +810,40 @@ impl<'source> Parser<'source> {
             };
         }
 
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            let mut brace_depth = 1u32;
-            while brace_depth > 0 && !self.at_eof() {
-                match self.current_token().kind {
-                    LeftCurlyBrace => brace_depth += 1,
-                    RightCurlyBrace => brace_depth -= 1,
-                    _ => {}
-                }
-                if brace_depth > 0 {
-                    self.next();
-                }
-            }
-            self.advance_if(RightCurlyBrace);
-            return Expression::Block {
-                ty: Type::uninferred(),
-                items: vec![],
-                span,
-            };
-        }
-
-        let mut items = vec![];
-
-        while self.is_not(RightCurlyBrace) && !self.too_many_errors() {
-            let position = self.position();
-            let item = self.parse_block_item();
-
-            self.advance_if(Semicolon);
-
-            items.push(item);
-            if self.position() == position {
-                self.next();
-            }
-        }
-
-        let span = self.close_brace_span(start, start);
-
-        self.leave_recursion();
+        let (items, span) = self.parse_braced_items(start, start);
 
         Expression::Block {
             ty: Type::uninferred(),
             items,
             span,
         }
+    }
+
+    fn parse_braced_items(
+        &mut self,
+        span_start: crate::lex::Token<'source>,
+        opening_brace: crate::lex::Token<'source>,
+    ) -> (Vec<Expression>, Span) {
+        if let Some(result) = self.with_recursion(|parser| {
+            let mut items = vec![];
+            while parser.is_not(RightCurlyBrace) && !parser.too_many_errors() {
+                let position = parser.position();
+                let item = parser.parse_block_item();
+                parser.advance_if(Semicolon);
+                items.push(item);
+                if parser.position() == position {
+                    parser.next();
+                }
+            }
+            let span = parser.close_brace_span(span_start, opening_brace);
+            (items, span)
+        }) {
+            return result;
+        }
+
+        let span = self.span_from_token(self.current_token());
+        self.consume_to_matching_close_brace();
+        (vec![], span)
     }
 
     pub(crate) fn parse_function_params(&mut self, mode: ParamMode) -> Vec<Binding> {
@@ -867,9 +867,9 @@ impl<'source> Parser<'source> {
         let mut params = vec![];
 
         while self.is_not(Pipe) {
-            let is_mut = self.advance_if(Mut);
+            let mut_span = self.parse_mut_span();
             let mut binding = self.parse_binding();
-            binding.mutable = is_mut;
+            binding.mut_span = mut_span;
             params.push(binding);
             self.expect_comma_or(Pipe);
         }
@@ -901,9 +901,9 @@ impl<'source> Parser<'source> {
         let return_annotation = self.parse_function_return_annotation();
 
         let body = if self.is(LeftCurlyBrace) {
-            self.parse_block_expression()
+            FunctionBody::Definition(Box::new(self.parse_block_expression()))
         } else {
-            Expression::NoOp
+            FunctionBody::Declaration
         };
 
         Expression::Function {
@@ -916,7 +916,7 @@ impl<'source> Parser<'source> {
             return_annotation,
             return_type: Type::uninferred(),
             visibility: Visibility::Private,
-            body: body.into(),
+            body,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }
@@ -954,8 +954,7 @@ impl<'source> Parser<'source> {
                 expression: expression.into(),
                 member: index.to_string().into(),
                 span: self.span_from_offset(expression_start),
-                dot_access_kind: None,
-                receiver_coercion: None,
+                resolution: DotAccessResolution::Unresolved,
             };
         }
 
@@ -968,8 +967,7 @@ impl<'source> Parser<'source> {
             expression: expression.into(),
             member: field.into(),
             span: self.span_from_offset(expression_start),
-            dot_access_kind: None,
-            receiver_coercion: None,
+            resolution: DotAccessResolution::Unresolved,
         }
     }
 
@@ -1053,14 +1051,7 @@ impl<'source> Parser<'source> {
             self.next(); // consume `assert`
         }
 
-        let (mutable, mut_span) = if self.is(Mut) {
-            let mut_token = self.current_token();
-            let span = Span::new(self.file_id, mut_token.byte_offset, mut_token.byte_length);
-            self.next(); // consume `mut`
-            (true, Some(span))
-        } else {
-            (false, None)
-        };
+        let mut_span = self.parse_mut_span();
 
         if assert && let Some(span) = mut_span {
             self.track_error_at(
@@ -1071,7 +1062,7 @@ impl<'source> Parser<'source> {
         }
 
         let mut binding = self.parse_binding_allowing_or();
-        binding.mutable = mutable;
+        binding.mut_span = mut_span;
 
         if !self.is(Equal)
             && let Some(Annotation::Constructor { span, .. }) = binding.annotation.as_ref()
@@ -1085,10 +1076,11 @@ impl<'source> Parser<'source> {
                     items: vec![],
                     span: stub_span,
                 }),
-                mut_span,
-                else_block: None,
-                else_span: None,
-                assert,
+                mode: if assert {
+                    LetMode::Assert
+                } else {
+                    LetMode::Plain
+                },
                 ty: Type::uninferred(),
                 span: stub_span,
             };
@@ -1098,30 +1090,33 @@ impl<'source> Parser<'source> {
 
         let expression = self.parse_expression();
 
-        let (else_block, else_span) = if self.is(Else) {
+        let else_clause = if self.is(Else) {
             let else_token = self.current_token();
             let span = Span::new(self.file_id, else_token.byte_offset, else_token.byte_length);
             self.next(); // consume `else`
-            (Some(Box::new(self.parse_block_expression())), Some(span))
+            Some((Box::new(self.parse_block_expression()), span))
         } else {
-            (None, None)
+            None
         };
 
-        if assert && else_block.is_some() {
-            self.track_error_at(
-                else_span.expect("else_block implies else_span"),
-                "`let assert` cannot have an `else` block",
-                "`let assert` already fails the test on mismatch. Remove the `else`",
-            );
-        }
+        let mode = match (assert, else_clause) {
+            (false, None) => LetMode::Plain,
+            (true, None) => LetMode::Assert,
+            (false, Some((block, else_span))) => LetMode::Else { block, else_span },
+            (true, Some((block, else_span))) => {
+                self.track_error_at(
+                    else_span,
+                    "`let assert` cannot have an `else` block",
+                    "`let assert` already fails the test on mismatch. Remove the `else`",
+                );
+                LetMode::InvalidAssertElse { block, else_span }
+            }
+        };
 
         Expression::Let {
             binding: Box::new(binding),
             value: expression.into(),
-            mut_span,
-            else_block,
-            else_span,
-            assert,
+            mode,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }
@@ -1460,46 +1455,7 @@ impl<'source> Parser<'source> {
 
         let brace_token = self.current_token();
         self.ensure(LeftCurlyBrace);
-
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            let mut brace_depth = 1u32;
-            while brace_depth > 0 && !self.at_eof() {
-                match self.current_token().kind {
-                    LeftCurlyBrace => brace_depth += 1,
-                    RightCurlyBrace => brace_depth -= 1,
-                    _ => {}
-                }
-                if brace_depth > 0 {
-                    self.next();
-                }
-            }
-            self.advance_if(RightCurlyBrace);
-            return Expression::TryBlock {
-                items: vec![],
-                ty: Type::uninferred(),
-                try_keyword_span,
-                span,
-            };
-        }
-
-        let mut items = vec![];
-
-        while self.is_not(RightCurlyBrace) && !self.too_many_errors() {
-            let position = self.position();
-            let item = self.parse_block_item();
-
-            self.advance_if(Semicolon);
-
-            items.push(item);
-            if self.position() == position {
-                self.next();
-            }
-        }
-
-        let span = self.close_brace_span(start, brace_token);
-
-        self.leave_recursion();
+        let (items, span) = self.parse_braced_items(start, brace_token);
 
         Expression::TryBlock {
             items,
@@ -1532,46 +1488,7 @@ impl<'source> Parser<'source> {
 
         let brace_token = self.current_token();
         self.ensure(LeftCurlyBrace);
-
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            let mut brace_depth = 1u32;
-            while brace_depth > 0 && !self.at_eof() {
-                match self.current_token().kind {
-                    LeftCurlyBrace => brace_depth += 1,
-                    RightCurlyBrace => brace_depth -= 1,
-                    _ => {}
-                }
-                if brace_depth > 0 {
-                    self.next();
-                }
-            }
-            self.advance_if(RightCurlyBrace);
-            return Expression::RecoverBlock {
-                items: vec![],
-                ty: Type::uninferred(),
-                recover_keyword_span,
-                span,
-            };
-        }
-
-        let mut items = vec![];
-
-        while self.is_not(RightCurlyBrace) && !self.too_many_errors() {
-            let position = self.position();
-            let item = self.parse_block_item();
-
-            self.advance_if(Semicolon);
-
-            items.push(item);
-            if self.position() == position {
-                self.next();
-            }
-        }
-
-        let span = self.close_brace_span(start, brace_token);
-
-        self.leave_recursion();
+        let (items, span) = self.parse_braced_items(start, brace_token);
 
         Expression::RecoverBlock {
             items,
@@ -1621,7 +1538,6 @@ impl<'source> Parser<'source> {
                 SelectArm {
                     pattern: SelectArmPattern::Receive {
                         binding: Box::new(binding),
-                        typed_pattern: None,
                         receive_expression,
                         body,
                     },
@@ -1667,17 +1583,6 @@ impl<'source> Parser<'source> {
                 }
             }
         }
-    }
-
-    pub(crate) fn with_control_flow_header<F, R>(&mut self, f: F) -> R
-    where
-        F: FnOnce(&mut Self) -> R,
-    {
-        let old = self.in_control_flow_header;
-        self.in_control_flow_header = true;
-        let result = f(self);
-        self.in_control_flow_header = old;
-        result
     }
 
     fn keyword_in_value_position(&self) -> bool {
@@ -1757,8 +1662,7 @@ impl<'source> Parser<'source> {
             value: keyword.into(),
             ty: Type::uninferred(),
             span,
-            binding_id: None,
-            qualified: None,
+            resolution: IdentifierResolution::Unresolved,
         }
     }
 
@@ -1905,7 +1809,7 @@ mod tests {
 
         assert_eq!(params.len(), 1);
         assert!(
-            params[0].mutable,
+            params[0].is_mutable(),
             "`mut x` lambda parameter should be mutable"
         );
     }

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -46,7 +46,6 @@ pub struct Parser<'source> {
     stream: TokenStream<'source>,
     errors: Vec<ParseError>,
     file_id: u32,
-    in_control_flow_header: bool,
     source: &'source str,
     depth: u32,
 }
@@ -81,7 +80,6 @@ impl<'source> Parser<'source> {
             stream,
             errors: Default::default(),
             file_id,
-            in_control_flow_header: false,
             source,
             depth: 0,
         }
@@ -543,7 +541,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn is_struct_instantiation(&self) -> bool {
+    fn is_struct_instantiation(&self, context: pratt::ExpressionContext) -> bool {
         let previous = self.stream.previous();
         if previous.kind != Identifier {
             return false;
@@ -557,7 +555,7 @@ impl<'source> Parser<'source> {
         }
 
         if first_ahead.kind == RightCurlyBrace {
-            if self.in_control_flow_header {
+            if context.is_control_flow_header() {
                 return is_uppercase && self.has_block_after_struct();
             }
             return is_uppercase;
@@ -568,7 +566,7 @@ impl<'source> Parser<'source> {
             return match second_ahead.kind {
                 Colon => self.stream.peek_ahead(3).kind != Colon,
                 Comma | RightCurlyBrace => {
-                    if self.in_control_flow_header {
+                    if context.is_control_flow_header() {
                         is_uppercase && self.has_block_after_struct()
                     } else {
                         is_uppercase
@@ -581,7 +579,17 @@ impl<'source> Parser<'source> {
         false
     }
 
-    fn enter_recursion(&mut self) -> bool {
+    fn with_recursion<T>(&mut self, parse: impl FnOnce(&mut Self) -> T) -> Option<T> {
+        let outer_depth = self.depth;
+        if !self.try_deepen() {
+            return None;
+        }
+        let result = parse(self);
+        self.depth = outer_depth;
+        Some(result)
+    }
+
+    fn try_deepen(&mut self) -> bool {
         if self.depth >= MAX_DEPTH {
             let span = self.span_from_token(self.current_token());
             self.track_error_at(span, "too deeply nested", "Reduce nesting depth");
@@ -589,10 +597,6 @@ impl<'source> Parser<'source> {
         }
         self.depth += 1;
         true
-    }
-
-    fn leave_recursion(&mut self) {
-        self.depth -= 1;
     }
 
     fn too_many_errors(&self) -> bool {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -2,7 +2,10 @@ use ecow::EcoString;
 
 use super::strings::cook_string_contents;
 use super::{MAX_TUPLE_ARITY, ParamMode, ParseError, Parser};
-use crate::ast::{Annotation, Binding, Literal, Pattern, RestPattern, Span, StructFieldPattern};
+use crate::ast::{
+    Annotation, Binding, ConstructorPatternResolution, Literal, Pattern, RecordPatternResolution,
+    RestPattern, SequencePatternResolution, Span, StructFieldPattern,
+};
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::types::Type;
@@ -28,36 +31,37 @@ impl<'source> Parser<'source> {
     }
 
     pub(crate) fn parse_pattern(&mut self) -> Pattern {
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            self.resync_on_error();
-            return Pattern::WildCard { span };
-        }
-        let start = self.current_token();
-        let mut result = self.parse_pattern_inner();
-        if self.advance_if(As) {
-            if !self.is(Identifier) {
-                self.track_error("expected identifier after `as`", "Use `as <name>`");
-            } else if self.current_token().text == "_" {
-                self.track_error(
-                    "`_` is not a valid `as` alias",
-                    "Use a named binding, or omit `as _`",
-                );
-                self.next();
-            } else {
-                let name: EcoString = self.current_token().text.into();
-                let name_span = self.span_from_token(self.current_token());
-                self.next();
-                result = Pattern::AsBinding {
-                    pattern: Box::new(result),
-                    name,
-                    name_span,
-                    span: self.span_from_tokens(start),
-                };
+        if let Some(result) = self.with_recursion(|parser| {
+            let start = parser.current_token();
+            let mut result = parser.parse_pattern_inner();
+            if parser.advance_if(As) {
+                if !parser.is(Identifier) {
+                    parser.track_error("expected identifier after `as`", "Use `as <name>`");
+                } else if parser.current_token().text == "_" {
+                    parser.track_error(
+                        "`_` is not a valid `as` alias",
+                        "Use a named binding, or omit `as _`",
+                    );
+                    parser.next();
+                } else {
+                    let name: EcoString = parser.current_token().text.into();
+                    let name_span = parser.span_from_token(parser.current_token());
+                    parser.next();
+                    result = Pattern::AsBinding {
+                        pattern: Box::new(result),
+                        name,
+                        name_span,
+                        span: parser.span_from_tokens(start),
+                    };
+                }
             }
+            result
+        }) {
+            return result;
         }
-        self.leave_recursion();
-        result
+        let span = self.span_from_token(self.current_token());
+        self.resync_on_error();
+        Pattern::WildCard { span }
     }
 
     fn parse_pattern_inner(&mut self) -> Pattern {
@@ -400,7 +404,7 @@ impl<'source> Parser<'source> {
         Pattern::Slice {
             prefix: elements,
             rest,
-            element_ty: Type::uninferred(),
+            resolution: SequencePatternResolution::Unresolved,
             span,
         }
     }
@@ -454,6 +458,7 @@ impl<'source> Parser<'source> {
                         identifier: full_name.into(),
                         fields: vec![],
                         rest: false,
+                        resolution: ConstructorPatternResolution::Unresolved,
                         ty: Type::uninferred(),
                         span,
                     }
@@ -548,6 +553,7 @@ impl<'source> Parser<'source> {
             identifier: name.into(),
             fields,
             rest,
+            resolution: RecordPatternResolution::Unresolved,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }
@@ -579,6 +585,7 @@ impl<'source> Parser<'source> {
             identifier: name.into(),
             fields,
             rest,
+            resolution: ConstructorPatternResolution::Unresolved,
             ty: Type::uninferred(),
             span: self.span_from_tokens(start),
         }
@@ -588,9 +595,8 @@ impl<'source> Parser<'source> {
         Binding {
             pattern: self.parse_pattern(),
             annotation: self.parse_optional_type_annotation(),
-            typed_pattern: None,
             ty: Type::uninferred(),
-            mutable: false,
+            mut_span: None,
         }
     }
 
@@ -598,9 +604,8 @@ impl<'source> Parser<'source> {
         Binding {
             pattern: self.parse_pattern_allowing_or(),
             annotation: self.parse_optional_type_annotation(),
-            typed_pattern: None,
             ty: Type::uninferred(),
-            mutable: false,
+            mut_span: None,
         }
     }
 
@@ -635,9 +640,8 @@ impl<'source> Parser<'source> {
                     span,
                 },
                 annotation: self.parse_optional_type_annotation(),
-                typed_pattern: None,
                 ty: Type::uninferred(),
-                mutable: false,
+                mut_span: None,
             };
         }
 
@@ -669,7 +673,7 @@ impl<'source> Parser<'source> {
             }
         }
 
-        let is_mut = self.advance_if(Mut);
+        let mut_span = self.parse_mut_span();
 
         let pattern = self.parse_pattern();
 
@@ -681,9 +685,8 @@ impl<'source> Parser<'source> {
             return Binding {
                 pattern,
                 annotation: None,
-                typed_pattern: None,
                 ty: Type::uninferred(),
-                mutable: false,
+                mut_span: None,
             };
         }
 
@@ -691,9 +694,8 @@ impl<'source> Parser<'source> {
             return Binding {
                 pattern,
                 annotation: None,
-                typed_pattern: None,
                 ty: Type::uninferred(),
-                mutable: is_mut,
+                mut_span,
             };
         }
 
@@ -703,10 +705,22 @@ impl<'source> Parser<'source> {
         Binding {
             pattern,
             annotation: Some(annotation),
-            typed_pattern: None,
             ty: Type::uninferred(),
-            mutable: is_mut,
+            mut_span,
         }
+    }
+
+    pub(crate) fn parse_mut_span(&mut self) -> Option<Span> {
+        if self.is_not(Mut) {
+            return None;
+        }
+        let token = self.current_token();
+        self.next();
+        Some(Span::new(
+            self.file_id,
+            token.byte_offset,
+            token.byte_length,
+        ))
     }
 
     fn try_parse_rest(&mut self) -> Option<RestPattern> {

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -3,10 +3,23 @@ use ecow::EcoString;
 use super::{ParseError, Parser};
 use crate::ast;
 use crate::lex::TokenKind::{self, *};
+use crate::program::DotAccessResolution;
 use crate::types::Type;
 
 const RANGE_PREC: u8 = 6;
 const CAST_PREC: u8 = 9;
+
+#[derive(Clone, Copy)]
+pub(super) enum ExpressionContext {
+    Normal,
+    ControlFlowHeader,
+}
+
+impl ExpressionContext {
+    pub(super) fn is_control_flow_header(self) -> bool {
+        matches!(self, Self::ControlFlowHeader)
+    }
+}
 
 impl<'source> Parser<'source> {
     /// Parses by grouping together operations in expressions based on precedence.
@@ -18,43 +31,47 @@ impl<'source> Parser<'source> {
     /// 4. For postfix operators: Transform the current expression into a larger one.
     ///
     /// The `min_prec` param sets the minimum precedence level for this parsing context.
-    pub(crate) fn pratt_parse(&mut self, min_prec: u8) -> ast::Expression {
-        if !self.enter_recursion() {
-            let span = self.span_from_token(self.current_token());
-            self.resync_on_error();
-            return ast::Expression::Unit {
-                ty: Type::uninferred(),
-                span,
-            };
+    pub(super) fn pratt_parse(
+        &mut self,
+        min_prec: u8,
+        context: ExpressionContext,
+    ) -> ast::Expression {
+        if let Some(result) =
+            self.with_recursion(|parser| parser.pratt_parse_inner(min_prec, context))
+        {
+            return result;
         }
+        let span = self.span_from_token(self.current_token());
+        self.resync_on_error();
+        ast::Expression::Unit {
+            ty: Type::uninferred(),
+            span,
+        }
+    }
 
+    fn pratt_parse_inner(&mut self, min_prec: u8, context: ExpressionContext) -> ast::Expression {
         let start = self.current_token();
-        let mut lhs = self.parse_left_hand_side();
-        let depth_before_loop = self.depth;
+        let mut lhs = self.parse_left_hand_side(context);
 
         while !self.at_eof() && !self.too_many_errors() {
             if self.check_go_channel_send() {
-                self.depth = depth_before_loop;
-                self.leave_recursion();
                 return lhs;
             }
 
-            if self.check_increment_decrement(&lhs, start.byte_offset) {
-                self.depth = depth_before_loop;
-                self.leave_recursion();
+            if self.check_increment_decrement(&lhs, start.byte_offset, context) {
                 return lhs;
             }
 
             if self.at_range() && RANGE_PREC > min_prec {
-                if !self.enter_recursion() {
+                if !self.try_deepen() {
                     break;
                 }
-                lhs = self.parse_range(Some(lhs.into()), start);
+                lhs = self.parse_range(Some(lhs.into()), start, context);
                 continue;
             }
 
             if self.current_token().kind == As && CAST_PREC > min_prec {
-                if !self.enter_recursion() {
+                if !self.try_deepen() {
                     break;
                 }
                 self.next();
@@ -78,11 +95,11 @@ impl<'source> Parser<'source> {
             if let Some(prec) = self.binary_operator_precedence(self.current_token().kind)
                 && prec > min_prec
             {
-                if !self.enter_recursion() {
+                if !self.try_deepen() {
                     break;
                 }
                 let operator = self.parse_binary_operator();
-                let rhs = self.pratt_parse(prec);
+                let rhs = self.pratt_parse(prec, context);
                 lhs = ast::Expression::Binary {
                     operator,
                     left: lhs.into(),
@@ -93,8 +110,8 @@ impl<'source> Parser<'source> {
                 continue;
             }
 
-            if self.is_postfix_operator(&lhs) {
-                if !self.enter_recursion() {
+            if self.is_postfix_operator(&lhs, context) {
+                if !self.try_deepen() {
                     break;
                 }
                 if self.is_format_string(&lhs)
@@ -110,9 +127,6 @@ impl<'source> Parser<'source> {
 
             break;
         }
-
-        self.depth = depth_before_loop;
-        self.leave_recursion();
 
         lhs
     }
@@ -142,12 +156,12 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn is_postfix_operator(&self, lhs: &ast::Expression) -> bool {
+    fn is_postfix_operator(&self, lhs: &ast::Expression, context: ExpressionContext) -> bool {
         match self.current_token().kind {
             LeftParen | LeftSquareBracket | QuestionMark | Dot => true,
             LeftCurlyBrace => match lhs {
                 ast::Expression::Identifier { .. } | ast::Expression::DotAccess { .. } => {
-                    self.is_struct_instantiation()
+                    self.is_struct_instantiation(context)
                 }
                 _ => false,
             },
@@ -167,7 +181,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn parse_left_hand_side(&mut self) -> ast::Expression {
+    fn parse_left_hand_side(&mut self, context: ExpressionContext) -> ast::Expression {
         let start = self.current_token();
 
         match start.kind {
@@ -185,7 +199,7 @@ impl<'source> Parser<'source> {
 
                 ast::Expression::Unary {
                     operator,
-                    expression: self.pratt_parse(prec).into(),
+                    expression: self.pratt_parse(prec, context).into(),
                     ty: Type::uninferred(),
                     span: self.span_from_tokens(start),
                 }
@@ -209,13 +223,13 @@ impl<'source> Parser<'source> {
                 }
                 let prec = self.prefix_operator_precedence(start.kind);
                 ast::Expression::Reference {
-                    expression: self.pratt_parse(prec).into(),
+                    expression: self.pratt_parse(prec, context).into(),
                     ty: Type::uninferred(),
                     span: self.span_from_tokens(start),
                 }
             }
 
-            _ => self.parse_atomic_expression(),
+            _ => self.parse_atomic_expression(context),
         }
     }
 
@@ -332,8 +346,7 @@ impl<'source> Parser<'source> {
                         expression: lhs.into(),
                         member: field,
                         span: self.span_from_tokens(field_start),
-                        dot_access_kind: None,
-                        receiver_coercion: None,
+                        resolution: DotAccessResolution::Unresolved,
                     }
                 }
             }
@@ -350,8 +363,8 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(crate) fn parse_range_end(&mut self) -> ast::Expression {
-        self.pratt_parse(RANGE_PREC)
+    pub(super) fn parse_range_end(&mut self, context: ExpressionContext) -> ast::Expression {
+        self.pratt_parse(RANGE_PREC, context)
     }
 
     fn check_go_channel_send(&mut self) -> bool {
@@ -381,7 +394,12 @@ impl<'source> Parser<'source> {
         true
     }
 
-    fn check_increment_decrement(&mut self, lhs: &ast::Expression, start_offset: u32) -> bool {
+    fn check_increment_decrement(
+        &mut self,
+        lhs: &ast::Expression,
+        start_offset: u32,
+        context: ExpressionContext,
+    ) -> bool {
         let current = self.current_token();
         let kind = current.kind;
         if kind != Plus && kind != Minus {
@@ -416,7 +434,7 @@ impl<'source> Parser<'source> {
                 after.kind,
                 EOF | Semicolon | RightCurlyBrace | RightParen | RightSquareBracket | Comma
             )
-            || (after.kind == LeftCurlyBrace && self.in_control_flow_header);
+            || (after.kind == LeftCurlyBrace && context.is_control_flow_header());
         if !ends_statement {
             return false;
         }

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -1,11 +1,11 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use ecow::EcoString;
 
 use crate::ast::{
     Annotation, EnumVariant, Generic, Literal, Span, StructFieldDefinition, StructKind,
 };
-use crate::types::Type;
+use crate::types::{Type, build_substitution_map, substitute};
 
 #[derive(Debug, Clone)]
 pub struct Definition {
@@ -29,13 +29,19 @@ pub enum TypeAttribute {
     Serialized,
 }
 
-pub type Attributes = HashMap<TypeAttribute, ()>;
+pub type Attributes = HashSet<TypeAttribute>;
+
+#[derive(Debug, Clone)]
+pub enum ValueKind {
+    Runtime,
+    Constant { value: Option<Literal> },
+}
 
 #[derive(Debug, Clone)]
 pub enum DefinitionBody {
     TypeAlias {
         generics: Vec<Generic>,
-        annotation: Annotation,
+        alias: AliasKind,
         methods: MethodSignatures,
         attributes: Attributes,
     },
@@ -57,6 +63,7 @@ pub enum DefinitionBody {
         definition: Interface,
     },
     Value {
+        kind: ValueKind,
         allowed_lints: Vec<String>,
         go_hints: Vec<String>,
         go_name: Option<String>,
@@ -65,11 +72,24 @@ pub enum DefinitionBody {
         /// `"Slice<E>, E"`). Lets emit rebuild Go's type arguments when the
         /// collapsed Lisette list cannot be projected onto Go's positionally.
         go_type_param_recipe: Option<String>,
-        /// The known literal value when this definition is a case-eligible
-        /// constant (usable as a Go `case` and as a const-pattern target).
-        /// `None` for variables, functions, and non-literal constants.
-        const_value: Option<Literal>,
     },
+}
+
+#[derive(Debug, Clone)]
+pub enum AliasKind {
+    Opaque(Annotation),
+    Transparent {
+        annotation: Annotation,
+        target: Type,
+    },
+}
+
+impl AliasKind {
+    pub fn annotation(&self) -> &Annotation {
+        match self {
+            Self::Opaque(annotation) | Self::Transparent { annotation, .. } => annotation,
+        }
+    }
 }
 
 impl DefinitionBody {
@@ -111,16 +131,53 @@ impl Definition {
         )
     }
 
-    pub fn is_pointer_backed_newtype<F>(&self, is_alias: F) -> bool
+    pub fn is_pointer_backed_newtype<'d, F>(&self, lookup: F) -> bool
     where
-        F: Fn(&str) -> bool,
+        F: Fn(&str) -> Option<&'d Definition>,
     {
         self.is_newtype()
             && matches!(
                 &self.body,
                 DefinitionBody::Struct { fields, .. }
-                    if crate::types::peel_alias(&fields[0].ty, is_alias).is_ref()
+                    if crate::types::peel_alias(&fields[0].ty, lookup).is_ref()
             )
+    }
+
+    pub fn instantiate_alias_target(&self, params: &[Type]) -> Option<Type> {
+        let DefinitionBody::TypeAlias {
+            generics,
+            alias: AliasKind::Transparent { target, .. },
+            ..
+        } = &self.body
+        else {
+            return None;
+        };
+        Some(substitute(
+            target,
+            &build_substitution_map(generics, params),
+        ))
+    }
+
+    pub fn instantiate_underlying(&self, params: &[Type]) -> Option<Type> {
+        if let Some(target) = self.instantiate_alias_target(params) {
+            return Some(target);
+        }
+        match &self.body {
+            DefinitionBody::Struct { fields, .. } if self.is_newtype() => {
+                Some(fields[0].ty.clone())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn is_transparent_type_alias(&self) -> bool {
+        matches!(
+            self.body,
+            DefinitionBody::TypeAlias {
+                alias: AliasKind::Transparent { .. },
+                ..
+            }
+        )
     }
 
     pub fn allowed_lints(&self) -> &[String] {
@@ -156,9 +213,22 @@ impl Definition {
 
     pub fn const_value(&self) -> Option<&Literal> {
         match &self.body {
-            DefinitionBody::Value { const_value, .. } => const_value.as_ref(),
+            DefinitionBody::Value {
+                kind: ValueKind::Constant { value },
+                ..
+            } => value.as_ref(),
             _ => None,
         }
+    }
+
+    pub fn is_const(&self) -> bool {
+        matches!(
+            self.body,
+            DefinitionBody::Value {
+                kind: ValueKind::Constant { .. },
+                ..
+            }
+        )
     }
 
     pub fn methods_mut(&mut self) -> Option<&mut MethodSignatures> {
@@ -181,27 +251,27 @@ impl Definition {
 
     pub fn is_display(&self) -> bool {
         self.attributes()
-            .is_some_and(|a| a.contains_key(&TypeAttribute::Display))
+            .is_some_and(|a| a.contains(&TypeAttribute::Display))
     }
 
     pub fn is_closed_domain(&self) -> bool {
         self.attributes()
-            .is_some_and(|a| a.contains_key(&TypeAttribute::ClosedDomain))
+            .is_some_and(|a| a.contains(&TypeAttribute::ClosedDomain))
     }
 
     pub fn is_serialized(&self) -> bool {
         self.attributes()
-            .is_some_and(|a| a.contains_key(&TypeAttribute::Serialized))
+            .is_some_and(|a| a.contains(&TypeAttribute::Serialized))
     }
 
     pub fn is_anon_struct(&self) -> bool {
         self.attributes()
-            .is_some_and(|a| a.contains_key(&TypeAttribute::AnonStruct))
+            .is_some_and(|a| a.contains(&TypeAttribute::AnonStruct))
     }
 
     pub fn has_hidden_embed(&self) -> bool {
         self.attributes()
-            .is_some_and(|a| a.contains_key(&TypeAttribute::HiddenEmbed))
+            .is_some_and(|a| a.contains(&TypeAttribute::HiddenEmbed))
     }
 
     pub fn is_type_definition(&self) -> bool {

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -5,30 +5,29 @@ use ecow::EcoString;
 use crate::ast::{BindingId as AstBindingId, Pattern, RestPattern, Span};
 use crate::types::Symbol;
 
-use super::{Definition, File, ModuleInfo};
+use super::{Definition, File};
 
 #[derive(Debug, Clone, Default)]
 pub struct UnusedInfo {
-    bindings: HashSet<Span>,
-    definitions: HashSet<Span>,
+    symbols: HashSet<Span>,
     pub imports_by_module: HashMap<EcoString, HashSet<EcoString>>,
 }
 
 impl UnusedInfo {
     pub fn mark_binding_unused(&mut self, span: Span) {
-        self.bindings.insert(span);
+        self.symbols.insert(span);
     }
 
     pub fn is_unused_binding(&self, pattern: &Pattern) -> bool {
         match pattern {
-            Pattern::Identifier { span, .. } => self.bindings.contains(span),
+            Pattern::Identifier { span, .. } => self.symbols.contains(span),
             Pattern::AsBinding { span, name, .. } => {
                 let name_span = Span::new(
                     span.file_id,
                     span.byte_offset + span.byte_length - name.len() as u32,
                     name.len() as u32,
                 );
-                self.bindings.contains(&name_span)
+                self.symbols.contains(&name_span)
             }
             _ => false,
         }
@@ -36,27 +35,25 @@ impl UnusedInfo {
 
     pub fn is_unused_rest_binding(&self, rest: &RestPattern) -> bool {
         match rest {
-            RestPattern::Bind { span, .. } => self.bindings.contains(span),
+            RestPattern::Bind { span, .. } => self.symbols.contains(span),
             _ => false,
         }
     }
 
     pub fn mark_definition_unused(&mut self, span: Span) {
-        self.definitions.insert(span);
+        self.symbols.insert(span);
     }
 
     pub fn is_unused_definition(&self, span: &Span) -> bool {
-        self.definitions.contains(span)
+        self.symbols.contains(span)
     }
 
     pub fn merge(&mut self, other: UnusedInfo) {
         let UnusedInfo {
-            bindings,
-            definitions,
+            symbols,
             imports_by_module,
         } = other;
-        self.bindings.extend(bindings);
-        self.definitions.extend(definitions);
+        self.symbols.extend(symbols);
         for (module, imports) in imports_by_module {
             self.imports_by_module
                 .entry(module)
@@ -103,13 +100,9 @@ pub struct EqualityIndex {
 
 #[derive(Debug, Clone)]
 enum EqualityInfo {
-    Method {
-        private_to_module: Option<String>,
-        synthesized: bool,
-    },
-    UfcsLowered {
-        private_to_module: Option<String>,
-    },
+    DeclaredMethod { private_to_module: Option<String> },
+    SynthesizedMethod { private_to_module: Option<String> },
+    UfcsLowered { private_to_module: Option<String> },
 }
 
 fn visible_from(private_to_module: &Option<String>, current_module: &str) -> bool {
@@ -120,19 +113,14 @@ fn visible_from(private_to_module: &Option<String>, current_module: &str) -> boo
 }
 
 impl EqualityIndex {
-    pub fn insert_method(
-        &mut self,
-        id: String,
-        private_to_module: Option<String>,
-        synthesized: bool,
-    ) {
-        self.by_id.insert(
-            id,
-            EqualityInfo::Method {
-                private_to_module,
-                synthesized,
-            },
-        );
+    pub fn insert_declared_method(&mut self, id: String, private_to_module: Option<String>) {
+        self.by_id
+            .insert(id, EqualityInfo::DeclaredMethod { private_to_module });
+    }
+
+    pub fn insert_synthesized_method(&mut self, id: String, private_to_module: Option<String>) {
+        self.by_id
+            .insert(id, EqualityInfo::SynthesizedMethod { private_to_module });
     }
 
     pub fn insert_ufcs_lowered(&mut self, id: String, private_to_module: Option<String>) {
@@ -143,7 +131,10 @@ impl EqualityIndex {
     pub fn usable_from(&self, id: &str, current_module: &str) -> bool {
         matches!(
             self.by_id.get(id),
-            Some(EqualityInfo::Method { private_to_module, .. })
+            Some(
+                EqualityInfo::DeclaredMethod { private_to_module }
+                    | EqualityInfo::SynthesizedMethod { private_to_module }
+            )
                 if visible_from(private_to_module, current_module)
         )
     }
@@ -159,10 +150,7 @@ impl EqualityIndex {
     pub fn is_synthesized(&self, id: &str) -> bool {
         matches!(
             self.by_id.get(id),
-            Some(EqualityInfo::Method {
-                synthesized: true,
-                ..
-            })
+            Some(EqualityInfo::SynthesizedMethod { .. })
         )
     }
 }
@@ -220,8 +208,6 @@ impl MutationInfo {
 pub struct EmitInput {
     pub files: HashMap<u32, File>,
     pub definitions: HashMap<Symbol, Definition>,
-    pub const_names: HashSet<Symbol>,
-    pub modules: HashMap<String, ModuleInfo>,
     pub entry_module_id: String,
     pub unused: UnusedInfo,
     pub mutations: MutationInfo,
@@ -231,8 +217,6 @@ pub struct EmitInput {
     pub test_index: TestIndex,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
-    pub bound_types: HashMap<crate::ast::Span, crate::types::Type>,
-    pub resolved_definitions: super::ResolvedDefinitions,
 }
 
 #[cfg(test)]
@@ -261,8 +245,7 @@ mod tests {
 
         a.merge(b);
 
-        assert_eq!(a.bindings.len(), 2);
-        assert_eq!(a.definitions.len(), 2);
+        assert_eq!(a.symbols.len(), 4);
         assert_eq!(a.imports_by_module["m1"].len(), 2);
         assert_eq!(a.imports_by_module["m2"].len(), 1);
     }

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -5,14 +5,15 @@ mod module;
 mod resolution;
 
 pub use definition::{
-    Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute, Visibility,
+    AliasKind, Attributes, Definition, DefinitionBody, Interface, MethodSignatures, TypeAttribute,
+    ValueKind, Visibility,
 };
 pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,
 };
 pub use file::{File, FileImport, go_import_default_name};
-pub use module::{Module, ModuleId, ModuleInfo};
+pub use module::{Module, ModuleId};
 pub use resolution::{
-    CallKind, ChannelOperation, DotAccessKind, NativeTypeKind, ReceiverCoercion,
-    ResolvedDefinitions, channel_operation, resolved_definition,
+    CallKind, ChannelOperation, DotAccessKind, DotAccessResolution, NativeTypeKind,
+    ReceiverCoercion, channel_operation, resolved_definition,
 };

--- a/crates/syntax/src/program/module.rs
+++ b/crates/syntax/src/program/module.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use super::definition::{Definition, Visibility};
 use super::file::{File, FileImport};
@@ -9,14 +9,10 @@ pub type ModuleId = String;
 #[derive(Debug, Clone)]
 pub struct Module {
     pub id: String,
-    /// file ID -> .lis file
+    /// file ID -> file. Source and declaration files are classified by [`File::is_d_lis`].
     pub files: HashMap<u32, File>,
-    /// file ID -> .d.lis file (declarations only)
-    pub typedefs: HashMap<u32, File>,
     /// qualified name -> definition
     pub definitions: HashMap<Symbol, Definition>,
-    /// Qualified names of module-level `const` bindings.
-    pub const_names: HashSet<Symbol>,
 }
 
 impl Module {
@@ -24,9 +20,7 @@ impl Module {
         Module {
             id: id.to_string(),
             files: Default::default(),
-            typedefs: Default::default(),
             definitions: Default::default(),
-            const_names: Default::default(),
         }
     }
 
@@ -47,23 +41,27 @@ impl Module {
     }
 
     pub fn file_ids(&self) -> impl Iterator<Item = u32> + '_ {
-        self.files.keys().copied()
+        self.source_file_entries().map(|(file_id, _)| *file_id)
     }
 
-    pub fn get_typedef_by_id(&self, file_id: u32) -> Option<&File> {
-        self.typedefs.get(&file_id)
+    pub fn source_files(&self) -> impl Iterator<Item = &File> {
+        self.files.values().filter(|file| !file.is_d_lis())
+    }
+
+    pub fn source_file_entries(&self) -> impl Iterator<Item = (&u32, &File)> {
+        self.files.iter().filter(|(_, file)| !file.is_d_lis())
+    }
+
+    pub fn typedef_files(&self) -> impl Iterator<Item = &File> {
+        self.files.values().filter(|file| file.is_d_lis())
+    }
+
+    pub fn is_typedef(&self, file_id: u32) -> bool {
+        self.files.get(&file_id).is_some_and(File::is_d_lis)
     }
 
     pub fn all_imports(&self) -> Vec<FileImport> {
-        self.files
-            .values()
-            .chain(self.typedefs.values())
-            .flat_map(|f| f.imports())
-            .collect()
-    }
-
-    pub fn all_typedefs(&self) -> impl Iterator<Item = &File> {
-        self.typedefs.values()
+        self.files.values().flat_map(|f| f.imports()).collect()
     }
 
     pub fn is_internal(&self) -> bool {
@@ -74,13 +72,6 @@ impl Module {
     }
 
     pub fn is_empty_stub(&self) -> bool {
-        self.files.is_empty() && self.typedefs.is_empty() && self.definitions.is_empty()
+        self.files.is_empty() && self.definitions.is_empty()
     }
-}
-
-pub struct ModuleInfo {
-    pub id: String,
-    pub path: String,
-    pub file_ids: Vec<u32>,
-    pub typedef_ids: Vec<u32>,
 }

--- a/crates/syntax/src/program/resolution.rs
+++ b/crates/syntax/src/program/resolution.rs
@@ -1,21 +1,11 @@
-use rustc_hash::FxHashMap as HashMap;
-
-use crate::ast::{Expression, Span};
+use crate::ast::Expression;
 use crate::types::Symbol;
 use crate::types::Type;
 
-pub type ResolvedDefinitions = HashMap<Span, Symbol>;
-
-pub fn resolved_definition<'a>(
-    expression: &'a Expression,
-    definitions: &'a ResolvedDefinitions,
-) -> Option<&'a str> {
+pub fn resolved_definition(expression: &Expression) -> Option<&str> {
     match expression.unwrap_parens() {
-        Expression::Identifier {
-            qualified: Some(definition),
-            ..
-        } => Some(definition),
-        Expression::DotAccess { span, .. } => definitions.get(span).map(Symbol::as_str),
+        Expression::Identifier { resolution, .. } => resolution.definition(),
+        Expression::DotAccess { resolution, .. } => resolution.definition(),
         _ => None,
     }
 }
@@ -120,6 +110,95 @@ pub enum DotAccessKind {
     },
     /// Static method (no `self` receiver)
     StaticMethod { is_exported: bool },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DotAccessResolution {
+    Unresolved,
+    StructField {
+        is_exported: bool,
+    },
+    TupleStructField {
+        is_newtype: bool,
+    },
+    TupleElement,
+    ModuleMember {
+        definition: Option<Symbol>,
+    },
+    EnumVariant {
+        definition: Symbol,
+    },
+    InstanceMethod {
+        is_exported: bool,
+        receiver_coercion: Option<ReceiverCoercion>,
+        definition: Option<Symbol>,
+    },
+    InstanceMethodValue {
+        is_exported: bool,
+        is_pointer_receiver: bool,
+        definition: Option<Symbol>,
+    },
+    StaticMethod {
+        is_exported: bool,
+        definition: Symbol,
+    },
+}
+
+impl DotAccessResolution {
+    pub fn kind(&self) -> Option<DotAccessKind> {
+        Some(match self {
+            Self::Unresolved => return None,
+            Self::StructField { is_exported } => DotAccessKind::StructField {
+                is_exported: *is_exported,
+            },
+            Self::TupleStructField { is_newtype } => DotAccessKind::TupleStructField {
+                is_newtype: *is_newtype,
+            },
+            Self::TupleElement => DotAccessKind::TupleElement,
+            Self::ModuleMember { .. } => DotAccessKind::ModuleMember,
+            Self::EnumVariant { .. } => DotAccessKind::EnumVariant,
+            Self::InstanceMethod { is_exported, .. } => DotAccessKind::InstanceMethod {
+                is_exported: *is_exported,
+            },
+            Self::InstanceMethodValue {
+                is_exported,
+                is_pointer_receiver,
+                ..
+            } => DotAccessKind::InstanceMethodValue {
+                is_exported: *is_exported,
+                is_pointer_receiver: *is_pointer_receiver,
+            },
+            Self::StaticMethod { is_exported, .. } => DotAccessKind::StaticMethod {
+                is_exported: *is_exported,
+            },
+        })
+    }
+
+    pub fn receiver_coercion(&self) -> Option<ReceiverCoercion> {
+        match self {
+            Self::InstanceMethod {
+                receiver_coercion, ..
+            } => *receiver_coercion,
+            _ => None,
+        }
+    }
+
+    pub fn definition(&self) -> Option<&str> {
+        match self {
+            Self::ModuleMember { definition }
+            | Self::InstanceMethod { definition, .. }
+            | Self::InstanceMethodValue { definition, .. } => {
+                definition.as_ref().map(Symbol::as_str)
+            }
+            Self::EnumVariant { definition } | Self::StaticMethod { definition, .. } => {
+                Some(definition)
+            }
+            Self::Unresolved
+            | Self::StructField { .. }
+            | Self::TupleStructField { .. }
+            | Self::TupleElement => None,
+        }
+    }
 }
 
 /// What kind of native built-in type (Slice, Map, Channel, etc.) a call targets.

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1,6 +1,5 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::Borrow;
-use std::cell::OnceCell;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -179,15 +178,15 @@ fn is_range_type_name(name: &str) -> bool {
     )
 }
 
-pub fn peel_to_range_type(ty: &Type) -> Option<&Type> {
-    std::iter::successors(Some(ty), |t| match t {
-        Type::Nominal {
-            underlying_ty: Some(u),
-            ..
-        } => Some(u.as_ref()),
-        _ => None,
-    })
-    .find(|t| t.get_name().is_some_and(is_range_type_name))
+pub fn peel_to_range_type<'d, F>(ty: &Type, lookup: F) -> Option<Type>
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    let peeled = peel_alias(ty, lookup);
+    peeled
+        .get_name()
+        .is_some_and(is_range_type_name)
+        .then_some(peeled)
 }
 
 /// type param name -> type variable
@@ -220,14 +219,9 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
     }
     match ty {
         Type::Parameter(name) => map.get(name).cloned().unwrap_or_else(|| ty.clone()),
-        Type::Nominal {
-            id,
-            params,
-            underlying_ty: underlying,
-        } => Type::Nominal {
+        Type::Nominal { id, params } => Type::Nominal {
             id: id.clone(),
             params: params.iter().map(|p| substitute(p, map)).collect(),
-            underlying_ty: underlying.as_ref().map(|u| Box::new(substitute(u, map))),
         },
         Type::Function(f) => f.rebuild(
             f.params
@@ -244,7 +238,7 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
                 .collect(),
             Box::new(substitute(&f.return_type, map)),
         ),
-        Type::Var { .. } | Type::Error => ty.clone(),
+        Type::Var { .. } | Type::Uninferred | Type::Ignored | Type::Error => ty.clone(),
         Type::Forall { vars, body } => {
             let has_overlap = map.keys().any(|k| vars.contains(k));
             let substituted_body = if has_overlap {
@@ -359,33 +353,24 @@ impl FunctionType {
     }
 }
 
-/// A unique handle identifying a type variable. The binding state (Unbound /
-/// Bound-to-a-Type) lives in a `TypeEnv` owned by the checker; the handle is
-/// a plain id so `Type` stays a pure value (Clone, Eq, Hash, Serialize).
+/// A unique handle identifying an inference variable in a checker's type environment.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TypeVarId(pub u32);
+pub struct TypeVarId(u32);
 
 impl TypeVarId {
-    const IGNORED: TypeVarId = TypeVarId(u32::MAX);
-    const UNINFERRED: TypeVarId = TypeVarId(u32::MAX - 1);
-
-    pub fn is_reserved(self) -> bool {
-        self == Self::IGNORED || self == Self::UNINFERRED
+    pub const fn new(index: u32) -> Self {
+        Self(index)
     }
 
-    pub(crate) fn as_u32(self) -> u32 {
+    pub const fn index(self) -> u32 {
         self.0
     }
 }
 
 impl std::fmt::Debug for TypeVarId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Self::IGNORED => write!(f, "ignored"),
-            Self::UNINFERRED => write!(f, "uninferred"),
-            TypeVarId(n) => write!(f, "#{}", n),
-        }
+        write!(f, "#{}", self.0)
     }
 }
 
@@ -402,7 +387,6 @@ pub enum Type {
     Nominal {
         id: Symbol,
         params: Vec<Type>,
-        underlying_ty: Option<Box<Type>>,
     },
 
     /// Module namespace handle. Produced by imports (e.g. `import http "net/http"`
@@ -419,6 +403,12 @@ pub enum Type {
         id: TypeVarId,
         hint: Option<EcoString>,
     },
+
+    /// Placeholder on syntax that has not entered type inference yet.
+    Uninferred,
+
+    /// Expected type for an expression whose value is intentionally discarded.
+    Ignored,
 
     Forall {
         vars: Vec<EcoString>,
@@ -449,6 +439,14 @@ pub enum Type {
     ReceiverPlaceholder,
 }
 
+struct TypePlaceholder(&'static str);
+
+impl std::fmt::Debug for TypePlaceholder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
 impl std::fmt::Debug for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -472,6 +470,14 @@ impl std::fmt::Debug for Type {
                 }
                 s.finish()
             }
+            Type::Uninferred => f
+                .debug_struct("Var")
+                .field("id", &TypePlaceholder("uninferred"))
+                .finish(),
+            Type::Ignored => f
+                .debug_struct("Var")
+                .field("id", &TypePlaceholder("ignored"))
+                .finish(),
             Type::Forall { vars, body } => f
                 .debug_struct("Forall")
                 .field("vars", vars)
@@ -517,6 +523,7 @@ impl PartialEq for Type {
             ) => id1 == id2 && params1 == params2,
             (Type::Function(f1), Type::Function(f2)) => f1 == f2,
             (Type::Var { id: id1, .. }, Type::Var { id: id2, .. }) => id1 == id2,
+            (Type::Uninferred, Type::Uninferred) | (Type::Ignored, Type::Ignored) => true,
             (
                 Type::Forall {
                     vars: vars1,
@@ -551,13 +558,6 @@ impl PartialEq for Type {
     }
 }
 
-thread_local! {
-    static INTERNED_INT: OnceCell<Type> = const { OnceCell::new() };
-    static INTERNED_STRING: OnceCell<Type> = const { OnceCell::new() };
-    static INTERNED_BOOL: OnceCell<Type> = const { OnceCell::new() };
-    static INTERNED_UNIT: OnceCell<Type> = const { OnceCell::new() };
-}
-
 impl Type {
     fn simple(kind: SimpleKind) -> Type {
         Self::Simple(kind)
@@ -580,48 +580,33 @@ impl Type {
     }
 
     pub fn int() -> Type {
-        INTERNED_INT.with(|cell| cell.get_or_init(|| Self::simple(SimpleKind::Int)).clone())
+        Self::simple(SimpleKind::Int)
     }
 
     pub fn string() -> Type {
-        INTERNED_STRING.with(|cell| {
-            cell.get_or_init(|| Self::simple(SimpleKind::String))
-                .clone()
-        })
+        Self::simple(SimpleKind::String)
     }
 
     pub fn bool() -> Type {
-        INTERNED_BOOL.with(|cell| cell.get_or_init(|| Self::simple(SimpleKind::Bool)).clone())
+        Self::simple(SimpleKind::Bool)
     }
 
     pub fn unit() -> Type {
-        INTERNED_UNIT.with(|cell| cell.get_or_init(|| Self::simple(SimpleKind::Unit)).clone())
+        Self::simple(SimpleKind::Unit)
     }
 }
 
 impl Type {
     pub fn uninferred() -> Self {
-        Self::Var {
-            id: TypeVarId::UNINFERRED,
-            hint: None,
-        }
+        Self::Uninferred
     }
 
     pub fn is_uninferred(&self) -> bool {
-        matches!(
-            self,
-            Self::Var {
-                id: TypeVarId::UNINFERRED,
-                ..
-            }
-        )
+        matches!(self, Self::Uninferred)
     }
 
     pub fn ignored() -> Self {
-        Self::Var {
-            id: TypeVarId::IGNORED,
-            hint: None,
-        }
+        Self::Ignored
     }
 
     pub fn get_type_params(&self) -> Option<&[Type]> {
@@ -635,17 +620,7 @@ impl Type {
     /// Direct child types, for read-only walks. Excludes `Function.bounds`.
     pub fn children(&self) -> Vec<&Type> {
         match self {
-            Type::Nominal {
-                params,
-                underlying_ty,
-                ..
-            } => {
-                let mut c: Vec<&Type> = params.iter().collect();
-                if let Some(u) = underlying_ty {
-                    c.push(u);
-                }
-                c
-            }
+            Type::Nominal { params, .. } => params.iter().collect(),
             Type::Compound { args, .. } => args.iter().collect(),
             Type::Function(f) => {
                 let mut c: Vec<&Type> = f.params.iter().map(|param| &param.ty).collect();
@@ -949,16 +924,6 @@ impl Type {
         }
     }
 
-    pub fn get_underlying(&self) -> Option<&Type> {
-        match self {
-            Type::Nominal {
-                underlying_ty: underlying,
-                ..
-            } => underlying.as_deref(),
-            _ => None,
-        }
-    }
-
     pub fn is_result(&self) -> bool {
         self.has_qualified_id("prelude.Result")
     }
@@ -1042,34 +1007,16 @@ impl Type {
         self.has_name("Unknown")
     }
 
-    pub fn resolves_to_unknown(&self) -> bool {
-        peel_alias(self, |_| true).is_unknown()
-    }
-
-    pub fn contains_unknown(&self) -> bool {
-        let peeled = peel_alias(self, |_| true);
-        if peeled.is_unknown() {
-            return true;
-        }
-        match &peeled {
-            Type::Compound { args, .. } => args.iter().any(|a| a.contains_unknown()),
-            Type::Function(f) => {
-                f.params.iter().any(|p| p.ty.contains_unknown()) || f.return_type.contains_unknown()
-            }
-            Type::Tuple(elements) => elements.iter().any(|e| e.contains_unknown()),
-            Type::Array { element, .. } => element.contains_unknown(),
-            Type::Nominal { params, .. } => params.iter().any(|p| p.contains_unknown()),
-            Type::Forall { body, .. } => body.contains_unknown(),
-            _ => false,
-        }
-    }
-
     pub fn is_receiver(&self) -> bool {
         self.is_native(CompoundKind::Receiver)
     }
 
     pub fn is_ignored(&self) -> bool {
-        matches!(self, Type::Var { id, .. } if *id == TypeVarId::IGNORED)
+        matches!(self, Type::Ignored)
+    }
+
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, Type::Uninferred | Type::Ignored)
     }
 
     pub fn is_variadic(&self) -> Option<Type> {
@@ -1103,27 +1050,6 @@ impl Type {
         self.is_byte_slice() || self.is_rune_slice()
     }
 
-    pub fn has_underlying_rune(&self) -> bool {
-        self.underlying_numeric_type().is_some_and(|t| t.is_rune())
-    }
-
-    pub fn has_underlying_byte(&self) -> bool {
-        self.underlying_numeric_type()
-            .is_some_and(|t| t.is_simple(SimpleKind::Byte) || t.is_simple(SimpleKind::Uint8))
-    }
-
-    pub fn has_byte_or_rune_slice_underlying(&self) -> bool {
-        if self.is_byte_or_rune_slice() {
-            return true;
-        }
-        match self {
-            Type::Nominal { underlying_ty, .. } => underlying_ty
-                .as_deref()
-                .is_some_and(|u| u.has_byte_or_rune_slice_underlying()),
-            _ => false,
-        }
-    }
-
     pub fn as_simple(&self) -> Option<SimpleKind> {
         match self {
             Type::Simple(kind) => Some(*kind),
@@ -1152,10 +1078,6 @@ impl Type {
         matches!(self, Type::Var { .. })
     }
 
-    pub fn is_type_var(&self) -> bool {
-        matches!(self, Type::Var { .. })
-    }
-
     /// A transparent alias over this keeps its name, wrapped in a `Nominal`
     /// that unification peels back to it.
     pub fn is_structural_alias_body(&self) -> bool {
@@ -1169,58 +1091,12 @@ impl Type {
         self.as_simple().is_some_and(SimpleKind::is_arithmetic)
     }
 
-    /// Whether `<`/`<=`/`>`/`>=` accept this type: an ordered numeric, a
-    /// string-backed type (resolved through named types), or a plain boolean.
-    pub fn is_orderable(&self) -> bool {
-        matches!(
-            self.underlying_simple_kind(),
-            Some(kind) if kind.is_ordered() || kind == SimpleKind::String
-        ) || self.is_boolean()
-    }
-
-    /// True for Go's `cmp.Ordered` set: ints, floats, strings, and named aliases over them.
-    pub fn satisfies_ordered_constraint(&self) -> bool {
-        if let Some(kind) = self.as_simple() {
-            return matches!(
-                kind,
-                SimpleKind::Int
-                    | SimpleKind::Int8
-                    | SimpleKind::Int16
-                    | SimpleKind::Int32
-                    | SimpleKind::Int64
-                    | SimpleKind::Uint
-                    | SimpleKind::Uint8
-                    | SimpleKind::Uint16
-                    | SimpleKind::Uint32
-                    | SimpleKind::Uint64
-                    | SimpleKind::Uintptr
-                    | SimpleKind::Byte
-                    | SimpleKind::Rune
-                    | SimpleKind::Float32
-                    | SimpleKind::Float64
-                    | SimpleKind::String
-            );
-        }
-        match self {
-            Type::Nominal { underlying_ty, .. } => underlying_ty
-                .as_deref()
-                .is_some_and(Type::satisfies_ordered_constraint),
-            Type::Parameter(_) => true,
-            _ => false,
-        }
-    }
-
     pub fn is_complex(&self) -> bool {
         self.as_simple().is_some_and(SimpleKind::is_complex)
     }
 
     pub fn is_unsigned_int(&self) -> bool {
         self.as_simple().is_some_and(SimpleKind::is_unsigned_int)
-    }
-
-    pub fn underlying_is_unsigned_int(&self) -> bool {
-        self.underlying_simple_kind()
-            .is_some_and(SimpleKind::is_unsigned_int)
     }
 
     pub fn is_never(&self) -> bool {
@@ -1234,14 +1110,7 @@ impl Type {
     pub fn contains_error(&self) -> bool {
         match self {
             Type::Error => true,
-            Type::Nominal {
-                params,
-                underlying_ty,
-                ..
-            } => {
-                params.iter().any(Type::contains_error)
-                    || underlying_ty.as_deref().is_some_and(Type::contains_error)
-            }
+            Type::Nominal { params, .. } => params.iter().any(Type::contains_error),
             Type::Compound { args, .. } => args.iter().any(Type::contains_error),
             Type::Function(f) => {
                 f.params.iter().any(|param| param.ty.contains_error())
@@ -1269,6 +1138,8 @@ impl Type {
             Type::Simple(_)
             | Type::Parameter(_)
             | Type::Never
+            | Type::Uninferred
+            | Type::Ignored
             | Type::Error
             | Type::ImportNamespace(_)
             | Type::ReceiverPlaceholder => false,
@@ -1308,6 +1179,8 @@ impl Type {
             Type::Simple(_)
             | Type::Parameter(_)
             | Type::Never
+            | Type::Uninferred
+            | Type::Ignored
             | Type::Error
             | Type::ImportNamespace(_)
             | Type::ReceiverPlaceholder => {}
@@ -1361,7 +1234,12 @@ impl Type {
             Type::Simple(kind) => {
                 names.remove(kind.leaf_name());
             }
-            Type::Never | Type::Error | Type::ImportNamespace(_) | Type::ReceiverPlaceholder => {}
+            Type::Never
+            | Type::Uninferred
+            | Type::Ignored
+            | Type::Error
+            | Type::ImportNamespace(_)
+            | Type::ReceiverPlaceholder => {}
         }
     }
 }
@@ -1400,10 +1278,6 @@ impl Type {
     pub fn get_function_params(&self) -> Option<&[FunctionParameter]> {
         match self {
             Type::Function(f) => Some(&f.params),
-            Type::Nominal {
-                underlying_ty: Some(inner),
-                ..
-            } => inner.get_function_params(),
             _ => None,
         }
     }
@@ -1475,64 +1349,219 @@ impl Type {
     }
 }
 
-/// Walk an alias chain via `underlying_ty` (preserves substitution); cycle
-/// guard defends against chains that slip past `circular_type_alias`.
-pub fn peel_alias<F>(ty: &Type, is_alias: F) -> Type
+/// Resolve transparent aliases from their canonical definition targets. The
+/// cycle guard defends against invalid external definitions and recovery types.
+pub fn peel_alias<'d, F>(ty: &Type, lookup: F) -> Type
 where
-    F: Fn(&str) -> bool,
+    F: Fn(&str) -> Option<&'d Definition>,
 {
     let mut current = ty.unwrap_forall().clone();
-    let mut seen: Vec<String> = Vec::new();
-    while let Type::Nominal {
-        id,
-        underlying_ty: Some(u),
-        ..
-    } = &current
-    {
-        if !is_alias(id.as_str()) {
+    let mut seen: HashSet<Symbol> = HashSet::default();
+    while let Type::Nominal { id, params } = &current {
+        if !seen.insert(id.clone()) {
             break;
         }
-        if seen.iter().any(|s| s == id.as_str()) {
+        let Some(target) =
+            lookup(id.as_str()).and_then(|definition| definition.instantiate_alias_target(params))
+        else {
             break;
-        }
-        seen.push(id.to_string());
-        current = u.unwrap_forall().clone();
+        };
+        current = target.unwrap_forall().clone();
     }
     current
 }
 
-pub fn is_nilable_go_type<'a>(ty: &Type, lookup: impl Fn(&str) -> Option<&'a Definition>) -> bool {
-    let is_alias = |id: &str| lookup(id).is_some_and(Definition::is_type_alias);
-    let is_interface = |id: &str| matches!(lookup(id), Some(d) if matches!(d.body, DefinitionBody::Interface { .. }));
-    resolves_to_pointer(ty, is_alias)
-        || resolves_to_interface(ty, is_alias, is_interface)
-        || resolves_to_function(ty, is_alias)
-}
-
-fn resolves_to_pointer<FA: Fn(&str) -> bool>(ty: &Type, is_alias: FA) -> bool {
-    fn as_pointer(ty: &Type) -> bool {
-        ty.is_ref() || ty.get_underlying().is_some_and(Type::is_ref)
-    }
-    as_pointer(ty) || as_pointer(&peel_alias(ty, is_alias))
-}
-
-fn resolves_to_interface<FA, FI>(ty: &Type, is_alias: FA, is_interface: FI) -> bool
+/// Return the immediate underlying type of a nominal occurrence, instantiated
+/// with that occurrence's type arguments.
+pub fn underlying_type<'d, F>(ty: &Type, lookup: F) -> Option<Type>
 where
-    FA: Fn(&str) -> bool,
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    let Type::Nominal { id, params } = ty.unwrap_forall() else {
+        return None;
+    };
+    lookup(id.as_str())?.instantiate_underlying(params)
+}
+
+/// Follow transparent aliases and newtype fields to their canonical
+/// representation. The cycle guard also makes this safe for recovery types
+/// built from invalid recursive declarations.
+pub fn peel_underlying<'d, F>(ty: &Type, lookup: F) -> Type
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    let mut current = ty.unwrap_forall().clone();
+    let mut seen: HashSet<Symbol> = HashSet::default();
+    while let Type::Nominal { id, params } = &current {
+        if !seen.insert(id.clone()) {
+            break;
+        }
+        let Some(underlying) =
+            lookup(id.as_str()).and_then(|definition| definition.instantiate_underlying(params))
+        else {
+            break;
+        };
+        current = underlying.unwrap_forall().clone();
+    }
+    current
+}
+
+pub fn resolves_to_unknown<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    peel_alias(ty, lookup).is_unknown()
+}
+
+pub fn contains_unknown<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    fn contains<'d, F>(ty: &Type, lookup: &F) -> bool
+    where
+        F: Fn(&str) -> Option<&'d Definition>,
+    {
+        let peeled = peel_alias(ty, lookup);
+        peeled.is_unknown()
+            || peeled
+                .children()
+                .into_iter()
+                .any(|child| contains(child, lookup))
+    }
+
+    contains(ty, &lookup)
+}
+
+pub fn underlying_simple_kind<'d, F>(ty: &Type, lookup: F) -> Option<SimpleKind>
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    peel_underlying(ty, lookup).as_simple()
+}
+
+pub fn underlying_numeric_type<'d, F>(ty: &Type, lookup: F) -> Option<Type>
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    let underlying = peel_underlying(ty, lookup);
+    underlying.is_numeric().then_some(underlying)
+}
+
+pub fn literal_adaptation_target<'d, F>(ty: &Type, lookup: F) -> Option<Type>
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    underlying_numeric_type(ty, &lookup).or_else(|| {
+        (matches!(ty.unwrap_forall(), Type::Nominal { .. })
+            && underlying_simple_kind(ty, &lookup) == Some(SimpleKind::Uintptr))
+        .then_some(Type::Simple(SimpleKind::Uintptr))
+    })
+}
+
+pub fn is_numeric_compatible_with<'d, F>(left: &Type, right: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    match (
+        underlying_numeric_type(left, &lookup),
+        underlying_numeric_type(right, &lookup),
+    ) {
+        (Some(left), Some(right)) => left.numeric_family() == right.numeric_family(),
+        _ => false,
+    }
+}
+
+pub fn is_aliased_numeric_type<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    matches!(ty.unwrap_forall(), Type::Nominal { .. })
+        && underlying_type(ty, &lookup).is_some()
+        && !ty.is_numeric()
+        && underlying_numeric_type(ty, lookup).is_some()
+}
+
+pub fn has_byte_or_rune_slice_underlying<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    peel_underlying(ty, lookup).is_byte_or_rune_slice()
+}
+
+pub fn is_orderable<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    matches!(
+        underlying_simple_kind(ty, lookup),
+        Some(kind) if kind.is_ordered() || kind == SimpleKind::String
+    ) || ty.is_boolean()
+}
+
+/// True for Go's `cmp.Ordered` set: ints, floats, strings, parameters, and
+/// named aliases over those types.
+pub fn satisfies_ordered_constraint<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    let Some(kind) = underlying_simple_kind(ty, lookup) else {
+        return matches!(ty.unwrap_forall(), Type::Parameter(_));
+    };
+    matches!(
+        kind,
+        SimpleKind::Int
+            | SimpleKind::Int8
+            | SimpleKind::Int16
+            | SimpleKind::Int32
+            | SimpleKind::Int64
+            | SimpleKind::Uint
+            | SimpleKind::Uint8
+            | SimpleKind::Uint16
+            | SimpleKind::Uint32
+            | SimpleKind::Uint64
+            | SimpleKind::Uintptr
+            | SimpleKind::Byte
+            | SimpleKind::Rune
+            | SimpleKind::Float32
+            | SimpleKind::Float64
+            | SimpleKind::String
+    )
+}
+
+pub fn is_nilable_go_type<'a>(ty: &Type, lookup: impl Fn(&str) -> Option<&'a Definition>) -> bool {
+    let is_interface = |id: &str| matches!(lookup(id), Some(d) if matches!(d.body, DefinitionBody::Interface { .. }));
+    resolves_to_pointer(ty, &lookup)
+        || resolves_to_interface(ty, &lookup, is_interface)
+        || resolves_to_function(ty, &lookup)
+}
+
+fn resolves_to_pointer<'d, F: Fn(&str) -> Option<&'d Definition>>(ty: &Type, lookup: &F) -> bool {
+    let as_pointer = |ty: &Type| {
+        ty.is_ref()
+            || underlying_type(ty, lookup)
+                .as_ref()
+                .is_some_and(Type::is_ref)
+    };
+    as_pointer(ty) || as_pointer(&peel_alias(ty, lookup))
+}
+
+fn resolves_to_interface<'d, F, FI>(ty: &Type, lookup: &F, is_interface: FI) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
     FI: Fn(&str) -> bool,
 {
-    matches!(peel_alias(ty, is_alias), Type::Nominal { id, .. } if is_interface(id.as_str()))
+    matches!(peel_alias(ty, lookup), Type::Nominal { id, .. } if is_interface(id.as_str()))
 }
 
-fn resolves_to_function<FA: Fn(&str) -> bool>(ty: &Type, is_alias: FA) -> bool {
-    fn as_function(ty: &Type) -> bool {
-        matches!(ty, Type::Function(_)) || matches!(ty.get_underlying(), Some(Type::Function(_)))
-    }
-    as_function(ty) || as_function(&peel_alias(ty, is_alias))
+fn resolves_to_function<'d, F: Fn(&str) -> Option<&'d Definition>>(ty: &Type, lookup: &F) -> bool {
+    let as_function = |ty: &Type| {
+        matches!(ty, Type::Function(_))
+            || matches!(underlying_type(ty, lookup), Some(Type::Function(_)))
+    };
+    as_function(ty) || as_function(&peel_alias(ty, lookup))
 }
 
-/// Walk an alias chain by id alone; used when no `Type` with
-/// `underlying_ty` is available (e.g. Go-name resolution).
+/// Walk an alias chain by id alone (for example during Go-name resolution).
 pub fn peel_alias_id<F>(id: &str, next_alias: F) -> String
 where
     F: Fn(&str) -> Option<String>,
@@ -1605,16 +1634,12 @@ impl Type {
             Type::Nominal {
                 id: name,
                 params: args,
-                underlying_ty: underlying,
             } => Type::Nominal {
                 id: name.clone(),
                 params: args
                     .iter()
                     .map(|a| Self::remove_vars_impl(a, vars))
                     .collect(),
-                underlying_ty: underlying
-                    .as_ref()
-                    .map(|u| Box::new(Self::remove_vars_impl(u, vars))),
             },
 
             Type::Function(f) => Type::function(
@@ -1633,14 +1658,14 @@ impl Type {
                 Self::remove_vars_impl(&f.return_type, vars).into(),
             ),
 
-            Type::Var { id, hint } => match vars.get(&id.0) {
+            Type::Var { id, hint } => match vars.get(&id.index()) {
                 Some(g) => Type::Parameter(g.clone()),
                 None => {
                     let name: EcoString = hint
                         .clone()
                         .unwrap_or_else(|| alpha_index(vars.len()).into());
 
-                    vars.insert(id.0, name.clone());
+                    vars.insert(id.index(), name.clone());
                     Type::Parameter(name)
                 }
             },
@@ -1664,9 +1689,12 @@ impl Type {
                 element: Box::new(Self::remove_vars_impl(element, vars)),
             },
             Type::Simple(_) | Type::Parameter(_) => ty.clone(),
-            Type::Never | Type::Error | Type::ImportNamespace(_) | Type::ReceiverPlaceholder => {
-                ty.clone()
-            }
+            Type::Never
+            | Type::Uninferred
+            | Type::Ignored
+            | Type::Error
+            | Type::ImportNamespace(_)
+            | Type::ReceiverPlaceholder => ty.clone(),
         }
     }
 
@@ -1688,6 +1716,8 @@ impl Type {
             Type::Simple(_)
             | Type::Parameter(_)
             | Type::Never
+            | Type::Uninferred
+            | Type::Ignored
             | Type::Error
             | Type::ImportNamespace(_)
             | Type::ReceiverPlaceholder => false,
@@ -1696,97 +1726,8 @@ impl Type {
 }
 
 impl Type {
-    pub fn underlying_numeric_type(&self) -> Option<Type> {
-        self.underlying_numeric_type_recursive(&mut HashSet::default())
-    }
-
-    pub fn has_underlying_numeric_type(&self) -> bool {
-        self.underlying_numeric_type().is_some()
-    }
-
-    pub fn literal_adaptation_target(&self) -> Option<Type> {
-        if let Some(numeric) = self.underlying_numeric_type() {
-            return Some(numeric);
-        }
-        match self {
-            Type::Nominal { .. } if self.underlying_simple_kind() == Some(SimpleKind::Uintptr) => {
-                Some(Type::Simple(SimpleKind::Uintptr))
-            }
-            _ => None,
-        }
-    }
-
-    pub fn underlying_simple_kind(&self) -> Option<SimpleKind> {
-        self.underlying_simple_kind_recursive(&mut HashSet::default())
-    }
-
-    fn underlying_simple_kind_recursive(
-        &self,
-        visited: &mut HashSet<Symbol>,
-    ) -> Option<SimpleKind> {
-        if let Some(kind) = self.as_simple() {
-            return Some(kind);
-        }
-        match self {
-            Type::Nominal {
-                id,
-                underlying_ty: Some(underlying),
-                ..
-            } => {
-                if !visited.insert(id.clone()) {
-                    return None;
-                }
-                underlying.underlying_simple_kind_recursive(visited)
-            }
-            _ => None,
-        }
-    }
-
-    fn underlying_numeric_type_recursive(&self, visited: &mut HashSet<Symbol>) -> Option<Type> {
-        match self {
-            Type::Simple(_) if self.is_numeric() => Some(self.clone()),
-            Type::Nominal {
-                id,
-                underlying_ty: underlying,
-                ..
-            } => {
-                if self.is_numeric() {
-                    return Some(self.clone());
-                }
-
-                if !visited.insert(id.clone()) {
-                    return None;
-                }
-
-                underlying
-                    .as_ref()?
-                    .underlying_numeric_type_recursive(visited)
-            }
-            _ => None,
-        }
-    }
-
     pub fn numeric_family(&self) -> Option<NumericFamily> {
         self.as_simple()?.numeric_family()
-    }
-
-    pub fn is_numeric_compatible_with(&self, other: &Type) -> bool {
-        let self_underlying_ty = self.underlying_numeric_type();
-        let other_underlying_ty = other.underlying_numeric_type();
-
-        match (self_underlying_ty, other_underlying_ty) {
-            (Some(s), Some(o)) => s.numeric_family() == o.numeric_family(),
-            _ => false,
-        }
-    }
-
-    pub fn is_aliased_numeric_type(&self) -> bool {
-        match self {
-            Type::Nominal { underlying_ty, .. } => {
-                underlying_ty.is_some() && !self.is_numeric() && self.has_underlying_numeric_type()
-            }
-            _ => false,
-        }
     }
 }
 
@@ -1859,7 +1800,7 @@ mod tests {
 
     fn unhinted_var(id: u32) -> Type {
         Type::Var {
-            id: TypeVarId(id),
+            id: TypeVarId::new(id),
             hint: None,
         }
     }

--- a/tests/_harness/builders.rs
+++ b/tests/_harness/builders.rs
@@ -69,7 +69,6 @@ pub fn con_type(name: &str, args: Vec<Type>) -> Type {
     Type::Nominal {
         id: format!("_entry_.{}", name).into(),
         params: args,
-        underlying_ty: None,
     }
 }
 

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -45,7 +45,6 @@ fn emit_inner(
     let test_index = syntax::program::TestIndex::default();
     let config = TestEmitConfig {
         definitions: &result.definitions,
-        const_names: &result.const_names,
         module_id: &result.module_id,
         go_module: "myproject",
         unused: &result.unused,
@@ -55,7 +54,6 @@ fn emit_inner(
         test_index: &test_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
-        resolved_definitions: &result.resolved_definitions,
     };
     let mut emitter = Planner::new_for_tests(&config, source_for_sourcemap);
     let emitted_files = emitter.emit_files(&[&file], &result.module_id);

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -1,4 +1,5 @@
 use diagnostics::{LisetteDiagnostic, LocalSink};
+use rustc_hash::FxHashMap as HashMap;
 use semantics::loader::Loader;
 use semantics::{
     checker::TaskState,
@@ -8,7 +9,11 @@ use semantics::{
     store::Store,
 };
 use stdlib::{Target, get_go_stdlib_typedef};
-use syntax::{ast::Expression, types::Type};
+use syntax::{
+    ast::Expression,
+    program::Definition,
+    types::{Symbol, Type},
+};
 
 use super::init_prelude;
 
@@ -34,6 +39,7 @@ pub fn infer(raw_source: &str) -> InferResult {
     InferResult {
         ast: result.ast,
         errors: result.errors,
+        definitions: result.definitions,
     }
 }
 
@@ -47,6 +53,7 @@ pub fn infer_with_go_typedefs(raw_source: &str, typedefs: &[(&str, &str)]) -> In
     InferResult {
         ast: result.ast,
         errors: result.errors,
+        definitions: result.definitions,
     }
 }
 
@@ -76,6 +83,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         return InferResult {
             ast: vec![],
             errors: sink.take(),
+            definitions: HashMap::default(),
         };
     }
 
@@ -138,16 +146,15 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
             checker.cursor.module_id = prev_module_id;
         }
 
-        for (module_id, typed_file) in std::mem::take(&mut checker.typed_files) {
-            store.store_file(&module_id, typed_file);
+        for (_, typed_file) in std::mem::take(&mut checker.typed_files) {
+            store.store_file(typed_file);
         }
 
         checker.check_post_inference_bounds(&store);
 
         let module = store.get_module(module_name).unwrap();
         let ast: Vec<_> = module
-            .files
-            .values()
+            .source_files()
             .flat_map(|f| f.items.clone())
             .collect();
 
@@ -169,15 +176,24 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         ast
     };
 
+    let definitions = store
+        .modules
+        .values()
+        .flat_map(|module| module.definitions.iter())
+        .map(|(name, definition)| (name.clone(), definition.clone()))
+        .collect();
+
     InferResult {
         ast,
         errors: sink.take(),
+        definitions,
     }
 }
 
 pub struct InferResult {
     pub ast: Vec<Expression>,
     pub errors: Vec<LisetteDiagnostic>,
+    definitions: HashMap<Symbol, Definition>,
 }
 
 impl InferResult {
@@ -188,7 +204,7 @@ impl InferResult {
             .get_expression_type_at(0)
             .unwrap_or_else(|| panic!("No expression found at index 0"));
 
-        if !types_equal(&actual, &expected) {
+        if !types_equal(&actual, &expected, &self.definitions) {
             panic!(
                 "Type mismatch at expression 0\nExpected: {}\nActual:   {}",
                 expected.stringify(),
@@ -207,7 +223,7 @@ impl InferResult {
             .get_expression_type_at(last_index)
             .unwrap_or_else(|| panic!("No expression found at index {}", last_index));
 
-        if !types_equal(&actual, &expected) {
+        if !types_equal(&actual, &expected, &self.definitions) {
             panic!(
                 "Type mismatch at expression {}\nExpected: {}\nActual: {}",
                 last_index,
@@ -453,11 +469,28 @@ impl VarBijection {
     }
 }
 
-fn types_equal(t1: &Type, t2: &Type) -> bool {
-    types_equal_with(t1, t2, &mut VarBijection::default())
+fn types_equal(t1: &Type, t2: &Type, definitions: &HashMap<Symbol, Definition>) -> bool {
+    types_equal_with(t1, t2, definitions, &mut VarBijection::default())
 }
 
-fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
+fn types_equal_with(
+    t1: &Type,
+    t2: &Type,
+    definitions: &HashMap<Symbol, Definition>,
+    vars: &mut VarBijection,
+) -> bool {
+    let resolved1 = if matches!(t1, Type::Nominal { .. }) {
+        syntax::types::peel_alias(t1, |id| definitions.get(id))
+    } else {
+        t1.clone()
+    };
+    let resolved2 = if matches!(t2, Type::Nominal { .. }) {
+        syntax::types::peel_alias(t2, |id| definitions.get(id))
+    } else {
+        t2.clone()
+    };
+    let (t1, t2) = (&resolved1, &resolved2);
+
     if let (Some(n1), Some(n2)) = (t1.get_name(), t2.get_name())
         && n1 == n2
     {
@@ -467,7 +500,7 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
             && args1
                 .iter()
                 .zip(args2.iter())
-                .all(|(a1, a2)| types_equal_with(a1, a2, vars))
+                .all(|(a1, a2)| types_equal_with(a1, a2, definitions, vars))
         {
             return true;
         }
@@ -481,7 +514,7 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
                 return args
                     .iter()
                     .zip(params.iter())
-                    .all(|(x, y)| types_equal_with(x, y, vars));
+                    .all(|(x, y)| types_equal_with(x, y, definitions, vars));
             }
         }
         (Type::Simple(kind), Type::Nominal { id, params, .. })
@@ -494,31 +527,13 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
         _ => {}
     }
 
-    if let Type::Nominal {
-        underlying_ty: Some(u),
-        ..
-    } = t1
-        && types_equal_with(u, t2, vars)
-    {
-        return true;
-    }
-    if let Type::Nominal {
-        underlying_ty: Some(u),
-        ..
-    } = t2
-        && types_equal_with(t1, u, vars)
-    {
-        return true;
-    }
-
     match (t1, t2) {
-        (Type::Var { id: a, .. }, Type::Var { id: b, .. }) => vars.unify(a.0, b.0),
+        (Type::Var { id: a, .. }, Type::Var { id: b, .. }) => vars.unify(a.index(), b.index()),
 
         (
             Type::Nominal {
                 id: id1,
                 params: args1,
-                underlying_ty: u1,
             },
             Type::Nominal {
                 id: id2,
@@ -533,12 +548,7 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
                 && args1
                     .iter()
                     .zip(args2.iter())
-                    .all(|(a1, a2)| types_equal_with(a1, a2, vars))
-            {
-                return true;
-            }
-            if let Some(u) = u1
-                && types_equal_with(u, t2, vars)
+                    .all(|(a1, a2)| types_equal_with(a1, a2, definitions, vars))
             {
                 return true;
             }
@@ -548,9 +558,9 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
         (Type::Function(f1), Type::Function(f2)) => {
             f1.params.len() == f2.params.len()
                 && f1.params.iter().zip(f2.params.iter()).all(|(a1, a2)| {
-                    a1.mutable == a2.mutable && types_equal_with(&a1.ty, &a2.ty, vars)
+                    a1.mutable == a2.mutable && types_equal_with(&a1.ty, &a2.ty, definitions, vars)
                 })
-                && types_equal_with(&f1.return_type, &f2.return_type, vars)
+                && types_equal_with(&f1.return_type, &f2.return_type, definitions, vars)
         }
 
         (Type::Tuple(elems1), Type::Tuple(elems2)) => {
@@ -558,7 +568,7 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
                 && elems1
                     .iter()
                     .zip(elems2.iter())
-                    .all(|(e1, e2)| types_equal_with(e1, e2, vars))
+                    .all(|(e1, e2)| types_equal_with(e1, e2, definitions, vars))
         }
 
         (Type::Simple(k1), Type::Simple(k2)) => k1 == k2,
@@ -569,7 +579,7 @@ fn types_equal_with(t1: &Type, t2: &Type, vars: &mut VarBijection) -> bool {
                 && a1
                     .iter()
                     .zip(a2.iter())
-                    .all(|(x, y)| types_equal_with(x, y, vars))
+                    .all(|(x, y)| types_equal_with(x, y, definitions, vars))
         }
 
         _ => false,

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -114,7 +114,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
         file_comment: None,
     };
 
-    store.store_file(TEST_MODULE_ID, typed_file);
+    store.store_file(typed_file);
     store.build_closed_domains();
 
     let inference_len = checker.sink.len();

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -52,11 +52,11 @@ pub fn register_test_builtins(store: &mut Store, _checker: &mut TaskState) {
                 name_span: None,
                 doc: None,
                 body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
                     go_type_param_recipe: None,
-                    const_value: None,
                 },
             },
         );
@@ -65,7 +65,6 @@ pub fn register_test_builtins(store: &mut Store, _checker: &mut TaskState) {
     let unknown = Type::Nominal {
         id: "prelude.Unknown".into(),
         params: vec![],
-        underlying_ty: None,
     };
     let unknown_map = Type::Compound {
         kind: CompoundKind::Map,

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -4,14 +4,11 @@ use diagnostics::{LisetteDiagnostic, LocalSink};
 use semantics::{checker::TaskState, checker::infer::InferCtx, store::Store};
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
-    ast::Expression,
+    ast::{Expression, FunctionBody},
     desugar,
     lex::Lexer,
     parse::Parser,
-    program::{
-        Definition, EqualityIndex, File, FileImport, MutationInfo, ResolvedDefinitions, UnusedInfo,
-        Visibility,
-    },
+    program::{Definition, EqualityIndex, File, FileImport, MutationInfo, UnusedInfo, Visibility},
     types::Symbol,
 };
 
@@ -104,14 +101,12 @@ impl CompiledTest {
         let (
             typed_ast,
             definitions,
-            const_names,
             unused,
             mutations,
             ufcs_methods,
             equality_index,
             go_package_names,
             go_module_ids,
-            resolved_definitions,
         ) = {
             let mut checker = TaskState::with_fresh_allocator();
             checker.extend_ufcs_methods(semantics::prelude::compute_prelude_ufcs(&store));
@@ -161,18 +156,15 @@ impl CompiledTest {
             InferCtx::new(&mut checker, &store).check_const_cycles(&[self.ast.as_slice()]);
 
             let test_file_id = store.new_file_id();
-            store.store_file(
+            store.store_file(File::new(
                 TEST_MODULE_ID,
-                File::new(
-                    TEST_MODULE_ID,
-                    "test.lis",
-                    "test.lis",
-                    "",
-                    self.ast.clone(),
-                    None,
-                    test_file_id,
-                ),
-            );
+                "test.lis",
+                "test.lis",
+                "",
+                self.ast.clone(),
+                None,
+                test_file_id,
+            ));
             checker.finalize_equality(&mut store);
             checker.check_pending_generic_bounds(&store);
 
@@ -208,18 +200,15 @@ impl CompiledTest {
             if !checker.failed() {
                 // Overwrite the stored file with the typed AST so passes::run
                 // sees post-inference items when iterating store.modules.
-                store.store_file(
+                store.store_file(File::new(
                     TEST_MODULE_ID,
-                    File::new(
-                        TEST_MODULE_ID,
-                        "test.lis",
-                        "test.lis",
-                        "",
-                        typed_ast.clone(),
-                        None,
-                        test_file_id,
-                    ),
-                );
+                    "test.lis",
+                    "test.lis",
+                    "",
+                    typed_ast.clone(),
+                    None,
+                    test_file_id,
+                ));
                 store.build_closed_domains();
                 let ufcs_methods = checker.shared_ufcs_methods();
                 let analysis = semantics::context::AnalysisContext::new(&store, &ufcs_methods);
@@ -263,12 +252,6 @@ impl CompiledTest {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
 
-            let const_names: HashSet<Symbol> = store
-                .modules
-                .values()
-                .flat_map(|m| m.const_names.iter().cloned())
-                .collect();
-
             let mut unused = UnusedInfo::default();
             let mut mutations = MutationInfo::default();
             for (&binding_id, b) in checker.facts.bindings.iter() {
@@ -280,7 +263,6 @@ impl CompiledTest {
 
             let ufcs_methods = checker.take_ufcs_methods();
             let equality_index = std::mem::take(&mut store.equality_index);
-            let resolved_definitions = std::mem::take(&mut checker.facts.resolved_definitions);
             let go_package_names = store.go_package_names.clone();
             let go_module_ids: HashSet<String> = store
                 .modules
@@ -294,14 +276,12 @@ impl CompiledTest {
             (
                 typed_ast,
                 definitions,
-                const_names,
                 unused,
                 mutations,
                 ufcs_methods,
                 equality_index,
                 go_package_names,
                 go_module_ids,
-                resolved_definitions,
             )
         };
 
@@ -309,7 +289,6 @@ impl CompiledTest {
             ast: typed_ast,
             errors: sink.take(),
             definitions,
-            const_names,
             module_id: TEST_MODULE_ID.to_string(),
             unused,
             mutations,
@@ -317,7 +296,6 @@ impl CompiledTest {
             equality_index,
             go_package_names,
             go_module_ids,
-            resolved_definitions,
         }
     }
 }
@@ -326,7 +304,6 @@ pub struct InferenceResult {
     pub ast: Vec<Expression>,
     pub errors: Vec<LisetteDiagnostic>,
     pub definitions: HashMap<Symbol, Definition>,
-    pub const_names: HashSet<Symbol>,
     pub module_id: String,
     pub unused: UnusedInfo,
     pub mutations: MutationInfo,
@@ -334,7 +311,6 @@ pub struct InferenceResult {
     pub equality_index: EqualityIndex,
     pub go_package_names: HashMap<String, String>,
     pub go_module_ids: HashSet<String>,
-    pub resolved_definitions: ResolvedDefinitions,
 }
 
 fn unwrap_test_wrapper(expression: Expression) -> Expression {
@@ -350,6 +326,9 @@ fn unwrap_test_wrapper(expression: Expression) -> Expression {
         unreachable!()
     };
 
+    let FunctionBody::Definition(body) = body else {
+        panic!("Expected definition for {TEST_WRAPPER_NAME} wrapper function");
+    };
     let Expression::Block { items, .. } = *body else {
         panic!(
             "Expected Block as body of {} wrapper function",

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -58,7 +58,6 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
     let test_index = syntax::program::TestIndex::default();
     let config = TestEmitConfig {
         definitions: &result.definitions,
-        const_names: &result.const_names,
         module_id: &result.module_id,
         go_module: GO_MODULE,
         unused: &result.unused,
@@ -68,7 +67,6 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         test_index: &test_index,
         go_package_names: &result.go_package_names,
         go_module_ids: &result.go_module_ids,
-        resolved_definitions: &result.resolved_definitions,
     };
     let mut emitter = Planner::new_for_tests(&config, None);
     let mut emitted_files = emitter.emit_files(&[&file], &result.module_id);

--- a/tests/spec/desugar/snapshots/pipeline_as_return.snap
+++ b/tests/spec/desugar/snapshots/pipeline_as_return.snap
@@ -19,59 +19,59 @@ description: "fn test() { x |> double; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "double",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 17,
-                            byte_length: 6,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Identifier {
-                            value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "double",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 1,
+                                byte_offset: 17,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 11,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 11,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_chained.snap
+++ b/tests/spec/desugar/snapshots/pipeline_chained.snap
@@ -19,87 +19,86 @@ description: "fn test() { x |> f |> g; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "g",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 22,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Call {
-                            expression: Identifier {
-                                value: "f",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 17,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 12,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "g",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 6,
+                                byte_offset: 22,
+                                byte_length: 1,
                             },
-                            call_kind: None,
+                            resolution: Unresolved,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        args: [
+                            Call {
+                                expression: Identifier {
+                                    value: "f",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 17,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 12,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 6,
+                                },
+                                call_kind: None,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 11,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 11,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_chained_with_partial_application.snap
+++ b/tests/spec/desugar/snapshots/pipeline_chained_with_partial_application.snap
@@ -19,115 +19,114 @@ description: "fn test() { x |> add(5) |> multiply(2); }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "multiply",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "multiply",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 8,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 8,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Call {
-                            expression: Identifier {
-                                value: "add",
+                        args: [
+                            Call {
+                                expression: Identifier {
+                                    value: "add",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 17,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 12,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    Literal {
+                                        literal: Integer {
+                                            value: 5,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 21,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 17,
-                                    byte_length: 3,
+                                    byte_offset: 12,
+                                    byte_length: 11,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [
-                                Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 12,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
+                            Literal {
+                                literal: Integer {
+                                    value: 2,
+                                    text: None,
                                 },
-                                Literal {
-                                    literal: Integer {
-                                        value: 5,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 21,
-                                        byte_length: 1,
-                                    },
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            spread: None,
-                            type_arguments: None,
-                            ty: Var {
-                                id: uninferred,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 1,
+                                },
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 11,
-                            },
-                            call_kind: None,
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
                         },
-                        Literal {
-                            literal: Integer {
-                                value: 2,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 26,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 26,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_in_block.snap
+++ b/tests/spec/desugar/snapshots/pipeline_in_block.snap
@@ -26,114 +26,110 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Block {
-                    items: [
-                        Let {
-                            binding: Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 25,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Block {
+                        items: [
+                            Let {
+                                binding: Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 25,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                            value: Literal {
-                                literal: Integer {
-                                    value: 5,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 29,
-                                    byte_length: 1,
-                                },
-                            },
-                            mut_span: None,
-                            else_block: None,
-                            else_span: None,
-                            assert: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 21,
-                                byte_length: 9,
-                            },
-                        },
-                        Call {
-                            expression: Identifier {
-                                value: "double",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 6,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Identifier {
-                                    value: "x",
+                                value: Literal {
+                                    literal: Integer {
+                                        value: 5,
+                                        text: None,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 36,
+                                        byte_offset: 29,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
-                            ],
-                            spread: None,
-                            type_arguments: None,
-                            ty: Var {
-                                id: uninferred,
+                                mode: Plain,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 21,
+                                    byte_length: 9,
+                                },
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 11,
+                            Call {
+                                expression: Identifier {
+                                    value: "double",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 6,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 36,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 11,
+                                },
+                                call_kind: None,
                             },
-                            call_kind: None,
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 36,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 36,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 42,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 42,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_in_format_string.snap
+++ b/tests/spec/desugar/snapshots/pipeline_in_format_string.snap
@@ -19,121 +19,117 @@ description: "fn test() { let x = 5; f\"result: {x |> double}\"; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 5,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 16,
+                                byte_offset: 20,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 5,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 1,
+                            byte_offset: 12,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 9,
-                    },
-                },
-                Literal {
-                    literal: FormatString(
-                        [
-                            Text(
-                                "result: ",
-                            ),
-                            Expression(
-                                Call {
-                                    expression: Identifier {
-                                        value: "double",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 39,
-                                            byte_length: 6,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    args: [
-                                        Identifier {
-                                            value: "x",
+                    Literal {
+                        literal: FormatString(
+                            [
+                                Text(
+                                    "result: ",
+                                ),
+                                Expression(
+                                    Call {
+                                        expression: Identifier {
+                                            value: "double",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 34,
-                                                byte_length: 1,
+                                                byte_offset: 39,
+                                                byte_length: 6,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
+                                        args: [
+                                            Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 34,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 34,
+                                            byte_length: 11,
+                                        },
+                                        call_kind: None,
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 11,
-                                    },
-                                    call_kind: None,
-                                },
-                            ),
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
+                                ),
+                            ],
+                        ),
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 23,
+                            byte_length: 24,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 23,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 40,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 40,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_in_let.snap
+++ b/tests/spec/desugar/snapshots/pipeline_in_let.snap
@@ -19,88 +19,84 @@ description: "fn test() { let result = x |> func; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 16,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "func",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 4,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "x",
+                        value: Call {
+                            expression: Identifier {
+                                value: "func",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 25,
-                                    byte_length: 1,
+                                    byte_offset: 30,
+                                    byte_length: 4,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                            args: [
+                                Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 25,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 25,
+                                byte_length: 9,
+                            },
+                            call_kind: None,
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 9,
+                            byte_offset: 12,
+                            byte_length: 22,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_multiple_in_function.snap
+++ b/tests/spec/desugar/snapshots/pipeline_multiple_in_function.snap
@@ -25,195 +25,183 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "a",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "double",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 6,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "x",
+                        value: Call {
+                            expression: Identifier {
+                                value: "double",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 23,
-                                    byte_length: 1,
+                                    byte_offset: 28,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                        ],
-                        spread: None,
-                        type_arguments: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 11,
-                        },
-                        call_kind: None,
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 19,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "b",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "triple",
+                            args: [
+                                Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 23,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 51,
-                                byte_length: 6,
+                                byte_offset: 23,
+                                byte_length: 11,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "y",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 46,
-                            byte_length: 11,
+                            byte_offset: 15,
+                            byte_length: 19,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "b",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Call {
+                            expression: Identifier {
+                                value: "triple",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 6,
+                                },
+                                resolution: Unresolved,
+                            },
+                            args: [
+                                Identifier {
+                                    value: "y",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 46,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 46,
+                                byte_length: 11,
+                            },
+                            call_kind: None,
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 38,
+                            byte_length: 19,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 19,
-                    },
-                },
-                Binary {
-                    operator: Addition,
-                    left: Identifier {
-                        value: "a",
+                    Binary {
+                        operator: Addition,
+                        left: Identifier {
+                            value: "a",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 61,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        right: Identifier {
+                            value: "b",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 65,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 61,
-                            byte_length: 1,
+                            byte_length: 5,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    right: Identifier {
-                        value: "b",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 65,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 61,
-                        byte_length: 5,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 57,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 57,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_nested_calls.snap
+++ b/tests/spec/desugar/snapshots/pipeline_nested_calls.snap
@@ -19,157 +19,155 @@ description: "fn test() { x |> add(multiply(2, 3)) |> subtract(1); }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "subtract",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 8,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Call {
-                            expression: Identifier {
-                                value: "add",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 17,
-                                    byte_length: 3,
-                                },
-                                binding_id: None,
-                                qualified: None,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "subtract",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            args: [
-                                Identifier {
-                                    value: "x",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 40,
+                                byte_length: 8,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Call {
+                                expression: Identifier {
+                                    value: "add",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 12,
-                                        byte_length: 1,
+                                        byte_offset: 17,
+                                        byte_length: 3,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                Call {
-                                    expression: Identifier {
-                                        value: "multiply",
+                                args: [
+                                    Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 12,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    Call {
+                                        expression: Identifier {
+                                            value: "multiply",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 21,
+                                                byte_length: 8,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: Integer {
+                                                    value: 2,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 30,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                            Literal {
+                                                literal: Integer {
+                                                    value: 3,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 33,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 21,
-                                            byte_length: 8,
+                                            byte_length: 14,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: Integer {
-                                                value: 2,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 30,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                        Literal {
-                                            literal: Integer {
-                                                value: 3,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 33,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 21,
-                                        byte_length: 14,
-                                    },
-                                    call_kind: None,
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            spread: None,
-                            type_arguments: None,
-                            ty: Var {
-                                id: uninferred,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 24,
+                                },
+                                call_kind: None,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 24,
+                            Literal {
+                                literal: Integer {
+                                    value: 1,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 49,
+                                    byte_length: 1,
+                                },
                             },
-                            call_kind: None,
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
                         },
-                        Literal {
-                            literal: Integer {
-                                value: 1,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 49,
-                                byte_length: 1,
-                            },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 39,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 39,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 44,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 44,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_partial_application_multiple_args.snap
+++ b/tests/spec/desugar/snapshots/pipeline_partial_application_multiple_args.snap
@@ -19,87 +19,87 @@ description: "fn test() { x |> clamp(0, 100); }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "clamp",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "clamp",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 17,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Literal {
+                                literal: Integer {
+                                    value: 0,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 1,
+                                },
+                            },
+                            Literal {
+                                literal: Integer {
+                                    value: 100,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 3,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 17,
-                            byte_length: 5,
+                            byte_offset: 12,
+                            byte_length: 18,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Literal {
-                            literal: Integer {
-                                value: 0,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 1,
-                            },
-                        },
-                        Literal {
-                            literal: Integer {
-                                value: 100,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 3,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 18,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_preserves_other_operators.snap
+++ b/tests/spec/desugar/snapshots/pipeline_preserves_other_operators.snap
@@ -19,30 +19,53 @@ description: "fn test() { let a = 1 + 2; let b = a |> double; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "a",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 16,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Literal {
-                            literal: Integer {
-                                value: 1,
-                                text: None,
+                        value: Binary {
+                            operator: Addition,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 1,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 20,
+                                    byte_length: 1,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 2,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -50,125 +73,94 @@ description: "fn test() { let a = 1 + 2; let b = a |> double; }"
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 20,
-                                byte_length: 1,
+                                byte_length: 5,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 2,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 24,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 5,
+                            byte_offset: 12,
+                            byte_length: 13,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 13,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "b",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "b",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "double",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 40,
-                                byte_length: 6,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "a",
+                        value: Call {
+                            expression: Identifier {
+                                value: "double",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 35,
-                                    byte_length: 1,
+                                    byte_offset: 40,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                            args: [
+                                Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 35,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 35,
+                                byte_length: 11,
+                            },
+                            call_kind: None,
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 35,
-                            byte_length: 11,
+                            byte_offset: 27,
+                            byte_length: 19,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 27,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 39,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 39,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_simple.snap
+++ b/tests/spec/desugar/snapshots/pipeline_simple.snap
@@ -19,59 +19,59 @@ description: "fn test() { x |> func; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 17,
-                            byte_length: 4,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Identifier {
-                            value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 1,
+                                byte_offset: 17,
+                                byte_length: 4,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 9,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 9,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 14,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 14,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_triple_chained.snap
+++ b/tests/spec/desugar/snapshots/pipeline_triple_chained.snap
@@ -19,115 +19,113 @@ description: "fn test() { x |> f |> g |> h; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "h",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Call {
-                            expression: Identifier {
-                                value: "g",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 22,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Call {
-                                    expression: Identifier {
-                                        value: "f",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 17,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    args: [
-                                        Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 12,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 12,
-                                        byte_length: 6,
-                                    },
-                                    call_kind: None,
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "h",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 11,
+                                byte_offset: 27,
+                                byte_length: 1,
                             },
-                            call_kind: None,
+                            resolution: Unresolved,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        args: [
+                            Call {
+                                expression: Identifier {
+                                    value: "g",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 22,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Call {
+                                        expression: Identifier {
+                                            value: "f",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 17,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 12,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 12,
+                                            byte_length: 6,
+                                        },
+                                        call_kind: None,
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 11,
+                                },
+                                call_kind: None,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 16,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 16,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_with_arithmetic.snap
+++ b/tests/spec/desugar/snapshots/pipeline_with_arithmetic.snap
@@ -19,30 +19,53 @@ description: "fn test() { (1 + 2) |> double; }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "double",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "double",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 23,
+                                byte_length: 6,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 6,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Paren {
-                            expression: Binary {
-                                operator: Addition,
-                                left: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
+                        args: [
+                            Paren {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 13,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 17,
+                                            byte_length: 1,
+                                        },
                                     },
                                     ty: Var {
                                         id: uninferred,
@@ -50,21 +73,7 @@ description: "fn test() { (1 + 2) |> double; }"
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 13,
-                                        byte_length: 1,
-                                    },
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 17,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
                                 },
                                 ty: Var {
@@ -72,42 +81,34 @@ description: "fn test() { (1 + 2) |> double; }"
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 13,
-                                    byte_length: 5,
+                                    byte_offset: 12,
+                                    byte_length: 7,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 7,
-                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 17,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 17,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 22,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 22,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_with_parens.snap
+++ b/tests/spec/desugar/snapshots/pipeline_with_parens.snap
@@ -19,59 +19,59 @@ description: "fn test() { x |> (f); }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "f",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 18,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    args: [
-                        Identifier {
-                            value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "f",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 12,
+                                byte_offset: 18,
                                 byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 12,
+                            byte_length: 8,
+                        },
+                        call_kind: None,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 8,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 13,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 13,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/desugar/snapshots/pipeline_with_partial_application.snap
+++ b/tests/spec/desugar/snapshots/pipeline_with_partial_application.snap
@@ -19,73 +19,73 @@ description: "fn test() { x |> add(5); }"
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "add",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "add",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 17,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 12,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 21,
+                                    byte_length: 1,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 17,
-                            byte_length: 3,
+                            byte_offset: 12,
+                            byte_length: 11,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 12,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 21,
-                                byte_length: 1,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 11,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -527,7 +527,6 @@ fn store_get_definition_domain_style_go_module() {
             ty: syntax::types::Type::Nominal {
                 id: "go:github.com/gorilla/mux.Router".into(),
                 params: vec![],
-                underlying_ty: None,
             },
             name: Some("Router".into()),
             name_span: Some(syntax::ast::Span::dummy()),

--- a/tests/spec/parse/snapshots/array_literal_operand.snap
+++ b/tests/spec/parse/snapshots/array_literal_operand.snap
@@ -21,127 +21,124 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Literal {
-                            literal: Slice(
-                                [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
+                        value: IndexedAccess {
+                            expression: Literal {
+                                literal: Slice(
+                                    [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 27,
+                                                byte_length: 1,
+                                            },
                                         },
-                                        ty: Var {
-                                            id: uninferred,
+                                        Literal {
+                                            literal: Integer {
+                                                value: 2,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 30,
+                                                byte_length: 1,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 27,
-                                            byte_length: 1,
+                                        Literal {
+                                            literal: Integer {
+                                                value: 3,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 33,
+                                                byte_length: 1,
+                                            },
                                         },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 2,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 30,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 3,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 33,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                            ),
+                                    ],
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 9,
+                                },
+                            },
+                            index: Identifier {
+                                value: "index",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 9,
+                                byte_offset: 35,
+                                byte_length: 7,
                             },
+                            from_colon_syntax: false,
                         },
-                        index: Identifier {
-                            value: "index",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 35,
-                            byte_length: 7,
+                            byte_offset: 13,
+                            byte_length: 29,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/array_new_turbofish_args.snap
+++ b/tests/spec/parse/snapshots/array_new_turbofish_args.snap
@@ -21,108 +21,104 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "_xs",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "_xs",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: DotAccess {
-                            expression: Identifier {
-                                value: "Array",
+                        value: Call {
+                            expression: DotAccess {
+                                expression: Identifier {
+                                    value: "Array",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 23,
+                                        byte_length: 5,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                member: "new",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 23,
-                                    byte_length: 5,
+                                    byte_length: 9,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            member: "new",
+                            args: [],
+                            spread: None,
+                            type_arguments: Unresolved(
+                                [
+                                    Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 33,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                    Constant {
+                                        value: 3,
+                                        text: None,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 38,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 23,
-                                byte_length: 9,
+                                byte_length: 19,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: Unresolved(
-                            [
-                                Constructor {
-                                    name: "int",
-                                    params: [],
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 33,
-                                        byte_length: 3,
-                                    },
-                                },
-                                Constant {
-                                    value: 3,
-                                    text: None,
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 38,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 19,
+                            byte_offset: 13,
+                            byte_length: 29,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/array_type_annotation.snap
+++ b/tests/spec/parse/snapshots/array_type_annotation.snap
@@ -55,7 +55,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,56 +73,57 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                IndexedAccess {
-                    expression: Identifier {
-                        value: "xs",
+        body: Definition(
+            Block {
+                items: [
+                    IndexedAccess {
+                        expression: Identifier {
+                            value: "xs",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 2,
+                            },
+                            resolution: Unresolved,
+                        },
+                        index: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 40,
+                                byte_length: 1,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 2,
+                            byte_offset: 39,
+                            byte_length: 3,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        from_colon_syntax: false,
                     },
-                    index: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 1,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 39,
-                        byte_length: 3,
-                    },
-                    from_colon_syntax: false,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 35,
+                    byte_length: 9,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 35,
-                byte_length: 9,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/assign_field.snap
+++ b/tests/spec/parse/snapshots/assign_field.snap
@@ -24,160 +24,156 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 35,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 38,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                                StructFieldAssignment {
+                                    name: "y",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 44,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 1,
+                                byte_offset: 27,
+                                byte_length: 19,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 35,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 38,
-                                        byte_length: 1,
-                                    },
-                                },
-                            },
-                            StructFieldAssignment {
-                                name: "y",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 44,
-                                        byte_length: 1,
-                                    },
-                                },
-                            },
-                        ],
-                        spread: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 19,
+                            byte_offset: 15,
+                            byte_length: 31,
                         },
                     },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 31,
-                    },
-                },
-                Assignment {
-                    target: DotAccess {
-                        expression: Identifier {
-                            value: "p",
+                    Assignment {
+                        target: DotAccess {
+                            expression: Identifier {
+                                value: "p",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "x",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 50,
-                                byte_length: 1,
+                                byte_length: 3,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "x",
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 56,
+                                byte_length: 2,
+                            },
                         },
+                        compound_operator: None,
                         span: Span {
                             file_id: 0,
                             byte_offset: 50,
-                            byte_length: 3,
-                        },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 56,
-                            byte_length: 2,
+                            byte_length: 8,
                         },
                     },
-                    compound_operator: None,
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 50,
-                        byte_length: 8,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 50,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 50,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/assign_index.snap
+++ b/tests/spec/parse/snapshots/assign_index.snap
@@ -24,118 +24,138 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "arr",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "arr",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 3,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Slice(
-                            [
-                                Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 30,
-                                        byte_length: 1,
-                                    },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
                                 },
-                                Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 33,
-                                        byte_length: 1,
-                                    },
-                                },
-                                Literal {
-                                    literal: Integer {
-                                        value: 3,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 36,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                        ),
-                        ty: Var {
-                            id: uninferred,
+                            ),
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 29,
-                            byte_length: 9,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 23,
-                    },
-                },
-                Assignment {
-                    target: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
+                        value: Literal {
+                            literal: Slice(
+                                [
+                                    Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 30,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 33,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    Literal {
+                                        literal: Integer {
+                                            value: 3,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 36,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 42,
+                                byte_offset: 29,
+                                byte_length: 9,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 23,
+                        },
+                    },
+                    Assignment {
+                        target: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Literal {
+                                literal: Integer {
+                                    value: 0,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 46,
+                                    byte_length: 1,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 45,
                                 byte_length: 3,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            from_colon_syntax: false,
                         },
-                        index: Literal {
+                        value: Literal {
                             literal: Integer {
-                                value: 0,
+                                value: 100,
                                 text: None,
                             },
                             ty: Var {
@@ -143,51 +163,28 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 46,
-                                byte_length: 1,
+                                byte_offset: 51,
+                                byte_length: 3,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
-                        },
+                        compound_operator: None,
                         span: Span {
                             file_id: 0,
-                            byte_offset: 45,
-                            byte_length: 3,
-                        },
-                        from_colon_syntax: false,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 100,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 3,
+                            byte_offset: 42,
+                            byte_length: 12,
                         },
                     },
-                    compound_operator: None,
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 42,
-                        byte_length: 12,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/assign_simple_var.snap
+++ b/tests/spec/parse/snapshots/assign_simple_var.snap
@@ -24,90 +24,34 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "count",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "count",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 5,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 31,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 17,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "count",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Identifier {
-                            value: "count",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 44,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
                         },
-                        right: Literal {
+                        value: Literal {
                             literal: Integer {
-                                value: 1,
+                                value: 0,
                                 text: None,
                             },
                             ty: Var {
@@ -115,36 +59,88 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 52,
+                                byte_offset: 31,
                                 byte_length: 1,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 9,
+                            byte_offset: 15,
+                            byte_length: 17,
                         },
                     },
-                    compound_operator: None,
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 36,
-                        byte_length: 17,
+                    Assignment {
+                        target: Identifier {
+                            value: "count",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        value: Binary {
+                            operator: Addition,
+                            left: Identifier {
+                                value: "count",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 44,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 1,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 52,
+                                    byte_length: 1,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 44,
+                                byte_length: 9,
+                            },
+                        },
+                        compound_operator: None,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 36,
+                            byte_length: 17,
+                        },
                     },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 45,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 45,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/associativity_addition_subtraction.snap
+++ b/tests/spec/parse/snapshots/associativity_addition_subtraction.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Binary {
-                            operator: Addition,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Subtraction,
+                            left: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
+                                    byte_offset: 34,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 9,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 9,
+                            byte_offset: 13,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/associativity_multiplication_division.snap
+++ b/tests/spec/parse/snapshots/associativity_multiplication_division.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Division,
-                        left: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Division,
+                            left: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
+                                    byte_offset: 34,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 9,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 9,
+                            byte_offset: 13,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/associativity_pipe.snap
+++ b/tests/spec/parse/snapshots/associativity_pipe.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Binary {
+                        value: Binary {
                             operator: Pipeline,
-                            left: Identifier {
-                                value: "a",
+                            left: Binary {
+                                operator: Pipeline,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 31,
+                                    byte_offset: 36,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 6,
+                                byte_length: 11,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_addition.snap
+++ b/tests/spec/parse/snapshots/binary_addition.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Binary {
+                            operator: Addition,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -52,55 +75,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_and.snap
+++ b/tests/spec/parse/snapshots/binary_and.snap
@@ -21,84 +21,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: And,
-                        left: Literal {
-                            literal: Boolean(
-                                true,
-                            ),
+                        value: Binary {
+                            operator: And,
+                            left: Literal {
+                                literal: Boolean(
+                                    true,
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 4,
+                                },
+                            },
+                            right: Literal {
+                                literal: Boolean(
+                                    false,
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 5,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 4,
+                                byte_length: 13,
                             },
                         },
-                        right: Literal {
-                            literal: Boolean(
-                                false,
-                            ),
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 5,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_division.snap
+++ b/tests/spec/parse/snapshots/binary_division.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Division,
-                        left: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Binary {
+                            operator: Division,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -52,55 +75,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_equal.snap
+++ b/tests/spec/parse/snapshots/binary_equal.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Equal,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: Equal,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_greater_than.snap
+++ b/tests/spec/parse/snapshots/binary_greater_than.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: GreaterThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 5,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 5,
+                            byte_offset: 13,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_greater_than_or_equal.snap
+++ b/tests/spec/parse/snapshots/binary_greater_than_or_equal.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: GreaterThanOrEqual,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: GreaterThanOrEqual,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_less_than.snap
+++ b/tests/spec/parse/snapshots/binary_less_than.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 5,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 5,
+                            byte_offset: 13,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_less_than_or_equal.snap
+++ b/tests/spec/parse/snapshots/binary_less_than_or_equal.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: LessThanOrEqual,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: LessThanOrEqual,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_multiplication.snap
+++ b/tests/spec/parse/snapshots/binary_multiplication.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Multiplication,
-                        left: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Binary {
+                            operator: Multiplication,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -52,55 +75,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_not_equal.snap
+++ b/tests/spec/parse/snapshots/binary_not_equal.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: NotEqual,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: NotEqual,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_or.snap
+++ b/tests/spec/parse/snapshots/binary_or.snap
@@ -21,84 +21,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Or,
-                        left: Literal {
-                            literal: Boolean(
-                                true,
-                            ),
+                        value: Binary {
+                            operator: Or,
+                            left: Literal {
+                                literal: Boolean(
+                                    true,
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 4,
+                                },
+                            },
+                            right: Literal {
+                                literal: Boolean(
+                                    false,
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 5,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 4,
+                                byte_length: 13,
                             },
                         },
-                        right: Literal {
-                            literal: Boolean(
-                                false,
-                            ),
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 5,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_remainder.snap
+++ b/tests/spec/parse/snapshots/binary_remainder.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Remainder,
-                        left: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Binary {
+                            operator: Remainder,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 3,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -52,55 +75,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 3,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/binary_subtraction.snap
+++ b/tests/spec/parse/snapshots/binary_subtraction.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Binary {
+                            operator: Subtraction,
+                            left: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 1,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -52,55 +75,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/brace_after_binary_is_block.snap
+++ b/tests/spec/parse/snapshots/brace_after_binary_is_block.snap
@@ -26,209 +26,196 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "a",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 19,
+                                byte_offset: 23,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 9,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "b",
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "b",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 2,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 32,
+                                byte_offset: 36,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 2,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 1,
+                            byte_offset: 28,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 28,
-                        byte_length: 9,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 45,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 3,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 45,
+                                byte_offset: 49,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 3,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 49,
-                            byte_length: 1,
+                            byte_offset: 41,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 41,
-                        byte_length: 9,
-                    },
-                },
-                Binary {
-                    operator: Addition,
-                    left: Identifier {
-                        value: "a",
+                    Binary {
+                        operator: Addition,
+                        left: Identifier {
+                            value: "a",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 54,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        right: Identifier {
+                            value: "b",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 58,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 54,
-                            byte_length: 1,
+                            byte_length: 5,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    right: Identifier {
-                        value: "b",
+                    Block {
+                        items: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 62,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 58,
-                            byte_length: 1,
+                            byte_offset: 60,
+                            byte_length: 5,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 54,
-                        byte_length: 5,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Block {
-                    items: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 62,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 60,
-                        byte_length: 5,
-                    },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 56,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 56,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/brace_after_call_is_block.snap
+++ b/tests/spec/parse/snapshots/brace_after_call_is_block.snap
@@ -33,32 +33,34 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Literal {
-                    literal: Integer {
-                        value: 1,
-                        text: None,
+        body: Definition(
+            Block {
+                items: [
+                    Literal {
+                        literal: Integer {
+                            value: 1,
+                            text: None,
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 25,
+                            byte_length: 1,
+                        },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 1,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 23,
+                    byte_length: 5,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 23,
-                byte_length: 5,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },
@@ -84,113 +86,109 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 47,
+                                byte_offset: 51,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 1,
+                            byte_offset: 43,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 9,
-                    },
-                },
-                Call {
-                    expression: Identifier {
-                        value: "get_value",
+                    Call {
+                        expression: Identifier {
+                            value: "get_value",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 56,
+                                byte_length: 9,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 56,
-                            byte_length: 9,
+                            byte_length: 11,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 56,
-                        byte_length: 11,
-                    },
-                    call_kind: None,
-                },
-                Block {
-                    items: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
+                    Block {
+                        items: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 70,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 70,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 68,
+                            byte_length: 5,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 68,
-                        byte_length: 5,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 39,
+                    byte_length: 36,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 39,
-                byte_length: 36,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/brace_after_paren_expr_is_block.snap
+++ b/tests/spec/parse/snapshots/brace_after_paren_expr_is_block.snap
@@ -25,152 +25,144 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 11,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 2,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 9,
-                    },
-                },
-                Paren {
-                    expression: Identifier {
-                        value: "foo",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 5,
-                    },
-                },
-                Block {
-                    items: [
-                        Identifier {
-                            value: "x",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 51,
+                                byte_offset: 25,
                                 byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 11,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 49,
-                        byte_length: 5,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 2,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 1,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 9,
+                        },
                     },
+                    Paren {
+                        expression: Identifier {
+                            value: "foo",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 44,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 43,
+                            byte_length: 5,
+                        },
+                    },
+                    Block {
+                        items: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 49,
+                            byte_length: 5,
+                        },
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 45,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 45,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
+++ b/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
@@ -21,112 +21,112 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: DotAccess {
-                        expression: Identifier {
-                            value: "Map",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: DotAccess {
+                            expression: Identifier {
+                                value: "Map",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 13,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "new",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 13,
-                                byte_length: 3,
+                                byte_length: 7,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "new",
+                        args: [],
+                        spread: None,
+                        type_arguments: Unresolved(
+                            [
+                                Constructor {
+                                    name: "string",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 21,
+                                        byte_length: 6,
+                                    },
+                                },
+                                Function {
+                                    params: [
+                                        FunctionAnnotationParameter {
+                                            annotation: Constructor {
+                                                name: "int",
+                                                params: [],
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 32,
+                                                    byte_length: 3,
+                                                },
+                                            },
+                                            mutable: false,
+                                        },
+                                        FunctionAnnotationParameter {
+                                            annotation: Constructor {
+                                                name: "int",
+                                                params: [],
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 37,
+                                                    byte_length: 3,
+                                                },
+                                            },
+                                            mutable: false,
+                                        },
+                                    ],
+                                    return_type: Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 45,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 19,
+                                    },
+                                },
+                            ],
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 7,
+                            byte_length: 38,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
+                        call_kind: None,
                     },
-                    args: [],
-                    spread: None,
-                    type_arguments: Unresolved(
-                        [
-                            Constructor {
-                                name: "string",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 21,
-                                    byte_length: 6,
-                                },
-                            },
-                            Function {
-                                params: [
-                                    FunctionAnnotationParameter {
-                                        annotation: Constructor {
-                                            name: "int",
-                                            params: [],
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 32,
-                                                byte_length: 3,
-                                            },
-                                        },
-                                        mutable: false,
-                                    },
-                                    FunctionAnnotationParameter {
-                                        annotation: Constructor {
-                                            name: "int",
-                                            params: [],
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 37,
-                                                byte_length: 3,
-                                            },
-                                        },
-                                        mutable: false,
-                                    },
-                                ],
-                                return_type: Constructor {
-                                    name: "int",
-                                    params: [],
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 45,
-                                        byte_length: 3,
-                                    },
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 29,
-                                    byte_length: 19,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 38,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 43,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 43,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_leading_args_and_spread_arg.snap
+++ b/tests/spec/parse/snapshots/call_with_leading_args_and_spread_arg.snap
@@ -21,86 +21,84 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 21,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: Some(
+                            Identifier {
+                                value: "xs",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 2,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ),
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 17,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "a",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 21,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: Some(
-                        Identifier {
-                            value: "xs",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 24,
-                                byte_length: 2,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ),
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 17,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 22,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 22,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_leading_args_and_spread_arg_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/call_with_leading_args_and_spread_arg_trailing_comma.snap
@@ -21,86 +21,84 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 21,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: Some(
+                            Identifier {
+                                value: "xs",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 2,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ),
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 18,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "a",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 21,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: Some(
-                        Identifier {
-                            value: "xs",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 24,
-                                byte_length: 2,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ),
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 18,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_range_full_arg.snap
+++ b/tests/spec/parse/snapshots/call_with_range_full_arg.snap
@@ -21,59 +21,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Range {
+                                start: None,
+                                end: None,
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 2,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 8,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Range {
-                            start: None,
-                            end: None,
-                            inclusive: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 2,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 8,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 13,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 13,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_range_to_arg.snap
+++ b/tests/spec/parse/snapshots/call_with_range_to_arg.snap
@@ -21,74 +21,75 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Range {
+                                start: None,
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 5,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 20,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 3,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 9,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Range {
-                            start: None,
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 5,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 20,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ),
-                            inclusive: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 3,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 9,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 14,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 14,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_range_to_inclusive_arg.snap
+++ b/tests/spec/parse/snapshots/call_with_range_to_inclusive_arg.snap
@@ -21,74 +21,75 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Range {
+                                start: None,
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 4,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 21,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                inclusive: true,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 4,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 10,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Range {
-                            start: None,
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 4,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 21,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ),
-                            inclusive: true,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 4,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 10,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 15,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 15,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_spread_arg.snap
+++ b/tests/spec/parse/snapshots/call_with_spread_arg.snap
@@ -21,59 +21,59 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [],
+                        spread: Some(
+                            Identifier {
+                                value: "xs",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 2,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ),
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 11,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [],
-                    spread: Some(
-                        Identifier {
-                            value: "xs",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 2,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ),
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 11,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_spread_arg_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/call_with_spread_arg_trailing_comma.snap
@@ -21,59 +21,59 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [],
+                        spread: Some(
+                            Identifier {
+                                value: "xs",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 2,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ),
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 12,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [],
-                    spread: Some(
-                        Identifier {
-                            value: "xs",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 18,
-                                byte_length: 2,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ),
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 12,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 17,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 17,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_type_arg_nested.snap
+++ b/tests/spec/parse/snapshots/call_with_type_arg_nested.snap
@@ -21,76 +21,77 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [],
+                        spread: None,
+                        type_arguments: Unresolved(
+                            [
+                                Constructor {
+                                    name: "Map",
+                                    params: [
+                                        Constructor {
+                                            name: "string",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 22,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 30,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 18,
+                                        byte_length: 16,
+                                    },
+                                },
+                            ],
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 24,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [],
-                    spread: None,
-                    type_arguments: Unresolved(
-                        [
-                            Constructor {
-                                name: "Map",
-                                params: [
-                                    Constructor {
-                                        name: "string",
-                                        params: [],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 22,
-                                            byte_length: 6,
-                                        },
-                                    },
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 30,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 18,
-                                    byte_length: 16,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_type_arg_simple.snap
+++ b/tests/spec/parse/snapshots/call_with_type_arg_simple.snap
@@ -21,71 +21,71 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: Unresolved(
+                            [
+                                Constructor {
+                                    name: "int",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 18,
+                                        byte_length: 3,
+                                    },
+                                },
+                            ],
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 12,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: Unresolved(
-                        [
-                            Constructor {
-                                name: "int",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 18,
-                                    byte_length: 3,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 12,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 17,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 17,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/call_with_type_args_multiple.snap
+++ b/tests/spec/parse/snapshots/call_with_type_args_multiple.snap
@@ -21,102 +21,101 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "func",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "func",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 27,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Identifier {
+                                value: "y",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: Unresolved(
+                            [
+                                Constructor {
+                                    name: "A",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 18,
+                                        byte_length: 1,
+                                    },
+                                },
+                                Constructor {
+                                    name: "B",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 21,
+                                        byte_length: 1,
+                                    },
+                                },
+                                Constructor {
+                                    name: "C",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 24,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ],
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 4,
+                            byte_length: 19,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Identifier {
-                            value: "y",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: Unresolved(
-                        [
-                            Constructor {
-                                name: "A",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 18,
-                                    byte_length: 1,
-                                },
-                            },
-                            Constructor {
-                                name: "B",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 21,
-                                    byte_length: 1,
-                                },
-                            },
-                            Constructor {
-                                name: "C",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 24,
-                                    byte_length: 1,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/chained_method_calls.snap
+++ b/tests/spec/parse/snapshots/chained_method_calls.snap
@@ -21,114 +21,109 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: DotAccess {
-                            expression: Call {
-                                expression: DotAccess {
-                                    expression: Identifier {
-                                        value: "obj",
+                        value: Call {
+                            expression: DotAccess {
+                                expression: Call {
+                                    expression: DotAccess {
+                                        expression: Identifier {
+                                            value: "obj",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 26,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "method1",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 26,
-                                            byte_length: 3,
+                                            byte_length: 11,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    member: "method1",
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 11,
+                                        byte_length: 13,
                                     },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
+                                member: "method2",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 13,
+                                    byte_length: 21,
                                 },
-                                call_kind: None,
+                                resolution: Unresolved,
                             },
-                            member: "method2",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 21,
+                                byte_length: 23,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 23,
+                            byte_offset: 13,
+                            byte_length: 36,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 36,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 41,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/complex_field_and_index_chain.snap
+++ b/tests/spec/parse/snapshots/complex_field_and_index_chain.snap
@@ -21,150 +21,142 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: DotAccess {
-                            expression: Call {
-                                expression: DotAccess {
-                                    expression: IndexedAccess {
-                                        expression: DotAccess {
-                                            expression: Identifier {
-                                                value: "obj",
+                        value: DotAccess {
+                            expression: DotAccess {
+                                expression: Call {
+                                    expression: DotAccess {
+                                        expression: IndexedAccess {
+                                            expression: DotAccess {
+                                                expression: Identifier {
+                                                    value: "obj",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 26,
+                                                        byte_length: 3,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
+                                                member: "field",
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 26,
-                                                    byte_length: 3,
+                                                    byte_length: 9,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
+                                                resolution: Unresolved,
                                             },
-                                            member: "field",
+                                            index: Identifier {
+                                                value: "i",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 36,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 26,
-                                                byte_length: 9,
+                                                byte_offset: 35,
+                                                byte_length: 3,
                                             },
-                                            dot_access_kind: None,
-                                            receiver_coercion: None,
+                                            from_colon_syntax: false,
                                         },
-                                        index: Identifier {
-                                            value: "i",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 36,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
+                                        member: "method",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 35,
-                                            byte_length: 3,
+                                            byte_length: 10,
                                         },
-                                        from_colon_syntax: false,
+                                        resolution: Unresolved,
                                     },
-                                    member: "method",
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 35,
-                                        byte_length: 10,
+                                        byte_length: 12,
                                     },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
+                                member: "nested",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 35,
-                                    byte_length: 12,
+                                    byte_length: 19,
                                 },
-                                call_kind: None,
+                                resolution: Unresolved,
                             },
-                            member: "nested",
+                            member: "value",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 35,
-                                byte_length: 19,
+                                byte_length: 25,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            resolution: Unresolved,
                         },
-                        member: "value",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 35,
-                            byte_length: 25,
+                            byte_offset: 13,
+                            byte_length: 47,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 47,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 52,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 52,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/compound_assignment.snap
+++ b/tests/spec/parse/snapshots/compound_assignment.snap
@@ -28,253 +28,246 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 23,
+                                byte_offset: 27,
+                                byte_length: 2,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 14,
+                        },
+                    },
+                    Assignment {
+                        target: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 33,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 5,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 14,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
-                        },
+                        compound_operator: Some(
+                            Addition,
+                        ),
                         span: Span {
                             file_id: 0,
                             byte_offset: 33,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 5,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 1,
+                            byte_length: 6,
                         },
                     },
-                    compound_operator: Some(
-                        Addition,
-                    ),
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 33,
-                        byte_length: 6,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
+                    Assignment {
+                        target: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 43,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
+                        value: Literal {
+                            literal: Integer {
+                                value: 3,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 1,
+                            },
+                        },
+                        compound_operator: Some(
+                            Subtraction,
+                        ),
                         span: Span {
                             file_id: 0,
                             byte_offset: 43,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 3,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 1,
+                            byte_length: 6,
                         },
                     },
-                    compound_operator: Some(
-                        Subtraction,
-                    ),
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 6,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
+                    Assignment {
+                        target: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 53,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
+                        value: Literal {
+                            literal: Integer {
+                                value: 2,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 58,
+                                byte_length: 1,
+                            },
+                        },
+                        compound_operator: Some(
+                            Multiplication,
+                        ),
                         span: Span {
                             file_id: 0,
                             byte_offset: 53,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 2,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 58,
-                            byte_length: 1,
+                            byte_length: 6,
                         },
                     },
-                    compound_operator: Some(
-                        Multiplication,
-                    ),
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 53,
-                        byte_length: 6,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
+                    Assignment {
+                        target: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 63,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
+                        value: Literal {
+                            literal: Integer {
+                                value: 4,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 68,
+                                byte_length: 1,
+                            },
+                        },
+                        compound_operator: Some(
+                            Division,
+                        ),
                         span: Span {
                             file_id: 0,
                             byte_offset: 63,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 4,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 68,
-                            byte_length: 1,
+                            byte_length: 6,
                         },
                     },
-                    compound_operator: Some(
-                        Division,
-                    ),
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 63,
-                        byte_length: 6,
-                    },
-                },
-                Assignment {
-                    target: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
+                    Assignment {
+                        target: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 73,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
+                        value: Literal {
+                            literal: Integer {
+                                value: 3,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 78,
+                                byte_length: 1,
+                            },
+                        },
+                        compound_operator: Some(
+                            Remainder,
+                        ),
                         span: Span {
                             file_id: 0,
                             byte_offset: 73,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 3,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 78,
-                            byte_length: 1,
+                            byte_length: 6,
                         },
                     },
-                    compound_operator: Some(
-                        Remainder,
-                    ),
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 73,
-                        byte_length: 6,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 71,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 71,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/const_basic.snap
+++ b/tests/spec/parse/snapshots/const_basic.snap
@@ -14,20 +14,22 @@ description: |
             byte_length: 11,
         },
         annotation: None,
-        expression: Literal {
-            literal: Integer {
-                value: 5,
-                text: None,
+        expression: Value(
+            Literal {
+                literal: Integer {
+                    value: 5,
+                    text: None,
+                },
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 1,
+                },
             },
-            ty: Var {
-                id: uninferred,
-            },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 1,
-            },
-        },
+        ),
         visibility: Private,
         ty: Var {
             id: uninferred,

--- a/tests/spec/parse/snapshots/const_string.snap
+++ b/tests/spec/parse/snapshots/const_string.snap
@@ -24,20 +24,22 @@ description: |
                 },
             },
         ),
-        expression: Literal {
-            literal: String {
-                value: "Hello",
-                raw: false,
+        expression: Value(
+            Literal {
+                literal: String {
+                    value: "Hello",
+                    raw: false,
+                },
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 7,
+                },
             },
-            ty: Var {
-                id: uninferred,
-            },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 7,
-            },
-        },
+        ),
         visibility: Private,
         ty: Var {
             id: uninferred,

--- a/tests/spec/parse/snapshots/const_with_type.snap
+++ b/tests/spec/parse/snapshots/const_with_type.snap
@@ -24,20 +24,22 @@ description: |
                 },
             },
         ),
-        expression: Literal {
-            literal: Float {
-                value: 3.14159,
-                text: None,
+        expression: Value(
+            Literal {
+                literal: Float {
+                    value: 3.14159,
+                    text: None,
+                },
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 7,
+                },
             },
-            ty: Var {
-                id: uninferred,
-            },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 7,
-            },
-        },
+        ),
         visibility: Private,
         ty: Var {
             id: uninferred,

--- a/tests/spec/parse/snapshots/directive_rawgo_invalid_arg.snap
+++ b/tests/spec/parse/snapshots/directive_rawgo_invalid_arg.snap
@@ -21,21 +21,23 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                RawGo {
-                    text: "?",
+        body: Definition(
+            Block {
+                items: [
+                    RawGo {
+                        text: "?",
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/directive_rawgo_valid.snap
+++ b/tests/spec/parse/snapshots/directive_rawgo_valid.snap
@@ -21,21 +21,23 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                RawGo {
-                    text: "fmt.Println(\\\"Hello\\\")",
+        body: Definition(
+            Block {
+                items: [
+                    RawGo {
+                        text: "fmt.Println(\\\"Hello\\\")",
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 37,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 37,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/directive_unknown.snap
+++ b/tests/spec/parse/snapshots/directive_unknown.snap
@@ -21,28 +21,30 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Unit {
-                    ty: Var {
-                        id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Unit {
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 13,
+                            byte_length: 8,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 8,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 13,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 13,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/empty_brace_after_lowercase_is_block.snap
+++ b/tests/spec/parse/snapshots/empty_brace_after_lowercase_is_block.snap
@@ -24,85 +24,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 25,
+                                byte_length: 1,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Identifier {
+                        value: "foo",
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 3,
+                        },
+                        resolution: Unresolved,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 11,
+                    Block {
+                        items: [],
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 34,
+                            byte_length: 2,
+                        },
                     },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Identifier {
-                    value: "foo",
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 3,
-                    },
-                    binding_id: None,
-                    qualified: None,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
                 },
-                Block {
-                    items: [],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 34,
-                        byte_length: 2,
-                    },
-                },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/empty_brace_after_uppercase_is_struct.snap
+++ b/tests/spec/parse/snapshots/empty_brace_after_uppercase_is_struct.snap
@@ -43,60 +43,58 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Foo",
+                            field_assignments: [],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 33,
+                                byte_offset: 42,
                                 byte_length: 6,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Foo",
-                        field_assignments: [],
-                        spread: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 6,
+                            byte_offset: 29,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/empty_struct_in_call_in_control_flow_header.snap
+++ b/tests/spec/parse/snapshots/empty_struct_in_call_in_control_flow_header.snap
@@ -65,7 +65,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -103,59 +102,59 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "Ok",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "Ok",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 58,
+                                byte_length: 2,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "d",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 61,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 58,
-                            byte_length: 2,
+                            byte_length: 5,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "d",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 61,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 58,
-                        byte_length: 5,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 54,
+                    byte_length: 11,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 54,
-                byte_length: 11,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },
@@ -181,163 +180,34 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                IfLet {
-                    pattern: EnumVariant {
-                        identifier: "Err",
-                        fields: [
-                            Identifier {
-                                identifier: "err",
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 91,
-                                    byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    IfLet {
+                        pattern: EnumVariant {
+                            identifier: "Err",
+                            fields: [
+                                Identifier {
+                                    identifier: "err",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 91,
+                                        byte_length: 3,
+                                    },
                                 },
-                            },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 87,
-                            byte_length: 8,
-                        },
-                    },
-                    scrutinee: Call {
-                        expression: Identifier {
-                            value: "foo",
+                            ],
+                            rest: false,
+                            resolution: Unresolved,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 98,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        args: [
-                            StructCall {
-                                name: "Data",
-                                field_assignments: [],
-                                spread: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 102,
-                                    byte_length: 7,
-                                },
-                            },
-                        ],
-                        spread: None,
-                        type_arguments: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 98,
-                            byte_length: 12,
-                        },
-                        call_kind: None,
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "panic",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 113,
-                                        byte_length: 5,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Identifier {
-                                        value: "err",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 119,
-                                            byte_length: 3,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 113,
-                                    byte_length: 10,
-                                },
-                                call_kind: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 111,
-                            byte_length: 14,
-                        },
-                    },
-                    alternative: Unit {
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 80,
-                            byte_length: 45,
-                        },
-                    },
-                    typed_pattern: None,
-                    else_span: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 80,
-                        byte_length: 45,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: WildCard {
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 132,
-                                byte_length: 1,
+                                byte_offset: 87,
+                                byte_length: 8,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Match {
-                        subject: Call {
+                        scrutinee: Call {
                             expression: Identifier {
                                 value: "foo",
                                 ty: Var {
@@ -345,11 +215,10 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 142,
+                                    byte_offset: 98,
                                     byte_length: 3,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             args: [
                                 StructCall {
@@ -361,7 +230,7 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 146,
+                                        byte_offset: 102,
                                         byte_length: 7,
                                     },
                                 },
@@ -373,73 +242,14 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 142,
+                                byte_offset: 98,
                                 byte_length: 12,
                             },
                             call_kind: None,
                         },
-                        arms: [
-                            MatchArm {
-                                pattern: EnumVariant {
-                                    identifier: "Ok",
-                                    fields: [
-                                        Identifier {
-                                            identifier: "d",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 164,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    ],
-                                    rest: false,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 161,
-                                        byte_length: 5,
-                                    },
-                                },
-                                expression: Identifier {
-                                    value: "d",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 170,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            },
-                            MatchArm {
-                                pattern: EnumVariant {
-                                    identifier: "Err",
-                                    fields: [
-                                        Identifier {
-                                            identifier: "err",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 181,
-                                                byte_length: 3,
-                                            },
-                                        },
-                                    ],
-                                    rest: false,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 177,
-                                        byte_length: 8,
-                                    },
-                                },
-                                expression: Call {
+                        consequence: Block {
+                            items: [
+                                Call {
                                     expression: Identifier {
                                         value: "panic",
                                         ty: Var {
@@ -447,11 +257,10 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 189,
+                                            byte_offset: 113,
                                             byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
                                     args: [
                                         Identifier {
@@ -461,11 +270,10 @@ description: |
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 195,
+                                                byte_offset: 119,
                                                 byte_length: 3,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
                                     ],
                                     spread: None,
@@ -475,45 +283,229 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 189,
+                                        byte_offset: 113,
                                         byte_length: 10,
                                     },
                                     call_kind: None,
                                 },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 111,
+                                byte_length: 14,
+                            },
+                        },
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 80,
+                                byte_length: 45,
+                            },
+                        },
+                        else_span: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 136,
-                            byte_length: 67,
+                            byte_offset: 80,
+                            byte_length: 45,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: WildCard {
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 132,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Match {
+                            subject: Call {
+                                expression: Identifier {
+                                    value: "foo",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 142,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    StructCall {
+                                        name: "Data",
+                                        field_assignments: [],
+                                        spread: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 146,
+                                            byte_length: 7,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 142,
+                                    byte_length: 12,
+                                },
+                                call_kind: None,
+                            },
+                            arms: [
+                                MatchArm {
+                                    pattern: EnumVariant {
+                                        identifier: "Ok",
+                                        fields: [
+                                            Identifier {
+                                                identifier: "d",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 164,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        ],
+                                        rest: false,
+                                        resolution: Unresolved,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 161,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                    expression: Identifier {
+                                        value: "d",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 170,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                },
+                                MatchArm {
+                                    pattern: EnumVariant {
+                                        identifier: "Err",
+                                        fields: [
+                                            Identifier {
+                                                identifier: "err",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 181,
+                                                    byte_length: 3,
+                                                },
+                                            },
+                                        ],
+                                        rest: false,
+                                        resolution: Unresolved,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 177,
+                                            byte_length: 8,
+                                        },
+                                    },
+                                    expression: Call {
+                                        expression: Identifier {
+                                            value: "panic",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 189,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Identifier {
+                                                value: "err",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 195,
+                                                    byte_length: 3,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 189,
+                                            byte_length: 10,
+                                        },
+                                        call_kind: None,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 136,
+                                byte_length: 67,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 128,
+                            byte_length: 75,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 128,
-                        byte_length: 75,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 76,
+                    byte_length: 130,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 76,
-                byte_length: 130,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/enum_variant_rest_pattern.snap
+++ b/tests/spec/parse/snapshots/enum_variant_rest_pattern.snap
@@ -167,7 +167,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -178,157 +177,158 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "s",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 83,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Shape.Triangle",
-                                fields: [],
-                                rest: true,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 91,
-                                    byte_length: 18,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "s",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 83,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Shape.Triangle",
+                                    fields: [],
+                                    rest: true,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 91,
+                                        byte_length: 18,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 113,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "triangle",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 119,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 113,
-                                        byte_length: 5,
+                                        byte_length: 17,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "triangle",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Shape.Circle",
+                                    fields: [],
+                                    rest: true,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 136,
+                                        byte_length: 16,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 119,
-                                            byte_length: 10,
+                                            byte_offset: 156,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 113,
-                                    byte_length: 17,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Shape.Circle",
-                                fields: [],
-                                rest: true,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 136,
-                                    byte_length: 16,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "circle",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 162,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 156,
-                                        byte_length: 5,
+                                        byte_length: 15,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "circle",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 162,
-                                            byte_length: 8,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 156,
-                                    byte_length: 15,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 77,
+                            byte_length: 99,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 77,
-                        byte_length: 99,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 73,
+                    byte_length: 105,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 73,
-                byte_length: 105,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/explicit_struct_in_binary_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/explicit_struct_in_binary_rhs_allowed.snap
@@ -69,101 +69,156 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 41,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 47,
+                                byte_length: 1,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 47,
-                            byte_length: 1,
+                            byte_offset: 37,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 37,
-                        byte_length: 11,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "foo",
+                    If {
+                        condition: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "foo",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 55,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: StructCall {
+                                name: "Bar",
+                                field_assignments: [
+                                    StructFieldAssignment {
+                                        name: "x",
+                                        name_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 67,
+                                            byte_length: 1,
+                                        },
+                                        value: Literal {
+                                            literal: Integer {
+                                                value: 42,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 70,
+                                                byte_length: 2,
+                                            },
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 61,
+                                    byte_length: 13,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 55,
-                                byte_length: 3,
+                                byte_length: 19,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: StructCall {
-                            name: "Bar",
-                            field_assignments: [
-                                StructFieldAssignment {
-                                    name: "x",
-                                    name_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 67,
-                                        byte_length: 1,
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                    value: Literal {
-                                        literal: Integer {
-                                            value: 42,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 70,
-                                            byte_length: 2,
-                                        },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 77,
+                                        byte_length: 4,
                                     },
                                 },
                             ],
-                            spread: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 61,
-                                byte_length: 13,
+                                byte_offset: 75,
+                                byte_length: 8,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 91,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 89,
+                                byte_length: 9,
                             },
                         },
                         ty: Var {
@@ -171,79 +226,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 55,
-                            byte_length: 19,
+                            byte_offset: 52,
+                            byte_length: 46,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 77,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 75,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 91,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 89,
-                            byte_length: 9,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 52,
-                        byte_length: 46,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 33,
+                    byte_length: 67,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 33,
-                byte_length: 67,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/field_access_after_call.snap
+++ b/tests/spec/parse/snapshots/field_access_after_call.snap
@@ -23,87 +23,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x_coord",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 7,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x_coord",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Call {
-                            expression: Identifier {
-                                value: "get_point",
+                        value: DotAccess {
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "get_point",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 9,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 29,
-                                    byte_length: 9,
+                                    byte_length: 11,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
+                            member: "x",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 29,
-                                byte_length: 11,
+                                byte_length: 13,
                             },
-                            call_kind: None,
+                            resolution: Unresolved,
                         },
-                        member: "x",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 29,
-                            byte_length: 13,
+                            byte_offset: 15,
+                            byte_length: 27,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/field_access_chained.snap
+++ b/tests/spec/parse/snapshots/field_access_chained.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,99 +48,93 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "username",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 8,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "username",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 8,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: DotAccess {
+                        value: DotAccess {
                             expression: DotAccess {
-                                expression: Identifier {
-                                    value: "cfg",
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "cfg",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 41,
+                                            byte_length: 3,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "auth",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 41,
-                                        byte_length: 3,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "auth",
+                                member: "user",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 41,
-                                    byte_length: 8,
+                                    byte_length: 13,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
+                                resolution: Unresolved,
                             },
-                            member: "user",
+                            member: "name",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 41,
-                                byte_length: 13,
+                                byte_length: 18,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            resolution: Unresolved,
                         },
-                        member: "name",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 18,
+                            byte_offset: 26,
+                            byte_length: 33,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 26,
-                        byte_length: 33,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 22,
+                    byte_length: 40,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 22,
-                byte_length: 40,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/field_access_method_call.snap
+++ b/tests/spec/parse/snapshots/field_access_method_call.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,87 +48,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "name",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "name",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: DotAccess {
-                            expression: Identifier {
-                                value: "user",
+                        value: Call {
+                            expression: DotAccess {
+                                expression: Identifier {
+                                    value: "user",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 36,
+                                        byte_length: 4,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                member: "get_name",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 36,
-                                    byte_length: 4,
+                                    byte_length: 13,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            member: "get_name",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 36,
-                                byte_length: 13,
+                                byte_length: 15,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 15,
+                            byte_offset: 25,
+                            byte_length: 26,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 33,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 33,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/field_access_tuple.snap
+++ b/tests/spec/parse/snapshots/field_access_tuple.snap
@@ -57,7 +57,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -68,128 +67,118 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "first_item",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 10,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "first_item",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 38,
+                                    byte_length: 10,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Identifier {
-                            value: "pair",
+                        value: DotAccess {
+                            expression: Identifier {
+                                value: "pair",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 4,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "0",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 51,
-                                byte_length: 4,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "0",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 6,
+                            byte_offset: 34,
+                            byte_length: 23,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 34,
-                        byte_length: 23,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "second_item",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 65,
-                                byte_length: 11,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "second_item",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 65,
+                                    byte_length: 11,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Identifier {
-                            value: "pair",
+                        value: DotAccess {
+                            expression: Identifier {
+                                value: "pair",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 79,
+                                    byte_length: 4,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "1",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 79,
-                                byte_length: 4,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "1",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 79,
-                            byte_length: 6,
+                            byte_offset: 61,
+                            byte_length: 24,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 61,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 30,
+                    byte_length: 58,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 30,
-                byte_length: 58,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/for_loop.snap
+++ b/tests/spec/parse/snapshots/for_loop.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,107 +60,104 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                For {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "item",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 39,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    For {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "item",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 39,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        iterable: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 47,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                    },
-                    iterable: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 47,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 59,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "item",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 65,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 59,
-                                        byte_length: 5,
+                                        byte_length: 11,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "item",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 65,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 59,
-                                    byte_length: 11,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 53,
+                                byte_length: 22,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 53,
-                            byte_length: 22,
+                            byte_offset: 35,
+                            byte_length: 40,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 35,
-                        byte_length: 40,
-                    },
-                    binding_id: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 31,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 31,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/for_loop_tuple_binding.snap
+++ b/tests/spec/parse/snapshots/for_loop_tuple_binding.snap
@@ -59,7 +59,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -70,137 +69,133 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                For {
-                    binding: Binding {
-                        pattern: Tuple {
-                            elements: [
-                                Identifier {
-                                    identifier: "key",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 46,
-                                        byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    For {
+                        binding: Binding {
+                            pattern: Tuple {
+                                elements: [
+                                    Identifier {
+                                        identifier: "key",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 46,
+                                            byte_length: 3,
+                                        },
                                     },
-                                },
-                                Identifier {
-                                    identifier: "value",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 5,
+                                    Identifier {
+                                        identifier: "value",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 51,
+                                            byte_length: 5,
+                                        },
                                     },
+                                ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 45,
+                                    byte_length: 12,
                                 },
-                            ],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 45,
-                                byte_length: 12,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        iterable: Identifier {
+                            value: "map_data",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 61,
+                                byte_length: 8,
+                            },
+                            resolution: Unresolved,
                         },
-                    },
-                    iterable: Identifier {
-                        value: "map_data",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 61,
-                            byte_length: 8,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 76,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "key",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 82,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        Identifier {
+                                            value: "value",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 87,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 76,
-                                        byte_length: 5,
+                                        byte_length: 17,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "key",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 82,
-                                            byte_length: 3,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    Identifier {
-                                        value: "value",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 87,
-                                            byte_length: 5,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 17,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 70,
+                                byte_length: 28,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 70,
-                            byte_length: 28,
+                            byte_offset: 41,
+                            byte_length: 57,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 41,
-                        byte_length: 57,
-                    },
-                    binding_id: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 37,
+                    byte_length: 63,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 37,
-                byte_length: 63,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_multiple.snap
+++ b/tests/spec/parse/snapshots/format_string_multiple.snap
@@ -21,100 +21,96 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "hello ",
+                                    ),
+                                    Expression(
+                                        Identifier {
+                                            value: "first",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 35,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ),
+                                    Text(
+                                        " ",
+                                    ),
+                                    Expression(
+                                        Identifier {
+                                            value: "last",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 43,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ),
+                                    Text(
+                                        "!",
+                                    ),
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 24,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: FormatString(
-                            [
-                                Text(
-                                    "hello ",
-                                ),
-                                Expression(
-                                    Identifier {
-                                        value: "first",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 35,
-                                            byte_length: 5,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ),
-                                Text(
-                                    " ",
-                                ),
-                                Expression(
-                                    Identifier {
-                                        value: "last",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 43,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ),
-                                Text(
-                                    "!",
-                                ),
-                            ],
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 24,
+                            byte_offset: 13,
+                            byte_length: 37,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 37,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 42,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 42,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_simple.snap
+++ b/tests/spec/parse/snapshots/format_string_simple.snap
@@ -21,64 +21,62 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "hello world",
+                                    ),
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 14,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: FormatString(
-                            [
-                                Text(
-                                    "hello world",
-                                ),
-                            ],
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 14,
+                            byte_offset: 13,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_with_field_access.snap
+++ b/tests/spec/parse/snapshots/format_string_with_field_access.snap
@@ -21,92 +21,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: FormatString(
-                            [
-                                Text(
-                                    "name: ",
-                                ),
-                                Expression(
-                                    DotAccess {
-                                        expression: Identifier {
-                                            value: "person",
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "name: ",
+                                    ),
+                                    Expression(
+                                        DotAccess {
+                                            expression: Identifier {
+                                                value: "person",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 35,
+                                                    byte_length: 6,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            member: "name",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 35,
-                                                byte_length: 6,
+                                                byte_length: 11,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                        member: "name",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 35,
-                                            byte_length: 11,
-                                        },
-                                        dot_access_kind: None,
-                                        receiver_coercion: None,
-                                    },
-                                ),
-                            ],
-                        ),
+                                    ),
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 22,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 22,
+                            byte_offset: 13,
+                            byte_length: 35,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 35,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 40,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 40,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_with_slice_literal_on_next_line.snap
+++ b/tests/spec/parse/snapshots/format_string_with_slice_literal_on_next_line.snap
@@ -43,88 +43,156 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "name",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "name",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: String {
+                                value: "test",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 43,
+                                byte_length: 6,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "test",
-                            raw: false,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 43,
-                            byte_length: 6,
+                            byte_offset: 32,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 17,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "msg",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 56,
-                                byte_length: 3,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "msg",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 56,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "items for ",
+                                    ),
+                                    Expression(
+                                        Identifier {
+                                            value: "name",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 75,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ),
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 62,
+                                byte_length: 19,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 52,
+                            byte_length: 29,
+                        },
                     },
-                    value: Literal {
-                        literal: FormatString(
+                    Literal {
+                        literal: Slice(
                             [
-                                Text(
-                                    "items for ",
-                                ),
-                                Expression(
-                                    Identifier {
-                                        value: "name",
+                                Identifier {
+                                    value: "msg",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 85,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "msg",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 75,
-                                            byte_length: 4,
+                                            byte_offset: 90,
+                                            byte_length: 3,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                ),
+                                    right: Literal {
+                                        literal: String {
+                                            value: "2",
+                                            raw: false,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 96,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 90,
+                                        byte_length: 9,
+                                    },
+                                },
                             ],
                         ),
                         ty: Var {
@@ -132,98 +200,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 62,
-                            byte_length: 19,
+                            byte_offset: 84,
+                            byte_length: 16,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 52,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Literal {
-                    literal: Slice(
-                        [
-                            Identifier {
-                                value: "msg",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 85,
-                                    byte_length: 3,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "msg",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 90,
-                                        byte_length: 3,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: String {
-                                        value: "2",
-                                        raw: false,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 96,
-                                        byte_length: 3,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 90,
-                                    byte_length: 9,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 84,
-                        byte_length: 16,
-                    },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 74,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 74,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_with_tuple_on_next_line.snap
+++ b/tests/spec/parse/snapshots/format_string_with_tuple_on_next_line.snap
@@ -51,160 +51,151 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "a",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 37,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 37,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 33,
-                        byte_length: 10,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "b",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 1,
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: FormatString(
-                            [
-                                Text(
-                                    "hello ",
-                                ),
-                                Expression(
-                                    Identifier {
-                                        value: "a",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 63,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ),
-                            ],
-                        ),
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 54,
-                            byte_length: 12,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 46,
-                        byte_length: 20,
-                    },
-                },
-                Tuple {
-                    elements: [
-                        Identifier {
-                            value: "a",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 70,
-                                byte_length: 1,
+                                byte_offset: 41,
+                                byte_length: 2,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        Identifier {
-                            value: "b",
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 33,
+                            byte_length: 10,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "b",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "hello ",
+                                    ),
+                                    Expression(
+                                        Identifier {
+                                            value: "a",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 63,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ),
+                                ],
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 73,
-                                byte_length: 1,
+                                byte_offset: 54,
+                                byte_length: 12,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 46,
+                            byte_length: 20,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 69,
-                        byte_length: 6,
+                    Tuple {
+                        elements: [
+                            Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 70,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 73,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 69,
+                            byte_length: 6,
+                        },
                     },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 29,
+                    byte_length: 48,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 29,
-                byte_length: 48,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/format_string_with_variable.snap
+++ b/tests/spec/parse/snapshots/format_string_with_variable.snap
@@ -21,79 +21,76 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: FormatString(
+                                [
+                                    Text(
+                                        "hello ",
+                                    ),
+                                    Expression(
+                                        Identifier {
+                                            value: "name",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 35,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ),
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 15,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: FormatString(
-                            [
-                                Text(
-                                    "hello ",
-                                ),
-                                Expression(
-                                    Identifier {
-                                        value: "name",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 35,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ),
-                            ],
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 15,
+                            byte_offset: 13,
+                            byte_length: 28,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 28,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 33,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 33,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_basic.snap
+++ b/tests/spec/parse/snapshots/function_basic.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -67,7 +66,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -86,168 +84,170 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 45,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 45,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: Addition,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 54,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 58,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 54,
-                                byte_length: 1,
+                                byte_length: 5,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 58,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 54,
-                            byte_length: 5,
+                            byte_offset: 41,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 41,
-                        byte_length: 18,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "result",
+                    If {
+                        condition: Binary {
+                            operator: GreaterThan,
+                            left: Identifier {
+                                value: "result",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 87,
+                                    byte_length: 6,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 96,
+                                    byte_length: 2,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 87,
-                                byte_length: 6,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 96,
-                                byte_length: 2,
+                                byte_length: 11,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 87,
-                            byte_length: 11,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        consequence: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 105,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Large!\\n",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 111,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 105,
-                                        byte_length: 5,
+                                        byte_length: 17,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Large!\\n",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 111,
-                                            byte_length: 10,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 105,
-                                    byte_length: 17,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 99,
+                                byte_length: 28,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 99,
-                            byte_length: 28,
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 84,
+                                byte_length: 43,
+                            },
                         },
-                    },
-                    alternative: Unit {
                         ty: Var {
                             id: uninferred,
                         },
@@ -257,48 +257,39 @@ description: |
                             byte_length: 43,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 84,
-                        byte_length: 43,
-                    },
-                },
-                Return {
-                    expression: Identifier {
-                        value: "result",
+                    Return {
+                        expression: Identifier {
+                            value: "result",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 137,
+                                byte_length: 6,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 137,
-                            byte_length: 6,
+                            byte_offset: 130,
+                            byte_length: 13,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 130,
-                        byte_length: 13,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 37,
+                    byte_length: 109,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 37,
-                byte_length: 109,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_main.snap
+++ b/tests/spec/parse/snapshots/function_main.snap
@@ -31,265 +31,29 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "total",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 20,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "total",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 20,
+                                    byte_length: 5,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Literal {
-                            literal: Integer {
-                                value: 7,
-                                text: None,
-                            },
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 1,
-                            },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 1,
-                            },
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 5,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 16,
-                        byte_length: 17,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "is_active",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 9,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Boolean(
-                            true,
-                        ),
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 54,
-                            byte_length: 4,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 20,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "pi",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 67,
-                                byte_length: 2,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Float {
-                            value: 3.14,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 72,
-                            byte_length: 4,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 63,
-                        byte_length: 13,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "name",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 85,
-                                byte_length: 4,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "Lisette",
-                            raw: false,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 92,
-                            byte_length: 9,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 81,
-                        byte_length: 20,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "initial",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 110,
-                                byte_length: 7,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Char(
-                            "L",
-                        ),
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 120,
-                            byte_length: 3,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 106,
-                        byte_length: 17,
-                    },
-                },
-                Match {
-                    subject: Identifier {
-                        value: "total",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 134,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
+                        value: Binary {
+                            operator: Addition,
+                            left: Literal {
                                 literal: Integer {
-                                    value: 12,
+                                    value: 7,
                                     text: None,
                                 },
                                 ty: Var {
@@ -297,124 +61,339 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 149,
+                                    byte_offset: 28,
+                                    byte_length: 1,
+                                },
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 1,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 5,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 16,
+                            byte_length: 17,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "is_active",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 9,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Boolean(
+                                true,
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 54,
+                                byte_length: 4,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 38,
+                            byte_length: 20,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "pi",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 67,
                                     byte_length: 2,
                                 },
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Float {
+                                value: 3.14,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 72,
+                                byte_length: 4,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 63,
+                            byte_length: 13,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "name",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 85,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: String {
+                                value: "Lisette",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 92,
+                                byte_length: 9,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 81,
+                            byte_length: 20,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "initial",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 110,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Char(
+                                "L",
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 120,
+                                byte_length: 3,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 106,
+                            byte_length: 17,
+                        },
+                    },
+                    Match {
+                        subject: Identifier {
+                            value: "total",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 134,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 12,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 149,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 155,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Correct!",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 161,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 155,
-                                        byte_length: 5,
+                                        byte_length: 17,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Correct!",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 181,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 161,
-                                            byte_length: 10,
+                                            byte_offset: 187,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 155,
-                                    byte_length: 17,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 181,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Incorrect!",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 193,
+                                                byte_length: 12,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 187,
-                                        byte_length: 5,
+                                        byte_length: 19,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Incorrect!",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 193,
-                                            byte_length: 12,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 187,
-                                    byte_length: 19,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 128,
+                            byte_length: 84,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 128,
-                        byte_length: 84,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 203,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 203,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_recursive.snap
+++ b/tests/spec/parse/snapshots/function_recursive.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -60,149 +59,51 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: LessThanOrEqual,
-                        left: Identifier {
-                            value: "n",
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: LessThanOrEqual,
+                            left: Identifier {
+                                value: "n",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 1,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 41,
+                                    byte_length: 1,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 36,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 1,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 1,
+                                byte_length: 6,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 6,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Return {
-                                expression: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 56,
-                                        byte_length: 1,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 49,
-                                    byte_length: 8,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 43,
-                            byte_length: 19,
-                        },
-                    },
-                    alternative: Unit {
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 29,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 33,
-                        byte_length: 29,
-                    },
-                },
-                Return {
-                    expression: Binary {
-                        operator: Multiplication,
-                        left: Identifier {
-                            value: "n",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 72,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Call {
-                            expression: Identifier {
-                                value: "factorial",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 9,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Binary {
-                                    operator: Subtraction,
-                                    left: Identifier {
-                                        value: "n",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 86,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
+                        consequence: Block {
+                            items: [
+                                Return {
+                                    expression: Literal {
                                         literal: Integer {
                                             value: 1,
                                             text: None,
@@ -212,7 +113,7 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 90,
+                                            byte_offset: 56,
                                             byte_length: 1,
                                         },
                                     },
@@ -221,51 +122,147 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 86,
-                                        byte_length: 5,
+                                        byte_offset: 49,
+                                        byte_length: 8,
                                     },
                                 },
                             ],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 76,
-                                byte_length: 16,
+                                byte_offset: 43,
+                                byte_length: 19,
                             },
-                            call_kind: None,
+                        },
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 33,
+                                byte_length: 29,
+                            },
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 72,
-                            byte_length: 20,
+                            byte_offset: 33,
+                            byte_length: 29,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
+                    Return {
+                        expression: Binary {
+                            operator: Multiplication,
+                            left: Identifier {
+                                value: "n",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 72,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Call {
+                                expression: Identifier {
+                                    value: "factorial",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 9,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Binary {
+                                        operator: Subtraction,
+                                        left: Identifier {
+                                            value: "n",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 86,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 90,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 86,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 76,
+                                    byte_length: 16,
+                                },
+                                call_kind: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 72,
+                                byte_length: 20,
+                            },
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 65,
+                            byte_length: 27,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 65,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 29,
+                    byte_length: 66,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 29,
-                byte_length: 66,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_with_empty_body.snap
+++ b/tests/spec/parse/snapshots/function_with_empty_body.snap
@@ -23,17 +23,19 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [],
-            ty: Var {
-                id: uninferred,
+        body: Definition(
+            Block {
+                items: [],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_with_generic.snap
+++ b/tests/spec/parse/snapshots/function_with_generic.snap
@@ -51,7 +51,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -70,73 +69,74 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 47,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 52,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 1,
+                            byte_offset: 31,
+                            byte_length: 29,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 47,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 52,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 39,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 39,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_with_multiple_returns.snap
+++ b/tests/spec/parse/snapshots/function_with_multiple_returns.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -60,94 +59,102 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 0,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
-                            },
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 30,
-                            byte_length: 5,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Return {
-                                expression: Unary {
-                                    operator: Negative,
-                                    expression: Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 50,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 49,
-                                        byte_length: 2,
-                                    },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 0,
+                                    text: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 42,
-                                    byte_length: 9,
+                                    byte_offset: 34,
+                                    byte_length: 1,
                                 },
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 30,
+                                byte_length: 5,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 20,
+                        consequence: Block {
+                            items: [
+                                Return {
+                                    expression: Unary {
+                                        operator: Negative,
+                                        expression: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 50,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 49,
+                                            byte_length: 2,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 42,
+                                        byte_length: 9,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 20,
+                            },
                         },
-                    },
-                    alternative: Unit {
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 29,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
@@ -157,48 +164,39 @@ description: |
                             byte_length: 29,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 27,
-                        byte_length: 29,
-                    },
-                },
-                Return {
-                    expression: Identifier {
-                        value: "x",
+                    Return {
+                        expression: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 66,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 66,
-                            byte_length: 1,
+                            byte_offset: 59,
+                            byte_length: 8,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 59,
-                        byte_length: 8,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 23,
+                    byte_length: 47,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 23,
-                byte_length: 47,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/function_with_nested_function.snap
+++ b/tests/spec/parse/snapshots/function_with_nested_function.snap
@@ -27,179 +27,180 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Function {
-                    doc: None,
-                    attributes: [],
-                    name: "inner",
-                    name_span: Span {
-                        file_id: 0,
-                        byte_offset: 19,
-                        byte_length: 5,
-                    },
-                    generics: [],
-                    params: [
-                        Binding {
-                            pattern: Identifier {
-                                identifier: "x",
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 25,
-                                    byte_length: 1,
-                                },
-                            },
-                            annotation: Some(
-                                Constructor {
-                                    name: "int",
-                                    params: [],
+        body: Definition(
+            Block {
+                items: [
+                    Function {
+                        doc: None,
+                        attributes: [],
+                        name: "inner",
+                        name_span: Span {
+                            file_id: 0,
+                            byte_offset: 19,
+                            byte_length: 5,
+                        },
+                        generics: [],
+                        params: [
+                            Binding {
+                                pattern: Identifier {
+                                    identifier: "x",
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 28,
-                                        byte_length: 3,
+                                        byte_offset: 25,
+                                        byte_length: 1,
                                     },
                                 },
-                            ),
-                            typed_pattern: None,
+                                annotation: Some(
+                                    Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 28,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                            },
+                        ],
+                        return_annotation: Constructor {
+                            name: "int",
+                            params: [],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 3,
+                            },
+                        },
+                        return_type: Var {
+                            id: uninferred,
+                        },
+                        visibility: Private,
+                        body: Definition(
+                            Block {
+                                items: [
+                                    Return {
+                                        expression: Binary {
+                                            operator: Multiplication,
+                                            left: Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 53,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Literal {
+                                                literal: Integer {
+                                                    value: 2,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 57,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 53,
+                                                byte_length: 5,
+                                            },
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 46,
+                                            byte_length: 12,
+                                        },
+                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 40,
+                                    byte_length: 23,
+                                },
+                            },
+                        ),
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 16,
+                            byte_length: 47,
+                        },
+                    },
+                    Call {
+                        expression: Identifier {
+                            value: "inner",
                             ty: Var {
                                 id: uninferred,
                             },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 68,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                    ],
-                    return_annotation: Constructor {
-                        name: "int",
-                        params: [],
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 3,
-                        },
-                    },
-                    return_type: Var {
-                        id: uninferred,
-                    },
-                    visibility: Private,
-                    body: Block {
-                        items: [
-                            Return {
-                                expression: Binary {
-                                    operator: Multiplication,
-                                    left: Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 53,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 2,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 57,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 5,
-                                    },
+                        args: [
+                            Literal {
+                                literal: Integer {
+                                    value: 5,
+                                    text: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 12,
+                                    byte_offset: 74,
+                                    byte_length: 1,
                                 },
                             },
                         ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 23,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 16,
-                        byte_length: 47,
-                    },
-                },
-                Call {
-                    expression: Identifier {
-                        value: "inner",
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 68,
-                            byte_length: 5,
+                            byte_length: 8,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Literal {
-                            literal: Integer {
-                                value: 5,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 74,
-                                byte_length: 1,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 68,
-                        byte_length: 8,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 12,
+                    byte_length: 67,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 12,
-                byte_length: 67,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_impl.snap
+++ b/tests/spec/parse/snapshots/generic_impl.snap
@@ -62,7 +62,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -91,63 +90,64 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: StructCall {
-                                name: "Box",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "value",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 66,
-                                            byte_length: 5,
-                                        },
-                                        value: Identifier {
-                                            value: "value",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: StructCall {
+                                    name: "Box",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "value",
+                                            name_span: Span {
                                                 file_id: 0,
                                                 byte_offset: 66,
                                                 byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            value: Identifier {
+                                                value: "value",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 66,
+                                                    byte_length: 5,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 60,
+                                        byte_length: 13,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 60,
-                                    byte_length: 13,
+                                    byte_offset: 53,
+                                    byte_length: 20,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 53,
-                                byte_length: 20,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 47,
+                            byte_length: 31,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 47,
-                        byte_length: 31,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/generic_mixed_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_mixed_bounds.snap
@@ -98,7 +98,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -123,7 +122,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -148,7 +146,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -167,42 +164,44 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 81,
+                                byte_length: 1,
+                            },
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 81,
-                            byte_length: 1,
+                            byte_offset: 74,
+                            byte_length: 8,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 74,
-                        byte_length: 8,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 70,
+                    byte_length: 15,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 70,
-                byte_length: 15,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_multiple_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_bounds.snap
@@ -68,7 +68,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -87,41 +86,42 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Identifier {
-                        value: "value",
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Identifier {
+                            value: "value",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 58,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 58,
-                            byte_length: 5,
+                            byte_offset: 51,
+                            byte_length: 12,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 51,
-                        byte_length: 12,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 19,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 19,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_multiple_params_with_bounds.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_params_with_bounds.snap
@@ -79,7 +79,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -104,7 +103,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -123,41 +121,43 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Literal {
-                        literal: Boolean(
-                            true,
-                        ),
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Literal {
+                            literal: Boolean(
+                                true,
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 65,
+                                byte_length: 4,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 65,
-                            byte_length: 4,
+                            byte_offset: 58,
+                            byte_length: 11,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 58,
-                        byte_length: 11,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 54,
+                    byte_length: 18,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 54,
-                byte_length: 18,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_multiple_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_multiple_unbounded.snap
@@ -59,7 +59,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -84,7 +83,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -121,66 +119,66 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Tuple {
-                        elements: [
-                            Identifier {
-                                value: "x",
-                                ty: Var {
-                                    id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Tuple {
+                            elements: [
+                                Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 49,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 49,
-                                    byte_length: 1,
+                                Identifier {
+                                    value: "y",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 52,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                            Identifier {
-                                value: "y",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 52,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 6,
                             },
-                        ],
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 6,
+                            byte_offset: 41,
+                            byte_length: 13,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 41,
-                        byte_length: 13,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 37,
+                    byte_length: 20,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 37,
-                byte_length: 20,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_single_bound.snap
+++ b/tests/spec/parse/snapshots/generic_single_bound.snap
@@ -59,7 +59,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -78,42 +77,44 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Literal {
-                        literal: String {
-                            value: "displayed",
-                            raw: false,
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Literal {
+                            literal: String {
+                                value: "displayed",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 55,
+                                byte_length: 11,
+                            },
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 55,
-                            byte_length: 11,
+                            byte_offset: 48,
+                            byte_length: 18,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 48,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 44,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 44,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_single_unbounded.snap
+++ b/tests/spec/parse/snapshots/generic_single_unbounded.snap
@@ -49,7 +49,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -68,41 +67,42 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 1,
+                            byte_offset: 31,
+                            byte_length: 8,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 8,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 15,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 15,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/generic_struct_instantiation.snap
+++ b/tests/spec/parse/snapshots/generic_struct_instantiation.snap
@@ -80,145 +80,138 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 52,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 42,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 56,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 48,
-                        byte_length: 10,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "c",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 66,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: Some(
-                            Constructor {
-                                name: "Container",
-                                params: [
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 79,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                ],
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 69,
-                                    byte_length: 14,
+                                    byte_offset: 52,
+                                    byte_length: 1,
                                 },
                             },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
                         },
-                    },
-                    value: StructCall {
-                        name: "Container",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "value",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 98,
-                                    byte_length: 5,
-                                },
-                                value: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 105,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
+                        value: Literal {
+                            literal: Integer {
+                                value: 42,
+                                text: None,
                             },
-                        ],
-                        spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 56,
+                                byte_length: 2,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 86,
-                            byte_length: 22,
+                            byte_offset: 48,
+                            byte_length: 10,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "c",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 66,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: Some(
+                                Constructor {
+                                    name: "Container",
+                                    params: [
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 79,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 69,
+                                        byte_length: 14,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Container",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "value",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 98,
+                                        byte_length: 5,
+                                    },
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 105,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 86,
+                                byte_length: 22,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 62,
+                            byte_length: 46,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 62,
-                        byte_length: 46,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 44,
+                    byte_length: 67,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 44,
-                byte_length: 67,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_complex_condition.snap
+++ b/tests/spec/parse/snapshots/if_complex_condition.snap
@@ -40,7 +40,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -65,7 +64,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -76,34 +74,57 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: Or,
-                        left: Binary {
-                            operator: And,
-                            left: Paren {
-                                expression: Binary {
-                                    operator: GreaterThan,
-                                    left: Binary {
-                                        operator: Multiplication,
-                                        left: Identifier {
-                                            value: "a",
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: Or,
+                            left: Binary {
+                                operator: And,
+                                left: Paren {
+                                    expression: Binary {
+                                        operator: GreaterThan,
+                                        left: Binary {
+                                            operator: Multiplication,
+                                            left: Identifier {
+                                                value: "a",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 34,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Literal {
+                                                literal: Integer {
+                                                    value: 2,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 38,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 34,
-                                                byte_length: 1,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
                                         },
                                         right: Literal {
                                             literal: Integer {
-                                                value: 2,
+                                                value: 50,
                                                 text: None,
                                             },
                                             ty: Var {
@@ -111,8 +132,8 @@ description: |
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 38,
-                                                byte_length: 1,
+                                                byte_offset: 42,
+                                                byte_length: 2,
                                             },
                                         },
                                         ty: Var {
@@ -121,21 +142,7 @@ description: |
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 34,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 50,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 42,
-                                            byte_length: 2,
+                                            byte_length: 10,
                                         },
                                     },
                                     ty: Var {
@@ -143,9 +150,21 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 10,
+                                        byte_offset: 33,
+                                        byte_length: 12,
                                     },
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 49,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
                                 ty: Var {
                                     id: uninferred,
@@ -153,21 +172,47 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 33,
-                                    byte_length: 12,
+                                    byte_length: 17,
                                 },
                             },
-                            right: Identifier {
-                                value: "b",
+                            right: Call {
+                                expression: Identifier {
+                                    value: "is_special",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 54,
+                                        byte_length: 10,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 65,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 49,
-                                    byte_length: 1,
+                                    byte_offset: 54,
+                                    byte_length: 13,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -175,71 +220,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 33,
-                                byte_length: 17,
+                                byte_length: 34,
                             },
                         },
-                        right: Call {
-                            expression: Identifier {
-                                value: "is_special",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 54,
-                                    byte_length: 10,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Identifier {
-                                    value: "a",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 65,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
+                        consequence: Block {
+                            items: [],
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 54,
-                                byte_length: 13,
+                                byte_offset: 68,
+                                byte_length: 30,
                             },
-                            call_kind: None,
                         },
-                        ty: Var {
-                            id: uninferred,
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 30,
+                                byte_length: 68,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 34,
-                        },
-                    },
-                    consequence: Block {
-                        items: [],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 68,
-                            byte_length: 30,
-                        },
-                    },
-                    alternative: Unit {
                         ty: Var {
                             id: uninferred,
                         },
@@ -249,25 +253,17 @@ description: |
                             byte_length: 68,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 68,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 74,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 74,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_else.snap
+++ b/tests/spec/parse/snapshots/if_else.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -53,174 +52,173 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "a",
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: GreaterThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 2,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 24,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 24,
-                            byte_length: 6,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        consequence: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "large",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 43,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 37,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "large",
-                                            raw: false,
-                                        },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 31,
+                                byte_length: 25,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 43,
-                                            byte_length: 7,
+                                            byte_offset: 68,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 31,
-                            byte_length: 25,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "small or medium",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 74,
+                                                byte_length: 17,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 68,
-                                        byte_length: 5,
+                                        byte_length: 24,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "small or medium",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 74,
-                                            byte_length: 17,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 68,
-                                    byte_length: 24,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 62,
+                                byte_length: 35,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 62,
-                            byte_length: 35,
+                            byte_offset: 21,
+                            byte_length: 76,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 76,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 82,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 82,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_else_if.snap
+++ b/tests/spec/parse/snapshots/if_else_if.snap
@@ -44,7 +44,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -55,102 +54,10 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "a",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 24,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 100,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 3,
-                            },
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 24,
-                            byte_length: 7,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 38,
-                                        byte_length: 5,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "very large",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 44,
-                                            byte_length: 12,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 19,
-                                },
-                                call_kind: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 32,
-                            byte_length: 30,
-                        },
-                    },
-                    alternative: If {
+        body: Definition(
+            Block {
+                items: [
+                    If {
                         condition: Binary {
                             operator: GreaterThan,
                             left: Identifier {
@@ -160,15 +67,14 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 71,
+                                    byte_offset: 24,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             right: Literal {
                                 literal: Integer {
-                                    value: 10,
+                                    value: 100,
                                     text: None,
                                 },
                                 ty: Var {
@@ -176,8 +82,8 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 75,
-                                    byte_length: 2,
+                                    byte_offset: 28,
+                                    byte_length: 3,
                                 },
                             },
                             ty: Var {
@@ -185,8 +91,8 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 71,
-                                byte_length: 6,
+                                byte_offset: 24,
+                                byte_length: 7,
                             },
                         },
                         consequence: Block {
@@ -199,16 +105,15 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 84,
+                                            byte_offset: 38,
                                             byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
                                     args: [
                                         Literal {
                                             literal: String {
-                                                value: "large",
+                                                value: "very large",
                                                 raw: false,
                                             },
                                             ty: Var {
@@ -216,8 +121,8 @@ description: |
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 90,
-                                                byte_length: 7,
+                                                byte_offset: 44,
+                                                byte_length: 12,
                                             },
                                         },
                                     ],
@@ -228,8 +133,8 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 84,
-                                        byte_length: 14,
+                                        byte_offset: 38,
+                                        byte_length: 19,
                                     },
                                     call_kind: None,
                                 },
@@ -239,62 +144,161 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 78,
-                                byte_length: 25,
+                                byte_offset: 32,
+                                byte_length: 30,
                             },
                         },
-                        alternative: Block {
-                            items: [
-                                Call {
-                                    expression: Identifier {
-                                        value: "print",
+                        alternative: If {
+                            condition: Binary {
+                                operator: GreaterThan,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 71,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Literal {
+                                    literal: Integer {
+                                        value: 10,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 75,
+                                        byte_length: 2,
+                                    },
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 71,
+                                    byte_length: 6,
+                                },
+                            },
+                            consequence: Block {
+                                items: [
+                                    Call {
+                                        expression: Identifier {
+                                            value: "print",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 84,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "large",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 90,
+                                                    byte_length: 7,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 84,
+                                            byte_length: 14,
+                                        },
+                                        call_kind: None,
+                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 78,
+                                    byte_length: 25,
+                                },
+                            },
+                            alternative: Block {
+                                items: [
+                                    Call {
+                                        expression: Identifier {
+                                            value: "print",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 115,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "small or medium",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 121,
+                                                    byte_length: 17,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 115,
-                                            byte_length: 5,
+                                            byte_length: 24,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "small or medium",
-                                                raw: false,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 121,
-                                                byte_length: 17,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 115,
-                                        byte_length: 24,
-                                    },
-                                    call_kind: None,
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 109,
+                                    byte_length: 35,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 109,
-                                byte_length: 35,
+                                byte_offset: 68,
+                                byte_length: 76,
                             },
                         },
                         ty: Var {
@@ -302,29 +306,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 68,
-                            byte_length: 76,
+                            byte_offset: 21,
+                            byte_length: 123,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 123,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 129,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 129,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_let_else.snap
+++ b/tests/spec/parse/snapshots/if_let_else.snap
@@ -52,7 +52,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,178 +62,176 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                IfLet {
-                    pattern: EnumVariant {
-                        identifier: "Some",
-                        fields: [
-                            Identifier {
-                                identifier: "x",
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 43,
-                                    byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    IfLet {
+                        pattern: EnumVariant {
+                            identifier: "Some",
+                            fields: [
+                                Identifier {
+                                    identifier: "x",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 43,
+                                        byte_length: 1,
+                                    },
                                 },
+                            ],
+                            rest: false,
+                            resolution: Unresolved,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 7,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 7,
+                        scrutinee: Identifier {
+                            value: "opt",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
                         },
-                    },
-                    scrutinee: Identifier {
-                        value: "opt",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        consequence: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 58,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 58,
-                                        byte_length: 5,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "x",
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 52,
+                                byte_length: 19,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 1,
+                                            byte_offset: 83,
+                                            byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 8,
-                                },
-                                call_kind: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 19,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "none",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 89,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 83,
-                                        byte_length: 5,
+                                        byte_length: 13,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "none",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 89,
-                                            byte_length: 6,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 83,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 77,
+                                byte_length: 24,
+                            },
+                        },
+                        else_span: Some(
+                            Span {
+                                file_id: 0,
+                                byte_offset: 72,
+                                byte_length: 4,
+                            },
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 77,
-                            byte_length: 24,
+                            byte_offset: 31,
+                            byte_length: 70,
                         },
                     },
-                    typed_pattern: None,
-                    else_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 72,
-                            byte_length: 4,
-                        },
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 70,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 76,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 76,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_let_else_if_let.snap
+++ b/tests/spec/parse/snapshots/if_let_else_if_let.snap
@@ -54,7 +54,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -89,7 +88,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -100,132 +98,44 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                IfLet {
-                    pattern: EnumVariant {
-                        identifier: "Some",
-                        fields: [
-                            Identifier {
-                                identifier: "x",
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 57,
-                                    byte_length: 1,
-                                },
-                            },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 7,
-                        },
-                    },
-                    scrutinee: Identifier {
-                        value: "a",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 62,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 70,
-                                        byte_length: 5,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 70,
-                                    byte_length: 8,
-                                },
-                                call_kind: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 64,
-                            byte_length: 19,
-                        },
-                    },
-                    alternative: IfLet {
+        body: Definition(
+            Block {
+                items: [
+                    IfLet {
                         pattern: EnumVariant {
                             identifier: "Some",
                             fields: [
                                 Identifier {
-                                    identifier: "y",
+                                    identifier: "x",
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 101,
+                                        byte_offset: 57,
                                         byte_length: 1,
                                     },
                                 },
                             ],
                             rest: false,
+                            resolution: Unresolved,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 96,
+                                byte_offset: 52,
                                 byte_length: 7,
                             },
                         },
                         scrutinee: Identifier {
-                            value: "b",
+                            value: "a",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 106,
+                                byte_offset: 62,
                                 byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
                         consequence: Block {
                             items: [
@@ -237,25 +147,23 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 114,
+                                            byte_offset: 70,
                                             byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
                                     args: [
                                         Identifier {
-                                            value: "y",
+                                            value: "x",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 120,
+                                                byte_offset: 76,
                                                 byte_length: 1,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
                                     ],
                                     spread: None,
@@ -265,7 +173,7 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 114,
+                                        byte_offset: 70,
                                         byte_length: 8,
                                     },
                                     call_kind: None,
@@ -276,69 +184,170 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 108,
+                                byte_offset: 64,
                                 byte_length: 19,
                             },
                         },
-                        alternative: Block {
-                            items: [
-                                Call {
-                                    expression: Identifier {
-                                        value: "print",
+                        alternative: IfLet {
+                            pattern: EnumVariant {
+                                identifier: "Some",
+                                fields: [
+                                    Identifier {
+                                        identifier: "y",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 101,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 96,
+                                    byte_length: 7,
+                                },
+                            },
+                            scrutinee: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 106,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            consequence: Block {
+                                items: [
+                                    Call {
+                                        expression: Identifier {
+                                            value: "print",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 114,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Identifier {
+                                                value: "y",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 120,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 114,
+                                            byte_length: 8,
+                                        },
+                                        call_kind: None,
+                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 108,
+                                    byte_length: 19,
+                                },
+                            },
+                            alternative: Block {
+                                items: [
+                                    Call {
+                                        expression: Identifier {
+                                            value: "print",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 139,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "both none",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 145,
+                                                    byte_length: 11,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 139,
-                                            byte_length: 5,
+                                            byte_length: 18,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "both none",
-                                                raw: false,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 145,
-                                                byte_length: 11,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 139,
-                                        byte_length: 18,
-                                    },
-                                    call_kind: None,
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 133,
+                                    byte_length: 29,
+                                },
+                            },
+                            else_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 128,
+                                    byte_length: 4,
+                                },
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 133,
-                                byte_length: 29,
+                                byte_offset: 89,
+                                byte_length: 73,
                             },
                         },
-                        typed_pattern: None,
                         else_span: Some(
                             Span {
                                 file_id: 0,
-                                byte_offset: 128,
+                                byte_offset: 84,
                                 byte_length: 4,
                             },
                         ),
@@ -347,37 +356,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 89,
-                            byte_length: 73,
+                            byte_offset: 45,
+                            byte_length: 117,
                         },
                     },
-                    typed_pattern: None,
-                    else_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 84,
-                            byte_length: 4,
-                        },
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 45,
-                        byte_length: 117,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 41,
+                    byte_length: 123,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 41,
-                byte_length: 123,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_let_expression.snap
+++ b/tests/spec/parse/snapshots/if_let_expression.snap
@@ -53,7 +53,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -72,80 +71,114 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IfLet {
-                        pattern: EnumVariant {
-                            identifier: "Some",
-                            fields: [
-                                Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 63,
-                                        byte_length: 1,
-                                    },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 6,
                                 },
-                            ],
-                            rest: false,
+                            },
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 58,
-                                byte_length: 7,
-                            },
                         },
-                        scrutinee: Identifier {
-                            value: "opt",
-                            ty: Var {
-                                id: uninferred,
+                        value: IfLet {
+                            pattern: EnumVariant {
+                                identifier: "Some",
+                                fields: [
+                                    Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 63,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 58,
+                                    byte_length: 7,
+                                },
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 68,
-                                byte_length: 3,
+                            scrutinee: Identifier {
+                                value: "opt",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 68,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
                             },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        consequence: Block {
-                            items: [
-                                Binary {
-                                    operator: Multiplication,
-                                    left: Identifier {
-                                        value: "x",
+                            consequence: Block {
+                                items: [
+                                    Binary {
+                                        operator: Multiplication,
+                                        left: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 78,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 2,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 82,
+                                                byte_length: 1,
+                                            },
+                                        },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 78,
-                                            byte_length: 1,
+                                            byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
                                     },
-                                    right: Literal {
+                                ],
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 72,
+                                    byte_length: 15,
+                                },
+                            },
+                            alternative: Block {
+                                items: [
+                                    Literal {
                                         literal: Integer {
-                                            value: 2,
+                                            value: 0,
                                             text: None,
                                         },
                                         ty: Var {
@@ -153,108 +186,69 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 82,
+                                            byte_offset: 99,
                                             byte_length: 1,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 78,
-                                        byte_length: 5,
-                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 93,
+                                    byte_length: 11,
+                                },
+                            },
+                            else_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 88,
+                                    byte_length: 4,
+                                },
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 72,
-                                byte_length: 15,
+                                byte_offset: 51,
+                                byte_length: 53,
                             },
                         },
-                        alternative: Block {
-                            items: [
-                                Literal {
-                                    literal: Integer {
-                                        value: 0,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 99,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 93,
-                                byte_length: 11,
-                            },
-                        },
-                        typed_pattern: None,
-                        else_span: Some(
-                            Span {
-                                file_id: 0,
-                                byte_offset: 88,
-                                byte_length: 4,
-                            },
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 53,
+                            byte_offset: 38,
+                            byte_length: 66,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Identifier {
+                        value: "result",
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 108,
+                            byte_length: 6,
+                        },
+                        resolution: Unresolved,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 66,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Identifier {
-                    value: "result",
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 108,
-                        byte_length: 6,
-                    },
-                    binding_id: None,
-                    qualified: None,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 34,
+                    byte_length: 82,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 34,
-                byte_length: 82,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_let_simple.snap
+++ b/tests/spec/parse/snapshots/if_let_simple.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,98 +60,107 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                IfLet {
-                    pattern: EnumVariant {
-                        identifier: "Some",
-                        fields: [
-                            Identifier {
-                                identifier: "x",
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 43,
-                                    byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    IfLet {
+                        pattern: EnumVariant {
+                            identifier: "Some",
+                            fields: [
+                                Identifier {
+                                    identifier: "x",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 43,
+                                        byte_length: 1,
+                                    },
                                 },
+                            ],
+                            rest: false,
+                            resolution: Unresolved,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 7,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 7,
+                        scrutinee: Identifier {
+                            value: "opt",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
                         },
-                    },
-                    scrutinee: Identifier {
-                        value: "opt",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        consequence: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 58,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 58,
-                                        byte_length: 5,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 8,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 52,
+                                byte_length: 19,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 19,
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 31,
+                                byte_length: 40,
+                            },
                         },
-                    },
-                    alternative: Unit {
+                        else_span: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -162,27 +170,17 @@ description: |
                             byte_length: 40,
                         },
                     },
-                    typed_pattern: None,
-                    else_span: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 40,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_nested.snap
+++ b/tests/spec/parse/snapshots/if_nested.snap
@@ -44,7 +44,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -69,7 +68,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -80,216 +78,222 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "a",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 0,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 32,
-                            byte_length: 5,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            If {
-                                condition: Binary {
-                                    operator: GreaterThan,
-                                    left: Identifier {
-                                        value: "b",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 47,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 51,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 47,
-                                        byte_length: 5,
-                                    },
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: GreaterThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                                consequence: Block {
-                                    items: [
-                                        Call {
-                                            expression: Identifier {
-                                                value: "print",
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 61,
-                                                    byte_length: 5,
-                                                },
-                                                binding_id: None,
-                                                qualified: None,
-                                            },
-                                            args: [
-                                                Literal {
-                                                    literal: String {
-                                                        value: "both positive",
-                                                        raw: false,
-                                                    },
-                                                    ty: Var {
-                                                        id: uninferred,
-                                                    },
-                                                    span: Span {
-                                                        file_id: 0,
-                                                        byte_offset: 67,
-                                                        byte_length: 15,
-                                                    },
-                                                },
-                                            ],
-                                            spread: None,
-                                            type_arguments: None,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 61,
-                                                byte_length: 22,
-                                            },
-                                            call_kind: None,
-                                        },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 37,
-                                    },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 1,
                                 },
-                                alternative: Block {
-                                    items: [
-                                        Call {
-                                            expression: Identifier {
-                                                value: "print",
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 104,
-                                                    byte_length: 5,
-                                                },
-                                                binding_id: None,
-                                                qualified: None,
-                                            },
-                                            args: [
-                                                Literal {
-                                                    literal: String {
-                                                        value: "a positive, b non-positive",
-                                                        raw: false,
-                                                    },
-                                                    ty: Var {
-                                                        id: uninferred,
-                                                    },
-                                                    span: Span {
-                                                        file_id: 0,
-                                                        byte_offset: 110,
-                                                        byte_length: 28,
-                                                    },
-                                                },
-                                            ],
-                                            spread: None,
-                                            type_arguments: None,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 104,
-                                                byte_length: 35,
-                                            },
-                                            call_kind: None,
-                                        },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 96,
-                                        byte_length: 50,
-                                    },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 0,
+                                    text: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 44,
-                                    byte_length: 102,
+                                    byte_offset: 36,
+                                    byte_length: 1,
                                 },
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 32,
+                                byte_length: 5,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 112,
+                        consequence: Block {
+                            items: [
+                                If {
+                                    condition: Binary {
+                                        operator: GreaterThan,
+                                        left: Identifier {
+                                            value: "b",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 47,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 51,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 47,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                    consequence: Block {
+                                        items: [
+                                            Call {
+                                                expression: Identifier {
+                                                    value: "print",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 61,
+                                                        byte_length: 5,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
+                                                args: [
+                                                    Literal {
+                                                        literal: String {
+                                                            value: "both positive",
+                                                            raw: false,
+                                                        },
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 67,
+                                                            byte_length: 15,
+                                                        },
+                                                    },
+                                                ],
+                                                spread: None,
+                                                type_arguments: None,
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 61,
+                                                    byte_length: 22,
+                                                },
+                                                call_kind: None,
+                                            },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 37,
+                                        },
+                                    },
+                                    alternative: Block {
+                                        items: [
+                                            Call {
+                                                expression: Identifier {
+                                                    value: "print",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 104,
+                                                        byte_length: 5,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
+                                                args: [
+                                                    Literal {
+                                                        literal: String {
+                                                            value: "a positive, b non-positive",
+                                                            raw: false,
+                                                        },
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 110,
+                                                            byte_length: 28,
+                                                        },
+                                                    },
+                                                ],
+                                                spread: None,
+                                                type_arguments: None,
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 104,
+                                                    byte_length: 35,
+                                                },
+                                                call_kind: None,
+                                            },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 96,
+                                            byte_length: 50,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 44,
+                                        byte_length: 102,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 112,
+                            },
                         },
-                    },
-                    alternative: Unit {
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 29,
+                                byte_length: 121,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
@@ -299,25 +303,17 @@ description: |
                             byte_length: 121,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 121,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 127,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 127,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/if_simple.snap
+++ b/tests/spec/parse/snapshots/if_simple.snap
@@ -40,7 +40,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -51,102 +50,110 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: GreaterThan,
-                        left: Identifier {
-                            value: "a",
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: GreaterThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 2,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 24,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 24,
-                            byte_length: 6,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        consequence: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "large",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 43,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 37,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "large",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 43,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 31,
+                                byte_length: 25,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 31,
-                            byte_length: 25,
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 35,
+                            },
                         },
-                    },
-                    alternative: Unit {
                         ty: Var {
                             id: uninferred,
                         },
@@ -156,25 +163,17 @@ description: |
                             byte_length: 35,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 35,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 41,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/impl_complex_return_type.snap
+++ b/tests/spec/parse/snapshots/impl_complex_return_type.snap
@@ -141,7 +141,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -170,54 +169,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 122,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "items",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 122,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "items",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 122,
-                                    byte_length: 10,
+                                    byte_offset: 115,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 115,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 109,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 109,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_method_bodies.snap
+++ b/tests/spec/parse/snapshots/impl_method_bodies.snap
@@ -105,7 +105,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -124,230 +123,227 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Let {
-                            binding: Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 101,
-                                        byte_length: 1,
+                body: Definition(
+                    Block {
+                        items: [
+                            Let {
+                                binding: Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 101,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                            value: Binary {
-                                operator: Addition,
-                                left: DotAccess {
-                                    expression: Identifier {
-                                        value: "self",
+                                value: Binary {
+                                    operator: Addition,
+                                    left: DotAccess {
+                                        expression: Identifier {
+                                            value: "self",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 105,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "value",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 105,
-                                            byte_length: 4,
+                                            byte_length: 10,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    member: "value",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 105,
-                                        byte_length: 10,
-                                    },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 118,
-                                        byte_length: 1,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 105,
-                                    byte_length: 14,
-                                },
-                            },
-                            mut_span: None,
-                            else_block: None,
-                            else_span: None,
-                            assert: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 97,
-                                byte_length: 22,
-                            },
-                        },
-                        Let {
-                            binding: Binding {
-                                pattern: Identifier {
-                                    identifier: "y",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 129,
-                                        byte_length: 1,
-                                    },
-                                },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                            value: Binary {
-                                operator: Multiplication,
-                                left: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 133,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 137,
-                                        byte_length: 1,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 133,
-                                    byte_length: 5,
-                                },
-                            },
-                            mut_span: None,
-                            else_block: None,
-                            else_span: None,
-                            assert: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 125,
-                                byte_length: 13,
-                            },
-                        },
-                        If {
-                            condition: Binary {
-                                operator: GreaterThan,
-                                left: Identifier {
-                                    value: "y",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 147,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 10,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 151,
-                                        byte_length: 2,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 147,
-                                    byte_length: 6,
-                                },
-                            },
-                            consequence: Block {
-                                items: [
-                                    Return {
-                                        expression: Identifier {
-                                            value: "y",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 169,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
                                         },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 162,
-                                            byte_length: 8,
+                                            byte_offset: 118,
+                                            byte_length: 1,
                                         },
                                     },
-                                ],
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 105,
+                                        byte_length: 14,
+                                    },
+                                },
+                                mode: Plain,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 154,
-                                    byte_length: 23,
+                                    byte_offset: 97,
+                                    byte_length: 22,
                                 },
                             },
-                            alternative: Unit {
+                            Let {
+                                binding: Binding {
+                                    pattern: Identifier {
+                                        identifier: "y",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 129,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                },
+                                value: Binary {
+                                    operator: Multiplication,
+                                    left: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 133,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 137,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 133,
+                                        byte_length: 5,
+                                    },
+                                },
+                                mode: Plain,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 125,
+                                    byte_length: 13,
+                                },
+                            },
+                            If {
+                                condition: Binary {
+                                    operator: GreaterThan,
+                                    left: Identifier {
+                                        value: "y",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 147,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 10,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 151,
+                                            byte_length: 2,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 147,
+                                        byte_length: 6,
+                                    },
+                                },
+                                consequence: Block {
+                                    items: [
+                                        Return {
+                                            expression: Identifier {
+                                                value: "y",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 169,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 162,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                    ],
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 154,
+                                        byte_length: 23,
+                                    },
+                                },
+                                alternative: Unit {
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 144,
+                                        byte_length: 33,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
@@ -357,48 +353,39 @@ description: |
                                     byte_length: 33,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 144,
-                                byte_length: 33,
-                            },
-                        },
-                        Return {
-                            expression: Identifier {
-                                value: "x",
+                            Return {
+                                expression: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 189,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 189,
-                                    byte_length: 1,
+                                    byte_offset: 182,
+                                    byte_length: 8,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 182,
-                                byte_length: 8,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 91,
+                            byte_length: 104,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 91,
-                        byte_length: 104,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_method_with_params.snap
+++ b/tests/spec/parse/snapshots/impl_method_with_params.snap
@@ -100,7 +100,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -125,7 +124,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -144,78 +142,77 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: Binary {
-                                operator: Addition,
-                                left: DotAccess {
-                                    expression: Identifier {
-                                        value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: DotAccess {
+                                        expression: Identifier {
+                                            value: "self",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 107,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "value",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 107,
-                                            byte_length: 4,
+                                            byte_length: 10,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    member: "value",
+                                    right: Identifier {
+                                        value: "amount",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 120,
+                                            byte_length: 6,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 107,
-                                        byte_length: 10,
+                                        byte_length: 19,
                                     },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
-                                },
-                                right: Identifier {
-                                    value: "amount",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 120,
-                                        byte_length: 6,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 107,
-                                    byte_length: 19,
+                                    byte_offset: 100,
+                                    byte_length: 26,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 100,
-                                byte_length: 26,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 94,
+                            byte_length: 37,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 94,
-                        byte_length: 37,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_mixed_visibility_methods.snap
+++ b/tests/spec/parse/snapshots/impl_mixed_visibility_methods.snap
@@ -108,7 +108,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -127,49 +126,57 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: Binary {
-                                operator: Multiplication,
-                                left: DotAccess {
-                                    expression: Identifier {
-                                        value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: Binary {
+                                    operator: Multiplication,
+                                    left: DotAccess {
+                                        expression: Identifier {
+                                            value: "self",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 105,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "value",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 105,
-                                            byte_length: 4,
+                                            byte_length: 10,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    member: "value",
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 118,
+                                            byte_length: 1,
+                                        },
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 105,
-                                        byte_length: 10,
-                                    },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 118,
-                                        byte_length: 1,
+                                        byte_length: 14,
                                     },
                                 },
                                 ty: Var {
@@ -177,29 +184,21 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 105,
-                                    byte_length: 14,
+                                    byte_offset: 98,
+                                    byte_length: 21,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 98,
-                                byte_length: 21,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 92,
+                            byte_length: 32,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 92,
-                        byte_length: 32,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -240,7 +239,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -259,68 +257,68 @@ description: |
                     id: uninferred,
                 },
                 visibility: Public,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: Call {
-                                expression: DotAccess {
-                                    expression: Identifier {
-                                        value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: Call {
+                                    expression: DotAccess {
+                                        expression: Identifier {
+                                            value: "self",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 174,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "private_helper",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 174,
-                                            byte_length: 4,
+                                            byte_length: 19,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    member: "private_helper",
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 174,
-                                        byte_length: 19,
+                                        byte_length: 21,
                                     },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 174,
-                                    byte_length: 21,
+                                    byte_offset: 167,
+                                    byte_length: 28,
                                 },
-                                call_kind: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 167,
-                                byte_length: 28,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 161,
+                            byte_length: 39,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 161,
-                        byte_length: 39,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -361,7 +359,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -386,7 +383,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -405,63 +401,64 @@ description: |
                     id: uninferred,
                 },
                 visibility: Public,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: StructCall {
-                                name: "Counter",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "value",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 280,
-                                            byte_length: 5,
-                                        },
-                                        value: Identifier {
-                                            value: "new_value",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: StructCall {
+                                    name: "Counter",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "value",
+                                            name_span: Span {
                                                 file_id: 0,
-                                                byte_offset: 287,
-                                                byte_length: 9,
+                                                byte_offset: 280,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            value: Identifier {
+                                                value: "new_value",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 287,
+                                                    byte_length: 9,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 270,
+                                        byte_length: 28,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 270,
-                                    byte_length: 28,
+                                    byte_offset: 263,
+                                    byte_length: 35,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 263,
-                                byte_length: 35,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 257,
+                            byte_length: 46,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 257,
-                        byte_length: 46,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_multiple_methods.snap
+++ b/tests/spec/parse/snapshots/impl_multiple_methods.snap
@@ -108,7 +108,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -127,54 +126,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 94,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "value",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 94,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "value",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 94,
-                                    byte_length: 10,
+                                    byte_offset: 87,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 87,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 81,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 81,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -215,7 +214,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -234,101 +232,101 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: StructCall {
-                                name: "Counter",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "value",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 175,
-                                            byte_length: 5,
-                                        },
-                                        value: Binary {
-                                            operator: Addition,
-                                            left: DotAccess {
-                                                expression: Identifier {
-                                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: StructCall {
+                                    name: "Counter",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "value",
+                                            name_span: Span {
+                                                file_id: 0,
+                                                byte_offset: 175,
+                                                byte_length: 5,
+                                            },
+                                            value: Binary {
+                                                operator: Addition,
+                                                left: DotAccess {
+                                                    expression: Identifier {
+                                                        value: "self",
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 182,
+                                                            byte_length: 4,
+                                                        },
+                                                        resolution: Unresolved,
+                                                    },
+                                                    member: "value",
                                                     ty: Var {
                                                         id: uninferred,
                                                     },
                                                     span: Span {
                                                         file_id: 0,
                                                         byte_offset: 182,
-                                                        byte_length: 4,
+                                                        byte_length: 10,
                                                     },
-                                                    binding_id: None,
-                                                    qualified: None,
+                                                    resolution: Unresolved,
                                                 },
-                                                member: "value",
+                                                right: Literal {
+                                                    literal: Integer {
+                                                        value: 1,
+                                                        text: None,
+                                                    },
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 195,
+                                                        byte_length: 1,
+                                                    },
+                                                },
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 182,
-                                                    byte_length: 10,
+                                                    byte_length: 14,
                                                 },
-                                                dot_access_kind: None,
-                                                receiver_coercion: None,
-                                            },
-                                            right: Literal {
-                                                literal: Integer {
-                                                    value: 1,
-                                                    text: None,
-                                                },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 195,
-                                                    byte_length: 1,
-                                                },
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 182,
-                                                byte_length: 14,
                                             },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 165,
+                                        byte_length: 33,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 165,
-                                    byte_length: 33,
+                                    byte_offset: 158,
+                                    byte_length: 40,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 158,
-                                byte_length: 40,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 152,
+                            byte_length: 51,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 152,
-                        byte_length: 51,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -362,64 +360,66 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: StructCall {
-                                name: "Counter",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "value",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 250,
-                                            byte_length: 5,
-                                        },
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: StructCall {
+                                    name: "Counter",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "value",
+                                            name_span: Span {
                                                 file_id: 0,
-                                                byte_offset: 257,
-                                                byte_length: 1,
+                                                byte_offset: 250,
+                                                byte_length: 5,
+                                            },
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 257,
+                                                    byte_length: 1,
+                                                },
                                             },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 240,
+                                        byte_length: 20,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 240,
-                                    byte_length: 20,
+                                    byte_offset: 233,
+                                    byte_length: 27,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 233,
-                                byte_length: 27,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 227,
+                            byte_length: 38,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 227,
-                        byte_length: 38,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_multiple_type_params.snap
+++ b/tests/spec/parse/snapshots/impl_multiple_type_params.snap
@@ -188,7 +188,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -207,54 +206,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 119,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "key",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 119,
-                                        byte_length: 4,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "key",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 119,
-                                    byte_length: 8,
+                                    byte_offset: 112,
+                                    byte_length: 15,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 112,
-                                byte_length: 15,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 106,
+                            byte_length: 26,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 106,
-                        byte_length: 26,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -314,7 +313,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -333,54 +331,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 185,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "value",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 185,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "value",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 185,
-                                    byte_length: 10,
+                                    byte_offset: 178,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 178,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 172,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 172,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_no_semicolons_after_methods.snap
+++ b/tests/spec/parse/snapshots/impl_no_semicolons_after_methods.snap
@@ -128,7 +128,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -153,7 +152,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -172,84 +170,84 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: StructCall {
-                                name: "Point",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "x",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 107,
-                                            byte_length: 1,
-                                        },
-                                        value: Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: StructCall {
+                                    name: "Point",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "x",
+                                            name_span: Span {
                                                 file_id: 0,
                                                 byte_offset: 107,
                                                 byte_length: 1,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                    },
-                                    StructFieldAssignment {
-                                        name: "y",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 110,
-                                            byte_length: 1,
-                                        },
-                                        value: Identifier {
-                                            value: "y",
-                                            ty: Var {
-                                                id: uninferred,
+                                            value: Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 107,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
                                             },
-                                            span: Span {
+                                        },
+                                        StructFieldAssignment {
+                                            name: "y",
+                                            name_span: Span {
                                                 file_id: 0,
                                                 byte_offset: 110,
                                                 byte_length: 1,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            value: Identifier {
+                                                value: "y",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 110,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 99,
+                                        byte_length: 14,
+                                    },
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 99,
-                                    byte_length: 14,
+                                    byte_offset: 92,
+                                    byte_length: 21,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 92,
-                                byte_length: 21,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 86,
+                            byte_length: 32,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 86,
-                        byte_length: 32,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },
@@ -290,7 +288,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -309,54 +306,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 163,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "x",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 163,
-                                        byte_length: 4,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "x",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 163,
-                                    byte_length: 6,
+                                    byte_offset: 156,
+                                    byte_length: 13,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 156,
-                                byte_length: 13,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 150,
+                            byte_length: 24,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 150,
-                        byte_length: 24,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_pub_method.snap
+++ b/tests/spec/parse/snapshots/impl_pub_method.snap
@@ -100,7 +100,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -119,54 +118,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Public,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 98,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "value",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 98,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "value",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 98,
-                                    byte_length: 10,
+                                    byte_offset: 91,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 91,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 85,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 85,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_simple.snap
+++ b/tests/spec/parse/snapshots/impl_simple.snap
@@ -100,7 +100,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -119,54 +118,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 94,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "value",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 94,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "value",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 94,
-                                    byte_length: 10,
+                                    byte_offset: 87,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 87,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 81,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 81,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_static_method.snap
+++ b/tests/spec/parse/snapshots/impl_static_method.snap
@@ -73,7 +73,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -98,7 +97,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -117,65 +115,65 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "a",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 74,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 78,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 74,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 78,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 74,
-                                    byte_length: 5,
+                                    byte_offset: 67,
+                                    byte_length: 12,
                                 },
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 67,
-                                byte_length: 12,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 61,
+                            byte_length: 23,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 61,
-                        byte_length: 23,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/impl_with_generics.snap
+++ b/tests/spec/parse/snapshots/impl_with_generics.snap
@@ -131,7 +131,6 @@ description: |
                                 },
                             },
                         ),
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -150,54 +149,54 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: Block {
-                    items: [
-                        Return {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "self",
+                body: Definition(
+                    Block {
+                        items: [
+                            Return {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "self",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 108,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "value",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 108,
-                                        byte_length: 4,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "value",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 108,
-                                    byte_length: 10,
+                                    byte_offset: 101,
+                                    byte_length: 17,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 101,
-                                byte_length: 17,
-                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 95,
+                            byte_length: 28,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 95,
-                        byte_length: 28,
-                    },
-                },
+                ),
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/import_mixed_with_function.snap
+++ b/tests/spec/parse/snapshots/import_mixed_with_function.snap
@@ -56,17 +56,19 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [],
-            ty: Var {
-                id: uninferred,
+        body: Definition(
+            Block {
+                items: [],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 22,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 22,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/indexing_after_call.snap
+++ b/tests/spec/parse/snapshots/indexing_after_call.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,98 +48,94 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "value",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "value",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 30,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Call {
-                            expression: Identifier {
-                                value: "get_map",
+                        value: IndexedAccess {
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "get_map",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 38,
+                                        byte_length: 7,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 38,
-                                    byte_length: 7,
+                                    byte_length: 9,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
+                            index: Identifier {
+                                value: "key",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 48,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 9,
+                                byte_offset: 47,
+                                byte_length: 5,
                             },
-                            call_kind: None,
+                            from_colon_syntax: false,
                         },
-                        index: Identifier {
-                            value: "key",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 48,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 47,
-                            byte_length: 5,
+                            byte_offset: 26,
+                            byte_length: 26,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 26,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 22,
+                    byte_length: 33,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 22,
-                byte_length: 33,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/indexing_chained.snap
+++ b/tests/spec/parse/snapshots/indexing_chained.snap
@@ -58,7 +58,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -83,7 +82,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -108,7 +106,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -119,108 +116,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "cell",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 64,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "cell",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 64,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: IndexedAccess {
-                            expression: Identifier {
-                                value: "matrix",
+                        value: IndexedAccess {
+                            expression: IndexedAccess {
+                                expression: Identifier {
+                                    value: "matrix",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 71,
+                                        byte_length: 6,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                index: Identifier {
+                                    value: "row",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 78,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 71,
-                                    byte_length: 6,
+                                    byte_offset: 77,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                from_colon_syntax: false,
                             },
                             index: Identifier {
-                                value: "row",
+                                value: "col",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 78,
+                                    byte_offset: 83,
                                     byte_length: 3,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 77,
+                                byte_offset: 82,
                                 byte_length: 5,
                             },
                             from_colon_syntax: false,
                         },
-                        index: Identifier {
-                            value: "col",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 83,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 82,
-                            byte_length: 5,
+                            byte_offset: 60,
+                            byte_length: 27,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 60,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 56,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 56,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/indexing_map.snap
+++ b/tests/spec/parse/snapshots/indexing_map.snap
@@ -57,7 +57,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -68,85 +67,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "active",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "active",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "data",
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "data",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 4,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Literal {
+                                literal: String {
+                                    value: "user_status",
+                                    raw: false,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 56,
+                                    byte_length: 13,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 51,
-                                byte_length: 4,
+                                byte_offset: 55,
+                                byte_length: 15,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            from_colon_syntax: false,
                         },
-                        index: Literal {
-                            literal: String {
-                                value: "user_status",
-                                raw: false,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 56,
-                                byte_length: 13,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 55,
-                            byte_length: 15,
+                            byte_offset: 38,
+                            byte_length: 32,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 32,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 34,
+                    byte_length: 39,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 34,
-                byte_length: 39,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/indexing_variable.snap
+++ b/tests/spec/parse/snapshots/indexing_variable.snap
@@ -48,7 +48,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -73,7 +72,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -84,84 +82,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "val",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "val",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 48,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Identifier {
+                                value: "i",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 52,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 48,
+                                byte_offset: 51,
                                 byte_length: 3,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            from_colon_syntax: false,
                         },
-                        index: Identifier {
-                            value: "i",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 52,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 3,
+                            byte_offset: 38,
+                            byte_length: 16,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 16,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 34,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 34,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/integer_in_type_argument_position.snap
+++ b/tests/spec/parse/snapshots/integer_in_type_argument_position.snap
@@ -55,7 +55,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -66,17 +65,19 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [],
-            ty: Var {
-                id: uninferred,
+        body: Definition(
+            Block {
+                items: [],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 31,
+                    byte_length: 2,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 31,
-                byte_length: 2,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_as_argument.snap
+++ b/tests/spec/parse/snapshots/lambda_as_argument.snap
@@ -48,7 +48,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -59,98 +58,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 38,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "map",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "numbers",
+                        value: Call {
+                            expression: Identifier {
+                                value: "map",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 51,
-                                    byte_length: 7,
+                                    byte_offset: 47,
+                                    byte_length: 3,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            Lambda {
-                                params: [
-                                    Binding {
-                                        pattern: Identifier {
-                                            identifier: "n",
+                            args: [
+                                Identifier {
+                                    value: "numbers",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 51,
+                                        byte_length: 7,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                Lambda {
+                                    params: [
+                                        Binding {
+                                            pattern: Identifier {
+                                                identifier: "n",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 61,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                            annotation: None,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                        },
+                                    ],
+                                    return_annotation: Unknown,
+                                    body: Binary {
+                                        operator: Multiplication,
+                                        left: Identifier {
+                                            value: "n",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 61,
+                                                byte_offset: 64,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 2,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 68,
                                                 byte_length: 1,
                                             },
                                         },
-                                        annotation: None,
-                                        typed_pattern: None,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                    },
-                                ],
-                                return_annotation: Unknown,
-                                body: Binary {
-                                    operator: Multiplication,
-                                    left: Identifier {
-                                        value: "n",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 64,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 2,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 68,
-                                            byte_length: 1,
+                                            byte_length: 5,
                                         },
                                     },
                                     ty: Var {
@@ -158,55 +162,44 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 64,
-                                        byte_length: 5,
+                                        byte_offset: 60,
+                                        byte_length: 9,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 60,
-                                    byte_length: 9,
-                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 47,
+                                byte_length: 23,
+                            },
+                            call_kind: None,
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 47,
-                            byte_length: 23,
+                            byte_offset: 34,
+                            byte_length: 36,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 34,
-                        byte_length: 36,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 30,
+                    byte_length: 43,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 30,
-                byte_length: 43,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_calling_immediately.snap
+++ b/tests/spec/parse/snapshots/lambda_calling_immediately.snap
@@ -23,72 +23,79 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Paren {
-                            expression: Lambda {
-                                params: [
-                                    Binding {
-                                        pattern: Identifier {
-                                            identifier: "x",
+                        value: Call {
+                            expression: Paren {
+                                expression: Lambda {
+                                    params: [
+                                        Binding {
+                                            pattern: Identifier {
+                                                identifier: "x",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 30,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                            annotation: None,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                        },
+                                    ],
+                                    return_annotation: Unknown,
+                                    body: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 30,
+                                                byte_offset: 33,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 37,
                                                 byte_length: 1,
                                             },
                                         },
-                                        annotation: None,
-                                        typed_pattern: None,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                    },
-                                ],
-                                return_annotation: Unknown,
-                                body: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
-                                        value: "x",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 33,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 37,
-                                            byte_length: 1,
+                                            byte_length: 5,
                                         },
                                     },
                                     ty: Var {
@@ -96,8 +103,8 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 33,
-                                        byte_length: 5,
+                                        byte_offset: 29,
+                                        byte_length: 9,
                                     },
                                 },
                                 ty: Var {
@@ -105,70 +112,59 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 29,
-                                    byte_length: 9,
+                                    byte_offset: 28,
+                                    byte_length: 11,
                                 },
                             },
+                            args: [
+                                Literal {
+                                    literal: Integer {
+                                        value: 5,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 40,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 28,
-                                byte_length: 11,
+                                byte_length: 14,
                             },
+                            call_kind: None,
                         },
-                        args: [
-                            Literal {
-                                literal: Integer {
-                                    value: 5,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 40,
-                                    byte_length: 1,
-                                },
-                            },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 14,
+                            byte_offset: 15,
+                            byte_length: 27,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_capturing_variable.snap
+++ b/tests/spec/parse/snapshots/lambda_capturing_variable.snap
@@ -24,155 +24,146 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "threshold",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 9,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 31,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 18,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "check",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 5,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 50,
-                                        byte_length: 1,
-                                    },
-                                },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Binary {
-                            operator: GreaterThan,
-                            left: Identifier {
-                                value: "x",
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "threshold",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 53,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "threshold",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 57,
+                                    byte_offset: 19,
                                     byte_length: 9,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 53,
-                                byte_length: 13,
+                                byte_offset: 31,
+                                byte_length: 2,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 49,
-                            byte_length: 17,
+                            byte_offset: 15,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "check",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 41,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 50,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                },
+                            ],
+                            return_annotation: Unknown,
+                            body: Binary {
+                                operator: GreaterThan,
+                                left: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 53,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "threshold",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 57,
+                                        byte_length: 9,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 53,
+                                    byte_length: 13,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 49,
+                                byte_length: 17,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 37,
+                            byte_length: 29,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 37,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 58,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 58,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_complex_expression.snap
+++ b/tests/spec/parse/snapshots/lambda_complex_expression.snap
@@ -48,7 +48,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -59,100 +58,142 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "filter",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 45,
-                                byte_length: 6,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        args: [
-                            Identifier {
-                                value: "items",
+                        value: Call {
+                            expression: Identifier {
+                                value: "filter",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 52,
-                                    byte_length: 5,
+                                    byte_offset: 45,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            Lambda {
-                                params: [
-                                    Binding {
-                                        pattern: Identifier {
-                                            identifier: "n",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 60,
-                                                byte_length: 1,
+                            args: [
+                                Identifier {
+                                    value: "items",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 52,
+                                        byte_length: 5,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                Lambda {
+                                    params: [
+                                        Binding {
+                                            pattern: Identifier {
+                                                identifier: "n",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 60,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                            annotation: None,
+                                            ty: Var {
+                                                id: uninferred,
                                             },
                                         },
-                                        annotation: None,
-                                        typed_pattern: None,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                    },
-                                ],
-                                return_annotation: Unknown,
-                                body: Binary {
-                                    operator: And,
-                                    left: Binary {
-                                        operator: GreaterThan,
-                                        left: Identifier {
-                                            value: "n",
+                                    ],
+                                    return_annotation: Unknown,
+                                    body: Binary {
+                                        operator: And,
+                                        left: Binary {
+                                            operator: GreaterThan,
+                                            left: Identifier {
+                                                value: "n",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 63,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 67,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 63,
-                                                byte_length: 1,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
                                         },
-                                        right: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
+                                        right: Binary {
+                                            operator: LessThan,
+                                            left: Identifier {
+                                                value: "n",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 72,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Literal {
+                                                literal: Integer {
+                                                    value: 100,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 76,
+                                                    byte_length: 3,
+                                                },
                                             },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 67,
-                                                byte_length: 1,
+                                                byte_offset: 72,
+                                                byte_length: 7,
                                             },
                                         },
                                         ty: Var {
@@ -161,45 +202,7 @@ description: |
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 63,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                    right: Binary {
-                                        operator: LessThan,
-                                        left: Identifier {
-                                            value: "n",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 72,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                        right: Literal {
-                                            literal: Integer {
-                                                value: 100,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 76,
-                                                byte_length: 3,
-                                            },
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 72,
-                                            byte_length: 7,
+                                            byte_length: 16,
                                         },
                                     },
                                     ty: Var {
@@ -207,55 +210,44 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 63,
-                                        byte_length: 16,
+                                        byte_offset: 59,
+                                        byte_length: 20,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 59,
-                                    byte_length: 20,
-                                },
+                            ],
+                            spread: None,
+                            type_arguments: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
-                        type_arguments: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 45,
+                                byte_length: 35,
+                            },
+                            call_kind: None,
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 45,
-                            byte_length: 35,
+                            byte_offset: 32,
+                            byte_length: 48,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 48,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 55,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 55,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_in_return.snap
+++ b/tests/spec/parse/snapshots/lambda_in_return.snap
@@ -23,55 +23,63 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 23,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                },
+                            ],
+                            return_annotation: Unknown,
+                            body: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 23,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Literal {
+                                    literal: Integer {
+                                        value: 2,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
                                         byte_length: 1,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "x",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Literal {
-                                literal: Integer {
-                                    value: 2,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 30,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
                             },
                             ty: Var {
@@ -79,8 +87,8 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 5,
+                                byte_offset: 22,
+                                byte_length: 9,
                             },
                         },
                         ty: Var {
@@ -88,29 +96,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 22,
-                            byte_length: 9,
+                            byte_offset: 15,
+                            byte_length: 16,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 16,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_multiple_params.snap
+++ b/tests/spec/parse/snapshots/lambda_multiple_params.snap
@@ -23,127 +23,121 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "add",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "add",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 26,
-                                        byte_length: 1,
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "y",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 1,
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "y",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 29,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
+                            ],
+                            return_annotation: Unknown,
+                            body: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 32,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Binary {
-                            operator: Addition,
-                            left: Identifier {
-                                value: "x",
+                                right: Identifier {
+                                    value: "y",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 36,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 32,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "y",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 36,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 5,
+                                byte_offset: 25,
+                                byte_length: 12,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 12,
+                            byte_offset: 15,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_nested.snap
+++ b/tests/spec/parse/snapshots/lambda_nested.snap
@@ -23,97 +23,102 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "outer",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 5,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 28,
-                                        byte_length: 1,
-                                    },
-                                },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "outer",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 5,
                                 },
                             },
-                        ],
-                        return_annotation: Unknown,
-                        body: Lambda {
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Lambda {
                             params: [
                                 Binding {
                                     pattern: Identifier {
-                                        identifier: "y",
+                                        identifier: "x",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 32,
+                                            byte_offset: 28,
                                             byte_length: 1,
                                         },
                                     },
                                     annotation: None,
-                                    typed_pattern: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                 },
                             ],
                             return_annotation: Unknown,
-                            body: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "x",
+                            body: Lambda {
+                                params: [
+                                    Binding {
+                                        pattern: Identifier {
+                                            identifier: "y",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                    },
+                                ],
+                                return_annotation: Unknown,
+                                body: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 35,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "y",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 39,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 35,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "y",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 39,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 35,
-                                    byte_length: 5,
+                                    byte_offset: 31,
+                                    byte_length: 9,
                                 },
                             },
                             ty: Var {
@@ -121,42 +126,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 9,
+                                byte_offset: 27,
+                                byte_length: 13,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 13,
+                            byte_offset: 15,
+                            byte_length: 25,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 25,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_no_params.snap
+++ b/tests/spec/parse/snapshots/lambda_no_params.snap
@@ -23,73 +23,71 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "f",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "f",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [],
-                        return_annotation: Unknown,
-                        body: Literal {
-                            literal: Integer {
-                                value: 42,
-                                text: None,
+                        value: Lambda {
+                            params: [],
+                            return_annotation: Unknown,
+                            body: Literal {
+                                literal: Integer {
+                                    value: 42,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 2,
+                                byte_offset: 23,
+                                byte_length: 5,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 5,
+                            byte_offset: 15,
+                            byte_length: 13,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 13,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 20,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 20,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_no_params_after_let.snap
+++ b/tests/spec/parse/snapshots/lambda_no_params_after_let.snap
@@ -43,172 +43,167 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "n",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "n",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 46,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 3,
+                                },
+                            ),
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 46,
+                                byte_offset: 50,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 50,
-                            byte_length: 1,
+                            byte_offset: 38,
+                            byte_length: 13,
                         },
                     },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 13,
-                    },
-                },
-                Lambda {
-                    params: [],
-                    return_annotation: Constructor {
-                        name: "int",
+                    Lambda {
                         params: [],
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 60,
-                            byte_length: 3,
+                        return_annotation: Constructor {
+                            name: "int",
+                            params: [],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 60,
+                                byte_length: 3,
+                            },
                         },
-                    },
-                    body: Block {
-                        items: [
-                            Assignment {
-                                target: Identifier {
-                                    value: "n",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 70,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                value: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
+                        body: Block {
+                            items: [
+                                Assignment {
+                                    target: Identifier {
                                         value: "n",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 74,
+                                            byte_offset: 70,
                                             byte_length: 1,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
+                                    value: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "n",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 74,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 78,
+                                                byte_length: 1,
+                                            },
                                         },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 78,
-                                            byte_length: 1,
+                                            byte_offset: 74,
+                                            byte_length: 5,
                                         },
                                     },
+                                    compound_operator: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 70,
+                                        byte_length: 9,
+                                    },
+                                },
+                                Identifier {
+                                    value: "n",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 74,
-                                        byte_length: 5,
+                                        byte_offset: 84,
+                                        byte_length: 1,
                                     },
+                                    resolution: Unresolved,
                                 },
-                                compound_operator: None,
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 70,
-                                    byte_length: 9,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                            Identifier {
-                                value: "n",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 84,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 64,
+                                byte_length: 25,
                             },
-                        ],
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 64,
-                            byte_length: 25,
+                            byte_offset: 54,
+                            byte_length: 35,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 54,
-                        byte_length: 35,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 34,
+                    byte_length: 57,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 34,
-                byte_length: 57,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_no_params_expr_after_let.snap
+++ b/tests/spec/parse/snapshots/lambda_no_params_expr_after_let.snap
@@ -40,86 +40,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
+                        value: Literal {
+                            literal: Integer {
+                                value: 42,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 2,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 10,
+                        },
                     },
-                    value: Literal {
-                        literal: Integer {
-                            value: 42,
-                            text: None,
+                    Lambda {
+                        params: [],
+                        return_annotation: Unknown,
+                        body: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 46,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 2,
+                            byte_offset: 43,
+                            byte_length: 4,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 10,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Lambda {
-                    params: [],
-                    return_annotation: Unknown,
-                    body: Identifier {
-                        value: "x",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 46,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 4,
-                    },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 23,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_single_param.snap
+++ b/tests/spec/parse/snapshots/lambda_single_param.snap
@@ -23,70 +23,77 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "double",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "double",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 29,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                },
+                            ],
+                            return_annotation: Unknown,
+                            body: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 29,
+                                        byte_offset: 32,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Literal {
+                                    literal: Integer {
+                                        value: 2,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 36,
                                         byte_length: 1,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "x",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 32,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Literal {
-                                literal: Integer {
-                                    value: 2,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 36,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
                             },
                             ty: Var {
@@ -94,42 +101,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 5,
+                                byte_offset: 28,
+                                byte_length: 9,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 9,
+                            byte_offset: 15,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_with_block_body.snap
+++ b/tests/spec/parse/snapshots/lambda_with_block_body.snap
@@ -26,79 +26,123 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "process",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 7,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "process",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 30,
-                                        byte_length: 1,
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 30,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    annotation: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: None,
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Block {
-                            items: [
-                                Let {
-                                    binding: Binding {
-                                        pattern: Identifier {
-                                            identifier: "doubled",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 43,
-                                                byte_length: 7,
+                            ],
+                            return_annotation: Unknown,
+                            body: Block {
+                                items: [
+                                    Let {
+                                        binding: Binding {
+                                            pattern: Identifier {
+                                                identifier: "doubled",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 43,
+                                                    byte_length: 7,
+                                                },
+                                            },
+                                            annotation: None,
+                                            ty: Var {
+                                                id: uninferred,
                                             },
                                         },
-                                        annotation: None,
-                                        typed_pattern: None,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                    },
-                                    value: Binary {
-                                        operator: Multiplication,
-                                        left: Identifier {
-                                            value: "x",
+                                        value: Binary {
+                                            operator: Multiplication,
+                                            left: Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 53,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Literal {
+                                                literal: Integer {
+                                                    value: 2,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 57,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 53,
-                                                byte_length: 1,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                        },
+                                        mode: Plain,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 39,
+                                            byte_length: 19,
+                                        },
+                                    },
+                                    Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "doubled",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 7,
+                                            },
+                                            resolution: Unresolved,
                                         },
                                         right: Literal {
                                             literal: Integer {
-                                                value: 2,
+                                                value: 1,
                                                 text: None,
                                             },
                                             ty: Var {
@@ -106,7 +150,7 @@ description: |
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 57,
+                                                byte_offset: 74,
                                                 byte_length: 1,
                                             },
                                         },
@@ -115,103 +159,50 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 53,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                    mut_span: None,
-                                    else_block: None,
-                                    else_span: None,
-                                    assert: false,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 39,
-                                        byte_length: 19,
-                                    },
-                                },
-                                Binary {
-                                    operator: Addition,
-                                    left: Identifier {
-                                        value: "doubled",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
                                             byte_offset: 64,
-                                            byte_length: 7,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 74,
-                                            byte_length: 1,
+                                            byte_length: 11,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 64,
-                                        byte_length: 11,
-                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 46,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 46,
+                                byte_offset: 29,
+                                byte_length: 50,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 29,
-                            byte_length: 50,
+                            byte_offset: 15,
+                            byte_length: 64,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 64,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 71,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 71,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_with_param_types.snap
+++ b/tests/spec/parse/snapshots/lambda_with_param_types.snap
@@ -23,147 +23,141 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "multiply",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 8,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "multiply",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 8,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "a",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 31,
-                                        byte_length: 1,
-                                    },
-                                },
-                                annotation: Some(
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "a",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 34,
-                                            byte_length: 3,
+                                            byte_offset: 31,
+                                            byte_length: 1,
                                         },
                                     },
-                                ),
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                            },
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "b",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 39,
-                                        byte_length: 1,
+                                    annotation: Some(
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 34,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
                                     },
                                 },
-                                annotation: Some(
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "b",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 42,
-                                            byte_length: 3,
+                                            byte_offset: 39,
+                                            byte_length: 1,
                                         },
                                     },
-                                ),
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
+                                    annotation: Some(
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 42,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
                                 },
-                            },
-                        ],
-                        return_annotation: Unknown,
-                        body: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "a",
+                            ],
+                            return_annotation: Unknown,
+                            body: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 47,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 51,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 47,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "b",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 51,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 5,
+                                byte_offset: 30,
+                                byte_length: 22,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 30,
-                            byte_length: 22,
+                            byte_offset: 15,
+                            byte_length: 37,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 37,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 44,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 44,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/lambda_with_type_annotation.snap
+++ b/tests/spec/parse/snapshots/lambda_with_type_annotation.snap
@@ -23,130 +23,125 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "square",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "square",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Lambda {
-                        params: [
-                            Binding {
-                                pattern: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 1,
-                                    },
-                                },
-                                annotation: Some(
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
+                        value: Lambda {
+                            params: [
+                                Binding {
+                                    pattern: Identifier {
+                                        identifier: "x",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 32,
-                                            byte_length: 3,
+                                            byte_offset: 29,
+                                            byte_length: 1,
                                         },
                                     },
-                                ),
-                                typed_pattern: None,
-                                ty: Var {
-                                    id: uninferred,
+                                    annotation: Some(
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                },
+                            ],
+                            return_annotation: Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 40,
+                                    byte_length: 3,
                                 },
                             },
-                        ],
-                        return_annotation: Constructor {
-                            name: "int",
-                            params: [],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 40,
-                                byte_length: 3,
-                            },
-                        },
-                        body: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "x",
+                            body: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 44,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 44,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "x",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 44,
-                                byte_length: 5,
+                                byte_offset: 28,
+                                byte_length: 21,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 21,
+                            byte_offset: 15,
+                            byte_length: 34,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 34,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 41,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_assert_basic.snap
+++ b/tests/spec/parse/snapshots/let_assert_basic.snap
@@ -23,74 +23,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: EnumVariant {
-                            identifier: "Ok",
-                            fields: [
-                                Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: EnumVariant {
+                                identifier: "Ok",
+                                fields: [
+                                    Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 29,
+                                            byte_length: 1,
+                                        },
                                     },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            rest: false,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Identifier {
+                            value: "result",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 5,
+                                byte_offset: 34,
+                                byte_length: 6,
                             },
+                            resolution: Unresolved,
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Identifier {
-                        value: "result",
+                        mode: Assert,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 34,
-                            byte_length: 6,
+                            byte_offset: 15,
+                            byte_length: 25,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: true,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 25,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_basic.snap
+++ b/tests/spec/parse/snapshots/let_basic.snap
@@ -23,61 +23,59 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 23,
+                                byte_length: 2,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 2,
+                            byte_offset: 15,
+                            byte_length: 10,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 10,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 17,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 17,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_complex_value.snap
+++ b/tests/spec/parse/snapshots/let_complex_value.snap
@@ -23,35 +23,58 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Division,
-                        left: Binary {
-                            operator: Multiplication,
-                            left: Paren {
-                                expression: Binary {
-                                    operator: Addition,
-                                    left: Literal {
-                                        literal: Integer {
-                                            value: 10,
-                                            text: None,
+                        value: Binary {
+                            operator: Division,
+                            left: Binary {
+                                operator: Multiplication,
+                                left: Paren {
+                                    expression: Binary {
+                                        operator: Addition,
+                                        left: Literal {
+                                            literal: Integer {
+                                                value: 10,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 29,
+                                                byte_length: 2,
+                                            },
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 5,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 34,
+                                                byte_length: 1,
+                                            },
                                         },
                                         ty: Var {
                                             id: uninferred,
@@ -59,21 +82,7 @@ description: |
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 29,
-                                            byte_length: 2,
-                                        },
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 5,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 34,
-                                            byte_length: 1,
+                                            byte_length: 6,
                                         },
                                     },
                                     ty: Var {
@@ -81,8 +90,22 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 6,
+                                        byte_offset: 28,
+                                        byte_length: 8,
+                                    },
+                                },
+                                right: Literal {
+                                    literal: Integer {
+                                        value: 2,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 39,
+                                        byte_length: 1,
                                     },
                                 },
                                 ty: Var {
@@ -91,22 +114,34 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 28,
-                                    byte_length: 8,
+                                    byte_length: 12,
                                 },
                             },
-                            right: Literal {
-                                literal: Integer {
-                                    value: 2,
-                                    text: None,
+                            right: Call {
+                                expression: Identifier {
+                                    value: "calculate_something",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 43,
+                                        byte_length: 19,
+                                    },
+                                    resolution: Unresolved,
                                 },
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 39,
-                                    byte_length: 1,
+                                    byte_offset: 43,
+                                    byte_length: 21,
                                 },
+                                call_kind: None,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -114,68 +149,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 28,
-                                byte_length: 12,
+                                byte_length: 36,
                             },
                         },
-                        right: Call {
-                            expression: Identifier {
-                                value: "calculate_something",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 43,
-                                    byte_length: 19,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 21,
-                            },
-                            call_kind: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 36,
+                            byte_offset: 15,
+                            byte_length: 49,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 49,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 56,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 56,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_destructure_struct.snap
+++ b/tests/spec/parse/snapshots/let_destructure_struct.snap
@@ -23,112 +23,110 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Struct {
-                            identifier: "Point",
-                            fields: [
-                                StructFieldPattern {
-                                    name: "x",
-                                    value: Identifier {
-                                        identifier: "x",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 27,
-                                            byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Struct {
+                                identifier: "Point",
+                                fields: [
+                                    StructFieldPattern {
+                                        name: "x",
+                                        value: Identifier {
+                                            identifier: "x",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 27,
+                                                byte_length: 1,
+                                            },
                                         },
                                     },
-                                },
-                                StructFieldPattern {
-                                    name: "y",
-                                    value: Identifier {
-                                        identifier: "y_coord",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 33,
-                                            byte_length: 7,
+                                    StructFieldPattern {
+                                        name: "y",
+                                        value: Identifier {
+                                            identifier: "y_coord",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 33,
+                                                byte_length: 7,
+                                            },
                                         },
                                     },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            rest: false,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 23,
+                                },
+                            },
+                            annotation: Some(
+                                Constructor {
+                                    name: "Point",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 44,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 23,
-                            },
                         },
-                        annotation: Some(
-                            Constructor {
-                                name: "Point",
-                                params: [],
+                        value: Call {
+                            expression: Identifier {
+                                value: "get_point",
+                                ty: Var {
+                                    id: uninferred,
+                                },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 44,
-                                    byte_length: 5,
+                                    byte_offset: 52,
+                                    byte_length: 9,
                                 },
+                                resolution: Unresolved,
                             },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "get_point",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 52,
-                                byte_length: 9,
+                                byte_length: 11,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 11,
+                            byte_offset: 15,
+                            byte_length: 48,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 48,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 55,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 55,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_destructure_tuple.snap
+++ b/tests/spec/parse/snapshots/let_destructure_tuple.snap
@@ -23,119 +23,116 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Tuple {
-                            elements: [
-                                Identifier {
-                                    identifier: "a",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 20,
-                                        byte_length: 1,
-                                    },
-                                },
-                                Identifier {
-                                    identifier: "b",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 23,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: Some(
-                            Tuple {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Tuple {
                                 elements: [
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
+                                    Identifier {
+                                        identifier: "a",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 28,
-                                            byte_length: 3,
+                                            byte_offset: 20,
+                                            byte_length: 1,
                                         },
                                     },
-                                    Constructor {
-                                        name: "string",
-                                        params: [],
+                                    Identifier {
+                                        identifier: "b",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 33,
-                                            byte_length: 6,
+                                            byte_offset: 23,
+                                            byte_length: 1,
                                         },
                                     },
                                 ],
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 27,
-                                    byte_length: 13,
+                                    byte_offset: 19,
+                                    byte_length: 6,
                                 },
                             },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: Some(
+                                Tuple {
+                                    elements: [
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 28,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                        Constructor {
+                                            name: "string",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 33,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 27,
+                                        byte_length: 13,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
                         },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "get_pair",
+                        value: Call {
+                            expression: Identifier {
+                                value: "get_pair",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 8,
+                                },
+                                resolution: Unresolved,
+                            },
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 43,
-                                byte_length: 8,
+                                byte_length: 10,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 43,
-                            byte_length: 10,
+                            byte_offset: 15,
+                            byte_length: 38,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 38,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 45,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 45,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_destructure_tuple_inferred.snap
+++ b/tests/spec/parse/snapshots/let_destructure_tuple_inferred.snap
@@ -23,91 +23,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Tuple {
-                            elements: [
-                                Identifier {
-                                    identifier: "a",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 20,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Tuple {
+                                elements: [
+                                    Identifier {
+                                        identifier: "a",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 20,
+                                            byte_length: 1,
+                                        },
                                     },
-                                },
-                                Identifier {
-                                    identifier: "b",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 23,
-                                        byte_length: 1,
+                                    Identifier {
+                                        identifier: "b",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 23,
+                                            byte_length: 1,
+                                        },
                                     },
+                                ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
                                 },
-                            ],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "get_pair",
+                        value: Call {
+                            expression: Identifier {
+                                value: "get_pair",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 8,
+                                },
+                                resolution: Unresolved,
+                            },
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 28,
-                                byte_length: 8,
+                                byte_length: 10,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 10,
+                            byte_offset: 15,
+                            byte_length: 23,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_destructure_tuple_wildcard.snap
+++ b/tests/spec/parse/snapshots/let_destructure_tuple_wildcard.snap
@@ -23,118 +23,115 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Tuple {
-                            elements: [
-                                WildCard {
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 20,
-                                        byte_length: 1,
-                                    },
-                                },
-                                Identifier {
-                                    identifier: "status_code",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 23,
-                                        byte_length: 11,
-                                    },
-                                },
-                            ],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 16,
-                            },
-                        },
-                        annotation: Some(
-                            Tuple {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Tuple {
                                 elements: [
-                                    Constructor {
-                                        name: "string",
-                                        params: [],
+                                    WildCard {
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 38,
-                                            byte_length: 6,
+                                            byte_offset: 20,
+                                            byte_length: 1,
                                         },
                                     },
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
+                                    Identifier {
+                                        identifier: "status_code",
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 46,
-                                            byte_length: 3,
+                                            byte_offset: 23,
+                                            byte_length: 11,
                                         },
                                     },
                                 ],
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 13,
+                                    byte_offset: 19,
+                                    byte_length: 16,
                                 },
                             },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: Some(
+                                Tuple {
+                                    elements: [
+                                        Constructor {
+                                            name: "string",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 38,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 46,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 13,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
                         },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "http_request",
+                        value: Call {
+                            expression: Identifier {
+                                value: "http_request",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 53,
+                                    byte_length: 12,
+                                },
+                                resolution: Unresolved,
+                            },
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 53,
-                                byte_length: 12,
+                                byte_length: 14,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 53,
-                            byte_length: 14,
+                            byte_offset: 15,
+                            byte_length: 52,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 52,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 59,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 59,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_else_basic.snap
+++ b/tests/spec/parse/snapshots/let_else_basic.snap
@@ -42,157 +42,151 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: EnumVariant {
-                            identifier: "Some",
-                            fields: [
-                                Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 39,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: EnumVariant {
+                                identifier: "Some",
+                                fields: [
+                                    Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 39,
+                                            byte_length: 1,
+                                        },
                                     },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            rest: false,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Identifier {
+                            value: "opt",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 7,
+                                byte_offset: 44,
+                                byte_length: 3,
                             },
+                            resolution: Unresolved,
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Identifier {
-                        value: "opt",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    mut_span: None,
-                    else_block: Some(
-                        Block {
-                            items: [
-                                Return {
-                                    expression: Identifier {
-                                        value: "None",
+                        mode: Else {
+                            block: Block {
+                                items: [
+                                    Return {
+                                        expression: Identifier {
+                                            value: "None",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 62,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 62,
-                                            byte_length: 4,
+                                            byte_offset: 55,
+                                            byte_length: 11,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 55,
-                                        byte_length: 11,
-                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 53,
+                                    byte_length: 16,
+                                },
+                            },
+                            else_span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 4,
+                            },
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 39,
+                        },
+                    },
+                    Call {
+                        expression: Identifier {
+                            value: "Some",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 53,
-                                byte_length: 16,
+                                byte_offset: 73,
+                                byte_length: 4,
                             },
+                            resolution: Unresolved,
                         },
-                    ),
-                    else_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 4,
-                        },
-                    ),
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 39,
-                    },
-                },
-                Call {
-                    expression: Identifier {
-                        value: "Some",
+                        args: [
+                            Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 78,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 73,
-                            byte_length: 4,
+                            byte_length: 7,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "x",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 78,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 73,
-                        byte_length: 7,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 56,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 56,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_else_complex_pattern.snap
+++ b/tests/spec/parse/snapshots/let_else_complex_pattern.snap
@@ -24,172 +24,166 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Tuple {
-                            elements: [
-                                Identifier {
-                                    identifier: "a",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 20,
-                                        byte_length: 1,
-                                    },
-                                },
-                                EnumVariant {
-                                    identifier: "Some",
-                                    fields: [
-                                        Identifier {
-                                            identifier: "b",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 28,
-                                                byte_length: 1,
-                                            },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Tuple {
+                                elements: [
+                                    Identifier {
+                                        identifier: "a",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 20,
+                                            byte_length: 1,
                                         },
-                                    ],
-                                    rest: false,
-                                    ty: Var {
-                                        id: uninferred,
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 23,
-                                        byte_length: 7,
+                                    EnumVariant {
+                                        identifier: "Some",
+                                        fields: [
+                                            Identifier {
+                                                identifier: "b",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 28,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        ],
+                                        rest: false,
+                                        resolution: Unresolved,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 23,
+                                            byte_length: 7,
+                                        },
                                     },
+                                ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 12,
                                 },
-                            ],
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 12,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Identifier {
-                        value: "tuple",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 34,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    mut_span: None,
-                    else_block: Some(
-                        Block {
-                            items: [
-                                Break {
-                                    value: None,
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 47,
-                                        byte_length: 5,
-                                    },
-                                },
-                            ],
+                        value: Identifier {
+                            value: "tuple",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 45,
-                                byte_length: 10,
+                                byte_offset: 34,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        mode: Else {
+                            block: Block {
+                                items: [
+                                    Break {
+                                        value: None,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 47,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 45,
+                                    byte_length: 10,
+                                },
+                            },
+                            else_span: Span {
+                                file_id: 0,
+                                byte_offset: 40,
+                                byte_length: 4,
                             },
                         },
-                    ),
-                    else_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 4,
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ),
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 40,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 40,
-                    },
-                },
-                Call {
-                    expression: Identifier {
-                        value: "use_values",
+                    Call {
+                        expression: Identifier {
+                            value: "use_values",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 59,
+                                byte_length: 10,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 70,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 73,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 59,
-                            byte_length: 10,
+                            byte_length: 16,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "a",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 70,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 73,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 59,
-                        byte_length: 16,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 67,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 67,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_else_with_break.snap
+++ b/tests/spec/parse/snapshots/let_else_with_break.snap
@@ -26,69 +26,143 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Loop {
-                    body: Block {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: EnumVariant {
-                                        identifier: "Some",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "item",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 35,
-                                                    byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Loop {
+                        body: Block {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: EnumVariant {
+                                            identifier: "Some",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "item",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 35,
+                                                        byte_length: 4,
+                                                    },
                                                 },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
                                             },
-                                        ],
-                                        rest: false,
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 30,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                        annotation: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 30,
-                                            byte_length: 10,
-                                        },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: Call {
-                                    expression: DotAccess {
-                                        expression: Identifier {
-                                            value: "iter",
+                                    value: Call {
+                                        expression: DotAccess {
+                                            expression: Identifier {
+                                                value: "iter",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 43,
+                                                    byte_length: 4,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            member: "next",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 43,
-                                                byte_length: 4,
+                                                byte_length: 9,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                        member: "next",
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 43,
-                                            byte_length: 9,
+                                            byte_length: 11,
                                         },
-                                        dot_access_kind: None,
-                                        receiver_coercion: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
+                                    mode: Else {
+                                        block: Block {
+                                            items: [
+                                                Break {
+                                                    value: None,
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 62,
+                                                        byte_length: 5,
+                                                    },
+                                                },
+                                            ],
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 60,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                        else_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 55,
+                                            byte_length: 4,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 44,
+                                    },
+                                },
+                                Call {
+                                    expression: Identifier {
+                                        value: "process",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 76,
+                                            byte_length: 7,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "item",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 84,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
                                     spread: None,
                                     type_arguments: None,
                                     ty: Var {
@@ -96,121 +170,41 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 43,
-                                        byte_length: 11,
+                                        byte_offset: 76,
+                                        byte_length: 13,
                                     },
                                     call_kind: None,
                                 },
-                                mut_span: None,
-                                else_block: Some(
-                                    Block {
-                                        items: [
-                                            Break {
-                                                value: None,
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 62,
-                                                    byte_length: 5,
-                                                },
-                                            },
-                                        ],
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 60,
-                                            byte_length: 10,
-                                        },
-                                    },
-                                ),
-                                else_span: Some(
-                                    Span {
-                                        file_id: 0,
-                                        byte_offset: 55,
-                                        byte_length: 4,
-                                    },
-                                ),
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 44,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                            Call {
-                                expression: Identifier {
-                                    value: "process",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 76,
-                                        byte_length: 7,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Identifier {
-                                        value: "item",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 84,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 74,
                             },
-                        ],
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 74,
+                            byte_offset: 15,
+                            byte_length: 79,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 79,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 85,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 85,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_else_with_continue.snap
+++ b/tests/spec/parse/snapshots/let_else_with_continue.snap
@@ -26,96 +26,167 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                For {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "item",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    For {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "item",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        iterable: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                    },
-                    iterable: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    body: Block {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: EnumVariant {
-                                        identifier: "Valid",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "data",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 49,
-                                                    byte_length: 4,
+                        body: Block {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: EnumVariant {
+                                            identifier: "Valid",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "data",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 49,
+                                                        byte_length: 4,
+                                                    },
                                                 },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
                                             },
-                                        ],
-                                        rest: false,
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 43,
+                                                byte_length: 11,
+                                            },
+                                        },
+                                        annotation: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 43,
-                                            byte_length: 11,
+                                    },
+                                    value: Call {
+                                        expression: Identifier {
+                                            value: "validate",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 57,
+                                                byte_length: 8,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: Call {
-                                    expression: Identifier {
-                                        value: "validate",
+                                        args: [
+                                            Identifier {
+                                                value: "item",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 66,
+                                                    byte_length: 4,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 57,
-                                            byte_length: 8,
+                                            byte_length: 14,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Identifier {
-                                            value: "item",
+                                    mode: Else {
+                                        block: Block {
+                                            items: [
+                                                Continue {
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 79,
+                                                        byte_length: 8,
+                                                    },
+                                                },
+                                            ],
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 66,
+                                                byte_offset: 77,
+                                                byte_length: 13,
+                                            },
+                                        },
+                                        else_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 72,
+                                            byte_length: 4,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 39,
+                                        byte_length: 51,
+                                    },
+                                },
+                                Call {
+                                    expression: Identifier {
+                                        value: "process",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 96,
+                                            byte_length: 7,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "data",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 104,
                                                 byte_length: 4,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
                                     ],
                                     spread: None,
@@ -125,118 +196,38 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 57,
-                                        byte_length: 14,
+                                        byte_offset: 96,
+                                        byte_length: 13,
                                     },
                                     call_kind: None,
                                 },
-                                mut_span: None,
-                                else_block: Some(
-                                    Block {
-                                        items: [
-                                            Continue {
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 79,
-                                                    byte_length: 8,
-                                                },
-                                            },
-                                        ],
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 77,
-                                            byte_length: 13,
-                                        },
-                                    },
-                                ),
-                                else_span: Some(
-                                    Span {
-                                        file_id: 0,
-                                        byte_offset: 72,
-                                        byte_length: 4,
-                                    },
-                                ),
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 39,
-                                    byte_length: 51,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                            Call {
-                                expression: Identifier {
-                                    value: "process",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 96,
-                                        byte_length: 7,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Identifier {
-                                        value: "data",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 104,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 96,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 33,
+                                byte_length: 81,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 81,
+                            byte_offset: 15,
+                            byte_length: 99,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 99,
-                    },
-                    binding_id: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 105,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 105,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_else_with_result.snap
+++ b/tests/spec/parse/snapshots/let_else_with_result.snap
@@ -32,84 +32,92 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: EnumVariant {
-                            identifier: "Ok",
-                            fields: [
-                                Identifier {
-                                    identifier: "value",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: EnumVariant {
+                                identifier: "Ok",
+                                fields: [
+                                    Identifier {
+                                        identifier: "value",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 29,
+                                            byte_length: 5,
+                                        },
                                     },
+                                ],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            rest: false,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 9,
+                                },
+                            },
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 9,
+                        },
+                        value: Call {
+                            expression: Identifier {
+                                value: "get_result",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 38,
+                                    byte_length: 10,
+                                },
+                                resolution: Unresolved,
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: Identifier {
-                            value: "get_result",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 38,
-                                byte_length: 10,
+                                byte_length: 12,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 12,
-                        },
-                        call_kind: None,
-                    },
-                    mut_span: None,
-                    else_block: Some(
-                        Block {
-                            items: [
-                                Return {
-                                    expression: Unary {
-                                        operator: Negative,
-                                        expression: Literal {
-                                            literal: Integer {
-                                                value: 1,
-                                                text: None,
+                        mode: Else {
+                            block: Block {
+                                items: [
+                                    Return {
+                                        expression: Unary {
+                                            operator: Negative,
+                                            expression: Literal {
+                                                literal: Integer {
+                                                    value: 1,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 66,
+                                                    byte_length: 1,
+                                                },
                                             },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 66,
-                                                byte_length: 1,
+                                                byte_offset: 65,
+                                                byte_length: 2,
                                             },
                                         },
                                         ty: Var {
@@ -117,70 +125,58 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 65,
-                                            byte_length: 2,
+                                            byte_offset: 58,
+                                            byte_length: 9,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 58,
-                                        byte_length: 9,
-                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            ty: Var {
-                                id: uninferred,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 56,
+                                    byte_length: 14,
+                                },
                             },
-                            span: Span {
+                            else_span: Span {
                                 file_id: 0,
-                                byte_offset: 56,
-                                byte_length: 14,
+                                byte_offset: 51,
+                                byte_length: 4,
                             },
                         },
-                    ),
-                    else_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 4,
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ),
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 22,
+                            byte_length: 48,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 22,
-                        byte_length: 48,
+                    Identifier {
+                        value: "value",
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 74,
+                            byte_length: 5,
+                        },
+                        resolution: Unresolved,
                     },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Identifier {
-                    value: "value",
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 74,
-                        byte_length: 5,
-                    },
-                    binding_id: None,
-                    qualified: None,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 18,
+                    byte_length: 63,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 18,
-                byte_length: 63,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_mutable.snap
+++ b/tests/spec/parse/snapshots/let_mutable.snap
@@ -23,68 +23,66 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "counter",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "counter",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 7,
+                                byte_offset: 33,
+                                byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_mutable_with_type.snap
+++ b/tests/spec/parse/snapshots/let_mutable_with_type.snap
@@ -23,77 +23,75 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "active",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: Some(
-                            Constructor {
-                                name: "bool",
-                                params: [],
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "active",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 31,
-                                    byte_length: 4,
+                                    byte_offset: 23,
+                                    byte_length: 6,
                                 },
                             },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: Some(
+                                Constructor {
+                                    name: "bool",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 4,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
                         },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Boolean(
-                            true,
-                        ),
+                        value: Literal {
+                            literal: Boolean(
+                                true,
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 4,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 4,
+                            byte_offset: 15,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_struct_literal.snap
+++ b/tests/spec/parse/snapshots/let_struct_literal.snap
@@ -23,105 +23,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 34,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                                StructFieldAssignment {
+                                    name: "y",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 40,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+                                byte_offset: 23,
+                                byte_length: 20,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 31,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 1,
-                                    },
-                                },
-                            },
-                            StructFieldAssignment {
-                                name: "y",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 40,
-                                        byte_length: 1,
-                                    },
-                                },
-                            },
-                        ],
-                        spread: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 20,
+                            byte_offset: 15,
+                            byte_length: 28,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 28,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 35,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 35,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/let_with_type.snap
+++ b/tests/spec/parse/snapshots/let_with_type.snap
@@ -23,71 +23,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "message",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "message",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: Some(
+                                Constructor {
+                                    name: "string",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 28,
+                                        byte_length: 6,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: String {
+                                value: "hello",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 19,
+                                byte_offset: 37,
                                 byte_length: 7,
                             },
                         },
-                        annotation: Some(
-                            Constructor {
-                                name: "string",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 28,
-                                    byte_length: 6,
-                                },
-                            },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "hello",
-                            raw: false,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 7,
+                            byte_offset: 15,
+                            byte_length: 29,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 36,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 36,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/loop_infinite.snap
+++ b/tests/spec/parse/snapshots/loop_infinite.snap
@@ -25,82 +25,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Loop {
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+        body: Definition(
+            Block {
+                items: [
+                    Loop {
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "forever",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 5,
+                                        byte_length: 16,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "forever",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 32,
-                                            byte_length: 9,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 16,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 27,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 27,
+                            byte_offset: 15,
+                            byte_length: 32,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 32,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 38,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 38,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/loop_with_break.snap
+++ b/tests/spec/parse/snapshots/loop_with_break.snap
@@ -27,60 +27,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Loop {
-                    body: Block {
-                        items: [
-                            If {
-                                condition: Call {
-                                    expression: Identifier {
-                                        value: "should_stop",
+        body: Definition(
+            Block {
+                items: [
+                    Loop {
+                        body: Block {
+                            items: [
+                                If {
+                                    condition: Call {
+                                        expression: Identifier {
+                                            value: "should_stop",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 29,
+                                                byte_length: 11,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 29,
-                                            byte_length: 11,
+                                            byte_length: 13,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 13,
-                                    },
-                                    call_kind: None,
-                                },
-                                consequence: Block {
-                                    items: [
-                                        Break {
-                                            value: None,
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 51,
-                                                byte_length: 5,
+                                    consequence: Block {
+                                        items: [
+                                            Break {
+                                                value: None,
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 51,
+                                                    byte_length: 5,
+                                                },
                                             },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
                                         },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 43,
+                                            byte_length: 20,
+                                        },
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 43,
-                                        byte_length: 20,
+                                    alternative: Unit {
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 37,
+                                        },
                                     },
-                                },
-                                alternative: Unit {
                                     ty: Var {
                                         id: uninferred,
                                     },
@@ -90,44 +99,36 @@ description: |
                                         byte_length: 37,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 37,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 47,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 47,
+                            byte_offset: 15,
+                            byte_length: 52,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 52,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 58,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 58,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/loop_with_break_value.snap
+++ b/tests/spec/parse/snapshots/loop_with_break_value.snap
@@ -27,91 +27,99 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Loop {
-                        body: Block {
-                            items: [
-                                If {
-                                    condition: Call {
-                                        expression: Identifier {
-                                            value: "done",
+                        value: Loop {
+                            body: Block {
+                                items: [
+                                    If {
+                                        condition: Call {
+                                            expression: Identifier {
+                                                value: "done",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 37,
+                                                    byte_length: 4,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            args: [],
+                                            spread: None,
+                                            type_arguments: None,
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 37,
-                                                byte_length: 4,
+                                                byte_length: 6,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            call_kind: None,
                                         },
-                                        args: [],
-                                        spread: None,
-                                        type_arguments: None,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 37,
-                                            byte_length: 6,
-                                        },
-                                        call_kind: None,
-                                    },
-                                    consequence: Block {
-                                        items: [
-                                            Break {
-                                                value: Some(
-                                                    Literal {
-                                                        literal: Integer {
-                                                            value: 42,
-                                                            text: None,
+                                        consequence: Block {
+                                            items: [
+                                                Break {
+                                                    value: Some(
+                                                        Literal {
+                                                            literal: Integer {
+                                                                value: 42,
+                                                                text: None,
+                                                            },
+                                                            ty: Var {
+                                                                id: uninferred,
+                                                            },
+                                                            span: Span {
+                                                                file_id: 0,
+                                                                byte_offset: 58,
+                                                                byte_length: 2,
+                                                            },
                                                         },
-                                                        ty: Var {
-                                                            id: uninferred,
-                                                        },
-                                                        span: Span {
-                                                            file_id: 0,
-                                                            byte_offset: 58,
-                                                            byte_length: 2,
-                                                        },
+                                                    ),
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 52,
+                                                        byte_length: 8,
                                                     },
-                                                ),
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 52,
-                                                    byte_length: 8,
                                                 },
+                                            ],
+                                            ty: Var {
+                                                id: uninferred,
                                             },
-                                        ],
-                                        ty: Var {
-                                            id: uninferred,
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 44,
+                                                byte_length: 23,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 44,
-                                            byte_length: 23,
+                                        alternative: Unit {
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 34,
+                                                byte_length: 33,
+                                            },
                                         },
-                                    },
-                                    alternative: Unit {
                                         ty: Var {
                                             id: uninferred,
                                         },
@@ -121,57 +129,46 @@ description: |
                                             byte_length: 33,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 33,
-                                    },
+                                ],
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 43,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 43,
+                                byte_offset: 23,
+                                byte_length: 48,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 48,
+                            byte_offset: 15,
+                            byte_length: 56,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 56,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 63,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 63,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/loop_with_continue.snap
+++ b/tests/spec/parse/snapshots/loop_with_continue.snap
@@ -28,59 +28,68 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Loop {
-                    body: Block {
-                        items: [
-                            If {
-                                condition: Call {
-                                    expression: Identifier {
-                                        value: "skip_this",
+        body: Definition(
+            Block {
+                items: [
+                    Loop {
+                        body: Block {
+                            items: [
+                                If {
+                                    condition: Call {
+                                        expression: Identifier {
+                                            value: "skip_this",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 29,
+                                                byte_length: 9,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 29,
-                                            byte_length: 9,
+                                            byte_length: 11,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 29,
-                                        byte_length: 11,
-                                    },
-                                    call_kind: None,
-                                },
-                                consequence: Block {
-                                    items: [
-                                        Continue {
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 49,
-                                                byte_length: 8,
+                                    consequence: Block {
+                                        items: [
+                                            Continue {
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 49,
+                                                    byte_length: 8,
+                                                },
                                             },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
                                         },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 41,
+                                            byte_length: 23,
+                                        },
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 41,
-                                        byte_length: 23,
+                                    alternative: Unit {
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 38,
+                                        },
                                     },
-                                },
-                                alternative: Unit {
                                     ty: Var {
                                         id: uninferred,
                                     },
@@ -90,71 +99,62 @@ description: |
                                         byte_length: 38,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 38,
-                                },
-                            },
-                            Call {
-                                expression: Identifier {
-                                    value: "process",
+                                Call {
+                                    expression: Identifier {
+                                        value: "process",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 69,
+                                            byte_length: 7,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 69,
-                                        byte_length: 7,
+                                        byte_length: 9,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 69,
-                                    byte_length: 9,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 63,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 63,
+                            byte_offset: 15,
+                            byte_length: 68,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 68,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 74,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 74,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_bool.snap
+++ b/tests/spec/parse/snapshots/match_bool.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -52,127 +51,126 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "active",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 6,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 4,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "active",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "start_service",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 33,
+                                byte_length: 6,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 46,
+                                        byte_length: 4,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "start_service",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 55,
+                                            byte_length: 13,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 55,
-                                        byte_length: 13,
+                                        byte_length: 15,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 55,
-                                    byte_length: 15,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 5,
+                                    call_kind: None,
                                 },
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "stop_service",
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 5,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "stop_service",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 85,
+                                            byte_length: 12,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 85,
-                                        byte_length: 12,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 85,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 27,
+                            byte_length: 77,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 27,
-                        byte_length: 77,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 23,
+                    byte_length: 83,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 23,
-                byte_length: 83,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_literal.snap
+++ b/tests/spec/parse/snapshots/match_literal.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -53,210 +52,208 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "code",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 30,
-                            byte_length: 4,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 200,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 3,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "code",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 30,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 200,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 3,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 48,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "OK",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 54,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 48,
-                                        byte_length: 5,
+                                        byte_length: 11,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "OK",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 404,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 65,
+                                        byte_length: 3,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 54,
-                                            byte_length: 4,
+                                            byte_offset: 72,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 11,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 404,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 65,
-                                    byte_length: 3,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Not Found",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 78,
+                                                byte_length: 11,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 72,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Not Found",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 96,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 78,
-                                            byte_length: 11,
+                                            byte_offset: 103,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 72,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 96,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Other",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 109,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 103,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Other",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 109,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 103,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 24,
+                            byte_length: 98,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 24,
-                        byte_length: 98,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 20,
+                    byte_length: 104,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 20,
-                byte_length: 104,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_mixed_patterns.snap
+++ b/tests/spec/parse/snapshots/match_mixed_patterns.snap
@@ -193,7 +193,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -204,555 +203,554 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "data",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "data",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 95,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 95,
-                            byte_length: 4,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Int",
-                                fields: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
+                        arms: [
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Int",
+                                    fields: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 115,
+                                                byte_length: 1,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 106,
+                                        byte_length: 11,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 115,
-                                            byte_length: 1,
+                                            byte_offset: 126,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 106,
-                                    byte_length: 11,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Zero",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 132,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 126,
-                                        byte_length: 5,
+                                        byte_length: 13,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Zero",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Int",
+                                    fields: [
+                                        Identifier {
+                                            identifier: "n",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 154,
+                                                byte_length: 1,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 145,
+                                        byte_length: 11,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 132,
-                                            byte_length: 6,
+                                            byte_offset: 165,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 126,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Int",
-                                fields: [
-                                    Identifier {
-                                        identifier: "n",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 154,
-                                            byte_length: 1,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Number",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 171,
+                                                byte_length: 8,
+                                            },
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 145,
-                                    byte_length: 11,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                        Identifier {
+                                            value: "n",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 181,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 165,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Number",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Pair",
+                                    fields: [
+                                        Tuple {
+                                            elements: [
+                                                Literal {
+                                                    literal: Integer {
+                                                        value: 0,
+                                                        text: None,
+                                                    },
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 200,
+                                                        byte_length: 1,
+                                                    },
+                                                },
+                                                Identifier {
+                                                    identifier: "y",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 203,
+                                                        byte_length: 1,
+                                                    },
+                                                },
+                                            ],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 199,
+                                                byte_length: 6,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 189,
+                                        byte_length: 17,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 171,
-                                            byte_length: 8,
+                                            byte_offset: 209,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "n",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 181,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 165,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Pair",
-                                fields: [
-                                    Tuple {
-                                        elements: [
-                                            Literal {
-                                                literal: Integer {
-                                                    value: 0,
-                                                    text: None,
-                                                },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 200,
-                                                    byte_length: 1,
-                                                },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Pair on Y axis",
+                                                raw: false,
                                             },
-                                            Identifier {
-                                                identifier: "y",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 203,
-                                                    byte_length: 1,
-                                                },
+                                            ty: Var {
+                                                id: uninferred,
                                             },
-                                        ],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 199,
-                                            byte_length: 6,
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 215,
+                                                byte_length: 16,
+                                            },
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 189,
-                                    byte_length: 17,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                        Identifier {
+                                            value: "y",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 233,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 209,
-                                        byte_length: 5,
+                                        byte_length: 26,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Pair on Y axis",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Pair",
+                                    fields: [
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 251,
+                                                byte_length: 1,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 241,
+                                        byte_length: 12,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 215,
-                                            byte_length: 16,
+                                            byte_offset: 261,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "y",
-                                        ty: Var {
-                                            id: uninferred,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Some pair",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 267,
+                                                byte_length: 11,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 233,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 209,
-                                    byte_length: 26,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Pair",
-                                fields: [
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 251,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 241,
-                                    byte_length: 12,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 261,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Some pair",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 267,
-                                            byte_length: 11,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 261,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
                             },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Text",
-                                fields: [
-                                    Literal {
-                                        literal: String {
-                                            value: "end",
-                                            raw: false,
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Text",
+                                    fields: [
+                                        Literal {
+                                            literal: String {
+                                                value: "end",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 295,
+                                                byte_length: 5,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 285,
+                                        byte_length: 16,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 295,
+                                            byte_offset: 305,
                                             byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 285,
-                                    byte_length: 16,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "End marker",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 311,
+                                                byte_length: 12,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 305,
-                                        byte_length: 5,
+                                        byte_length: 19,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "End marker",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Text",
+                                    fields: [
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 340,
+                                                byte_length: 1,
+                                            },
                                         },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 330,
+                                        byte_length: 12,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 311,
-                                            byte_length: 12,
+                                            byte_offset: 350,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 305,
-                                    byte_length: 19,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Text",
-                                fields: [
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 340,
-                                            byte_length: 1,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Some text",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 356,
+                                                byte_length: 11,
+                                            },
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 330,
-                                    byte_length: 12,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 350,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Some text",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Data.Nothing",
+                                    fields: [],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 374,
+                                        byte_length: 12,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 356,
-                                            byte_length: 11,
+                                            byte_offset: 394,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 350,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Data.Nothing",
-                                fields: [],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 374,
-                                    byte_length: 12,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Nothing",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 400,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 394,
-                                        byte_length: 5,
+                                        byte_length: 16,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Nothing",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 400,
-                                            byte_length: 9,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 394,
-                                    byte_length: 16,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 89,
+                            byte_length: 326,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 89,
-                        byte_length: 326,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 85,
+                    byte_length: 332,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 85,
-                byte_length: 332,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_nested_adt.snap
+++ b/tests/spec/parse/snapshots/match_nested_adt.snap
@@ -71,7 +71,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -82,286 +81,287 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "opt_res",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "opt_res",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 57,
+                                byte_length: 7,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 57,
-                            byte_length: 7,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Some",
-                                fields: [
-                                    EnumVariant {
-                                        identifier: "Ok",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "value",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 79,
-                                                    byte_length: 5,
+                        arms: [
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Some",
+                                    fields: [
+                                        EnumVariant {
+                                            identifier: "Ok",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "value",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 79,
+                                                        byte_length: 5,
+                                                    },
                                                 },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
                                             },
-                                        ],
-                                        rest: false,
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 76,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 71,
+                                        byte_length: 15,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 9,
+                                            byte_offset: 90,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 71,
-                                    byte_length: 15,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Success:",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 96,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "value",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 108,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 90,
-                                        byte_length: 5,
+                                        byte_length: 24,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Success:",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Some",
+                                    fields: [
+                                        EnumVariant {
+                                            identifier: "Err",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "msg",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 129,
+                                                        byte_length: 3,
+                                                    },
+                                                },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 125,
+                                                byte_length: 8,
+                                            },
                                         },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 96,
-                                            byte_length: 10,
-                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                    Identifier {
-                                        value: "value",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 120,
+                                        byte_length: 14,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 108,
+                                            byte_offset: 139,
                                             byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 90,
-                                    byte_length: 24,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Some",
-                                fields: [
-                                    EnumVariant {
-                                        identifier: "Err",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "msg",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 129,
-                                                    byte_length: 3,
-                                                },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Inner Error:",
+                                                raw: false,
                                             },
-                                        ],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 145,
+                                                byte_length: 14,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 125,
-                                            byte_length: 8,
+                                        Identifier {
+                                            value: "msg",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 161,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 120,
-                                    byte_length: 14,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 139,
-                                        byte_length: 5,
+                                        byte_length: 26,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Inner Error:",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "None",
+                                    fields: [],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 171,
+                                        byte_length: 4,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 145,
-                                            byte_length: 14,
+                                            byte_offset: 190,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "msg",
-                                        ty: Var {
-                                            id: uninferred,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "No value",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 196,
+                                                byte_length: 10,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 161,
-                                            byte_length: 3,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 139,
-                                    byte_length: 26,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "None",
-                                fields: [],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 171,
-                                    byte_length: 4,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 190,
-                                        byte_length: 5,
+                                        byte_length: 17,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "No value",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 196,
-                                            byte_length: 10,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 190,
-                                    byte_length: 17,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 51,
+                            byte_length: 161,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 51,
-                        byte_length: 161,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 167,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 167,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_nested_adt_with_wildcards.snap
+++ b/tests/spec/parse/snapshots/match_nested_adt_with_wildcards.snap
@@ -169,7 +169,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -180,357 +179,358 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "state",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "state",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 98,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 98,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "State.Running",
-                                fields: [
-                                    WildCard {
+                        arms: [
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "State.Running",
+                                    fields: [
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 124,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 110,
+                                        byte_length: 16,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 124,
-                                            byte_length: 1,
+                                            byte_offset: 135,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 110,
-                                    byte_length: 16,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Running",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 141,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 135,
-                                        byte_length: 5,
+                                        byte_length: 16,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Running",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "State.Stopped",
+                                    fields: [],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 157,
+                                        byte_length: 13,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 141,
-                                            byte_length: 9,
+                                            byte_offset: 182,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 135,
-                                    byte_length: 16,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "State.Stopped",
-                                fields: [],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 157,
-                                    byte_length: 13,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Stopped",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 188,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 182,
-                                        byte_length: 5,
+                                        byte_length: 16,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Stopped",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "State.Error",
+                                    fields: [
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 216,
+                                                byte_length: 1,
+                                            },
                                         },
+                                        EnumVariant {
+                                            identifier: "None",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 219,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 204,
+                                        byte_length: 20,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 188,
-                                            byte_length: 9,
+                                            byte_offset: 229,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 182,
-                                    byte_length: 16,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "State.Error",
-                                fields: [
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 216,
-                                            byte_length: 1,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Error without code",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 235,
+                                                byte_length: 20,
+                                            },
                                         },
-                                    },
-                                    EnumVariant {
-                                        identifier: "None",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 219,
-                                            byte_length: 4,
-                                        },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 204,
-                                    byte_length: 20,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 229,
-                                        byte_length: 5,
+                                        byte_length: 27,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Error without code",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 235,
-                                            byte_length: 20,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 229,
-                                    byte_length: 27,
-                                },
-                                call_kind: None,
                             },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "State.Error",
-                                fields: [
-                                    Identifier {
-                                        identifier: "msg",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 274,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                    EnumVariant {
-                                        identifier: "Some",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "code",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 284,
-                                                    byte_length: 4,
-                                                },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "State.Error",
+                                    fields: [
+                                        Identifier {
+                                            identifier: "msg",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 274,
+                                                byte_length: 3,
                                             },
-                                        ],
-                                        rest: false,
+                                        },
+                                        EnumVariant {
+                                            identifier: "Some",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "code",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 284,
+                                                        byte_length: 4,
+                                                    },
+                                                },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 279,
+                                                byte_length: 10,
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 262,
+                                        byte_length: 28,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 279,
-                                            byte_length: 10,
+                                            byte_offset: 294,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 262,
-                                    byte_length: 28,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Error with code",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 300,
+                                                byte_length: 17,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "msg",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 319,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        Identifier {
+                                            value: "code",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 324,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 294,
-                                        byte_length: 5,
+                                        byte_length: 35,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Error with code",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 300,
-                                            byte_length: 17,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "msg",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 319,
-                                            byte_length: 3,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    Identifier {
-                                        value: "code",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 324,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 294,
-                                    byte_length: 35,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 92,
+                            byte_length: 242,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 92,
-                        byte_length: 242,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 88,
+                    byte_length: 248,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 88,
-                byte_length: 248,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_string.snap
+++ b/tests/spec/parse/snapshots/match_string.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -53,210 +52,208 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "command",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 7,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: String {
-                                    value: "start",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 7,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "command",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "exec",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 7,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: String {
+                                        value: "start",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 7,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "exec",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 61,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "start",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 66,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 61,
-                                        byte_length: 4,
+                                        byte_length: 13,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "start",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: String {
+                                        value: "stop",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 80,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "exec",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 66,
-                                            byte_length: 7,
+                                            byte_offset: 91,
+                                            byte_length: 4,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 61,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: String {
-                                    value: "stop",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 80,
-                                    byte_length: 6,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "exec",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "stop",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 96,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 91,
-                                        byte_length: 4,
+                                        byte_length: 12,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "stop",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 109,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 96,
-                                            byte_length: 6,
+                                            byte_offset: 120,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 91,
-                                    byte_length: 12,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 109,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Unknown command",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 126,
+                                                byte_length: 17,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 120,
-                                        byte_length: 5,
+                                        byte_length: 24,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Unknown command",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 126,
-                                            byte_length: 17,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 120,
-                                    byte_length: 24,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 119,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 119,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 125,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 125,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_struct.snap
+++ b/tests/spec/parse/snapshots/match_struct.snap
@@ -43,7 +43,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -54,439 +53,436 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "p",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 29,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "x",
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 48,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    },
-                                    StructFieldPattern {
-                                        name: "y",
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 54,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 20,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "p",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 29,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "x",
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 48,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                        StructFieldPattern {
+                                            name: "y",
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 54,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 20,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 61,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Origin",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 67,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 61,
-                                        byte_length: 5,
+                                        byte_length: 15,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Origin",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "x",
+                                            value: Identifier {
+                                                identifier: "x",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 90,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                         },
+                                        StructFieldPattern {
+                                            name: "y",
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 96,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 82,
+                                        byte_length: 17,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 67,
-                                            byte_length: 8,
+                                            byte_offset: 106,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 61,
-                                    byte_length: 15,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "x",
-                                        value: Identifier {
-                                            identifier: "x",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 90,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    },
-                                    StructFieldPattern {
-                                        name: "y",
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "On X axis",
+                                                raw: false,
                                             },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 96,
-                                                byte_length: 1,
+                                                byte_offset: 112,
+                                                byte_length: 11,
                                             },
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 82,
-                                    byte_length: 17,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 125,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 106,
-                                        byte_length: 5,
+                                        byte_length: 21,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "On X axis",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 112,
-                                            byte_length: 11,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 125,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 106,
-                                    byte_length: 21,
-                                },
-                                call_kind: None,
                             },
-                        },
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "x",
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 0,
-                                                text: None,
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "x",
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 0,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 144,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                        StructFieldPattern {
+                                            name: "y",
+                                            value: Identifier {
+                                                identifier: "y",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 147,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 133,
+                                        byte_length: 17,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 157,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "On Y axis",
+                                                raw: false,
                                             },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 144,
-                                                byte_length: 1,
+                                                byte_offset: 163,
+                                                byte_length: 11,
                                             },
                                         },
-                                    },
-                                    StructFieldPattern {
-                                        name: "y",
-                                        value: Identifier {
-                                            identifier: "y",
+                                        Identifier {
+                                            value: "y",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 147,
+                                                byte_offset: 176,
                                                 byte_length: 1,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 133,
-                                    byte_length: 17,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 157,
-                                        byte_length: 5,
+                                        byte_length: 21,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "On Y axis",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "x",
+                                            value: Identifier {
+                                                identifier: "x",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 192,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                         },
+                                        StructFieldPattern {
+                                            name: "y",
+                                            value: Identifier {
+                                                identifier: "y",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 195,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 184,
+                                        byte_length: 14,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 163,
-                                            byte_length: 11,
+                                            byte_offset: 208,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "y",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 176,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 157,
-                                    byte_length: 21,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "x",
-                                        value: Identifier {
-                                            identifier: "x",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Somewhere else",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 192,
-                                                byte_length: 1,
+                                                byte_offset: 214,
+                                                byte_length: 16,
                                             },
                                         },
-                                    },
-                                    StructFieldPattern {
-                                        name: "y",
-                                        value: Identifier {
-                                            identifier: "y",
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 195,
+                                                byte_offset: 232,
                                                 byte_length: 1,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 184,
-                                    byte_length: 14,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                        Identifier {
+                                            value: "y",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 235,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 208,
-                                        byte_length: 5,
+                                        byte_length: 29,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Somewhere else",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 214,
-                                            byte_length: 16,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 232,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    Identifier {
-                                        value: "y",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 235,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 208,
-                                    byte_length: 29,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 23,
+                            byte_length: 219,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 23,
-                        byte_length: 219,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 19,
+                    byte_length: 225,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 19,
-                byte_length: 225,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_struct_uppercase_shorthand.snap
+++ b/tests/spec/parse/snapshots/match_struct_uppercase_shorthand.snap
@@ -40,7 +40,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -51,83 +50,84 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "p",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "p",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 29,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "X",
+                                            value: Identifier {
+                                                identifier: "X",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 45,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 11,
+                                    },
+                                },
+                                expression: Identifier {
+                                    value: "X",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 52,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 29,
-                            byte_length: 1,
+                            byte_offset: 23,
+                            byte_length: 35,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "X",
-                                        value: Identifier {
-                                            identifier: "X",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 45,
-                                                byte_length: 1,
-                                            },
-                                        },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 11,
-                                },
-                            },
-                            expression: Identifier {
-                                value: "X",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 52,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 23,
-                        byte_length: 35,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 19,
+                    byte_length: 41,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 19,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_tuple_pattern.snap
+++ b/tests/spec/parse/snapshots/match_tuple_pattern.snap
@@ -61,7 +61,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -72,395 +71,388 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "pair",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 4,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 49,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 52,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 6,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "pair",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 49,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 52,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 58,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Origin",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 58,
-                                        byte_length: 5,
+                                        byte_length: 15,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Origin",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        Identifier {
+                                            identifier: "x",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 80,
+                                                byte_length: 1,
+                                            },
                                         },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 83,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 79,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 8,
+                                            byte_offset: 89,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 15,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    Identifier {
-                                        identifier: "x",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 80,
-                                            byte_length: 1,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "On X axis",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 95,
+                                                byte_length: 11,
+                                            },
                                         },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 108,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 83,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 79,
-                                    byte_length: 6,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 89,
-                                        byte_length: 5,
+                                        byte_length: 21,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "On X axis",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 95,
-                                            byte_length: 11,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 108,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 89,
-                                    byte_length: 21,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 117,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Identifier {
-                                        identifier: "y",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 120,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 116,
-                                    byte_length: 6,
+                                    call_kind: None,
                                 },
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 117,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Identifier {
+                                            identifier: "y",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 120,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 116,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 126,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "On Y axis",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 132,
+                                                byte_length: 11,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "y",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 145,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 126,
-                                        byte_length: 5,
+                                        byte_length: 21,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "On Y axis",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        Identifier {
+                                            identifier: "x",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 154,
+                                                byte_length: 1,
+                                            },
                                         },
+                                        Identifier {
+                                            identifier: "y",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 157,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 153,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 132,
-                                            byte_length: 11,
+                                            byte_offset: 163,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "y",
-                                        ty: Var {
-                                            id: uninferred,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Coords",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 169,
+                                                byte_length: 8,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 145,
-                                            byte_length: 1,
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 179,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 126,
-                                    byte_length: 21,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    Identifier {
-                                        identifier: "x",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 154,
-                                            byte_length: 1,
+                                        Identifier {
+                                            value: "y",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 182,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                    Identifier {
-                                        identifier: "y",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 157,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 153,
-                                    byte_length: 6,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 163,
-                                        byte_length: 5,
+                                        byte_length: 21,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Coords",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 169,
-                                            byte_length: 8,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 179,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    Identifier {
-                                        value: "y",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 182,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 163,
-                                    byte_length: 21,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 31,
+                            byte_length: 158,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 158,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 164,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 164,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_tuple_pattern_with_wildcard.snap
+++ b/tests/spec/parse/snapshots/match_tuple_pattern_with_wildcard.snap
@@ -69,7 +69,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -80,269 +79,266 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "triple",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "triple",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 48,
+                                byte_length: 6,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 6,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    Literal {
-                                        literal: String {
-                                            value: "status",
-                                            raw: false,
+                        arms: [
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        Literal {
+                                            literal: String {
+                                                value: "status",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 62,
+                                                byte_length: 8,
+                                            },
                                         },
+                                        Identifier {
+                                            identifier: "code",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 72,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 78,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 61,
+                                        byte_length: 19,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 62,
-                                            byte_length: 8,
+                                            byte_offset: 84,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        identifier: "code",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 72,
-                                            byte_length: 4,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Status code:",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 90,
+                                                byte_length: 14,
+                                            },
                                         },
-                                    },
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 78,
-                                            byte_length: 1,
+                                        Identifier {
+                                            value: "code",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 106,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 61,
-                                    byte_length: 19,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 84,
-                                        byte_length: 5,
+                                        byte_length: 27,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Status code:",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 90,
-                                            byte_length: 14,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "code",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 106,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 84,
-                                    byte_length: 27,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Tuple {
-                                elements: [
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 118,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    WildCard {
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 121,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Boolean(
-                                            true,
-                                        ),
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 124,
-                                            byte_length: 4,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 117,
-                                    byte_length: 12,
+                                    call_kind: None,
                                 },
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            MatchArm {
+                                pattern: Tuple {
+                                    elements: [
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 118,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        WildCard {
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 121,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Boolean(
+                                                true,
+                                            ),
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 124,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 117,
+                                        byte_length: 12,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 140,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Active",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 146,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 140,
-                                        byte_length: 5,
+                                        byte_length: 15,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Active",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 161,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 146,
-                                            byte_length: 8,
+                                            byte_offset: 184,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 140,
-                                    byte_length: 15,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 161,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "Other",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 190,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 184,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "Other",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 190,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 184,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 42,
+                            byte_length: 161,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 42,
-                        byte_length: 161,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 38,
+                    byte_length: 167,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 38,
-                byte_length: 167,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/match_unit_pattern.snap
+++ b/tests/spec/parse/snapshots/match_unit_pattern.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -52,97 +51,97 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "val",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Unit {
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 2,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "val",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Unit {
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 38,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 44,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "It's unit!",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 50,
+                                                byte_length: 12,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 44,
-                                        byte_length: 5,
+                                        byte_length: 19,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "It's unit!",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 50,
-                                            byte_length: 12,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 44,
-                                    byte_length: 19,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 22,
+                            byte_length: 110,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 22,
-                        byte_length: 110,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 18,
+                    byte_length: 116,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 18,
-                byte_length: 116,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/method_call_with_type_args.snap
+++ b/tests/spec/parse/snapshots/method_call_with_type_args.snap
@@ -21,84 +21,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: DotAccess {
-                        expression: Identifier {
-                            value: "obj",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: DotAccess {
+                            expression: Identifier {
+                                value: "obj",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 13,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "method",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 13,
-                                byte_length: 3,
+                                byte_length: 10,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "method",
+                        args: [
+                            Identifier {
+                                value: "arg",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: Unresolved(
+                            [
+                                Constructor {
+                                    name: "int",
+                                    params: [],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 24,
+                                        byte_length: 3,
+                                    },
+                                },
+                            ],
+                        ),
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 10,
+                            byte_length: 20,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Identifier {
-                            value: "arg",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: Unresolved(
-                        [
-                            Constructor {
-                                name: "int",
-                                params: [],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 24,
-                                    byte_length: 3,
-                                },
-                            },
-                        ],
-                    ),
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 20,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/negative_literal_on_new_line_is_unary.snap
+++ b/tests/spec/parse/snapshots/negative_literal_on_new_line_is_unary.snap
@@ -35,124 +35,120 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "foo",
+                        value: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "foo",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 36,
+                                            byte_length: 3,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 36,
-                                        byte_length: 3,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 36,
-                                    byte_length: 5,
-                                },
-                                call_kind: None,
-                            },
-                            Unary {
-                                operator: Negative,
-                                expression: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
+                                Unary {
+                                    operator: Negative,
+                                    expression: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 47,
+                                            byte_length: 1,
+                                        },
                                     },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 47,
-                                        byte_length: 1,
+                                        byte_offset: 46,
+                                        byte_length: 2,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 2,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 30,
+                                byte_length: 22,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 30,
-                            byte_length: 22,
+                            byte_offset: 22,
+                            byte_length: 30,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Identifier {
+                        value: "x",
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 56,
+                            byte_length: 1,
+                        },
+                        resolution: Unresolved,
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 22,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-                Identifier {
-                    value: "x",
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 56,
-                        byte_length: 1,
-                    },
-                    binding_id: None,
-                    qualified: None,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 18,
+                    byte_length: 41,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 18,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/negative_pattern_i64_min.snap
+++ b/tests/spec/parse/snapshots/negative_pattern_i64_min.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -60,98 +59,99 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 41,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 9223372036854775808,
+                                        text: Some(
+                                            "-9223372036854775808",
+                                        ),
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 49,
+                                        byte_length: 20,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "min",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 73,
+                                        byte_length: 5,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 84,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "other",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 89,
+                                        byte_length: 7,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 1,
+                            byte_offset: 35,
+                            byte_length: 66,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 9223372036854775808,
-                                    text: Some(
-                                        "-9223372036854775808",
-                                    ),
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 49,
-                                    byte_length: 20,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "min",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 73,
-                                    byte_length: 5,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 84,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "other",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 89,
-                                    byte_length: 7,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 35,
-                        byte_length: 66,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 31,
+                    byte_length: 72,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 31,
-                byte_length: 72,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/negative_pattern_integer.snap
+++ b/tests/spec/parse/snapshots/negative_pattern_integer.snap
@@ -43,7 +43,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -62,160 +61,161 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 18446744073709551611,
+                                        text: Some(
+                                            "-5",
+                                        ),
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "negative five",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 51,
+                                        byte_length: 15,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 18446744073709551615,
+                                        text: Some(
+                                            "-1",
+                                        ),
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 72,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "negative one",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 78,
+                                        byte_length: 14,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 98,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "zero",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 103,
+                                        byte_length: 6,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 115,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "other",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 120,
+                                        byte_length: 7,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 1,
+                            byte_offset: 31,
+                            byte_length: 101,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 18446744073709551611,
-                                    text: Some(
-                                        "-5",
-                                    ),
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 45,
-                                    byte_length: 2,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "negative five",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 51,
-                                    byte_length: 15,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 18446744073709551615,
-                                    text: Some(
-                                        "-1",
-                                    ),
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 72,
-                                    byte_length: 2,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "negative one",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 78,
-                                    byte_length: 14,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 98,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "zero",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 103,
-                                    byte_length: 6,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 115,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "other",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 120,
-                                    byte_length: 7,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 101,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 107,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 107,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/nested_indexing.snap
+++ b/tests/spec/parse/snapshots/nested_indexing.snap
@@ -21,73 +21,115 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: IndexedAccess {
-                            expression: Identifier {
-                                value: "arr",
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 3,
+                                    byte_offset: 17,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
-                            index: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "i",
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: IndexedAccess {
+                            expression: IndexedAccess {
+                                expression: Identifier {
+                                    value: "arr",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                index: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "i",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 30,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "j",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 34,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 30,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "j",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
+                                    byte_offset: 29,
+                                    byte_length: 7,
+                                },
+                                from_colon_syntax: false,
+                            },
+                            index: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "k",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "l",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 37,
                                     byte_length: 5,
                                 },
                             },
@@ -96,81 +138,32 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 29,
+                                byte_offset: 36,
                                 byte_length: 7,
                             },
                             from_colon_syntax: false,
                         },
-                        index: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "k",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "l",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 37,
-                                byte_length: 5,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 7,
+                            byte_offset: 13,
+                            byte_length: 30,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 35,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 35,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/nested_struct_init.snap
+++ b/tests/spec/parse/snapshots/nested_struct_init.snap
@@ -21,149 +21,147 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Outer",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "inner",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 34,
-                                    byte_length: 5,
-                                },
-                                value: StructCall {
-                                    name: "Inner",
-                                    field_assignments: [
-                                        StructFieldAssignment {
-                                            name: "x",
-                                            name_span: Span {
-                                                file_id: 0,
-                                                byte_offset: 49,
-                                                byte_length: 1,
-                                            },
-                                            value: Literal {
-                                                literal: Integer {
-                                                    value: 1,
-                                                    text: None,
-                                                },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 52,
-                                                    byte_length: 1,
-                                                },
-                                            },
-                                        },
-                                        StructFieldAssignment {
-                                            name: "y",
-                                            name_span: Span {
-                                                file_id: 0,
-                                                byte_offset: 55,
-                                                byte_length: 1,
-                                            },
-                                            value: Literal {
-                                                literal: Integer {
-                                                    value: 2,
-                                                    text: None,
-                                                },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 58,
-                                                    byte_length: 1,
-                                                },
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 41,
-                                        byte_length: 20,
-                                    },
+                                    byte_offset: 17,
+                                    byte_length: 6,
                                 },
                             },
-                            StructFieldAssignment {
-                                name: "z",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 63,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 3,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Outer",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "inner",
+                                    name_span: Span {
                                         file_id: 0,
-                                        byte_offset: 66,
+                                        byte_offset: 34,
+                                        byte_length: 5,
+                                    },
+                                    value: StructCall {
+                                        name: "Inner",
+                                        field_assignments: [
+                                            StructFieldAssignment {
+                                                name: "x",
+                                                name_span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 49,
+                                                    byte_length: 1,
+                                                },
+                                                value: Literal {
+                                                    literal: Integer {
+                                                        value: 1,
+                                                        text: None,
+                                                    },
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 52,
+                                                        byte_length: 1,
+                                                    },
+                                                },
+                                            },
+                                            StructFieldAssignment {
+                                                name: "y",
+                                                name_span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 55,
+                                                    byte_length: 1,
+                                                },
+                                                value: Literal {
+                                                    literal: Integer {
+                                                        value: 2,
+                                                        text: None,
+                                                    },
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 58,
+                                                        byte_length: 1,
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 41,
+                                            byte_length: 20,
+                                        },
+                                    },
+                                },
+                                StructFieldAssignment {
+                                    name: "z",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 63,
                                         byte_length: 1,
                                     },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 3,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 66,
+                                            byte_length: 1,
+                                        },
+                                    },
                                 },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 43,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 43,
+                            byte_offset: 13,
+                            byte_length: 56,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 56,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 61,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 61,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/nested_tuple_field_access.snap
+++ b/tests/spec/parse/snapshots/nested_tuple_field_access.snap
@@ -74,7 +74,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -85,38 +84,48 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 44,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 44,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: DotAccess {
-                            expression: Identifier {
-                                value: "nested",
+                        value: DotAccess {
+                            expression: DotAccess {
+                                expression: Identifier {
+                                    value: "nested",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 6,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                member: "0",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 48,
-                                    byte_length: 6,
+                                    byte_length: 8,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             member: "0",
                             ty: Var {
@@ -125,46 +134,31 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 48,
-                                byte_length: 8,
+                                byte_length: 10,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            resolution: Unresolved,
                         },
-                        member: "0",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 10,
+                            byte_offset: 40,
+                            byte_length: 18,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 40,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 36,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 36,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_booleans.snap
+++ b/tests/spec/parse/snapshots/or_pattern_booleans.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -66,7 +65,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -85,36 +83,236 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Tuple {
-                        elements: [
-                            Identifier {
-                                value: "a",
-                                ty: Var {
-                                    id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Tuple {
+                            elements: [
+                                Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 1,
+                                Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 51,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                            Identifier {
-                                value: "b",
-                                ty: Var {
-                                    id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 47,
+                                byte_length: 6,
+                            },
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Tuple {
+                                            elements: [
+                                                Literal {
+                                                    literal: Boolean(
+                                                        true,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 61,
+                                                        byte_length: 4,
+                                                    },
+                                                },
+                                                Literal {
+                                                    literal: Boolean(
+                                                        true,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 67,
+                                                        byte_length: 4,
+                                                    },
+                                                },
+                                            ],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 60,
+                                                byte_length: 12,
+                                            },
+                                        },
+                                        Tuple {
+                                            elements: [
+                                                Literal {
+                                                    literal: Boolean(
+                                                        false,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 76,
+                                                        byte_length: 5,
+                                                    },
+                                                },
+                                                Literal {
+                                                    literal: Boolean(
+                                                        false,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 83,
+                                                        byte_length: 5,
+                                                    },
+                                                },
+                                            ],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 75,
+                                                byte_length: 14,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 60,
+                                        byte_length: 29,
+                                    },
                                 },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 51,
-                                    byte_length: 1,
+                                expression: Literal {
+                                    literal: String {
+                                        value: "same",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 93,
+                                        byte_length: 6,
+                                    },
                                 },
-                                binding_id: None,
-                                qualified: None,
+                            },
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Tuple {
+                                            elements: [
+                                                Literal {
+                                                    literal: Boolean(
+                                                        true,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 106,
+                                                        byte_length: 4,
+                                                    },
+                                                },
+                                                Literal {
+                                                    literal: Boolean(
+                                                        false,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 112,
+                                                        byte_length: 5,
+                                                    },
+                                                },
+                                            ],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 105,
+                                                byte_length: 13,
+                                            },
+                                        },
+                                        Tuple {
+                                            elements: [
+                                                Literal {
+                                                    literal: Boolean(
+                                                        false,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 122,
+                                                        byte_length: 5,
+                                                    },
+                                                },
+                                                Literal {
+                                                    literal: Boolean(
+                                                        true,
+                                                    ),
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 129,
+                                                        byte_length: 4,
+                                                    },
+                                                },
+                                            ],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 121,
+                                                byte_length: 13,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 105,
+                                        byte_length: 29,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "different",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 138,
+                                        byte_length: 11,
+                                    },
+                                },
                             },
                         ],
                         ty: Var {
@@ -122,221 +320,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 47,
-                            byte_length: 6,
+                            byte_offset: 41,
+                            byte_length: 113,
                         },
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Tuple {
-                                        elements: [
-                                            Literal {
-                                                literal: Boolean(
-                                                    true,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 61,
-                                                    byte_length: 4,
-                                                },
-                                            },
-                                            Literal {
-                                                literal: Boolean(
-                                                    true,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 67,
-                                                    byte_length: 4,
-                                                },
-                                            },
-                                        ],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 60,
-                                            byte_length: 12,
-                                        },
-                                    },
-                                    Tuple {
-                                        elements: [
-                                            Literal {
-                                                literal: Boolean(
-                                                    false,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 76,
-                                                    byte_length: 5,
-                                                },
-                                            },
-                                            Literal {
-                                                literal: Boolean(
-                                                    false,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 83,
-                                                    byte_length: 5,
-                                                },
-                                            },
-                                        ],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 75,
-                                            byte_length: 14,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 60,
-                                    byte_length: 29,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "same",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 93,
-                                    byte_length: 6,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Tuple {
-                                        elements: [
-                                            Literal {
-                                                literal: Boolean(
-                                                    true,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 106,
-                                                    byte_length: 4,
-                                                },
-                                            },
-                                            Literal {
-                                                literal: Boolean(
-                                                    false,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 112,
-                                                    byte_length: 5,
-                                                },
-                                            },
-                                        ],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 105,
-                                            byte_length: 13,
-                                        },
-                                    },
-                                    Tuple {
-                                        elements: [
-                                            Literal {
-                                                literal: Boolean(
-                                                    false,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 122,
-                                                    byte_length: 5,
-                                                },
-                                            },
-                                            Literal {
-                                                literal: Boolean(
-                                                    true,
-                                                ),
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 129,
-                                                    byte_length: 4,
-                                                },
-                                            },
-                                        ],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 121,
-                                            byte_length: 13,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 105,
-                                    byte_length: 29,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "different",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 138,
-                                    byte_length: 11,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 41,
-                        byte_length: 113,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 37,
+                    byte_length: 119,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 37,
-                byte_length: 119,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_enum_variants.snap
+++ b/tests/spec/parse/snapshots/or_pattern_enum_variants.snap
@@ -91,7 +91,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -110,123 +109,127 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "c",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "c",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 71,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        EnumVariant {
+                                            identifier: "Red",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 79,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                        EnumVariant {
+                                            identifier: "Green",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 85,
+                                                byte_length: 5,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 79,
+                                        byte_length: 11,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "warm",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 94,
+                                        byte_length: 6,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: EnumVariant {
+                                    identifier: "Blue",
+                                    fields: [],
+                                    rest: false,
+                                    resolution: Unresolved,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 106,
+                                        byte_length: 4,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "cool",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 114,
+                                        byte_length: 6,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 71,
-                            byte_length: 1,
+                            byte_offset: 65,
+                            byte_length: 60,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    EnumVariant {
-                                        identifier: "Red",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 79,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                    EnumVariant {
-                                        identifier: "Green",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 85,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 79,
-                                    byte_length: 11,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "warm",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 94,
-                                    byte_length: 6,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: EnumVariant {
-                                identifier: "Blue",
-                                fields: [],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 106,
-                                    byte_length: 4,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "cool",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 114,
-                                    byte_length: 6,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 65,
-                        byte_length: 60,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 61,
+                    byte_length: 66,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 61,
-                byte_length: 66,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_multiple_arms.snap
+++ b/tests/spec/parse/snapshots/or_pattern_multiple_arms.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,200 +60,201 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 45,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 49,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 5,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "binary",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 54,
+                                        byte_length: 8,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 2,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 68,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 3,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 72,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 5,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 76,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 7,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 80,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 68,
+                                        byte_length: 13,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "small prime",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 85,
+                                        byte_length: 13,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 104,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "other",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 109,
+                                        byte_length: 7,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 1,
+                            byte_offset: 31,
+                            byte_length: 90,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 45,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 49,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 45,
-                                    byte_length: 5,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "binary",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 54,
-                                    byte_length: 8,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 2,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 68,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 3,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 72,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 5,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 7,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 80,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 68,
-                                    byte_length: 13,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "small prime",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 85,
-                                    byte_length: 13,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 104,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "other",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 109,
-                                    byte_length: 7,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 90,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 96,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 96,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_parenthesized.snap
+++ b/tests/spec/parse/snapshots/or_pattern_parenthesized.snap
@@ -80,7 +80,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -99,94 +98,97 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "c",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "c",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 61,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        EnumVariant {
+                                            identifier: "Red",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 70,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                        EnumVariant {
+                                            identifier: "Blue",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 76,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 70,
+                                        byte_length: 10,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 85,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 61,
-                            byte_length: 1,
+                            byte_offset: 55,
+                            byte_length: 36,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    EnumVariant {
-                                        identifier: "Red",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 70,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                    EnumVariant {
-                                        identifier: "Blue",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 4,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 70,
-                                    byte_length: 10,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 85,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 55,
-                        byte_length: 36,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 51,
+                    byte_length: 42,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 51,
-                byte_length: 42,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_simple.snap
+++ b/tests/spec/parse/snapshots/or_pattern_simple.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -60,133 +59,134 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "x",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 45,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 2,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 49,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: Integer {
+                                                value: 3,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 53,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 9,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "small",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 58,
+                                        byte_length: 7,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 71,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: String {
+                                        value: "other",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 7,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 1,
+                            byte_offset: 31,
+                            byte_length: 57,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 45,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 2,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 49,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: Integer {
-                                            value: 3,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 53,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 45,
-                                    byte_length: 9,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "small",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 7,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 71,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: String {
-                                    value: "other",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 7,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 57,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 63,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 63,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_strings.snap
+++ b/tests/spec/parse/snapshots/or_pattern_strings.snap
@@ -42,7 +42,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,167 +60,75 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "s",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "s",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 1,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Literal {
-                                        literal: String {
-                                            value: "yes",
-                                            raw: false,
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Literal {
+                                            literal: String {
+                                                value: "yes",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 45,
+                                                byte_length: 5,
+                                            },
                                         },
-                                        ty: Var {
-                                            id: uninferred,
+                                        Literal {
+                                            literal: String {
+                                                value: "y",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 53,
+                                                byte_length: 3,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 45,
-                                            byte_length: 5,
+                                        Literal {
+                                            literal: String {
+                                                value: "true",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 59,
+                                                byte_length: 6,
+                                            },
                                         },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 20,
                                     },
-                                    Literal {
-                                        literal: String {
-                                            value: "y",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 53,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: String {
-                                            value: "true",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 59,
-                                            byte_length: 6,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 45,
-                                    byte_length: 20,
                                 },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 69,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    Literal {
-                                        literal: String {
-                                            value: "no",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 4,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: String {
-                                            value: "n",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 83,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                    Literal {
-                                        literal: String {
-                                            value: "false",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 89,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 20,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 100,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 107,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Unary {
-                                operator: Negative,
                                 expression: Literal {
                                     literal: Integer {
                                         value: 1,
@@ -232,40 +139,133 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 113,
+                                        byte_offset: 69,
                                         byte_length: 1,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
+                            },
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        Literal {
+                                            literal: String {
+                                                value: "no",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 76,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: String {
+                                                value: "n",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 83,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                        Literal {
+                                            literal: String {
+                                                value: "false",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 89,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 20,
+                                    },
                                 },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 112,
-                                    byte_length: 2,
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 100,
+                                        byte_length: 1,
+                                    },
                                 },
                             },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 107,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Unary {
+                                    operator: Negative,
+                                    expression: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 113,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 112,
+                                        byte_length: 2,
+                                    },
+                                },
+                            },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 31,
+                            byte_length: 88,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 88,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 94,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 94,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/or_pattern_with_bindings.snap
+++ b/tests/spec/parse/snapshots/or_pattern_with_bindings.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -69,103 +68,106 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "opt",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "opt",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 44,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Or {
+                                    patterns: [
+                                        EnumVariant {
+                                            identifier: "Some",
+                                            fields: [
+                                                Identifier {
+                                                    identifier: "x",
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 59,
+                                                        byte_length: 1,
+                                                    },
+                                                },
+                                            ],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 54,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                        EnumVariant {
+                                            identifier: "None",
+                                            fields: [],
+                                            rest: false,
+                                            resolution: Unresolved,
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 4,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 54,
+                                        byte_length: 14,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 72,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 3,
+                            byte_offset: 38,
+                            byte_length: 40,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Or {
-                                patterns: [
-                                    EnumVariant {
-                                        identifier: "Some",
-                                        fields: [
-                                            Identifier {
-                                                identifier: "x",
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 59,
-                                                    byte_length: 1,
-                                                },
-                                            },
-                                        ],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 54,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                    EnumVariant {
-                                        identifier: "None",
-                                        fields: [],
-                                        rest: false,
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 4,
-                                        },
-                                    },
-                                ],
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 54,
-                                    byte_length: 14,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 72,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 38,
-                        byte_length: 40,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 34,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 34,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_around_call.snap
+++ b/tests/spec/parse/snapshots/paren_around_call.snap
@@ -21,99 +21,96 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Paren {
-                        expression: Call {
-                            expression: Identifier {
-                                value: "calculate",
+                        value: Paren {
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "calculate",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 27,
+                                        byte_length: 9,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Literal {
+                                        literal: Integer {
+                                            value: 5,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 27,
-                                    byte_length: 9,
+                                    byte_length: 12,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [
-                                Literal {
-                                    literal: Integer {
-                                        value: 5,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 37,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 12,
+                                byte_offset: 26,
+                                byte_length: 14,
                             },
-                            call_kind: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 14,
+                            byte_offset: 13,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_in_condition.snap
+++ b/tests/spec/parse/snapshots/paren_in_condition.snap
@@ -40,7 +40,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -65,7 +64,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -76,39 +74,48 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                If {
-                    condition: Binary {
-                        operator: And,
-                        left: Paren {
-                            expression: Binary {
-                                operator: GreaterThan,
-                                left: Identifier {
-                                    value: "a",
+        body: Definition(
+            Block {
+                items: [
+                    If {
+                        condition: Binary {
+                            operator: And,
+                            left: Paren {
+                                expression: Binary {
+                                    operator: GreaterThan,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 33,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 0,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 1,
+                                        },
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 33,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 0,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 37,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
                                 },
                                 ty: Var {
@@ -116,8 +123,55 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 33,
-                                    byte_length: 5,
+                                    byte_offset: 32,
+                                    byte_length: 7,
+                                },
+                            },
+                            right: Paren {
+                                expression: Binary {
+                                    operator: LessThan,
+                                    left: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 44,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 10,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 48,
+                                            byte_length: 2,
+                                        },
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 44,
+                                        byte_length: 6,
+                                    },
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 8,
                                 },
                             },
                             ty: Var {
@@ -126,78 +180,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 32,
-                                byte_length: 7,
+                                byte_length: 19,
                             },
                         },
-                        right: Paren {
-                            expression: Binary {
-                                operator: LessThan,
-                                left: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 44,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 10,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 48,
-                                        byte_length: 2,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 44,
-                                    byte_length: 6,
-                                },
-                            },
+                        consequence: Block {
+                            items: [],
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 8,
+                                byte_offset: 52,
+                                byte_length: 16,
                             },
                         },
-                        ty: Var {
-                            id: uninferred,
+                        alternative: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 29,
+                                byte_length: 39,
+                            },
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 32,
-                            byte_length: 19,
-                        },
-                    },
-                    consequence: Block {
-                        items: [],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 16,
-                        },
-                    },
-                    alternative: Unit {
                         ty: Var {
                             id: uninferred,
                         },
@@ -207,25 +213,17 @@ description: |
                             byte_length: 39,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 39,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 45,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 45,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_in_return.snap
+++ b/tests/spec/parse/snapshots/paren_in_return.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -82,45 +80,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Paren {
-                        expression: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "a",
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Paren {
+                            expression: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 44,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 44,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "b",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 44,
-                                byte_length: 5,
+                                byte_offset: 43,
+                                byte_length: 7,
                             },
                         },
                         ty: Var {
@@ -128,29 +134,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 43,
-                            byte_length: 7,
+                            byte_offset: 36,
+                            byte_length: 14,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 36,
-                        byte_length: 14,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 32,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 32,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_multiple_nested.snap
+++ b/tests/spec/parse/snapshots/paren_multiple_nested.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -88,7 +86,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -113,7 +110,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -124,92 +120,97 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 49,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Paren {
-                        expression: Binary {
-                            operator: Addition,
-                            left: Identifier {
-                                value: "w",
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 59,
-                                    byte_length: 1,
+                                    byte_offset: 49,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
-                            right: Paren {
-                                expression: Binary {
-                                    operator: Multiplication,
-                                    left: Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Paren {
+                            expression: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "w",
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                    right: Paren {
-                                        expression: Binary {
-                                            operator: Subtraction,
-                                            left: Identifier {
-                                                value: "y",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 59,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Paren {
+                                    expression: Binary {
+                                        operator: Multiplication,
+                                        left: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Paren {
+                                            expression: Binary {
+                                                operator: Subtraction,
+                                                left: Identifier {
+                                                    value: "y",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 69,
+                                                        byte_length: 1,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
+                                                right: Identifier {
+                                                    value: "z",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 73,
+                                                        byte_length: 1,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 69,
-                                                    byte_length: 1,
+                                                    byte_length: 5,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
-                                            },
-                                            right: Identifier {
-                                                value: "z",
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 73,
-                                                    byte_length: 1,
-                                                },
-                                                binding_id: None,
-                                                qualified: None,
                                             },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 69,
-                                                byte_length: 5,
+                                                byte_offset: 68,
+                                                byte_length: 7,
                                             },
                                         },
                                         ty: Var {
@@ -217,8 +218,8 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 68,
-                                            byte_length: 7,
+                                            byte_offset: 64,
+                                            byte_length: 11,
                                         },
                                     },
                                     ty: Var {
@@ -226,8 +227,8 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 64,
-                                        byte_length: 11,
+                                        byte_offset: 63,
+                                        byte_length: 13,
                                     },
                                 },
                                 ty: Var {
@@ -235,8 +236,8 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 63,
-                                    byte_length: 13,
+                                    byte_offset: 59,
+                                    byte_length: 17,
                                 },
                             },
                             ty: Var {
@@ -244,42 +245,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 59,
-                                byte_length: 17,
+                                byte_offset: 58,
+                                byte_length: 19,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 58,
-                            byte_length: 19,
+                            byte_offset: 45,
+                            byte_length: 32,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 45,
-                        byte_length: 32,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 41,
+                    byte_length: 39,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 41,
-                byte_length: 39,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_nested.snap
+++ b/tests/spec/parse/snapshots/paren_nested.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,7 +60,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -86,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -111,7 +108,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -122,66 +118,85 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Paren {
-                            expression: Binary {
-                                operator: Multiplication,
-                                left: Paren {
-                                    expression: Binary {
-                                        operator: Addition,
-                                        left: Identifier {
-                                            value: "a",
+                        value: Binary {
+                            operator: Subtraction,
+                            left: Paren {
+                                expression: Binary {
+                                    operator: Multiplication,
+                                    left: Paren {
+                                        expression: Binary {
+                                            operator: Addition,
+                                            left: Identifier {
+                                                value: "a",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 58,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Identifier {
+                                                value: "b",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 62,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 58,
-                                                byte_length: 1,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                        right: Identifier {
-                                            value: "b",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 62,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
                                         },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 58,
-                                            byte_length: 5,
+                                            byte_offset: 57,
+                                            byte_length: 7,
                                         },
+                                    },
+                                    right: Identifier {
+                                        value: "c",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 67,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
                                     },
                                     ty: Var {
                                         id: uninferred,
@@ -189,30 +204,29 @@ description: |
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 57,
-                                        byte_length: 7,
+                                        byte_length: 11,
                                     },
-                                },
-                                right: Identifier {
-                                    value: "c",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 67,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 57,
-                                    byte_length: 11,
+                                    byte_offset: 56,
+                                    byte_length: 13,
                                 },
+                            },
+                            right: Identifier {
+                                value: "d",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 72,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -220,54 +234,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 56,
-                                byte_length: 13,
+                                byte_length: 17,
                             },
                         },
-                        right: Identifier {
-                            value: "d",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 72,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 56,
-                            byte_length: 17,
+                            byte_offset: 43,
+                            byte_length: 30,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 41,
+                    byte_length: 35,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 41,
-                byte_length: 35,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_override_and_or.snap
+++ b/tests/spec/parse/snapshots/paren_override_and_or.snap
@@ -21,75 +21,81 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: And,
-                        left: Identifier {
-                            value: "a",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Paren {
-                            expression: Binary {
-                                operator: Or,
-                                left: Identifier {
-                                    value: "b",
+                        value: Binary {
+                            operator: And,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Paren {
+                                expression: Binary {
+                                    operator: Or,
+                                    left: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 32,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "c",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 32,
-                                        byte_length: 1,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "c",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 37,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 32,
-                                    byte_length: 6,
+                                    byte_offset: 31,
+                                    byte_length: 8,
                                 },
                             },
                             ty: Var {
@@ -97,42 +103,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 8,
+                                byte_offset: 26,
+                                byte_length: 13,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_override_multiplication_addition.snap
+++ b/tests/spec/parse/snapshots/paren_override_multiplication_addition.snap
@@ -21,63 +21,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Multiplication,
-                        left: Paren {
-                            expression: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "a",
+                        value: Binary {
+                            operator: Multiplication,
+                            left: Paren {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 27,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 31,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 27,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 31,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 27,
-                                    byte_length: 5,
+                                    byte_offset: 26,
+                                    byte_length: 7,
                                 },
+                            },
+                            right: Identifier {
+                                value: "c",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -85,54 +104,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 7,
+                                byte_length: 11,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_precedence_override.snap
+++ b/tests/spec/parse/snapshots/paren_precedence_override.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,7 +60,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -86,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -97,63 +94,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 39,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 39,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Multiplication,
-                        left: Paren {
-                            expression: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "a",
+                        value: Binary {
+                            operator: Multiplication,
+                            left: Paren {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 49,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 49,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 49,
-                                    byte_length: 5,
+                                    byte_offset: 48,
+                                    byte_length: 7,
                                 },
+                            },
+                            right: Identifier {
+                                value: "c",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 58,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -161,54 +177,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 48,
-                                byte_length: 7,
+                                byte_length: 11,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 58,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 11,
+                            byte_offset: 35,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 35,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 33,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 33,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_simple_literal.snap
+++ b/tests/spec/parse/snapshots/paren_simple_literal.snap
@@ -21,71 +21,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Paren {
-                        expression: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Paren {
+                            expression: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 22,
+                                    byte_length: 2,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 22,
-                                byte_length: 2,
+                                byte_offset: 21,
+                                byte_length: 4,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 4,
+                            byte_offset: 13,
+                            byte_length: 12,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 12,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 17,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 17,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/paren_simple_variable.snap
+++ b/tests/spec/parse/snapshots/paren_simple_variable.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -47,70 +46,67 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Paren {
-                        expression: Identifier {
-                            value: "y",
+                        value: Paren {
+                            expression: Identifier {
+                                value: "y",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 1,
+                                byte_offset: 27,
+                                byte_length: 3,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 3,
+                            byte_offset: 19,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 19,
-                        byte_length: 11,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 16,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 16,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/parse_pattern_string_multiline.snap
+++ b/tests/spec/parse/snapshots/parse_pattern_string_multiline.snap
@@ -21,96 +21,97 @@ description: |-
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "s",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "s",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 18,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: String {
+                                        value: "a\nb",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 22,
+                                        byte_length: 5,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 34,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 39,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 18,
-                            byte_length: 1,
+                            byte_offset: 12,
+                            byte_length: 30,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: String {
-                                    value: "a\nb",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 22,
-                                    byte_length: 5,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 31,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 34,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 39,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/parse_raw_string_crlf_normalised.snap
+++ b/tests/spec/parse/snapshots/parse_raw_string_crlf_normalised.snap
@@ -21,61 +21,59 @@ description: |-
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "s",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 16,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "s",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: String {
+                                value: "a\nb",
+                                raw: true,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 7,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "a\nb",
-                            raw: true,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 7,
+                            byte_offset: 12,
+                            byte_length: 15,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 15,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 19,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 19,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/parse_string_crlf_normalised.snap
+++ b/tests/spec/parse/snapshots/parse_string_crlf_normalised.snap
@@ -21,61 +21,59 @@ description: |-
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "s",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 16,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "s",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: String {
+                                value: "a\nb",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 6,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "a\nb",
-                            raw: false,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 6,
+                            byte_offset: 12,
+                            byte_length: 14,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 14,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 18,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 18,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/parse_string_multiline_preserves_indent.snap
+++ b/tests/spec/parse/snapshots/parse_string_multiline_preserves_indent.snap
@@ -21,61 +21,59 @@ description: |-
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "s",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 16,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "s",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 16,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: String {
+                                value: "a\n    b",
+                                raw: false,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 9,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "a\n    b",
-                            raw: false,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 9,
+                            byte_offset: 12,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 12,
-                        byte_length: 17,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 10,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 10,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_chained.snap
+++ b/tests/spec/parse/snapshots/pipe_chained.snap
@@ -21,55 +21,74 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Binary {
+                        value: Binary {
                             operator: Pipeline,
                             left: Binary {
                                 operator: Pipeline,
-                                left: Identifier {
-                                    value: "x",
+                                left: Binary {
+                                    operator: Pipeline,
+                                    left: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "f",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 31,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 1,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 right: Identifier {
-                                    value: "f",
+                                    value: "g",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 31,
+                                        byte_offset: 36,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
                                 ty: Var {
                                     id: uninferred,
@@ -77,21 +96,20 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 6,
+                                    byte_length: 11,
                                 },
                             },
                             right: Identifier {
-                                value: "g",
+                                value: "h",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 36,
+                                    byte_offset: 41,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -99,54 +117,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 11,
+                                byte_length: 16,
                             },
                         },
-                        right: Identifier {
-                            value: "h",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 16,
+                            byte_offset: 13,
+                            byte_length: 29,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_chained_with_calls.snap
+++ b/tests/spec/parse/snapshots/pipe_chained_with_calls.snap
@@ -21,61 +21,109 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Binary {
+                        value: Binary {
                             operator: Pipeline,
                             left: Binary {
                                 operator: Pipeline,
-                                left: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
+                                left: Binary {
+                                    operator: Pipeline,
+                                    left: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 26,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Call {
-                                    expression: Identifier {
-                                        value: "add",
+                                    right: Call {
+                                        expression: Identifier {
+                                            value: "add",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 31,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: Integer {
+                                                    value: 5,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 35,
+                                                    byte_length: 1,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 31,
-                                            byte_length: 3,
+                                            byte_length: 6,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 11,
+                                    },
+                                },
+                                right: Call {
+                                    expression: Identifier {
+                                        value: "multiply",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 41,
+                                            byte_length: 8,
+                                        },
+                                        resolution: Unresolved,
                                     },
                                     args: [
                                         Literal {
                                             literal: Integer {
-                                                value: 5,
+                                                value: 2,
                                                 text: None,
                                             },
                                             ty: Var {
@@ -83,7 +131,7 @@ description: |
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 35,
+                                                byte_offset: 50,
                                                 byte_length: 1,
                                             },
                                         },
@@ -95,8 +143,8 @@ description: |
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 31,
-                                        byte_length: 6,
+                                        byte_offset: 41,
+                                        byte_length: 11,
                                     },
                                     call_kind: None,
                                 },
@@ -106,27 +154,26 @@ description: |
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 11,
+                                    byte_length: 26,
                                 },
                             },
                             right: Call {
                                 expression: Identifier {
-                                    value: "multiply",
+                                    value: "subtract",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 41,
+                                        byte_offset: 56,
                                         byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
                                 args: [
                                     Literal {
                                         literal: Integer {
-                                            value: 2,
+                                            value: 3,
                                             text: None,
                                         },
                                         ty: Var {
@@ -134,7 +181,7 @@ description: |
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 50,
+                                            byte_offset: 65,
                                             byte_length: 1,
                                         },
                                     },
@@ -146,7 +193,7 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 41,
+                                    byte_offset: 56,
                                     byte_length: 11,
                                 },
                                 call_kind: None,
@@ -157,83 +204,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 26,
+                                byte_length: 41,
                             },
                         },
-                        right: Call {
-                            expression: Identifier {
-                                value: "subtract",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 56,
-                                    byte_length: 8,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            args: [
-                                Literal {
-                                    literal: Integer {
-                                        value: 3,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 65,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 56,
-                                byte_length: 11,
-                            },
-                            call_kind: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 41,
+                            byte_offset: 13,
+                            byte_length: 54,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 54,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 59,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 59,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_precedence_addition.snap
+++ b/tests/spec/parse/snapshots/pipe_precedence_addition.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Binary {
-                            operator: Addition,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Pipeline,
+                            left: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "func",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
-                                    byte_length: 1,
+                                    byte_offset: 35,
+                                    byte_length: 4,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 13,
                             },
                         },
-                        right: Identifier {
-                            value: "func",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 4,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_precedence_or.snap
+++ b/tests/spec/parse/snapshots/pipe_precedence_or.snap
@@ -21,77 +21,95 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Binary {
-                            operator: Pipeline,
-                            left: Identifier {
-                                value: "a",
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_offset: 17,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
-                            right: Binary {
-                                operator: Or,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Binary {
+                            operator: Pipeline,
+                            left: Binary {
+                                operator: Pipeline,
                                 left: Identifier {
-                                    value: "f",
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Binary {
+                                    operator: Or,
+                                    left: Identifier {
+                                        value: "f",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 31,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 36,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 31,
-                                        byte_length: 1,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 36,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 31,
-                                    byte_length: 6,
+                                    byte_offset: 26,
+                                    byte_length: 11,
                                 },
+                            },
+                            right: Identifier {
+                                value: "g",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 41,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -99,54 +117,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 11,
+                                byte_length: 16,
                             },
                         },
-                        right: Identifier {
-                            value: "g",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 16,
+                            byte_offset: 13,
+                            byte_length: 29,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_simple.snap
+++ b/tests/spec/parse/snapshots/pipe_simple.snap
@@ -21,84 +21,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Identifier {
-                            value: "x",
+                        value: Binary {
+                            operator: Pipeline,
+                            left: Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "func",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 31,
+                                    byte_length: 4,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 1,
+                                byte_length: 9,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "func",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 4,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 9,
+                            byte_offset: 13,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pipe_with_call.snap
+++ b/tests/spec/parse/snapshots/pipe_with_call.snap
@@ -21,113 +21,109 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Pipeline,
-                        left: Identifier {
-                            value: "x",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Call {
-                            expression: Identifier {
-                                value: "add",
+                        value: Binary {
+                            operator: Pipeline,
+                            left: Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Call {
+                                expression: Identifier {
+                                    value: "add",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [
+                                    Literal {
+                                        literal: Integer {
+                                            value: 5,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 35,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 31,
-                                    byte_length: 3,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [
-                                Literal {
-                                    literal: Integer {
-                                        value: 5,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 35,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 6,
+                                byte_offset: 26,
+                                byte_length: 11,
                             },
-                            call_kind: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/postfix_expression_with_propagate.snap
+++ b/tests/spec/parse/snapshots/postfix_expression_with_propagate.snap
@@ -21,53 +21,157 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Propagate {
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "func",
+                        value: Binary {
+                            operator: Addition,
+                            left: Propagate {
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "func",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 4,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 6,
+                                    byte_length: 7,
                                 },
-                                call_kind: None,
+                            },
+                            right: Propagate {
+                                expression: Call {
+                                    expression: DotAccess {
+                                        expression: Identifier {
+                                            value: "obj",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 36,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        member: "method",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 36,
+                                            byte_length: 10,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "a",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 47,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        Binary {
+                                            operator: Addition,
+                                            left: Identifier {
+                                                value: "b",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 50,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Identifier {
+                                                value: "c",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 54,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 50,
+                                                byte_length: 5,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 36,
+                                        byte_length: 20,
+                                    },
+                                    call_kind: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 36,
+                                    byte_length: 21,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,142 +179,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 7,
+                                byte_length: 31,
                             },
                         },
-                        right: Propagate {
-                            expression: Call {
-                                expression: DotAccess {
-                                    expression: Identifier {
-                                        value: "obj",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 36,
-                                            byte_length: 3,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    member: "method",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 36,
-                                        byte_length: 10,
-                                    },
-                                    dot_access_kind: None,
-                                    receiver_coercion: None,
-                                },
-                                args: [
-                                    Identifier {
-                                        value: "a",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 47,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    Binary {
-                                        operator: Addition,
-                                        left: Identifier {
-                                            value: "b",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 50,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                        right: Identifier {
-                                            value: "c",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 54,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 50,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 36,
-                                    byte_length: 20,
-                                },
-                                call_kind: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 21,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 31,
+                            byte_offset: 13,
+                            byte_length: 44,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 44,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 49,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 49,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/postfix_method_call.snap
+++ b/tests/spec/parse/snapshots/postfix_method_call.snap
@@ -21,87 +21,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: DotAccess {
-                            expression: Identifier {
-                                value: "obj",
+                        value: Call {
+                            expression: DotAccess {
+                                expression: Identifier {
+                                    value: "obj",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                member: "method",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 3,
+                                    byte_length: 10,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            member: "method",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 10,
+                                byte_length: 12,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 12,
+                            byte_offset: 13,
+                            byte_length: 25,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 25,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/postfix_propagate_operator.snap
+++ b/tests/spec/parse/snapshots/postfix_propagate_operator.snap
@@ -21,70 +21,67 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Propagate {
-                        expression: Identifier {
-                            value: "expr",
+                        value: Propagate {
+                            expression: Identifier {
+                                value: "expr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 4,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 4,
+                                byte_length: 5,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 5,
+                            byte_offset: 13,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/postfix_tuple_field_access.snap
+++ b/tests/spec/parse/snapshots/postfix_tuple_field_access.snap
@@ -21,73 +21,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Identifier {
-                            value: "tuple",
+                        value: DotAccess {
+                            expression: Identifier {
+                                value: "tuple",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            member: "0",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 7,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            resolution: Unresolved,
                         },
-                        member: "0",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 7,
+                            byte_offset: 13,
+                            byte_length: 20,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_addition_equal.snap
+++ b/tests/spec/parse/snapshots/precedence_addition_equal.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Equal,
-                        left: Binary {
-                            operator: Addition,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Equal,
+                            left: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
+                                    byte_offset: 35,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 10,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 10,
+                            byte_offset: 13,
+                            byte_length: 23,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 28,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 28,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_addition_multiplication.snap
+++ b/tests/spec/parse/snapshots/precedence_addition_multiplication.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Binary {
-                            operator: Multiplication,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Addition,
+                            left: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 30,
+                                    byte_offset: 34,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 5,
+                                byte_length: 9,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 9,
+                            byte_offset: 13,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_and_or.snap
+++ b/tests/spec/parse/snapshots/precedence_and_or.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Or,
-                        left: Binary {
-                            operator: And,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Or,
+                            left: Binary {
+                                operator: And,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 31,
+                                    byte_offset: 36,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 6,
+                                byte_length: 11,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_equal_addition.snap
+++ b/tests/spec/parse/snapshots/precedence_equal_addition.snap
@@ -21,108 +21,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Equal,
-                        left: Identifier {
-                            value: "a",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Binary {
-                            operator: Addition,
+                        value: Binary {
+                            operator: Equal,
                             left: Identifier {
-                                value: "b",
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Binary {
+                                operator: Addition,
+                                left: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "c",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 35,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 31,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "c",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 35,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 5,
+                                byte_offset: 26,
+                                byte_length: 10,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 10,
+                            byte_offset: 13,
+                            byte_length: 23,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 28,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 28,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_equal_and.snap
+++ b/tests/spec/parse/snapshots/precedence_equal_and.snap
@@ -21,53 +21,72 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: And,
-                        left: Binary {
-                            operator: Equal,
-                            left: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: And,
+                            left: Binary {
+                                operator: Equal,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 31,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 1,
+                                    byte_length: 6,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             right: Identifier {
-                                value: "b",
+                                value: "c",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 31,
+                                    byte_offset: 36,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -75,54 +94,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 6,
+                                byte_length: 11,
                             },
                         },
-                        right: Identifier {
-                            value: "c",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_multiplication_addition.snap
+++ b/tests/spec/parse/snapshots/precedence_multiplication_addition.snap
@@ -21,108 +21,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Identifier {
-                            value: "a",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Binary {
-                            operator: Multiplication,
+                        value: Binary {
+                            operator: Addition,
                             left: Identifier {
-                                value: "b",
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Binary {
+                                operator: Multiplication,
+                                left: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 30,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "c",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 34,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 30,
-                                    byte_length: 1,
+                                    byte_length: 5,
                                 },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            right: Identifier {
-                                value: "c",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 34,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 30,
-                                byte_length: 5,
+                                byte_offset: 26,
+                                byte_length: 9,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 9,
+                            byte_offset: 13,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/precedence_unary_binary.snap
+++ b/tests/spec/parse/snapshots/precedence_unary_binary.snap
@@ -21,40 +21,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: And,
-                        left: Unary {
-                            operator: Not,
-                            expression: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: And,
+                            left: Unary {
+                                operator: Not,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 27,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 27,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -62,54 +82,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 7,
                             },
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 7,
+                            byte_offset: 13,
+                            byte_length: 20,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/propagate_after_call.snap
+++ b/tests/spec/parse/snapshots/propagate_after_call.snap
@@ -23,84 +23,81 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "data",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "data",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Propagate {
-                        expression: Call {
-                            expression: Identifier {
-                                value: "load_data",
+                        value: Propagate {
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "load_data",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 9,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 9,
+                                    byte_length: 11,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 11,
+                                byte_length: 12,
                             },
-                            call_kind: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 12,
+                            byte_offset: 15,
+                            byte_length: 23,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/propagate_in_chain.snap
+++ b/tests/spec/parse/snapshots/propagate_in_chain.snap
@@ -23,97 +23,93 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "user",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "user",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Propagate {
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "load_config",
+                        value: DotAccess {
+                            expression: Propagate {
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "load_config",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 11,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 11,
+                                        byte_length: 13,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 13,
+                                    byte_length: 14,
                                 },
-                                call_kind: None,
                             },
+                            member: "user",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 14,
+                                byte_length: 19,
                             },
+                            resolution: Unresolved,
                         },
-                        member: "user",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 19,
+                            byte_offset: 15,
+                            byte_length: 30,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 37,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 37,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/propagate_in_chain_multiple.snap
+++ b/tests/spec/parse/snapshots/propagate_in_chain_multiple.snap
@@ -23,120 +23,115 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "name",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "name",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: DotAccess {
-                        expression: Propagate {
-                            expression: DotAccess {
-                                expression: Propagate {
-                                    expression: Call {
-                                        expression: Identifier {
-                                            value: "load_config",
+                        value: DotAccess {
+                            expression: Propagate {
+                                expression: DotAccess {
+                                    expression: Propagate {
+                                        expression: Call {
+                                            expression: Identifier {
+                                                value: "load_config",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 26,
+                                                    byte_length: 11,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            args: [],
+                                            spread: None,
+                                            type_arguments: None,
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 26,
-                                                byte_length: 11,
+                                                byte_length: 13,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            call_kind: None,
                                         },
-                                        args: [],
-                                        spread: None,
-                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 26,
-                                            byte_length: 13,
+                                            byte_length: 14,
                                         },
-                                        call_kind: None,
                                     },
+                                    member: "user",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 14,
+                                        byte_length: 19,
                                     },
+                                    resolution: Unresolved,
                                 },
-                                member: "user",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 19,
+                                    byte_length: 20,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
                             },
+                            member: "name",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 20,
+                                byte_length: 25,
                             },
+                            resolution: Unresolved,
                         },
-                        member: "name",
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 25,
+                            byte_offset: 15,
+                            byte_length: 36,
                         },
-                        dot_access_kind: None,
-                        receiver_coercion: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 36,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 43,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 43,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/propagate_simple.snap
+++ b/tests/spec/parse/snapshots/propagate_simple.snap
@@ -57,7 +57,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -68,70 +67,67 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "value",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "value",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Propagate {
-                        expression: Identifier {
-                            value: "res",
+                        value: Propagate {
+                            expression: Identifier {
+                                value: "res",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 51,
-                                byte_length: 3,
+                                byte_length: 4,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 4,
+                            byte_offset: 39,
+                            byte_length: 16,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 39,
-                        byte_length: 16,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 35,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 35,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pub_const.snap
+++ b/tests/spec/parse/snapshots/pub_const.snap
@@ -24,20 +24,22 @@ description: |
                 },
             },
         ),
-        expression: Literal {
-            literal: Integer {
-                value: 100,
-                text: None,
+        expression: Value(
+            Literal {
+                literal: Integer {
+                    value: 100,
+                    text: None,
+                },
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 22,
+                    byte_length: 3,
+                },
             },
-            ty: Var {
-                id: uninferred,
-            },
-            span: Span {
-                file_id: 0,
-                byte_offset: 22,
-                byte_length: 3,
-            },
-        },
+        ),
         visibility: Public,
         ty: Var {
             id: uninferred,

--- a/tests/spec/parse/snapshots/pub_function.snap
+++ b/tests/spec/parse/snapshots/pub_function.snap
@@ -21,17 +21,19 @@ description: |
             id: uninferred,
         },
         visibility: Public,
-        body: Block {
-            items: [],
-            ty: Var {
-                id: uninferred,
+        body: Definition(
+            Block {
+                items: [],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 16,
+                    byte_length: 3,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 16,
-                byte_length: 3,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/pub_interface.snap
+++ b/tests/spec/parse/snapshots/pub_interface.snap
@@ -37,7 +37,6 @@ description: |
                             },
                         },
                         annotation: None,
-                        typed_pattern: None,
                         ty: Var {
                             id: uninferred,
                         },
@@ -48,7 +47,7 @@ description: |
                     id: uninferred,
                 },
                 visibility: Private,
-                body: NoOp,
+                body: Declaration,
                 ty: Var {
                     id: uninferred,
                 },

--- a/tests/spec/parse/snapshots/range_exclusive.snap
+++ b/tests/spec/parse/snapshots/range_exclusive.snap
@@ -21,90 +21,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Range {
-                        start: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 21,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
                             },
-                        ),
-                        end: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 10,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 24,
-                                    byte_length: 2,
-                                },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ),
-                        inclusive: false,
+                        },
+                        value: Range {
+                            start: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 21,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            end: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 10,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 24,
+                                        byte_length: 2,
+                                    },
+                                },
+                            ),
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 5,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 5,
+                            byte_offset: 13,
+                            byte_length: 13,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 13,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 18,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 18,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_from.snap
+++ b/tests/spec/parse/snapshots/range_from.snap
@@ -21,89 +21,89 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                For {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "i",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    iterable: Range {
-                        start: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    For {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "i",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 22,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
                             },
-                        ),
-                        end: None,
-                        inclusive: false,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 22,
-                            byte_length: 3,
-                        },
-                    },
-                    body: Block {
-                        items: [
-                            Break {
-                                value: None,
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 28,
-                                    byte_length: 5,
-                                },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                        },
+                        iterable: Range {
+                            start: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 22,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            end: None,
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 22,
+                                byte_length: 3,
+                            },
+                        },
+                        body: Block {
+                            items: [
+                                Break {
+                                    value: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 28,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 10,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 10,
+                            byte_offset: 13,
+                            byte_length: 23,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 23,
-                    },
-                    binding_id: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_full.snap
+++ b/tests/spec/parse/snapshots/range_full.snap
@@ -46,7 +46,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -57,84 +56,81 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "copy",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "copy",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 39,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Range {
+                                start: None,
+                                end: None,
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 2,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 32,
+                                byte_offset: 42,
                                 byte_length: 4,
                             },
+                            from_colon_syntax: false,
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 39,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        index: Range {
-                            start: None,
-                            end: None,
-                            inclusive: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 2,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 4,
+                            byte_offset: 28,
+                            byte_length: 18,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 28,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_in_for_loop.snap
+++ b/tests/spec/parse/snapshots/range_in_for_loop.snap
@@ -21,137 +21,135 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                For {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "i",
+        body: Definition(
+            Block {
+                items: [
+                    For {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "i",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        iterable: Range {
+                            start: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 22,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            end: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 5,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 25,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
+                                byte_offset: 22,
+                                byte_length: 4,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    iterable: Range {
-                        start: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 22,
-                                    byte_length: 1,
-                                },
-                            },
-                        ),
-                        end: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 5,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 25,
-                                    byte_length: 1,
-                                },
-                            },
-                        ),
-                        inclusive: false,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 22,
-                            byte_length: 4,
-                        },
-                    },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 29,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "i",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 35,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 29,
-                                        byte_length: 5,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "i",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 35,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 29,
-                                    byte_length: 8,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 13,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 27,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 27,
-                    },
-                    binding_id: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_inclusive.snap
+++ b/tests/spec/parse/snapshots/range_inclusive.snap
@@ -21,90 +21,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Range {
-                        start: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 21,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
                             },
-                        ),
-                        end: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 10,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 25,
-                                    byte_length: 2,
-                                },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ),
-                        inclusive: true,
+                        },
+                        value: Range {
+                            start: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 21,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            end: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 10,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 25,
+                                        byte_length: 2,
+                                    },
+                                },
+                            ),
+                            inclusive: true,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 6,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 14,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 14,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 19,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 19,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_precedence_with_arithmetic.snap
+++ b/tests/spec/parse/snapshots/range_precedence_with_arithmetic.snap
@@ -21,48 +21,71 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Range {
-                        start: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 21,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
                             },
-                        ),
-                        end: Some(
-                            Binary {
-                                operator: Addition,
-                                left: Literal {
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Range {
+                            start: Some(
+                                Literal {
                                     literal: Integer {
-                                        value: 1,
+                                        value: 0,
                                         text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 21,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            end: Some(
+                                Binary {
+                                    operator: Addition,
+                                    left: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 24,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 2,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 28,
+                                            byte_length: 1,
+                                        },
                                     },
                                     ty: Var {
                                         id: uninferred,
@@ -70,66 +93,41 @@ description: |
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 24,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
                                 },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 2,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 28,
-                                        byte_length: 1,
-                                    },
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 24,
-                                    byte_length: 5,
-                                },
+                            ),
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ),
-                        inclusive: false,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 8,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 8,
+                            byte_offset: 13,
+                            byte_length: 16,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 16,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_precedence_with_comparison.snap
+++ b/tests/spec/parse/snapshots/range_precedence_with_comparison.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -47,114 +46,111 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Equal,
-                        left: Range {
-                            start: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 0,
-                                        text: None,
+                        value: Binary {
+                            operator: Equal,
+                            left: Range {
+                                start: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 0,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 32,
+                                            byte_length: 1,
+                                        },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
+                                ),
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 5,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 35,
+                                            byte_length: 1,
+                                        },
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 32,
-                                        byte_length: 1,
-                                    },
+                                ),
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ),
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 5,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 35,
-                                        byte_length: 1,
-                                    },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 4,
                                 },
-                            ),
-                            inclusive: false,
+                            },
+                            right: Identifier {
+                                value: "other",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 40,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 32,
-                                byte_length: 4,
+                                byte_length: 13,
                             },
                         },
-                        right: Identifier {
-                            value: "other",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 40,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 32,
-                            byte_length: 13,
+                            byte_offset: 24,
+                            byte_length: 21,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 24,
-                        byte_length: 21,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 22,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 22,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_slice_indexing.snap
+++ b/tests/spec/parse/snapshots/range_slice_indexing.snap
@@ -46,7 +46,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -57,114 +56,111 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "sub",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "sub",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 38,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Range {
+                                start: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 42,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 4,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 45,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 4,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 3,
+                                byte_offset: 41,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            from_colon_syntax: false,
                         },
-                        index: Range {
-                            start: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 42,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ),
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 4,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 45,
-                                        byte_length: 1,
-                                    },
-                                },
-                            ),
-                            inclusive: false,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 4,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 6,
+                            byte_offset: 28,
+                            byte_length: 19,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 28,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_to.snap
+++ b/tests/spec/parse/snapshots/range_to.snap
@@ -46,7 +46,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -57,99 +56,96 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "head",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 4,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 39,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        index: Range {
-                            start: None,
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 3,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 45,
-                                        byte_length: 1,
-                                    },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "head",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 4,
                                 },
-                            ),
-                            inclusive: false,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 39,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Range {
+                                start: None,
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 3,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 45,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                inclusive: false,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 3,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 3,
+                                byte_offset: 42,
+                                byte_length: 5,
                             },
+                            from_colon_syntax: false,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 5,
+                            byte_offset: 28,
+                            byte_length: 19,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 28,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_to_inclusive.snap
+++ b/tests/spec/parse/snapshots/range_to_inclusive.snap
@@ -46,7 +46,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -57,99 +56,96 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "head",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 32,
-                                byte_length: 4,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: IndexedAccess {
-                        expression: Identifier {
-                            value: "arr",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 39,
-                                byte_length: 3,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        index: Range {
-                            start: None,
-                            end: Some(
-                                Literal {
-                                    literal: Integer {
-                                        value: 3,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 46,
-                                        byte_length: 1,
-                                    },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "head",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 32,
+                                    byte_length: 4,
                                 },
-                            ),
-                            inclusive: true,
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: IndexedAccess {
+                            expression: Identifier {
+                                value: "arr",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 39,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Range {
+                                start: None,
+                                end: Some(
+                                    Literal {
+                                        literal: Integer {
+                                            value: 3,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 46,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                ),
+                                inclusive: true,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 43,
+                                    byte_length: 4,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 4,
+                                byte_offset: 42,
+                                byte_length: 6,
                             },
+                            from_colon_syntax: false,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 6,
+                            byte_offset: 28,
+                            byte_length: 20,
                         },
-                        from_colon_syntax: false,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 28,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/range_with_expressions.snap
+++ b/tests/spec/parse/snapshots/range_with_expressions.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,7 +60,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -72,88 +70,84 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 37,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Range {
+                            start: Some(
+                                Identifier {
+                                    value: "start",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 5,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ),
+                            end: Some(
+                                Identifier {
+                                    value: "end",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 48,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ),
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 37,
-                                byte_length: 1,
+                                byte_offset: 41,
+                                byte_length: 10,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Range {
-                        start: Some(
-                            Identifier {
-                                value: "start",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 5,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        ),
-                        end: Some(
-                            Identifier {
-                                value: "end",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 3,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        ),
-                        inclusive: false,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 10,
+                            byte_offset: 33,
+                            byte_length: 18,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 33,
-                        byte_length: 18,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 31,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 31,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/raw_string_in_function_arg.snap
+++ b/tests/spec/parse/snapshots/raw_string_in_function_arg.snap
@@ -21,60 +21,61 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "f",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "f",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Literal {
+                                literal: String {
+                                    value: "C:\\Users\\me",
+                                    raw: true,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 15,
+                                    byte_length: 14,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 13,
-                            byte_length: 1,
+                            byte_length: 17,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        Literal {
-                            literal: String {
-                                value: "C:\\Users\\me",
-                                raw: true,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 15,
-                                byte_length: 14,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 17,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 22,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 22,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/raw_string_in_match_pattern.snap
+++ b/tests/spec/parse/snapshots/raw_string_in_match_pattern.snap
@@ -27,126 +27,127 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "s",
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "s",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 1,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: String {
+                                        value: "\\d+",
+                                        raw: true,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 6,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 39,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: Literal {
+                                    literal: String {
+                                        value: "plain",
+                                        raw: false,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 46,
+                                        byte_length: 7,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 2,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 57,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 64,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 69,
+                                        byte_length: 1,
+                                    },
+                                },
+                            },
+                        ],
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 60,
                         },
-                        binding_id: None,
-                        qualified: None,
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Literal {
-                                literal: String {
-                                    value: "\\d+",
-                                    raw: true,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 29,
-                                    byte_length: 6,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 39,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: Literal {
-                                literal: String {
-                                    value: "plain",
-                                    raw: false,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 7,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 2,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 57,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 64,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 69,
-                                    byte_length: 1,
-                                },
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 60,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 66,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 66,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/raw_string_in_rawgo_directive.snap
+++ b/tests/spec/parse/snapshots/raw_string_in_rawgo_directive.snap
@@ -21,21 +21,23 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                RawGo {
-                    text: "if x > 0 {\\n}",
+        body: Definition(
+            Block {
+                items: [
+                    RawGo {
+                        text: "if x > 0 {\\n}",
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 28,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 28,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/raw_string_in_slice.snap
+++ b/tests/spec/parse/snapshots/raw_string_in_slice.snap
@@ -21,103 +21,101 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "xs",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 2,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "xs",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 2,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Slice(
+                                [
+                                    Literal {
+                                        literal: String {
+                                            value: "\\d",
+                                            raw: true,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 23,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                    Literal {
+                                        literal: String {
+                                            value: "\\s",
+                                            raw: true,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 30,
+                                            byte_length: 5,
+                                        },
+                                    },
+                                    Literal {
+                                        literal: String {
+                                            value: "plain",
+                                            raw: false,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 7,
+                                        },
+                                    },
+                                ],
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 22,
+                                byte_length: 23,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Slice(
-                            [
-                                Literal {
-                                    literal: String {
-                                        value: "\\d",
-                                        raw: true,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 23,
-                                        byte_length: 5,
-                                    },
-                                },
-                                Literal {
-                                    literal: String {
-                                        value: "\\s",
-                                        raw: true,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 30,
-                                        byte_length: 5,
-                                    },
-                                },
-                                Literal {
-                                    literal: String {
-                                        value: "plain",
-                                        raw: false,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 37,
-                                        byte_length: 7,
-                                    },
-                                },
-                            ],
-                        ),
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 22,
-                            byte_length: 23,
+                            byte_offset: 13,
+                            byte_length: 32,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 32,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 37,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 37,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/raw_string_literal_assignment.snap
+++ b/tests/spec/parse/snapshots/raw_string_literal_assignment.snap
@@ -21,61 +21,59 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: String {
+                                value: "\\d+\\.\\d+",
+                                raw: true,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 11,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: String {
-                            value: "\\d+\\.\\d+",
-                            raw: true,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 11,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/recover_block_basic.snap
+++ b/tests/spec/parse/snapshots/recover_block_basic.snap
@@ -23,91 +23,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: RecoverBlock {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "foo",
+                        value: RecoverBlock {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "foo",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 38,
+                                            byte_length: 3,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 38,
-                                        byte_length: 3,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 5,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            recover_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 7,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 17,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        recover_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 7,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 17,
+                            byte_offset: 15,
+                            byte_length: 30,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 30,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 37,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 37,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/recover_block_empty.snap
+++ b/tests/spec/parse/snapshots/recover_block_empty.snap
@@ -23,63 +23,61 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
+                        value: RecoverBlock {
+                            items: [],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            recover_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 7,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 10,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
-                        },
-                    },
-                    value: RecoverBlock {
-                        items: [],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        recover_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 7,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 10,
+                            byte_offset: 15,
+                            byte_length: 23,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/recover_block_multiple_statements.snap
+++ b/tests/spec/parse/snapshots/recover_block_multiple_statements.snap
@@ -26,158 +26,150 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: RecoverBlock {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "x",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 46,
-                                            byte_length: 1,
+                        value: RecoverBlock {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "x",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 46,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: Call {
-                                    expression: Identifier {
-                                        value: "foo",
+                                    value: Call {
+                                        expression: Identifier {
+                                            value: "foo",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 50,
+                                                byte_length: 3,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 50,
-                                            byte_length: 3,
+                                            byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
+                                    mode: Plain,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 50,
-                                        byte_length: 5,
+                                        byte_offset: 42,
+                                        byte_length: 13,
                                     },
-                                    call_kind: None,
                                 },
-                                mut_span: None,
-                                else_block: None,
-                                else_span: None,
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 42,
-                                    byte_length: 13,
-                                },
-                            },
-                            Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "x",
+                                Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 61,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 65,
+                                            byte_length: 1,
+                                        },
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 61,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 65,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 61,
-                                    byte_length: 5,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            recover_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 7,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 42,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        recover_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 7,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 42,
+                            byte_offset: 15,
+                            byte_length: 55,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 55,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 62,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 62,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/recover_block_nested.snap
+++ b/tests/spec/parse/snapshots/recover_block_nested.snap
@@ -28,164 +28,156 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "outer",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "outer",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: RecoverBlock {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "inner",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 45,
-                                            byte_length: 5,
+                        value: RecoverBlock {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "inner",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 45,
+                                                byte_length: 5,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: RecoverBlock {
-                                    items: [
-                                        Call {
-                                            expression: Identifier {
-                                                value: "inner_risky",
+                                    value: RecoverBlock {
+                                        items: [
+                                            Call {
+                                                expression: Identifier {
+                                                    value: "inner_risky",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 69,
+                                                        byte_length: 11,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
+                                                args: [],
+                                                spread: None,
+                                                type_arguments: None,
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 69,
-                                                    byte_length: 11,
+                                                    byte_length: 13,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
+                                                call_kind: None,
                                             },
-                                            args: [],
-                                            spread: None,
-                                            type_arguments: None,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 69,
-                                                byte_length: 13,
-                                            },
-                                            call_kind: None,
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
                                         },
-                                    ],
+                                        recover_keyword_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 7,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 35,
+                                        },
+                                    },
+                                    mode: Plain,
                                     ty: Var {
                                         id: uninferred,
                                     },
-                                    recover_keyword_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 7,
-                                    },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 35,
+                                        byte_offset: 41,
+                                        byte_length: 47,
                                     },
                                 },
-                                mut_span: None,
-                                else_block: None,
-                                else_span: None,
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 41,
-                                    byte_length: 47,
-                                },
-                            },
-                            Call {
-                                expression: Identifier {
-                                    value: "outer_risky",
+                                Call {
+                                    expression: Identifier {
+                                        value: "outer_risky",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 94,
+                                            byte_length: 11,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 94,
-                                        byte_length: 11,
+                                        byte_length: 13,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 94,
-                                    byte_length: 13,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            recover_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 7,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 84,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        recover_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 7,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 84,
+                            byte_offset: 15,
+                            byte_length: 96,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 96,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 103,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 103,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/recover_block_with_semicolon.snap
+++ b/tests/spec/parse/snapshots/recover_block_with_semicolon.snap
@@ -25,91 +25,88 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: RecoverBlock {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "do_something",
+                        value: RecoverBlock {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "do_something",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 42,
+                                            byte_length: 12,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 42,
-                                        byte_length: 12,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 42,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            recover_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 7,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 33,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        recover_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 7,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 33,
+                            byte_offset: 15,
+                            byte_length: 46,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 46,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 53,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 53,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/return_bare_followed_by_code.snap
+++ b/tests/spec/parse/snapshots/return_bare_followed_by_code.snap
@@ -24,10 +24,20 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Return {
-                    expression: Unit {
+        body: Definition(
+            Block {
+                items: [
+                    Return {
+                        expression: Unit {
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 15,
+                                byte_length: 6,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
@@ -37,68 +47,56 @@ description: |
                             byte_length: 6,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 6,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 5,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 29,
+                                byte_offset: 33,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 5,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 1,
+                            byte_offset: 25,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 9,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/select_match_receive.snap
+++ b/tests/spec/parse/snapshots/select_match_receive.snap
@@ -54,7 +54,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -65,214 +64,212 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Select {
-                    arms: [
-                        SelectArm {
-                            pattern: MatchReceive {
-                                receive_expression: Call {
-                                    expression: DotAccess {
-                                        expression: Identifier {
-                                            value: "ch",
+        body: Definition(
+            Block {
+                items: [
+                    Select {
+                        arms: [
+                            SelectArm {
+                                pattern: MatchReceive {
+                                    receive_expression: Call {
+                                        expression: DotAccess {
+                                            expression: Identifier {
+                                                value: "ch",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 50,
+                                                    byte_length: 2,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            member: "receive",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 50,
-                                                byte_length: 2,
+                                                byte_length: 10,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                        member: "receive",
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 50,
-                                            byte_length: 10,
+                                            byte_length: 12,
                                         },
-                                        dot_access_kind: None,
-                                        receiver_coercion: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 50,
-                                        byte_length: 12,
-                                    },
-                                    call_kind: None,
-                                },
-                                arms: [
-                                    MatchArm {
-                                        pattern: EnumVariant {
-                                            identifier: "Some",
-                                            fields: [
-                                                Identifier {
-                                                    identifier: "v",
+                                    arms: [
+                                        MatchArm {
+                                            pattern: EnumVariant {
+                                                identifier: "Some",
+                                                fields: [
+                                                    Identifier {
+                                                        identifier: "v",
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 76,
+                                                            byte_length: 1,
+                                                        },
+                                                    },
+                                                ],
+                                                rest: false,
+                                                resolution: Unresolved,
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 71,
+                                                    byte_length: 7,
+                                                },
+                                            },
+                                            expression: Call {
+                                                expression: Identifier {
+                                                    value: "process",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
                                                     span: Span {
                                                         file_id: 0,
-                                                        byte_offset: 76,
-                                                        byte_length: 1,
+                                                        byte_offset: 82,
+                                                        byte_length: 7,
                                                     },
+                                                    resolution: Unresolved,
                                                 },
-                                            ],
-                                            rest: false,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 71,
-                                                byte_length: 7,
-                                            },
-                                        },
-                                        expression: Call {
-                                            expression: Identifier {
-                                                value: "process",
+                                                args: [
+                                                    Identifier {
+                                                        value: "v",
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 90,
+                                                            byte_length: 1,
+                                                        },
+                                                        resolution: Unresolved,
+                                                    },
+                                                ],
+                                                spread: None,
+                                                type_arguments: None,
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 82,
-                                                    byte_length: 7,
+                                                    byte_length: 10,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
+                                                call_kind: None,
                                             },
-                                            args: [
-                                                Identifier {
-                                                    value: "v",
+                                        },
+                                        MatchArm {
+                                            pattern: EnumVariant {
+                                                identifier: "None",
+                                                fields: [],
+                                                rest: false,
+                                                resolution: Unresolved,
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 100,
+                                                    byte_length: 4,
+                                                },
+                                            },
+                                            expression: Call {
+                                                expression: Identifier {
+                                                    value: "handle_close",
                                                     ty: Var {
                                                         id: uninferred,
                                                     },
                                                     span: Span {
                                                         file_id: 0,
-                                                        byte_offset: 90,
-                                                        byte_length: 1,
+                                                        byte_offset: 108,
+                                                        byte_length: 12,
                                                     },
-                                                    binding_id: None,
-                                                    qualified: None,
+                                                    resolution: Unresolved,
                                                 },
-                                            ],
-                                            spread: None,
-                                            type_arguments: None,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 82,
-                                                byte_length: 10,
-                                            },
-                                            call_kind: None,
-                                        },
-                                    },
-                                    MatchArm {
-                                        pattern: EnumVariant {
-                                            identifier: "None",
-                                            fields: [],
-                                            rest: false,
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 100,
-                                                byte_length: 4,
-                                            },
-                                        },
-                                        expression: Call {
-                                            expression: Identifier {
-                                                value: "handle_close",
+                                                args: [],
+                                                spread: None,
+                                                type_arguments: None,
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 108,
-                                                    byte_length: 12,
+                                                    byte_length: 14,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
+                                                call_kind: None,
                                             },
-                                            args: [],
-                                            spread: None,
-                                            type_arguments: None,
+                                        },
+                                    ],
+                                },
+                            },
+                            SelectArm {
+                                pattern: WildCard {
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "default",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 108,
-                                                byte_length: 14,
+                                                byte_offset: 140,
+                                                byte_length: 7,
                                             },
-                                            call_kind: None,
+                                            resolution: Unresolved,
                                         },
-                                    },
-                                ],
-                            },
-                        },
-                        SelectArm {
-                            pattern: WildCard {
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "default",
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 140,
-                                            byte_length: 7,
+                                            byte_length: 9,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 140,
-                                        byte_length: 9,
-                                    },
-                                    call_kind: None,
                                 },
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 31,
+                            byte_length: 123,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 123,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 129,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 129,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/select_multiple_arms.snap
+++ b/tests/spec/parse/snapshots/select_multiple_arms.snap
@@ -52,7 +52,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -87,7 +86,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -98,244 +96,238 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Select {
-                    arms: [
-                        SelectArm {
-                            pattern: Receive {
-                                binding: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 71,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Select {
+                        arms: [
+                            SelectArm {
+                                pattern: Receive {
+                                    binding: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 71,
+                                            byte_length: 1,
+                                        },
                                     },
-                                },
-                                typed_pattern: None,
-                                receive_expression: Identifier {
-                                    value: "ch1",
-                                    ty: Var {
-                                        id: uninferred,
+                                    receive_expression: Identifier {
+                                        value: "ch1",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 75,
+                                            byte_length: 3,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 75,
-                                        byte_length: 3,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "process",
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "process",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 82,
+                                                byte_length: 7,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 90,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 82,
-                                            byte_length: 7,
+                                            byte_length: 10,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 90,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 82,
-                                        byte_length: 10,
-                                    },
-                                    call_kind: None,
                                 },
                             },
-                        },
-                        SelectArm {
-                            pattern: Send {
-                                send_expression: Call {
-                                    expression: DotAccess {
-                                        expression: Identifier {
-                                            value: "ch2",
+                            SelectArm {
+                                pattern: Send {
+                                    send_expression: Call {
+                                        expression: DotAccess {
+                                            expression: Identifier {
+                                                value: "ch2",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 98,
+                                                    byte_length: 3,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            member: "send",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 98,
-                                                byte_length: 3,
+                                                byte_length: 8,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                        member: "send",
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "hello",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 107,
+                                                    byte_length: 7,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 98,
-                                            byte_length: 8,
+                                            byte_length: 17,
                                         },
-                                        dot_access_kind: None,
-                                        receiver_coercion: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "hello",
-                                                raw: false,
-                                            },
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "print",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 107,
-                                                byte_length: 7,
+                                                byte_offset: 119,
+                                                byte_length: 5,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 98,
-                                        byte_length: 17,
-                                    },
-                                    call_kind: None,
-                                },
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "print",
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "sent",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 125,
+                                                    byte_length: 6,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 119,
-                                            byte_length: 5,
+                                            byte_length: 13,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "sent",
-                                                raw: false,
-                                            },
+                                },
+                            },
+                            SelectArm {
+                                pattern: WildCard {
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "print",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 125,
-                                                byte_length: 6,
+                                                byte_offset: 143,
+                                                byte_length: 5,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 119,
-                                        byte_length: 13,
-                                    },
-                                    call_kind: None,
-                                },
-                            },
-                        },
-                        SelectArm {
-                            pattern: WildCard {
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "print",
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "default",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 149,
+                                                    byte_length: 9,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 143,
-                                            byte_length: 5,
+                                            byte_length: 16,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "default",
-                                                raw: false,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 149,
-                                                byte_length: 9,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 143,
-                                        byte_length: 16,
-                                    },
-                                    call_kind: None,
                                 },
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 54,
+                            byte_length: 110,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 54,
-                        byte_length: 110,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 50,
+                    byte_length: 116,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 50,
-                byte_length: 116,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/select_receive.snap
+++ b/tests/spec/parse/snapshots/select_receive.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,97 +60,95 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Select {
-                    arms: [
-                        SelectArm {
-                            pattern: Receive {
-                                binding: Identifier {
-                                    identifier: "x",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 49,
-                                        byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Select {
+                        arms: [
+                            SelectArm {
+                                pattern: Receive {
+                                    binding: Identifier {
+                                        identifier: "x",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 49,
+                                            byte_length: 1,
+                                        },
                                     },
-                                },
-                                typed_pattern: None,
-                                receive_expression: Identifier {
-                                    value: "ch",
-                                    ty: Var {
-                                        id: uninferred,
+                                    receive_expression: Identifier {
+                                        value: "ch",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 2,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 2,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "process",
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "process",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 59,
+                                                byte_length: 7,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 67,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 59,
-                                            byte_length: 7,
+                                            byte_length: 10,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 67,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 59,
-                                        byte_length: 10,
-                                    },
-                                    call_kind: None,
                                 },
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 42,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 42,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 48,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 48,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/select_send.snap
+++ b/tests/spec/parse/snapshots/select_send.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,131 +60,130 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Select {
-                    arms: [
-                        SelectArm {
-                            pattern: Send {
-                                send_expression: Call {
-                                    expression: DotAccess {
-                                        expression: Identifier {
-                                            value: "ch",
+        body: Definition(
+            Block {
+                items: [
+                    Select {
+                        arms: [
+                            SelectArm {
+                                pattern: Send {
+                                    send_expression: Call {
+                                        expression: DotAccess {
+                                            expression: Identifier {
+                                                value: "ch",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 43,
+                                                    byte_length: 2,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            member: "send",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 43,
-                                                byte_length: 2,
+                                                byte_length: 7,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            resolution: Unresolved,
                                         },
-                                        member: "send",
+                                        args: [
+                                            Literal {
+                                                literal: Integer {
+                                                    value: 42,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 51,
+                                                    byte_length: 2,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 43,
-                                            byte_length: 7,
+                                            byte_length: 11,
                                         },
-                                        dot_access_kind: None,
-                                        receiver_coercion: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: Integer {
-                                                value: 42,
-                                                text: None,
-                                            },
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "print",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 51,
-                                                byte_length: 2,
+                                                byte_offset: 58,
+                                                byte_length: 5,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 43,
-                                        byte_length: 11,
-                                    },
-                                    call_kind: None,
-                                },
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "print",
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "sent",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 64,
+                                                    byte_length: 6,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 58,
-                                            byte_length: 5,
+                                            byte_length: 13,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "sent",
-                                                raw: false,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 64,
-                                                byte_length: 6,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 58,
-                                        byte_length: 13,
-                                    },
-                                    call_kind: None,
                                 },
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 46,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 46,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 52,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 52,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/select_wildcard.snap
+++ b/tests/spec/parse/snapshots/select_wildcard.snap
@@ -25,76 +25,77 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Select {
-                    arms: [
-                        SelectArm {
-                            pattern: WildCard {
-                                body: Call {
-                                    expression: Identifier {
-                                        value: "print",
+        body: Definition(
+            Block {
+                items: [
+                    Select {
+                        arms: [
+                            SelectArm {
+                                pattern: WildCard {
+                                    body: Call {
+                                        expression: Identifier {
+                                            value: "print",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 33,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [
+                                            Literal {
+                                                literal: String {
+                                                    value: "default",
+                                                    raw: false,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 39,
+                                                    byte_length: 9,
+                                                },
+                                            },
+                                        ],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 33,
-                                            byte_length: 5,
+                                            byte_length: 16,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [
-                                        Literal {
-                                            literal: String {
-                                                value: "default",
-                                                raw: false,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 39,
-                                                byte_length: 9,
-                                            },
-                                        },
-                                    ],
-                                    spread: None,
-                                    type_arguments: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 33,
-                                        byte_length: 16,
-                                    },
-                                    call_kind: None,
                                 },
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 39,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 39,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 45,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 45,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_blocked_in_control_flow_header.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_blocked_in_control_flow_header.snap
@@ -26,250 +26,238 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 11,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: EnumVariant {
-                            identifier: "Bar",
-                            fields: [],
-                            rest: false,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 3,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 2,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 11,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 49,
+                                byte_offset: 25,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 3,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 53,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: EnumVariant {
+                                identifier: "Bar",
+                                fields: [],
+                                rest: false,
+                                resolution: Unresolved,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 2,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 40,
+                                byte_length: 1,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 11,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 45,
-                        byte_length: 9,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 49,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 3,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 53,
+                                byte_length: 1,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 45,
+                            byte_length: 9,
+                        },
                     },
-                },
-                If {
-                    condition: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "foo",
+                    If {
+                        condition: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "foo",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 61,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "Bar",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 67,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 61,
-                                byte_length: 3,
+                                byte_length: 9,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Identifier {
-                            value: "Bar",
+                        consequence: Block {
+                            items: [
+                                Identifier {
+                                    value: "x",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 73,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ],
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 67,
-                                byte_length: 3,
+                                byte_offset: 71,
+                                byte_length: 5,
                             },
-                            binding_id: None,
-                            qualified: None,
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Integer {
+                                        value: 0,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 84,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 82,
+                                byte_length: 5,
+                            },
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 61,
-                            byte_length: 9,
+                            byte_offset: 58,
+                            byte_length: 29,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Identifier {
-                                value: "x",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 73,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 71,
-                            byte_length: 5,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Integer {
-                                    value: 0,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 84,
-                                    byte_length: 1,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 82,
-                            byte_length: 5,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 58,
-                        byte_length: 29,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 78,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 78,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_in_binary_rhs_allowed_outside_control_flow.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_binary_rhs_allowed_outside_control_flow.snap
@@ -25,163 +25,155 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 11,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 34,
+                                byte_offset: 25,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 3,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 1,
+                            byte_offset: 15,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 3,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 1,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 30,
+                            byte_length: 9,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 9,
-                    },
-                },
-                Binary {
-                    operator: LessThan,
-                    left: Identifier {
-                        value: "foo",
+                    Binary {
+                        operator: LessThan,
+                        left: Identifier {
+                            value: "foo",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 43,
+                                byte_length: 3,
+                            },
+                            resolution: Unresolved,
+                        },
+                        right: StructCall {
+                            name: "Bar",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 55,
+                                        byte_length: 1,
+                                    },
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 55,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 49,
+                                byte_length: 9,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 43,
-                            byte_length: 3,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    right: StructCall {
-                        name: "Bar",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 55,
-                                    byte_length: 1,
-                                },
-                                value: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 55,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            },
-                        ],
-                        spread: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 49,
-                            byte_length: 9,
+                            byte_length: 15,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 15,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 49,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 49,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_in_comparison_rhs_with_body_after.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_comparison_rhs_with_body_after.snap
@@ -84,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -95,100 +94,154 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 55,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 55,
+                                byte_offset: 59,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 59,
-                            byte_length: 1,
+                            byte_offset: 51,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 51,
-                        byte_length: 9,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: Equal,
-                        left: Identifier {
-                            value: "other",
+                    If {
+                        condition: Binary {
+                            operator: Equal,
+                            left: Identifier {
+                                value: "other",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 67,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: StructCall {
+                                name: "Point",
+                                field_assignments: [
+                                    StructFieldAssignment {
+                                        name: "x",
+                                        name_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 84,
+                                            byte_length: 1,
+                                        },
+                                        value: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 84,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 76,
+                                    byte_length: 11,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 67,
-                                byte_length: 5,
+                                byte_length: 20,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: StructCall {
-                            name: "Point",
-                            field_assignments: [
-                                StructFieldAssignment {
-                                    name: "x",
-                                    name_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 84,
-                                        byte_length: 1,
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                    value: Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 84,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 90,
+                                        byte_length: 4,
                                     },
                                 },
                             ],
-                            spread: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 76,
-                                byte_length: 11,
+                                byte_offset: 88,
+                                byte_length: 8,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 104,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 102,
+                                byte_length: 9,
                             },
                         },
                         ty: Var {
@@ -196,79 +249,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 67,
-                            byte_length: 20,
+                            byte_offset: 64,
+                            byte_length: 47,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 90,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 88,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 104,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 102,
-                            byte_length: 9,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 64,
-                        byte_length: 47,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 66,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 66,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_in_logical_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_logical_rhs_allowed.snap
@@ -85,7 +85,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -96,166 +95,215 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 55,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 55,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Boolean(
-                            true,
-                        ),
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 61,
-                            byte_length: 4,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 51,
-                        byte_length: 14,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 73,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 77,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 69,
-                        byte_length: 9,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: And,
-                        left: Identifier {
-                            value: "foo",
+                        value: Literal {
+                            literal: Boolean(
+                                true,
+                            ),
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 85,
-                                byte_length: 3,
+                                byte_offset: 61,
+                                byte_length: 4,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Binary {
-                            operator: Equal,
-                            left: StructCall {
-                                name: "Point",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "x",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 100,
-                                            byte_length: 1,
-                                        },
-                                        value: Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 51,
+                            byte_length: 14,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 73,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 77,
+                                byte_length: 1,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 69,
+                            byte_length: 9,
+                        },
+                    },
+                    If {
+                        condition: Binary {
+                            operator: And,
+                            left: Identifier {
+                                value: "foo",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 85,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Binary {
+                                operator: Equal,
+                                left: StructCall {
+                                    name: "Point",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "x",
+                                            name_span: Span {
                                                 file_id: 0,
                                                 byte_offset: 100,
                                                 byte_length: 1,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            value: Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 100,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 92,
+                                        byte_length: 11,
+                                    },
+                                },
+                                right: Identifier {
+                                    value: "other",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 107,
+                                        byte_length: 5,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 92,
-                                    byte_length: 11,
+                                    byte_length: 20,
                                 },
-                            },
-                            right: Identifier {
-                                value: "other",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 107,
-                                    byte_length: 5,
-                                },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 92,
-                                byte_length: 20,
+                                byte_offset: 85,
+                                byte_length: 27,
+                            },
+                        },
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 115,
+                                        byte_length: 4,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 113,
+                                byte_length: 8,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 129,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 127,
+                                byte_length: 9,
                             },
                         },
                         ty: Var {
@@ -263,79 +311,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 85,
-                            byte_length: 27,
+                            byte_offset: 82,
+                            byte_length: 54,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 115,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 113,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 129,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 127,
-                            byte_length: 9,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 82,
-                        byte_length: 54,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 91,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 91,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_in_nested_if_condition.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_nested_if_condition.snap
@@ -84,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -109,7 +108,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -120,192 +118,194 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 65,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 65,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 69,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 61,
-                        byte_length: 9,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "ok",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 78,
-                                byte_length: 2,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "foo",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 83,
-                                byte_length: 3,
+                                byte_offset: 69,
+                                byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: If {
-                            condition: Binary {
-                                operator: Equal,
-                                left: StructCall {
-                                    name: "Point",
-                                    field_assignments: [
-                                        StructFieldAssignment {
-                                            name: "x",
-                                            name_span: Span {
-                                                file_id: 0,
-                                                byte_offset: 100,
-                                                byte_length: 1,
-                                            },
-                                            value: Identifier {
-                                                value: "x",
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 61,
+                            byte_length: 9,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "ok",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 78,
+                                    byte_length: 2,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "foo",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 83,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: If {
+                                condition: Binary {
+                                    operator: Equal,
+                                    left: StructCall {
+                                        name: "Point",
+                                        field_assignments: [
+                                            StructFieldAssignment {
+                                                name: "x",
+                                                name_span: Span {
                                                     file_id: 0,
                                                     byte_offset: 100,
                                                     byte_length: 1,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
+                                                value: Identifier {
+                                                    value: "x",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 100,
+                                                        byte_length: 1,
+                                                    },
+                                                    resolution: Unresolved,
+                                                },
                                             },
+                                        ],
+                                        spread: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
-                                    ],
-                                    spread: None,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 92,
+                                            byte_length: 11,
+                                        },
+                                    },
+                                    right: Identifier {
+                                        value: "other",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 107,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 92,
-                                        byte_length: 11,
+                                        byte_length: 20,
                                     },
                                 },
-                                right: Identifier {
-                                    value: "other",
+                                consequence: Block {
+                                    items: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 115,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 107,
+                                        byte_offset: 113,
                                         byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 92,
-                                    byte_length: 20,
-                                },
-                            },
-                            consequence: Block {
-                                items: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
+                                alternative: Block {
+                                    items: [
+                                        Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 126,
+                                                byte_length: 1,
+                                            },
                                         },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 115,
-                                            byte_length: 1,
-                                        },
+                                    ],
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 113,
-                                    byte_length: 5,
-                                },
-                            },
-                            alternative: Block {
-                                items: [
-                                    Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 126,
-                                            byte_length: 1,
-                                        },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 124,
+                                        byte_length: 5,
                                     },
-                                ],
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 124,
-                                    byte_length: 5,
+                                    byte_offset: 89,
+                                    byte_length: 40,
                                 },
                             },
                             ty: Var {
@@ -313,42 +313,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 89,
-                                byte_length: 40,
+                                byte_offset: 83,
+                                byte_length: 46,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 83,
-                            byte_length: 46,
+                            byte_offset: 74,
+                            byte_length: 55,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 74,
-                        byte_length: 55,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 57,
+                    byte_length: 75,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 57,
-                byte_length: 75,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/shorthand_struct_in_parenthesized_condition.snap
+++ b/tests/spec/parse/snapshots/shorthand_struct_in_parenthesized_condition.snap
@@ -84,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -95,190 +94,186 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 55,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 59,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 51,
-                        byte_length: 9,
-                    },
-                },
-                If {
-                    condition: Paren {
-                        expression: Binary {
-                            operator: Equal,
-                            left: StructCall {
-                                name: "Point",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "x",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 76,
-                                            byte_length: 1,
-                                        },
-                                        value: Identifier {
-                                            value: "x",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 76,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 68,
-                                    byte_length: 11,
+                                    byte_offset: 55,
+                                    byte_length: 1,
                                 },
                             },
-                            right: Identifier {
-                                value: "other",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 83,
-                                    byte_length: 5,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 68,
-                                byte_length: 20,
+                                byte_offset: 59,
+                                byte_length: 1,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 67,
-                            byte_length: 22,
-                        },
-                    },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 92,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 90,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 106,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 104,
+                            byte_offset: 51,
                             byte_length: 9,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
+                    If {
+                        condition: Paren {
+                            expression: Binary {
+                                operator: Equal,
+                                left: StructCall {
+                                    name: "Point",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "x",
+                                            name_span: Span {
+                                                file_id: 0,
+                                                byte_offset: 76,
+                                                byte_length: 1,
+                                            },
+                                            value: Identifier {
+                                                value: "x",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 76,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 68,
+                                        byte_length: 11,
+                                    },
+                                },
+                                right: Identifier {
+                                    value: "other",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 83,
+                                        byte_length: 5,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 68,
+                                    byte_length: 20,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 67,
+                                byte_length: 22,
+                            },
+                        },
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 92,
+                                        byte_length: 4,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 90,
+                                byte_length: 8,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 106,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 104,
+                                byte_length: 9,
+                            },
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 64,
+                            byte_length: 49,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 64,
-                        byte_length: 49,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 47,
+                    byte_length: 68,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 47,
-                byte_length: 68,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/slice_pattern_empty.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_empty.snap
@@ -51,7 +51,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -62,150 +61,147 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [],
-                                rest: Absent,
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 2,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [],
+                                    rest: Absent,
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 56,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "empty",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 62,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 56,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "empty",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 62,
-                                            byte_length: 7,
+                                            byte_offset: 81,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 56,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "not empty",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 87,
+                                                byte_length: 11,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 81,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "not empty",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 87,
-                                            byte_length: 11,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 81,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 72,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 72,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 78,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 78,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/slice_pattern_rest_only.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_rest_only.snap
@@ -50,7 +50,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -61,105 +60,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [],
-                                rest: Discard(
-                                    Span {
-                                        file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 2,
-                                    },
-                                ),
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 4,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [],
+                                    rest: Discard(
+                                        Span {
+                                            file_id: 0,
+                                            byte_offset: 51,
+                                            byte_length: 2,
+                                        },
+                                    ),
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 4,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 58,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "any slice",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 11,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 58,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "any slice",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 11,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 49,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 49,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 55,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 55,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/slice_pattern_single.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_single.snap
@@ -51,7 +51,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -62,172 +61,168 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [
-                                    Identifier {
-                                        identifier: "x",
+                        arms: [
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [
+                                        Identifier {
+                                            identifier: "x",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 51,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
+                                    rest: Absent,
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 3,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 51,
-                                            byte_length: 1,
+                                            byte_offset: 57,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: Absent,
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 3,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "single",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 63,
+                                                byte_length: 8,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 73,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 57,
-                                        byte_length: 5,
+                                        byte_length: 18,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "single",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: WildCard {
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 81,
+                                        byte_length: 1,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 63,
-                                            byte_length: 8,
+                                            byte_offset: 86,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "other",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 92,
+                                                byte_length: 7,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 73,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 57,
-                                    byte_length: 18,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: WildCard {
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 81,
-                                    byte_length: 1,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 86,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "other",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 92,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 86,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 73,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 73,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 79,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 79,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/slice_pattern_suffix.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_suffix.snap
@@ -51,7 +51,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -62,175 +61,169 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [],
-                                rest: Bind {
-                                    name: "init",
+                        arms: [
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [],
+                                    rest: Bind {
+                                        name: "init",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 4,
+                                        },
+                                    },
+                                    resolution: Unresolved,
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 4,
+                                        byte_offset: 50,
+                                        byte_length: 14,
                                     },
                                 },
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 14,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 68,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "last is",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 74,
+                                                byte_length: 9,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "last",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 85,
+                                                byte_length: 4,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 68,
-                                        byte_length: 5,
+                                        byte_length: 22,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "last is",
-                                            raw: false,
-                                        },
+                            },
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [],
+                                    rest: Absent,
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 96,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 74,
-                                            byte_length: 9,
+                                            byte_offset: 102,
+                                            byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                    Identifier {
-                                        value: "last",
-                                        ty: Var {
-                                            id: uninferred,
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "empty",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 108,
+                                                byte_length: 7,
+                                            },
                                         },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 85,
-                                            byte_length: 4,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 68,
-                                    byte_length: 22,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [],
-                                rest: Absent,
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 96,
-                                    byte_length: 2,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 102,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "empty",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 108,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 102,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 89,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 89,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 95,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 95,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
+++ b/tests/spec/parse/snapshots/slice_pattern_with_rest.snap
@@ -51,7 +51,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -62,184 +61,178 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Match {
-                    subject: Identifier {
-                        value: "items",
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 38,
-                            byte_length: 5,
-                        },
-                        binding_id: None,
-                        qualified: None,
-                    },
-                    arms: [
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [],
-                                rest: Absent,
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 2,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Match {
+                        subject: Identifier {
+                            value: "items",
+                            ty: Var {
+                                id: uninferred,
                             },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 38,
+                                byte_length: 5,
+                            },
+                            resolution: Unresolved,
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [],
+                                    rest: Absent,
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 2,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 56,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "empty",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 62,
+                                                byte_length: 7,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 56,
-                                        byte_length: 5,
+                                        byte_length: 14,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "empty",
-                                            raw: false,
+                            },
+                            MatchArm {
+                                pattern: Slice {
+                                    prefix: [
+                                        Identifier {
+                                            identifier: "first",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 77,
+                                                byte_length: 5,
+                                            },
                                         },
+                                    ],
+                                    rest: Bind {
+                                        name: "rest",
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 86,
+                                            byte_length: 4,
+                                        },
+                                    },
+                                    resolution: Unresolved,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 76,
+                                        byte_length: 15,
+                                    },
+                                },
+                                expression: Call {
+                                    expression: Identifier {
+                                        value: "print",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 62,
-                                            byte_length: 7,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 56,
-                                    byte_length: 14,
-                                },
-                                call_kind: None,
-                            },
-                        },
-                        MatchArm {
-                            pattern: Slice {
-                                prefix: [
-                                    Identifier {
-                                        identifier: "first",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 77,
+                                            byte_offset: 95,
                                             byte_length: 5,
                                         },
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                rest: Bind {
-                                    name: "rest",
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 86,
-                                        byte_length: 4,
-                                    },
-                                },
-                                element_ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 76,
-                                    byte_length: 15,
-                                },
-                            },
-                            expression: Call {
-                                expression: Identifier {
-                                    value: "print",
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "head",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 101,
+                                                byte_length: 6,
+                                            },
+                                        },
+                                        Identifier {
+                                            value: "first",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 109,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 95,
-                                        byte_length: 5,
+                                        byte_length: 20,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "head",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 101,
-                                            byte_length: 6,
-                                        },
-                                    },
-                                    Identifier {
-                                        value: "first",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 109,
-                                            byte_length: 5,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 95,
-                                    byte_length: 20,
-                                },
-                                call_kind: None,
                             },
+                        ],
+                        ty: Var {
+                            id: uninferred,
                         },
-                    ],
-                    ty: Var {
-                        id: uninferred,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 88,
+                        },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 32,
-                        byte_length: 88,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 28,
+                    byte_length: 94,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 28,
-                byte_length: 94,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/spread_struct_in_binary_rhs_allowed.snap
+++ b/tests/spec/parse/snapshots/spread_struct_in_binary_rhs_allowed.snap
@@ -84,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -95,92 +94,146 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "foo",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "foo",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 56,
+                                byte_length: 1,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 56,
-                            byte_length: 1,
+                            byte_offset: 46,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 46,
-                        byte_length: 11,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "foo",
+                    If {
+                        condition: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "foo",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 64,
+                                    byte_length: 3,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: StructCall {
+                                name: "Bar",
+                                field_assignments: [],
+                                spread: From(
+                                    Identifier {
+                                        value: "base",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 78,
+                                            byte_length: 4,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 70,
+                                    byte_length: 14,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 64,
-                                byte_length: 3,
+                                byte_length: 20,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: StructCall {
-                            name: "Bar",
-                            field_assignments: [],
-                            spread: From(
-                                Identifier {
-                                    value: "base",
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 78,
+                                        byte_offset: 87,
                                         byte_length: 4,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
-                            ),
+                            ],
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 70,
-                                byte_length: 14,
+                                byte_offset: 85,
+                                byte_length: 8,
+                            },
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 101,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 99,
+                                byte_length: 9,
                             },
                         },
                         ty: Var {
@@ -188,79 +241,21 @@ description: |
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 64,
-                            byte_length: 20,
+                            byte_offset: 61,
+                            byte_length: 47,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 87,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 85,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 101,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 99,
-                            byte_length: 9,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 61,
-                        byte_length: 47,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 42,
+                    byte_length: 68,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 42,
-                byte_length: 68,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/standalone_range_to_binding.snap
+++ b/tests/spec/parse/snapshots/standalone_range_to_binding.snap
@@ -21,95 +21,93 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "r",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: Some(
-                            Constructor {
-                                name: "RangeTo",
-                                params: [
-                                    Constructor {
-                                        name: "int",
-                                        params: [],
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 28,
-                                            byte_length: 3,
-                                        },
-                                    },
-                                ],
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "r",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 20,
-                                    byte_length: 12,
-                                },
-                            },
-                        ),
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Range {
-                        start: None,
-                        end: Some(
-                            Literal {
-                                literal: Integer {
-                                    value: 5,
-                                    text: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
                             },
-                        ),
-                        inclusive: false,
+                            annotation: Some(
+                                Constructor {
+                                    name: "RangeTo",
+                                    params: [
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 28,
+                                                byte_length: 3,
+                                            },
+                                        },
+                                    ],
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 20,
+                                        byte_length: 12,
+                                    },
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Range {
+                            start: None,
+                            end: Some(
+                                Literal {
+                                    literal: Integer {
+                                        value: 5,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ),
+                            inclusive: false,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 35,
+                                byte_length: 3,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 35,
-                            byte_length: 3,
+                            byte_offset: 13,
+                            byte_length: 25,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 25,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_autofill_only.snap
+++ b/tests/spec/parse/snapshots/struct_autofill_only.snap
@@ -21,66 +21,64 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [],
-                        spread: Autofill {
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [],
+                            spread: Autofill {
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 2,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 2,
+                                byte_offset: 21,
+                                byte_length: 12,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 12,
+                            byte_offset: 13,
+                            byte_length: 20,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 25,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 25,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_autofill_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/struct_autofill_trailing_comma.snap
@@ -21,89 +21,87 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 29,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 32,
-                                        byte_length: 1,
-                                    },
-                                },
                             },
-                        ],
-                        spread: Autofill {
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 2,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 32,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: Autofill {
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 2,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 19,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 19,
+                            byte_offset: 13,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_autofill_with_fields.snap
+++ b/tests/spec/parse/snapshots/struct_autofill_with_fields.snap
@@ -21,89 +21,87 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 29,
+                                    byte_offset: 17,
                                     byte_length: 1,
                                 },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 32,
-                                        byte_length: 1,
-                                    },
-                                },
                             },
-                        ],
-                        spread: Autofill {
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 2,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 32,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: Autofill {
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 2,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 21,
+                                byte_length: 18,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 21,
-                            byte_length: 18,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_in_if_condition.snap
+++ b/tests/spec/parse/snapshots/struct_in_if_condition.snap
@@ -84,7 +84,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -103,180 +102,176 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 63,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 1,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 63,
+                                byte_offset: 67,
                                 byte_length: 1,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 1,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 67,
-                            byte_length: 1,
+                            byte_offset: 59,
+                            byte_length: 9,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 59,
-                        byte_length: 9,
-                    },
-                },
-                If {
-                    condition: Binary {
-                        operator: Equal,
-                        left: StructCall {
-                            name: "Point",
-                            field_assignments: [
-                                StructFieldAssignment {
-                                    name: "x",
-                                    name_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 83,
-                                        byte_length: 1,
-                                    },
-                                    value: Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
+                    If {
+                        condition: Binary {
+                            operator: Equal,
+                            left: StructCall {
+                                name: "Point",
+                                field_assignments: [
+                                    StructFieldAssignment {
+                                        name: "x",
+                                        name_span: Span {
                                             file_id: 0,
                                             byte_offset: 83,
                                             byte_length: 1,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        value: Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 83,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
                                     },
+                                ],
+                                spread: None,
+                                ty: Var {
+                                    id: uninferred,
                                 },
-                            ],
-                            spread: None,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 75,
+                                    byte_length: 11,
+                                },
+                            },
+                            right: Identifier {
+                                value: "other",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 90,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 75,
-                                byte_length: 11,
+                                byte_length: 20,
                             },
                         },
-                        right: Identifier {
-                            value: "other",
+                        consequence: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        true,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 98,
+                                        byte_length: 4,
+                                    },
+                                },
+                            ],
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 90,
-                                byte_length: 5,
+                                byte_offset: 96,
+                                byte_length: 8,
                             },
-                            binding_id: None,
-                            qualified: None,
+                        },
+                        alternative: Block {
+                            items: [
+                                Literal {
+                                    literal: Boolean(
+                                        false,
+                                    ),
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 112,
+                                        byte_length: 5,
+                                    },
+                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 110,
+                                byte_length: 9,
+                            },
                         },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 75,
-                            byte_length: 20,
+                            byte_offset: 72,
+                            byte_length: 47,
                         },
                     },
-                    consequence: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    true,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 98,
-                                    byte_length: 4,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 96,
-                            byte_length: 8,
-                        },
-                    },
-                    alternative: Block {
-                        items: [
-                            Literal {
-                                literal: Boolean(
-                                    false,
-                                ),
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 112,
-                                    byte_length: 5,
-                                },
-                            },
-                        ],
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 110,
-                            byte_length: 9,
-                        },
-                    },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 72,
-                        byte_length: 47,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 55,
+                    byte_length: 66,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 55,
-                byte_length: 66,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_in_match_subject.snap
+++ b/tests/spec/parse/snapshots/struct_in_match_subject.snap
@@ -79,148 +79,145 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: Literal {
+                            literal: Integer {
+                                value: 42,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 54,
+                                byte_length: 2,
+                            },
                         },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 42,
-                            text: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 54,
-                            byte_length: 2,
+                            byte_offset: 46,
+                            byte_length: 10,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 46,
-                        byte_length: 10,
-                    },
-                },
-                Match {
-                    subject: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 74,
-                                    byte_length: 1,
+                    Match {
+                        subject: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 74,
+                                        byte_length: 1,
+                                    },
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 74,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                 },
-                                value: Identifier {
-                                    value: "x",
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 66,
+                                byte_length: 11,
+                            },
+                        },
+                        arms: [
+                            MatchArm {
+                                pattern: Struct {
+                                    identifier: "Point",
+                                    fields: [
+                                        StructFieldPattern {
+                                            name: "x",
+                                            value: Identifier {
+                                                identifier: "val",
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 95,
+                                                    byte_length: 3,
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    rest: false,
+                                    resolution: Unresolved,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 74,
-                                        byte_length: 1,
+                                        byte_offset: 84,
+                                        byte_length: 16,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                },
+                                expression: Identifier {
+                                    value: "val",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 104,
+                                        byte_length: 3,
+                                    },
+                                    resolution: Unresolved,
                                 },
                             },
                         ],
-                        spread: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 66,
-                            byte_length: 11,
+                            byte_offset: 60,
+                            byte_length: 52,
                         },
                     },
-                    arms: [
-                        MatchArm {
-                            pattern: Struct {
-                                identifier: "Point",
-                                fields: [
-                                    StructFieldPattern {
-                                        name: "x",
-                                        value: Identifier {
-                                            identifier: "val",
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 95,
-                                                byte_length: 3,
-                                            },
-                                        },
-                                    },
-                                ],
-                                rest: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 84,
-                                    byte_length: 16,
-                                },
-                            },
-                            expression: Identifier {
-                                value: "val",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 104,
-                                    byte_length: 3,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                        },
-                    ],
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 60,
-                        byte_length: 52,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 42,
+                    byte_length: 72,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 42,
-                byte_length: 72,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_init_operand.snap
+++ b/tests/spec/parse/snapshots/struct_init_operand.snap
@@ -21,132 +21,129 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Call {
-                        expression: DotAccess {
-                            expression: StructCall {
-                                name: "Point",
-                                field_assignments: [
-                                    StructFieldAssignment {
-                                        name: "x",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 34,
-                                            byte_length: 1,
-                                        },
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 1,
-                                                text: None,
-                                            },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                        value: Call {
+                            expression: DotAccess {
+                                expression: StructCall {
+                                    name: "Point",
+                                    field_assignments: [
+                                        StructFieldAssignment {
+                                            name: "x",
+                                            name_span: Span {
                                                 file_id: 0,
-                                                byte_offset: 37,
+                                                byte_offset: 34,
                                                 byte_length: 1,
                                             },
-                                        },
-                                    },
-                                    StructFieldAssignment {
-                                        name: "y",
-                                        name_span: Span {
-                                            file_id: 0,
-                                            byte_offset: 40,
-                                            byte_length: 1,
-                                        },
-                                        value: Literal {
-                                            literal: Integer {
-                                                value: 2,
-                                                text: None,
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 1,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 37,
+                                                    byte_length: 1,
+                                                },
                                             },
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
+                                        },
+                                        StructFieldAssignment {
+                                            name: "y",
+                                            name_span: Span {
                                                 file_id: 0,
-                                                byte_offset: 43,
+                                                byte_offset: 40,
                                                 byte_length: 1,
                                             },
+                                            value: Literal {
+                                                literal: Integer {
+                                                    value: 2,
+                                                    text: None,
+                                                },
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 43,
+                                                    byte_length: 1,
+                                                },
+                                            },
                                         },
+                                    ],
+                                    spread: None,
+                                    ty: Var {
+                                        id: uninferred,
                                     },
-                                ],
-                                spread: None,
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 26,
+                                        byte_length: 20,
+                                    },
+                                },
+                                member: "distance",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 26,
-                                    byte_length: 20,
+                                    byte_length: 29,
                                 },
+                                resolution: Unresolved,
                             },
-                            member: "distance",
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 29,
+                                byte_length: 31,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 31,
+                            byte_offset: 13,
+                            byte_length: 44,
                         },
-                        call_kind: None,
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 44,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 49,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 49,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_as_arg.snap
+++ b/tests/spec/parse/snapshots/struct_literal_as_arg.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,103 +48,103 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Call {
-                    expression: Identifier {
-                        value: "process",
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "process",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 25,
+                                byte_length: 7,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            StructCall {
+                                name: "Point",
+                                field_assignments: [
+                                    StructFieldAssignment {
+                                        name: "x",
+                                        name_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 41,
+                                            byte_length: 1,
+                                        },
+                                        value: Identifier {
+                                            value: "x_val",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 44,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    },
+                                    StructFieldAssignment {
+                                        name: "y",
+                                        name_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 51,
+                                            byte_length: 1,
+                                        },
+                                        value: Literal {
+                                            literal: Integer {
+                                                value: 0,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 54,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    },
+                                ],
+                                spread: None,
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 24,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
                             byte_offset: 25,
-                            byte_length: 7,
+                            byte_length: 33,
                         },
-                        binding_id: None,
-                        qualified: None,
+                        call_kind: None,
                     },
-                    args: [
-                        StructCall {
-                            name: "Point",
-                            field_assignments: [
-                                StructFieldAssignment {
-                                    name: "x",
-                                    name_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 41,
-                                        byte_length: 1,
-                                    },
-                                    value: Identifier {
-                                        value: "x_val",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 44,
-                                            byte_length: 5,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                },
-                                StructFieldAssignment {
-                                    name: "y",
-                                    name_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 1,
-                                    },
-                                    value: Literal {
-                                        literal: Integer {
-                                            value: 0,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 54,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                },
-                            ],
-                            spread: None,
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 24,
-                            },
-                        },
-                    ],
-                    spread: None,
-                    type_arguments: None,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 33,
-                    },
-                    call_kind: None,
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 40,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 40,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_empty.snap
+++ b/tests/spec/parse/snapshots/struct_literal_empty.snap
@@ -23,60 +23,58 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "e",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "e",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
+                        value: StructCall {
+                            name: "Empty",
+                            field_assignments: [],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 23,
+                                byte_length: 8,
+                            },
                         },
-                    },
-                    value: StructCall {
-                        name: "Empty",
-                        field_assignments: [],
-                        spread: None,
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 8,
+                            byte_offset: 15,
+                            byte_length: 16,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 16,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 23,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_mixed.snap
+++ b/tests/spec/parse/snapshots/struct_literal_mixed.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,118 +72,114 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 38,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 50,
+                                    byte_offset: 38,
                                     byte_length: 1,
                                 },
-                                value: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
                                         file_id: 0,
                                         byte_offset: 50,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            },
-                            StructFieldAssignment {
-                                name: "y",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 53,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 10,
-                                        text: None,
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 50,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
                                     },
+                                },
+                                StructFieldAssignment {
+                                    name: "y",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 53,
+                                        byte_length: 1,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 10,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 56,
+                                            byte_length: 2,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: From(
+                                Identifier {
+                                    value: "base",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 56,
-                                        byte_length: 2,
+                                        byte_offset: 62,
+                                        byte_length: 4,
                                     },
+                                    resolution: Unresolved,
                                 },
+                            ),
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: From(
-                            Identifier {
-                                value: "base",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 62,
-                                    byte_length: 4,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 42,
+                                byte_length: 26,
                             },
-                        ),
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 26,
+                            byte_offset: 34,
+                            byte_length: 34,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 34,
-                        byte_length: 34,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 30,
+                    byte_length: 41,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 30,
-                byte_length: 41,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_nested.snap
+++ b/tests/spec/parse/snapshots/struct_literal_nested.snap
@@ -41,7 +41,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -52,148 +51,145 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "data",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 4,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "data",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 4,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Data",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "id",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 47,
-                                    byte_length: 2,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
-                                    },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
+                        value: StructCall {
+                            name: "Data",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "id",
+                                    name_span: Span {
                                         file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 1,
+                                        byte_offset: 47,
+                                        byte_length: 2,
+                                    },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 51,
+                                            byte_length: 1,
+                                        },
                                     },
                                 },
-                            },
-                            StructFieldAssignment {
-                                name: "payload",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 58,
-                                    byte_length: 7,
-                                },
-                                value: StructCall {
-                                    name: "Payload",
-                                    field_assignments: [
-                                        StructFieldAssignment {
-                                            name: "user",
-                                            name_span: Span {
-                                                file_id: 0,
-                                                byte_offset: 77,
-                                                byte_length: 4,
-                                            },
-                                            value: Identifier {
-                                                value: "user",
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
+                                StructFieldAssignment {
+                                    name: "payload",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 58,
+                                        byte_length: 7,
+                                    },
+                                    value: StructCall {
+                                        name: "Payload",
+                                        field_assignments: [
+                                            StructFieldAssignment {
+                                                name: "user",
+                                                name_span: Span {
                                                     file_id: 0,
                                                     byte_offset: 77,
                                                     byte_length: 4,
                                                 },
-                                                binding_id: None,
-                                                qualified: None,
-                                            },
-                                        },
-                                        StructFieldAssignment {
-                                            name: "status",
-                                            name_span: Span {
-                                                file_id: 0,
-                                                byte_offset: 83,
-                                                byte_length: 6,
-                                            },
-                                            value: Literal {
-                                                literal: String {
-                                                    value: "active",
-                                                    raw: false,
+                                                value: Identifier {
+                                                    value: "user",
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 77,
+                                                        byte_length: 4,
+                                                    },
+                                                    resolution: Unresolved,
                                                 },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
+                                            },
+                                            StructFieldAssignment {
+                                                name: "status",
+                                                name_span: Span {
                                                     file_id: 0,
-                                                    byte_offset: 91,
-                                                    byte_length: 8,
+                                                    byte_offset: 83,
+                                                    byte_length: 6,
+                                                },
+                                                value: Literal {
+                                                    literal: String {
+                                                        value: "active",
+                                                        raw: false,
+                                                    },
+                                                    ty: Var {
+                                                        id: uninferred,
+                                                    },
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 91,
+                                                        byte_length: 8,
+                                                    },
                                                 },
                                             },
+                                        ],
+                                        spread: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
-                                    ],
-                                    spread: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 67,
-                                        byte_length: 34,
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 67,
+                                            byte_length: 34,
+                                        },
                                     },
                                 },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 36,
+                                byte_length: 70,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 70,
+                            byte_offset: 25,
+                            byte_length: 81,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 81,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 88,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 88,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_shorthand.snap
+++ b/tests/spec/parse/snapshots/struct_literal_shorthand.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,103 +72,99 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 45,
+                                    byte_offset: 33,
                                     byte_length: 1,
                                 },
-                                value: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
                                         file_id: 0,
                                         byte_offset: 45,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            },
-                            StructFieldAssignment {
-                                name: "y",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 48,
-                                    byte_length: 1,
-                                },
-                                value: Identifier {
-                                    value: "y",
-                                    ty: Var {
-                                        id: uninferred,
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 45,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                    span: Span {
+                                },
+                                StructFieldAssignment {
+                                    name: "y",
+                                    name_span: Span {
                                         file_id: 0,
                                         byte_offset: 48,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    value: Identifier {
+                                        value: "y",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 48,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                 },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 14,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 14,
+                            byte_offset: 29,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_literal_spread.snap
+++ b/tests/spec/parse/snapshots/struct_literal_spread.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,96 +48,93 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "cfg",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 3,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "cfg",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 3,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Config",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "enabled",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 50,
-                                    byte_length: 7,
+                        value: StructCall {
+                            name: "Config",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "enabled",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 50,
+                                        byte_length: 7,
+                                    },
+                                    value: Literal {
+                                        literal: Boolean(
+                                            true,
+                                        ),
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 59,
+                                            byte_length: 4,
+                                        },
+                                    },
                                 },
-                                value: Literal {
-                                    literal: Boolean(
-                                        true,
-                                    ),
+                            ],
+                            spread: From(
+                                Identifier {
+                                    value: "defaults",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 59,
-                                        byte_length: 4,
+                                        byte_offset: 67,
+                                        byte_length: 8,
                                     },
+                                    resolution: Unresolved,
                                 },
+                            ),
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: From(
-                            Identifier {
-                                value: "defaults",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 67,
-                                    byte_length: 8,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 41,
+                                byte_length: 36,
                             },
-                        ),
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 41,
-                            byte_length: 36,
+                            byte_offset: 31,
+                            byte_length: 46,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 46,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 53,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 53,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_shorthand_syntax.snap
+++ b/tests/spec/parse/snapshots/struct_shorthand_syntax.snap
@@ -25,189 +25,177 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 10,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 10,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "y",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 20,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 37,
-                            byte_length: 2,
-                        },
-                    },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 10,
-                    },
-                },
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 6,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
                                     file_id: 0,
-                                    byte_offset: 64,
+                                    byte_offset: 19,
                                     byte_length: 1,
                                 },
-                                value: Identifier {
-                                    value: "x",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 10,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 23,
+                                byte_length: 2,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 10,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "y",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Literal {
+                            literal: Integer {
+                                value: 20,
+                                text: None,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 37,
+                                byte_length: 2,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 29,
+                            byte_length: 10,
+                        },
+                    },
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
                                         file_id: 0,
                                         byte_offset: 64,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                            },
-                            StructFieldAssignment {
-                                name: "y",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 67,
-                                    byte_length: 1,
-                                },
-                                value: Identifier {
-                                    value: "y",
-                                    ty: Var {
-                                        id: uninferred,
+                                    value: Identifier {
+                                        value: "x",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 64,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                    span: Span {
+                                },
+                                StructFieldAssignment {
+                                    name: "y",
+                                    name_span: Span {
                                         file_id: 0,
                                         byte_offset: 67,
                                         byte_length: 1,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    value: Identifier {
+                                        value: "y",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 67,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                 },
+                            ],
+                            spread: None,
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 56,
+                                byte_length: 14,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 56,
-                            byte_length: 14,
+                            byte_offset: 43,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 43,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 62,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 62,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_spread_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/struct_spread_trailing_comma.snap
@@ -36,7 +36,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -47,74 +46,71 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "p",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 28,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [],
-                        spread: From(
-                            Identifier {
-                                value: "base",
-                                ty: Var {
-                                    id: uninferred,
-                                },
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "p",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 42,
-                                    byte_length: 4,
+                                    byte_offset: 28,
+                                    byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
-                        ),
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [],
+                            spread: From(
+                                Identifier {
+                                    value: "base",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 42,
+                                        byte_length: 4,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                            ),
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 32,
+                                byte_length: 17,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 32,
-                            byte_length: 17,
+                            byte_offset: 24,
+                            byte_length: 25,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 24,
-                        byte_length: 25,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 22,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 22,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/struct_update_syntax.snap
+++ b/tests/spec/parse/snapshots/struct_update_syntax.snap
@@ -21,97 +21,94 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: StructCall {
-                        name: "Point",
-                        field_assignments: [
-                            StructFieldAssignment {
-                                name: "x",
-                                name_span: Span {
-                                    file_id: 0,
-                                    byte_offset: 34,
-                                    byte_length: 1,
-                                },
-                                value: Literal {
-                                    literal: Integer {
-                                        value: 1,
-                                        text: None,
+                        value: StructCall {
+                            name: "Point",
+                            field_assignments: [
+                                StructFieldAssignment {
+                                    name: "x",
+                                    name_span: Span {
+                                        file_id: 0,
+                                        byte_offset: 34,
+                                        byte_length: 1,
                                     },
+                                    value: Literal {
+                                        literal: Integer {
+                                            value: 1,
+                                            text: None,
+                                        },
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 37,
+                                            byte_length: 1,
+                                        },
+                                    },
+                                },
+                            ],
+                            spread: From(
+                                Identifier {
+                                    value: "base_point",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 37,
-                                        byte_length: 1,
+                                        byte_offset: 42,
+                                        byte_length: 10,
                                     },
+                                    resolution: Unresolved,
                                 },
+                            ),
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        spread: From(
-                            Identifier {
-                                value: "base_point",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 42,
-                                    byte_length: 10,
-                                },
-                                binding_id: None,
-                                qualified: None,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 26,
+                                byte_length: 28,
                             },
-                        ),
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 28,
+                            byte_offset: 13,
+                            byte_length: 41,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 41,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/subtraction_of_unary_minus_literal.snap
+++ b/tests/spec/parse/snapshots/subtraction_of_unary_minus_literal.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,53 +48,61 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 25,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 25,
+                                    byte_length: 6,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Identifier {
-                            value: "a",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
                         },
-                        right: Unary {
-                            operator: Negative,
-                            expression: Literal {
-                                literal: Integer {
-                                    value: 1,
-                                    text: None,
+                        value: Binary {
+                            operator: Subtraction,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Unary {
+                                operator: Negative,
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 1,
+                                    },
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 1,
+                                    byte_offset: 36,
+                                    byte_length: 2,
                                 },
                             },
                             ty: Var {
@@ -103,42 +110,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 2,
+                                byte_offset: 34,
+                                byte_length: 4,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 34,
-                            byte_length: 4,
+                            byte_offset: 21,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 17,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/subtraction_of_unary_minus_variable.snap
+++ b/tests/spec/parse/snapshots/subtraction_of_unary_minus_variable.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,95 +72,91 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Subtraction,
-                        left: Identifier {
-                            value: "a",
+                        value: Binary {
+                            operator: Subtraction,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Unary {
+                                operator: Negative,
+                                expression: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 44,
+                                    byte_length: 2,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 42,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        right: Unary {
-                            operator: Negative,
-                            expression: Identifier {
-                                value: "b",
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 45,
-                                    byte_length: 1,
-                                },
-                                binding_id: None,
-                                qualified: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 44,
-                                byte_length: 2,
+                                byte_length: 4,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 4,
+                            byte_offset: 29,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 17,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/task_with_block.snap
+++ b/tests/spec/parse/snapshots/task_with_block.snap
@@ -25,82 +25,83 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Task {
-                    expression: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+        body: Definition(
+            Block {
+                items: [
+                    Task {
+                        expression: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 26,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Literal {
+                                            literal: String {
+                                                value: "concurrent task",
+                                                raw: false,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 17,
+                                            },
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 26,
-                                        byte_length: 5,
+                                        byte_length: 24,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Literal {
-                                        literal: String {
-                                            value: "concurrent task",
-                                            raw: false,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 32,
-                                            byte_length: 17,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 26,
-                                    byte_length: 24,
-                                },
-                                call_kind: None,
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 20,
+                                byte_length: 35,
+                            },
+                        },
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 35,
+                            byte_offset: 15,
+                            byte_length: 40,
                         },
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 40,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 46,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 46,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/task_with_expression.snap
+++ b/tests/spec/parse/snapshots/task_with_expression.snap
@@ -23,55 +23,56 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Task {
-                    expression: Call {
-                        expression: Identifier {
-                            value: "compute",
+        body: Definition(
+            Block {
+                items: [
+                    Task {
+                        expression: Call {
+                            expression: Identifier {
+                                value: "compute",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 20,
+                                    byte_length: 7,
+                                },
+                                resolution: Unresolved,
+                            },
+                            args: [],
+                            spread: None,
+                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 20,
-                                byte_length: 7,
+                                byte_length: 9,
                             },
-                            binding_id: None,
-                            qualified: None,
+                            call_kind: None,
                         },
-                        args: [],
-                        spread: None,
-                        type_arguments: None,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 9,
+                            byte_offset: 15,
+                            byte_length: 14,
                         },
-                        call_kind: None,
                     },
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 14,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 21,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 21,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/try_block_basic.snap
+++ b/tests/spec/parse/snapshots/try_block_basic.snap
@@ -25,101 +25,98 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: TryBlock {
-                        items: [
-                            Propagate {
-                                expression: Call {
-                                    expression: Identifier {
-                                        value: "risky",
+                        value: TryBlock {
+                            items: [
+                                Propagate {
+                                    expression: Call {
+                                        expression: Identifier {
+                                            value: "risky",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 38,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 38,
-                                            byte_length: 5,
+                                            byte_length: 7,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 38,
-                                        byte_length: 7,
+                                        byte_length: 8,
                                     },
-                                    call_kind: None,
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 8,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            try_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 3,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 22,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        try_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 3,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 22,
+                            byte_offset: 15,
+                            byte_length: 35,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 35,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 42,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 42,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/try_block_multiple_statements.snap
+++ b/tests/spec/parse/snapshots/try_block_multiple_statements.snap
@@ -27,233 +27,219 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: TryBlock {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "a",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 42,
-                                            byte_length: 1,
+                        value: TryBlock {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "a",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 42,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: Propagate {
-                                    expression: Call {
-                                        expression: Identifier {
-                                            value: "get_a",
+                                    value: Propagate {
+                                        expression: Call {
+                                            expression: Identifier {
+                                                value: "get_a",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 46,
+                                                    byte_length: 5,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            args: [],
+                                            spread: None,
+                                            type_arguments: None,
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 46,
-                                                byte_length: 5,
+                                                byte_length: 7,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            call_kind: None,
                                         },
-                                        args: [],
-                                        spread: None,
-                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 46,
-                                            byte_length: 7,
+                                            byte_length: 8,
                                         },
-                                        call_kind: None,
                                     },
+                                    mode: Plain,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 46,
-                                        byte_length: 8,
+                                        byte_offset: 38,
+                                        byte_length: 16,
                                     },
                                 },
-                                mut_span: None,
-                                else_block: None,
-                                else_span: None,
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 16,
-                                },
-                            },
-                            Let {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "b",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 64,
-                                            byte_length: 1,
+                                Let {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "b",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 64,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: Propagate {
-                                    expression: Call {
-                                        expression: Identifier {
-                                            value: "get_b",
+                                    value: Propagate {
+                                        expression: Call {
+                                            expression: Identifier {
+                                                value: "get_b",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 68,
+                                                    byte_length: 5,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            args: [],
+                                            spread: None,
+                                            type_arguments: None,
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 68,
-                                                byte_length: 5,
+                                                byte_length: 7,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
+                                            call_kind: None,
                                         },
-                                        args: [],
-                                        spread: None,
-                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 68,
-                                            byte_length: 7,
+                                            byte_length: 8,
                                         },
-                                        call_kind: None,
                                     },
+                                    mode: Plain,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 68,
-                                        byte_length: 8,
+                                        byte_offset: 60,
+                                        byte_length: 16,
                                     },
                                 },
-                                mut_span: None,
-                                else_block: None,
-                                else_span: None,
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 60,
-                                    byte_length: 16,
-                                },
-                            },
-                            Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "a",
+                                Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 82,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 86,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 82,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 86,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 82,
-                                    byte_length: 5,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            try_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 3,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 63,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        try_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 3,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 63,
+                            byte_offset: 15,
+                            byte_length: 76,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 76,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 83,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 83,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/try_block_nested.snap
+++ b/tests/spec/parse/snapshots/try_block_nested.snap
@@ -28,184 +28,176 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "outer",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "outer",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: TryBlock {
-                        items: [
-                            Let {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "inner",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 41,
-                                            byte_length: 5,
+                        value: TryBlock {
+                            items: [
+                                Let {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "inner",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 41,
+                                                byte_length: 5,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                },
-                                value: TryBlock {
-                                    items: [
-                                        Propagate {
-                                            expression: Call {
-                                                expression: Identifier {
-                                                    value: "inner_risky",
+                                    value: TryBlock {
+                                        items: [
+                                            Propagate {
+                                                expression: Call {
+                                                    expression: Identifier {
+                                                        value: "inner_risky",
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 61,
+                                                            byte_length: 11,
+                                                        },
+                                                        resolution: Unresolved,
+                                                    },
+                                                    args: [],
+                                                    spread: None,
+                                                    type_arguments: None,
                                                     ty: Var {
                                                         id: uninferred,
                                                     },
                                                     span: Span {
                                                         file_id: 0,
                                                         byte_offset: 61,
-                                                        byte_length: 11,
+                                                        byte_length: 13,
                                                     },
-                                                    binding_id: None,
-                                                    qualified: None,
+                                                    call_kind: None,
                                                 },
-                                                args: [],
-                                                spread: None,
-                                                type_arguments: None,
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
                                                 span: Span {
                                                     file_id: 0,
                                                     byte_offset: 61,
-                                                    byte_length: 13,
+                                                    byte_length: 14,
                                                 },
-                                                call_kind: None,
                                             },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        try_keyword_span: Span {
+                                            file_id: 0,
+                                            byte_offset: 49,
+                                            byte_length: 3,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 49,
+                                            byte_length: 32,
+                                        },
+                                    },
+                                    mode: Plain,
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 44,
+                                    },
+                                },
+                                Propagate {
+                                    expression: Call {
+                                        expression: Identifier {
+                                            value: "outer_risky",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 61,
-                                                byte_length: 14,
+                                                byte_offset: 87,
+                                                byte_length: 11,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    try_keyword_span: Span {
-                                        file_id: 0,
-                                        byte_offset: 49,
-                                        byte_length: 3,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 49,
-                                        byte_length: 32,
-                                    },
-                                },
-                                mut_span: None,
-                                else_block: None,
-                                else_span: None,
-                                assert: false,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 44,
-                                },
-                            },
-                            Propagate {
-                                expression: Call {
-                                    expression: Identifier {
-                                        value: "outer_risky",
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 87,
-                                            byte_length: 11,
+                                            byte_length: 13,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 87,
-                                        byte_length: 13,
+                                        byte_length: 14,
                                     },
-                                    call_kind: None,
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 87,
-                                    byte_length: 14,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            try_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 3,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 27,
+                                byte_length: 78,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        try_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 3,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 27,
-                            byte_length: 78,
+                            byte_offset: 15,
+                            byte_length: 90,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 90,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 97,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 97,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/try_block_with_control_flow.snap
+++ b/tests/spec/parse/snapshots/try_block_with_control_flow.snap
@@ -30,117 +30,123 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: TryBlock {
-                        items: [
-                            For {
-                                binding: Binding {
-                                    pattern: Identifier {
-                                        identifier: "i",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 42,
-                                            byte_length: 1,
+                        value: TryBlock {
+                            items: [
+                                For {
+                                    binding: Binding {
+                                        pattern: Identifier {
+                                            identifier: "i",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 42,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        annotation: None,
+                                        ty: Var {
+                                            id: uninferred,
                                         },
                                     },
-                                    annotation: None,
-                                    typed_pattern: None,
-                                    ty: Var {
-                                        id: uninferred,
+                                    iterable: Identifier {
+                                        value: "items",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 47,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
                                     },
-                                },
-                                iterable: Identifier {
-                                    value: "items",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 47,
-                                        byte_length: 5,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                body: Block {
-                                    items: [
-                                        If {
-                                            condition: Binary {
-                                                operator: GreaterThan,
-                                                left: Identifier {
-                                                    value: "i",
+                                    body: Block {
+                                        items: [
+                                            If {
+                                                condition: Binary {
+                                                    operator: GreaterThan,
+                                                    left: Identifier {
+                                                        value: "i",
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 64,
+                                                            byte_length: 1,
+                                                        },
+                                                        resolution: Unresolved,
+                                                    },
+                                                    right: Literal {
+                                                        literal: Integer {
+                                                            value: 10,
+                                                            text: None,
+                                                        },
+                                                        ty: Var {
+                                                            id: uninferred,
+                                                        },
+                                                        span: Span {
+                                                            file_id: 0,
+                                                            byte_offset: 68,
+                                                            byte_length: 2,
+                                                        },
+                                                    },
                                                     ty: Var {
                                                         id: uninferred,
                                                     },
                                                     span: Span {
                                                         file_id: 0,
                                                         byte_offset: 64,
-                                                        byte_length: 1,
+                                                        byte_length: 6,
                                                     },
-                                                    binding_id: None,
-                                                    qualified: None,
                                                 },
-                                                right: Literal {
-                                                    literal: Integer {
-                                                        value: 10,
-                                                        text: None,
-                                                    },
+                                                consequence: Block {
+                                                    items: [
+                                                        Break {
+                                                            value: None,
+                                                            span: Span {
+                                                                file_id: 0,
+                                                                byte_offset: 81,
+                                                                byte_length: 5,
+                                                            },
+                                                        },
+                                                    ],
                                                     ty: Var {
                                                         id: uninferred,
                                                     },
                                                     span: Span {
                                                         file_id: 0,
-                                                        byte_offset: 68,
-                                                        byte_length: 2,
+                                                        byte_offset: 71,
+                                                        byte_length: 24,
                                                     },
                                                 },
-                                                ty: Var {
-                                                    id: uninferred,
-                                                },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 64,
-                                                    byte_length: 6,
-                                                },
-                                            },
-                                            consequence: Block {
-                                                items: [
-                                                    Break {
-                                                        value: None,
-                                                        span: Span {
-                                                            file_id: 0,
-                                                            byte_offset: 81,
-                                                            byte_length: 5,
-                                                        },
+                                                alternative: Unit {
+                                                    ty: Var {
+                                                        id: uninferred,
                                                     },
-                                                ],
-                                                ty: Var {
-                                                    id: uninferred,
+                                                    span: Span {
+                                                        file_id: 0,
+                                                        byte_offset: 61,
+                                                        byte_length: 34,
+                                                    },
                                                 },
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 71,
-                                                    byte_length: 24,
-                                                },
-                                            },
-                                            alternative: Unit {
                                                 ty: Var {
                                                     id: uninferred,
                                                 },
@@ -150,107 +156,94 @@ description: |
                                                     byte_length: 34,
                                                 },
                                             },
+                                        ],
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 53,
+                                            byte_length: 48,
+                                        },
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 38,
+                                        byte_length: 63,
+                                    },
+                                },
+                                Propagate {
+                                    expression: Call {
+                                        expression: Identifier {
+                                            value: "get_value",
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
-                                                byte_offset: 61,
-                                                byte_length: 34,
+                                                byte_offset: 107,
+                                                byte_length: 9,
                                             },
+                                            resolution: Unresolved,
                                         },
-                                    ],
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 53,
-                                        byte_length: 48,
-                                    },
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 63,
-                                },
-                                binding_id: None,
-                            },
-                            Propagate {
-                                expression: Call {
-                                    expression: Identifier {
-                                        value: "get_value",
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 107,
-                                            byte_length: 9,
+                                            byte_length: 11,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 107,
-                                        byte_length: 11,
+                                        byte_length: 12,
                                     },
-                                    call_kind: None,
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 107,
-                                    byte_length: 12,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            try_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 3,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 95,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        try_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 3,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 95,
+                            byte_offset: 15,
+                            byte_length: 108,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 108,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 115,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 115,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/try_block_with_semicolon.snap
+++ b/tests/spec/parse/snapshots/try_block_with_semicolon.snap
@@ -25,101 +25,98 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: TryBlock {
-                        items: [
-                            Propagate {
-                                expression: Call {
-                                    expression: Identifier {
-                                        value: "do_something",
+                        value: TryBlock {
+                            items: [
+                                Propagate {
+                                    expression: Call {
+                                        expression: Identifier {
+                                            value: "do_something",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 38,
+                                                byte_length: 12,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        args: [],
+                                        spread: None,
+                                        type_arguments: None,
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 38,
-                                            byte_length: 12,
+                                            byte_length: 14,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        call_kind: None,
                                     },
-                                    args: [],
-                                    spread: None,
-                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 38,
-                                        byte_length: 14,
+                                        byte_length: 15,
                                     },
-                                    call_kind: None,
                                 },
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 15,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
+                            try_keyword_span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 3,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 28,
+                                byte_length: 30,
+                            },
+                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
-                        try_keyword_span: Span {
-                            file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 3,
-                        },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 30,
+                            byte_offset: 15,
+                            byte_length: 43,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 43,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 50,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 50,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_double_negation.snap
+++ b/tests/spec/parse/snapshots/unary_double_negation.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,82 +48,79 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "still_a",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 25,
-                                byte_length: 7,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "still_a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 25,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Negative,
-                        expression: Unary {
+                        value: Unary {
                             operator: Negative,
-                            expression: Identifier {
-                                value: "a",
+                            expression: Unary {
+                                operator: Negative,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 37,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 37,
-                                    byte_length: 1,
+                                    byte_offset: 36,
+                                    byte_length: 2,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 36,
-                                byte_length: 2,
+                                byte_offset: 35,
+                                byte_length: 3,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 35,
-                            byte_length: 3,
+                            byte_offset: 21,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 17,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_double_not.snap
+++ b/tests/spec/parse/snapshots/unary_double_not.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,82 +48,79 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "still_a",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 26,
-                                byte_length: 7,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "still_a",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 7,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Unary {
+                        value: Unary {
                             operator: Not,
-                            expression: Identifier {
-                                value: "a",
+                            expression: Unary {
+                                operator: Not,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 38,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 38,
-                                    byte_length: 1,
+                                    byte_offset: 37,
+                                    byte_length: 2,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 37,
-                                byte_length: 2,
+                                byte_offset: 36,
+                                byte_length: 3,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 36,
-                            byte_length: 3,
+                            byte_offset: 22,
+                            byte_length: 17,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 22,
-                        byte_length: 17,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 18,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 18,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_minus_literal.snap
+++ b/tests/spec/parse/snapshots/unary_minus_literal.snap
@@ -23,72 +23,70 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 1,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 1,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Negative,
-                        expression: Literal {
-                            literal: Integer {
-                                value: 10,
-                                text: None,
+                        value: Unary {
+                            operator: Negative,
+                            expression: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 2,
+                                },
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 24,
-                                byte_length: 2,
+                                byte_offset: 23,
+                                byte_length: 3,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 23,
-                            byte_length: 3,
+                            byte_offset: 15,
+                            byte_length: 11,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 11,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 18,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 18,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_minus_parenthesized.snap
+++ b/tests/spec/parse/snapshots/unary_minus_parenthesized.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,62 +72,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Negative,
-                        expression: Paren {
-                            expression: Binary {
-                                operator: Addition,
-                                left: Identifier {
-                                    value: "a",
+                        value: Unary {
+                            operator: Negative,
+                            expression: Paren {
+                                expression: Binary {
+                                    operator: Addition,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 44,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 48,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 44,
-                                        byte_length: 1,
+                                        byte_length: 5,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 48,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 44,
-                                    byte_length: 5,
+                                    byte_offset: 43,
+                                    byte_length: 7,
                                 },
                             },
                             ty: Var {
@@ -137,42 +142,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 43,
-                                byte_length: 7,
+                                byte_offset: 42,
+                                byte_length: 8,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 8,
+                            byte_offset: 29,
+                            byte_length: 21,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 21,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 28,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 28,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_minus_variable.snap
+++ b/tests/spec/parse/snapshots/unary_minus_variable.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,71 +48,68 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "negation_count",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 14,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "negation_count",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 14,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Negative,
-                        expression: Identifier {
-                            value: "count",
+                        value: Unary {
+                            operator: Negative,
+                            expression: Identifier {
+                                value: "count",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 5,
+                                byte_offset: 46,
+                                byte_length: 6,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 46,
-                            byte_length: 6,
+                            byte_offset: 25,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 25,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 21,
+                    byte_length: 34,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 21,
-                byte_length: 34,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_not_literal.snap
+++ b/tests/spec/parse/snapshots/unary_not_literal.snap
@@ -23,71 +23,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "is_not_true",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 11,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "is_not_true",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 11,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Literal {
-                            literal: Boolean(
-                                true,
-                            ),
+                        value: Unary {
+                            operator: Not,
+                            expression: Literal {
+                                literal: Boolean(
+                                    true,
+                                ),
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 4,
+                                },
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 4,
+                                byte_offset: 33,
+                                byte_length: 5,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 5,
+                            byte_offset: 15,
+                            byte_length: 23,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 23,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 30,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 30,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_not_negation.snap
+++ b/tests/spec/parse/snapshots/unary_not_negation.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,82 +48,79 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "weird",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 25,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "weird",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 25,
+                                    byte_length: 5,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Unary {
-                            operator: Negative,
-                            expression: Identifier {
-                                value: "a",
+                        value: Unary {
+                            operator: Not,
+                            expression: Unary {
+                                operator: Negative,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 35,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 35,
-                                    byte_length: 1,
+                                    byte_offset: 34,
+                                    byte_length: 2,
                                 },
-                                binding_id: None,
-                                qualified: None,
                             },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 2,
+                                byte_offset: 33,
+                                byte_length: 3,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 33,
-                            byte_length: 3,
+                            byte_offset: 21,
+                            byte_length: 15,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 21,
-                        byte_length: 15,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 17,
+                    byte_length: 22,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 17,
-                byte_length: 22,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_not_parenthesized.snap
+++ b/tests/spec/parse/snapshots/unary_not_parenthesized.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,62 +72,69 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Paren {
-                            expression: Binary {
-                                operator: And,
-                                left: Identifier {
-                                    value: "a",
+                        value: Unary {
+                            operator: Not,
+                            expression: Paren {
+                                expression: Binary {
+                                    operator: And,
+                                    left: Identifier {
+                                        value: "a",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 46,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    right: Identifier {
+                                        value: "b",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 51,
+                                            byte_length: 1,
+                                        },
+                                        resolution: Unresolved,
+                                    },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 46,
-                                        byte_length: 1,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                right: Identifier {
-                                    value: "b",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 51,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 46,
-                                    byte_length: 6,
+                                    byte_offset: 45,
+                                    byte_length: 8,
                                 },
                             },
                             ty: Var {
@@ -137,42 +142,31 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 45,
-                                byte_length: 8,
+                                byte_offset: 44,
+                                byte_length: 9,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 9,
+                            byte_offset: 31,
+                            byte_length: 22,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 22,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 29,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 29,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_not_variable.snap
+++ b/tests/spec/parse/snapshots/unary_not_variable.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,71 +48,68 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "is_inactive",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 34,
-                                byte_length: 11,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "is_inactive",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 11,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Identifier {
-                            value: "is_active",
+                        value: Unary {
+                            operator: Not,
+                            expression: Identifier {
+                                value: "is_active",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 49,
+                                    byte_length: 9,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 49,
-                                byte_length: 9,
+                                byte_offset: 48,
+                                byte_length: 10,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 48,
-                            byte_length: 10,
+                            byte_offset: 30,
+                            byte_length: 28,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 30,
-                        byte_length: 28,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 26,
+                    byte_length: 35,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 26,
-                byte_length: 35,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_negation_add.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_negation_add.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,40 +72,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Unary {
-                            operator: Negative,
-                            expression: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Addition,
+                            left: Unary {
+                                operator: Negative,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 43,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 43,
+                                    byte_offset: 42,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -115,54 +133,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 42,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 6,
+                            byte_offset: 29,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_negation_field.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_negation_field.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -49,84 +48,80 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "negation_x",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 10,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "negation_x",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 27,
+                                    byte_length: 10,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Negative,
-                        expression: DotAccess {
-                            expression: Identifier {
-                                value: "p",
+                        value: Unary {
+                            operator: Negative,
+                            expression: DotAccess {
+                                expression: Identifier {
+                                    value: "p",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 41,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                member: "x",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 41,
-                                    byte_length: 1,
+                                    byte_length: 3,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
-                            member: "x",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 41,
-                                byte_length: 3,
+                                byte_offset: 40,
+                                byte_length: 4,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 40,
-                            byte_length: 4,
+                            byte_offset: 23,
+                            byte_length: 21,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 23,
-                        byte_length: 21,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 19,
+                    byte_length: 28,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 19,
-                byte_length: 28,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_negation_multiplication.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_negation_multiplication.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,40 +72,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 33,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Multiplication,
-                        left: Unary {
-                            operator: Negative,
-                            expression: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Multiplication,
+                            left: Unary {
+                                operator: Negative,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 43,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 43,
+                                    byte_offset: 42,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 47,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -115,54 +133,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 42,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 47,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 6,
+                            byte_offset: 29,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 29,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 25,
+                    byte_length: 26,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 25,
-                byte_length: 26,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_not_and.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_not_and.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,40 +72,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: And,
-                        left: Unary {
-                            operator: Not,
-                            expression: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: And,
+                            left: Unary {
+                                operator: Not,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 45,
+                                    byte_offset: 44,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -115,54 +133,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 44,
-                                byte_length: 2,
+                                byte_length: 7,
                             },
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 7,
+                            byte_offset: 31,
+                            byte_length: 20,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_not_call.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_not_call.snap
@@ -23,85 +23,82 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 19,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Call {
-                            expression: Identifier {
-                                value: "is_ready",
+                        value: Unary {
+                            operator: Not,
+                            expression: Call {
+                                expression: Identifier {
+                                    value: "is_ready",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 8,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 29,
-                                    byte_length: 8,
+                                    byte_length: 10,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                call_kind: None,
                             },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 29,
-                                byte_length: 10,
+                                byte_offset: 28,
+                                byte_length: 11,
                             },
-                            call_kind: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 28,
-                            byte_length: 11,
+                            byte_offset: 15,
+                            byte_length: 24,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 24,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_precedence_not_or.snap
+++ b/tests/spec/parse/snapshots/unary_precedence_not_or.snap
@@ -38,7 +38,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -63,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -74,40 +72,60 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 35,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 35,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Or,
-                        left: Unary {
-                            operator: Not,
-                            expression: Identifier {
-                                value: "a",
+                        value: Binary {
+                            operator: Or,
+                            left: Unary {
+                                operator: Not,
+                                expression: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 45,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 45,
+                                    byte_offset: 44,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
                                     byte_length: 1,
                                 },
-                                binding_id: None,
-                                qualified: None,
+                                resolution: Unresolved,
                             },
                             ty: Var {
                                 id: uninferred,
@@ -115,54 +133,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 44,
-                                byte_length: 2,
+                                byte_length: 7,
                             },
                         },
-                        right: Identifier {
-                            value: "b",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 1,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 7,
+                            byte_offset: 31,
+                            byte_length: 20,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 31,
-                        byte_length: 20,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 27,
+                    byte_length: 27,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 27,
-                byte_length: 27,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_reference.snap
+++ b/tests/spec/parse/snapshots/unary_reference.snap
@@ -21,70 +21,67 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Reference {
-                        expression: Identifier {
-                            value: "x",
+                        value: Reference {
+                            expression: Identifier {
+                                value: "x",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 27,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 1,
+                                byte_offset: 26,
+                                byte_length: 2,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 2,
+                            byte_offset: 13,
+                            byte_length: 15,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 15,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 20,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 20,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_reference_complex.snap
+++ b/tests/spec/parse/snapshots/unary_reference_complex.snap
@@ -21,117 +21,112 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Reference {
-                        expression: DotAccess {
-                            expression: Paren {
-                                expression: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
-                                        value: "a",
+                        value: Reference {
+                            expression: DotAccess {
+                                expression: Paren {
+                                    expression: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "a",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 28,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Identifier {
+                                            value: "b",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 28,
-                                            byte_length: 1,
+                                            byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Identifier {
-                                        value: "b",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 32,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
                                     },
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 28,
-                                        byte_length: 5,
+                                        byte_offset: 27,
+                                        byte_length: 7,
                                     },
                                 },
+                                member: "field",
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 27,
-                                    byte_length: 7,
+                                    byte_length: 13,
                                 },
+                                resolution: Unresolved,
                             },
-                            member: "field",
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 13,
+                                byte_offset: 26,
+                                byte_length: 14,
                             },
-                            dot_access_kind: None,
-                            receiver_coercion: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 14,
+                            byte_offset: 13,
+                            byte_length: 27,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 27,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 32,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 32,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_reference_precedence.snap
+++ b/tests/spec/parse/snapshots/unary_reference_precedence.snap
@@ -21,30 +21,53 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Binary {
-                        operator: Addition,
-                        left: Reference {
-                            expression: Literal {
+                        value: Binary {
+                            operator: Addition,
+                            left: Reference {
+                                expression: Literal {
+                                    literal: Integer {
+                                        value: 1,
+                                        text: None,
+                                    },
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 27,
+                                        byte_length: 1,
+                                    },
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 26,
+                                    byte_length: 2,
+                                },
+                            },
+                            right: Literal {
                                 literal: Integer {
-                                    value: 1,
+                                    value: 2,
                                     text: None,
                                 },
                                 ty: Var {
@@ -52,7 +75,7 @@ description: |
                                 },
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 27,
+                                    byte_offset: 31,
                                     byte_length: 1,
                                 },
                             },
@@ -62,55 +85,30 @@ description: |
                             span: Span {
                                 file_id: 0,
                                 byte_offset: 26,
-                                byte_length: 2,
+                                byte_length: 6,
                             },
                         },
-                        right: Literal {
-                            literal: Integer {
-                                value: 2,
-                                text: None,
-                            },
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 31,
-                                byte_length: 1,
-                            },
-                        },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 6,
+                            byte_offset: 13,
+                            byte_length: 19,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 19,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 24,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 24,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/unary_with_postfix.snap
+++ b/tests/spec/parse/snapshots/unary_with_postfix.snap
@@ -21,98 +21,94 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "result",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 17,
-                                byte_length: 6,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "result",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 17,
+                                    byte_length: 6,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
                             },
                         },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                    },
-                    value: Unary {
-                        operator: Not,
-                        expression: Call {
-                            expression: DotAccess {
-                                expression: Identifier {
-                                    value: "obj",
+                        value: Unary {
+                            operator: Not,
+                            expression: Call {
+                                expression: DotAccess {
+                                    expression: Identifier {
+                                        value: "obj",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 27,
+                                            byte_length: 3,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    member: "method",
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 27,
-                                        byte_length: 3,
+                                        byte_length: 10,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    resolution: Unresolved,
                                 },
-                                member: "method",
+                                args: [],
+                                spread: None,
+                                type_arguments: None,
                                 ty: Var {
                                     id: uninferred,
                                 },
                                 span: Span {
                                     file_id: 0,
                                     byte_offset: 27,
-                                    byte_length: 10,
+                                    byte_length: 12,
                                 },
-                                dot_access_kind: None,
-                                receiver_coercion: None,
+                                call_kind: None,
                             },
-                            args: [],
-                            spread: None,
-                            type_arguments: None,
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 27,
-                                byte_length: 12,
+                                byte_offset: 26,
+                                byte_length: 13,
                             },
-                            call_kind: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 26,
-                            byte_length: 13,
+                            byte_offset: 13,
+                            byte_length: 26,
                         },
                     },
-                    mut_span: None,
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 13,
-                        byte_length: 26,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 31,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 31,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/while_let_simple.snap
+++ b/tests/spec/parse/snapshots/while_let_simple.snap
@@ -62,7 +62,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -73,247 +72,239 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "i",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 48,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 52,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 44,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 40,
-                        byte_length: 13,
-                    },
-                },
-                WhileLet {
-                    pattern: EnumVariant {
-                        identifier: "Some",
-                        fields: [
-                            Identifier {
-                                identifier: "x",
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "i",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 72,
+                                    byte_offset: 48,
                                     byte_length: 1,
                                 },
                             },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 44,
+                                    byte_length: 3,
+                                },
+                            ),
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 67,
-                            byte_length: 7,
-                        },
-                    },
-                    scrutinee: IndexedAccess {
-                        expression: Identifier {
-                            value: "items",
+                        value: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 77,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        index: Identifier {
-                            value: "i",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 83,
+                                byte_offset: 52,
                                 byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 82,
-                            byte_length: 3,
+                            byte_offset: 40,
+                            byte_length: 13,
                         },
-                        from_colon_syntax: false,
                     },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                    WhileLet {
+                        pattern: EnumVariant {
+                            identifier: "Some",
+                            fields: [
+                                Identifier {
+                                    identifier: "x",
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 72,
+                                        byte_length: 1,
+                                    },
+                                },
+                            ],
+                            rest: false,
+                            resolution: Unresolved,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 67,
+                                byte_length: 7,
+                            },
+                        },
+                        scrutinee: IndexedAccess {
+                            expression: Identifier {
+                                value: "items",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 77,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Identifier {
+                                value: "i",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 83,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 82,
+                                byte_length: 3,
+                            },
+                            from_colon_syntax: false,
+                        },
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 92,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "x",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 98,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 92,
-                                        byte_length: 5,
+                                        byte_length: 8,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
-                                        value: "x",
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 98,
-                                            byte_length: 1,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 92,
-                                    byte_length: 8,
-                                },
-                                call_kind: None,
-                            },
-                            Assignment {
-                                target: Identifier {
-                                    value: "i",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 106,
-                                        byte_length: 1,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                value: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
+                                Assignment {
+                                    target: Identifier {
                                         value: "i",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 110,
+                                            byte_offset: 106,
                                             byte_length: 1,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
+                                    value: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "i",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 110,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 114,
+                                                byte_length: 1,
+                                            },
                                         },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 114,
-                                            byte_length: 1,
+                                            byte_offset: 110,
+                                            byte_length: 5,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
+                                    compound_operator: None,
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 110,
-                                        byte_length: 5,
+                                        byte_offset: 106,
+                                        byte_length: 9,
                                     },
                                 },
-                                compound_operator: None,
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 106,
-                                    byte_length: 9,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 86,
+                                byte_length: 34,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 86,
-                            byte_length: 34,
+                            byte_offset: 57,
+                            byte_length: 63,
                         },
                     },
-                    typed_pattern: None,
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 57,
-                        byte_length: 63,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 36,
+                    byte_length: 86,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 36,
-                byte_length: 86,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/while_let_tuple_pattern.snap
+++ b/tests/spec/parse/snapshots/while_let_tuple_pattern.snap
@@ -80,7 +80,6 @@ description: |
                         },
                     },
                 ),
-                typed_pattern: None,
                 ty: Var {
                     id: uninferred,
                 },
@@ -91,288 +90,279 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "i",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 55,
-                                byte_length: 1,
-                            },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 59,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 51,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 47,
-                        byte_length: 13,
-                    },
-                },
-                WhileLet {
-                    pattern: EnumVariant {
-                        identifier: "Some",
-                        fields: [
-                            Tuple {
-                                elements: [
-                                    Identifier {
-                                        identifier: "a",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 80,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                    Identifier {
-                                        identifier: "b",
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 83,
-                                            byte_length: 1,
-                                        },
-                                    },
-                                ],
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "i",
                                 span: Span {
                                     file_id: 0,
-                                    byte_offset: 79,
-                                    byte_length: 6,
+                                    byte_offset: 55,
+                                    byte_length: 1,
                                 },
                             },
-                        ],
-                        rest: false,
-                        ty: Var {
-                            id: uninferred,
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 3,
+                                },
+                            ),
                         },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 74,
-                            byte_length: 12,
-                        },
-                    },
-                    scrutinee: IndexedAccess {
-                        expression: Identifier {
-                            value: "pairs",
+                        value: Literal {
+                            literal: Integer {
+                                value: 0,
+                                text: None,
+                            },
                             ty: Var {
                                 id: uninferred,
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 89,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
-                        },
-                        index: Identifier {
-                            value: "i",
-                            ty: Var {
-                                id: uninferred,
-                            },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 95,
+                                byte_offset: 59,
                                 byte_length: 1,
                             },
-                            binding_id: None,
-                            qualified: None,
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 94,
-                            byte_length: 3,
+                            byte_offset: 47,
+                            byte_length: 13,
                         },
-                        from_colon_syntax: false,
                     },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
+                    WhileLet {
+                        pattern: EnumVariant {
+                            identifier: "Some",
+                            fields: [
+                                Tuple {
+                                    elements: [
+                                        Identifier {
+                                            identifier: "a",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 80,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                        Identifier {
+                                            identifier: "b",
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 83,
+                                                byte_length: 1,
+                                            },
+                                        },
+                                    ],
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 104,
-                                        byte_length: 5,
+                                        byte_offset: 79,
+                                        byte_length: 6,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
                                 },
-                                args: [
-                                    Binary {
-                                        operator: Addition,
-                                        left: Identifier {
-                                            value: "a",
+                            ],
+                            rest: false,
+                            resolution: Unresolved,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 74,
+                                byte_length: 12,
+                            },
+                        },
+                        scrutinee: IndexedAccess {
+                            expression: Identifier {
+                                value: "pairs",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 89,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            index: Identifier {
+                                value: "i",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 95,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 94,
+                                byte_length: 3,
+                            },
+                            from_colon_syntax: false,
+                        },
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 104,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Binary {
+                                            operator: Addition,
+                                            left: Identifier {
+                                                value: "a",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 110,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
+                                            right: Identifier {
+                                                value: "b",
+                                                ty: Var {
+                                                    id: uninferred,
+                                                },
+                                                span: Span {
+                                                    file_id: 0,
+                                                    byte_offset: 114,
+                                                    byte_length: 1,
+                                                },
+                                                resolution: Unresolved,
+                                            },
                                             ty: Var {
                                                 id: uninferred,
                                             },
                                             span: Span {
                                                 file_id: 0,
                                                 byte_offset: 110,
-                                                byte_length: 1,
+                                                byte_length: 5,
                                             },
-                                            binding_id: None,
-                                            qualified: None,
                                         },
-                                        right: Identifier {
-                                            value: "b",
-                                            ty: Var {
-                                                id: uninferred,
-                                            },
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 114,
-                                                byte_length: 1,
-                                            },
-                                            binding_id: None,
-                                            qualified: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 110,
-                                            byte_length: 5,
-                                        },
-                                    },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 104,
-                                    byte_length: 12,
-                                },
-                                call_kind: None,
-                            },
-                            Assignment {
-                                target: Identifier {
-                                    value: "i",
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 122,
-                                        byte_length: 1,
+                                        byte_offset: 104,
+                                        byte_length: 12,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                value: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
+                                Assignment {
+                                    target: Identifier {
                                         value: "i",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 126,
+                                            byte_offset: 122,
                                             byte_length: 1,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
+                                    value: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "i",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 126,
+                                                byte_length: 1,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 130,
+                                                byte_length: 1,
+                                            },
                                         },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 130,
-                                            byte_length: 1,
+                                            byte_offset: 126,
+                                            byte_length: 5,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
+                                    compound_operator: None,
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 126,
-                                        byte_length: 5,
+                                        byte_offset: 122,
+                                        byte_length: 9,
                                     },
                                 },
-                                compound_operator: None,
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 122,
-                                    byte_length: 9,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 98,
+                                byte_length: 38,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 98,
-                            byte_length: 38,
+                            byte_offset: 64,
+                            byte_length: 72,
                         },
                     },
-                    typed_pattern: None,
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 64,
-                        byte_length: 72,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 43,
+                    byte_length: 95,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 43,
-                byte_length: 95,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/parse/snapshots/while_loop.snap
+++ b/tests/spec/parse/snapshots/while_loop.snap
@@ -27,77 +27,34 @@ description: |
             id: uninferred,
         },
         visibility: Private,
-        body: Block {
-            items: [
-                Let {
-                    binding: Binding {
-                        pattern: Identifier {
-                            identifier: "count",
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 23,
-                                byte_length: 5,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "count",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 23,
+                                    byte_length: 5,
+                                },
                             },
-                        },
-                        annotation: None,
-                        typed_pattern: None,
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        mutable: true,
-                    },
-                    value: Literal {
-                        literal: Integer {
-                            value: 0,
-                            text: None,
-                        },
-                        ty: Var {
-                            id: uninferred,
-                        },
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 31,
-                            byte_length: 1,
-                        },
-                    },
-                    mut_span: Some(
-                        Span {
-                            file_id: 0,
-                            byte_offset: 19,
-                            byte_length: 3,
-                        },
-                    ),
-                    else_block: None,
-                    else_span: None,
-                    assert: false,
-                    ty: Var {
-                        id: uninferred,
-                    },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 15,
-                        byte_length: 17,
-                    },
-                },
-                While {
-                    condition: Binary {
-                        operator: LessThan,
-                        left: Identifier {
-                            value: "count",
+                            annotation: None,
                             ty: Var {
                                 id: uninferred,
                             },
-                            span: Span {
-                                file_id: 0,
-                                byte_offset: 42,
-                                byte_length: 5,
-                            },
-                            binding_id: None,
-                            qualified: None,
+                            mut_span: Some(
+                                Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 3,
+                                },
+                            ),
                         },
-                        right: Literal {
+                        value: Literal {
                             literal: Integer {
-                                value: 10,
+                                value: 0,
                                 text: None,
                             },
                             ty: Var {
@@ -105,147 +62,183 @@ description: |
                             },
                             span: Span {
                                 file_id: 0,
-                                byte_offset: 50,
-                                byte_length: 2,
+                                byte_offset: 31,
+                                byte_length: 1,
                             },
                         },
+                        mode: Plain,
                         ty: Var {
                             id: uninferred,
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 42,
-                            byte_length: 10,
+                            byte_offset: 15,
+                            byte_length: 17,
                         },
                     },
-                    body: Block {
-                        items: [
-                            Call {
-                                expression: Identifier {
-                                    value: "print",
+                    While {
+                        condition: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "count",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 42,
+                                    byte_length: 5,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Literal {
+                                literal: Integer {
+                                    value: 10,
+                                    text: None,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 50,
+                                    byte_length: 2,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 42,
+                                byte_length: 10,
+                            },
+                        },
+                        body: Block {
+                            items: [
+                                Call {
+                                    expression: Identifier {
+                                        value: "print",
+                                        ty: Var {
+                                            id: uninferred,
+                                        },
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 59,
+                                            byte_length: 5,
+                                        },
+                                        resolution: Unresolved,
+                                    },
+                                    args: [
+                                        Identifier {
+                                            value: "count",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 65,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                    ],
+                                    spread: None,
+                                    type_arguments: None,
                                     ty: Var {
                                         id: uninferred,
                                     },
                                     span: Span {
                                         file_id: 0,
                                         byte_offset: 59,
-                                        byte_length: 5,
+                                        byte_length: 12,
                                     },
-                                    binding_id: None,
-                                    qualified: None,
+                                    call_kind: None,
                                 },
-                                args: [
-                                    Identifier {
+                                Assignment {
+                                    target: Identifier {
                                         value: "count",
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
-                                            byte_offset: 65,
+                                            byte_offset: 77,
                                             byte_length: 5,
                                         },
-                                        binding_id: None,
-                                        qualified: None,
+                                        resolution: Unresolved,
                                     },
-                                ],
-                                spread: None,
-                                type_arguments: None,
-                                ty: Var {
-                                    id: uninferred,
-                                },
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 59,
-                                    byte_length: 12,
-                                },
-                                call_kind: None,
-                            },
-                            Assignment {
-                                target: Identifier {
-                                    value: "count",
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 77,
-                                        byte_length: 5,
-                                    },
-                                    binding_id: None,
-                                    qualified: None,
-                                },
-                                value: Binary {
-                                    operator: Addition,
-                                    left: Identifier {
-                                        value: "count",
+                                    value: Binary {
+                                        operator: Addition,
+                                        left: Identifier {
+                                            value: "count",
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 85,
+                                                byte_length: 5,
+                                            },
+                                            resolution: Unresolved,
+                                        },
+                                        right: Literal {
+                                            literal: Integer {
+                                                value: 1,
+                                                text: None,
+                                            },
+                                            ty: Var {
+                                                id: uninferred,
+                                            },
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 93,
+                                                byte_length: 1,
+                                            },
+                                        },
                                         ty: Var {
                                             id: uninferred,
                                         },
                                         span: Span {
                                             file_id: 0,
                                             byte_offset: 85,
-                                            byte_length: 5,
-                                        },
-                                        binding_id: None,
-                                        qualified: None,
-                                    },
-                                    right: Literal {
-                                        literal: Integer {
-                                            value: 1,
-                                            text: None,
-                                        },
-                                        ty: Var {
-                                            id: uninferred,
-                                        },
-                                        span: Span {
-                                            file_id: 0,
-                                            byte_offset: 93,
-                                            byte_length: 1,
+                                            byte_length: 9,
                                         },
                                     },
-                                    ty: Var {
-                                        id: uninferred,
-                                    },
+                                    compound_operator: None,
                                     span: Span {
                                         file_id: 0,
-                                        byte_offset: 85,
-                                        byte_length: 9,
+                                        byte_offset: 77,
+                                        byte_length: 17,
                                     },
                                 },
-                                compound_operator: None,
-                                span: Span {
-                                    file_id: 0,
-                                    byte_offset: 77,
-                                    byte_length: 17,
-                                },
+                            ],
+                            ty: Var {
+                                id: uninferred,
                             },
-                        ],
-                        ty: Var {
-                            id: uninferred,
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 53,
+                                byte_length: 46,
+                            },
                         },
                         span: Span {
                             file_id: 0,
-                            byte_offset: 53,
-                            byte_length: 46,
+                            byte_offset: 36,
+                            byte_length: 63,
                         },
                     },
-                    span: Span {
-                        file_id: 0,
-                        byte_offset: 36,
-                        byte_length: 63,
-                    },
+                ],
+                ty: Var {
+                    id: uninferred,
                 },
-            ],
-            ty: Var {
-                id: uninferred,
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 90,
+                },
             },
-            span: Span {
-                file_id: 0,
-                byte_offset: 11,
-                byte_length: 90,
-            },
-        },
+        ),
         ty: Var {
             id: uninferred,
         },

--- a/tests/spec/representation.rs
+++ b/tests/spec/representation.rs
@@ -1,9 +1,14 @@
 use crate::_harness::infer;
-use syntax::ast::{BinaryOperator, Expression};
+use syntax::ast::{
+    Annotation, BinaryOperator, CallTypeArguments, ConstructorPatternResolution, Expression,
+    Pattern,
+};
 use syntax::lex::Lexer;
 use syntax::parse::Parser;
-use syntax::program::{BindingMutation, MutationInfo};
-use syntax::types::{FunctionParameter, SubstitutionMap, Type, substitute};
+use syntax::program::{
+    BindingMutation, Definition, DefinitionBody, File, Module, MutationInfo, ValueKind, Visibility,
+};
+use syntax::types::{FunctionParameter, SubstitutionMap, Type, TypeVarId, substitute};
 
 fn walk(expression: &Expression, visit: &mut impl FnMut(&Expression)) {
     visit(expression);
@@ -106,5 +111,249 @@ fn main() -> int { identity<int>(1) }
 
     let checked = checked.expect("expected an explicitly instantiated call");
     assert_eq!(checked.annotations().len(), 1);
-    assert_eq!(checked.resolved_types(), Some([Type::int()].as_slice()));
+    let resolved = checked
+        .resolved_types()
+        .expect("checked call must have resolved type arguments");
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0], Type::int());
+}
+
+#[test]
+fn checked_call_type_arguments_cannot_have_misaligned_types() {
+    let resolved = CallTypeArguments::resolved([(Annotation::Unknown, Type::int())]);
+    assert_eq!(resolved.annotations().len(), 1);
+    let types = resolved.resolved_types().expect("call is checked");
+    assert_eq!(types.len(), 1);
+    assert_eq!(types[0], Type::int());
+
+    let const_like = CallTypeArguments::checked_without_types(vec![Annotation::Unknown]);
+    assert_eq!(const_like.annotations().len(), 1);
+    assert!(
+        const_like
+            .resolved_types()
+            .expect("call is checked")
+            .is_empty()
+    );
+}
+
+#[test]
+fn placeholder_types_are_not_reserved_type_variable_ids() {
+    let variable = Type::Var {
+        id: TypeVarId::new(u32::MAX),
+        hint: None,
+    };
+
+    assert!(variable.is_variable());
+    assert_eq!(variable, variable.clone());
+    assert!(!Type::uninferred().is_variable());
+    assert!(!Type::ignored().is_variable());
+    assert!(Type::uninferred().is_uninferred());
+    assert!(Type::ignored().is_ignored());
+}
+
+#[test]
+fn statement_only_try_tail_has_unit_success_type() {
+    let result = infer(
+        r#"
+fn test() -> Result<(), string> {
+  let mut value = 0
+  try {
+    let _ = Ok(1)?
+    value = 1
+  }
+}
+"#,
+    )
+    .assert_no_errors();
+
+    let mut success_type = None;
+    for item in &result.ast {
+        walk(item, &mut |expression| {
+            if let Expression::TryBlock { ty, .. } = expression {
+                success_type = Some(ty.ok_type());
+            }
+        });
+    }
+
+    assert_eq!(success_type, Some(Type::unit()));
+}
+
+#[test]
+fn generic_bounds_have_an_explicit_resolution_transition() {
+    let source = "fn constrained<T: Comparable>(value: T) -> T { value }";
+    let parsed = syntax::build_ast(source, 0);
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    let [Expression::Function { generics, .. }] = parsed.ast.as_slice() else {
+        panic!("expected one function");
+    };
+    let [generic] = generics.as_slice() else {
+        panic!("expected one generic");
+    };
+    assert_eq!(generic.bound_count(), 1);
+    assert!(!generic.bounds_are_resolved());
+    assert!(generic.resolved_bounds().is_none());
+
+    let inferred = infer(source).assert_no_errors();
+    let generic = inferred
+        .ast
+        .iter()
+        .find_map(|item| match item {
+            Expression::Function { name, generics, .. } if name == "constrained" => {
+                generics.first()
+            }
+            _ => None,
+        })
+        .expect("expected constrained function");
+    assert!(generic.bounds_are_resolved());
+    assert_eq!(generic.resolved_bounds().unwrap().count(), 1);
+}
+
+#[test]
+fn inference_enriches_the_canonical_pattern_tree() {
+    let source = r#"
+enum Item { Value(int) }
+
+fn unwrap(item: Item) -> int {
+  match item {
+    Item.Value(value) => value,
+  }
+}
+"#;
+
+    let parsed = syntax::build_ast(source, 0);
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    let mut parsed_pattern = None;
+    for item in &parsed.ast {
+        walk(item, &mut |expression| {
+            if let Expression::Match { arms, .. } = expression {
+                parsed_pattern = arms.first().map(|arm| arm.pattern.clone());
+            }
+        });
+    }
+    assert!(matches!(
+        parsed_pattern,
+        Some(Pattern::EnumVariant {
+            resolution: ConstructorPatternResolution::Unresolved,
+            ..
+        })
+    ));
+
+    let inferred = infer(source).assert_no_errors();
+    let mut checked_pattern = None;
+    for item in &inferred.ast {
+        walk(item, &mut |expression| {
+            if let Expression::Match { arms, .. } = expression {
+                checked_pattern = arms.first().map(|arm| arm.pattern.clone());
+            }
+        });
+    }
+    let Some(Pattern::EnumVariant {
+        fields,
+        ty,
+        resolution:
+            ConstructorPatternResolution::EnumVariant {
+                enum_name,
+                variant_name,
+            },
+        ..
+    }) = checked_pattern
+    else {
+        panic!("expected a resolved constructor pattern");
+    };
+    assert_eq!(variant_name, "Item.Value");
+    assert_eq!(ty.get_qualified_id(), Some(enum_name.as_str()));
+    assert!(
+        matches!(fields.as_slice(), [Pattern::Identifier { identifier, .. }] if identifier == "value")
+    );
+}
+
+#[test]
+fn inferred_signatures_retain_transparent_alias_identity() {
+    let result = infer(
+        r#"
+type UserId = int
+fn identity(value: UserId) -> UserId { value }
+"#,
+    )
+    .assert_no_errors();
+
+    let function_ty = result
+        .ast
+        .iter()
+        .find_map(|expression| match expression {
+            Expression::Function { name, ty, .. } if name == "identity" => ty.as_function_type(),
+            _ => None,
+        })
+        .expect("expected identity's function type");
+    let [parameter] = function_ty.params.as_slice() else {
+        panic!("expected one parameter");
+    };
+
+    for ty in [&parameter.ty, function_ty.return_type.as_ref()] {
+        assert!(
+            matches!(ty, Type::Nominal { id, params } if id.last_segment() == "UserId" && params.is_empty()),
+            "transparent alias identity was lost: {ty:?}"
+        );
+    }
+}
+
+fn value_definition(kind: ValueKind) -> Definition {
+    Definition {
+        visibility: Visibility::Private,
+        ty: Type::int(),
+        name: None,
+        name_span: None,
+        doc: None,
+        body: DefinitionBody::Value {
+            kind,
+            allowed_lints: vec![],
+            go_hints: vec![],
+            go_name: None,
+            go_type_param_recipe: None,
+        },
+    }
+}
+
+#[test]
+fn nonliteral_constants_remain_distinguishable_from_runtime_values() {
+    let constant = value_definition(ValueKind::Constant { value: None });
+    let runtime = value_definition(ValueKind::Runtime);
+
+    assert!(constant.is_const());
+    assert!(constant.const_value().is_none());
+    assert!(!runtime.is_const());
+}
+
+#[test]
+fn module_derives_file_classification_from_each_file() {
+    let mut module = Module::new("example");
+    let source = File::new("example", "main.lis", "main.lis", "", vec![], None, 1);
+    let typedef = File::new(
+        "example",
+        "native.d.lis",
+        "native.d.lis",
+        "",
+        vec![],
+        None,
+        2,
+    );
+    module.files.insert(source.id, source);
+    module.files.insert(typedef.id, typedef);
+
+    assert_eq!(module.source_files().count(), 1);
+    assert_eq!(module.typedef_files().count(), 1);
+    assert_eq!(module.file_ids().collect::<Vec<_>>(), vec![1]);
+    assert!(module.get_file(2).is_some());
+    assert!(module.is_typedef(2));
+}
+
+#[test]
+fn recursion_depth_is_scoped_to_each_top_level_item() {
+    let source = (0..80)
+        .map(|index| format!("fn item_{index}() -> int {{ 1 }}\n"))
+        .collect::<String>();
+    let parsed = syntax::build_ast(&source, 0);
+
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    assert_eq!(parsed.ast.len(), 80);
 }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -17656,11 +17656,8 @@ fn main() {
 }
 
 #[test]
-fn float_equality_without_abs_rejected_newtype_subtraction_no_diagnostic() {
-    let mut fs = MockFileSystem::new();
-    fs.add_file(
-        ENTRY_MODULE_ID,
-        "main.lis",
+fn float_equality_without_abs_newtype_alias() {
+    let diagnostics = crate::_harness::lint::lint(
         r#"
 struct Distance(float64)
 type DA = Distance
@@ -17671,14 +17668,13 @@ fn main() {
 }
 "#,
     );
-    let result = compile_check(fs);
-    assert!(
-        !result
-            .lints
-            .iter()
-            .any(|d| d.plain_message() == "Float equality without `abs`"),
-        "must not fire when the checker rejected the subtraction: {:?}",
-        result.lints
+    let count = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code_str() == Some("lint.float_equality_without_abs"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "an alias to a newtype has the same numeric identity and must fire: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
Reshapes some data structures so that invariants the code was assuming are now carried by types instead. 

- Sentinel values become variants: the reserved `TypeVarId` values standing for "ignored" and "not yet inferred" are now `Type::Ignored` and `Type::Uninferred`
- Clusters of optional fields become enums: `IdentifierResolution`, `DotAccessResolution`, `LetMode`, `FunctionBody`, `AliasKind`, `ValueKind`.
- Parallel vectors become vectors of pairs: `CallTypeArguments`, `Generic` bounds
- Structures that had to agree collapse into one: `TypedPattern` is folded into `Pattern`
- Derived data stops being stored: `Type::Nominal` drops its inline `underlying_ty`

As a side effect, `Expression` shrinks from 344 to 288 bytes and `Type` from 48 to 40.