### PR TITLE
fix: never split a lambda param list to fit a long call

### DIFF
--- a/crates/format/src/formatter/expression.rs
+++ b/crates/format/src/formatter/expression.rs
@@ -539,6 +539,7 @@ impl<'a> Formatter<'a> {
             .append(strict_break("", " "))
             .append(self.expression(right_operand))
             .group()
+            .measure_flat()
     }
 
     fn pipeline(&mut self, left: &'a Expression, right: &'a Expression) -> Document<'a> {
@@ -670,8 +671,8 @@ impl<'a> Formatter<'a> {
                     .append("(")
                     .append(spread_doc.group().next_break_fits(true))
                     .append(")")
-                    .next_break_fits(false)
-                    .group();
+                    .group()
+                    .next_break_fits(false);
             }
             let mut entries = self.call_arg_entries(args);
             let spread_start = spread_expr.get_span().byte_offset;
@@ -679,15 +680,7 @@ impl<'a> Formatter<'a> {
             let spread_doc = self.expression(spread_expr).append(Document::str("..."));
             let (body, close_sep) =
                 Self::join_pattern_entries(entries, Some((spread_leading, spread_doc)), "");
-            return head
-                .append("(")
-                .append(strict_break("", ""))
-                .append(body)
-                .nest(INDENT_WIDTH)
-                .append(close_sep)
-                .append(")")
-                .next_break_fits(false)
-                .group();
+            return Self::wrap_args(head, body, close_sep).next_break_fits(false);
         }
 
         let Some((last, init)) = args
