### PR TITLE
fix: check function types invariantly at param and return

### DIFF
--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
@@ -1,6 +1,7 @@
 use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, IdentifierResolution, Pattern};
 use syntax::program::{CallKind, DotAccessKind};
+use syntax::types::Type;
 
 use super::helpers::lambda_is_annotated;
 use crate::passes::walk::NodeCtx;
@@ -8,7 +9,11 @@ use semantics::facts::Facts;
 
 pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Lambda {
-        params, body, span, ..
+        params,
+        body,
+        span,
+        ty: lambda_ty,
+        ..
     } = expression
     else {
         return;
@@ -54,8 +59,14 @@ pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
         param_names.push(identifier.as_str());
     }
 
-    let Some(callee_name) = hoistable_callee(callee.unwrap_parens(), &param_names, ctx.facts)
-    else {
+    let callee = callee.unwrap_parens();
+    let callee_ty = callee.get_type();
+
+    if !signatures_match(lambda_ty, &callee_ty) {
+        return;
+    }
+
+    let Some(callee_name) = hoistable_callee(callee, &callee_ty, &param_names, ctx.facts) else {
         return;
     };
 
@@ -69,6 +80,25 @@ pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
     ctx.sink.push(diagnostic);
 }
 
+fn signatures_match(lambda_ty: &Type, callee_ty: &Type) -> bool {
+    let (lambda_positions, callee_positions) = (
+        lambda_ty.unwrap_forall().children(),
+        callee_ty.unwrap_forall().children(),
+    );
+
+    lambda_positions.len() == callee_positions.len()
+        && lambda_positions
+            .iter()
+            .zip(&callee_positions)
+            .all(|(closure_ty, callee_ty)| {
+                closure_ty == callee_ty || is_unresolved(closure_ty) || is_unresolved(callee_ty)
+            })
+}
+
+fn is_unresolved(ty: &Type) -> bool {
+    matches!(ty, Type::Var { .. } | Type::Parameter(_))
+}
+
 fn lambda_body(body: &Expression) -> &Expression {
     match body.unwrap_parens() {
         Expression::Block { items, .. } if items.len() == 1 => items[0].unwrap_parens(),
@@ -76,11 +106,15 @@ fn lambda_body(body: &Expression) -> &Expression {
     }
 }
 
-fn hoistable_callee(callee: &Expression, params: &[&str], facts: &Facts) -> Option<String> {
+fn hoistable_callee(
+    callee: &Expression,
+    callee_ty: &Type,
+    params: &[&str],
+    facts: &Facts,
+) -> Option<String> {
     // A `mut`-param callee (e.g. `sort.Ints`) is valid only wrapped in a closure,
     // never as a bare function value.
-    if callee
-        .get_type()
+    if callee_ty
         .get_function_params()
         .is_some_and(|params| params.iter().any(|param| param.mutable))
     {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -96,7 +96,7 @@ impl InferCtx<'_> {
                 }
                 let before = self.sink.len();
                 if self
-                    .try_unify(arm_ty, &obligation.result_ty, arm_span)
+                    .try_unify(&obligation.result_ty, arm_ty, arm_span)
                     .is_err()
                     && self.sink.len() == before
                 {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -606,10 +606,19 @@ impl InferCtx<'_> {
         right_operand_ty: &Type,
         span: &Span,
     ) {
+        let errors_before = self.sink.len();
         if self
             .try_unify(left_operand_ty, right_operand_ty, span)
             .is_err()
         {
+            if self.sink.len() == errors_before
+                && self
+                    .try_unify(right_operand_ty, left_operand_ty, span)
+                    .is_ok()
+            {
+                return;
+            }
+
             let left_resolved = left_operand_ty.resolve_in(&self.env);
             let right_resolved = right_operand_ty.resolve_in(&self.env);
             self.sink

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -761,7 +761,7 @@ impl InferCtx<'_> {
         let candidate_ty = ty.strip_refs().resolve_in(&self.env);
         let mut receiver_pinned = true;
         let mut resolved_impl_method = None;
-        self.scopes.increment_type_param_depth();
+        self.scopes.enter_invariant_position();
         let sig_match = self.speculatively(|this| {
             let mut ctx = InferCtx::new(this, store);
             if let Some(receiver) = &receiver_to_pin {
@@ -778,7 +778,7 @@ impl InferCtx<'_> {
             }
             result
         });
-        self.scopes.decrement_type_param_depth();
+        self.scopes.exit_invariant_position();
 
         SignatureCheck {
             receiver_pinned,

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -52,6 +52,12 @@ pub enum Dispatched {
     Fallthrough,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClosureAdapter {
+    Widens,
+    Narrows,
+}
+
 impl InferCtx<'_> {
     /// Make two types equal. Returns `false` when they do not match.
     ///
@@ -112,7 +118,7 @@ impl InferCtx<'_> {
             (Type::Var { id, .. }, _) => self.unify_type_variable(*id, &r2, span, false),
             (_, Type::Var { id, .. }) => self.unify_type_variable(*id, &r1, span, true),
 
-            _ if r1_is_unknown && self.scopes.is_inside_type_param() => {
+            _ if r1_is_unknown && self.scopes.is_inside_invariant_position() => {
                 Err(UnifyError::TypeMismatch)
             }
             _ if r1_is_unknown => Ok(()),
@@ -205,10 +211,7 @@ impl InferCtx<'_> {
                 // rejected inside generic positions.
                 let a1 = a1.clone();
                 let a2 = a2.clone();
-                self.scopes.increment_type_param_depth();
-                let result = self.unify_pairs(a1.iter().zip(a2.iter()), span);
-                self.scopes.decrement_type_param_depth();
-                result
+                self.in_invariant_position(|this| this.unify_pairs(a1.iter().zip(a2.iter()), span))
             }
 
             (Nominal { .. }, Nominal { .. }) => self.unify_constructors(&r1, &r2, span),
@@ -276,7 +279,7 @@ impl InferCtx<'_> {
     fn should_unify_refs(&self, t1: &Type, t2: &Type) -> bool {
         let either_is_ref = t1.is_ref() || t2.is_ref();
         let both_concrete = !t1.is_variable() && !t2.is_variable();
-        let neither_is_interface = !self.is_interface(t1) && !self.is_interface(t2);
+        let neither_is_interface = !self.store.is_interface(t1) && !self.store.is_interface(t2);
         let neither_is_unknown = !t1.is_unknown() && !t2.is_unknown();
         let neither_is_error = !t1.is_error() && !t2.is_error();
         let neither_is_never = !t1.is_never() && !t2.is_never();
@@ -300,13 +303,11 @@ impl InferCtx<'_> {
             .is_some_and(|definition| definition.is_transparent_type_alias())
     }
 
-    fn is_interface(&self, ty: &Type) -> bool {
-        let store = self.store;
-        if let Type::Nominal { id, .. } = ty {
-            store.get_interface(id).is_some()
-        } else {
-            false
-        }
+    fn in_invariant_position<T>(&mut self, unify: impl FnOnce(&mut Self) -> T) -> T {
+        self.scopes.enter_invariant_position();
+        let result = unify(self);
+        self.scopes.exit_invariant_position();
+        result
     }
 
     fn unify_refs(&mut self, t1: &Type, t2: &Type, span: &Span) -> Result<(), UnifyError> {
@@ -425,16 +426,16 @@ impl InferCtx<'_> {
         // Bail on the first error rather than collecting via `unify_pairs`:
         // continuing past a failed pair would bind subsequent type variables
         // and erase their original names from the diagnostic.
-        self.scopes.increment_type_param_depth();
-        let mut result = Ok(());
-        for (p1, p2) in params1.iter().zip(params2) {
-            if let Err(e) = self.try_unify(p1, p2, span) {
-                result = Err(e);
-                break;
+        self.in_invariant_position(|this| {
+            let mut result = Ok(());
+            for (p1, p2) in params1.iter().zip(params2) {
+                if let Err(e) = this.try_unify(p1, p2, span) {
+                    result = Err(e);
+                    break;
+                }
             }
-        }
-        self.scopes.decrement_type_param_depth();
-        result
+            result
+        })
     }
 
     fn try_coerce_or_satisfy_interface(
@@ -464,7 +465,7 @@ impl InferCtx<'_> {
             return Ok(());
         }
 
-        if self.scopes.is_inside_type_param() {
+        if self.scopes.is_inside_invariant_position() {
             return Err(UnifyError::TypeMismatch);
         }
 
@@ -482,20 +483,13 @@ impl InferCtx<'_> {
             && symbol1.starts_with("go:")
             && store.get_interface(symbol1).is_some()
         {
-            return self.try_unify(&params2[0], t1, span);
+            return self.try_unify(t1, &params2[0], span);
         }
 
         if let Some(interface) = store.get_interface(symbol1).cloned() {
             return self
                 .satisfies_interface(t2, &interface, symbol1, params1, span)
                 .and_then(|()| self.check_pointer_receivers(t2, &interface, symbol1, span))
-                .map_err(|_| UnifyError::AlreadyReported);
-        }
-
-        if let Some(interface) = store.get_interface(symbol2).cloned() {
-            return self
-                .satisfies_interface(t1, &interface, symbol2, params2, span)
-                .and_then(|()| self.check_pointer_receivers(t1, &interface, symbol2, span))
                 .map_err(|_| UnifyError::AlreadyReported);
         }
 
@@ -547,14 +541,17 @@ impl InferCtx<'_> {
             return Err(UnifyError::TypeMismatch);
         }
 
-        let params_result = self.unify_pairs(
-            f1.params
-                .iter()
-                .zip(&f2.params)
-                .map(|(left, right)| (&left.ty, &right.ty)),
-            span,
-        );
-        let return_type_result = self.try_unify(&f1.return_type, &f2.return_type, span);
+        let (params_result, return_type_result) = self.in_invariant_position(|this| {
+            let params_result = this.unify_pairs(
+                f1.params
+                    .iter()
+                    .zip(&f2.params)
+                    .map(|(left, right)| (&left.ty, &right.ty)),
+                span,
+            );
+            let return_type_result = this.try_unify(&f1.return_type, &f2.return_type, span);
+            (params_result, return_type_result)
+        });
 
         for bound in &f1.bounds {
             self.check_function_bound(bound, &f1.params, span);
@@ -806,8 +803,22 @@ impl InferCtx<'_> {
                 {
                     format!("Annotate the slice literal: `let xs: {} = [v1, v2, ...]`", expected)
                 }
-                _ => "The expected type contains `Unknown`. Produce the value in a context where the expected type provides the `Unknown` slot (annotation, parameter type, struct field, or return position).".to_string(),
+                _ if self.store.resolve_to_function_type(expected).is_some()
+                    && self.store.resolve_to_function_type(actual).is_some() =>
+                {
+                    "Function types must match exactly, and `Unknown` matches only `Unknown`. Declare the function with the expected signature and narrow with `assert_type` inside, or wrap it in a closure that narrows at the call site".to_string()
+                }
+                _ => format!(
+                    "`Unknown` matches only `Unknown`, never a concrete type. Build `{expected}` from a value already annotated as `Unknown`, e.g. `let value: Unknown = ...`, or change the expected type to `{actual}`"
+                ),
             };
+        }
+
+        if self.store.is_interface(actual) && !self.store.is_interface(expected) {
+            return format!(
+                "An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<{}>(value)?`",
+                expected
+            );
         }
 
         if self.store.is_numeric_compatible_with(expected, actual) {
@@ -820,10 +831,53 @@ impl InferCtx<'_> {
             return "Remove the `()` so that the type matches".to_string();
         }
 
+        match self.closure_adapter(expected, actual) {
+            Some(ClosureAdapter::Widens) => {
+                return "Function types must match exactly. Wrap the value in a closure to convert at the call site, e.g. `|value| callee(value)`".to_string();
+            }
+            Some(ClosureAdapter::Narrows) => {
+                return "Function types must match exactly. Wrap the value in a closure that narrows the interface value with `assert_type`, or change the signature to match".to_string();
+            }
+            None => {}
+        }
+
         format!(
             "Change the type annotation to `{}` or convert the value to `{}`",
             actual, expected
         )
+    }
+
+    fn closure_adapter(&self, expected: &Type, actual: &Type) -> Option<ClosureAdapter> {
+        if !matches!((expected, actual), (Function(_), Function(_))) {
+            return None;
+        }
+
+        let (expected_positions, actual_positions) = (expected.children(), actual.children());
+        if expected_positions.len() != actual_positions.len() {
+            return None;
+        }
+        let return_index = expected_positions.len().checked_sub(1)?;
+
+        let mut adapter = None;
+        for (index, (left, right)) in expected_positions.iter().zip(&actual_positions).enumerate() {
+            if left == right {
+                continue;
+            }
+            if !self.store.is_interface(left) && !self.store.is_interface(right) {
+                return None;
+            }
+            let narrows = if index == return_index {
+                self.store.is_interface(right)
+            } else {
+                self.store.is_interface(left)
+            };
+            if narrows {
+                adapter = Some(ClosureAdapter::Narrows);
+            } else if adapter.is_none() {
+                adapter = Some(ClosureAdapter::Widens);
+            }
+        }
+        adapter
     }
 
     /// Whether the emitter absorbs this bounded generic into a pointer type argument

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -92,7 +92,7 @@ struct InheritedContext {
     loop_depth: DepthCounter,
     defer_block_depth: DepthCounter,
     negation_depth: DepthCounter,
-    type_param_depth: DepthCounter,
+    invariant_depth: DepthCounter,
     use_context: UseContext,
     in_test_handle: bool,
     test_fn_name: Option<EcoString>,
@@ -552,16 +552,16 @@ impl Scopes {
         std::mem::replace(&mut self.let_binding_rhs, value)
     }
 
-    pub(crate) fn increment_type_param_depth(&mut self) {
-        self.current_mut().inherited.type_param_depth.increment();
+    pub(crate) fn enter_invariant_position(&mut self) {
+        self.current_mut().inherited.invariant_depth.increment();
     }
 
-    pub(crate) fn decrement_type_param_depth(&mut self) {
-        self.current_mut().inherited.type_param_depth.decrement();
+    pub(crate) fn exit_invariant_position(&mut self) {
+        self.current_mut().inherited.invariant_depth.decrement();
     }
 
-    pub(crate) fn is_inside_type_param(&self) -> bool {
-        self.current().inherited.type_param_depth.is_active()
+    pub(crate) fn is_inside_invariant_position(&self) -> bool {
+        self.current().inherited.invariant_depth.is_active()
     }
 
     pub(crate) fn set_impl_receiver_type(&mut self, ty: Option<Type>) {

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -1698,6 +1698,27 @@ fn main() {
 }
 
 #[test]
+fn interface_value_narrowed_with_assert_type_satisfies_concrete_positions() {
+    infer(
+        r#"
+struct FooError {}
+impl FooError { fn Error(self) -> string { "foo failed" } }
+struct Holder { inner: FooError }
+fn take(f: FooError) -> string { f.Error() }
+fn unwrap(e: error) -> Option<FooError> { assert_type<FooError>(e) }
+fn main() {
+  let e: error = FooError {}
+  let concrete = assert_type<FooError>(e).unwrap_or(FooError {})
+  let held = Holder { inner: concrete }
+  let _ = take(held.inner)
+  let _ = unwrap(e)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn failed_cast_to_interface_reports_single_error() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1810,6 +1810,189 @@ fn test() {
 }
 
 #[test]
+fn infer_function_value_with_concrete_param_where_interface_param_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+struct Bar {
+  map_foo_err: fn(FooError) -> string,
+}
+
+fn build(mapper: fn(error) -> string) -> string {
+  mapper(FooError {})
+}
+
+fn test() {
+  let bar = Bar { map_foo_err: |foo| foo.Error() }
+  let _result = build(bar.map_foo_err)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_value_with_interface_param_where_concrete_param_expected() {
+    let input = r#"
+enum Bar {
+  Wrap(error),
+}
+
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn run(make_bar: fn(FooError) -> Bar) -> Bar {
+  make_bar(FooError {})
+}
+
+fn test() -> Bar {
+  run(Bar.Wrap)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_value_with_concrete_return_where_interface_return_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn make_foo_err() -> FooError {
+  FooError {}
+}
+
+fn run(make: fn() -> error) -> string {
+  make().Error()
+}
+
+fn test() -> string {
+  run(make_foo_err)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_function_value_with_concrete_param_where_unknown_param_expected() {
+    let input = r#"
+fn apply(f: fn(Unknown) -> int) -> int {
+  f(1)
+}
+
+fn double(value: int) -> int {
+  value * 2
+}
+
+fn test() -> int {
+  apply(double)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_concrete_type_argument_where_unknown_type_argument_expected() {
+    let input = r#"
+struct Box<T> {
+  pub value: T,
+}
+
+fn take(b: Box<Unknown>) -> int {
+  assert_type<int>(b.value).unwrap_or(0)
+}
+
+fn test() -> int {
+  let b: Box<int> = Box { value: 1 }
+  take(b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_value_where_concrete_param_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn take(f: FooError) -> string { f.Error() }
+
+fn test() -> string {
+  let e: error = FooError {}
+  take(e)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_value_where_concrete_annotation_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn test() -> string {
+  let e: error = FooError {}
+  let concrete: FooError = e
+  concrete.Error()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_value_where_concrete_field_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+struct Holder {
+  pub inner: FooError,
+}
+
+fn test() -> string {
+  let e: error = FooError {}
+  let held = Holder { inner: e }
+  held.inner.Error()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_interface_value_where_concrete_return_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn unwrap(e: error) -> FooError { e }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_called_function_when_function_alias_expected() {
     let input = r#"
 type Cmd = fn() -> int

--- a/tests/ui/errors/snapshots/infer_concrete_type_argument_where_unknown_type_argument_expected.snap
+++ b/tests/ui/errors/snapshots/infer_concrete_type_argument_where_unknown_type_argument_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:12:8]
+ 11 │   let b: Box<int> = Box { value: 1 }
+ 12 │   take(b)
+    ·        ┬
+    ·        ╰── expected `Box<Unknown>`, found `Box<int>`
+ 13 │ }
+    ╰────
+  help: `Unknown` matches only `Unknown`, never a concrete type. Build `Box<Unknown>` from a value already annotated as `Unknown`, e.g. `let value: Unknown = ...`, or change the expected type to `Box<int>` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_function_value_with_concrete_param_where_interface_param_expected.snap
+++ b/tests/ui/errors/snapshots/infer_function_value_with_concrete_param_where_interface_param_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:18:23]
+ 17 │   let bar = Bar { map_foo_err: |foo| foo.Error() }
+ 18 │   let _result = build(bar.map_foo_err)
+    ·                       ───────┬───────
+    ·                              ╰── expected `fn (error) -> string`, found `fn (FooError) -> string`
+ 19 │ }
+    ╰────
+  help: Function types must match exactly. Wrap the value in a closure that narrows the interface value with `assert_type`, or change the signature to match · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_function_value_with_concrete_param_where_unknown_param_expected.snap
+++ b/tests/ui/errors/snapshots/infer_function_value_with_concrete_param_where_unknown_param_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:11:9]
+ 10 │ fn test() -> int {
+ 11 │   apply(double)
+    ·         ───┬──
+    ·            ╰── expected `fn (Unknown) -> int`, found `fn (int) -> int`
+ 12 │ }
+    ╰────
+  help: Function types must match exactly, and `Unknown` matches only `Unknown`. Declare the function with the expected signature and narrow with `assert_type` inside, or wrap it in a closure that narrows at the call site · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_function_value_with_concrete_return_where_interface_return_expected.snap
+++ b/tests/ui/errors/snapshots/infer_function_value_with_concrete_return_where_interface_return_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:17:7]
+ 16 │ fn test() -> string {
+ 17 │   run(make_foo_err)
+    ·       ──────┬─────
+    ·             ╰── expected `fn () -> error`, found `fn () -> FooError`
+ 18 │ }
+    ╰────
+  help: Function types must match exactly. Wrap the value in a closure to convert at the call site, e.g. `|value| callee(value)` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_function_value_with_interface_param_where_concrete_param_expected.snap
+++ b/tests/ui/errors/snapshots/infer_function_value_with_interface_param_where_concrete_param_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:17:7]
+ 16 │ fn test() -> Bar {
+ 17 │   run(Bar.Wrap)
+    ·       ────┬───
+    ·           ╰── expected `fn (FooError) -> Bar`, found `fn (error) -> Bar`
+ 18 │ }
+    ╰────
+  help: Function types must match exactly. Wrap the value in a closure to convert at the call site, e.g. `|value| callee(value)` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_value_where_concrete_annotation_expected.snap
+++ b/tests/ui/errors/snapshots/infer_interface_value_where_concrete_annotation_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:10:28]
+  9 │   let e: error = FooError {}
+ 10 │   let concrete: FooError = e
+    ·                            ┬
+    ·                            ╰── expected `FooError`, found `error`
+ 11 │   concrete.Error()
+    ╰────
+  help: An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<FooError>(value)?` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_value_where_concrete_field_expected.snap
+++ b/tests/ui/errors/snapshots/infer_interface_value_where_concrete_field_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:14:30]
+ 13 │   let e: error = FooError {}
+ 14 │   let held = Holder { inner: e }
+    ·                              ┬
+    ·                              ╰── expected `FooError`, found `error`
+ 15 │   held.inner.Error()
+    ╰────
+  help: An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<FooError>(value)?` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_value_where_concrete_param_expected.snap
+++ b/tests/ui/errors/snapshots/infer_interface_value_where_concrete_param_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:12:8]
+ 11 │   let e: error = FooError {}
+ 12 │   take(e)
+    ·        ┬
+    ·        ╰── expected `FooError`, found `error`
+ 13 │ }
+    ╰────
+  help: An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<FooError>(value)?` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_value_where_concrete_return_expected.snap
+++ b/tests/ui/errors/snapshots/infer_interface_value_where_concrete_return_expected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:8:35]
+ 7 │ 
+ 8 │ fn unwrap(e: error) -> FooError { e }
+   ·                                   ┬
+   ·                                   ╰── expected `FooError`, found `error`
+   ╰────
+  help: An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<FooError>(value)?` · code: [infer.type_mismatch]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -15123,6 +15123,70 @@ fn main() {
 }
 
 #[test]
+fn redundant_closure_coerced_param_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+enum Bar {
+  Wrap(error),
+}
+
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn run(make_bar: fn(FooError) -> Bar) -> Bar {
+  make_bar(FooError {})
+}
+
+fn main() {
+  let _ = run(|e| Bar.Wrap(e))
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_coerced_return_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn make_foo_err() -> FooError {
+  FooError {}
+}
+
+fn run(make: fn() -> error) -> string {
+  make().Error()
+}
+
+fn main() {
+  let _ = run(|| make_foo_err())
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_closure_generic_callee() {
+    assert_lint_snapshot!(
+        r#"
+fn identity<T>(value: T) -> T { value }
+
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs.map(|x| identity(x))
+}
+"#
+    );
+}
+
+#[test]
 fn redundant_closure_mut_param_callee_no_warning() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/redundant_closure_generic_callee.snap
+++ b/tests/ui/lint/snapshots/redundant_closure_generic_callee.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ● Redundant closure
+   ╭─[test.lis:6:18]
+ 5 │   let xs = [1, 2, 3]
+ 6 │   let _ = xs.map(|x| identity(x))
+   ·                  ───────┬───────
+   ·                         ╰── can be simpler
+ 7 │ }
+   ╰────
+  help: Replace this closure with `identity` · code: [lint.redundant_closure]


### PR DESCRIPTION
A fn value must now match the expected sig exactly, e.g. passing `fn(FooError) -> string` where `fn(error) -> string` is expected is rejected. Relatedly, the redundant closure lint no longer flags a closure whose sig differs from the callee it wraps.

```rs
struct Bar {
  map_foo_err: fn(FooError) -> string,
}

fn build(mapper: fn(error) -> string) -> string {
  mapper(FooError {})
}

fn main() {
  let bar = Bar { map_foo_err: |foo| foo.Error() }

  let _rejected = build(bar.map_foo_err)
  // expected `fn (error) -> string`, found `fn (FooError) -> string`

  let _ok = build(|e| assert_type<FooError>(e).map_or("not a FooError", bar.map_foo_err))
}
```

Fix #1110