### PR TITLE
refactor: simplify bindgen

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -154,16 +154,19 @@ func ParseTargets(s string) ([]Target, error) {
 		return nil, fmt.Errorf("empty target list")
 	}
 	var targets []Target
+	seen := make(map[Target]bool)
 	for _, part := range strings.Split(s, ",") {
 		part = strings.TrimSpace(part)
-		slash := strings.Index(part, "/")
-		if slash < 0 {
+		goos, goarch, ok := strings.Cut(part, "/")
+		if !ok || goos == "" || goarch == "" || strings.Contains(goarch, "/") {
 			return nil, fmt.Errorf("target %q: expected GOOS/GOARCH", part)
 		}
-		targets = append(targets, Target{
-			GOOS:   part[:slash],
-			GOARCH: part[slash+1:],
-		})
+		target := Target{goos: goos, goarch: goarch}
+		if seen[target] {
+			return nil, fmt.Errorf("duplicate target %q", part)
+		}
+		seen[target] = true
+		targets = append(targets, target)
 	}
 	return targets, nil
 }
@@ -171,81 +174,36 @@ func ParseTargets(s string) ([]Target, error) {
 func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goVersion string, cfg *config.Config) GeneratePkgResult {
 	converter := convert.NewConverter(pkg.PkgPath, pkg, cfg)
 	exports := extract.ExtractExports(pkg, converter.EmbedIsFaithful)
-	var results []convert.ConvertResult
-	for _, exp := range exports {
-		results = append(results, converter.Convert(exp))
-	}
-
-	converter.FinalizeInterfaceBuilders(results)
-
-	constGroups, constantTypes, constGroupTypeNames, bitFlagSetTypeNames := convert.DetectConstGroups(results, exports, cfg, pkg.PkgPath)
-
-	groupConstants := make(map[string][]convert.ConvertResult)
-	for i, result := range results {
-		if typeName, isGroupConstant := constantTypes[i]; isGroupConstant {
-			groupConstants[typeName] = append(groupConstants[typeName], result)
-		}
-	}
-
-	groupTypeResult := make(map[string]convert.ConvertResult)
-	for _, result := range results {
-		if result.Kind == extract.ExportType && constGroupTypeNames[result.Name] {
-			groupTypeResult[result.Name] = result
-		}
-	}
+	converted := converter.ConvertAll(exports)
 
 	closedDomainTypeNames := make(map[string]bool)
-	for typeName := range constGroupTypeNames {
-		if cfg.IsClosedDomain(pkg.PkgPath, typeName) {
-			closedDomainTypeNames[typeName] = true
+	for _, group := range converted.ConstGroups {
+		if cfg.IsClosedDomain(pkg.PkgPath, group.Type.Name) {
+			closedDomainTypeNames[group.Type.Name] = true
 		}
 	}
 
-	emitter := emit.NewEmitter(cfg, pkg.PkgPath, pkg.Name, bitFlagSetTypeNames, closedDomainTypeNames)
+	emitter := emit.NewEmitter(cfg, pkg.PkgPath, pkg.Name, converted.BitFlagSetTypeNames, closedDomainTypeNames)
 	emitter.EmitHeader(displayPath, pkg.Name, lisetteVersion, goVersion)
 
-	selfQualifies := false
-	for _, result := range results {
-		if result.Kind == extract.ExportType && convert.CollidesWithBuiltinType(result.Name, len(result.TypeParams)) {
-			selfQualifies = true
-			break
-		}
-	}
-	emitter.EmitImports(converter.ExternalPkgs(), selfQualifies)
+	emitter.EmitImports(converted.ExternalPkgs, converted.NeedsSelfQualification())
 
-	for _, synth := range converter.SyntheticStructs() {
+	for _, synth := range converted.SyntheticTypes {
 		emitter.EmitExport(synth)
 	}
 
-	emittedTypeNames := make(map[string]bool)
-	for _, result := range results {
-		if result.Kind == extract.ExportType {
-			emittedTypeNames[result.Name] = true
-		}
-	}
-	for _, handle := range converter.OpaqueHandles() {
-		if emittedTypeNames[handle.Name] {
-			continue
-		}
+	for _, handle := range converted.OpaqueTypes {
 		emitter.EmitExport(handle)
 	}
 
-	for _, group := range constGroups {
-		if typeResult, ok := groupTypeResult[group.TypeName]; ok {
-			emitter.EmitExport(typeResult)
-		}
-		for _, constResult := range groupConstants[group.TypeName] {
-			emitter.EmitTypedConst(constResult, group.TypeName)
+	for _, group := range converted.ConstGroups {
+		emitter.EmitExport(group.Type)
+		for _, constant := range group.Constants {
+			emitter.EmitTypedConst(constant, group.Type.Name)
 		}
 	}
 
-	for i, result := range results {
-		if _, isGroupConstant := constantTypes[i]; isGroupConstant {
-			continue
-		}
-		if result.Kind == extract.ExportType && constGroupTypeNames[result.Name] {
-			continue
-		}
+	for _, result := range converted.Symbols {
 		if result.SkipReason != nil {
 			if result.Kind == extract.ExportMethod && emitter.CollectSkippedMethod(result) {
 				continue
@@ -258,8 +216,8 @@ func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goV
 
 	emitter.EmitImplBlocks()
 
-	externalImports := make([]string, 0, len(converter.ExternalPkgs()))
-	for path := range converter.ExternalPkgs() {
+	externalImports := make([]string, 0, len(converted.ExternalPkgs))
+	for path := range converted.ExternalPkgs {
 		externalImports = append(externalImports, path)
 	}
 

--- a/bindgen/internal/cli/generate_std.go
+++ b/bindgen/internal/cli/generate_std.go
@@ -23,15 +23,15 @@ type GenerateStdResult struct {
 }
 
 type Target struct {
-	GOOS, GOARCH string
+	goos, goarch string
 }
 
 func (t Target) String() string {
-	return t.GOOS + "/" + t.GOARCH
+	return t.goos + "/" + t.goarch
 }
 
 func (t Target) Suffix() string {
-	return t.GOOS + "_" + t.GOARCH
+	return t.goos + "_" + t.goarch
 }
 
 // GenerateStd generates per-target `.d.lis` files and deduplicates them
@@ -54,7 +54,7 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 		}
 
 		loadStart := time.Now()
-		pkgs, err := extract.LoadPackages(pkgPaths, target.GOOS, target.GOARCH)
+		pkgs, err := extract.LoadPackages(pkgPaths, target.goos, target.goarch)
 		if err != nil {
 			return GenerateStdResult{}, fmt.Errorf("target %s: failed to load packages: %w", target, err)
 		}
@@ -123,8 +123,8 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 func listStdlibPackages(target Target) ([]string, error) {
 	cmd := exec.Command("go", "list", "std")
 	cmd.Env = append(os.Environ(),
-		"GOOS="+target.GOOS,
-		"GOARCH="+target.GOARCH,
+		"GOOS="+target.goos,
+		"GOARCH="+target.goarch,
 		"CGO_ENABLED=0",
 	)
 	out, err := cmd.Output()
@@ -168,14 +168,14 @@ func writeDedupedTypedefs(outDir string, partition partitioned) error {
 		return nil
 	}
 
-	for pkgPath, content := range partition.common {
-		if err := write(filepath.Join(outDir, pkgPath+".d.lis"), content); err != nil {
-			return err
+	for pkgPath, pkg := range partition {
+		if len(pkg.variants) == 1 {
+			if err := write(filepath.Join(outDir, pkgPath+".d.lis"), pkg.variants[0].content); err != nil {
+				return err
+			}
+			continue
 		}
-	}
-
-	for pkgPath, variants := range partition.variants {
-		for _, v := range variants {
+		for _, v := range pkg.variants {
 			if err := write(filepath.Join(outDir, suffixedPath(pkgPath, v.canonical)), v.content); err != nil {
 				return err
 			}

--- a/bindgen/internal/cli/partition.go
+++ b/bindgen/internal/cli/partition.go
@@ -11,18 +11,13 @@ type variant struct {
 	content   string
 }
 
-type partitioned struct {
-	common          map[string]string    // pkgPath -> shared content
-	variants        map[string][]variant // pkgPath -> per-content variants (divergent only)
-	intendedTargets map[string][]Target  // pkgPath -> targets where it is available
+type packagePartition struct {
+	targets  []Target
+	variants []variant
 }
 
-// partitionByTarget classifies packages as common (suffixless, byte-identical
-// across every target where present) or divergent (one variant per content
-// equivalence class). Header-only outputs are dropped — they signal a
-// build-tag stub like `log/syslog` on windows. Lookup gates by
-// `intendedTargets` before falling through, so a shared file is never
-// returned for an unsupported target.
+type partitioned map[string]packagePartition
+
 func partitionByTarget(captured map[Target]map[string]string, targets []Target) partitioned {
 	hasRealContent := make(map[string]bool)
 	for _, results := range captured {
@@ -32,14 +27,6 @@ func partitionByTarget(captured map[Target]map[string]string, targets []Target) 
 			}
 		}
 	}
-	for _, results := range captured {
-		for pkgPath, content := range results {
-			if isHeaderOnly(content) && hasRealContent[pkgPath] {
-				delete(results, pkgPath)
-			}
-		}
-	}
-
 	allPkgs := make(map[string]struct{})
 	for _, results := range captured {
 		for pkgPath := range results {
@@ -47,18 +34,14 @@ func partitionByTarget(captured map[Target]map[string]string, targets []Target) 
 		}
 	}
 
-	result := partitioned{
-		common:          make(map[string]string),
-		variants:        make(map[string][]variant),
-		intendedTargets: make(map[string][]Target),
-	}
+	result := make(partitioned, len(allPkgs))
 
 	for pkgPath := range allPkgs {
 		var presentTargets []Target
 		var groups []*variant
 		for _, target := range targets {
 			content, ok := captured[target][pkgPath]
-			if !ok {
+			if !ok || (isHeaderOnly(content) && hasRealContent[pkgPath]) {
 				continue
 			}
 			presentTargets = append(presentTargets, target)
@@ -80,12 +63,7 @@ func partitionByTarget(captured map[Target]map[string]string, targets []Target) 
 			}
 		}
 
-		if len(presentTargets) < len(targets) {
-			result.intendedTargets[pkgPath] = presentTargets
-		}
-
-		if len(groups) == 1 {
-			result.common[pkgPath] = groups[0].content
+		if len(groups) == 0 {
 			continue
 		}
 
@@ -93,7 +71,10 @@ func partitionByTarget(captured map[Target]map[string]string, targets []Target) 
 		for i, g := range groups {
 			variants[i] = *g
 		}
-		result.variants[pkgPath] = variants
+		result[pkgPath] = packagePartition{
+			targets:  presentTargets,
+			variants: variants,
+		}
 	}
 
 	return result

--- a/bindgen/internal/cli/partition_test.go
+++ b/bindgen/internal/cli/partition_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPartitionByTargetKeepsAvailabilityWithSharedContent(t *testing.T) {
+	targets := []Target{
+		{goos: "darwin", goarch: "arm64"},
+		{goos: "linux", goarch: "amd64"},
+		{goos: "windows", goarch: "amd64"},
+	}
+	captured := map[Target]map[string]string{
+		targets[0]: {"plugin": "content"},
+		targets[1]: {"plugin": "content"},
+		targets[2]: {},
+	}
+
+	got := partitionByTarget(captured, targets)["plugin"]
+
+	if len(got.variants) != 1 || !reflect.DeepEqual(got.targets, targets[:2]) {
+		t.Fatalf("shared package partition = %#v, want one variant on first two targets", got)
+	}
+}
+
+func TestPartitionByTargetDoesNotMutateCapturedHeaderStub(t *testing.T) {
+	targets := []Target{
+		{goos: "linux", goarch: "amd64"},
+		{goos: "windows", goarch: "amd64"},
+	}
+	captured := map[Target]map[string]string{
+		targets[0]: {"log/syslog": "pub type Writer\n"},
+		targets[1]: {"log/syslog": "// header only\n"},
+	}
+
+	got := partitionByTarget(captured, targets)["log/syslog"]
+
+	if len(got.targets) != 1 || got.targets[0] != targets[0] {
+		t.Fatalf("stubbed package targets = %v, want [%v]", got.targets, targets[0])
+	}
+	if _, ok := captured[targets[1]]["log/syslog"]; !ok {
+		t.Fatal("partitionByTarget mutated its captured input")
+	}
+}
+
+func TestParseTargetsRejectsInvalidAndDuplicateTargets(t *testing.T) {
+	invalid := []string{
+		"/amd64",
+		"linux/",
+		"linux/amd64/extra",
+		"linux/amd64,linux/amd64",
+	}
+	for _, input := range invalid {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseTargets(input); err == nil {
+				t.Fatalf("ParseTargets(%q) succeeded", input)
+			}
+		})
+	}
+}

--- a/bindgen/internal/cli/rust_index.go
+++ b/bindgen/internal/cli/rust_index.go
@@ -82,13 +82,22 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 		return nil
 	}
 
-	commonPaths := sortedKeys(partition.common)
+	var commonPaths []string
+	for pkgPath, pkg := range partition {
+		if len(pkg.variants) == 1 {
+			commonPaths = append(commonPaths, pkgPath)
+		}
+	}
+	slices.Sort(commonPaths)
 	commonEntries := buildEntries(commonPaths, nil)
 
 	// Invert variants into per-target entries pointing at canonical files.
 	perTarget := make(map[Target]map[string]Target)
-	for pkgPath, variants := range partition.variants {
-		for _, v := range variants {
+	for pkgPath, pkg := range partition {
+		if len(pkg.variants) == 1 {
+			continue
+		}
+		for _, v := range pkg.variants {
 			for _, t := range v.targets {
 				if perTarget[t] == nil {
 					perTarget[t] = make(map[string]Target)
@@ -115,10 +124,10 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 		overlayBlocks.WriteString(buildEntries(paths, entries))
 		overlayBlocks.WriteString("    ])\n});\n\n")
 
-		fmt.Fprintf(&matchArms, "        (%q, %q) => Some(&%s),\n", target.GOOS, target.GOARCH, staticName)
+		fmt.Fprintf(&matchArms, "        (%q, %q) => Some(&%s),\n", target.goos, target.goarch, staticName)
 	}
 
-	intendedEntries := buildIntendedEntries(partition.intendedTargets)
+	intendedEntries := buildIntendedEntries(partition, len(targets))
 
 	content := fmt.Sprintf(rustIndexFileTemplate,
 		commonEntries,
@@ -134,15 +143,6 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 
 	fmt.Fprintf(os.Stderr, "\nGenerated: %s\n", rustFilePath)
 	return nil
-}
-
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	return keys
 }
 
 // buildEntries renders HashMap entries for a typedef map. When `canonical`
@@ -163,27 +163,29 @@ func buildEntries(pkgPaths []string, canonical map[string]Target) string {
 	return b.String()
 }
 
-func buildIntendedEntries(intended map[string][]Target) string {
-	pkgs := make([]string, 0, len(intended))
-	for pkg := range intended {
-		pkgs = append(pkgs, pkg)
+func buildIntendedEntries(partition partitioned, targetCount int) string {
+	var pkgs []string
+	for pkgPath, pkg := range partition {
+		if len(pkg.targets) < targetCount {
+			pkgs = append(pkgs, pkgPath)
+		}
 	}
 	slices.Sort(pkgs)
 
 	var b strings.Builder
-	for _, pkg := range pkgs {
+	for _, pkgPath := range pkgs {
 		var pairs strings.Builder
-		for i, t := range intended[pkg] {
+		for i, t := range partition[pkgPath].targets {
 			if i > 0 {
 				pairs.WriteString(", ")
 			}
-			fmt.Fprintf(&pairs, "(%q, %q)", t.GOOS, t.GOARCH)
+			fmt.Fprintf(&pairs, "(%q, %q)", t.goos, t.goarch)
 		}
-		fmt.Fprintf(&b, "            (%q, &[%s][..]),\n", pkg, pairs.String())
+		fmt.Fprintf(&b, "            (%q, &[%s][..]),\n", pkgPath, pairs.String())
 	}
 	return b.String()
 }
 
 func overlayStaticName(target Target) string {
-	return "GO_STDLIB_" + strings.ToUpper(target.GOOS) + "_" + strings.ToUpper(target.GOARCH)
+	return "GO_STDLIB_" + strings.ToUpper(target.goos) + "_" + strings.ToUpper(target.goarch)
 }

--- a/bindgen/internal/convert/anonstruct.go
+++ b/bindgen/internal/convert/anonstruct.go
@@ -42,13 +42,13 @@ func (c *Converter) internAnonStruct(s *types.Struct) TypeResult {
 	}
 
 	key := anonShapeKey(fields)
-	if idx, ok := c.synthByShape[key]; ok {
-		return TypeResult{LisetteType: c.synth[idx].result.Name}
+	for _, existing := range c.synth {
+		if existing.key == key {
+			return TypeResult{LisetteType: existing.result.Name}
+		}
 	}
 
 	name := c.mintAnonName(fields)
-	c.synthByShape[key] = len(c.synth)
-	c.synthTaken[name] = true
 	c.synth = append(c.synth, syntheticStruct{
 		key: key,
 		result: ConvertResult{
@@ -100,31 +100,25 @@ func (c *Converter) mintAnonName(fields []StructField) string {
 	}
 	base := b.String()
 
-	c.seedReservedNames()
 	name := base
-	for i := 2; c.synthTaken[name]; i++ {
+	for i := 2; c.syntheticNameTaken(name); i++ {
 		name = fmt.Sprintf("%s_%d", base, i)
 	}
 	return name
 }
 
-// seedReservedNames reserves the package's declared names so a synthesized name
-// never clashes with a real type. Runs once.
-func (c *Converter) seedReservedNames() {
-	if c.reservedSeeded {
-		return
+func (c *Converter) syntheticNameTaken(name string) bool {
+	if c.pkg != nil && c.pkg.Types != nil && c.pkg.Types.Scope().Lookup(name) != nil {
+		return true
 	}
-	c.reservedSeeded = true
-	if c.pkg == nil || c.pkg.Types == nil {
-		return
+	for _, existing := range c.synth {
+		if existing.result.Name == name {
+			return true
+		}
 	}
-	for _, name := range c.pkg.Types.Scope().Names() {
-		c.synthTaken[name] = true
-	}
+	return false
 }
 
-// synthMark/rollbackSynth bracket a probe whose result may be discarded, so any
-// type minted during it does not leak into the output as an orphan.
 func (c *Converter) synthMark() int {
 	if c == nil {
 		return 0
@@ -136,15 +130,10 @@ func (c *Converter) rollbackSynth(checkpoint int) {
 	if c == nil {
 		return
 	}
-	for i := checkpoint; i < len(c.synth); i++ {
-		delete(c.synthByShape, c.synth[i].key)
-		delete(c.synthTaken, c.synth[i].result.Name)
-	}
 	c.synth = c.synth[:checkpoint]
 }
 
-// SyntheticStructs returns the synthesized types, name-sorted for stable emission.
-func (c *Converter) SyntheticStructs() []ConvertResult {
+func (c *Converter) syntheticStructs() []ConvertResult {
 	out := make([]ConvertResult, len(c.synth))
 	for i, s := range c.synth {
 		out[i] = s.result

--- a/bindgen/internal/convert/const_groups.go
+++ b/bindgen/internal/convert/const_groups.go
@@ -11,29 +11,26 @@ import (
 	"github.com/ivov/lisette/bindgen/internal/extract"
 )
 
-// ConstGroupInfo describes a Go defined primitive type (e.g. `type Duration
-// int64`) together with the constants declared at that type. It emits as a named
-// primitive struct plus package-level typed constants.
-type ConstGroupInfo struct {
-	TypeName       string
-	UnderlyingType string // e.g., "int64" for time.Duration
-	Variants       []EnumVariant
-}
-
 type constInfo struct {
-	index int
-	name  string
-	value string
+	object types.Object
+	result ConvertResult
 }
 
-// DetectConstGroups groups exported constants by their named primitive type,
-// returning one ConstGroupInfo per group (minimum two constants, not a bit-flag
-// set). `constGroupTypeNames` is the set of type names that own such a group.
-func DetectConstGroups(results []ConvertResult, exports []extract.SymbolExport, cfg *config.Config, pkgPath string) (constGroups []ConstGroupInfo, constantTypes map[int]string, constGroupTypeNames map[string]bool, bitFlagSetTypeNames map[string]bool) {
+type convertedSymbol struct {
+	export extract.SymbolExport
+	result ConvertResult
+}
+
+func classifyConstGroups(symbols []convertedSymbol, cfg *config.Config, pkgPath string) (regular []ConvertResult, groups []ConstGroup, bitFlagSetTypeNames map[string]bool) {
 	typeToConstants := make(map[string][]constInfo)
 	typeToUnderlying := make(map[string]string)
+	typeResults := make(map[string]ConvertResult)
 
-	for i, result := range results {
+	for _, symbol := range symbols {
+		result := symbol.result
+		if result.Kind == extract.ExportType {
+			typeResults[result.Name] = result
+		}
 		if result.Kind != extract.ExportConstant {
 			continue
 		}
@@ -44,8 +41,7 @@ func DetectConstGroups(results []ConvertResult, exports []extract.SymbolExport, 
 			continue
 		}
 
-		exp := exports[i]
-		constObj, ok := exp.Obj.(*types.Const)
+		constObj, ok := symbol.export.Obj.(*types.Const)
 		if !ok {
 			continue
 		}
@@ -83,15 +79,14 @@ func DetectConstGroups(results []ConvertResult, exports []extract.SymbolExport, 
 		}
 
 		typeToConstants[typeName] = append(typeToConstants[typeName], constInfo{
-			index: i,
-			name:  result.Name,
-			value: result.ConstValue,
+			object: symbol.export.Obj,
+			result: result,
 		})
 	}
 
-	constantTypes = make(map[int]string)
-	constGroupTypeNames = make(map[string]bool)
 	bitFlagSetTypeNames = make(map[string]bool)
+	groupedObjects := make(map[types.Object]bool)
+	groupedTypeNames := make(map[string]bool)
 
 	typeNames := make([]string, 0, len(typeToConstants))
 	for typeName := range typeToConstants {
@@ -104,6 +99,10 @@ func DetectConstGroups(results []ConvertResult, exports []extract.SymbolExport, 
 		if len(constants) < 2 {
 			continue
 		}
+		typeResult, hasType := typeResults[typeName]
+		if !hasType {
+			continue
+		}
 
 		// Bit operations on a string-underlying type are not meaningful;
 		// neither H13 nor the config override applies here.
@@ -114,24 +113,27 @@ func DetectConstGroups(results []ConvertResult, exports []extract.SymbolExport, 
 			continue
 		}
 
-		var variants []EnumVariant
-		for _, c := range constants {
-			variants = append(variants, EnumVariant{
-				Name:  c.name,
-				Value: c.value,
-			})
-			constantTypes[c.index] = typeName
+		constantResults := make([]ConvertResult, 0, len(constants))
+		for _, constant := range constants {
+			constantResults = append(constantResults, constant.result)
+			groupedObjects[constant.object] = true
 		}
-
-		constGroups = append(constGroups, ConstGroupInfo{
-			TypeName:       typeName,
-			UnderlyingType: typeToUnderlying[typeName],
-			Variants:       variants,
+		groups = append(groups, ConstGroup{
+			Type:      typeResult,
+			Constants: constantResults,
 		})
-		constGroupTypeNames[typeName] = true
+		groupedTypeNames[typeName] = true
 	}
 
-	return constGroups, constantTypes, constGroupTypeNames, bitFlagSetTypeNames
+	regular = make([]ConvertResult, 0, len(symbols))
+	for _, symbol := range symbols {
+		if groupedObjects[symbol.export.Obj] ||
+			(symbol.result.Kind == extract.ExportType && groupedTypeNames[symbol.result.Name]) {
+			continue
+		}
+		regular = append(regular, symbol.result)
+	}
+	return regular, groups, bitFlagSetTypeNames
 }
 
 // looksLikeBitFlags classifies a named integer type as a bit-flag set.
@@ -150,7 +152,7 @@ func looksLikeBitFlags(constants []constInfo) bool {
 	}
 
 	for _, c := range constants {
-		val := parseIntValue(c.value)
+		val := parseIntValue(c.result.ConstValue)
 		if val == 0 {
 			continue
 		}
@@ -165,7 +167,7 @@ func looksLikeBitFlags(constants []constInfo) bool {
 func isSequentialRange(constants []constInfo) bool {
 	vals := make([]int64, 0, len(constants))
 	for _, c := range constants {
-		vals = append(vals, parseIntValue(c.value))
+		vals = append(vals, parseIntValue(c.result.ConstValue))
 	}
 	slices.Sort(vals)
 	if vals[0] != 0 && vals[0] != 1 {

--- a/bindgen/internal/convert/const_groups_test.go
+++ b/bindgen/internal/convert/const_groups_test.go
@@ -1,11 +1,18 @@
 package convert
 
-import "testing"
+import (
+	"go/constant"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/ivov/lisette/bindgen/internal/extract"
+)
 
 func mkConsts(values ...string) []constInfo {
 	out := make([]constInfo, len(values))
 	for i, v := range values {
-		out[i] = constInfo{index: i, name: "C", value: v}
+		out[i] = constInfo{result: ConvertResult{ConstValue: v}}
 	}
 	return out
 }
@@ -83,5 +90,24 @@ func TestIsSequentialRange(t *testing.T) {
 				t.Errorf("%s: want %v, got %v", c.name, c.want, got)
 			}
 		})
+	}
+}
+
+func TestClassifyConstGroupsMovesTypeAndConstantsOutOfRegularSymbols(t *testing.T) {
+	pkg := types.NewPackage("example.com/status", "status")
+	typeObj := types.NewTypeName(token.NoPos, pkg, "Status", nil)
+	named := types.NewNamed(typeObj, types.Typ[types.Int], nil)
+	first := types.NewConst(token.NoPos, pkg, "Ready", named, constant.MakeInt64(1))
+	second := types.NewConst(token.NoPos, pkg, "Done", named, constant.MakeInt64(2))
+	symbols := []convertedSymbol{
+		{export: extract.SymbolExport{Obj: typeObj}, result: ConvertResult{Name: "Status", Kind: extract.ExportType}},
+		{export: extract.SymbolExport{Obj: first}, result: ConvertResult{Name: "Ready", Kind: extract.ExportConstant, ConstValue: "1"}},
+		{export: extract.SymbolExport{Obj: second}, result: ConvertResult{Name: "Done", Kind: extract.ExportConstant, ConstValue: "2"}},
+	}
+
+	regular, groups, _ := classifyConstGroups(symbols, nil, pkg.Path())
+
+	if len(regular) != 0 || len(groups) != 1 || groups[0].Type.Name != "Status" || len(groups[0].Constants) != 2 {
+		t.Fatalf("classification = regular %#v, groups %#v", regular, groups)
 	}
 }

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -6,7 +6,6 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
-	"maps"
 	"slices"
 	"strings"
 
@@ -114,21 +113,17 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 		result.CollapsedTypeParamRecipe = strings.Join(recipe, ", ")
 	}
 
-	prevSubs := c.typeParamSubstitutions
-	c.typeParamSubstitutions = substitutions
-	defer func() { c.typeParamSubstitutions = prevSubs }()
-
 	liftedSpecs, paramOverrides := c.liftReflectionDecodeParams(signature, result.Name, result.TypeParams)
 	result.TypeParams = liftedSpecs
 
-	params, skip := c.convertParams(signature, result.Name, result.Name, paramOverrides, true)
+	params, skip := c.convertParams(signature, result.Name, result.Name, paramOverrides, true, substitutions)
 	if skip != nil {
 		result.SkipReason = skip
 		return
 	}
 	result.Params = params
 
-	returnType := c.applyReturnType(result, signature, result.Name)
+	returnType := c.applyReturnType(result, signature, result.Name, substitutions)
 
 	c.resolveNilability(result, signature, returnType, nilabilityDecision{
 		obj:               symbolExport.Obj,
@@ -158,7 +153,7 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 // applySentinelInt rewrites a bare `int` return into `Option<int>` when
 // the config declares a sentinel; emit then writes the matching flag.
 func (c *Converter) applySentinelInt(result *ConvertResult, qualifiedName string) {
-	if c.cfg == nil || result.ReturnType != "int" {
+	if result.ReturnType != "int" {
 		return
 	}
 	value, ok := c.cfg.SentinelInt(c.currentPkgPath, qualifiedName)
@@ -169,7 +164,7 @@ func (c *Converter) applySentinelInt(result *ConvertResult, qualifiedName string
 	result.SentinelInt = &value
 }
 
-func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName string, paramOverrides map[int]string, directEligible bool) ([]FunctionParameter, *SkipReason) {
+func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName string, paramOverrides map[int]string, directEligible bool, substitutions map[string]string) ([]FunctionParameter, *SkipReason) {
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, lookupName)
 	nilableParams := c.cfg.NilableParams(c.currentPkgPath, lookupName)
 
@@ -190,7 +185,7 @@ func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName s
 		if named, ok := c.directHandleIfEligible(param.Type(), directEligible); ok {
 			paramType = TypeResult{LisetteType: named.Obj().Name()}
 		} else {
-			paramType = convertParamType(param.Type(), name, nilableParams, c)
+			paramType = convertParamType(param.Type(), name, nilableParams, c, substitutions)
 		}
 		if paramType.SkipReason != nil {
 			return nil, paramType.SkipReason
@@ -213,8 +208,8 @@ func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName s
 	return out, nil
 }
 
-func (c *Converter) applyReturnType(result *ConvertResult, sig *types.Signature, lookupName string) TypeResult {
-	returnType := ReturnsToLisette(sig, c, lookupName)
+func (c *Converter) applyReturnType(result *ConvertResult, sig *types.Signature, lookupName string, substitutions map[string]string) TypeResult {
+	returnType := returnsToLisetteWithSubstitutions(sig, c, lookupName, substitutions)
 	if returnType.LisetteType != "" {
 		result.ReturnType = returnType.LisetteType
 	} else if returnType.SkipReason != nil {
@@ -377,14 +372,14 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	}
 	liftedSpecs, paramOverrides := c.liftReflectionDecodeParams(signature, qualifiedName, methodSpecs)
 
-	params, skip := c.convertParams(signature, qualifiedName, result.Name, paramOverrides, true)
+	params, skip := c.convertParams(signature, qualifiedName, result.Name, paramOverrides, true, nil)
 	if skip != nil {
 		result.SkipReason = skip
 		return
 	}
 	result.Params = params
 
-	returnType := c.applyReturnType(result, signature, qualifiedName)
+	returnType := c.applyReturnType(result, signature, qualifiedName, nil)
 
 	lookups := []configKey{{c.currentPkgPath, qualifiedName}}
 	if symbolExport.IsPromoted && symbolExport.OriginalTypeName != "" {
@@ -436,7 +431,7 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 
 	if isFluentBuilderCandidate(result, symbolExport, signature) {
 		if fn := c.findFuncDecl(symbolExport.Obj); fn != nil && isFluentMethod(fn, ncGetReceiverName(fn)) {
-			if c.cfg == nil || !c.cfg.ShouldDenyUnusedValue(c.currentPkgPath, qualifiedName) {
+			if !c.cfg.ShouldDenyUnusedValue(c.currentPkgPath, qualifiedName) {
 				result.BuilderMethod = true
 			}
 		}
@@ -502,14 +497,14 @@ func returnIsReceiverShaped(sig *types.Signature) bool {
 	return false
 }
 
-// FinalizeInterfaceBuilders carries the BuilderMethod flag from concrete methods to matching interface methods, when a concrete implementer is itself marked.
-func (c *Converter) FinalizeInterfaceBuilders(results []ConvertResult) {
+func (c *Converter) finalizeInterfaceBuilders(symbols []convertedSymbol) {
 	if c.pkg == nil || c.pkg.Types == nil {
 		return
 	}
 
 	concreteBuilders := make(map[string]map[string]bool)
-	for _, r := range results {
+	for _, symbol := range symbols {
+		r := symbol.result
 		if r.Kind != extract.ExportMethod || r.Receiver == nil || !r.BuilderMethod {
 			continue
 		}
@@ -525,8 +520,8 @@ func (c *Converter) FinalizeInterfaceBuilders(results []ConvertResult) {
 	}
 
 	scope := c.pkg.Types.Scope()
-	for i := range results {
-		result := &results[i]
+	for i := range symbols {
+		result := &symbols[i].result
 		if result.Kind != extract.ExportType || !result.IsInterface || len(result.InterfaceMethods) == 0 {
 			continue
 		}
@@ -767,7 +762,7 @@ func (c *Converter) convertVariable(result *ConvertResult, exp extract.SymbolExp
 	}
 
 	isNilable := isNilableGoType(exp.GoType)
-	forceNonNilable := c.cfg != nil && (c.cfg.IsNonNilableVar(c.currentPkgPath, result.Name) || c.cfg.IsNonNilableReturn(c.currentPkgPath, result.Name))
+	forceNonNilable := c.cfg.IsNonNilableVar(c.currentPkgPath, result.Name) || c.cfg.IsNonNilableReturn(c.currentPkgPath, result.Name)
 	if !forceNonNilable && isNilable {
 		forceNonNilable = c.isProvenNonNilVar(exp.Obj)
 	}
@@ -820,14 +815,8 @@ func (c *Converter) EmbedIsFaithful(field *types.Var) bool {
 		}
 		return true
 	}
-	// Probe runs before the owner's Convert checkpoint; snapshot/restore so its synth structs and imports do not leak.
-	synthMark := c.synthMark()
-	savedPkgs := make(ExternalPkgs, len(c.externalPkgs))
-	maps.Copy(savedPkgs, c.externalPkgs)
-	faithful := embeddedStructField(field, c).IsEmbedded
-	c.rollbackSynth(synthMark)
-	c.externalPkgs = savedPkgs
-	return faithful
+	probe := c.forkProbe()
+	return embeddedStructField(field, probe).IsEmbedded
 }
 
 // unexportedSamePkgStruct returns the named type behind t (peeling one pointer)
@@ -1134,12 +1123,6 @@ func collectTypeParams(
 		}
 	}
 
-	if len(substitutions) > 0 && conv != nil {
-		prev := conv.typeParamSubstitutions
-		conv.typeParamSubstitutions = substitutions
-		defer func() { conv.typeParamSubstitutions = prev }()
-	}
-
 	for tp := range typeParams.TypeParams() {
 		name := tp.Obj().Name()
 		constraint := tp.Constraint()
@@ -1155,7 +1138,7 @@ func collectTypeParams(
 			continue
 		}
 
-		if boundExpr, ok := recognizeBound(constraint, conv); ok {
+		if boundExpr, ok := recognizeBound(constraint, conv, substitutions); ok {
 			specs = append(specs, TypeParamSpec{Name: name, Bound: boundExpr})
 			recipe = append(recipe, name)
 			continue
@@ -1592,12 +1575,8 @@ func (c *Converter) interfaceRepresentable(named *types.Named) bool {
 	defer delete(c.ifaceProbing, named)
 
 	iface := named.Underlying().(*types.Interface)
-	synthMark := c.synthMark()
-	savedPkgs := make(ExternalPkgs, len(c.externalPkgs))
-	maps.Copy(savedPkgs, c.externalPkgs)
-	_, representable := c.extractInterfaceMethods(iface, named.Obj().Name())
-	c.rollbackSynth(synthMark)
-	c.externalPkgs = savedPkgs
+	probe := c.forkProbe()
+	_, representable := probe.extractInterfaceMethods(iface, named.Obj().Name())
 	c.ifaceRepresentable[named] = representable
 	return representable
 }
@@ -1780,7 +1759,7 @@ func (c *Converter) directHandleIfEligible(t types.Type, directEligible bool) (*
 	return c.directHandle(t)
 }
 
-func (c *Converter) OpaqueHandles() []ConvertResult {
+func (c *Converter) opaqueHandles() []ConvertResult {
 	if c.directProducers == nil {
 		c.computeDirectProducers()
 	}
@@ -1904,7 +1883,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 		}
 
 		qualifiedName := typeName + "." + method.Name()
-		params, skip := c.convertParams(signature, qualifiedName, method.Name(), nil, false)
+		params, skip := c.convertParams(signature, qualifiedName, method.Name(), nil, false, nil)
 		if skip != nil {
 			return nil, false
 		}
@@ -1916,7 +1895,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 
 		// Interface methods are contracts; any nilable return permits nil.
 		if isSingleNilableResult(signature) && !returnType.IsDirectError &&
-			(c.cfg == nil || !c.cfg.IsNonNilableReturn(c.currentPkgPath, qualifiedName)) {
+			!c.cfg.IsNonNilableReturn(c.currentPkgPath, qualifiedName) {
 			returnType.LisetteType = optionOf(returnType.LisetteType)
 		}
 

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"maps"
+	"slices"
 
 	"github.com/ivov/lisette/bindgen/internal/config"
 	"github.com/ivov/lisette/bindgen/internal/extract"
@@ -21,7 +23,6 @@ type ConvertResult struct {
 	TypeParams       TypeParamSpecs
 	Fields           []StructField     // for structs
 	InterfaceMethods []InterfaceMethod // for interfaces
-	Variants         []EnumVariant     // for enums (via iota)
 	ConstValue       string            // for constants
 	SkipReason       *SkipReason
 	// SkipNote attaches a leading "SKIPPED returns-with"/"SKIPPED type-with"
@@ -96,13 +97,36 @@ func (m *InterfaceMethod) HasReturn() bool {
 	return m.ReturnType != "" && m.ReturnType != "()"
 }
 
-type EnumVariant struct {
-	Name  string
-	Value string
-}
-
 // ExternalPkgs maps package paths to package names (e.g., "time" -> "time").
 type ExternalPkgs map[string]string
+
+type ConstGroup struct {
+	Type      ConvertResult
+	Constants []ConvertResult
+}
+
+type PackageConversion struct {
+	Symbols             []ConvertResult
+	ConstGroups         []ConstGroup
+	SyntheticTypes      []ConvertResult
+	OpaqueTypes         []ConvertResult
+	ExternalPkgs        ExternalPkgs
+	BitFlagSetTypeNames map[string]bool
+}
+
+func (p PackageConversion) NeedsSelfQualification() bool {
+	for _, result := range p.Symbols {
+		if result.Kind == extract.ExportType && CollidesWithBuiltinType(result.Name, len(result.TypeParams)) {
+			return true
+		}
+	}
+	for _, group := range p.ConstGroups {
+		if CollidesWithBuiltinType(group.Type.Name, len(group.Type.TypeParams)) {
+			return true
+		}
+	}
+	return false
+}
 
 // ASCII SOH/STX, used to wrap a package path in reference strings so the
 // emitter can substitute it with the resolved local prefix after collision
@@ -120,7 +144,7 @@ type Converter struct {
 	currentPkgPath           string
 	externalPkgs             ExternalPkgs
 	pkg                      *packages.Package
-	cfg                      *config.Config
+	cfg                      config.Config
 	uniformPointerTypes      map[string]bool              // lazily computed; types with 10+ single-pointer-return methods
 	manyToOneTypes           map[string]bool              // lazily computed; return types with 10+ free functions
 	majorityPointerTypes     map[string]bool              // lazily computed; types where ≥20 methods return same *T (>90%)
@@ -135,28 +159,28 @@ type Converter struct {
 	ifaceRepresentable       map[*types.Named]bool        // memoized per-interface "bindgen can emit this" verdicts
 	ifaceProbing             map[*types.Named]bool        // interfaces with an in-flight representability probe, to break self-referential cycles
 	shallowUnderlyingCache   map[token.Pos]types.Type     // lazily built; spec-level wrapped type by Named.Obj().Pos(). nil sentinels cached.
-	// Set per-function-conversion: maps `S` to `Slice<E>` for the `S ~[]E` shape.
-	typeParamSubstitutions map[string]string
 	// Stand-ins for Go anonymous struct types, in first-seen order.
-	synth          []syntheticStruct
-	synthByShape   map[string]int  // shape key -> index into synth
-	synthTaken     map[string]bool // names reserved against collision
-	reservedSeeded bool
+	synth []syntheticStruct
 }
 
 func NewConverter(pkgPath string, pkg *packages.Package, cfg *config.Config) *Converter {
+	var effectiveConfig config.Config
+	if cfg != nil {
+		effectiveConfig = *cfg
+	}
 	return &Converter{
 		currentPkgPath: pkgPath,
 		externalPkgs:   make(ExternalPkgs),
 		pkg:            pkg,
-		cfg:            cfg,
-		synthByShape:   make(map[string]int),
-		synthTaken:     make(map[string]bool),
+		cfg:            effectiveConfig,
 	}
 }
 
-func (c *Converter) ExternalPkgs() ExternalPkgs {
-	return c.externalPkgs
+func (c *Converter) forkProbe() *Converter {
+	probe := *c
+	probe.externalPkgs = maps.Clone(c.externalPkgs)
+	probe.synth = slices.Clone(c.synth)
+	return &probe
 }
 
 func (c *Converter) trackExternalPkg(pkgPath, pkgName string) {
@@ -234,7 +258,7 @@ func (c *Converter) salvageInternalAlias(rhs types.Type, reason *SkipReason) (st
 	return under.LisetteType, true
 }
 
-func (c *Converter) Convert(symbolExport extract.SymbolExport) ConvertResult {
+func (c *Converter) convert(symbolExport extract.SymbolExport) ConvertResult {
 	result := ConvertResult{
 		Name: symbolExport.Name,
 		Kind: symbolExport.Kind,
@@ -261,4 +285,38 @@ func (c *Converter) Convert(symbolExport extract.SymbolExport) ConvertResult {
 	}
 
 	return result
+}
+
+func (c *Converter) ConvertAll(exports []extract.SymbolExport) PackageConversion {
+	converted := make([]convertedSymbol, 0, len(exports))
+	for _, exp := range exports {
+		result := c.convert(exp)
+		converted = append(converted, convertedSymbol{export: exp, result: result})
+	}
+
+	c.finalizeInterfaceBuilders(converted)
+
+	regular, groups, bitFlagSetTypeNames := classifyConstGroups(converted, &c.cfg, c.currentPkgPath)
+	emittedTypeNames := make(map[string]bool)
+	for _, symbol := range converted {
+		if symbol.result.Kind == extract.ExportType {
+			emittedTypeNames[symbol.result.Name] = true
+		}
+	}
+
+	var opaqueTypes []ConvertResult
+	for _, handle := range c.opaqueHandles() {
+		if !emittedTypeNames[handle.Name] {
+			opaqueTypes = append(opaqueTypes, handle)
+		}
+	}
+
+	return PackageConversion{
+		Symbols:             regular,
+		ConstGroups:         groups,
+		SyntheticTypes:      c.syntheticStructs(),
+		OpaqueTypes:         opaqueTypes,
+		ExternalPkgs:        maps.Clone(c.externalPkgs),
+		BitFlagSetTypeNames: bitFlagSetTypeNames,
+	}
 }

--- a/bindgen/internal/convert/nilcheck.go
+++ b/bindgen/internal/convert/nilcheck.go
@@ -434,7 +434,7 @@ func (c *Converter) isProvenNonNilCallResult(call *ast.CallExpr) bool {
 		}
 	}
 
-	if c.cfg != nil && c.cfg.IsNonNilableReturn(calleePkg, qualName) {
+	if c.cfg.IsNonNilableReturn(calleePkg, qualName) {
 		return true
 	}
 
@@ -506,7 +506,7 @@ func (c *Converter) crossPkgFuncDecl(obj types.Object, pkgPath string) *ast.Func
 	}
 	tempConv, ok := c.crossPkgConverters[pkgPath]
 	if !ok {
-		tempConv = NewConverter(pkgPath, importedPkg, c.cfg)
+		tempConv = NewConverter(pkgPath, importedPkg, &c.cfg)
 		tempConv.noCrossPkg = true
 		c.crossPkgConverters[pkgPath] = tempConv
 	}
@@ -550,7 +550,7 @@ func (c *Converter) isProvenNonNilCrossPkgFunc(obj types.Object, pkgPath string)
 	}
 	tempConv, ok := c.crossPkgConverters[pkgPath]
 	if !ok {
-		tempConv = NewConverter(pkgPath, importedPkg, c.cfg)
+		tempConv = NewConverter(pkgPath, importedPkg, &c.cfg)
 		tempConv.noCrossPkg = true
 		c.crossPkgConverters[pkgPath] = tempConv
 	}

--- a/bindgen/internal/convert/returns.go
+++ b/bindgen/internal/convert/returns.go
@@ -40,7 +40,11 @@ func ioInterfaceFromPackage(pkg *types.Package, name string) *types.Interface {
 // ReturnsToLisette converts a Go function's return types to Lisette.
 // The qualifiedName is used for config lookups (e.g. "LookupEnv" or "Rat.Float64").
 func ReturnsToLisette(signature *types.Signature, conv *Converter, qualifiedName string) TypeResult {
-	return returnsToLisetteRecursive(signature, make(map[types.Type]bool), conv, qualifiedName)
+	return returnsToLisetteRecursive(signature, make(map[types.Type]bool), conv, qualifiedName, nil)
+}
+
+func returnsToLisetteWithSubstitutions(signature *types.Signature, conv *Converter, qualifiedName string, substitutions map[string]string) TypeResult {
+	return returnsToLisetteRecursive(signature, make(map[types.Type]bool), conv, qualifiedName, substitutions)
 }
 
 // maybeWrapNilableFunction wraps function-typed returns in Option.
@@ -52,7 +56,7 @@ func ReturnsToLisette(signature *types.Signature, conv *Converter, qualifiedName
 func maybeWrapNilableFunction(t types.Type, lisetteType string, conv *Converter, qualifiedName string) (string, bool) {
 	switch t.(type) {
 	case *types.Signature:
-		if conv != nil && conv.cfg != nil && conv.cfg.IsNonNilableReturn(conv.currentPkgPath, qualifiedName) {
+		if conv != nil && conv.cfg.IsNonNilableReturn(conv.currentPkgPath, qualifiedName) {
 			return lisetteType, false
 		}
 		return optionOf(lisetteType), true
@@ -60,7 +64,7 @@ func maybeWrapNilableFunction(t types.Type, lisetteType string, conv *Converter,
 		if _, ok := t.Underlying().(*types.Signature); !ok {
 			return lisetteType, false
 		}
-		if conv != nil && conv.cfg != nil && conv.cfg.ShouldWrapNilableReturn(conv.currentPkgPath, qualifiedName) {
+		if conv != nil && conv.cfg.ShouldWrapNilableReturn(conv.currentPkgPath, qualifiedName) {
 			return optionOf(lisetteType), true
 		}
 		return lisetteType, false
@@ -69,11 +73,11 @@ func maybeWrapNilableFunction(t types.Type, lisetteType string, conv *Converter,
 	}
 }
 
-func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]bool, conv *Converter, qualifiedName string) TypeResult {
+func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]bool, conv *Converter, qualifiedName string, substitutions map[string]string) TypeResult {
 	results := signature.Results()
 
 	if results.Len() == 0 {
-		if conv != nil && conv.cfg != nil && conv.cfg.IsNeverReturn(conv.currentPkgPath, qualifiedName) {
+		if conv != nil && conv.cfg.IsNeverReturn(conv.currentPkgPath, qualifiedName) {
 			return TypeResult{LisetteType: "Never"}
 		}
 		return TypeResult{LisetteType: "()"}
@@ -81,10 +85,10 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 
 	if results.Len() == 1 {
 		if isErrorType(results.At(0).Type()) {
-			if conv.cfg != nil && conv.cfg.HasDirectError(conv.currentPkgPath, qualifiedName) {
+			if conv.cfg.HasDirectError(conv.currentPkgPath, qualifiedName) {
 				return TypeResult{LisetteType: "error"}
 			}
-			if conv.cfg != nil && conv.cfg.HasNilableError(conv.currentPkgPath, qualifiedName) {
+			if conv.cfg.HasNilableError(conv.currentPkgPath, qualifiedName) {
 				return TypeResult{LisetteType: "Option<error>"}
 			}
 			if looksLikeNilableError(qualifiedName, signature) {
@@ -96,7 +100,7 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 		if isPointerToErrorImpl(results.At(0).Type()) {
 			return TypeResult{LisetteType: "error", IsDirectError: true}
 		}
-		elem := toLisetteRecursive(results.At(0).Type(), seen, conv)
+		elem := toLisetteRecursive(results.At(0).Type(), seen, conv, substitutions)
 		if elem.SkipReason == nil {
 			wrapped, applied := maybeWrapNilableFunction(results.At(0).Type(), elem.LisetteType, conv, qualifiedName)
 			elem.LisetteType = wrapped
@@ -118,12 +122,12 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 	}
 
 	if isErrorType(last.Type()) {
-		inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName)
+		inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName, substitutions)
 		innerType := inner.LisetteType
 		if inner.SkipReason != nil {
 			innerType = "Unknown"
 		}
-		if (conv.cfg != nil && conv.cfg.IsPartialResult(conv.currentPkgPath, qualifiedName)) ||
+		if conv.cfg.IsPartialResult(conv.currentPkgPath, qualifiedName) ||
 			isPartialIOMethod(signature, qualifiedName) {
 			return TypeResult{
 				LisetteType:          partialOf(innerType),
@@ -142,7 +146,7 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 	if isBoolType(last.Type()) {
 		if shouldConvertToOption(last.Name(), conv, qualifiedName) {
 			nilable := results.Len() == 2 && isNilableGoType(results.At(0).Type())
-			inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName)
+			inner := collectReturnTypes(results, 0, results.Len()-1, seen, conv, qualifiedName, substitutions)
 			innerType := inner.LisetteType
 			if inner.SkipReason != nil {
 				innerType = "Unknown"
@@ -156,12 +160,12 @@ func returnsToLisetteRecursive(signature *types.Signature, seen map[types.Type]b
 		}
 	}
 
-	return collectReturnTypes(results, 0, results.Len(), seen, conv, qualifiedName)
+	return collectReturnTypes(results, 0, results.Len(), seen, conv, qualifiedName, substitutions)
 }
 
 // shouldConvertToOption determines if a (T, bool) return should become Option<T>.
 func shouldConvertToOption(boolName string, conv *Converter, qualifiedName string) bool {
-	if conv.cfg != nil && conv.cfg.HasBoolAsFlag(conv.currentPkgPath, qualifiedName) {
+	if conv.cfg.HasBoolAsFlag(conv.currentPkgPath, qualifiedName) {
 		return false
 	}
 
@@ -182,7 +186,7 @@ func shouldConvertToOption(boolName string, conv *Converter, qualifiedName strin
 // crates/syntax/src/parse/mod.rs.
 const maxReturnTupleArity = 5
 
-func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Type]bool, conv *Converter, qualifiedName string) TypeResult {
+func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Type]bool, conv *Converter, qualifiedName string, substitutions map[string]string) TypeResult {
 	count := end - start
 
 	if count == 0 {
@@ -190,7 +194,7 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 	}
 
 	if count == 1 {
-		elem := toLisetteRecursive(results.At(start).Type(), seen, conv)
+		elem := toLisetteRecursive(results.At(start).Type(), seen, conv, substitutions)
 		if elem.SkipReason == nil {
 			wrapped, applied := maybeWrapNilableFunction(results.At(start).Type(), elem.LisetteType, conv, qualifiedName)
 			elem.LisetteType = wrapped
@@ -211,7 +215,7 @@ func collectReturnTypes(results *types.Tuple, start, end int, seen map[types.Typ
 	var elems []string
 	anyApplied := false
 	for i := start; i < end; i++ {
-		elem := toLisetteRecursive(results.At(i).Type(), seen, conv)
+		elem := toLisetteRecursive(results.At(i).Type(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}

--- a/bindgen/internal/convert/typeparams.go
+++ b/bindgen/internal/convert/typeparams.go
@@ -74,11 +74,11 @@ func (ps TypeParamSpecs) UseBlock() string {
 // Named-type identity is checked before .Underlying(), which discards the
 // wrapper — afterwards cmp.Ordered's structural shape would short-circuit
 // as plain `comparable`.
-func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, ok bool) {
+func recognizeBound(constraint types.Type, conv *Converter, substitutions map[string]string) (boundExpr string, ok bool) {
 	if named, isNamed := constraint.(*types.Named); isNamed {
 		obj := named.Obj()
 		if obj.Pkg() != nil && obj.Pkg().Path() == "cmp" && obj.Name() == "Ordered" {
-			return qualifyTypeNameBound(obj, nil, conv)
+			return qualifyTypeNameBound(obj, nil, conv, substitutions)
 		}
 	}
 
@@ -108,12 +108,12 @@ func recognizeBound(constraint types.Type, conv *Converter) (boundExpr string, o
 	if iface.IsMethodSet() && iface.NumMethods() > 0 {
 		switch t := constraint.(type) {
 		case *types.Named:
-			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv)
+			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv, substitutions)
 		case *types.Alias:
 			if isGenericAlias(t) {
 				return "", false
 			}
-			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv)
+			return qualifyTypeNameBound(t.Obj(), t.TypeArgs(), conv, substitutions)
 		}
 	}
 
@@ -153,7 +153,7 @@ func isOrderedBasicKind(kind types.BasicKind) bool {
 // Renders a Named or Alias bound by its TypeName, qualifying with the package
 // alias when external and tracking the external package on conv. Bounds in the
 // current package render unqualified to avoid a self-import.
-func qualifyTypeNameBound(obj *types.TypeName, typeArgs *types.TypeList, conv *Converter) (string, bool) {
+func qualifyTypeNameBound(obj *types.TypeName, typeArgs *types.TypeList, conv *Converter, substitutions map[string]string) (string, bool) {
 	pkg := obj.Pkg()
 	if pkg == nil {
 		if obj.Name() == "error" {
@@ -176,7 +176,7 @@ func qualifyTypeNameBound(obj *types.TypeName, typeArgs *types.TypeList, conv *C
 	}
 	args := make([]string, 0, typeArgs.Len())
 	for arg := range typeArgs.Types() {
-		result := ToLisette(arg, conv)
+		result := toLisetteWithSubstitutions(arg, conv, substitutions)
 		if result.SkipReason != nil {
 			return "", false
 		}

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -24,23 +24,27 @@ type TypeResult struct {
 }
 
 func ToLisette(t types.Type, conv *Converter) TypeResult {
-	return toLisetteRecursive(t, make(map[types.Type]bool), conv)
+	return toLisetteRecursive(t, make(map[types.Type]bool), conv, nil)
+}
+
+func toLisetteWithSubstitutions(t types.Type, conv *Converter, substitutions map[string]string) TypeResult {
+	return toLisetteRecursive(t, make(map[types.Type]bool), conv, substitutions)
 }
 
 // ToLisetteNilable converts a Go type to Lisette, wrapping pointer and
 // interface types in Option<>. Used for struct fields and collection elements
 // where Go pointers/interfaces can be nil.
 func ToLisetteNilable(t types.Type, conv *Converter) TypeResult {
-	return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv)
+	return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv, nil)
 }
 
 // convertParamType wraps a `*T` parameter in `Option<>` when the param's name
 // appears in `nilable` — used for Go APIs where passing nil means "use default".
-func convertParamType(t types.Type, name string, nilable []string, conv *Converter) TypeResult {
+func convertParamType(t types.Type, name string, nilable []string, conv *Converter, substitutions map[string]string) TypeResult {
 	if slices.Contains(nilable, name) {
-		return ToLisetteNilable(t, conv)
+		return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv, substitutions)
 	}
-	return ToLisette(t, conv)
+	return toLisetteWithSubstitutions(t, conv, substitutions)
 }
 
 // isNilableGoType reports whether t is a Go-nilable type (pointer or non-empty non-error interface).
@@ -61,7 +65,7 @@ func isNilableGoType(t types.Type) bool {
 	}
 	return false
 }
-func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter) TypeResult {
+func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter, substitutions map[string]string) TypeResult {
 	if seen[t] {
 		return TypeResult{LisetteType: "Unknown"}
 	}
@@ -73,39 +77,39 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		return TypeResult{LisetteType: basicToLisette(t)}
 
 	case *types.Slice:
-		elem := toLisetteRecursive(t.Elem(), seen, conv)
+		elem := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
 		return TypeResult{LisetteType: sliceOf(elem.LisetteType)}
 
 	case *types.Array:
-		elem := toLisetteRecursive(t.Elem(), seen, conv)
+		elem := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
 		return TypeResult{LisetteType: arrayOf(elem.LisetteType, t.Len())}
 
 	case *types.Map:
-		key := toLisetteRecursive(t.Key(), seen, conv)
+		key := toLisetteRecursive(t.Key(), seen, conv, substitutions)
 		if key.SkipReason != nil {
 			return key
 		}
-		val := toLisetteRecursive(t.Elem(), seen, conv)
+		val := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if val.SkipReason != nil {
 			return val
 		}
 		return TypeResult{LisetteType: mapOf(key.LisetteType, val.LisetteType)}
 
 	case *types.Pointer:
-		elem := toLisetteRecursive(t.Elem(), seen, conv)
+		elem := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
 		return TypeResult{LisetteType: refOf(elem.LisetteType)}
 
 	case *types.Chan:
-		elem := toLisetteRecursive(t.Elem(), seen, conv)
+		elem := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
@@ -119,7 +123,7 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		}
 
 	case *types.Signature:
-		return signatureToLisette(t, seen, conv)
+		return signatureToLisette(t, seen, conv, substitutions)
 
 	case *types.Interface:
 		if t.Empty() {
@@ -131,14 +135,12 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		return TypeResult{LisetteType: "Unknown"}
 
 	case *types.Named:
-		return namedToLisette(t, seen, conv)
+		return namedToLisette(t, seen, conv, substitutions)
 
 	case *types.TypeParam:
 		name := t.Obj().Name()
-		if conv != nil && conv.typeParamSubstitutions != nil {
-			if substituted, ok := conv.typeParamSubstitutions[name]; ok {
-				return TypeResult{LisetteType: substituted}
-			}
+		if substituted, ok := substitutions[name]; ok {
+			return TypeResult{LisetteType: substituted}
 		}
 		return TypeResult{LisetteType: name}
 
@@ -152,7 +154,7 @@ func toLisetteRecursive(t types.Type, seen map[types.Type]bool, conv *Converter)
 		return conv.internAnonStruct(t)
 
 	case *types.Alias:
-		return toLisetteRecursive(t.Rhs(), seen, conv)
+		return toLisetteRecursive(t.Rhs(), seen, conv, substitutions)
 
 	default:
 		return TypeResult{SkipReason: &SkipReason{
@@ -226,12 +228,12 @@ func basicToLisette(t *types.Basic) string {
 	}
 }
 
-func signatureToLisette(signature *types.Signature, seen map[types.Type]bool, conv *Converter) TypeResult {
+func signatureToLisette(signature *types.Signature, seen map[types.Type]bool, conv *Converter, substitutions map[string]string) TypeResult {
 	var params []string
 
 	param := signature.Params()
 	for param := range param.Variables() {
-		paramType := toLisetteRecursive(param.Type(), seen, conv)
+		paramType := toLisetteRecursive(param.Type(), seen, conv, substitutions)
 		if paramType.SkipReason != nil {
 			return paramType
 		}
@@ -245,7 +247,7 @@ func signatureToLisette(signature *types.Signature, seen map[types.Type]bool, co
 
 	returnType := "()"
 	if signature.Results().Len() > 0 {
-		ret := returnsToLisetteRecursive(signature, seen, conv, "")
+		ret := returnsToLisetteRecursive(signature, seen, conv, "", substitutions)
 		if ret.SkipReason != nil {
 			return ret
 		}
@@ -255,7 +257,7 @@ func signatureToLisette(signature *types.Signature, seen map[types.Type]bool, co
 	return TypeResult{LisetteType: fmt.Sprintf("fn(%s) -> %s", strings.Join(params, ", "), returnType)}
 }
 
-func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) TypeResult {
+func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter, substitutions map[string]string) TypeResult {
 	obj := t.Obj()
 	pkg := obj.Pkg()
 
@@ -287,7 +289,7 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 		}
 		if conv != nil {
 			if iface := conv.bestImplementedInterface(t); iface != nil {
-				return toLisetteRecursive(iface, seen, conv)
+				return toLisetteRecursive(iface, seen, conv, substitutions)
 			}
 		}
 		if s, ok := t.Underlying().(*types.Struct); ok && s.NumFields() > 0 {
@@ -296,7 +298,7 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 				Message: fmt.Sprintf("underlying type %q is unexported", obj.Name()),
 			}}
 		}
-		return toLisetteRecursive(t.Underlying(), seen, conv)
+		return toLisetteRecursive(t.Underlying(), seen, conv, substitutions)
 	}
 
 	typeName := obj.Name()
@@ -305,7 +307,7 @@ func namedToLisette(t *types.Named, seen map[types.Type]bool, conv *Converter) T
 	if typeArgs != nil && typeArgs.Len() > 0 {
 		var args []string
 		for arg := range typeArgs.Types() {
-			result := toLisetteRecursive(arg, seen, conv)
+			result := toLisetteRecursive(arg, seen, conv, substitutions)
 			if result.SkipReason != nil {
 				return result
 			}
@@ -367,10 +369,10 @@ func wrapOption(r TypeResult) TypeResult {
 // Option<Name> — Go func values are nilable, and zero-value (nil) is meaningful
 // in struct literals.
 // The nilable flag propagates into collection element types (Slice, Map values).
-func toLisetteNilableRecursive(t types.Type, seen map[types.Type]bool, conv *Converter) TypeResult {
+func toLisetteNilableRecursive(t types.Type, seen map[types.Type]bool, conv *Converter, substitutions map[string]string) TypeResult {
 	switch t := t.(type) {
 	case *types.Pointer:
-		elem := toLisetteRecursive(t.Elem(), seen, conv)
+		elem := toLisetteRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
@@ -380,49 +382,49 @@ func toLisetteNilableRecursive(t types.Type, seen map[types.Type]bool, conv *Con
 		return TypeResult{LisetteType: optionOf(refOf(elem.LisetteType))}
 
 	case *types.Signature:
-		return wrapOption(toLisetteRecursive(t, seen, conv))
+		return wrapOption(toLisetteRecursive(t, seen, conv, substitutions))
 
 	case *types.Named:
 		switch u := t.Underlying().(type) {
 		case *types.Interface:
 			if !u.Empty() && !isErrorInterface(u) {
-				return wrapOption(namedToLisette(t, seen, conv))
+				return wrapOption(namedToLisette(t, seen, conv, substitutions))
 			}
 		case *types.Signature:
-			return wrapOption(namedToLisette(t, seen, conv))
+			return wrapOption(namedToLisette(t, seen, conv, substitutions))
 		}
-		return namedToLisette(t, seen, conv)
+		return namedToLisette(t, seen, conv, substitutions)
 
 	case *types.Slice:
-		elem := toLisetteNilableRecursive(t.Elem(), seen, conv)
+		elem := toLisetteNilableRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
 		return TypeResult{LisetteType: sliceOf(elem.LisetteType)}
 
 	case *types.Array:
-		elem := toLisetteNilableRecursive(t.Elem(), seen, conv)
+		elem := toLisetteNilableRecursive(t.Elem(), seen, conv, substitutions)
 		if elem.SkipReason != nil {
 			return elem
 		}
 		return TypeResult{LisetteType: arrayOf(elem.LisetteType, t.Len())}
 
 	case *types.Map:
-		key := toLisetteRecursive(t.Key(), seen, conv)
+		key := toLisetteRecursive(t.Key(), seen, conv, substitutions)
 		if key.SkipReason != nil {
 			return key
 		}
-		val := toLisetteNilableRecursive(t.Elem(), seen, conv)
+		val := toLisetteNilableRecursive(t.Elem(), seen, conv, substitutions)
 		if val.SkipReason != nil {
 			return val
 		}
 		return TypeResult{LisetteType: mapOf(key.LisetteType, val.LisetteType)}
 
 	case *types.Alias:
-		return toLisetteNilableRecursive(t.Rhs(), seen, conv)
+		return toLisetteNilableRecursive(t.Rhs(), seen, conv, substitutions)
 
 	default:
-		return toLisetteRecursive(t, seen, conv)
+		return toLisetteRecursive(t, seen, conv, substitutions)
 	}
 }
 

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -39,7 +39,7 @@ type Emitter struct {
 	stats             stats
 	skipped           int
 	methods           map[string][]convert.ConvertResult // receiver type name -> methods
-	cfg               *config.Config
+	cfg               config.Config
 	pkgPath           string
 	pkgName           string            // package name, used to self-qualify prelude-colliding types
 	pkgAliases        map[string]string // package path -> local prefix used in references
@@ -48,9 +48,13 @@ type Emitter struct {
 }
 
 func NewEmitter(cfg *config.Config, pkgPath, pkgName string, bitFlagSetTypes, closedDomainTypes map[string]bool) *Emitter {
+	var effectiveConfig config.Config
+	if cfg != nil {
+		effectiveConfig = *cfg
+	}
 	return &Emitter{
 		methods:           make(map[string][]convert.ConvertResult),
-		cfg:               cfg,
+		cfg:               effectiveConfig,
 		pkgPath:           pkgPath,
 		pkgName:           pkgName,
 		bitFlagSetTypes:   bitFlagSetTypes,
@@ -422,7 +426,7 @@ func allowDiscardLint(returnType string) string {
 //   - Close() error
 //   - Flush() error
 func (e *Emitter) shouldAllowUnusedResult(qualifiedName, methodName string, result convert.ConvertResult) bool {
-	if e.cfg != nil && e.cfg.ShouldAllowUnusedResult(e.pkgPath, qualifiedName) {
+	if e.cfg.ShouldAllowUnusedResult(e.pkgPath, qualifiedName) {
 		return true
 	}
 

--- a/bindgen/tests/bindgen_test.go
+++ b/bindgen/tests/bindgen_test.go
@@ -221,9 +221,9 @@ func TestGenerateStd(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	targets := []cli.Target{
-		{GOOS: "darwin", GOARCH: "arm64"},
-		{GOOS: "linux", GOARCH: "amd64"},
+	targets, err := cli.ParseTargets("darwin/arm64,linux/amd64")
+	if err != nil {
+		t.Fatalf("parse targets: %v", err)
 	}
 	result, err := cli.GenerateStd(context.Background(), tmpDir, "0.0.0", "0.0.0", nil, targets)
 	if err != nil {
@@ -257,7 +257,10 @@ func TestGenerateStdRejectsSingleTarget(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	targets := []cli.Target{{GOOS: "darwin", GOARCH: "arm64"}}
+	targets, err := cli.ParseTargets("darwin/arm64")
+	if err != nil {
+		t.Fatalf("parse targets: %v", err)
+	}
 	_, err = cli.GenerateStd(context.Background(), tmpDir, "0.0.0", "0.0.0", nil, targets)
 	if err == nil {
 		t.Fatal("expected GenerateStd to reject single-target invocation")


### PR DESCRIPTION
- Simplify how generated bindings are collected.
- Remove duplicated state and manual bookkeeping.
- Make target-specific generation easier to follow.
- Simplify handling of anon structs and generic types.