### PR TITLE
refactor: simplify LSP's state model

### DIFF
--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -13,10 +13,14 @@ use syntax::lex::Lexer;
 use syntax::parse::Parser;
 use syntax::types::{CompoundKind, Type};
 
-use crate::paths::{module_id_to_dir, uri_to_module_file};
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
-use crate::state::{CachedSnapshot, SharedState};
+use crate::state::{AnalysisRequest, SharedState};
+
+enum AnalysisError {
+    Diagnostics(Vec<Diagnostic>),
+    Superseded,
+}
 
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
 pub(crate) fn type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String> {
@@ -55,23 +59,16 @@ pub(crate) fn find_module_by_alias(
 
 impl SharedState {
     async fn run_analysis(&self, uri: &Url) -> Result<AnalysisSnapshot, Vec<Diagnostic>> {
-        let config = self.ensure_config(uri).await.ok_or_else(Vec::new)?;
-        let (module_id, filename) = uri_to_module_file(&config, uri).ok_or_else(Vec::new)?;
+        let project = self.project.for_analysis(uri).await.ok_or_else(Vec::new)?;
+        let config = project.config;
+        let filename = project.filename;
+        let loader = project.loader;
 
         let source = self
             .documents
             .get(uri)
-            .map(|doc| doc.content.clone())
+            .map(|document| document.content().to_string())
             .ok_or_else(Vec::new)?;
-
-        let loader_clone = {
-            let mut loader = self.loader.write().await;
-            let module_dir = module_id_to_dir(&config, &module_id);
-            loader.set_entry_module_path(Some(module_dir));
-            let clone = loader.clone();
-            loader.set_entry_module_path(None);
-            clone
-        };
 
         let lex_result = Lexer::new(&source, 0).lex();
         if lex_result.failed() {
@@ -97,31 +94,31 @@ impl SharedState {
             .map(Into::into)
             .collect();
 
-        let (locator, manifest_error) = if config.standalone_mode {
+        let standalone = config.is_standalone();
+        let (locator, manifest_error) = if standalone {
             (TypedefLocator::default(), None)
         } else {
-            match TypedefLocator::from_project(&config.root) {
+            match TypedefLocator::from_project(config.root()) {
                 Ok(r) => (r, None),
                 Err(msg) => (TypedefLocator::default(), Some(msg)),
             }
         };
 
-        let (locator, session, bindgen_error) =
-            if config.standalone_mode || manifest_error.is_some() {
-                (locator, None, None)
-            } else if let Some(setup) = self.bindgen_setup.as_ref() {
-                match setup.for_project(&config.root, locator.target()) {
-                    Ok(session) => {
-                        let with_runner = locator.clone().with_bindgen(session.bindgen.clone());
-                        (with_runner, Some(session), None)
-                    }
-                    Err(msg) => (locator, None, Some(msg)),
+        let (locator, session, bindgen_error) = if standalone || manifest_error.is_some() {
+            (locator, None, None)
+        } else if let Some(setup) = self.bindgen_setup.as_ref() {
+            match setup.for_project(config.root(), locator.target()) {
+                Ok(session) => {
+                    let with_runner = locator.clone().with_bindgen(session.bindgen.clone());
+                    (with_runner, Some(session), None)
                 }
-            } else {
-                (locator, None, None)
-            };
+                Err(msg) => (locator, None, Some(msg)),
+            }
+        } else {
+            (locator, None, None)
+        };
 
-        let project_kind = if config.standalone_mode || config.root.join("src/main.lis").exists() {
+        let project_kind = if standalone || config.root().join("src/main.lis").exists() {
             ProjectKind::Binary
         } else {
             ProjectKind::Library
@@ -130,10 +127,10 @@ impl SharedState {
         let analyze_output = analyze(AnalyzeInput {
             config: SemanticConfig {
                 run_lints: !has_parse_errors,
-                standalone_mode: config.standalone_mode,
+                standalone_mode: standalone,
                 load_siblings: true,
             },
-            loader: &loader_clone,
+            loader: &loader,
             entry: Some(EntryFile {
                 source,
                 display_path: filename.clone(),
@@ -141,10 +138,10 @@ impl SharedState {
                 ast: desugar_result.ast,
                 file_comment: parse_result.file_comment,
             }),
-            project_root: if config.standalone_mode {
+            project_root: if standalone {
                 None
             } else {
-                Some(config.root.clone())
+                Some(config.root().to_path_buf())
             },
             compile_phase: CompilePhase::Check,
             project_kind,
@@ -190,71 +187,73 @@ impl SharedState {
         ))
     }
 
-    async fn run_analysis_cached(
-        &self,
-        uri: &Url,
-    ) -> Result<Arc<AnalysisSnapshot>, Vec<Diagnostic>> {
-        let pre_version = self.documents.get(uri).map(|d| d.version);
+    async fn run_analysis_cached(&self, uri: &Url) -> Result<Arc<AnalysisSnapshot>, AnalysisError> {
+        let document = self.documents.get(uri).ok_or(AnalysisError::Superseded)?;
+        let request = document.request_analysis();
+        drop(document);
 
-        if let Some(cached) = self.snapshots.get(uri)
-            && Some(cached.version) == pre_version
+        let revision = match request {
+            AnalysisRequest::Cached(snapshot) => return Ok(snapshot),
+            AnalysisRequest::Required(revision) => revision,
+        };
+
+        let snapshot = Arc::new(
+            self.run_analysis(uri)
+                .await
+                .map_err(AnalysisError::Diagnostics)?,
+        );
+
+        if let Some(mut document) = self.documents.get_mut(uri)
+            && document.cache_analysis(&revision, Arc::clone(&snapshot))
         {
-            return Ok(Arc::clone(&cached.snapshot));
+            return Ok(snapshot);
         }
 
-        let snapshot = Arc::new(self.run_analysis(uri).await?);
-
-        let post_version = self.documents.get(uri).map(|d| d.version);
-        if pre_version == post_version
-            && let Some(version) = pre_version
-        {
-            if !snapshot.has_parse_errors {
-                self.last_valid_snapshot
-                    .insert(uri.clone(), Arc::clone(&snapshot));
-            }
-            self.snapshots.insert(
-                uri.clone(),
-                CachedSnapshot {
-                    snapshot: Arc::clone(&snapshot),
-                    version,
-                },
-            );
-        }
-
-        Ok(snapshot)
+        Err(AnalysisError::Superseded)
     }
 
-    pub(crate) async fn analyze_and_convert(&self, uri: &Url) -> Vec<Diagnostic> {
+    pub(crate) async fn analyze_and_convert(&self, uri: &Url) -> Option<Vec<Diagnostic>> {
         let snapshot = match self.run_analysis_cached(uri).await {
             Ok(s) => s,
-            Err(syntax_diagnostics) => return syntax_diagnostics,
+            Err(AnalysisError::Diagnostics(diagnostics)) => return Some(diagnostics),
+            Err(AnalysisError::Superseded) => return None,
         };
 
-        let Some(file_id) = snapshot.get_file_id(uri) else {
-            return vec![];
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return vec![];
+        let Some(document) = snapshot.document(uri) else {
+            return Some(vec![]);
         };
 
-        snapshot
-            .result
-            .errors
-            .iter()
-            .chain(&snapshot.result.lints)
-            .filter(|d| {
-                let fid = d.file_id();
-                fid == Some(file_id) || fid.is_none()
-            })
-            .map(|d| convert_diagnostic(d, line_index))
-            .collect()
+        Some(
+            snapshot
+                .result
+                .errors
+                .iter()
+                .chain(&snapshot.result.lints)
+                .filter(|d| {
+                    let fid = d.file_id();
+                    fid == Some(document.file_id) || fid.is_none()
+                })
+                .map(|d| convert_diagnostic(d, document.line_index))
+                .collect(),
+        )
     }
 
     pub(crate) async fn get_snapshot(&self, uri: &Url) -> Option<Arc<AnalysisSnapshot>> {
-        self.run_analysis_cached(uri)
-            .await
-            .ok()
-            .or_else(|| self.last_valid_snapshot.get(uri).map(|s| Arc::clone(&s)))
+        self.run_analysis_cached(uri).await.ok().or_else(|| {
+            self.documents
+                .get(uri)
+                .and_then(|document| document.last_valid_analysis())
+        })
+    }
+
+    pub(crate) fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
+        self.documents
+            .iter()
+            .filter_map(|document| match document.request_analysis() {
+                AnalysisRequest::Cached(snapshot) => Some(snapshot),
+                AnalysisRequest::Required(_) => None,
+            })
+            .collect()
     }
 }
 

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -513,13 +513,11 @@ fn record_pattern_field_span(
 /// Resolve the definition span at the given cursor offset.
 ///
 /// Checks binding definitions first, then falls back to expression-based resolution.
-/// `extra_match` handles caller-specific arms (e.g. DotAccess for references, rename guards).
-pub(crate) fn resolve_definition_span(
+pub(crate) fn resolve_symbol_definition_span(
     snapshot: &AnalysisSnapshot,
     file: &syntax::program::File,
     file_id: u32,
     offset: u32,
-    extra_match: impl FnOnce(&Expression) -> Option<syntax::ast::Span>,
 ) -> Option<syntax::ast::Span> {
     snapshot
         .facts()
@@ -539,6 +537,14 @@ pub(crate) fn resolve_definition_span(
                     resolution: IdentifierResolution::Binding(id),
                     ..
                 } => snapshot.facts().bindings.get(id).map(|b| b.span),
+
+                Expression::Identifier {
+                    resolution: IdentifierResolution::Definition(qname),
+                    ..
+                } => snapshot
+                    .definitions()
+                    .get(qname.as_str())
+                    .and_then(|definition| definition.name_span),
 
                 Expression::Function { name_span, .. }
                 | Expression::Interface { name_span, .. }
@@ -588,7 +594,24 @@ pub(crate) fn resolve_definition_span(
                     ..
                 } => resolve_struct_call_field(field_assignments, name, ty, offset, file, snapshot),
 
-                other => extra_match(other),
+                Expression::DotAccess {
+                    expression,
+                    member,
+                    span,
+                    ..
+                } => resolve_dot_access_definition(expression, member, *span, file, snapshot),
+
+                Expression::Match { arms, .. } => {
+                    resolve_match_pattern_definition(arms, offset, file, snapshot)
+                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, snapshot))
+                }
+
+                Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
+                    resolve_enum_in_pattern(pattern, offset, file, snapshot)
+                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, snapshot))
+                }
+
+                _ => resolve_word_at_offset(&file.source, offset, file, snapshot),
             }
         })
 }

--- a/crates/lsp/src/document.rs
+++ b/crates/lsp/src/document.rs
@@ -1,54 +1,20 @@
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use tower_lsp::lsp_types::Url;
 
-use crate::paths::uri_to_module_file;
-use crate::position::LineIndex;
 use crate::state::{DocumentState, SharedState};
 
 impl SharedState {
-    pub(crate) async fn ensure_config(
-        &self,
-        file_uri: &Url,
-    ) -> Option<crate::project::ProjectConfig> {
-        if let Some(config) = self.project_config.read().await.as_ref() {
-            return Some(config.clone());
-        }
-
-        let file_path = file_uri.to_file_path().ok()?;
-
-        let config = crate::project::find_project_root(&file_path)
-            .unwrap_or_else(|| crate::project::resolve_standalone_root(&file_path));
-
-        {
-            let mut loader = self.loader.write().await;
-            loader.set_config(config.clone());
-        }
-
-        *self.project_config.write().await = Some(config.clone());
-        Some(config)
-    }
-
     pub(crate) async fn update_document(&self, uri: Url, content: String, version: i32) {
-        let line_index = LineIndex::new(&content);
+        self.project.update_overlay(&uri, content.clone()).await;
 
-        if let Some(config) = self.ensure_config(&uri).await
-            && let Some((module_id, filename)) = uri_to_module_file(&config, &uri)
-        {
-            let mut loader = self.loader.write().await;
-            loader.set_overlay(&module_id, &filename, content.clone());
+        if let Some(mut document) = self.documents.get_mut(&uri) {
+            document.update(content, version);
+        } else {
+            self.documents
+                .insert(uri, DocumentState::new(content, version));
         }
-
-        self.documents.insert(
-            uri,
-            DocumentState {
-                content,
-                line_index,
-                version,
-            },
-        );
     }
 
     pub(crate) async fn publish_diagnostics(&self, uri: Url) {
@@ -60,11 +26,13 @@ impl SharedState {
             return;
         }
 
-        let version = self.documents.get(&uri).map(|d| d.version);
+        let version = self.documents.get(&uri).map(|document| document.version());
 
-        let diagnostics = self.analyze_and_convert(&uri).await;
+        let Some(diagnostics) = self.analyze_and_convert(&uri).await else {
+            return;
+        };
 
-        let current_version = self.documents.get(&uri).map(|d| d.version);
+        let current_version = self.documents.get(&uri).map(|document| document.version());
         if version != current_version {
             return; // Discard stale results
         }
@@ -75,34 +43,31 @@ impl SharedState {
     }
 
     pub(crate) async fn recheck_open_documents(self: &Arc<Self>) {
-        self.snapshots.clear();
-        let uris: Vec<Url> = self
-            .documents
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
+        let mut uris = Vec::with_capacity(self.documents.len());
+        for mut document in self.documents.iter_mut() {
+            document.invalidate_analysis();
+            uris.push(document.key().clone());
+        }
         for uri in uris {
             self.schedule_diagnostics(uri).await;
         }
     }
 
     async fn schedule_diagnostics(self: &Arc<Self>, uri: Url) {
-        if let Some((_, (_, old_handle))) = self.pending_diagnostics.remove(&uri) {
-            old_handle.abort();
-        }
+        let Some(mut document) = self.documents.get_mut(&uri) else {
+            return;
+        };
 
-        let generation = self.diagnostics_generation.fetch_add(1, Ordering::Relaxed);
         let state = Arc::clone(self);
         let diagnostics_uri = uri.clone();
         let handle = tokio::spawn(async move {
+            let task_id = tokio::task::id();
             tokio::time::sleep(Duration::from_millis(300)).await;
             state.publish_diagnostics(diagnostics_uri.clone()).await;
-            state
-                .pending_diagnostics
-                .remove_if(&diagnostics_uri, |_, (g, _)| *g == generation);
+            if let Some(mut document) = state.documents.get_mut(&diagnostics_uri) {
+                document.finish_diagnostics(task_id);
+            }
         });
-
-        self.pending_diagnostics
-            .insert(uri, (generation, handle.abort_handle()));
+        document.set_pending_diagnostics(handle.abort_handle());
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -29,11 +29,10 @@ use crate::completion::{
 };
 use crate::definition::{
     find_struct_field_span, is_generated_typedef_span, lookup_definition_span,
-    resolve_annotation_definition, resolve_definition_span, resolve_dot_access_definition,
-    resolve_enum_in_pattern, resolve_import_span, resolve_match_pattern_definition,
-    resolve_struct_call_field, resolve_word_at_offset, word_at_offset,
+    resolve_annotation_definition, resolve_dot_access_definition, resolve_enum_in_pattern,
+    resolve_import_span, resolve_match_pattern_definition, resolve_struct_call_field,
+    resolve_symbol_definition_span, resolve_word_at_offset, word_at_offset,
 };
-use crate::paths::uri_to_module_file;
 use crate::project::find_project_root;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
@@ -60,11 +59,7 @@ impl LanguageServer for Backend {
         if let Some(root) = workspace_root
             && let Some(config) = find_project_root(&root)
         {
-            {
-                let mut loader = self.loader.write().await;
-                loader.set_config(config.clone());
-            }
-            *self.project_config.write().await = Some(config);
+            self.project.initialize(config).await;
         }
 
         // Off the async executor: the first run for a version writes the full stdlib.
@@ -119,7 +114,6 @@ impl LanguageServer for Backend {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri;
         let content = params.text_document.text;
-        self.snapshots.remove(&uri);
         self.update_document(uri.clone(), content, params.text_document.version)
             .await;
         self.publish_diagnostics(uri).await;
@@ -140,22 +134,9 @@ impl LanguageServer for Backend {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = &params.text_document.uri;
-        if let Some((_, (_, handle))) = self.pending_diagnostics.remove(uri) {
-            handle.abort();
-        }
         self.documents.remove(uri);
-        self.snapshots.remove(uri);
-        self.last_valid_snapshot.remove(uri);
 
-        let overlay_removed = if let Some(config) = self.project_config.read().await.as_ref()
-            && let Some((module_id, filename)) = uri_to_module_file(config, uri)
-        {
-            let mut loader = self.loader.write().await;
-            loader.remove_overlay(&module_id, &filename);
-            true
-        } else {
-            false
-        };
+        let overlay_removed = self.project.remove_overlay(uri).await;
 
         self.client
             .publish_diagnostics(uri.clone(), vec![], None)
@@ -172,8 +153,10 @@ impl LanguageServer for Backend {
             let Some(doc) = self.documents.get(uri) else {
                 return Ok(None);
             };
-            let end = doc.line_index.offset_to_position(doc.content.len() as u32);
-            (doc.content.clone(), end)
+            let end = doc
+                .line_index()
+                .offset_to_position(doc.content().len() as u32);
+            (doc.content().to_string(), end)
         };
 
         let formatted = match format::format_source(&source) {
@@ -209,19 +192,12 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file = cursor.document.file;
+        let line_index = cursor.document.line_index;
+        let offset = cursor.offset;
 
         let Some(expression) = find_expression_at(&file.items, offset) else {
             return Ok(None);
@@ -259,15 +235,11 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(document) = snapshot.document(uri) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
+        let file = document.file;
+        let line_index = document.line_index;
 
         let eof = file.source.len() as u32;
         let start = line_index
@@ -295,19 +267,12 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file_id = cursor.document.file_id;
+        let file = cursor.document.file;
+        let offset = cursor.offset;
 
         let Some(expression) = find_expression_at(&file.items, offset) else {
             return Ok(None);
@@ -343,12 +308,11 @@ impl LanguageServer for Backend {
                             lookup_definition_span(first, file, &snapshot).or_else(|| {
                                 resolve_import_span(first, file, &snapshot.result.go_package_names)
                             })
-                            && let Some(uri) = snapshot.get_uri(span.file_id)
-                            && let Some(idx) = snapshot.get_line_index(span.file_id)
+                            && let Some(source) = snapshot.source(span.file_id)
                         {
                             return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                                uri: uri.clone(),
-                                range: idx.span_to_range(span),
+                                uri: source.uri.clone(),
+                                range: source.line_index.span_to_range(span),
                             })));
                         }
                     }
@@ -479,17 +443,14 @@ impl LanguageServer for Backend {
             return Ok(None);
         }
 
-        let Some(target_uri) = snapshot.get_uri(definition_span.file_id) else {
-            return Ok(None);
-        };
-        let Some(target_line_index) = snapshot.get_line_index(definition_span.file_id) else {
+        let Some(target) = snapshot.source(definition_span.file_id) else {
             return Ok(None);
         };
 
-        let range = target_line_index.span_to_range(definition_span);
+        let range = target.line_index.span_to_range(definition_span);
 
         Ok(Some(GotoDefinitionResponse::Scalar(Location {
-            uri: target_uri.clone(),
+            uri: target.uri.clone(),
             range,
         })))
     }
@@ -505,15 +466,11 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(document) = snapshot.document(uri) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
+        let file = document.file;
+        let line_index = document.line_index;
 
         fn expression_to_symbol(
             expression: &syntax::ast::Expression,
@@ -617,98 +574,38 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
+        let file_id = cursor.document.file_id;
+        let file = cursor.document.file;
+        let offset = cursor.offset;
 
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
-
-        let definition_span = resolve_definition_span(
-            &snapshot,
-            file,
-            file_id,
-            offset,
-            |expression| match expression {
-                syntax::ast::Expression::Identifier {
-                    resolution: IdentifierResolution::Definition(qname),
-                    ..
-                } => snapshot
-                    .definitions()
-                    .get(qname.as_str())
-                    .and_then(|d| d.name_span),
-
-                syntax::ast::Expression::DotAccess {
-                    expression,
-                    member,
-                    span,
-                    ..
-                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
-
-                syntax::ast::Expression::Match { arms, .. } => {
-                    resolve_match_pattern_definition(arms, offset, file, &snapshot)
-                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
-                }
-
-                syntax::ast::Expression::IfLet { pattern, .. }
-                | syntax::ast::Expression::WhileLet { pattern, .. } => {
-                    resolve_enum_in_pattern(pattern, offset, file, &snapshot)
-                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
-                }
-
-                _ => resolve_word_at_offset(&file.source, offset, file, &snapshot),
-            },
-        );
+        let definition_span = resolve_symbol_definition_span(&snapshot, file, file_id, offset);
 
         let Some(definition_span) = definition_span else {
             return Ok(None);
         };
 
-        let Some(definition_uri) = snapshot.get_uri(definition_span.file_id).cloned() else {
+        let Some(definition_source) = snapshot.source(definition_span.file_id) else {
             return Ok(None);
         };
+        let definition_uri = definition_source.uri.clone();
 
         let mut locations = Vec::new();
 
-        if params.context.include_declaration
-            && let Some(definition_line_index) = snapshot.get_line_index(definition_span.file_id)
-        {
+        if params.context.include_declaration {
             locations.push(Location {
                 uri: definition_uri.clone(),
-                range: definition_line_index.span_to_range(definition_span),
+                range: definition_source.line_index.span_to_range(definition_span),
             });
         }
 
-        for entry in self.snapshots.iter() {
-            let snap = &entry.value().snapshot;
-            let Some(target_file_id) = snap.get_file_id(&definition_uri) else {
-                continue;
-            };
-            let target_span = syntax::ast::Span::new(
-                target_file_id,
-                definition_span.byte_offset,
-                definition_span.byte_length,
-            );
-            for usage in &snap.facts().usages {
-                if usage.definition_span == target_span
-                    && let Some(usage_uri) = snap.get_uri(usage.usage_span.file_id)
-                    && let Some(usage_line_index) = snap.get_line_index(usage.usage_span.file_id)
-                {
-                    let usage_span = trailing_segment_span(usage.usage_span, snap);
-                    locations.push(Location {
-                        uri: usage_uri.clone(),
-                        range: usage_line_index.span_to_range(usage_span),
-                    });
-                }
-            }
-        }
+        locations.extend(usage_locations(
+            self.open_document_snapshots(),
+            &definition_uri,
+            definition_span,
+        ));
 
         locations.sort_by(|a, b| {
             a.uri
@@ -736,18 +633,13 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file_id = cursor.document.file_id;
+        let file = cursor.document.file;
+        let line_index = cursor.document.line_index;
+        let offset = cursor.offset;
 
         for binding in snapshot.facts().bindings.values() {
             let span = binding.span;
@@ -985,62 +877,26 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file_id = cursor.document.file_id;
+        let file = cursor.document.file;
+        let offset = cursor.offset;
 
         let mut edits: std::collections::HashMap<Url, Vec<TextEdit>> =
             std::collections::HashMap::new();
 
-        let definition_span = resolve_definition_span(
-            &snapshot,
-            file,
-            file_id,
-            offset,
-            |expression| match expression {
-                syntax::ast::Expression::Identifier {
-                    resolution: IdentifierResolution::Definition(qname),
-                    ..
-                } => {
-                    if validation::check_rename_guards(qname.as_str()).is_err() {
-                        return None;
-                    }
-                    snapshot
-                        .definitions()
-                        .get(qname.as_str())
-                        .and_then(|d| d.name_span)
-                }
+        if let Some(syntax::ast::Expression::Identifier {
+            resolution: IdentifierResolution::Definition(qname),
+            ..
+        }) = find_expression_at(&file.items, offset)
+            && validation::check_rename_guards(qname.as_str()).is_err()
+        {
+            return Ok(None);
+        }
 
-                syntax::ast::Expression::DotAccess {
-                    expression,
-                    member,
-                    span,
-                    ..
-                } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
-
-                syntax::ast::Expression::Match { arms, .. } => {
-                    resolve_match_pattern_definition(arms, offset, file, &snapshot)
-                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
-                }
-
-                syntax::ast::Expression::IfLet { pattern, .. }
-                | syntax::ast::Expression::WhileLet { pattern, .. } => {
-                    resolve_enum_in_pattern(pattern, offset, file, &snapshot)
-                        .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
-                }
-
-                _ => resolve_word_at_offset(&file.source, offset, file, &snapshot),
-            },
-        );
+        let definition_span = resolve_symbol_definition_span(&snapshot, file, file_id, offset);
 
         let Some(definition_span) = definition_span else {
             return Ok(None);
@@ -1050,43 +906,28 @@ impl LanguageServer for Backend {
             return Ok(None);
         }
 
-        let Some(definition_uri) = snapshot.get_uri(definition_span.file_id).cloned() else {
+        let Some(definition_source) = snapshot.source(definition_span.file_id) else {
             return Ok(None);
         };
+        let definition_uri = definition_source.uri.clone();
 
-        if let Some(definition_line_index) = snapshot.get_line_index(definition_span.file_id) {
-            edits
-                .entry(definition_uri.clone())
-                .or_default()
-                .push(TextEdit {
-                    range: definition_line_index.span_to_range(definition_span),
-                    new_text: new_name.clone(),
-                });
-        }
+        edits
+            .entry(definition_uri.clone())
+            .or_default()
+            .push(TextEdit {
+                range: definition_source.line_index.span_to_range(definition_span),
+                new_text: new_name.clone(),
+            });
 
-        for entry in self.snapshots.iter() {
-            let snap = &entry.value().snapshot;
-            let Some(target_file_id) = snap.get_file_id(&definition_uri) else {
-                continue;
-            };
-            let target_span = syntax::ast::Span::new(
-                target_file_id,
-                definition_span.byte_offset,
-                definition_span.byte_length,
-            );
-            for usage in &snap.facts().usages {
-                if usage.definition_span == target_span
-                    && let Some(usage_uri) = snap.get_uri(usage.usage_span.file_id)
-                    && let Some(usage_line_index) = snap.get_line_index(usage.usage_span.file_id)
-                {
-                    let replace_span = trailing_segment_span(usage.usage_span, snap);
-
-                    edits.entry(usage_uri.clone()).or_default().push(TextEdit {
-                        range: usage_line_index.span_to_range(replace_span),
-                        new_text: new_name.clone(),
-                    });
-                }
-            }
+        for location in usage_locations(
+            self.open_document_snapshots(),
+            &definition_uri,
+            definition_span,
+        ) {
+            edits.entry(location.uri).or_default().push(TextEdit {
+                range: location.range,
+                new_text: new_name.clone(),
+            });
         }
 
         if edits.is_empty() {
@@ -1105,12 +946,11 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(document) = snapshot.document(uri) else {
             return Ok(None);
         };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
+        let file_id = document.file_id;
+        let line_index = document.line_index;
 
         let mut actions: Vec<CodeActionOrCommand> = Vec::new();
 
@@ -1166,18 +1006,12 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file_id = cursor.document.file_id;
+        let file = cursor.document.file;
+        let offset = cursor.offset;
 
         // An in-progress `#[ ... ]` is exclusive: when the cursor is in attribute
         // position, offer only the attributes relevant to the target it attaches
@@ -1286,39 +1120,7 @@ impl LanguageServer for Backend {
 
         let mut items = Vec::new();
 
-        const KEYWORDS: &[&str] = &[
-            "fn",
-            "let",
-            "if",
-            "else",
-            "match",
-            "enum",
-            "struct",
-            "type",
-            "interface",
-            "impl",
-            "const",
-            "return",
-            "defer",
-            "import",
-            "mut",
-            "pub",
-            "for",
-            "in",
-            "while",
-            "loop",
-            "break",
-            "continue",
-            "select",
-            "task",
-            "try",
-            "recover",
-            "assert",
-            "as",
-            "true",
-            "false",
-        ];
-        for kw in KEYWORDS {
+        for kw in validation::KEYWORDS {
             items.push(CompletionItem {
                 label: kw.to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
@@ -1396,18 +1198,11 @@ impl LanguageServer for Backend {
         let Some(snapshot) = self.get_snapshot(uri).await else {
             return Ok(None);
         };
-        let Some(file_id) = snapshot.get_file_id(uri) else {
+        let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let Some(file) = snapshot.files().get(&file_id) else {
-            return Ok(None);
-        };
-        let Some(line_index) = snapshot.get_line_index(file_id) else {
-            return Ok(None);
-        };
-        let Some(offset) = line_index.position_to_offset(position) else {
-            return Ok(None);
-        };
+        let file = cursor.document.file;
+        let offset = cursor.offset;
 
         Ok(signature_help::handle(&file.items, offset))
     }
@@ -1443,6 +1238,37 @@ fn trailing_segment_span(
         }
         None => usage_span,
     }
+}
+
+fn usage_locations(
+    snapshots: impl IntoIterator<Item = std::sync::Arc<AnalysisSnapshot>>,
+    definition_uri: &Url,
+    definition_span: syntax::ast::Span,
+) -> Vec<Location> {
+    let mut locations = Vec::new();
+    for snapshot in snapshots {
+        let Some(target_document) = snapshot.document(definition_uri) else {
+            continue;
+        };
+        let target_span = syntax::ast::Span::new(
+            target_document.file_id,
+            definition_span.byte_offset,
+            definition_span.byte_length,
+        );
+        for usage in &snapshot.facts().usages {
+            if usage.definition_span == target_span
+                && let Some(source) = snapshot.source(usage.usage_span.file_id)
+            {
+                locations.push(Location {
+                    uri: source.uri.clone(),
+                    range: source
+                        .line_index
+                        .span_to_range(trailing_segment_span(usage.usage_span, &snapshot)),
+                });
+            }
+        }
+    }
+    locations
 }
 
 /// Last identifier token in `usage_text`'s head (the run of id chars, dots and

--- a/crates/lsp/src/loader.rs
+++ b/crates/lsp/src/loader.rs
@@ -3,17 +3,81 @@ use std::fs::{read_dir, read_to_string};
 use std::path::{Path, PathBuf};
 
 use semantics::loader::{DiscoveredModules, FileContent, Files, Loader};
+use tokio::sync::{RwLock, RwLockMappedWriteGuard, RwLockWriteGuard};
+use tower_lsp::lsp_types::Url;
 
-use crate::paths::{ENTRY_MODULE_ID, module_id_to_dir};
-use crate::project::ProjectConfig;
+use crate::paths::{ENTRY_MODULE_ID, module_id_to_dir, uri_to_module_file};
+use crate::project::{ProjectConfig, find_project_root, resolve_standalone_root};
 
-#[derive(Clone)]
+pub(crate) struct ProjectState {
+    loader: RwLock<Option<OverlayLoader>>,
+}
+
+pub(crate) struct ProjectAnalysis {
+    pub(crate) config: ProjectConfig,
+    pub(crate) filename: String,
+    pub(crate) loader: AnalysisLoader,
+}
+
+impl ProjectState {
+    pub(crate) fn new() -> Self {
+        Self {
+            loader: RwLock::new(None),
+        }
+    }
+
+    pub(crate) async fn initialize(&self, config: ProjectConfig) {
+        *self.loader.write().await = Some(OverlayLoader::new(config));
+    }
+
+    async fn loader_for(&self, uri: &Url) -> Option<RwLockMappedWriteGuard<'_, OverlayLoader>> {
+        let mut loader = self.loader.write().await;
+        if loader.is_none() {
+            let path = uri.to_file_path().ok()?;
+            let config = find_project_root(&path).unwrap_or_else(|| resolve_standalone_root(&path));
+            *loader = Some(OverlayLoader::new(config));
+        }
+        Some(RwLockWriteGuard::map(loader, |loader| {
+            loader.as_mut().expect("loader was initialized above")
+        }))
+    }
+
+    pub(crate) async fn update_overlay(&self, uri: &Url, content: String) {
+        let Some(mut project) = self.loader_for(uri).await else {
+            return;
+        };
+        let Some((module_id, filename)) = uri_to_module_file(&project.config, uri) else {
+            return;
+        };
+        project.set_overlay(&module_id, &filename, content);
+    }
+
+    pub(crate) async fn remove_overlay(&self, uri: &Url) -> bool {
+        let mut project = self.loader.write().await;
+        let Some(project) = project.as_mut() else {
+            return false;
+        };
+        let Some((module_id, filename)) = uri_to_module_file(&project.config, uri) else {
+            return false;
+        };
+        project.remove_overlay(&module_id, &filename);
+        true
+    }
+
+    pub(crate) async fn for_analysis(&self, uri: &Url) -> Option<ProjectAnalysis> {
+        let project = self.loader_for(uri).await?;
+        let (module_id, filename) = uri_to_module_file(&project.config, uri)?;
+        Some(ProjectAnalysis {
+            config: project.config.clone(),
+            filename,
+            loader: project.for_analysis(module_id_to_dir(&project.config, &module_id)),
+        })
+    }
+}
+
 pub(crate) struct OverlayLoader {
     config: ProjectConfig,
-    /// module_id -> filename -> content (in-memory overrides)
-    overlays: HashMap<String, HashMap<String, String>>,
-    /// Override path for ENTRY_MODULE_ID (set when analyzing submodule files).
-    entry_module_path_override: Option<PathBuf>,
+    overlays: HashMap<(String, String), String>,
 }
 
 impl OverlayLoader {
@@ -21,43 +85,57 @@ impl OverlayLoader {
         Self {
             config,
             overlays: HashMap::default(),
-            entry_module_path_override: None,
         }
-    }
-
-    pub(crate) fn set_config(&mut self, config: ProjectConfig) {
-        self.config = config;
     }
 
     pub(crate) fn set_overlay(&mut self, module_id: &str, filename: &str, content: String) {
         self.overlays
-            .entry(module_id.to_string())
-            .or_default()
-            .insert(filename.to_string(), content);
+            .insert((module_id.to_string(), filename.to_string()), content);
     }
 
     pub(crate) fn remove_overlay(&mut self, module_id: &str, filename: &str) {
-        if let Some(module_overlays) = self.overlays.get_mut(module_id) {
-            module_overlays.remove(filename);
-        }
+        self.overlays
+            .remove(&(module_id.to_string(), filename.to_string()));
     }
 
-    pub(crate) fn set_entry_module_path(&mut self, path: Option<PathBuf>) {
-        self.entry_module_path_override = path;
-    }
-
-    fn module_path(&self, module_id: &str) -> PathBuf {
-        if module_id == ENTRY_MODULE_ID
-            && let Some(ref override_path) = self.entry_module_path_override
-        {
-            return override_path.clone();
+    pub(crate) fn for_analysis(&self, entry_module_path: PathBuf) -> AnalysisLoader {
+        AnalysisLoader {
+            config: self.config.clone(),
+            overlays: self.overlays.clone(),
+            entry_module_path,
         }
-
-        module_id_to_dir(&self.config, module_id)
     }
 }
 
-impl Loader for OverlayLoader {
+pub(crate) struct AnalysisLoader {
+    config: ProjectConfig,
+    overlays: HashMap<(String, String), String>,
+    entry_module_path: PathBuf,
+}
+
+impl AnalysisLoader {
+    fn module_path(&self, module_id: &str) -> PathBuf {
+        if module_id == ENTRY_MODULE_ID {
+            self.entry_module_path.clone()
+        } else {
+            module_id_to_dir(&self.config, module_id)
+        }
+    }
+
+    fn derive_module_id(&self, path: &Path) -> Option<String> {
+        let source_root = self.config.source_root();
+        if path == source_root {
+            Some(ENTRY_MODULE_ID.to_string())
+        } else {
+            path.strip_prefix(source_root)
+                .ok()
+                .and_then(|p| p.to_str())
+                .map(|s| s.to_string())
+        }
+    }
+}
+
+impl Loader for AnalysisLoader {
     fn scan_folder(&self, module_id: &str) -> Files {
         let folder_path = self.module_path(module_id);
         let mut files = HashMap::default();
@@ -77,28 +155,17 @@ impl Loader for OverlayLoader {
             }
         }
 
-        if module_id == ENTRY_MODULE_ID {
-            if let Some(ref override_path) = self.entry_module_path_override {
-                if let Some(actual_module_id) = self.derive_module_id(override_path)
-                    && let Some(module_overlays) = self.overlays.get(&actual_module_id)
-                {
-                    for (filename, content) in module_overlays {
-                        files.insert(
-                            filename.clone(),
-                            FileContent::new(content.clone(), filename.clone()),
-                        );
-                    }
-                }
-            } else if let Some(module_overlays) = self.overlays.get(ENTRY_MODULE_ID) {
-                for (filename, content) in module_overlays {
-                    files.insert(
-                        filename.clone(),
-                        FileContent::new(content.clone(), filename.clone()),
-                    );
-                }
-            }
-        } else if let Some(module_overlays) = self.overlays.get(module_id) {
-            for (filename, content) in module_overlays {
+        let overlay_module = if module_id == ENTRY_MODULE_ID {
+            self.derive_module_id(&self.entry_module_path)
+        } else {
+            Some(module_id.to_string())
+        };
+        if let Some(overlay_module) = overlay_module {
+            for ((_, filename), content) in self
+                .overlays
+                .iter()
+                .filter(|((module, _), _)| module == &overlay_module)
+            {
                 files.insert(
                     filename.clone(),
                     FileContent::new(content.clone(), filename.clone()),
@@ -117,27 +184,45 @@ impl Loader for OverlayLoader {
     }
 }
 
-impl OverlayLoader {
-    fn derive_module_id(&self, path: &Path) -> Option<String> {
-        if self.config.standalone_mode {
-            if path == self.config.root {
-                Some(ENTRY_MODULE_ID.to_string())
-            } else {
-                path.strip_prefix(&self.config.root)
-                    .ok()
-                    .and_then(|p| p.to_str())
-                    .map(|s| s.to_string())
-            }
-        } else {
-            let src_dir = self.config.root.join("src");
-            if path == src_dir {
-                Some(ENTRY_MODULE_ID.to_string())
-            } else {
-                path.strip_prefix(&src_dir)
-                    .ok()
-                    .and_then(|p| p.to_str())
-                    .map(|s| s.to_string())
-            }
-        }
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn project_state_owns_config_and_overlay_lifecycle() {
+        let temp = tempdir().unwrap();
+        let first_root = temp.path().join("first");
+        let second_root = temp.path().join("second");
+        fs::create_dir_all(&first_root).unwrap();
+        fs::create_dir_all(&second_root).unwrap();
+        let first_path = first_root.join("main.lis");
+        let second_path = second_root.join("main.lis");
+        fs::write(&first_path, "disk").unwrap();
+        fs::write(&second_path, "other").unwrap();
+        let first_uri = Url::from_file_path(&first_path).unwrap();
+        let second_uri = Url::from_file_path(&second_path).unwrap();
+
+        let project = ProjectState::new();
+        project
+            .update_overlay(&first_uri, "memory".to_string())
+            .await;
+
+        let analysis = project.for_analysis(&first_uri).await.unwrap();
+        assert_eq!(
+            analysis.loader.scan_folder(ENTRY_MODULE_ID)["main.lis"].source,
+            "memory"
+        );
+        assert!(project.for_analysis(&second_uri).await.is_none());
+
+        assert!(project.remove_overlay(&first_uri).await);
+        let analysis = project.for_analysis(&first_uri).await.unwrap();
+        assert_eq!(
+            analysis.loader.scan_folder(ENTRY_MODULE_ID)["main.lis"].source,
+            "disk"
+        );
     }
 }

--- a/crates/lsp/src/paths.rs
+++ b/crates/lsp/src/paths.rs
@@ -7,16 +7,11 @@ use crate::project::ProjectConfig;
 pub(crate) const ENTRY_MODULE_ID: &str = "_entry_";
 
 pub(crate) fn module_id_to_dir(config: &ProjectConfig, module_id: &str) -> PathBuf {
-    if config.standalone_mode {
-        if module_id == ENTRY_MODULE_ID {
-            config.root.clone()
-        } else {
-            config.root.join(module_id)
-        }
-    } else if module_id == ENTRY_MODULE_ID {
-        config.root.join("src")
+    let source_root = config.source_root();
+    if module_id == ENTRY_MODULE_ID {
+        source_root
     } else {
-        config.root.join("src").join(module_id)
+        source_root.join(module_id)
     }
 }
 
@@ -25,51 +20,59 @@ pub(crate) fn module_file_to_path(
     module_id: &str,
     filename: &str,
 ) -> PathBuf {
-    if config.standalone_mode {
-        if module_id == ENTRY_MODULE_ID {
-            config.root.join(filename)
-        } else {
-            config.root.join(module_id).join(filename)
-        }
-    } else {
-        let module_dir = if module_id == ENTRY_MODULE_ID {
-            config.root.join("src")
-        } else {
-            config.root.join("src").join(module_id)
-        };
-        module_dir.join(filename)
-    }
+    module_id_to_dir(config, module_id).join(filename)
 }
 
 fn path_to_module_file(config: &ProjectConfig, file_path: &Path) -> Option<(String, String)> {
     let filename = file_path.file_name()?.to_str()?.to_string();
 
-    if config.standalone_mode {
-        if file_path.parent()? == config.root {
-            return Some((ENTRY_MODULE_ID.to_string(), filename));
-        }
-        let relative = file_path.strip_prefix(&config.root).ok()?;
-        let module_id = relative.parent()?.to_str()?.to_string();
-        Some((module_id, filename))
+    let source_root = config.source_root();
+    let relative = file_path.strip_prefix(&source_root).ok()?;
+    let parent = relative.parent()?;
+    let module_id = if parent.as_os_str().is_empty() {
+        ENTRY_MODULE_ID.to_string()
     } else {
-        let src_dir = config.root.join("src");
-        let relative = file_path.strip_prefix(&src_dir).ok()?;
-
-        let module_id = if relative
-            .parent()
-            .map(|p| p.as_os_str().is_empty())
-            .unwrap_or(true)
-        {
-            ENTRY_MODULE_ID.to_string()
-        } else {
-            relative.parent()?.to_str()?.to_string()
-        };
-
-        Some((module_id, filename))
-    }
+        parent.to_str()?.to_string()
+    };
+    Some((module_id, filename))
 }
 
 pub(crate) fn uri_to_module_file(config: &ProjectConfig, uri: &Url) -> Option<(String, String)> {
     let file_path = uri.to_file_path().ok()?;
     path_to_module_file(config, &file_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_source_root_maps_to_entry_module() {
+        let config = ProjectConfig::Workspace(PathBuf::from("workspace"));
+
+        assert_eq!(
+            path_to_module_file(&config, Path::new("workspace/src/main.lis")),
+            Some((ENTRY_MODULE_ID.to_string(), "main.lis".to_string()))
+        );
+    }
+
+    #[test]
+    fn workspace_subdirectory_maps_to_named_module() {
+        let config = ProjectConfig::Workspace(PathBuf::from("workspace"));
+
+        assert_eq!(
+            path_to_module_file(&config, Path::new("workspace/src/math/vector.lis")),
+            Some(("math".to_string(), "vector.lis".to_string()))
+        );
+    }
+
+    #[test]
+    fn standalone_subdirectory_maps_to_named_module() {
+        let config = ProjectConfig::Standalone(PathBuf::from("standalone"));
+
+        assert_eq!(
+            path_to_module_file(&config, Path::new("standalone/math/vector.lis")),
+            Some(("math".to_string(), "vector.lis".to_string()))
+        );
+    }
 }

--- a/crates/lsp/src/position.rs
+++ b/crates/lsp/src/position.rs
@@ -20,6 +20,10 @@ impl LineIndex {
         }
     }
 
+    pub(crate) fn source(&self) -> &str {
+        &self.source
+    }
+
     pub(crate) fn position_to_offset(&self, position: Position) -> Option<u32> {
         let line_start = *self.line_starts.get(position.line as usize)?;
         let line_end = self

--- a/crates/lsp/src/project.rs
+++ b/crates/lsp/src/project.rs
@@ -1,9 +1,28 @@
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProjectConfig {
-    pub(crate) root: PathBuf,
-    pub(crate) standalone_mode: bool,
+pub(crate) enum ProjectConfig {
+    Standalone(PathBuf),
+    Workspace(PathBuf),
+}
+
+impl ProjectConfig {
+    pub(crate) fn root(&self) -> &Path {
+        match self {
+            Self::Standalone(root) | Self::Workspace(root) => root,
+        }
+    }
+
+    pub(crate) fn source_root(&self) -> PathBuf {
+        match self {
+            Self::Standalone(root) => root.clone(),
+            Self::Workspace(root) => root.join("src"),
+        }
+    }
+
+    pub(crate) fn is_standalone(&self) -> bool {
+        matches!(self, Self::Standalone(_))
+    }
 }
 
 pub(crate) fn find_project_root(start_path: &Path) -> Option<ProjectConfig> {
@@ -16,10 +35,7 @@ pub(crate) fn find_project_root(start_path: &Path) -> Option<ProjectConfig> {
     loop {
         let manifest = current.join("lisette.toml");
         if manifest.exists() {
-            return Some(ProjectConfig {
-                root: current,
-                standalone_mode: false,
-            });
+            return Some(ProjectConfig::Workspace(current));
         }
 
         if !current.pop() {
@@ -36,8 +52,5 @@ pub(crate) fn resolve_standalone_root(file_path: &Path) -> ProjectConfig {
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
 
-    ProjectConfig {
-        root,
-        standalone_mode: true,
-    }
+    ProjectConfig::Standalone(root)
 }

--- a/crates/lsp/src/service.rs
+++ b/crates/lsp/src/service.rs
@@ -21,16 +21,40 @@ pub fn build_service(
     let (exit_sender, exit_receiver) = oneshot::channel();
     let adapter = ProtocolAdapter {
         inner: service,
-        saw_shutdown: false,
-        exit_sender: Some(exit_sender),
+        state: ProtocolState::Running(exit_sender),
     };
     (adapter, socket, exit_receiver)
 }
 
 pub struct ProtocolAdapter<S> {
     inner: S,
-    saw_shutdown: bool,
-    exit_sender: Option<oneshot::Sender<i32>>,
+    state: ProtocolState,
+}
+
+enum ProtocolState {
+    Running(oneshot::Sender<i32>),
+    Shutdown(oneshot::Sender<i32>),
+    Exited,
+}
+
+impl ProtocolState {
+    fn shutdown(&mut self) {
+        let current = std::mem::replace(self, Self::Exited);
+        *self = match current {
+            Self::Running(sender) | Self::Shutdown(sender) => Self::Shutdown(sender),
+            Self::Exited => Self::Exited,
+        };
+    }
+
+    fn exit(&mut self) {
+        let current = std::mem::replace(self, Self::Exited);
+        let (sender, code) = match current {
+            Self::Running(sender) => (sender, 1),
+            Self::Shutdown(sender) => (sender, 0),
+            Self::Exited => return,
+        };
+        let _ = sender.send(code);
+    }
 }
 
 impl<S: Service<Request>> Service<Request> for ProtocolAdapter<S> {
@@ -44,14 +68,8 @@ impl<S: Service<Request>> Service<Request> for ProtocolAdapter<S> {
 
     fn call(&mut self, request: Request) -> Self::Future {
         match request.method() {
-            "shutdown" => self.saw_shutdown = true,
-            "exit" => {
-                // The LSP spec requires the process to exit with 0 when
-                // shutdown preceded exit, with 1 otherwise.
-                if let Some(sender) = self.exit_sender.take() {
-                    let _ = sender.send(if self.saw_shutdown { 0 } else { 1 });
-                }
-            }
+            "shutdown" => self.state.shutdown(),
+            "exit" => self.state.exit(),
             _ => {}
         }
         let request = if request.params().is_some_and(|params| params.is_null()) {
@@ -65,5 +83,42 @@ impl<S: Service<Request>> Service<Request> for ProtocolAdapter<S> {
             request
         };
         self.inner.call(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_after_shutdown_reports_success() {
+        let (sender, mut receiver) = oneshot::channel();
+        let mut state = ProtocolState::Running(sender);
+
+        state.shutdown();
+        state.exit();
+
+        assert_eq!(receiver.try_recv(), Ok(0));
+    }
+
+    #[test]
+    fn exit_without_shutdown_reports_failure() {
+        let (sender, mut receiver) = oneshot::channel();
+        let mut state = ProtocolState::Running(sender);
+
+        state.exit();
+
+        assert_eq!(receiver.try_recv(), Ok(1));
+    }
+
+    #[test]
+    fn repeated_exit_keeps_first_result() {
+        let (sender, mut receiver) = oneshot::channel();
+        let mut state = ProtocolState::Running(sender);
+
+        state.exit();
+        state.exit();
+
+        assert_eq!(receiver.try_recv(), Ok(1));
     }
 }

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -4,7 +4,7 @@ use diagnostics::SemanticResult;
 use semantics::facts::Facts;
 use syntax::program::{Definition, File};
 use syntax::types::Symbol;
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{Position, Url};
 
 use crate::paths::{ENTRY_MODULE_ID, module_file_to_path};
 use crate::position::LineIndex;
@@ -14,15 +14,24 @@ pub(crate) struct AnalysisSnapshot {
     pub(crate) result: SemanticResult,
     facts: Facts,
     pub(crate) has_parse_errors: bool,
-    uri_to_id: HashMap<Url, u32>,
-    id_to_uri: HashMap<u32, Url>,
-    line_indexes: HashMap<u32, LineIndex>,
+    sources: HashMap<u32, SnapshotSource>,
 }
 
-// SAFETY: AnalysisSnapshot is immutable after construction. Non-Send/Sync types
-// it transitively contains are never mutated after analyze() returns.
-unsafe impl Send for AnalysisSnapshot {}
-unsafe impl Sync for AnalysisSnapshot {}
+pub(crate) struct SnapshotSource {
+    pub(crate) uri: Url,
+    pub(crate) line_index: LineIndex,
+}
+
+pub(crate) struct SnapshotDocument<'a> {
+    pub(crate) file_id: u32,
+    pub(crate) file: &'a File,
+    pub(crate) line_index: &'a LineIndex,
+}
+
+pub(crate) struct SnapshotPosition<'a> {
+    pub(crate) document: SnapshotDocument<'a>,
+    pub(crate) offset: u32,
+}
 
 impl AnalysisSnapshot {
     pub(crate) fn new(
@@ -32,9 +41,7 @@ impl AnalysisSnapshot {
         config: &ProjectConfig,
         analyzed_uri: &Url,
     ) -> Self {
-        let mut uri_to_id = HashMap::default();
-        let mut id_to_uri = HashMap::default();
-        let mut line_indexes = HashMap::default();
+        let mut sources = HashMap::default();
 
         let analyzed_path = analyzed_uri.to_file_path().ok();
         let analyzed_filename = analyzed_path
@@ -75,36 +82,45 @@ impl AnalysisSnapshot {
                 }
             };
 
-            uri_to_id.insert(uri.clone(), *file_id);
-            id_to_uri.insert(*file_id, uri);
-            line_indexes.insert(*file_id, LineIndex::new(&file.source));
+            sources.insert(
+                *file_id,
+                SnapshotSource {
+                    uri,
+                    line_index: LineIndex::new(&file.source),
+                },
+            );
         }
 
         Self {
             result,
             facts,
             has_parse_errors,
-            uri_to_id,
-            id_to_uri,
-            line_indexes,
+            sources,
         }
     }
 
-    pub(crate) fn get_file_id(&self, uri: &Url) -> Option<u32> {
-        self.uri_to_id.get(uri).copied()
+    pub(crate) fn document(&self, uri: &Url) -> Option<SnapshotDocument<'_>> {
+        let (file_id, source) = self.sources.iter().find(|(_, source)| &source.uri == uri)?;
+        Some(SnapshotDocument {
+            file_id: *file_id,
+            file: self.result.files.get(file_id)?,
+            line_index: &source.line_index,
+        })
     }
 
-    pub(crate) fn get_uri(&self, file_id: u32) -> Option<&Url> {
-        self.id_to_uri.get(&file_id)
+    pub(crate) fn position(&self, uri: &Url, position: Position) -> Option<SnapshotPosition<'_>> {
+        let document = self.document(uri)?;
+        let offset = document.line_index.position_to_offset(position)?;
+        Some(SnapshotPosition { document, offset })
+    }
+
+    pub(crate) fn source(&self, file_id: u32) -> Option<&SnapshotSource> {
+        self.sources.get(&file_id)
     }
 
     /// On-disk path of a `go:` typedef file, if `file_id` names one.
     pub(crate) fn typedef_path(&self, file_id: u32) -> Option<&std::path::Path> {
         self.result.typedef_paths.get(&file_id).map(|p| p.as_path())
-    }
-
-    pub(crate) fn get_line_index(&self, file_id: u32) -> Option<&LineIndex> {
-        self.line_indexes.get(&file_id)
     }
 
     pub(crate) fn files(&self) -> &HashMap<u32, File> {

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use dashmap::DashMap;
 use deps::BindgenSetup;
@@ -8,20 +6,14 @@ use tokio::task::AbortHandle;
 use tower_lsp::Client;
 use tower_lsp::lsp_types::Url;
 
-use crate::loader::OverlayLoader;
+use crate::loader::ProjectState;
 use crate::position::LineIndex;
-use crate::project::ProjectConfig;
 use crate::snapshot::AnalysisSnapshot;
 
 pub struct SharedState {
     pub(crate) client: Client,
-    pub(crate) project_config: tokio::sync::RwLock<Option<ProjectConfig>>,
+    pub(crate) project: ProjectState,
     pub(crate) documents: DashMap<Url, DocumentState>,
-    pub(crate) loader: tokio::sync::RwLock<OverlayLoader>,
-    pub(crate) snapshots: DashMap<Url, CachedSnapshot>,
-    pub(crate) last_valid_snapshot: DashMap<Url, Arc<AnalysisSnapshot>>,
-    pub(crate) pending_diagnostics: DashMap<Url, (u64, AbortHandle)>,
-    pub(crate) diagnostics_generation: AtomicU64,
     pub(crate) bindgen_setup: Option<Arc<dyn BindgenSetup>>,
 }
 
@@ -36,36 +28,245 @@ impl std::ops::Deref for Backend {
     }
 }
 
-pub(crate) struct CachedSnapshot {
-    pub(crate) snapshot: Arc<AnalysisSnapshot>,
-    pub(crate) version: i32,
+pub(crate) struct DocumentState {
+    line_index: LineIndex,
+    version: i32,
+    analysis: DocumentAnalysis,
+    pending_diagnostics: Option<AbortHandle>,
 }
 
-pub(crate) struct DocumentState {
-    pub(crate) content: String,
-    pub(crate) line_index: LineIndex,
-    pub(crate) version: i32,
+struct DocumentAnalysis {
+    revision: AnalysisRevision,
+    result: AnalysisResult,
+}
+
+#[derive(Clone)]
+pub(crate) struct AnalysisRevision(Arc<()>);
+
+pub(crate) enum AnalysisRequest {
+    Cached(Arc<AnalysisSnapshot>),
+    Required(AnalysisRevision),
+}
+
+#[derive(Default)]
+enum AnalysisResult {
+    #[default]
+    Empty,
+    Stale(Arc<AnalysisSnapshot>),
+    Valid(Arc<AnalysisSnapshot>),
+    Invalid {
+        current: Arc<AnalysisSnapshot>,
+        last_valid: Option<Arc<AnalysisSnapshot>>,
+    },
+}
+
+impl Default for DocumentAnalysis {
+    fn default() -> Self {
+        Self {
+            revision: AnalysisRevision(Arc::new(())),
+            result: AnalysisResult::default(),
+        }
+    }
+}
+
+impl DocumentAnalysis {
+    fn current(&self) -> Option<Arc<AnalysisSnapshot>> {
+        match &self.result {
+            AnalysisResult::Valid(snapshot)
+            | AnalysisResult::Invalid {
+                current: snapshot, ..
+            } => Some(Arc::clone(snapshot)),
+            AnalysisResult::Empty | AnalysisResult::Stale(_) => None,
+        }
+    }
+
+    fn last_valid(&self) -> Option<Arc<AnalysisSnapshot>> {
+        match &self.result {
+            AnalysisResult::Stale(snapshot) | AnalysisResult::Valid(snapshot) => {
+                Some(Arc::clone(snapshot))
+            }
+            AnalysisResult::Invalid { last_valid, .. } => last_valid.clone(),
+            AnalysisResult::Empty => None,
+        }
+    }
+
+    fn request(&self) -> AnalysisRequest {
+        match self.current() {
+            Some(snapshot) => AnalysisRequest::Cached(snapshot),
+            None => AnalysisRequest::Required(self.revision.clone()),
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.revision = AnalysisRevision(Arc::new(()));
+        let current = std::mem::take(&mut self.result);
+        self.result = match current {
+            AnalysisResult::Valid(snapshot) | AnalysisResult::Stale(snapshot) => {
+                AnalysisResult::Stale(snapshot)
+            }
+            AnalysisResult::Invalid {
+                last_valid: Some(snapshot),
+                ..
+            } => AnalysisResult::Stale(snapshot),
+            AnalysisResult::Empty
+            | AnalysisResult::Invalid {
+                last_valid: None, ..
+            } => AnalysisResult::Empty,
+        };
+    }
+
+    fn update(&mut self, revision: &AnalysisRevision, snapshot: Arc<AnalysisSnapshot>) -> bool {
+        if !Arc::ptr_eq(&self.revision.0, &revision.0) {
+            return false;
+        }
+        if snapshot.has_parse_errors {
+            self.result = AnalysisResult::Invalid {
+                current: snapshot,
+                last_valid: self.last_valid(),
+            };
+        } else {
+            self.result = AnalysisResult::Valid(snapshot);
+        }
+        true
+    }
+}
+
+impl DocumentState {
+    pub(crate) fn new(content: String, version: i32) -> Self {
+        Self {
+            line_index: LineIndex::new(&content),
+            version,
+            analysis: DocumentAnalysis::default(),
+            pending_diagnostics: None,
+        }
+    }
+
+    pub(crate) fn update(&mut self, content: String, version: i32) {
+        self.line_index = LineIndex::new(&content);
+        self.version = version;
+        self.analysis.invalidate();
+    }
+
+    pub(crate) fn content(&self) -> &str {
+        self.line_index.source()
+    }
+
+    pub(crate) fn line_index(&self) -> &LineIndex {
+        &self.line_index
+    }
+
+    pub(crate) fn version(&self) -> i32 {
+        self.version
+    }
+
+    pub(crate) fn request_analysis(&self) -> AnalysisRequest {
+        self.analysis.request()
+    }
+
+    pub(crate) fn last_valid_analysis(&self) -> Option<Arc<AnalysisSnapshot>> {
+        self.analysis.last_valid()
+    }
+
+    pub(crate) fn cache_analysis(
+        &mut self,
+        revision: &AnalysisRevision,
+        snapshot: Arc<AnalysisSnapshot>,
+    ) -> bool {
+        self.analysis.update(revision, snapshot)
+    }
+
+    pub(crate) fn invalidate_analysis(&mut self) {
+        self.analysis.invalidate();
+    }
+
+    pub(crate) fn abort_pending_diagnostics(&mut self) {
+        if let Some(handle) = self.pending_diagnostics.take() {
+            handle.abort();
+        }
+    }
+
+    pub(crate) fn set_pending_diagnostics(&mut self, handle: AbortHandle) {
+        self.abort_pending_diagnostics();
+        self.pending_diagnostics = Some(handle);
+    }
+
+    pub(crate) fn finish_diagnostics(&mut self, task_id: tokio::task::Id) {
+        if self
+            .pending_diagnostics
+            .as_ref()
+            .is_some_and(|handle| handle.id() == task_id)
+        {
+            self.pending_diagnostics = None;
+        }
+    }
+}
+
+impl Drop for DocumentState {
+    fn drop(&mut self) {
+        self.abort_pending_diagnostics();
+    }
 }
 
 impl Backend {
     pub(crate) fn new(client: Client, bindgen_setup: Option<Arc<dyn BindgenSetup>>) -> Self {
-        let placeholder_config = ProjectConfig {
-            root: PathBuf::from("."),
-            standalone_mode: true,
-        };
-
         Self {
             shared_state: Arc::new(SharedState {
                 client,
-                project_config: tokio::sync::RwLock::new(None),
+                project: ProjectState::new(),
                 documents: DashMap::new(),
-                loader: tokio::sync::RwLock::new(OverlayLoader::new(placeholder_config)),
-                snapshots: DashMap::new(),
-                last_valid_snapshot: DashMap::new(),
-                pending_diagnostics: DashMap::new(),
-                diagnostics_generation: AtomicU64::new(0),
                 bindgen_setup,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dropping_document_aborts_pending_diagnostics() {
+        let task = tokio::spawn(std::future::pending::<()>());
+        let mut document = DocumentState::new(String::new(), 1);
+        document.set_pending_diagnostics(task.abort_handle());
+
+        drop(document);
+
+        assert!(
+            task.await
+                .expect_err("task should be aborted")
+                .is_cancelled()
+        );
+    }
+
+    #[tokio::test]
+    async fn replacing_pending_diagnostics_aborts_previous_task() {
+        let old_task = tokio::spawn(std::future::pending::<()>());
+        let new_task = tokio::spawn(std::future::pending::<()>());
+        let mut document = DocumentState::new(String::new(), 1);
+        document.set_pending_diagnostics(old_task.abort_handle());
+
+        document.set_pending_diagnostics(new_task.abort_handle());
+
+        assert!(
+            old_task
+                .await
+                .expect_err("old task should be aborted")
+                .is_cancelled()
+        );
+        drop(document);
+        let _ = new_task.await;
+    }
+
+    #[test]
+    fn invalidation_rejects_an_in_flight_analysis() {
+        let mut document = DocumentState::new(String::new(), 1);
+        let AnalysisRequest::Required(revision) = document.request_analysis() else {
+            panic!("new document should require analysis");
+        };
+
+        document.invalidate_analysis();
+
+        assert!(!Arc::ptr_eq(&document.analysis.revision.0, &revision.0));
     }
 }

--- a/crates/lsp/src/validation.rs
+++ b/crates/lsp/src/validation.rs
@@ -1,5 +1,5 @@
 /// All keywords, including contextual ones (`var`, `self`).
-const KEYWORDS: &[&str] = &[
+pub(crate) const KEYWORDS: &[&str] = &[
     "fn",
     "let",
     "if",

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -302,6 +302,8 @@ async fn completion_includes_keywords() {
     assert!(labels.iter().any(|l| l == "match"));
     assert!(labels.iter().any(|l| l == "struct"));
     assert!(labels.iter().any(|l| l == "enum"));
+    assert!(labels.iter().any(|l| l == "var"));
+    assert!(labels.iter().any(|l| l == "self"));
 
     client.shutdown().await;
 }


### PR DESCRIPTION
Simplifies the LSP’s state model and removes several manually synchronized representations:

- Makes documents the canonical owner of content, analysis snapshots, and diagnostic tasks.
- Unifies project config and overlays.
- Prevents invalidated in-flight analyses from restoring stale cache entries.
- Replaces parallel snapshot lookup maps with document/position views.
- Models shutdown states explicitly.