@@ -696,39 +689,26 @@ impl<'a> Formatter<'a> {
         else {
             let entries = self.call_arg_entries(args);
             let (body, close_sep) = Self::join_pattern_entries(entries, None, "");
-            return head
-                .append("(")
-                .append(strict_break("", ""))
-                .append(body)
-                .nest(INDENT_WIDTH)
-                .append(close_sep)
-                .append(")")
-                .group();
+            return Self::wrap_args(head, body, close_sep);
         };
 
-        if init.is_empty() {
-            let last_doc = self.expression(last).group().next_break_fits(true);
-            head.append("(")
-                .append(last_doc)
-                .append(")")
-                .next_break_fits(false)
-                .group()
-        } else {
-            let mut entries = self.call_arg_entries(init);
-            let last_start = last.get_span().byte_offset;
-            let last_leading = self.split_for_rest(&mut entries, last_start);
-            let last_doc = self.expression(last).group().next_break_fits(true);
-            let (body, close_sep) =
-                Self::join_pattern_entries(entries, Some((last_leading, last_doc)), "");
-            head.append("(")
-                .append(strict_break("", ""))
-                .append(body)
-                .nest(INDENT_WIDTH)
-                .append(close_sep)
-                .append(")")
-                .next_break_fits(false)
-                .group()
-        }
+        let mut entries = self.call_arg_entries(init);
+        let last_start = last.get_span().byte_offset;
+        let last_leading = self.split_for_rest(&mut entries, last_start);
+        let last_doc = self.expression(last).group().next_break_fits(true);
+        let (body, close_sep) =
+            Self::join_pattern_entries(entries, Some((last_leading, last_doc)), "");
+        Self::wrap_args(head, body, close_sep).next_break_fits(false)
+    }
+
+    fn wrap_args(head: Document<'a>, body: Document<'a>, close_sep: Document<'a>) -> Document<'a> {
+        head.append("(")
+            .append(strict_break("", ""))
+            .append(body)
+            .nest_if_broken(INDENT_WIDTH)
+            .append(close_sep)
+            .append(")")
+            .group()
     }
 
     fn call_arg_entries(&mut self, args: &'a [Expression]) -> Vec<PatternEntry<'a>> {
@@ -870,7 +850,7 @@ impl<'a> Formatter<'a> {
 
         Document::str(name)
             .append(" {")
-            .append(strict_break(" ", " "))
+            .append(strict_break("", " "))
             .append(body)
             .nest(INDENT_WIDTH)
             .append(close_sep)
@@ -919,6 +899,7 @@ impl<'a> Formatter<'a> {
                 .append(strict_break(",", ""))
                 .append("|")
                 .group()
+                .measure_flat()
         };
 
         let return_doc = if return_annotation.is_unknown() {

--- a/crates/format/src/formatter/pattern.rs
+++ b/crates/format/src/formatter/pattern.rs
@@ -84,7 +84,7 @@ impl<'a> Formatter<'a> {
                     let (body, close_sep) = Self::join_pattern_entries(entries, rest_info, " ");
                     Document::string(identifier.to_string())
                         .append(" {")
-                        .append(strict_break(" ", " "))
+                        .append(strict_break("", " "))
                         .append(body)
                         .nest(INDENT_WIDTH)
                         .append(close_sep)

--- a/crates/format/src/formatter/sequence.rs
+++ b/crates/format/src/formatter/sequence.rs
@@ -330,7 +330,7 @@ mod tests {
         let entries = vec![entry(None, "a", None)];
         let (body, close_sep) = Formatter::join_pattern_entries(entries, None, " ");
         let out = Document::str("{")
-            .append(strict_break(" ", " "))
+            .append(strict_break("", " "))
             .append(body)
             .nest(2)
             .append(close_sep)

--- a/crates/format/src/lindig.rs
+++ b/crates/format/src/lindig.rs
@@ -45,6 +45,10 @@ fn fits(
                 _ => docs.push((indent, mode, doc)),
             },
 
+            Document::MeasureFlat(doc) => {
+                docs.push((indent, Mode::ForcedUnbroken, doc));
+            }
+
             Document::Text(s) => {
                 current_width += s.graphemes(true).count() as isize;
             }
@@ -65,16 +69,12 @@ fn fits(
                 }
             }
 
-            Document::NextBreakFits(doc, enabled) => {
-                if *enabled {
-                    match mode {
-                        Mode::ForcedUnbroken => docs.push((indent, mode, doc)),
-                        _ => docs.push((indent, Mode::ForcedBroken, doc)),
-                    }
-                } else {
-                    docs.push((indent, Mode::ForcedUnbroken, doc));
-                }
-            }
+            Document::NextBreakFits(doc, enabled) => match (*enabled, mode) {
+                (true, Mode::ForcedUnbroken) => docs.push((indent, mode, doc)),
+                (true, _) => docs.push((indent, Mode::ForcedBroken, doc)),
+                (false, Mode::ForcedBroken) => docs.push((indent, mode, doc)),
+                (false, _) => docs.push((indent, Mode::ForcedUnbroken, doc)),
+            },
 
             Document::Sequence(vec) => {
                 for doc in vec.iter().rev() {
@@ -200,7 +200,9 @@ fn format(
                 }
             }
 
-            Document::ForceBroken(document) | Document::NextBreakFits(document, _) => {
+            Document::ForceBroken(document)
+            | Document::NextBreakFits(document, _)
+            | Document::MeasureFlat(document) => {
                 docs.push((indent, mode, document));
             }
         }
@@ -212,6 +214,7 @@ pub enum Document<'a> {
     Newline,
     ForceBroken(Box<Self>),
     NextBreakFits(Box<Self>, bool),
+    MeasureFlat(Box<Self>),
     StrictBreak { broken: &'a str, unbroken: &'a str },
     FlexBreak { broken: &'a str, unbroken: &'a str },
     Sequence(Vec<Self>),
@@ -253,6 +256,10 @@ impl<'a> Document<'a> {
 
     pub fn next_break_fits(self, enabled: bool) -> Self {
         Self::NextBreakFits(Box::new(self), enabled)
+    }
+
+    pub fn measure_flat(self) -> Self {
+        Self::MeasureFlat(Box::new(self))
     }
 
     pub fn append(self, second: impl Documentable<'a>) -> Self {

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -717,6 +717,63 @@ fn lambda_with_block() {
 }
 
 #[test]
+fn lambda_arg_keeps_params_intact_in_overlong_call() {
+    assert_format_snapshot!(
+        "fn main() {\n  let handler = some_quite_long_method_name_which_causes_weird_formatting(|a_rather_long_parameter_name| a_rather_long_parameter_name + 1)\n}"
+    );
+}
+
+#[test]
+fn lambda_block_arg_keeps_params_intact_in_overlong_call() {
+    assert_format_snapshot!(
+        "fn main() {\n  let handler = some_quite_long_method_name_which_causes_weird_formatting(|a_rather_long_parameter_name| { a_rather_long_parameter_name + 1 })\n}"
+    );
+}
+
+#[test]
+fn lambda_block_arg_keeps_params_intact_after_leading_args() {
+    assert_format_snapshot!(
+        "fn main() {\n  let handler = some_quite_long_method_name(items, |a_rather_long_parameter_name| { a_rather_long_parameter_name + 1 })\n}"
+    );
+}
+
+#[test]
+fn lambda_arg_expands_call_instead_of_wrapping_body() {
+    assert_format_snapshot!(
+        "fn main() {\n  let z = f(first_arg, |x| a_very_long_name_one_here + a_very_long_name_two_here_x)\n}"
+    );
+}
+
+#[test]
+fn match_arg_expands_call_instead_of_wrapping_subject() {
+    assert_format_snapshot!(
+        "fn main() {\n  let z = f(first_arg, match a_scrutinee_name_one + a_scrutinee_name_two_here_long { 1 => 2, _ => 3 })\n}"
+    );
+}
+
+#[test]
+fn lambda_arg_hugs_through_nested_call() {
+    assert_format_snapshot!(
+        "fn f(items: Slice<int>, id: int) -> Result<Slice<int>, string> {\n  Ok(items.map(|t| if t.id == id { models.Task { status: models.Status.Done, ..t } } else { t }))\n}"
+    );
+}
+
+#[test]
+fn lambda_match_body_arg_hugs_call_parens() {
+    assert_format_snapshot!("fn test() { items.map(|x| match x { Some(v) => v, None => 0 }) }");
+}
+
+#[test]
+fn lambda_block_arg_hugs_call_parens() {
+    assert_format_snapshot!("fn test() { foo(|x| { x + 1 }) }");
+}
+
+#[test]
+fn lambda_block_arg_hugs_call_parens_after_leading_args() {
+    assert_format_snapshot!("fn test() { foo(a, b, |x| { x + 1 }) }");
+}
+
+#[test]
 fn loop_break() {
     assert_format_snapshot!("fn test() { loop { break } }");
 }

--- a/tests/spec/format/snapshots/comment_same_line_trailing_before_struct_pattern_rest.snap
+++ b/tests/spec/format/snapshots/comment_same_line_trailing_before_struct_pattern_rest.snap
@@ -15,7 +15,7 @@ struct Point { x: int, y: int, z: int }
 
 fn f(p: Point) -> int {
   match p {
-    Point { 
+    Point {
       x: 1, // trailing
       ..,
     } => 0,

--- a/tests/spec/format/snapshots/comment_same_line_trailing_before_struct_spread.snap
+++ b/tests/spec/format/snapshots/comment_same_line_trailing_before_struct_spread.snap
@@ -11,7 +11,7 @@ description: |-
 struct Point { x: int, y: int }
 
 fn f(other: Point) -> Point {
-  Point { 
+  Point {
     x: 1, // trailing
     ..other,
   }

--- a/tests/spec/format/snapshots/comment_same_line_trailing_on_struct_pattern_field.snap
+++ b/tests/spec/format/snapshots/comment_same_line_trailing_on_struct_pattern_field.snap
@@ -15,7 +15,7 @@ struct Point { x: int, y: int }
 
 fn f(p: Point) -> int {
   match p {
-    Point { 
+    Point {
       x: 1, // trailing struct field
       y: 2,
     } => 0,

--- a/tests/spec/format/snapshots/lambda_arg_expands_call_instead_of_wrapping_body.snap
+++ b/tests/spec/format/snapshots/lambda_arg_expands_call_instead_of_wrapping_body.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let z = f(first_arg, |x| a_very_long_name_one_here + a_very_long_name_two_here_x)
+  }
+---
+fn main() {
+  let z = f(
+    first_arg,
+    |x| a_very_long_name_one_here + a_very_long_name_two_here_x,
+  )
+}

--- a/tests/spec/format/snapshots/lambda_arg_hugs_through_nested_call.snap
+++ b/tests/spec/format/snapshots/lambda_arg_hugs_through_nested_call.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn f(items: Slice<int>, id: int) -> Result<Slice<int>, string> {
+    Ok(items.map(|t| if t.id == id { models.Task { status: models.Status.Done, ..t } } else { t }))
+  }
+---
+fn f(items: Slice<int>, id: int) -> Result<Slice<int>, string> {
+  Ok(items.map(|t| if t.id == id {
+    models.Task { status: models.Status.Done, ..t }
+  } else {
+    t
+  }))
+}

--- a/tests/spec/format/snapshots/lambda_arg_keeps_params_intact_in_overlong_call.snap
+++ b/tests/spec/format/snapshots/lambda_arg_keeps_params_intact_in_overlong_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let handler = some_quite_long_method_name_which_causes_weird_formatting(|a_rather_long_parameter_name| a_rather_long_parameter_name + 1)
+  }
+---
+fn main() {
+  let handler = some_quite_long_method_name_which_causes_weird_formatting(
+    |a_rather_long_parameter_name| a_rather_long_parameter_name + 1,
+  )
+}

--- a/tests/spec/format/snapshots/lambda_block_arg_hugs_call_parens.snap
+++ b/tests/spec/format/snapshots/lambda_block_arg_hugs_call_parens.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() { foo(|x| { x + 1 }) }"
+---
+fn test() {
+  foo(|x| {
+    x + 1
+  })
+}

--- a/tests/spec/format/snapshots/lambda_block_arg_hugs_call_parens_after_leading_args.snap
+++ b/tests/spec/format/snapshots/lambda_block_arg_hugs_call_parens_after_leading_args.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() { foo(a, b, |x| { x + 1 }) }"
+---
+fn test() {
+  foo(a, b, |x| {
+    x + 1
+  })
+}

--- a/tests/spec/format/snapshots/lambda_block_arg_keeps_params_intact_after_leading_args.snap
+++ b/tests/spec/format/snapshots/lambda_block_arg_keeps_params_intact_after_leading_args.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let handler = some_quite_long_method_name(items, |a_rather_long_parameter_name| { a_rather_long_parameter_name + 1 })
+  }
+---
+fn main() {
+  let handler = some_quite_long_method_name(
+    items,
+    |a_rather_long_parameter_name| {
+      a_rather_long_parameter_name + 1
+    },
+  )
+}

--- a/tests/spec/format/snapshots/lambda_block_arg_keeps_params_intact_in_overlong_call.snap
+++ b/tests/spec/format/snapshots/lambda_block_arg_keeps_params_intact_in_overlong_call.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let handler = some_quite_long_method_name_which_causes_weird_formatting(|a_rather_long_parameter_name| { a_rather_long_parameter_name + 1 })
+  }
+---
+fn main() {
+  let handler = some_quite_long_method_name_which_causes_weird_formatting(
+    |a_rather_long_parameter_name| {
+      a_rather_long_parameter_name + 1
+    },
+  )
+}

--- a/tests/spec/format/snapshots/lambda_match_body_arg_hugs_call_parens.snap
+++ b/tests/spec/format/snapshots/lambda_match_body_arg_hugs_call_parens.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() { items.map(|x| match x { Some(v) => v, None => 0 }) }"
+---
+fn test() {
+  items.map(|x| match x {
+    Some(v) => v,
+    None => 0,
+  })
+}

--- a/tests/spec/format/snapshots/match_arg_expands_call_instead_of_wrapping_subject.snap
+++ b/tests/spec/format/snapshots/match_arg_expands_call_instead_of_wrapping_subject.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let z = f(first_arg, match a_scrutinee_name_one + a_scrutinee_name_two_here_long { 1 => 2, _ => 3 })
+  }
+---
+fn main() {
+  let z = f(
+    first_arg,
+    match a_scrutinee_name_one + a_scrutinee_name_two_here_long {
+      1 => 2,
+      _ => 3,
+    },
+  )
+}

--- a/tests/spec/format/snapshots/struct_instantiation_spread_with_comment.snap
+++ b/tests/spec/format/snapshots/struct_instantiation_spread_with_comment.snap
@@ -10,7 +10,7 @@ description: |-
   }
 ---
 fn test() {
-  Point { 
+  Point {
     x: 1,
     // inherit the rest
     ..other,


### PR DESCRIPTION
`lis format` no longer splits a lambda's param list onto its own lines to make a long call fit. The call's parens expand instead, keeping `|params|` on one line.

Also, broken struct literals and struct patterns no longer emit a trailing space after the opening brace.

Fix #1112