### PR TITLE
fix: accept Go function values in prelude combinators

### DIFF
--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -139,7 +139,7 @@ impl Planner<'_> {
         self.lower_abi_wrapping_with_payload_bridge(call_str, abi, result_ty, None, target)
     }
 
-    fn lower_abi_wrapping_with_payload_bridge(
+    pub(crate) fn lower_abi_wrapping_with_payload_bridge(
         &mut self,
         call_str: &str,
         abi: &CallableReturnAbi,

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
 use crate::Renderer;
-use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use crate::abi::callable::{CallableAbi, CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::coercion::{LayoutBridge, resolve_layout_bridge};
 use crate::abi::layout::{FunctionLayout, ValueLayout};
 use crate::control_flow::fallible::{
@@ -673,7 +673,7 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        abi: &CallableReturnAbi,
+        abi: &CallableAbi,
     ) -> String {
         self.require_stdlib();
 
@@ -684,7 +684,7 @@ impl Planner<'_> {
         let ret_ty_str = self.go_type_string(&return_type);
 
         let mut statements = Vec::new();
-        let outcome = match abi {
+        let outcome = match &abi.result {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => {
                 unreachable!("passthrough Go function needs no wrapper")
             }
@@ -697,9 +697,15 @@ impl Planner<'_> {
                 )));
                 Some(self.plan_tuple_from_vars(&mut statements, &temp_vars, &return_type))
             }
-            _ => {
-                let (wrap, outcome) =
-                    self.lower_abi_wrapping(&call_str, abi, &return_type, WrapperTarget::Return);
+            result => {
+                let payload_bridge = self.go_return_payload_bridge(abi, &return_type);
+                let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
+                    &call_str,
+                    result,
+                    &return_type,
+                    payload_bridge.as_ref(),
+                    WrapperTarget::Return,
+                );
                 statements.extend(wrap);
                 outcome
             }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -621,9 +621,7 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(param_ty.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_abi = self
-            .classify_direct_emission(param_ret)
-            .unwrap_or_else(|| self.value_return_abi(param_ret));
+        let param_abi = self.callable_return_abi(param_ret);
 
         let arg_ty = arg.get_type();
         let arg_fn = self
@@ -687,9 +685,7 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(variadic_inner.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_abi = self
-            .classify_direct_emission(param_ret)
-            .unwrap_or_else(|| self.value_return_abi(param_ret));
+        let param_abi = self.callable_return_abi(param_ret);
 
         let spread_ty = spread.get_type();
         let element_ty = spread_ty.unwrap_forall().inner()?;

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -31,25 +31,29 @@ impl Planner<'_> {
             && matches!(callee.origin, CallableOrigin::GoInterop)
         {
             let abi = &callee.abi.result;
-            let source_layout = ValueLayout::Function {
-                function_type: expression.get_type(),
-                layout: callee.abi.function_layout(),
-            };
+            let matches_slot = self.go_fn_slot_abi(expression, ctx).as_ref() == Some(abi);
             let target_layout = self.value_layout(&expression.get_type(), SlotOrigin::Lisette);
-            let same_abi = matches!(
-                &target_layout,
-                ValueLayout::Function { layout, .. } if layout.return_abi == *abi
-            );
-            let layout_coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
-            if !ctx.is_callee() && same_abi && !layout_coercion.is_identity() {
-                let value = self.plan_operand(expression, ctx);
-                return value.map_rendered_as_computed(|setup, value, _| {
-                    let (bridge_setup, value) = layout_coercion.lower(self, value);
-                    setup.extend(bridge_setup);
-                    GoExpression::opaque_with_deferred_evaluation(value, true)
-                });
+            let same_abi = matches_slot
+                && matches!(
+                    &target_layout,
+                    ValueLayout::Function { layout, .. } if layout.return_abi == *abi
+                );
+            if !ctx.is_callee() && same_abi {
+                let source_layout = ValueLayout::Function {
+                    function_type: expression.get_type(),
+                    layout: callee.abi.function_layout(),
+                };
+                let layout_coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
+                if !layout_coercion.is_identity() {
+                    let value = self.plan_operand(expression, ctx);
+                    return value.map_rendered_as_computed(|setup, value, _| {
+                        let (bridge_setup, value) = layout_coercion.lower(self, value);
+                        setup.extend(bridge_setup);
+                        GoExpression::opaque_with_deferred_evaluation(value, true)
+                    });
+                }
             }
-            if !self.go_fn_matches_lowered_slot(expression, abi, ctx) {
+            if !matches_slot {
                 let mut setup = Vec::new();
                 let value = if self.go_fn_needs_lowered_tuple_adapter(expression, abi, ctx) {
                     self.emit_go_fn_lowered_tuple_adapter(&mut setup, expression)
@@ -58,7 +62,7 @@ impl Planner<'_> {
                 {
                     self.emit_go_fn_sentinel_adapter(&mut setup, expression, *value)
                 } else {
-                    self.emit_go_fn_wrapper(&mut setup, expression, abi)
+                    self.emit_go_fn_wrapper(&mut setup, expression, &callee.abi)
                 };
                 return ValuePlan::computed(
                     setup,
@@ -171,25 +175,21 @@ impl Planner<'_> {
         emit_lisette_callback_wrapper(self, setup, &raw, fn_ty)
     }
 
-    /// True when a Go function value's natural ABI matches the slot's
-    /// lowered shape — wrapping would be identity.
-    fn go_fn_matches_lowered_slot(
+    /// Result ABI the slot expects from a Go function value, or `None` when
+    /// the value is not a function. A forced-tagged slot calls through a
+    /// Lisette-shaped callback, so it wants the tagged ABI, not the lowered one.
+    fn go_fn_slot_abi(
         &self,
         expression: &Expression,
-        source: &CallableReturnAbi,
         ctx: ExpressionContext<'_>,
-    ) -> bool {
-        if ctx.forces_tagged_go_function() {
-            return false;
-        }
+    ) -> Option<CallableReturnAbi> {
         let fn_ty = expression.get_type();
-        let Some(f) = fn_ty.as_function_type() else {
-            return false;
-        };
-        let target = self
-            .classify_direct_emission(&f.return_type)
-            .unwrap_or_else(|| self.value_return_abi(&f.return_type));
-        source == &target
+        let f = fn_ty.as_function_type()?;
+        Some(if ctx.forces_tagged_go_function() {
+            self.value_return_abi(&f.return_type)
+        } else {
+            self.callable_return_abi(&f.return_type)
+        })
     }
 
     /// True when a tuple-ok fallible Go function value must be wrapped to match a lowered slot.
@@ -199,29 +199,21 @@ impl Planner<'_> {
         source: &CallableReturnAbi,
         ctx: ExpressionContext<'_>,
     ) -> bool {
-        if ctx.forces_tagged_go_function() {
-            return false;
-        }
-        let fn_ty = expression.get_type();
-        let Some(f) = fn_ty.as_function_type() else {
-            return false;
-        };
-        let target = self
-            .classify_direct_emission(&f.return_type)
-            .unwrap_or_else(|| self.value_return_abi(&f.return_type));
         matches!(
-            (source, target),
+            (source, self.go_fn_slot_abi(expression, ctx)),
             (
                 CallableReturnAbi::Result {
                     payload: PayloadLayout::Flattened,
                 } | CallableReturnAbi::Partial {
                     payload: PayloadLayout::Flattened,
                 },
-                CallableReturnAbi::Result {
-                    payload: PayloadLayout::Packed,
-                } | CallableReturnAbi::Partial {
-                    payload: PayloadLayout::Packed,
-                }
+                Some(
+                    CallableReturnAbi::Result {
+                        payload: PayloadLayout::Packed,
+                    } | CallableReturnAbi::Partial {
+                        payload: PayloadLayout::Packed,
+                    }
+                )
             )
         )
     }

--- a/tests/e2e_smoke_project/src/go_interop.test.lis
+++ b/tests/e2e_smoke_project/src/go_interop.test.lis
@@ -7,6 +7,7 @@ import "go:strconv"
 import "go:strings"
 import "go:sync"
 import "go:time"
+import "go:unicode"
 
 #[test]
 fn go_tuple_destructure() {
@@ -71,6 +72,38 @@ fn pipeline_go_stdlib_chained() {
 fn pipeline_go_stdlib_with_args() {
   let result = "hello" |> strings.Repeat(3)
   assert result == "hellohellohello"
+}
+
+#[test]
+fn go_fn_value_as_prelude_map_arg() {
+  let ys = ["a", "b"].map(strings.ToUpper)
+  assert ys.equals(["A", "B"])
+}
+
+#[test]
+fn go_fn_value_as_prelude_filter_arg() {
+  let letters = "a1b".runes().filter(unicode.IsLetter)
+  assert letters.equals(['a', 'b'])
+}
+
+#[test]
+#[allow(float_cmp)]
+fn go_fn_value_as_prelude_fold_arg() {
+  let biggest = [1.0, 5.0, 3.0].fold(0.0, math.Max)
+  assert biggest == 5.0
+}
+
+#[test]
+fn go_fn_value_as_option_map_arg() {
+  let greeting: Option<string> = Some("hi")
+  assert greeting.map(strings.ToUpper) == Some("HI")
+}
+
+#[test]
+fn go_fallible_fn_value_as_prelude_map_arg() {
+  let parsed = ["1", "2"].map(strconv.Atoi)
+  let sum = parsed.fold(0, |acc, r| acc + r.unwrap_or(0))
+  assert sum == 3
 }
 
 #[test]

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -430,6 +430,98 @@ fn main() {
 }
 
 #[test]
+fn interop_direct_prelude_map_arg() {
+    let input = r#"
+import "go:strings"
+
+fn main() {
+  let xs: Slice<string> = ["a"]
+  let ys = xs.map(strings.ToUpper)
+  let _ = ys
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_direct_prelude_filter_arg() {
+    let input = r#"
+import "go:unicode"
+
+fn main() {
+  let cs: Slice<rune> = ['a', '1']
+  let letters = cs.filter(unicode.IsLetter)
+  let _ = letters
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_direct_prelude_fold_arg() {
+    let input = r#"
+import "go:math"
+
+fn main() {
+  let xs: Slice<float64> = [1.0, 5.0]
+  let biggest = xs.fold(0.0, math.Max)
+  let _ = biggest
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_direct_option_map_arg() {
+    let input = r#"
+import "go:strings"
+
+fn main() {
+  let s: Option<string> = Some("a")
+  let upper = s.map(strings.ToUpper)
+  let _ = upper
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_sentinel_prelude_map_arg() {
+    let input = r#"
+import "go:example.com/idx"
+
+fn main() {
+  let xs: Slice<string> = ["hello"]
+  let ys = xs.map(idx.Find)
+  let _ = ys
+}
+"#;
+    let typedef = r#"
+#[go(sentinel_minus_one)]
+pub fn Find(s: string) -> Option<int>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/idx", typedef)]);
+}
+
+#[test]
+fn interop_comma_ok_slice_option_prelude_map_arg() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  let keys: Slice<string> = ["k"]
+  let out = keys.map(aws.Fetch)
+  let _ = out
+}
+"#;
+    let typedef = r#"
+#[go(comma_ok)]
+pub fn Fetch(key: string) -> Option<Slice<Option<string>>>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
 fn interop_result_let_mut() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/interop_comma_ok_slice_option_prelude_map_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_slice_option_prelude_map_arg.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/aws"
+  
+  fn main() {
+    let keys: Slice<string> = ["k"]
+    let out = keys.map(aws.Fetch)
+    let _ = out
+  }
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	keys := []string{"k"}
+	out := lisette.SliceMap(keys, func(arg0 string) lisette.Option[[]lisette.Option[string]] {
+		ret_1, ret_2 := aws.Fetch(arg0)
+		if ret_2 {
+			src_3 := ret_1
+			wrapped_4 := make([]lisette.Option[string], len(src_3))
+			for i_5, v_6 := range src_3 {
+				if v_6 != nil {
+					wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+				} else {
+					wrapped_4[i_5] = lisette.MakeOptionNone[string]()
+				}
+			}
+			return lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_4)
+		} else {
+			return lisette.MakeOptionNone[[]lisette.Option[string]]()
+		}
+	})
+	_ = out
+}

--- a/tests/spec/emit/snapshots/interop_direct_option_map_arg.snap
+++ b/tests/spec/emit/snapshots/interop_direct_option_map_arg.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:strings"
+  
+  fn main() {
+    let s: Option<string> = Some("a")
+    let upper = s.map(strings.ToUpper)
+    let _ = upper
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"strings"
+)
+
+func main() {
+	s := lisette.MakeOptionSome("a")
+	upper := lisette.OptionMap(s, strings.ToUpper)
+	_ = upper
+}

--- a/tests/spec/emit/snapshots/interop_direct_prelude_filter_arg.snap
+++ b/tests/spec/emit/snapshots/interop_direct_prelude_filter_arg.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:unicode"
+  
+  fn main() {
+    let cs: Slice<rune> = ['a', '1']
+    let letters = cs.filter(unicode.IsLetter)
+    let _ = letters
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"unicode"
+)
+
+func main() {
+	cs := []rune{'a', '1'}
+	letters := lisette.SliceFilter(cs, unicode.IsLetter)
+	_ = letters
+}

--- a/tests/spec/emit/snapshots/interop_direct_prelude_fold_arg.snap
+++ b/tests/spec/emit/snapshots/interop_direct_prelude_fold_arg.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:math"
+  
+  fn main() {
+    let xs: Slice<float64> = [1.0, 5.0]
+    let biggest = xs.fold(0.0, math.Max)
+    let _ = biggest
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"math"
+)
+
+func main() {
+	xs := []float64{1.0, 5.0}
+	biggest := lisette.SliceFold(xs, 0.0, math.Max)
+	_ = biggest
+}

--- a/tests/spec/emit/snapshots/interop_direct_prelude_map_arg.snap
+++ b/tests/spec/emit/snapshots/interop_direct_prelude_map_arg.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:strings"
+  
+  fn main() {
+    let xs: Slice<string> = ["a"]
+    let ys = xs.map(strings.ToUpper)
+    let _ = ys
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"strings"
+)
+
+func main() {
+	xs := []string{"a"}
+	ys := lisette.SliceMap(xs, strings.ToUpper)
+	_ = ys
+}

--- a/tests/spec/emit/snapshots/interop_sentinel_prelude_map_arg.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_prelude_map_arg.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/idx"
+  
+  fn main() {
+    let xs: Slice<string> = ["hello"]
+    let ys = xs.map(idx.Find)
+    let _ = ys
+  }
+---
+package main
+
+import (
+	"example.com/idx"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	xs := []string{"hello"}
+	ys := lisette.SliceMap(xs, func(arg0 string) lisette.Option[int] {
+		ret_1 := idx.Find(arg0)
+		return lisette.OptionFromCommaOk[int](ret_1, ret_1 != -1)
+	})
+	_ = ys
+}


### PR DESCRIPTION
Allows passing an imported Go function directly to a prelude combinator.

```rs
import "go:fmt"
import "go:strings"

fn main() {
  fmt.Println(["a"].map(strings.ToUpper))
}
```
