### PR TITLE
fix: rebuild arrays and tuples whose elements widen to interfaces

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -1,11 +1,12 @@
 use syntax::ast::Expression;
+use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
 use crate::Planner;
 use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::names::go_name;
-use crate::plan::bodies::LoweredStatement;
+use crate::plan::bodies::{LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
 
 use super::callable::AbiTransition;
 use super::layout::{FunctionLayout, ValueLayout};
@@ -13,8 +14,18 @@ use super::layout::{FunctionLayout, ValueLayout};
 pub(crate) enum CoercionPlan {
     Identity,
     WrapAsInterface(AdapterPlan),
-    WrapNewtype { ty: Type },
+    WrapNewtype {
+        ty: Type,
+    },
     Layout(LayoutBridge),
+    RebuildArray {
+        array_type: Type,
+        element: Box<CoercionPlan>,
+    },
+    RebuildTuple {
+        slot_types: Vec<Type>,
+        elements: Vec<CoercionPlan>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,10 +99,14 @@ impl LayoutBridge {
 
 impl CoercionPlan {
     pub(crate) fn internal(planner: &Planner<'_>, from: &Type, to: &Type) -> Self {
-        if let Some(plan) = planner.needs_adapter(from, to) {
+        if from == to {
+            Self::Identity
+        } else if let Some(plan) = planner.needs_adapter(from, to) {
             Self::WrapAsInterface(plan)
         } else if needs_newtype_wrap(planner, from, to) {
             Self::WrapNewtype { ty: to.clone() }
+        } else if let Some(rebuild) = aggregate_rebuild(planner, from, to) {
+            rebuild
         } else {
             Self::Identity
         }
@@ -131,6 +146,14 @@ impl CoercionPlan {
                 format!("{}({})", type_name, value)
             }
             Self::Layout(bridge) => planner.plan_layout_bridge(&mut statements, &value, &bridge),
+            Self::RebuildArray {
+                array_type,
+                element,
+            } => planner.plan_array_rebuild(&mut statements, &value, &array_type, *element),
+            Self::RebuildTuple {
+                slot_types,
+                elements,
+            } => planner.plan_tuple_rebuild(&mut statements, &value, &slot_types, elements),
         };
         (statements, value)
     }
@@ -151,6 +174,74 @@ impl Planner<'_> {
         let (setup, value) = coercion.lower(self, emitted);
         output.push_str(&Renderer.render_setup(&setup));
         value
+    }
+
+    /// Bind `value` to a name that can be read more than once.
+    fn stable_source(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        hint: &str,
+        value: &str,
+    ) -> String {
+        if go_name::is_plain_identifier(value) {
+            return value.to_string();
+        }
+        self.hoist_tmp_value_statement(statements, hint, value)
+    }
+
+    fn plan_array_rebuild(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: &str,
+        array_type: &Type,
+        element: CoercionPlan,
+    ) -> String {
+        let source = self.stable_source(statements, "src", value);
+        let go_type = self.go_type_string(array_type);
+        let output = self.fresh_var(Some("boxed"));
+        self.declare(&output);
+        statements.push(LoweredStatement::VarDecl {
+            name: output.clone(),
+            go_type,
+            value: None,
+        });
+
+        let index = self.fresh_var(Some("i"));
+        self.declare(&index);
+        let (mut body, coerced) = element.lower(self, format!("{source}[{index}]"));
+        body.push(LoweredStatement::RawGo(format!(
+            "{output}[{index}] = {coerced}\n"
+        )));
+        statements.push(LoweredStatement::Loop(LoopPlan {
+            prologue: Vec::new(),
+            kind: LoopKind::Generated { label: None },
+            header: format!("for {index} := range {source} {{\n"),
+            body: LoweredBlock { statements: body },
+        }));
+        output
+    }
+
+    fn plan_tuple_rebuild(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: &str,
+        slot_types: &[Type],
+        elements: Vec<CoercionPlan>,
+    ) -> String {
+        let source = self.stable_source(statements, "tup", value);
+
+        let mut arguments = Vec::with_capacity(elements.len());
+        for (index, element) in elements.into_iter().enumerate() {
+            let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
+            let (element_setup, coerced) = element.lower(self, format!("{source}.{field}"));
+            statements.extend(element_setup);
+            arguments.push(coerced);
+        }
+        format!(
+            "{}({})",
+            self.make_tuple_callee(slot_types, slot_types.len()),
+            arguments.join(", ")
+        )
     }
 }
 
@@ -412,6 +503,52 @@ fn is_go_interface_slot(planner: &Planner<'_>, ty: &Type) -> bool {
         .facts
         .as_interface(ty)
         .is_some_and(|id| go_name::is_go_import(&id))
+}
+
+fn aggregate_rebuild(planner: &Planner<'_>, from: &Type, to: &Type) -> Option<CoercionPlan> {
+    match (from, to) {
+        (
+            Type::Array {
+                length: from_length,
+                element: from_element,
+            },
+            Type::Array {
+                length: to_length,
+                element: to_element,
+            },
+        ) if from_length == to_length => {
+            let element = widening_element_plan(planner, from_element, to_element)?;
+            Some(CoercionPlan::RebuildArray {
+                array_type: to.clone(),
+                element: Box::new(element),
+            })
+        }
+        (Type::Tuple(from_elements), Type::Tuple(to_elements))
+            if from_elements.len() == to_elements.len() =>
+        {
+            let elements: Vec<Option<CoercionPlan>> = from_elements
+                .iter()
+                .zip(to_elements)
+                .map(|(from, to)| widening_element_plan(planner, from, to))
+                .collect();
+            if elements.iter().all(Option::is_none) {
+                return None;
+            }
+            Some(CoercionPlan::RebuildTuple {
+                slot_types: to_elements.clone(),
+                elements: elements
+                    .into_iter()
+                    .map(|element| element.unwrap_or(CoercionPlan::Identity))
+                    .collect(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn widening_element_plan(planner: &Planner<'_>, from: &Type, to: &Type) -> Option<CoercionPlan> {
+    let plan = CoercionPlan::internal(planner, from, to);
+    (from != to && (planner.facts.is_interface(to) || !plan.is_identity())).then_some(plan)
 }
 
 fn needs_newtype_wrap(planner: &Planner<'_>, from: &Type, to: &Type) -> bool {

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -619,6 +619,7 @@ fn emit_lowered_tuple_tail(
         let (mut statements, parts) = planner
             .sequence_values(stages, CaptureBoundary::SiblingSequence, "_ret")
             .into_rendered();
+        let parts = planner.coerce_elements_to_slots(&mut statements, elements, parts, &slot_tys);
         statements.push(multi_value_return(parts));
         return statements;
     }

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -468,44 +468,6 @@ impl Planner<'_> {
         }
         (go_ret, body)
     }
-
-    pub(crate) fn resolve_tuple_slot_types(
-        &mut self,
-        inferred: Vec<Type>,
-        in_tail: bool,
-    ) -> Vec<Type> {
-        let resolved = self.return_ctx();
-        let return_slots = resolved.ty().and_then(|ty| {
-            let Type::Tuple(slots) = ty else {
-                return None;
-            };
-            (slots.len() == inferred.len()).then(|| slots.clone())
-        });
-
-        let Some(return_slots) = return_slots else {
-            return inferred;
-        };
-
-        if in_tail {
-            return return_slots;
-        }
-
-        return_slots
-            .iter()
-            .zip(inferred.iter())
-            .map(|(declared, inferred_slot)| {
-                let needs_widening = self.needs_adapter(inferred_slot, declared).is_some()
-                    || self.facts.is_interface(declared)
-                    || (declared.get_qualified_id().is_some()
-                        && declared.get_qualified_id() == inferred_slot.get_qualified_id());
-                if needs_widening {
-                    declared.clone()
-                } else {
-                    inferred_slot.clone()
-                }
-            })
-            .collect()
-    }
 }
 
 fn write_method_header(

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -312,9 +312,39 @@ impl Planner<'_> {
         }
     }
 
-    /// Emit a Go tuple literal. `in_tail` widens slot types to the declared
-    /// return slots so per-element coercion matches the return site.
-    /// Plan a tuple literal as `lisette.MakeTupleN(...)`.
+    pub(crate) fn coerce_elements_to_slots(
+        &mut self,
+        setup: &mut Vec<LoweredStatement>,
+        elements: &[Expression],
+        rendered: Vec<String>,
+        slot_types: &[Type],
+    ) -> Vec<String> {
+        let mut coerced_elements = Vec::with_capacity(rendered.len());
+        for (index, (element, rendered)) in elements.iter().zip(rendered).enumerate() {
+            let Some(slot) = slot_types.get(index) else {
+                coerced_elements.push(rendered);
+                continue;
+            };
+            let coercion = CoercionPlan::internal(self, &element.get_type(), slot);
+            let (coercion_setup, coerced) = coercion.lower(self, rendered);
+            setup.extend(coercion_setup);
+            coerced_elements.push(coerced);
+        }
+        coerced_elements
+    }
+
+    pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> String {
+        self.require_stdlib();
+        if !slot_types.iter().any(|slot| self.facts.is_interface(slot)) {
+            return format!("lisette.MakeTuple{}", arity);
+        }
+        let rendered: Vec<String> = slot_types
+            .iter()
+            .map(|slot| self.go_type_string(slot))
+            .collect();
+        format!("lisette.MakeTuple{}[{}]", arity, rendered.join(", "))
+    }
+
     pub(crate) fn plan_tuple_value(
         &mut self,
         elements: &[Expression],
@@ -325,7 +355,10 @@ impl Planner<'_> {
             Type::Tuple(slots) => slots.clone(),
             _ => Vec::new(),
         };
-        let slot_types = self.resolve_tuple_slot_types(inferred_slot_types, in_tail);
+        let slot_types = match in_tail.then(|| tail_return_slots(self, &inferred_slot_types)) {
+            Some(Some(return_slots)) => return_slots,
+            _ => inferred_slot_types,
+        };
 
         let stages: Vec<ValuePlan> = elements
             .iter()
@@ -340,34 +373,9 @@ impl Planner<'_> {
         let effect = sequenced.effect;
         let (mut setup, element_expressions) = sequenced.into_rendered();
 
-        let mut wrapped_expressions: Vec<String> = Vec::with_capacity(element_expressions.len());
-        for (i, (expr, emitted)) in elements.iter().zip(element_expressions).enumerate() {
-            let value = match slot_types.get(i) {
-                Some(slot) => {
-                    let coercion = CoercionPlan::internal(self, &expr.get_type(), slot);
-                    let (coercion_setup, coerced) = coercion.lower(self, emitted);
-                    setup.extend(coercion_setup);
-                    coerced
-                }
-                None => emitted,
-            };
-            wrapped_expressions.push(value);
-        }
-        let element_expressions = wrapped_expressions;
-
-        self.require_stdlib();
-        let arity = element_expressions.len();
-
-        let needs_explicit_type_args =
-            !slot_types.is_empty() && slot_types.iter().any(|t| self.facts.is_interface(t));
-
-        let callee = if !needs_explicit_type_args {
-            format!("lisette.MakeTuple{}", arity)
-        } else {
-            let slot_ty_strs: Vec<String> =
-                slot_types.iter().map(|t| self.go_type_string(t)).collect();
-            format!("lisette.MakeTuple{}[{}]", arity, slot_ty_strs.join(", "))
-        };
+        let element_expressions =
+            self.coerce_elements_to_slots(&mut setup, elements, element_expressions, &slot_types);
+        let callee = self.make_tuple_callee(&slot_types, element_expressions.len());
         ValuePlan::observable_call(
             setup,
             GoExpression::call(
@@ -715,6 +723,14 @@ impl Planner<'_> {
             Some(DefinitionBody::Enum { .. })
         )
     }
+}
+
+fn tail_return_slots(planner: &Planner<'_>, inferred: &[Type]) -> Option<Vec<Type>> {
+    let return_ctx = planner.return_ctx();
+    let Some(Type::Tuple(slots)) = return_ctx.ty() else {
+        return None;
+    };
+    (slots.len() == inferred.len()).then(|| slots.clone())
 }
 
 fn is_native_method_call(expression: &Expression) -> bool {

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -70,6 +70,15 @@ pub(crate) fn go_package_name(module: &str) -> &str {
     module.rsplit('/').next().unwrap_or(module)
 }
 
+pub(crate) fn is_plain_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 pub(crate) fn sanitize_package_name(name: &str) -> Cow<'_, str> {
     let has_bad_chars = name.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_');
     let starts_with_digit = name.starts_with(|c: char| c.is_ascii_digit());

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -2,6 +2,7 @@ use crate::Planner;
 use crate::abi::callable::CallableReturnAbi;
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
 use crate::patterns::tree_emitter::TreePlanner;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
@@ -407,7 +408,7 @@ impl Planner<'_> {
         let staged = self.stage_composite(subject, ExpressionContext::value());
         let (subject_setup, value) = staged.into_parts();
         setup.extend(subject_setup);
-        if !any_guard && is_plain_go_identifier(&value) {
+        if !any_guard && is_plain_identifier(&value) {
             return (value, SubjectDeclaration::None);
         }
         let declaration = SubjectDeclaration::Deferred {
@@ -416,15 +417,6 @@ impl Planner<'_> {
         };
         (var, declaration)
     }
-}
-
-fn is_plain_go_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => return false,
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Recognize `[Ok(<...>), Err(<...>)]` (in either order, no guards).

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -62,40 +62,23 @@ fn unwrap_unary_negation(expression: &Expression) -> &Expression {
 }
 
 /// Pick the Go type for a `let` binding's `var X T` temp. Diverging values
-/// use the binding type so dead `return x` paths still typecheck; branching
-/// values that produce tuples widen slots to match the assignment site.
+/// use the binding type so dead `return x` paths still typecheck.
 fn resolve_let_temp_declaration_ty(
-    planner: &mut Planner,
+    planner: &Planner,
     value: &Expression,
     binding_ty: &Type,
 ) -> Type {
     let value_ty = value.get_type();
-    let widens_to_interface =
-        planner.facts.as_interface(binding_ty).is_some() && *binding_ty != value_ty;
-    if !value_ty.is_unit() && !value_ty.is_never() && widens_to_interface {
+    if value_ty.is_unit() || value_ty.is_never() {
+        if binding_ty.is_unit() || binding_ty.is_variable() || binding_ty.is_placeholder() {
+            return value_ty;
+        }
         return binding_ty.clone();
     }
-    let base = if value_ty.is_unit() || value_ty.is_never() {
-        if !binding_ty.is_unit() && !binding_ty.is_variable() && !binding_ty.is_placeholder() {
-            binding_ty.clone()
-        } else {
-            value_ty
-        }
-    } else {
-        value_ty
-    };
-    let is_branching = matches!(
-        value,
-        Expression::If { .. }
-            | Expression::IfLet { .. }
-            | Expression::Match { .. }
-            | Expression::Select { .. }
-    );
-    if is_branching && let Type::Tuple(slots) = &base {
-        Type::Tuple(planner.resolve_tuple_slot_types(slots.clone(), false))
-    } else {
-        base
+    if planner.facts.is_interface(binding_ty) && *binding_ty != value_ty {
+        return binding_ty.clone();
     }
+    value_ty
 }
 
 impl Planner<'_> {

--- a/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
+++ b/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
@@ -24,12 +24,14 @@ func (r Reader2) Read(_ []uint8) (int, error) {
 func pick(flag bool) (io.Reader, int) {
 	var result lisette.Tuple2[io.Reader, int]
 	if flag {
-		result = lisette.MakeTuple2[io.Reader, int](Reader1{}, 1)
+		tup_1 := lisette.MakeTuple2(Reader1{}, 1)
+		result = lisette.MakeTuple2[io.Reader, int](tup_1.First, tup_1.Second)
 	} else {
-		result = lisette.MakeTuple2[io.Reader, int](Reader2{}, 2)
+		tup_2 := lisette.MakeTuple2(Reader2{}, 2)
+		result = lisette.MakeTuple2[io.Reader, int](tup_2.First, tup_2.Second)
 	}
-	tup_1 := result
-	return tup_1.First, tup_1.Second
+	tup_3 := result
+	return tup_3.First, tup_3.Second
 }
 
 func main() {

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -1,3 +1,4 @@
+use crate::assert_emit_snapshot;
 use crate::assert_emit_snapshot_with_go_typedefs;
 
 #[test]
@@ -843,4 +844,325 @@ pub struct Server {
 pub fn NewHandler() -> Handler
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/srv", typedef)]);
+}
+
+#[test]
+fn array_of_concrete_widens_to_interface_elements_in_argument_position() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn first(errs: Array<error, 2>) -> string {
+  errs[0].Error()
+}
+
+fn test() {
+  let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+  if first(concrete) != "boom" {
+    panic("array argument lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_of_concrete_widens_to_interface_elements_in_let_annotation() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn first(errs: Array<error, 2>) -> string {
+  errs[0].Error()
+}
+
+fn test() {
+  let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+  let widened: Array<error, 2> = concrete
+  if first(widened) != "boom" {
+    panic("annotated array binding lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_of_concrete_widens_to_interface_elements_in_return_position() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn widen() -> Array<error, 2> {
+  let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+  concrete
+}
+
+fn test() {
+  if widen()[1].Error() != "boom" {
+    panic("returned array lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_of_concrete_widens_to_interface_elements_in_struct_field() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+struct Holder {
+  errs: Array<error, 2>,
+}
+
+fn test() {
+  let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+  let holder = Holder { errs: concrete }
+  if holder.errs[0].Error() != "boom" {
+    panic("struct field lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_of_concrete_widens_to_interface_elements_in_assignment() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+struct Quiet {}
+
+impl Quiet {
+  fn Error(self) -> string {
+    "quiet"
+  }
+}
+
+fn test() {
+  let mut errs: Array<error, 2> = [Quiet {}, Quiet {}]
+  let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+  errs = concrete
+  if errs[0].Error() != "boom" {
+    panic("assignment lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_built_at_interface_element_type_needs_no_rebuild() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn first(errs: Array<error, 2>) -> string {
+  errs[0].Error()
+}
+
+fn test() {
+  let errs: Array<error, 2> = [Boom {}, Boom {}]
+  if first(errs) != "boom" {
+    panic("array built at the interface element type was rebuilt wrongly")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_of_concrete_widens_to_interface_elements_in_argument_position() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn describe(pair: (error, int)) -> string {
+  pair.0.Error()
+}
+
+fn test() {
+  let concrete = (Boom {}, 1)
+  if describe(concrete) != "boom" {
+    panic("tuple argument lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_of_concrete_widens_to_interface_elements_in_let_annotation() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn describe(pair: (error, int)) -> string {
+  pair.0.Error()
+}
+
+fn test() {
+  let widened: (error, int) = (Boom {}, 1)
+  if describe(widened) != "boom" {
+    panic("annotated tuple binding lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_of_concrete_widens_to_interface_elements_in_struct_field() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+struct Holder {
+  pair: (error, int),
+}
+
+fn test() {
+  let concrete = (Boom {}, 1)
+  let holder = Holder { pair: concrete }
+  if holder.pair.0.Error() != "boom" {
+    panic("struct field lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_of_concrete_widens_to_interface_elements_in_match_arm() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn describe(pair: (error, int)) -> string {
+  pair.0.Error()
+}
+
+fn test() {
+  let pair: (error, int) = match 1 {
+    1 => (Boom {}, 1),
+    _ => (Boom {}, 2),
+  }
+  if describe(pair) != "boom" {
+    panic("match arm lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nested_array_of_tuples_widens_to_interface_elements() {
+    let input = r#"
+struct Boom {}
+
+impl Boom {
+  fn Error(self) -> string {
+    "boom"
+  }
+}
+
+fn first(rows: Array<(error, int), 2>) -> string {
+  rows[0].0.Error()
+}
+
+fn test() {
+  let concrete: Array<(Boom, int), 2> = [(Boom {}, 1), (Boom {}, 2)]
+  if first(concrete) != "boom" {
+    panic("nested container lost its interface elements")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_tail_return_wraps_adapter_for_interface_slot() {
+    let input = r#"
+struct Thing {
+  v: int,
+}
+
+interface Box<T> {
+  fn get() -> T
+}
+
+struct Bar {}
+
+impl Bar {
+  fn get(self) -> Option<Ref<Thing>> {
+    None
+  }
+}
+
+fn make() -> (Box<Option<Ref<Thing>>>, int) {
+  (Bar {}, 2)
+}
+
+fn test() {
+  let pair = make()
+  match pair.0.get() {
+    Some(_) => panic("expected None"),
+    None => {},
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
 }

--- a/tests/spec/emit/snapshots/array_built_at_interface_element_type_needs_no_rebuild.snap
+++ b/tests/spec/emit/snapshots/array_built_at_interface_element_type_needs_no_rebuild.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn first(errs: Array<error, 2>) -> string {
+    errs[0].Error()
+  }
+  
+  fn test() {
+    let errs: Array<error, 2> = [Boom {}, Boom {}]
+    if first(errs) != "boom" {
+      panic("array built at the interface element type was rebuilt wrongly")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func first(errs [2]error) string {
+	return errs[0].Error()
+}
+
+func test() {
+	errs := [2]error{Boom{}, Boom{}}
+	if first(errs) != "boom" {
+		panic("array built at the interface element type was rebuilt wrongly")
+	}
+}

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_argument_position.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn first(errs: Array<error, 2>) -> string {
+    errs[0].Error()
+  }
+  
+  fn test() {
+    let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+    if first(concrete) != "boom" {
+      panic("array argument lost its interface elements")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func first(errs [2]error) string {
+	return errs[0].Error()
+}
+
+func test() {
+	concrete := [2]Boom{Boom{}, Boom{}}
+	var boxed_1 [2]error
+	for i_2 := range concrete {
+		boxed_1[i_2] = concrete[i_2]
+	}
+	if first(boxed_1) != "boom" {
+		panic("array argument lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_assignment.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_assignment.snap
@@ -1,0 +1,55 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  struct Quiet {}
+  
+  impl Quiet {
+    fn Error(self) -> string {
+      "quiet"
+    }
+  }
+  
+  fn test() {
+    let mut errs: Array<error, 2> = [Quiet {}, Quiet {}]
+    let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+    errs = concrete
+    if errs[0].Error() != "boom" {
+      panic("assignment lost its interface elements")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+type Quiet struct{}
+
+func (q Quiet) Error() string {
+	return "quiet"
+}
+
+func test() {
+	errs := [2]error{Quiet{}, Quiet{}}
+	concrete := [2]Boom{Boom{}, Boom{}}
+	var boxed_1 [2]error
+	for i_2 := range concrete {
+		boxed_1[i_2] = concrete[i_2]
+	}
+	errs = boxed_1
+	if errs[0].Error() != "boom" {
+		panic("assignment lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_let_annotation.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_let_annotation.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn first(errs: Array<error, 2>) -> string {
+    errs[0].Error()
+  }
+  
+  fn test() {
+    let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+    let widened: Array<error, 2> = concrete
+    if first(widened) != "boom" {
+      panic("annotated array binding lost its interface elements")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func first(errs [2]error) string {
+	return errs[0].Error()
+}
+
+func test() {
+	concrete := [2]Boom{Boom{}, Boom{}}
+	var boxed_1 [2]error
+	for i_2 := range concrete {
+		boxed_1[i_2] = concrete[i_2]
+	}
+	widened := boxed_1
+	if first(widened) != "boom" {
+		panic("annotated array binding lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn widen() -> Array<error, 2> {
+    let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+    concrete
+  }
+  
+  fn test() {
+    if widen()[1].Error() != "boom" {
+      panic("returned array lost its interface elements")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func widen() [2]error {
+	concrete := [2]Boom{Boom{}, Boom{}}
+	var boxed_1 [2]error
+	for i_2 := range concrete {
+		boxed_1[i_2] = concrete[i_2]
+	}
+	return boxed_1
+}
+
+func test() {
+	_base_1 := widen()
+	if _base_1[1].Error() != "boom" {
+		panic("returned array lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_struct_field.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  struct Holder {
+    errs: Array<error, 2>,
+  }
+  
+  fn test() {
+    let concrete: Array<Boom, 2> = [Boom {}, Boom {}]
+    let holder = Holder { errs: concrete }
+    if holder.errs[0].Error() != "boom" {
+      panic("struct field lost its interface elements")
+    }
+  }
+---
+package main
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+type Holder struct {
+	errs [2]error
+}
+
+func test() {
+	concrete := [2]Boom{Boom{}, Boom{}}
+	var boxed_1 [2]error
+	for i_2 := range concrete {
+		boxed_1[i_2] = concrete[i_2]
+	}
+	holder := Holder{errs: boxed_1}
+	if holder.errs[0].Error() != "boom" {
+		panic("struct field lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/nested_array_of_tuples_widens_to_interface_elements.snap
+++ b/tests/spec/emit/snapshots/nested_array_of_tuples_widens_to_interface_elements.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn first(rows: Array<(error, int), 2>) -> string {
+    rows[0].0.Error()
+  }
+  
+  fn test() {
+    let concrete: Array<(Boom, int), 2> = [(Boom {}, 1), (Boom {}, 2)]
+    if first(concrete) != "boom" {
+      panic("nested container lost its interface elements")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func first(rows [2]lisette.Tuple2[error, int]) string {
+	return rows[0].First.Error()
+}
+
+func test() {
+	concrete := [2]lisette.Tuple2[Boom, int]{lisette.MakeTuple2(Boom{}, 1), lisette.MakeTuple2(Boom{}, 2)}
+	var boxed_1 [2]lisette.Tuple2[error, int]
+	for i_2 := range concrete {
+		tup_3 := concrete[i_2]
+		boxed_1[i_2] = lisette.MakeTuple2[error, int](tup_3.First, tup_3.Second)
+	}
+	if first(boxed_1) != "boom" {
+		panic("nested container lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
+++ b/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
@@ -39,9 +39,9 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var result lisette.Tuple2[tea.Model, lisette.Option[tea.Cmd]]
+	var result lisette.Tuple2[Model, lisette.Option[func() tea.Msg]]
 	_ = msg
-	result = lisette.MakeTuple2[tea.Model, lisette.Option[tea.Cmd]](m, lisette.MakeOptionSome[tea.Cmd](tea.Quit))
+	result = lisette.MakeTuple2(m, lisette.MakeOptionSome(tea.Quit))
 	tup_1 := result
 	opt_2 := tup_1.Second
 	var unwrap_3 tea.Cmd

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_argument_position.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn describe(pair: (error, int)) -> string {
+    pair.0.Error()
+  }
+  
+  fn test() {
+    let concrete = (Boom {}, 1)
+    if describe(concrete) != "boom" {
+      panic("tuple argument lost its interface elements")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func describe(pair lisette.Tuple2[error, int]) string {
+	return pair.First.Error()
+}
+
+func test() {
+	concrete := lisette.MakeTuple2(Boom{}, 1)
+	if describe(lisette.MakeTuple2[error, int](concrete.First, concrete.Second)) != "boom" {
+		panic("tuple argument lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_let_annotation.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_let_annotation.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn describe(pair: (error, int)) -> string {
+    pair.0.Error()
+  }
+  
+  fn test() {
+    let widened: (error, int) = (Boom {}, 1)
+    if describe(widened) != "boom" {
+      panic("annotated tuple binding lost its interface elements")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func describe(pair lisette.Tuple2[error, int]) string {
+	return pair.First.Error()
+}
+
+func test() {
+	tup_1 := lisette.MakeTuple2(Boom{}, 1)
+	widened := lisette.MakeTuple2[error, int](tup_1.First, tup_1.Second)
+	if describe(widened) != "boom" {
+		panic("annotated tuple binding lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_match_arm.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_match_arm.snap
@@ -1,0 +1,53 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  fn describe(pair: (error, int)) -> string {
+    pair.0.Error()
+  }
+  
+  fn test() {
+    let pair: (error, int) = match 1 {
+      1 => (Boom {}, 1),
+      _ => (Boom {}, 2),
+    }
+    if describe(pair) != "boom" {
+      panic("match arm lost its interface elements")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+func describe(pair lisette.Tuple2[error, int]) string {
+	return pair.First.Error()
+}
+
+func test() {
+	var pair lisette.Tuple2[error, int]
+	if 1 == 1 {
+		tup_1 := lisette.MakeTuple2(Boom{}, 1)
+		pair = lisette.MakeTuple2[error, int](tup_1.First, tup_1.Second)
+	} else {
+		tup_2 := lisette.MakeTuple2(Boom{}, 2)
+		pair = lisette.MakeTuple2[error, int](tup_2.First, tup_2.Second)
+	}
+	if describe(pair) != "boom" {
+		panic("match arm lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_struct_field.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn Error(self) -> string {
+      "boom"
+    }
+  }
+  
+  struct Holder {
+    pair: (error, int),
+  }
+  
+  fn test() {
+    let concrete = (Boom {}, 1)
+    let holder = Holder { pair: concrete }
+    if holder.pair.0.Error() != "boom" {
+      panic("struct field lost its interface elements")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Boom struct{}
+
+func (b Boom) Error() string {
+	return "boom"
+}
+
+type Holder struct {
+	pair lisette.Tuple2[error, int]
+}
+
+func test() {
+	concrete := lisette.MakeTuple2(Boom{}, 1)
+	holder := Holder{pair: lisette.MakeTuple2[error, int](concrete.First, concrete.Second)}
+	if holder.pair.First.Error() != "boom" {
+		panic("struct field lost its interface elements")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
+++ b/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
@@ -1,0 +1,73 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Thing {
+    v: int,
+  }
+  
+  interface Box<T> {
+    fn get() -> T
+  }
+  
+  struct Bar {}
+  
+  impl Bar {
+    fn get(self) -> Option<Ref<Thing>> {
+      None
+    }
+  }
+  
+  fn make() -> (Box<Option<Ref<Thing>>>, int) {
+    (Bar {}, 2)
+  }
+  
+  fn test() {
+    let pair = make()
+    match pair.0.get() {
+      Some(_) => panic("expected None"),
+      None => {},
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Thing struct {
+	v int
+}
+
+type Box[T any] interface {
+	get() T
+}
+
+type Bar struct{}
+
+func (b Bar) get() *Thing {
+	return nil
+}
+
+func make_() (Box[lisette.Option[*Thing]], int) {
+	return _lisAdapter_Bar_Box_0{inner: Bar{}}, 2
+}
+
+func test() {
+	ret_1, ret_2 := make_()
+	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
+	pair := tup_3
+	subject_4 := pair.First.get()
+	if subject_4.Tag == lisette.OptionSome {
+		panic("expected None")
+	}
+}
+
+type _lisAdapter_Bar_Box_0 struct {
+	inner Bar
+}
+
+func (a _lisAdapter_Bar_Box_0) get() lisette.Option[*Thing] {
+	raw_1 := a.inner.get()
+	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
+	return option_2
+}


### PR DESCRIPTION
An array or tuple whose elements widen to an interface now compiles.

```rs
import "go:fmt"

struct FooError {}

impl FooError {
  fn Error(self) -> string { "foo failed" }
}

fn take_array(errs: Array<error, 2>) -> int { errs.length() }
fn take_tuple(pair: (error, int)) -> int { pair.1 }

fn main() {
  let xs: Array<FooError, 2> = [FooError {}, FooError {}]
  let pair = (FooError {}, 1)

  fmt.Println(take_array(xs))
  fmt.Println(take_tuple(pair))
}
```