### PR TITLE
fix: reject embedding a non-interface in an interface

### DIFF
--- a/crates/diagnostics/src/embed.rs
+++ b/crates/diagnostics/src/embed.rs
@@ -81,6 +81,17 @@ pub fn pointer_backed_newtype(target: &str, span: Span) -> LisetteDiagnostic {
         ))
 }
 
+pub fn non_interface_parent(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot embed this type in an interface")
+        .with_infer_code("embed_non_interface")
+        .with_span_label(&span, "not an interface")
+        .with_help(format!(
+            "An interface can only embed another interface, but `{}` is not one. \
+             Embed an interface, or declare the methods you need directly.",
+            target
+        ))
+}
+
 pub fn option_target(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot embed `Option<T>`")
         .with_infer_code("embed_option_target")

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -364,11 +364,10 @@ impl InferCtx<'_> {
         let deref_ty = ty.strip_refs();
         let mut names = Vec::new();
 
-        if let Type::Nominal { .. } = deref_ty {
-            let qualified_name = deref_ty.get_qualified_name();
-            if let Some(fields) = store.fields_of(&qualified_name) {
-                names.extend(fields.iter().map(|f| f.name.to_string()));
-            }
+        if let Type::Nominal { id, .. } = &deref_ty
+            && let Some(fields) = store.fields_of(id)
+        {
+            names.extend(fields.iter().map(|f| f.name.to_string()));
         }
 
         let methods = self.get_all_methods(store, &deref_ty);
@@ -405,8 +404,8 @@ impl InferCtx<'_> {
         let store = self.store;
         let deref_ty = ty.strip_refs();
 
-        if let Type::Nominal { .. } = deref_ty
-            && let Some(fields) = store.fields_of(&deref_ty.get_qualified_name())
+        if let Type::Nominal { id, .. } = &deref_ty
+            && let Some(fields) = store.fields_of(id)
             && fields.iter().any(|f| f.name == member)
         {
             return true;
@@ -417,11 +416,12 @@ impl InferCtx<'_> {
 
     fn as_struct_field(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
-        let Type::Nominal { .. } = &args.deref_ty else {
+        let Type::Nominal {
+            id: qualified_name, ..
+        } = &args.deref_ty
+        else {
             return None;
         };
-
-        let qualified_name = args.deref_ty.get_qualified_name();
         let resolved_struct_ty = store.peel_alias(&args.deref_ty);
         let Type::Nominal {
             id: struct_name, ..
@@ -476,7 +476,7 @@ impl InferCtx<'_> {
         if is_cross_module && !field_is_pub {
             self.sink.push(diagnostics::infer::private_field_access(
                 args.member_name,
-                &qualified_name,
+                qualified_name,
                 *args.span,
             ));
         }
@@ -499,9 +499,13 @@ impl InferCtx<'_> {
 
     fn as_promoted_field(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {
         let store = self.store;
-        if !matches!(args.deref_ty, Type::Nominal { .. })
-            || !promotion::has_direct_embed(store, &args.deref_ty)
-        {
+        let Type::Nominal {
+            id: qualified_name, ..
+        } = &args.deref_ty
+        else {
+            return None;
+        };
+        if !promotion::has_direct_embed(store, &args.deref_ty) {
             return None;
         }
 
@@ -532,7 +536,7 @@ impl InferCtx<'_> {
         if is_cross_module && !visibility.is_public() {
             self.sink.push(diagnostics::infer::private_field_access(
                 args.member_name,
-                args.deref_ty.get_qualified_name().as_str(),
+                qualified_name.as_str(),
                 *args.span,
             ));
         }

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -23,8 +23,10 @@ impl InferCtx<'_> {
         self.check_undeclared_impl_type_params(&annotation, &generics);
         let impl_ty = self.convert_receiver_to_type(store, &annotation, &span);
 
-        if self.impl_has_simple_type_params(&impl_ty, &generics) {
-            let receiver_qualified = impl_ty.get_qualified_name();
+        if let Type::Nominal { id, .. } = &impl_ty
+            && self.impl_has_simple_type_params(&impl_ty, &generics)
+        {
+            let receiver_qualified = id.clone();
             self.register_receiver_type_bounds(store, &receiver_qualified, &generics);
         }
 
@@ -118,7 +120,10 @@ impl InferCtx<'_> {
         let new_parents = parents
             .into_iter()
             .map(|parent| {
+                let before = self.sink.len();
                 let parent_ty = self.convert_to_type(store, &parent.annotation, &parent.span);
+                self.sink.truncate(before);
+                self.check_interface_parent(&parent_ty, parent.span);
                 ParentInterface {
                     annotation: parent.annotation,
                     span: parent.span,
@@ -139,5 +144,19 @@ impl InferCtx<'_> {
             span,
             visibility,
         }
+    }
+
+    fn check_interface_parent(&mut self, parent_ty: &Type, span: Span) {
+        if parent_ty.is_error() {
+            return;
+        }
+        let (core, _) = self.store.peel_refs_and_aliases(parent_ty);
+        if self.store.is_interface(&core) {
+            return;
+        }
+        self.sink.push(diagnostics::embed::non_interface_parent(
+            &parent_ty.to_string(),
+            span,
+        ));
     }
 }

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -36,10 +36,11 @@ fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
             return false;
         }
         store.get_interface(type_id).is_some_and(|iface| {
-            iface
-                .parents
-                .iter()
-                .any(|parent| walk(store, parent.get_qualified_name().as_str(), method, seen))
+            iface.parents.iter().any(|parent| {
+                parent
+                    .get_qualified_name()
+                    .is_some_and(|id| walk(store, id.as_str(), method, seen))
+            })
         })
     }
     walk(
@@ -285,7 +286,9 @@ impl InferCtx<'_> {
             }
         }
         for parent in &interface.parents {
-            let parent_name = parent.get_qualified_name();
+            let Some(parent_name) = parent.get_qualified_name() else {
+                continue;
+            };
             if let Some(parent_interface) = store.get_interface(&parent_name) {
                 self.collect_pointer_receiver_methods(
                     check,
@@ -468,7 +471,9 @@ impl InferCtx<'_> {
         });
         covered
             && interface.parents.iter().all(|parent| {
-                let parent_name = parent.get_qualified_name();
+                let Some(parent_name) = parent.get_qualified_name() else {
+                    return true;
+                };
                 match store.get_interface(&parent_name) {
                     Some(parent_interface) => self.own_methods_cover_interface(
                         own,
@@ -632,7 +637,9 @@ impl InferCtx<'_> {
         }
 
         for parent in &interface.parents {
-            let parent_name = parent.get_qualified_name();
+            let Some(parent_name) = parent.get_qualified_name() else {
+                continue;
+            };
             if let Some(parent_interface) = store.get_interface(&parent_name).cloned() {
                 let parent_type_args = parent.get_type_params().unwrap_or_default();
                 let substituted_parent_args: Vec<Type> = parent_type_args
@@ -870,7 +877,7 @@ fn method_definition_public(
     }
     let interface = store.get_interface(owner)?;
     interface.parents.iter().find_map(|parent| {
-        method_definition_public(store, parent.get_qualified_name().as_str(), method, seen)
+        method_definition_public(store, parent.get_qualified_name()?.as_str(), method, seen)
     })
 }
 
@@ -889,13 +896,14 @@ fn interface_declares_methods(
         return true;
     }
     interface.parents.iter().any(|parent| {
-        let parent_name = parent.get_qualified_name();
-        seen.insert(parent_name.to_string())
-            && store
-                .get_interface(&parent_name)
-                .is_some_and(|parent_interface| {
-                    interface_declares_methods(store, parent_interface, seen)
-                })
+        parent.get_qualified_name().is_some_and(|parent_name| {
+            seen.insert(parent_name.to_string())
+                && store
+                    .get_interface(&parent_name)
+                    .is_some_and(|parent_interface| {
+                        interface_declares_methods(store, parent_interface, seen)
+                    })
+        })
     })
 }
 

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -145,9 +145,8 @@ impl TaskState {
             self.scopes.pop();
             return;
         };
-        // `Array` is a prelude built-in with no qualified name, so reject a user
-        // impl on it here, before `get_qualified_name` below would panic.
-        if matches!(receiver_ty, Type::Array { .. }) {
+        // Prelude built-ins like `Array` have no qualified name to key methods by.
+        let Some(receiver_qualified_name) = receiver_ty.get_qualified_name() else {
             self.sink.push(diagnostics::infer::impl_on_foreign_type(
                 type_name,
                 crate::prelude::PRELUDE_MODULE_ID,
@@ -155,8 +154,7 @@ impl TaskState {
             ));
             self.scopes.pop();
             return;
-        }
-        let receiver_qualified_name = receiver_ty.get_qualified_name();
+        };
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
 

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1315,12 +1315,16 @@ impl Type {
         }
     }
 
-    pub fn get_qualified_name(&self) -> Symbol {
-        match self.strip_refs() {
-            Type::Nominal { id, .. } => id,
-            Type::Simple(kind) => Symbol::from_parts("prelude", kind.leaf_name()),
-            Type::Compound { kind, .. } => Symbol::from_parts("prelude", kind.leaf_name()),
-            _ => panic!("called get_qualified_name on {:#?}", self),
+    pub fn get_qualified_name(&self) -> Option<Symbol> {
+        let mut current = self;
+        while current.is_ref() {
+            current = current.get_type_params()?.first()?;
+        }
+        match current {
+            Type::Nominal { id, .. } => Some(id.clone()),
+            Type::Simple(kind) => Some(Symbol::from_parts("prelude", kind.leaf_name())),
+            Type::Compound { kind, .. } => Some(Symbol::from_parts("prelude", kind.leaf_name())),
+            _ => None,
         }
     }
 

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -351,6 +351,10 @@ impl InferResult {
         self
     }
 
+    pub fn assert_resolve_code_once(self, code: &str) -> Self {
+        self.assert_code_count(&format!("resolve.{}", code), 1)
+    }
+
     pub fn assert_infer_code_once(self, code: &str) -> Self {
         self.assert_code_count(&format!("infer.{}", code), 1)
     }

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -5512,6 +5512,136 @@ fn interface_embedding_no_conflict() {
 }
 
 #[test]
+fn interface_embedding_unresolved_parent_survives_conformance_check() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        r#"
+interface Child {
+  embed Undefined
+}
+
+struct Foo {}
+
+fn take(_c: Child) -> int { 1 }
+
+fn main() {
+  let _ = take(Foo {})
+}
+"#,
+    );
+    infer_module("main", fs).assert_resolve_code_once("type_not_found");
+}
+
+#[test]
+fn interface_embedding_builtin_rejected() {
+    infer(
+        r#"
+    interface Child {
+      embed int
+    }
+
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code_once("embed_non_interface");
+}
+
+#[test]
+fn interface_embedding_struct_rejected() {
+    infer(
+        r#"
+    struct Base {}
+
+    impl Base {
+      fn ping(self) -> int { 1 }
+    }
+
+    interface Child {
+      embed Base
+    }
+
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code_once("embed_non_interface");
+}
+
+#[test]
+fn interface_embedding_type_parameter_rejected() {
+    infer(
+        r#"
+    interface Child<T> {
+      embed T
+    }
+
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code_once("embed_non_interface");
+}
+
+#[test]
+fn interface_embedding_function_type_rejected() {
+    infer(
+        r#"
+    interface Child {
+      embed fn() -> int
+    }
+
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code_once("embed_non_interface");
+}
+
+#[test]
+fn interface_embedding_ref_to_interface_reports_ref_only() {
+    infer(
+        r#"
+    interface Parent {
+      fn ping() -> int
+    }
+
+    interface Child {
+      embed Ref<Parent>
+    }
+
+    fn main() {}
+        "#,
+    )
+    .assert_infer_code("ref_of_interface")
+    .assert_infer_code_count("embed_non_interface", 0);
+}
+
+#[test]
+fn interface_embedding_prelude_error_accepted() {
+    infer(
+        r#"
+    interface Failure {
+      embed error
+      fn code() -> int
+    }
+
+    struct MyError {}
+
+    impl MyError {
+      fn Error(self) -> string { "boom" }
+      fn code(self) -> int { 1 }
+    }
+
+    fn describe(f: Failure) -> string { f.Error() }
+
+    fn main() {
+      let _ = describe(MyError {})
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn byte_uint8_alias_direct_assignment() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9358,6 +9358,25 @@ fn main() {}
 }
 
 #[test]
+fn infer_impl_on_ref_to_builtin_array() {
+    let mut fs = MockFileSystem::new();
+
+    let source = r#"
+impl Ref<Array<int, 3>> {
+  fn first(self) -> int {
+    0
+  }
+}
+
+fn main() {}
+"#;
+    fs.add_file("main", "main.lis", source);
+
+    let result = infer_module("main", fs);
+    assert_multimodule_infer_error_snapshot!(result, source);
+}
+
+#[test]
 fn infer_non_pub_interface_with_pub_implementations() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/ui/errors/snapshots/infer_impl_on_ref_to_builtin_array.snap
+++ b/tests/ui/errors/snapshots/infer_impl_on_ref_to_builtin_array.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot implement methods on foreign type
+   ╭─[main.lis:2:1]
+ 1 │     
+ 2 │ ╭─▶ impl Ref<Array<int, 3>> {
+ 3 │ │     fn first(self) -> int {
+ 4 │ │       0
+ 5 │ │     }
+ 6 │ ├─▶ }
+   · ╰──── `Array` is defined in module `prelude`
+ 7 │     
+   ╰────
+  help: Methods can only be defined on types in the same module. Use a standalone function instead: `fn my_method(w: Array) { ... }` · code: [infer.impl_on_foreign_type]


### PR DESCRIPTION
Embedding a non-interface in an interface is now reported as an error. 

```rs
struct Base {}

interface Child {
  embed Base
}
```

```
✕ Cannot embed this type in an interface
   ╭─[main.lis:4:9]
 3 │ interface Child {
 4 │   embed Base
   ·         ──┬─
   ·           ╰── not an interface
 5 │ }
   ╰────
  help: An interface can only embed another interface, but `Base` is not one. Embed an interface, or declare the methods you need directly · code: [infer.embed_non_interface]
```

Same ICE was reachable from `impl Ref<Array<int, 3>>`, which now also rejects.

Fix #1111
