### PR TITLE
refactor: model more semantics state with types

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -45,7 +45,8 @@ impl CompileMode {
     fn phase(self) -> CompilePhase {
         match self {
             Self::Check => CompilePhase::Check,
-            Self::Emit { .. } | Self::Test => CompilePhase::Emit,
+            Self::Emit { .. } => CompilePhase::Emit,
+            Self::Test => CompilePhase::Test,
         }
     }
 
@@ -174,7 +175,6 @@ pub fn compile(input: CompileInput<'_>, config: &CompileConfig, fs: &dyn Loader)
         project_root: config.scope.project_root(),
         compile_phase: config.mode.phase(),
         project_kind,
-        emit_tests,
         locator: config.locator.clone(),
         go_module: config.go_module.clone(),
         disable_cache,
@@ -324,6 +324,7 @@ mod tests {
             mode: match target_phase {
                 CompilePhase::Check => CompileMode::Check,
                 CompilePhase::Emit => CompileMode::Emit { sourcemap: false },
+                CompilePhase::Test => CompileMode::Test,
             },
             go_module: "test".to_string(),
             entry_package_name: entry_package_name.to_string(),
@@ -473,7 +474,6 @@ mod tests {
             project_root: Some(project_dir.to_path_buf()),
             compile_phase: CompilePhase::Check,
             project_kind: ProjectKind::Binary,
-            emit_tests: false,
             locator,
             go_module: "test".to_string(),
             disable_cache: false,
@@ -579,7 +579,6 @@ mod tests {
             project_root: Some(project_dir.to_path_buf()),
             compile_phase: CompilePhase::Check,
             project_kind: ProjectKind::Binary,
-            emit_tests: false,
             locator,
             go_module: "test".to_string(),
             disable_cache: false,

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -145,7 +145,6 @@ impl SharedState {
             },
             compile_phase: CompilePhase::Check,
             project_kind,
-            emit_tests: false,
             locator,
             go_module: String::new(),
             disable_cache: false,

--- a/crates/passes/src/passes/lints/ast_walk/checks/out_of_domain.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/out_of_domain.rs
@@ -132,7 +132,10 @@ fn negate_literal(literal: &Literal, base: SimpleKind) -> Option<DomainValue> {
 }
 
 fn is_member(domain: &ClosedDomain, value: &DomainValue) -> bool {
-    domain.members.iter().any(|member| member.value == *value)
+    domain
+        .members
+        .iter()
+        .any(|member| member.value(domain.base) == *value)
 }
 
 fn emit(span: Span, domain: &ClosedDomain, ctx: &NodeCtx) {
@@ -145,8 +148,8 @@ fn emit(span: Span, domain: &ClosedDomain, ctx: &NodeCtx) {
 
 /// Renders a member as the user wrote it: runes keep their `'...'` surface form,
 /// everything else renders its comparable value (already sign-corrected).
-fn render_member(member: &ClosedMember) -> String {
-    match (&member.literal, &member.value) {
+fn render_member(member: &ClosedMember, base: SimpleKind) -> String {
+    match (member.literal(), member.value(base)) {
         (Literal::Char(text), _) => format!("'{text}'"),
         (_, DomainValue::Int(value)) => value.to_string(),
         (_, DomainValue::Str(value)) => format!("\"{value}\""),
@@ -163,16 +166,22 @@ fn render_valid(domain: &ClosedDomain) -> String {
         return format!(
             "{}={} ..= {}={}",
             first.display_name,
-            render_member(first),
+            render_member(first, domain.base),
             last.display_name,
-            render_member(last),
+            render_member(last, domain.base),
         );
     }
 
     domain
         .members
         .iter()
-        .map(|member| format!("{}={}", member.display_name, render_member(member)))
+        .map(|member| {
+            format!(
+                "{}={}",
+                member.display_name,
+                render_member(member, domain.base)
+            )
+        })
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -183,7 +192,7 @@ fn render_valid(domain: &ClosedDomain) -> String {
 fn is_contiguous_integer_domain(domain: &ClosedDomain) -> bool {
     let mut previous: Option<i128> = None;
     for member in &domain.members {
-        let DomainValue::Int(value) = member.value else {
+        let DomainValue::Int(value) = member.value(domain.base) else {
             return false;
         };
         if previous.is_some_and(|p| value != p + 1) {

--- a/crates/semantics/src/cache/bounds.rs
+++ b/crates/semantics/src/cache/bounds.rs
@@ -10,8 +10,8 @@ use crate::store::Store;
 
 struct CachedFileBounds {
     file_id: u32,
-    items: Vec<Expression>,
     missing_types: Vec<Expression>,
+    bounds_to_restore: Vec<(Symbol, Vec<Generic>)>,
     imports: Vec<FileImport>,
 }
 
@@ -69,19 +69,23 @@ fn restore_module_bounds(
         .map(|(file_id, source)| {
             let items = syntax::build_ast(&source, file_id).ast;
             let imports = cached_imports(&items);
-            let missing_types = items
-                .iter()
-                .filter(|item| {
-                    type_name(item).is_some_and(|name| {
-                        !cached_names.contains(&Symbol::from_parts(module_id, name))
-                    })
-                })
-                .cloned()
-                .collect();
+            let mut missing_types = Vec::new();
+            let mut bounds_to_restore = Vec::new();
+            for item in items {
+                let Some((bare_name, generics)) = type_generics(&item) else {
+                    continue;
+                };
+                let name = Symbol::from_parts(module_id, bare_name);
+                if !cached_names.contains(&name) {
+                    missing_types.push(item);
+                } else if pending.contains(&name) {
+                    bounds_to_restore.push((name, generics.to_vec()));
+                }
+            }
             CachedFileBounds {
                 file_id,
-                items,
                 missing_types,
+                bounds_to_restore,
                 imports,
             }
         })
@@ -121,18 +125,10 @@ fn restore_module_bounds(
     }
 
     for file in files {
-        let definitions: Vec<(Symbol, Vec<Generic>)> = file
-            .items
-            .iter()
-            .filter_map(|item| {
-                let (name, generics) = type_generics(item)?;
-                let name = Symbol::from_parts(module_id, name);
-                pending.contains(&name).then(|| (name, generics.to_vec()))
-            })
-            .collect();
-        if definitions.is_empty() {
+        if file.bounds_to_restore.is_empty() {
             continue;
         }
+        let definitions = file.bounds_to_restore;
         checker.with_file_context_mut(
             store,
             module_id,
@@ -144,10 +140,10 @@ fn restore_module_bounds(
                     let Some(span) = generics.first().map(|generic| generic.span) else {
                         continue;
                     };
-                    checker.scopes.push();
-                    checker.put_in_scope(&generics);
-                    let resolved = checker.resolve_generic_bounds(&*store, &generics, &span);
-                    checker.scopes.pop();
+                    let resolved = checker.with_scope(|checker| {
+                        checker.put_in_scope(&generics);
+                        checker.resolve_generic_bounds(&*store, &generics, &span)
+                    });
 
                     let Some(definition) = store
                         .get_module_mut(module_id)
@@ -185,16 +181,6 @@ fn cached_imports(items: &[Expression]) -> Vec<FileImport> {
             })
         })
         .collect()
-}
-
-fn type_name(expression: &Expression) -> Option<&str> {
-    match expression {
-        Expression::Enum { name, .. }
-        | Expression::Struct { name, .. }
-        | Expression::Interface { name, .. }
-        | Expression::TypeAlias { name, .. } => Some(name),
-        _ => None,
-    }
 }
 
 fn type_generics(expression: &Expression) -> Option<(&str, &[Generic])> {

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -183,16 +183,12 @@ pub(crate) fn compute_module_hash(production_hash: u64, dep_hashes: &HashMap<Str
     hasher.finish()
 }
 
-pub(crate) fn get_dependency_module_hashes(
-    module_id: &str,
-    edges: &HashMap<String, HashSet<String>>,
+pub(crate) fn get_dependency_module_hashes<'a>(
+    dependencies: impl IntoIterator<Item = &'a String>,
     module_hashes: &HashMap<String, u64>,
 ) -> HashMap<String, u64> {
-    let Some(deps) = edges.get(module_id) else {
-        return HashMap::default();
-    };
-
-    deps.iter()
+    dependencies
+        .into_iter()
         .map(|dep_id| {
             let hash = if dep_id.starts_with("go:") || dep_id == "prelude" {
                 STDLIB_HASH
@@ -243,7 +239,6 @@ pub(crate) fn try_load_cache(
     expected_dep_hashes: &HashMap<String, u64>,
     expected_artifact_hash: Option<u64>,
     project_root: &Path,
-    check_go_files: bool,
 ) -> Option<ModuleInterface> {
     let path = cache_path(project_root, module_id);
     let interface: ModuleInterface = disk::read(&path).ok()?;
@@ -253,8 +248,8 @@ pub(crate) fn try_load_cache(
         return None;
     }
 
-    if check_go_files {
-        if interface.emit_stamp != expected_artifact_hash {
+    if let Some(expected_artifact_hash) = expected_artifact_hash {
+        if interface.emit_stamp != Some(expected_artifact_hash) {
             return None;
         }
         if !all_go_outputs_exist(module_id, &interface.files, project_root) {
@@ -363,10 +358,7 @@ fn extract_public_definitions(
 }
 
 pub(crate) struct CachedModuleBuild {
-    pub module_id: String,
     pub module: Module,
-    /// `(file_id, module_id)` pairs for the store's file -> module index.
-    pub file_map: Vec<(u32, String)>,
     pub ufcs_methods: Vec<(String, String)>,
 }
 
@@ -378,12 +370,10 @@ pub(crate) fn build_cached_module(
 ) -> CachedModuleBuild {
     let mut module = Module::new(&module_id);
     let mut file_ids: Vec<u32> = Vec::with_capacity(cached.files.len());
-    let mut file_map: Vec<(u32, String)> = Vec::with_capacity(cached.files.len());
 
     for (index, cached_file) in cached.files.iter().enumerate() {
         let file_id = file_id_base + index as u32;
         file_ids.push(file_id);
-        file_map.push((file_id, module_id.clone()));
 
         let display_path = cached_file_display_path(display_base, &module_id, &cached_file.name);
         let file = File::new_cached(
@@ -401,9 +391,7 @@ pub(crate) fn build_cached_module(
     }
 
     CachedModuleBuild {
-        module_id,
         module,
-        file_map,
         ufcs_methods: cached.ufcs_methods,
     }
 }
@@ -797,7 +785,7 @@ mod tests {
         let mut module_hashes = HashMap::default();
         module_hashes.insert("user_mod".to_string(), 12345u64);
 
-        let result = get_dependency_module_hashes("my_mod", &edges, &module_hashes);
+        let result = get_dependency_module_hashes(&edges["my_mod"], &module_hashes);
 
         assert_eq!(result.get("go:fmt"), Some(&STDLIB_HASH));
         assert_eq!(result.get("prelude"), Some(&STDLIB_HASH));
@@ -942,7 +930,7 @@ mod tests {
         let path = cache_path(root, "greet");
         std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
 
-        let loaded = try_load_cache("greet", 100, &HashMap::default(), None, root, false);
+        let loaded = try_load_cache("greet", 100, &HashMap::default(), None, root);
         assert!(loaded.is_some(), "Check phase must accept unstamped cache");
 
         let loaded = try_load_cache(
@@ -951,7 +939,6 @@ mod tests {
             &HashMap::default(),
             Some(compute_emit_artifact_hash(100, "github.com/test/x")),
             root,
-            true,
         );
         assert!(
             loaded.is_none(),
@@ -989,15 +976,7 @@ mod tests {
         std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
 
         assert!(
-            try_load_cache(
-                "greet",
-                100,
-                &HashMap::default(),
-                Some(artifact_hash),
-                root,
-                true,
-            )
-            .is_some()
+            try_load_cache("greet", 100, &HashMap::default(), Some(artifact_hash), root).is_some()
         );
 
         let stamp = EmitStamp {
@@ -1007,15 +986,7 @@ mod tests {
         apply_emit_stamps(root, &[(stamp, None)]).unwrap();
 
         assert!(
-            try_load_cache(
-                "greet",
-                100,
-                &HashMap::default(),
-                Some(artifact_hash),
-                root,
-                true,
-            )
-            .is_none()
+            try_load_cache("greet", 100, &HashMap::default(), Some(artifact_hash), root).is_none()
         );
     }
 }

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -12,6 +12,45 @@ impl<'a> InferCtx<'a> {
     pub fn new(state: &'a mut TaskState, store: &'a Store) -> Self {
         Self { state, store }
     }
+
+    pub(crate) fn with_scope<T>(
+        &mut self,
+        f: impl for<'scope> FnOnce(&mut InferCtx<'scope>) -> T,
+    ) -> T {
+        let store = self.store;
+        self.state.with_scope(|state| {
+            let mut context = InferCtx::new(state, store);
+            f(&mut context)
+        })
+    }
+
+    pub(crate) fn without_enclosing_loop<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let depth = self.scopes.reset_loop_depth();
+        let result = f(self);
+        self.scopes.restore_loop_depth(depth);
+        result
+    }
+
+    pub(crate) fn in_defer_block<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.scopes.increment_defer_block_depth();
+        let result = self.without_enclosing_loop(f);
+        self.scopes.decrement_defer_block_depth();
+        result
+    }
+
+    pub(crate) fn in_negation<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.scopes.increment_negation_depth();
+        let result = f(self);
+        self.scopes.decrement_negation_depth();
+        result
+    }
+
+    pub(crate) fn with_temporary_bindings<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let checkpoint = self.facts.binding_checkpoint();
+        let result = f(self);
+        self.facts.remove_bindings_from(checkpoint);
+        result
+    }
 }
 
 impl Deref for InferCtx<'_> {

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -147,9 +147,9 @@ impl InferCtx<'_> {
             self.new_type_var()
         };
 
-        let prior_let_rhs = self.scopes.set_let_binding_rhs(true);
-        let new_value = self.with_value_context(|s| s.infer_expression(*value, &ty));
-        self.scopes.set_let_binding_rhs(prior_let_rhs);
+        let new_value = self.with_let_binding_rhs(|state| {
+            state.with_value_context(|state| state.infer_expression(*value, &ty))
+        });
 
         let new_mode = mode.map_else(|else_expression, else_span| {
             let else_ty = self.new_type_var();

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -1,5 +1,5 @@
 use crate::checker::EnvResolve;
-use crate::facts::BranchSubsumption;
+use crate::facts::{BranchArm, BranchSubsumption};
 use syntax::ast::BindingKind;
 use syntax::ast::{Binding, Expression, IfLetAlternative, MatchArm, Pattern, Span};
 use syntax::types::{SimpleKind, Type};
@@ -34,46 +34,36 @@ impl InferCtx<'_> {
     pub(crate) fn reconcile_and_unify(
         &mut self,
         result_ty: &Type,
-        branch_types: &[Type],
-        branch_spans: &[Span],
+        branches: &[BranchArm],
         span: &Span,
     ) {
-        if branch_types.is_empty() {
+        if branches.is_empty() {
             return;
         }
-        if branch_types
+        if branches
             .iter()
-            .any(|t| self.contains_pending_branch_var(t))
+            .any(|branch| self.contains_pending_branch_var(&branch.ty))
         {
-            self.record_branch_subsumption(result_ty, branch_types, branch_spans);
+            self.record_branch_subsumption(result_ty, branches);
             return;
         }
-        match self.reconcile_branch_types(branch_types, span) {
+        match self.reconcile_branch_types(branches, span) {
             BranchReconciliation::FirstBranch => {
-                self.unify(result_ty, &branch_types[0], span);
+                self.unify(result_ty, &branches[0].ty, span);
             }
             BranchReconciliation::Widened(ty) => {
                 self.unify(result_ty, &ty, span);
             }
             BranchReconciliation::Failed => {
-                self.record_branch_subsumption(result_ty, branch_types, branch_spans);
+                self.record_branch_subsumption(result_ty, branches);
             }
         }
     }
 
-    fn record_branch_subsumption(
-        &mut self,
-        result_ty: &Type,
-        branch_types: &[Type],
-        branch_spans: &[Span],
-    ) {
+    fn record_branch_subsumption(&mut self, result_ty: &Type, branches: &[BranchArm]) {
         self.facts.branch_subsumptions.push(BranchSubsumption {
             result_ty: result_ty.clone(),
-            arms: branch_types
-                .iter()
-                .cloned()
-                .zip(branch_spans.iter().copied())
-                .collect(),
+            arms: branches.to_vec(),
         });
     }
 
@@ -89,19 +79,25 @@ impl InferCtx<'_> {
     pub fn resolve_branch_subsumptions(&mut self) {
         let obligations = std::mem::take(&mut self.facts.branch_subsumptions);
         for obligation in obligations.into_iter().rev() {
-            for (arm_ty, arm_span) in &obligation.arms {
-                let arm = arm_ty.resolve_in(&self.env);
+            for branch in &obligation.arms {
+                let arm = branch.ty.resolve_in(&self.env);
                 if arm.is_never() || arm.is_error() {
                     continue;
                 }
                 let store = self.store;
                 let (unification, reported) = self.tracking_diagnostics(|this| {
-                    InferCtx::new(this, store).try_unify(&obligation.result_ty, arm_ty, arm_span)
+                    InferCtx::new(this, store).try_unify(
+                        &obligation.result_ty,
+                        &branch.ty,
+                        &branch.span,
+                    )
                 });
                 if unification.is_err() && !reported {
                     let result = obligation.result_ty.resolve_in(&self.env);
                     self.sink.push(diagnostics::infer::branch_type_mismatch(
-                        &arm, *arm_span, &result,
+                        &arm,
+                        branch.span,
+                        &result,
                     ));
                 }
             }
@@ -110,18 +106,19 @@ impl InferCtx<'_> {
 
     fn reconcile_branch_types(
         &mut self,
-        branch_types: &[Type],
+        branches: &[BranchArm],
         span: &Span,
     ) -> BranchReconciliation {
         let store = self.store;
-        if branch_types.len() < 2 {
+        if branches.len() < 2 {
             return BranchReconciliation::FirstBranch;
         }
 
-        let mut common = branch_types[0].clone();
+        let mut common = branches[0].ty.clone();
         let mut widened_to: Option<Type> = None;
 
-        for next in &branch_types[1..] {
+        for branch in &branches[1..] {
+            let next = &branch.ty;
             if self
                 .speculatively(|this| InferCtx::new(this, store).try_unify(&common, next, span))
                 .is_ok()
@@ -181,13 +178,9 @@ impl InferCtx<'_> {
     where
         F: FnOnce(&mut Self) -> Expression,
     {
-        self.increment_try_block_loop_depth();
-        self.increment_recover_block_loop_depth();
         self.scopes.increment_loop_depth();
         let result = f(self);
         self.scopes.decrement_loop_depth();
-        self.decrement_recover_block_loop_depth();
-        self.decrement_try_block_loop_depth();
         result
     }
 
@@ -198,12 +191,17 @@ impl InferCtx<'_> {
     where
         F: FnOnce(&mut Self) -> Expression,
     {
-        let prev_break_type = self.scopes.loop_break_type().cloned();
-        self.scopes.clear_loop_break_type();
-        let result = self.infer_in_loop_context(f);
-        if let Some(prev) = prev_break_type {
-            self.scopes.set_loop_break_type(prev);
-        }
+        self.with_loop_break_type(None, |this| this.infer_in_loop_context(f))
+    }
+
+    fn with_loop_break_type<T>(
+        &mut self,
+        break_type: Option<Type>,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let previous = self.scopes.replace_loop_break_type(break_type);
+        let result = f(self);
+        self.scopes.replace_loop_break_type(previous);
         result
     }
 
@@ -266,8 +264,16 @@ impl InferCtx<'_> {
             let alternative_span = new_alternative.get_span();
             self.reconcile_and_unify(
                 expected_ty,
-                &[consequence_ty.clone(), alternative_ty.clone()],
-                &[consequence_span, alternative_span],
+                &[
+                    BranchArm {
+                        ty: consequence_ty.clone(),
+                        span: consequence_span,
+                    },
+                    BranchArm {
+                        ty: alternative_ty.clone(),
+                        span: alternative_span,
+                    },
+                ],
                 &span,
             );
         }
@@ -429,39 +435,42 @@ impl InferCtx<'_> {
         let new_arms = arms
             .into_iter()
             .map(|a| {
-                self.scopes.push();
+                self.with_scope(|this| {
+                    let pattern_ty = subject_ty.resolve_in(&this.env);
+                    let new_pattern = this.infer_pattern(a.pattern, pattern_ty, arm_kind);
 
-                let pattern_ty = subject_ty.resolve_in(&self.env);
-                let new_pattern = self.infer_pattern(a.pattern, pattern_ty, arm_kind);
+                    let new_guard = a
+                        .guard
+                        .map(|guard| Box::new(this.infer_condition(*guard, &span)));
 
-                let new_guard = a
-                    .guard
-                    .map(|guard| Box::new(self.infer_condition(*guard, &span)));
+                    let independent_ty;
+                    let arm_expected = if arms_independent || needs_reconciliation {
+                        independent_ty = this.new_type_var();
+                        &independent_ty
+                    } else {
+                        &result_ty
+                    };
+                    // Arm body is a tail-like context where Never calls are valid.
+                    let new_expression = this.infer_root_expression(*a.expression, arm_expected);
 
-                let independent_ty;
-                let arm_expected = if arms_independent || needs_reconciliation {
-                    independent_ty = self.new_type_var();
-                    &independent_ty
-                } else {
-                    &result_ty
-                };
-                // Arm body is a tail-like context where Never calls are valid.
-                let new_expression = self.infer_root_expression(*a.expression, arm_expected);
-
-                self.scopes.pop();
-
-                MatchArm {
-                    pattern: new_pattern,
-                    guard: new_guard,
-                    expression: Box::new(new_expression),
-                }
+                    MatchArm {
+                        pattern: new_pattern,
+                        guard: new_guard,
+                        expression: Box::new(new_expression),
+                    }
+                })
             })
             .collect::<Vec<_>>();
 
         if needs_reconciliation {
-            let arm_types: Vec<Type> = new_arms.iter().map(|a| a.expression.get_type()).collect();
-            let arm_spans: Vec<Span> = new_arms.iter().map(|a| a.expression.get_span()).collect();
-            self.reconcile_and_unify(&result_ty, &arm_types, &arm_spans, &span);
+            let branches: Vec<BranchArm> = new_arms
+                .iter()
+                .map(|arm| BranchArm {
+                    ty: arm.expression.get_type(),
+                    span: arm.expression.get_span(),
+                })
+                .collect();
+            self.reconcile_and_unify(&result_ty, &branches, &span);
         } else if is_statement && let Some(first_arm) = new_arms.first() {
             // In statement position, set the match's type from the first arm so the
             // expression still has a well-defined type for inspection, even though
@@ -481,16 +490,9 @@ impl InferCtx<'_> {
     ) -> Expression {
         let break_ty = self.new_type_var();
 
-        let prev_break_type = self.scopes.loop_break_type().cloned();
-        self.scopes.set_loop_break_type(break_ty.clone());
-
-        let new_body = self.infer_in_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        if let Some(prev) = prev_break_type {
-            self.scopes.set_loop_break_type(prev);
-        } else {
-            self.scopes.clear_loop_break_type();
-        }
+        let new_body = self.with_loop_break_type(Some(break_ty.clone()), |this| {
+            this.infer_in_loop_context(|this| this.infer_expression(*body, &Type::ignored()))
+        });
 
         let loop_type = if new_body.contains_break() {
             break_ty.clone()
@@ -552,17 +554,16 @@ impl InferCtx<'_> {
             &new_scrutinee.get_span(),
         );
 
-        self.scopes.push();
-        let new_pattern = self.infer_pattern(
-            pattern,
-            scrutinee_ty.resolve_in(&self.env),
-            BindingKind::WhileLet,
-        );
-
-        let new_body =
-            self.infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        self.scopes.pop();
+        let (new_pattern, new_body) = self.with_scope(|this| {
+            let new_pattern = this.infer_pattern(
+                pattern,
+                scrutinee_ty.resolve_in(&this.env),
+                BindingKind::WhileLet,
+            );
+            let new_body = this
+                .infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
+            (new_pattern, new_body)
+        });
 
         Expression::WhileLet {
             pattern: new_pattern,
@@ -704,42 +705,38 @@ impl InferCtx<'_> {
             self.unify(&element_ty, &annotated_ty, &span);
         }
 
-        // Push a new scope so the loop variable doesn't shadow outer bindings
-        self.scopes.push();
+        let (new_binding, new_body) = self.with_scope(|this| {
+            let inferred_pattern = this.infer_pattern(
+                binding.pattern,
+                element_ty.clone(),
+                BindingKind::Let { mutable: false },
+            );
 
-        let inferred_pattern = self.infer_pattern(
-            binding.pattern,
-            element_ty.clone(),
-            BindingKind::Let { mutable: false },
-        );
+            let new_binding = Binding {
+                pattern: inferred_pattern,
+                annotation: binding.annotation,
+                ty: element_ty.clone(),
+                mut_span: None,
+            };
 
-        let new_binding = Binding {
-            pattern: inferred_pattern,
-            annotation: binding.annotation,
-            ty: element_ty.clone(),
-            mut_span: None,
-        };
-
-        // When iterating over types that yield multiple values (`Map`, `EnumeratedSlice`),
-        // Go's `range` returns multiple values, so the binding must be a tuple literal.
-        // This does NOT apply to `Slice<(A, B)>` where the element is already a tuple value.
-        let requires_tuple_destructuring = matches!(iterable_ty_name, "Map" | "EnumeratedSlice")
-            || matches!(iter_seq, Some(IterSeqKind::Seq2));
-        if requires_tuple_destructuring && element_ty.is_tuple() {
-            match &new_binding.pattern {
-                Pattern::Tuple { .. } => (),
-                Pattern::WildCard { .. } => (),
-                _ => {
-                    self.sink
-                        .push(diagnostics::infer::tuple_literal_required_in_loop(span));
+            let requires_tuple_destructuring =
+                matches!(iterable_ty_name, "Map" | "EnumeratedSlice")
+                    || matches!(iter_seq, Some(IterSeqKind::Seq2));
+            if requires_tuple_destructuring && element_ty.is_tuple() {
+                match &new_binding.pattern {
+                    Pattern::Tuple { .. } => (),
+                    Pattern::WildCard { .. } => (),
+                    _ => {
+                        this.sink
+                            .push(diagnostics::infer::tuple_literal_required_in_loop(span));
+                    }
                 }
             }
-        }
 
-        let new_body =
-            self.infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
-
-        self.scopes.pop();
+            let new_body = this
+                .infer_in_non_value_loop_context(|s| s.infer_expression(*body, &Type::ignored()));
+            (new_binding, new_body)
+        });
 
         Expression::For {
             binding: Box::new(new_binding),
@@ -824,20 +821,12 @@ impl InferCtx<'_> {
         self.unify(expected_ty, &unit_ty, &span);
 
         let is_block = matches!(*expression, Expression::Block { .. });
-        let saved_loop_depth = if is_block {
-            self.scopes.increment_defer_block_depth();
-            self.scopes.reset_loop_depth()
-        } else {
-            0
-        };
-
         let defer_ty = self.new_type_var();
-        let new_expression = self.infer_expression(*expression, &defer_ty);
-
-        if is_block {
-            self.scopes.restore_loop_depth(saved_loop_depth);
-            self.scopes.decrement_defer_block_depth();
-        }
+        let new_expression = if is_block {
+            self.in_defer_block(|this| this.infer_expression(*expression, &defer_ty))
+        } else {
+            self.infer_expression(*expression, &defer_ty)
+        };
 
         if let Some(propagate_span) = Self::find_propagate(&new_expression) {
             self.sink
@@ -961,12 +950,9 @@ impl InferCtx<'_> {
         self.unify(expected_ty, &unit_ty, &span);
 
         // task spawns a new goroutine — enclosing loop context doesn't apply
-        let saved_loop_depth = self.scopes.reset_loop_depth();
-
         let task_ty = self.new_type_var();
-        let new_expression = self.infer_expression(*expression, &task_ty);
-
-        self.scopes.restore_loop_depth(saved_loop_depth);
+        let new_expression =
+            self.without_enclosing_loop(|this| this.infer_expression(*expression, &task_ty));
 
         Expression::Task {
             expression: new_expression.into(),

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -209,9 +209,8 @@ impl InferCtx<'_> {
         expected_ty: &Type,
     ) -> Expression {
         let expression_ty = self.new_type_var();
-        let prior_dot_access_base = self.scopes.set_dot_access_base(true);
-        let new_expression = self.infer_expression(*expression, &expression_ty);
-        self.scopes.set_dot_access_base(prior_dot_access_base);
+        let new_expression =
+            self.with_dot_access_base(|state| state.infer_expression(*expression, &expression_ty));
         let resolved_expression_ty =
             self.normalize_aliased_ref(expression_ty.resolve_in(&self.env));
 

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -17,6 +17,7 @@ use super::primitives::contains_deref;
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
 use crate::checker::registration::test_functions::normalize_test_params;
+use crate::checker::scopes::DeferredMapKeyCheck;
 use crate::inference::ProjectKind;
 use crate::store::ENTRY_MODULE_ID;
 
@@ -32,10 +33,14 @@ struct TypeConversionCall {
 
 struct CallSignature {
     parameters: Vec<FunctionParameter>,
-    variadic: Option<FunctionParameter>,
-    declared_parameter_count: usize,
+    variadic: Option<VariadicParameter>,
     return_type: Type,
     bounds: Vec<Bound>,
+}
+
+struct VariadicParameter {
+    parameter: FunctionParameter,
+    first_index: usize,
 }
 
 impl InferCtx<'_> {
@@ -146,70 +151,66 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::invalid_main_signature(name_span));
         }
 
-        self.scopes.push();
+        let (generics, new_params, return_ty, base_fn_ty, new_body) = self.with_scope(|this| {
+            this.put_in_scope(&generics);
+            let generics = this.ensure_generic_bounds(store, generics, &span);
+            let bounds = resolved_generic_bounds(&generics);
 
-        self.put_in_scope(&generics);
-        let generics = self.ensure_generic_bounds(store, generics, &span);
-        let bounds = resolved_generic_bounds(&generics);
+            let resolved_expected = expected_ty.resolve_in(&this.env);
+            let expected_function = store.resolve_to_function_type(&resolved_expected);
+            let expected_params = expected_function
+                .as_ref()
+                .and_then(Type::get_function_params)
+                .unwrap_or_default();
+            let is_test = attributes.iter().any(|a| a.name == "test");
+            let params = normalize_test_params(params, is_test);
+            let new_params = this.infer_function_params(params, expected_params, true);
 
-        let resolved_expected = expected_ty.resolve_in(&self.env);
-        let expected_function = store.resolve_to_function_type(&resolved_expected);
-        let expected_params = expected_function
-            .as_ref()
-            .and_then(Type::get_function_params)
-            .unwrap_or_default();
-        let is_test = attributes.iter().any(|a| a.name == "test");
-        let params = normalize_test_params(params, is_test);
-        let new_params = self.infer_function_params(params, expected_params, true);
-
-        if is_test
-            || new_params
+            if is_test {
+                this.scopes.set_test_fn_name(name.clone());
+            } else if new_params
                 .iter()
-                .any(|p| self.param_provides_test_handle(p))
-        {
-            self.scopes.mark_test_handle();
-        }
-        if is_test {
-            self.scopes.set_test_fn_name(name.clone());
-        }
-        self.mark_test_context_params_used(&new_params);
+                .any(|param| this.param_provides_test_handle(param))
+            {
+                this.scopes.mark_test_handle();
+            }
+            this.mark_test_context_params_used(&new_params);
 
-        let unit_ty = self.type_unit();
-        let return_ty =
-            self.infer_return_type(&return_annotation, &resolved_expected, &span, unit_ty);
+            let unit_ty = this.type_unit();
+            let return_ty =
+                this.infer_return_type(&return_annotation, &resolved_expected, &span, unit_ty);
 
-        self.scopes.current_mut().fn_return_type = Some(return_ty.clone());
+            this.scopes.current_mut().fn_return_type = Some(return_ty.clone());
 
-        let base_fn_ty = Type::function(
-            new_params
-                .iter()
-                .map(|param| {
-                    FunctionParameter::named(
-                        param.ty.clone(),
-                        param.pattern.get_identifier(),
-                        param.is_mutable(),
-                    )
-                })
-                .collect(),
-            bounds,
-            return_ty.clone().into(),
-        );
+            let base_fn_ty = Type::function(
+                new_params
+                    .iter()
+                    .map(|param| {
+                        FunctionParameter::named(
+                            param.ty.clone(),
+                            param.pattern.get_identifier(),
+                            param.is_mutable(),
+                        )
+                    })
+                    .collect(),
+                bounds,
+                return_ty.clone().into(),
+            );
 
-        // The later unused-expression check honors allow attributes.
-        let has_implicit_unit_return = return_annotation == Annotation::Unknown;
-        let body_ty = if has_implicit_unit_return {
-            Type::ignored()
-        } else {
-            return_ty.clone()
-        };
+            let has_implicit_unit_return = return_annotation == Annotation::Unknown;
+            let body_ty = if has_implicit_unit_return {
+                Type::ignored()
+            } else {
+                return_ty.clone()
+            };
 
-        let new_body = body.map_definition(|body| {
-            self.infer_function_body(Box::new(body), &body_ty, &return_annotation, &return_ty)
+            let new_body = body.map_definition(|body| {
+                this.infer_function_body(Box::new(body), &body_ty, &return_annotation, &return_ty)
+            });
+
+            this.check_deferred_map_key_bounds(store);
+            (generics, new_params, return_ty, base_fn_ty, new_body)
         });
-
-        self.check_deferred_map_key_bounds(store);
-
-        self.scopes.pop();
 
         let fn_ty = if generics.is_empty() {
             base_fn_ty
@@ -250,68 +251,62 @@ impl InferCtx<'_> {
         expected_ty: &Type,
     ) -> Expression {
         let store = self.store;
-        self.scopes.push();
+        let (new_params, base_fn_ty, new_body) = self.with_scope(|this| {
+            let resolved_expected = expected_ty.resolve_in(&this.env);
+            let expected_function = store.resolve_to_function_type(&resolved_expected);
+            let expected_params = expected_function
+                .as_ref()
+                .and_then(Type::get_function_params)
+                .unwrap_or_default();
+            let new_params = this.infer_function_params(params, expected_params, false);
 
-        // Resolve type variables so that a Go function alias bound via speculative
-        // unification (e.g. T = tea.Cmd) is visible as its underlying function shape.
-        let resolved_expected = expected_ty.resolve_in(&self.env);
-        let expected_function = store.resolve_to_function_type(&resolved_expected);
-        let expected_params = expected_function
-            .as_ref()
-            .and_then(Type::get_function_params)
-            .unwrap_or_default();
-        let new_params = self.infer_function_params(params, expected_params, false);
-
-        if new_params
-            .iter()
-            .any(|p| self.param_provides_test_handle(p))
-        {
-            self.scopes.mark_test_handle();
-        }
-        self.mark_test_context_params_used(&new_params);
-
-        let default_return = self.new_type_var();
-        let return_ty = self.infer_return_type(
-            &return_annotation,
-            &resolved_expected,
-            &span,
-            default_return,
-        );
-
-        self.scopes.current_mut().fn_return_type = Some(return_ty.clone());
-
-        let base_fn_ty = Type::function(
-            new_params
+            if new_params
                 .iter()
-                .map(|param| {
-                    FunctionParameter::named(
-                        param.ty.clone(),
-                        param.pattern.get_identifier(),
-                        param.is_mutable(),
-                    )
-                })
-                .collect(),
-            vec![],
-            return_ty.clone().into(),
-        );
+                .any(|param| this.param_provides_test_handle(param))
+            {
+                this.scopes.mark_test_handle();
+            }
+            this.mark_test_context_params_used(&new_params);
 
-        // Reset loop depth — closures introduce a new function scope, so
-        // `defer` inside a closure body should not be flagged as "defer in loop"
-        // even when the closure is lexically inside a loop.
-        let saved_loop_depth = self.scopes.reset_loop_depth();
-        // The later unused-expression check honors allow attributes.
-        let relax_body_to_unit = return_annotation == Annotation::Unknown && return_ty.is_unit();
-        let body_ty = if relax_body_to_unit {
-            Type::ignored()
-        } else {
-            return_ty.clone()
-        };
-        let new_body = self.infer_function_body(body, &body_ty, &return_annotation, &return_ty);
-        self.scopes.restore_loop_depth(saved_loop_depth);
+            let default_return = this.new_type_var();
+            let return_ty = this.infer_return_type(
+                &return_annotation,
+                &resolved_expected,
+                &span,
+                default_return,
+            );
 
-        self.check_deferred_map_key_bounds(store);
+            this.scopes.current_mut().fn_return_type = Some(return_ty.clone());
 
-        self.scopes.pop();
+            let base_fn_ty = Type::function(
+                new_params
+                    .iter()
+                    .map(|param| {
+                        FunctionParameter::named(
+                            param.ty.clone(),
+                            param.pattern.get_identifier(),
+                            param.is_mutable(),
+                        )
+                    })
+                    .collect(),
+                vec![],
+                return_ty.clone().into(),
+            );
+
+            let relax_body_to_unit =
+                return_annotation == Annotation::Unknown && return_ty.is_unit();
+            let body_ty = if relax_body_to_unit {
+                Type::ignored()
+            } else {
+                return_ty.clone()
+            };
+            let new_body = this.without_enclosing_loop(|this| {
+                this.infer_function_body(body, &body_ty, &return_annotation, &return_ty)
+            });
+
+            this.check_deferred_map_key_bounds(store);
+            (new_params, base_fn_ty, new_body)
+        });
 
         self.unify(expected_ty, &base_fn_ty, &span);
 
@@ -374,9 +369,10 @@ impl InferCtx<'_> {
         let store = self.store;
         let callee_ty = self.new_type_var();
 
-        let prev_context = self.scopes.set_callee_context();
-        let callee_expression = self.infer_expression(*expression, &callee_ty);
-        self.scopes.restore_use_context(prev_context);
+        let callee_expression = self
+            .with_use_context(crate::checker::scopes::UseContext::Callee, |state| {
+                state.infer_expression(*expression, &callee_ty)
+            });
 
         let forall_ty = self.resolve_callee_forall_type(&callee_expression, &type_args);
         let (callee_ty, type_arguments) =
@@ -400,7 +396,6 @@ impl InferCtx<'_> {
         let CallSignature {
             parameters,
             variadic,
-            declared_parameter_count,
             return_type: return_ty,
             bounds,
         } = self.extract_call_signature(callee_ty, &args, &callee_expression);
@@ -443,7 +438,10 @@ impl InferCtx<'_> {
         self.check_call_arity(&parameters, &new_args, &callee_expression, &span);
         self.check_mut_param_arguments(&new_args, &parameters, &callee_expression);
 
-        self.check_range_to_for_variadic(&new_args, variadic.as_ref());
+        self.check_range_to_for_variadic(
+            &new_args,
+            variadic.as_ref().map(|variadic| &variadic.parameter),
+        );
 
         if let Some(idx) = substring_range_idx
             && let Some(arg) = new_args.get(idx)
@@ -458,17 +456,21 @@ impl InferCtx<'_> {
 
         let new_spread = spread.map(|spread_expr| match &variadic {
             Some(variadic) => {
-                let expected = if variadic.ty.is_unknown() {
+                let expected = if variadic.parameter.ty.is_unknown() {
                     let var = self.new_type_var();
                     self.type_slice(var)
                 } else {
-                    self.type_slice(variadic.ty.clone())
+                    self.type_slice(variadic.parameter.ty.clone())
                 };
                 let inferred =
                     self.with_value_context(|s| s.infer_expression(*spread_expr, &expected));
-                if variadic.mutable {
+                if variadic.parameter.mutable {
                     let callee_label = callee_label(&callee_expression);
-                    self.check_arg_against_mut_param(&inferred, &variadic.ty, &callee_label);
+                    self.check_arg_against_mut_param(
+                        &inferred,
+                        &variadic.parameter.ty,
+                        &callee_label,
+                    );
                 }
                 inferred
             }
@@ -499,14 +501,24 @@ impl InferCtx<'_> {
         if let Some((CompoundKind::Map, arguments)) = resolved_return.as_compound()
             && let Some(key) = arguments.first()
         {
-            let check_concrete = matches!(
+            let check = if matches!(
                 call_kind,
                 CallKind::NativeConstructor(NativeTypeKind::Map)
                     | CallKind::NativeMethod(NativeTypeKind::Map)
                     | CallKind::NativeMethodIdentifier(NativeTypeKind::Map)
-            ) && !expected_is_map;
-            self.scopes
-                .defer_map_key_check(key.clone(), span, check_concrete);
+            ) && !expected_is_map
+            {
+                DeferredMapKeyCheck::Comparable {
+                    key: key.clone(),
+                    span,
+                }
+            } else {
+                DeferredMapKeyCheck::Bounds {
+                    key: key.clone(),
+                    span,
+                }
+            };
+            self.scopes.defer_map_key_check(check);
         }
 
         self.check_native_mutating_call(&callee_expression, &span);
@@ -533,17 +545,17 @@ impl InferCtx<'_> {
         if type_args.is_empty()
             && new_spread.is_none()
             && let Some(variadic) = &variadic
-            && new_args.len() < declared_parameter_count
+            && new_args.len() <= variadic.first_index
         {
             let already_covered = return_check_recorded
-                && resolved_return.contains_type(&variadic.ty.resolve_in(&self.env));
+                && resolved_return.contains_type(&variadic.parameter.ty.resolve_in(&self.env));
             if !already_covered {
                 let module_id = self.cursor.module_id.clone();
                 self.facts
                     .deferred
                     .generic_calls
                     .push(crate::facts::GenericCallCheck {
-                        ty: variadic.ty.clone(),
+                        ty: variadic.parameter.ty.clone(),
                         span,
                         module_id,
                     });
@@ -933,68 +945,69 @@ impl InferCtx<'_> {
         let function_ty = self.store.resolve_to_function_type(&callee_ty);
         let is_variadic = function_ty.as_ref().and_then(Type::is_variadic);
 
-        let (parameters, variadic, declared_parameter_count, return_type) =
-            match self.extract_function_type(&callee_ty) {
-                Some((mut params, return_type)) => {
-                    let declared_parameter_count = params.len();
-                    let variadic = is_variadic.map(|variadic_ty| {
-                        let variadic = params
-                            .pop()
-                            .expect("variadic function has a trailing parameter");
-                        while params.len() < arg_count {
-                            params.push(variadic.with_type(variadic_ty.clone()));
-                        }
-                        variadic.with_type(variadic_ty)
-                    });
-                    (params, variadic, declared_parameter_count, return_type)
-                }
-                None if callee_ty.is_variable() => {
-                    let parameters = (0..arg_count)
-                        .map(|_| FunctionParameter::new(self.new_type_var(), false))
-                        .collect();
-                    (parameters, None, arg_count, self.new_type_var())
-                }
-                None if callee_ty.resolve_in(&self.env).is_error() => {
-                    let parameters = (0..arg_count)
-                        .map(|_| FunctionParameter::new(Type::Error, false))
-                        .collect();
-                    (parameters, None, arg_count, Type::Error)
-                }
-                None => {
-                    let callee_name = match callee_expression.unwrap_parens() {
-                        Expression::Identifier {
-                            value, resolution, ..
-                        } if !matches!(resolution, IdentifierResolution::Binding(_)) => {
-                            Some(value.as_str())
-                        }
+        let (parameters, variadic, return_type) = match self.extract_function_type(&callee_ty) {
+            Some((mut params, return_type)) => {
+                let variadic = is_variadic.map(|variadic_ty| {
+                    let parameter = params
+                        .pop()
+                        .expect("variadic function has a trailing parameter");
+                    let first_index = params.len();
+                    while params.len() < arg_count {
+                        params.push(parameter.with_type(variadic_ty.clone()));
+                    }
+                    VariadicParameter {
+                        parameter: parameter.with_type(variadic_ty),
+                        first_index,
+                    }
+                });
+                (params, variadic, return_type)
+            }
+            None if callee_ty.is_variable() => {
+                let parameters = (0..arg_count)
+                    .map(|_| FunctionParameter::new(self.new_type_var(), false))
+                    .collect();
+                (parameters, None, self.new_type_var())
+            }
+            None if callee_ty.resolve_in(&self.env).is_error() => {
+                let parameters = (0..arg_count)
+                    .map(|_| FunctionParameter::new(Type::Error, false))
+                    .collect();
+                (parameters, None, Type::Error)
+            }
+            None => {
+                let callee_name = match callee_expression.unwrap_parens() {
+                    Expression::Identifier {
+                        value, resolution, ..
+                    } if !matches!(resolution, IdentifierResolution::Binding(_)) => {
+                        Some(value.as_str())
+                    }
+                    _ => None,
+                };
+                let arg_name = if args.len() == 1 {
+                    match args[0].unwrap_parens() {
+                        Expression::Identifier { value, .. } => Some(value.as_str()),
                         _ => None,
-                    };
-                    let arg_name = if args.len() == 1 {
-                        match args[0].unwrap_parens() {
-                            Expression::Identifier { value, .. } => Some(value.as_str()),
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    };
-                    self.sink.push(diagnostics::infer::not_callable(
-                        &callee_ty,
-                        callee_name,
-                        arg_name,
-                        self.store.underlying_type(&callee_ty).is_some(),
-                        callee_expression.get_span(),
-                    ));
-                    let parameters = (0..arg_count)
-                        .map(|_| FunctionParameter::new(Type::Error, false))
-                        .collect();
-                    (parameters, None, arg_count, Type::Error)
-                }
-            };
+                    }
+                } else {
+                    None
+                };
+                self.sink.push(diagnostics::infer::not_callable(
+                    &callee_ty,
+                    callee_name,
+                    arg_name,
+                    self.store.underlying_type(&callee_ty).is_some(),
+                    callee_expression.get_span(),
+                ));
+                let parameters = (0..arg_count)
+                    .map(|_| FunctionParameter::new(Type::Error, false))
+                    .collect();
+                (parameters, None, Type::Error)
+            }
+        };
 
         CallSignature {
             parameters,
             variadic,
-            declared_parameter_count,
             return_type,
             bounds,
         }

--- a/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
+++ b/crates/semantics/src/checker/infer/expressions/impl_blocks.rs
@@ -15,58 +15,53 @@ impl InferCtx<'_> {
         span: Span,
     ) -> Expression {
         let store = self.store;
-        self.scopes.push();
+        let (generics, impl_ty, new_methods) = self.with_scope(|this| {
+            this.put_in_scope(&generics);
+            let generics = this.ensure_generic_bounds(store, generics, &span);
 
-        self.put_in_scope(&generics);
-        let generics = self.ensure_generic_bounds(store, generics, &span);
+            this.check_undeclared_impl_type_params(&annotation, &generics);
+            let impl_ty = this.convert_receiver_to_type(store, &annotation, &span);
 
-        self.check_undeclared_impl_type_params(&annotation, &generics);
-        let impl_ty = self.convert_receiver_to_type(store, &annotation, &span);
-
-        if let Type::Nominal { id, .. } = &impl_ty
-            && self.impl_has_simple_type_params(&impl_ty, &generics)
-        {
-            let receiver_qualified = id.clone();
-            self.register_receiver_type_bounds(store, &receiver_qualified, &generics);
-        }
-
-        let receiver_ty = if generics.is_empty() {
-            impl_ty.clone()
-        } else {
-            Type::Forall {
-                vars: generics.iter().map(|g| g.name.clone()).collect(),
-                body: Box::new(impl_ty.clone()),
+            if let Type::Nominal { id, .. } = &impl_ty
+                && this.impl_has_simple_type_params(&impl_ty, &generics)
+            {
+                let receiver_qualified = id.clone();
+                this.register_receiver_type_bounds(store, &receiver_qualified, &generics);
             }
-        };
 
-        let scope = self.scopes.current_mut();
-        scope.insert_value(receiver_name.to_string(), receiver_ty);
+            let receiver_ty = if generics.is_empty() {
+                impl_ty.clone()
+            } else {
+                Type::Forall {
+                    vars: generics.iter().map(|g| g.name.clone()).collect(),
+                    body: Box::new(impl_ty.clone()),
+                }
+            };
 
-        // If this is a tuple struct with a constructor, the receiver_name (which is the
-        // type name) shadows the constructor function in the parent scope. Re-insert the
-        // constructor so it's callable from within impl methods.
-        if let Type::Nominal { id, .. } = &impl_ty
-            && let Some(ctor_ty) = store
-                .get_definition(id)
-                .and_then(Definition::constructor_type)
-        {
-            self.scopes
-                .current_mut()
-                .insert_value(receiver_name.to_string(), ctor_ty);
-        }
+            let scope = this.scopes.current_mut();
+            scope.insert_value(receiver_name.to_string(), receiver_ty);
 
-        self.scopes.set_impl_receiver_type(Some(impl_ty.clone()));
+            if let Type::Nominal { id, .. } = &impl_ty
+                && let Some(ctor_ty) = store
+                    .get_definition(id)
+                    .and_then(Definition::constructor_type)
+            {
+                this.scopes
+                    .current_mut()
+                    .insert_value(receiver_name.to_string(), ctor_ty);
+            }
 
-        let new_methods: Vec<Expression> = methods
-            .into_iter()
-            .map(|method| {
-                let method_ty = self.new_type_var();
-                self.infer_expression(method, &method_ty)
-            })
-            .collect();
+            this.scopes.set_impl_receiver_type(impl_ty.clone());
 
-        self.scopes.set_impl_receiver_type(None);
-        self.scopes.pop();
+            let new_methods = methods
+                .into_iter()
+                .map(|method| {
+                    let method_ty = this.new_type_var();
+                    this.infer_expression(method, &method_ty)
+                })
+                .collect();
+            (generics, impl_ty, new_methods)
+        });
 
         Expression::ImplBlock {
             annotation,
@@ -94,39 +89,36 @@ impl InferCtx<'_> {
             unreachable!()
         };
 
-        self.scopes.push();
-        self.put_in_scope(&generics);
-        let generics = self.ensure_generic_bounds(store, generics, &span);
+        let (generics, new_method_signatures, new_parents) = self.with_scope(|this| {
+            this.put_in_scope(&generics);
+            let generics = this.ensure_generic_bounds(store, generics, &span);
 
-        // Interface method parameters are declarations, not implementations — they
-        // have no body and are always "unused". Remove their bindings so the unused
-        // parameter lint doesn't fire.
-        let checkpoint = self.facts.binding_checkpoint();
-        let new_method_signatures = method_signatures
-            .into_iter()
-            .map(|method_signature| {
-                let signature_ty = self.new_type_var();
-                self.infer_expression(method_signature, &signature_ty)
-            })
-            .collect();
-        self.facts.remove_bindings_from(checkpoint);
+            let new_method_signatures = this.with_temporary_bindings(|this| {
+                method_signatures
+                    .into_iter()
+                    .map(|method_signature| {
+                        let signature_ty = this.new_type_var();
+                        this.infer_expression(method_signature, &signature_ty)
+                    })
+                    .collect()
+            });
 
-        let new_parents = parents
-            .into_iter()
-            .map(|parent| {
-                let parent_ty = self.without_diagnostics(|this| {
-                    this.convert_to_type(store, &parent.annotation, &parent.span)
-                });
-                self.check_interface_parent(&parent_ty, parent.span);
-                ParentInterface {
-                    annotation: parent.annotation,
-                    span: parent.span,
-                    ty: parent_ty,
-                }
-            })
-            .collect();
-
-        self.scopes.pop();
+            let new_parents = parents
+                .into_iter()
+                .map(|parent| {
+                    let parent_ty = this.without_diagnostics(|this| {
+                        this.convert_to_type(store, &parent.annotation, &parent.span)
+                    });
+                    this.check_interface_parent(&parent_ty, parent.span);
+                    ParentInterface {
+                        annotation: parent.annotation,
+                        span: parent.span,
+                        ty: parent_ty,
+                    }
+                })
+                .collect();
+            (generics, new_method_signatures, new_parents)
+        });
 
         Expression::Interface {
             doc,

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -291,13 +291,40 @@ impl InferCtx<'_> {
         }
     }
 
+    fn with_use_context<F, R>(&mut self, context: crate::checker::scopes::UseContext, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let prev_ctx = self.scopes.replace_use_context(context);
+        let result = f(self);
+        self.scopes.restore_use_context(prev_ctx);
+        result
+    }
+
     fn with_value_context<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {
-        let prev_ctx = self.scopes.set_value_context();
+        self.with_use_context(crate::checker::scopes::UseContext::Value, f)
+    }
+
+    fn with_dot_access_base<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let previous = self.scopes.replace_dot_access_base(true);
         let result = f(self);
-        self.scopes.restore_use_context(prev_ctx);
+        self.scopes.replace_dot_access_base(previous);
+        result
+    }
+
+    fn with_let_binding_rhs<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let previous = self.scopes.replace_let_binding_rhs(true);
+        let result = f(self);
+        self.scopes.replace_let_binding_rhs(previous);
         result
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -53,16 +53,15 @@ impl InferCtx<'_> {
             self.new_type_var()
         };
 
-        if operator == Negative {
-            self.scopes.increment_negation_depth();
-        }
-
-        let new_expression =
-            self.with_value_context(|s| s.infer_expression(*operand, &operand_expected_ty));
-
-        if operator == Negative {
-            self.scopes.decrement_negation_depth();
-        }
+        let new_expression = if operator == Negative {
+            self.in_negation(|this| {
+                this.with_value_context(|this| {
+                    this.infer_expression(*operand, &operand_expected_ty)
+                })
+            })
+        } else {
+            self.with_value_context(|this| this.infer_expression(*operand, &operand_expected_ty))
+        };
         let operand_span = new_expression.get_span();
 
         let expression_ty = match operator {

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -798,59 +798,61 @@ impl InferCtx<'_> {
         let mut inferred = vec![first];
 
         for pattern in patterns.iter().skip(1) {
-            self.scopes.push();
-            let checkpoint = self.facts.binding_checkpoint();
-            let alt = self.infer_pattern_inner(pattern.clone(), expected_ty.clone(), kind, false);
-            let alt_bindings = collect_pattern_bindings(&alt);
-            let alt_names: HashSet<&str> =
-                alt_bindings.iter().map(|(name, _)| name.as_str()).collect();
+            let alt = self.with_temporary_bindings(|this| {
+                this.with_scope(|this| {
+                    let alt =
+                        this.infer_pattern_inner(pattern.clone(), expected_ty.clone(), kind, false);
+                    let alt_bindings = collect_pattern_bindings(&alt);
+                    let alt_names: HashSet<&str> =
+                        alt_bindings.iter().map(|(name, _)| name.as_str()).collect();
 
-            if first_names != alt_names {
-                let missing_in_alt: Vec<&str> =
-                    first_names.difference(&alt_names).copied().collect();
-                let missing_in_first: Vec<&str> =
-                    alt_names.difference(&first_names).copied().collect();
+                    if first_names != alt_names {
+                        let missing_in_alt: Vec<&str> =
+                            first_names.difference(&alt_names).copied().collect();
+                        let missing_in_first: Vec<&str> =
+                            alt_names.difference(&first_names).copied().collect();
 
-                let error_span = if let Some(name) = missing_in_alt.first() {
-                    first_bindings
-                        .iter()
-                        .find(|(n, _)| n == *name)
-                        .map(|(_, s)| *s)
-                } else if let Some(name) = missing_in_first.first() {
-                    alt_bindings
-                        .iter()
-                        .find(|(n, _)| n == *name)
-                        .map(|(_, s)| *s)
-                } else {
-                    None
-                };
+                        let error_span = if let Some(name) = missing_in_alt.first() {
+                            first_bindings
+                                .iter()
+                                .find(|(n, _)| n == *name)
+                                .map(|(_, s)| *s)
+                        } else if let Some(name) = missing_in_first.first() {
+                            alt_bindings
+                                .iter()
+                                .find(|(n, _)| n == *name)
+                                .map(|(_, s)| *s)
+                        } else {
+                            None
+                        };
 
-                self.sink
-                    .push(diagnostics::infer::or_pattern_binding_mismatch(
-                        error_span.unwrap_or(span),
-                        &missing_in_alt,
-                        &missing_in_first,
-                    ));
-                self.facts.or_pattern_error_spans.insert(span);
-            } else {
-                for (name, alt_span) in &alt_bindings {
-                    if let Some(first_ty) = first_binding_types.get(name)
-                        && let Some(alt_ty) = self.scopes.lookup_value(name)
-                    {
-                        let first_resolved = first_ty.resolve_in(&self.env);
-                        let alt_resolved = alt_ty.resolve_in(&self.env);
-                        if first_resolved != alt_resolved {
-                            self.sink.push(diagnostics::infer::or_pattern_type_mismatch(
-                                *alt_span,
-                                &first_resolved.to_string(),
-                                &alt_resolved.to_string(),
+                        this.sink
+                            .push(diagnostics::infer::or_pattern_binding_mismatch(
+                                error_span.unwrap_or(span),
+                                &missing_in_alt,
+                                &missing_in_first,
                             ));
+                        this.facts.or_pattern_error_spans.insert(span);
+                    } else {
+                        for (name, alt_span) in &alt_bindings {
+                            if let Some(first_ty) = first_binding_types.get(name)
+                                && let Some(alt_ty) = this.scopes.lookup_value(name)
+                            {
+                                let first_resolved = first_ty.resolve_in(&this.env);
+                                let alt_resolved = alt_ty.resolve_in(&this.env);
+                                if first_resolved != alt_resolved {
+                                    this.sink.push(diagnostics::infer::or_pattern_type_mismatch(
+                                        *alt_span,
+                                        &first_resolved.to_string(),
+                                        &alt_resolved.to_string(),
+                                    ));
+                                }
+                            }
                         }
                     }
-                }
-            }
-            self.scopes.pop();
-            self.facts.remove_bindings_from(checkpoint);
+                    alt
+                })
+            });
             inferred.push(alt);
         }
 

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -152,15 +152,15 @@ impl InferCtx<'_> {
             };
         }
 
-        self.scopes.push();
-        self.register_block_local_items(&items);
-
-        let new_items = self.infer_block_items(items, expected_ty.clone());
-
-        let last_item = new_items.last().expect("block must have at least one item");
-        let block_ty = last_item.get_type();
-
-        self.scopes.pop();
+        let (new_items, block_ty) = self.with_scope(|this| {
+            this.register_block_local_items(&items);
+            let new_items = this.infer_block_items(items, expected_ty.clone());
+            let block_ty = new_items
+                .last()
+                .expect("block must have at least one item")
+                .get_type();
+            (new_items, block_ty)
+        });
 
         Expression::Block {
             items: new_items,
@@ -380,15 +380,14 @@ impl InferCtx<'_> {
         // Prevent simple assignment targets from being marked as "used" in the lint system.
         // Complex targets like `a[i]` or `r.*` have subexpressions that ARE being read.
         let is_simple_target = matches!(&*target, Expression::Identifier { .. });
-        let prev_ctx = if is_simple_target {
-            Some(self.scopes.set_assignment_target_context())
+        let new_target = if is_simple_target {
+            self.with_use_context(
+                crate::checker::scopes::UseContext::AssignmentTarget,
+                |state| state.infer_expression(*target, &target_ty),
+            )
         } else {
-            None
+            self.infer_expression(*target, &target_ty)
         };
-        let new_target = self.infer_expression(*target, &target_ty);
-        if let Some(ctx) = prev_ctx {
-            self.scopes.restore_use_context(ctx);
-        }
 
         if let Some(kind) =
             check_non_addressable_assignment_target(&new_target, &self.env, self.store)
@@ -597,17 +596,13 @@ impl InferCtx<'_> {
                 self.new_type_var()
             };
 
-            let prev_ctx = if !is_last {
-                Some(self.scopes.set_statement_context())
+            let inferred_item = if !is_last {
+                self.with_use_context(crate::checker::scopes::UseContext::Statement, |state| {
+                    state.infer_root_expression(item, &expression_ty)
+                })
             } else {
-                None
+                self.infer_root_expression(item, &expression_ty)
             };
-
-            let inferred_item = self.infer_root_expression(item, &expression_ty);
-
-            if let Some(ctx) = prev_ctx {
-                self.scopes.restore_use_context(ctx);
-            }
 
             if let Some(cause) = inferred_item.diverges() {
                 diverged_at = Some((i, cause));

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -1,5 +1,5 @@
 use crate::checker::EnvResolve;
-use crate::checker::scopes::{DepthCounter, RecoverBlockContext, TryBlockContext, TryCarrier};
+use crate::checker::scopes::{RecoverBlockContext, TryBlockContext, TryCarrier, TryUsage};
 use syntax::ast::{Expression, Span};
 use syntax::types::Type;
 
@@ -48,7 +48,7 @@ impl InferCtx<'_> {
                     .scopes
                     .lookup_try_block_context_mut()
                     .expect("try block context was just found");
-                let has_mismatch = ctx.carrier.observe(observed);
+                let has_mismatch = ctx.usage.observe(observed);
                 (ctx.ok_ty.clone(), ctx.err_ty.clone(), has_mismatch)
             };
 
@@ -225,32 +225,25 @@ impl InferCtx<'_> {
         let ok_ty = self.new_type_var();
         let err_ty = self.new_type_var();
 
-        self.scopes.push();
-        {
-            let scope = self.scopes.current_mut();
-            scope.try_block_context = Some(TryBlockContext {
+        let (new_items, usage) = self.with_scope(|this| {
+            let entry_loop_depth = this.scopes.loop_depth();
+            this.scopes.set_try_block_context(TryBlockContext {
                 ok_ty: ok_ty.clone(),
                 err_ty: err_ty.clone(),
-                carrier: TryCarrier::Unset,
-                loop_depth: DepthCounter::new(),
+                usage: TryUsage::default(),
+                entry_loop_depth,
             });
-        }
-
-        self.register_block_local_items(&items);
-
-        let new_items = self.infer_block_items(items, ok_ty.clone());
-
-        let carrier = {
-            let ctx = self
+            this.register_block_local_items(&items);
+            let new_items = this.infer_block_items(items, ok_ty.clone());
+            let usage = this
                 .scopes
-                .current()
-                .try_block_context
-                .as_ref()
-                .expect("try_block_context must exist");
-            ctx.carrier
-        };
+                .current_try_block_context()
+                .expect("try block scope must carry its context")
+                .usage;
+            (new_items, usage)
+        });
 
-        if !carrier.was_used() {
+        if !usage.was_used() {
             self.sink
                 .push(diagnostics::infer::try_block_no_question_mark(
                     try_keyword_span,
@@ -290,41 +283,27 @@ impl InferCtx<'_> {
             inner_ty
         };
 
-        let block_ty = match carrier {
-            TryCarrier::Result => {
+        let block_ty = match usage {
+            TryUsage::Carrier(TryCarrier::Result) => {
                 self.unify(&ok_ty, &inner_ty, &span);
                 self.type_result(store, inner_ty, err_ty)
             }
-            TryCarrier::Option => {
+            TryUsage::Carrier(TryCarrier::Option) => {
                 self.unify(&ok_ty, &inner_ty, &span);
                 self.type_option(store, inner_ty)
             }
-            TryCarrier::Unset | TryCarrier::Unknown => {
+            TryUsage::Unused | TryUsage::Unknown => {
                 let new_err_ty = self.new_type_var();
                 self.type_result(store, inner_ty, new_err_ty)
             }
         };
 
         self.unify(expected_ty, &block_ty, &try_keyword_span);
-        self.scopes.pop();
-
         Expression::TryBlock {
             items: new_items,
             ty: block_ty,
             try_keyword_span,
             span,
-        }
-    }
-
-    pub(super) fn increment_try_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_try_block_context_mut() {
-            ctx.loop_depth.increment();
-        }
-    }
-
-    pub(super) fn decrement_try_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_try_block_context_mut() {
-            ctx.loop_depth.decrement();
         }
     }
 
@@ -354,19 +333,13 @@ impl InferCtx<'_> {
             };
         }
 
-        self.scopes.push();
-        {
-            let scope = self.scopes.current_mut();
-            scope.recover_block_context = Some(RecoverBlockContext {
-                loop_depth: DepthCounter::new(),
-            });
-        }
-
-        self.register_block_local_items(&items);
-
-        let new_items = self.infer_block_items(items, inner_ty);
-
-        self.scopes.pop();
+        let new_items = self.with_scope(|this| {
+            let entry_loop_depth = this.scopes.loop_depth();
+            this.scopes
+                .set_recover_block_context(RecoverBlockContext { entry_loop_depth });
+            this.register_block_local_items(&items);
+            this.infer_block_items(items, inner_ty)
+        });
 
         let last_item = new_items.last().expect("block must have at least one item");
         let result_inner_ty = last_item.get_type();
@@ -386,18 +359,6 @@ impl InferCtx<'_> {
             ty: block_ty,
             recover_keyword_span,
             span,
-        }
-    }
-
-    pub(super) fn increment_recover_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_recover_block_context_mut() {
-            ctx.loop_depth.increment();
-        }
-    }
-
-    pub(super) fn decrement_recover_block_loop_depth(&mut self) {
-        if let Some(ctx) = self.scopes.lookup_recover_block_context_mut() {
-            ctx.loop_depth.decrement();
         }
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -1,5 +1,5 @@
 use crate::checker::EnvResolve;
-use crate::facts::SelectExhaustivenessCheck;
+use crate::facts::{BranchArm, SelectExhaustivenessCheck};
 use syntax::ast::{Expression, MatchArm, Pattern, SelectArm, Span};
 use syntax::program::{ChannelOperation, channel_operation};
 use syntax::types::{Type, unqualified_name};
@@ -55,12 +55,7 @@ impl InferCtx<'_> {
         let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
         let value_position = needs_reconciliation && !expected_ty.is_ignored();
 
-        let mut arm_target_types: Vec<Type> = if needs_reconciliation {
-            Vec::with_capacity(arms.len())
-        } else {
-            Vec::new()
-        };
-        let mut arm_target_spans: Vec<Span> = if value_position {
+        let mut branches: Vec<BranchArm> = if needs_reconciliation {
             Vec::with_capacity(arms.len())
         } else {
             Vec::new()
@@ -69,59 +64,61 @@ impl InferCtx<'_> {
         let new_arms: Vec<SelectArm> = arms
             .into_iter()
             .map(|arm| {
-                self.scopes.push();
+                self.with_scope(|this| {
+                    let independent_ty;
+                    let arm_target = if needs_reconciliation {
+                        independent_ty = this.new_type_var();
+                        &independent_ty
+                    } else {
+                        &result_ty
+                    };
 
-                let independent_ty;
-                let arm_target = if needs_reconciliation {
-                    independent_ty = self.new_type_var();
-                    &independent_ty
-                } else {
-                    &result_ty
-                };
+                    let new_arm = match arm {
+                        SelectArm::Receive {
+                            binding,
+                            receive_expression,
+                            body,
+                            ..
+                        } => {
+                            this.infer_select_receive(binding, receive_expression, body, arm_target)
+                        }
 
-                let new_arm = match arm {
-                    SelectArm::Receive {
-                        binding,
-                        receive_expression,
-                        body,
-                        ..
-                    } => self.infer_select_receive(binding, receive_expression, body, arm_target),
+                        SelectArm::Send {
+                            send_expression,
+                            body,
+                        } => this.infer_select_send(send_expression, body, arm_target),
 
-                    SelectArm::Send {
-                        send_expression,
-                        body,
-                    } => self.infer_select_send(send_expression, body, arm_target),
+                        SelectArm::MatchReceive {
+                            receive_expression,
+                            arms: match_arms,
+                        } => this.infer_select_match_receive(
+                            receive_expression,
+                            match_arms,
+                            arm_target,
+                            value_position,
+                        ),
 
-                    SelectArm::MatchReceive {
-                        receive_expression,
-                        arms: match_arms,
-                    } => self.infer_select_match_receive(
-                        receive_expression,
-                        match_arms,
-                        arm_target,
-                        value_position,
-                    ),
+                        SelectArm::WildCard { body } => {
+                            this.infer_select_wildcard(body, arm_target)
+                        }
+                    };
 
-                    SelectArm::WildCard { body } => self.infer_select_wildcard(body, arm_target),
-                };
+                    if needs_reconciliation {
+                        branches.push(BranchArm {
+                            ty: arm_target.clone(),
+                            span: select_arm_body_span(&new_arm),
+                        });
+                    }
 
-                if needs_reconciliation {
-                    arm_target_types.push(arm_target.clone());
-                }
-                if value_position {
-                    arm_target_spans.push(select_arm_body_span(&new_arm));
-                }
-
-                self.scopes.pop();
-
-                new_arm
+                    new_arm
+                })
             })
             .collect();
 
         if value_position {
-            self.reconcile_and_unify(&result_ty, &arm_target_types, &arm_target_spans, &span);
-        } else if needs_reconciliation && let Some(first) = arm_target_types.first() {
-            let _ = self.try_unify(&result_ty, first, &span);
+            self.reconcile_and_unify(&result_ty, &branches, &span);
+        } else if let Some(first) = branches.first() {
+            let _ = self.try_unify(&result_ty, &first.ty, &span);
         }
 
         let shorthand_receive_count = new_arms
@@ -285,12 +282,7 @@ impl InferCtx<'_> {
         let needs_reconciliation = result_ty.resolve_in(&self.env).is_variable();
         let reconcile_in_value_position = needs_reconciliation && value_position;
 
-        let mut arm_expression_types: Vec<Type> = if needs_reconciliation {
-            Vec::with_capacity(match_arms.len())
-        } else {
-            Vec::new()
-        };
-        let mut arm_expression_spans: Vec<Span> = if reconcile_in_value_position {
+        let mut branches: Vec<BranchArm> = if needs_reconciliation {
             Vec::with_capacity(match_arms.len())
         } else {
             Vec::new()
@@ -299,58 +291,51 @@ impl InferCtx<'_> {
         let new_match_arms: Vec<MatchArm> = match_arms
             .into_iter()
             .map(|match_arm| {
-                self.scopes.push();
+                self.with_scope(|this| {
+                    let new_pattern = this.infer_pattern(
+                        match_arm.pattern,
+                        pattern_ty.clone(),
+                        syntax::ast::BindingKind::MatchArm,
+                    );
 
-                let new_pattern = self.infer_pattern(
-                    match_arm.pattern,
-                    pattern_ty.clone(),
-                    syntax::ast::BindingKind::MatchArm,
-                );
+                    let bool_ty = this.type_bool();
+                    let new_guard = match_arm.guard.map(|guard| {
+                        let guard_expression = this.infer_expression(*guard, &bool_ty);
+                        Box::new(guard_expression)
+                    });
 
-                let bool_ty = self.type_bool();
-                let new_guard = match_arm.guard.map(|guard| {
-                    let guard_expression = self.infer_expression(*guard, &bool_ty);
-                    Box::new(guard_expression)
-                });
+                    let independent_ty;
+                    let arm_expected = if needs_reconciliation {
+                        independent_ty = this.new_type_var();
+                        &independent_ty
+                    } else {
+                        result_ty
+                    };
 
-                let independent_ty;
-                let arm_expected = if needs_reconciliation {
-                    independent_ty = self.new_type_var();
-                    &independent_ty
-                } else {
-                    result_ty
-                };
+                    let new_expression =
+                        this.infer_root_expression(*match_arm.expression, arm_expected);
 
-                let new_expression =
-                    self.infer_root_expression(*match_arm.expression, arm_expected);
+                    if needs_reconciliation {
+                        branches.push(BranchArm {
+                            ty: arm_expected.clone(),
+                            span: new_expression.get_span(),
+                        });
+                    }
 
-                if needs_reconciliation {
-                    arm_expression_types.push(arm_expected.clone());
-                }
-                if reconcile_in_value_position {
-                    arm_expression_spans.push(new_expression.get_span());
-                }
-
-                self.scopes.pop();
-
-                MatchArm {
-                    pattern: new_pattern,
-                    guard: new_guard,
-                    expression: Box::new(new_expression),
-                }
+                    MatchArm {
+                        pattern: new_pattern,
+                        guard: new_guard,
+                        expression: Box::new(new_expression),
+                    }
+                })
             })
             .collect();
 
         let span = new_receive_expression.get_span();
         if reconcile_in_value_position {
-            self.reconcile_and_unify(
-                result_ty,
-                &arm_expression_types,
-                &arm_expression_spans,
-                &span,
-            );
-        } else if needs_reconciliation && let Some(first) = arm_expression_types.first() {
-            let _ = self.try_unify(result_ty, first, &span);
+            self.reconcile_and_unify(result_ty, &branches, &span);
+        } else if let Some(first) = branches.first() {
+            let _ = self.try_unify(result_ty, &first.ty, &span);
         }
 
         SelectArm::MatchReceive {

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -104,28 +104,27 @@ impl InferCtx<'_> {
             .unwrap_or_else(|| ty.to_string());
         let pair = (type_id, interface_qualified_id.to_string());
 
-        if !self.satisfying_stack.insert(pair.clone()) {
+        let Some(violations) = self.with_satisfaction_check(pair, |this| {
+            let adapter_capable =
+                this.adapter_capable_receiver(ty, interface, interface_qualified_id);
+            let mut check = ConformanceTraversal {
+                receiver: ty,
+                span: *span,
+                adapter_capable,
+                violations: Vec::new(),
+                visiting: rustc_hash::FxHashSet::default(),
+            };
+            this.collect_interface_violations(
+                &mut check,
+                interface,
+                interface_qualified_id,
+                type_args,
+                None,
+            );
+            check.violations
+        }) else {
             return Ok(());
-        }
-
-        let adapter_capable = self.adapter_capable_receiver(ty, interface, interface_qualified_id);
-        let mut check = ConformanceTraversal {
-            receiver: ty,
-            span: *span,
-            adapter_capable,
-            violations: Vec::new(),
-            visiting: rustc_hash::FxHashSet::default(),
         };
-        self.collect_interface_violations(
-            &mut check,
-            interface,
-            interface_qualified_id,
-            type_args,
-            None,
-        );
-        let violations = check.violations;
-
-        self.satisfying_stack.remove(&pair);
 
         let builtin_receiver = self.is_builtin_receiver(ty);
 
@@ -201,6 +200,20 @@ impl InferCtx<'_> {
                 ));
         }
         Err(violations)
+    }
+
+    fn with_satisfaction_check<T>(
+        &mut self,
+        pair: (String, String),
+        check: impl FnOnce(&mut Self) -> T,
+    ) -> Option<T> {
+        if !self.satisfying_stack.insert(pair.clone()) {
+            return None;
+        }
+        let result = check(self);
+        let removed = self.satisfying_stack.remove(&pair);
+        debug_assert!(removed, "satisfaction check must remove its own guard");
+        Some(result)
     }
 
     fn is_builtin_receiver(&self, ty: &Type) -> bool {
@@ -599,34 +612,35 @@ impl InferCtx<'_> {
                 &map,
             );
 
-            if signature.receiver_pinned && signature.matched {
-                self.validate_comma_ok_abi(
-                    check,
-                    interface,
-                    interface_qualified_id,
-                    method_name,
-                    impl_method_name.as_str(),
-                );
-            }
-
-            if !signature.receiver_pinned {
-                method_violations.push(InterfaceMethodViolation::Missing(MissingMethod {
-                    name: method_name.to_string(),
-                    signature: method_ty.clone(),
-                    private_candidate: None,
-                }));
-            } else if !signature.matched {
-                method_violations.push(InterfaceMethodViolation::Incompatible {
-                    name: method_name.to_string(),
-                    expected: signature.substituted_method,
-                    actual: signature.incompatible_impl,
-                });
-            } else {
-                let spelling_pinned = syntax::go_names::interface_matches_by_source_name(
-                    interface_qualified_id,
-                    interface_is_public,
-                );
-                self.record_conformance_use(ty, impl_method_name.as_str(), spelling_pinned);
+            match signature {
+                SignatureCheck::Matched => {
+                    self.validate_comma_ok_abi(
+                        check,
+                        interface,
+                        interface_qualified_id,
+                        method_name,
+                        impl_method_name.as_str(),
+                    );
+                    let spelling_pinned = syntax::go_names::interface_matches_by_source_name(
+                        interface_qualified_id,
+                        interface_is_public,
+                    );
+                    self.record_conformance_use(ty, impl_method_name.as_str(), spelling_pinned);
+                }
+                SignatureCheck::ReceiverMismatch => {
+                    method_violations.push(InterfaceMethodViolation::Missing(MissingMethod {
+                        name: method_name.to_string(),
+                        signature: method_ty.clone(),
+                        private_candidate: None,
+                    }));
+                }
+                SignatureCheck::Incompatible { expected, actual } => {
+                    method_violations.push(InterfaceMethodViolation::Incompatible {
+                        name: method_name.to_string(),
+                        expected,
+                        actual,
+                    });
+                }
             }
         }
 
@@ -720,7 +734,7 @@ impl InferCtx<'_> {
             &impl_method,
             map,
         );
-        (signature.receiver_pinned && signature.matched).then_some(impl_name)
+        matches!(signature, SignatureCheck::Matched).then_some(impl_name)
     }
 
     fn check_method_signature(
@@ -767,33 +781,39 @@ impl InferCtx<'_> {
         )
         .unwrap_or_else(|| impl_method_without_receiver.clone());
 
-        let candidate_ty = ty.strip_refs().resolve_in(&self.env);
-        let mut receiver_pinned = true;
-        let mut resolved_impl_method = None;
-        self.scopes.enter_invariant_position();
-        let sig_match = self.speculatively(|this| {
-            let mut ctx = InferCtx::new(this, store);
-            if let Some(receiver) = &receiver_to_pin {
-                ctx.try_unify(receiver, &candidate_ty, &Span::dummy())
-                    .inspect_err(|_| receiver_pinned = false)?;
-            }
-            let result = ctx.try_unify(
-                &strip_bounds(&substituted_method),
-                &strip_bounds(&impl_for_unify),
-                &Span::dummy(),
-            );
-            if result.is_err() {
-                resolved_impl_method = Some(impl_method_without_receiver.resolve_in(&ctx.env));
-            }
-            result
-        });
-        self.scopes.exit_invariant_position();
+        enum Mismatch {
+            Receiver,
+            Signature,
+        }
 
-        SignatureCheck {
-            receiver_pinned,
-            matched: sig_match.is_ok(),
-            substituted_method,
-            incompatible_impl: resolved_impl_method.unwrap_or(impl_method_without_receiver),
+        let candidate_ty = ty.strip_refs().resolve_in(&self.env);
+        let mut resolved_impl_method = None;
+        let sig_match = self.in_invariant_position(|ctx| {
+            ctx.speculatively(|this| {
+                let mut ctx = InferCtx::new(this, store);
+                if let Some(receiver) = &receiver_to_pin {
+                    ctx.try_unify(receiver, &candidate_ty, &Span::dummy())
+                        .map_err(|_| Mismatch::Receiver)?;
+                }
+                ctx.try_unify(
+                    &strip_bounds(&substituted_method),
+                    &strip_bounds(&impl_for_unify),
+                    &Span::dummy(),
+                )
+                .map_err(|_| {
+                    resolved_impl_method = Some(impl_method_without_receiver.resolve_in(&ctx.env));
+                    Mismatch::Signature
+                })
+            })
+        });
+
+        match sig_match {
+            Ok(()) => SignatureCheck::Matched,
+            Err(Mismatch::Receiver) => SignatureCheck::ReceiverMismatch,
+            Err(Mismatch::Signature) => SignatureCheck::Incompatible {
+                expected: substituted_method,
+                actual: resolved_impl_method.unwrap_or(impl_method_without_receiver),
+            },
         }
     }
 
@@ -858,11 +878,10 @@ enum SelectedMethod {
     Missing,
 }
 
-struct SignatureCheck {
-    receiver_pinned: bool,
-    matched: bool,
-    substituted_method: Type,
-    incompatible_impl: Type,
+enum SignatureCheck {
+    Matched,
+    ReceiverMismatch,
+    Incompatible { expected: Type, actual: Type },
 }
 
 fn method_definition_public(

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -92,7 +92,7 @@ impl InferCtx<'_> {
                     file_comment: file.file_comment,
                 };
 
-                ctx.typed_files.push((module_id.to_string(), typed_file));
+                ctx.typed_files.push(typed_file);
             },
         );
     }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -303,7 +303,7 @@ impl InferCtx<'_> {
             .is_some_and(|definition| definition.is_transparent_type_alias())
     }
 
-    fn in_invariant_position<T>(&mut self, unify: impl FnOnce(&mut Self) -> T) -> T {
+    pub(super) fn in_invariant_position<T>(&mut self, unify: impl FnOnce(&mut Self) -> T) -> T {
         self.scopes.enter_invariant_position();
         let result = unify(self);
         self.scopes.exit_invariant_position();

--- a/crates/semantics/src/checker/infer/validation/const_cycles.rs
+++ b/crates/semantics/src/checker/infer/validation/const_cycles.rs
@@ -11,6 +11,11 @@ struct ConstEntry<'a> {
     body: &'a Expression,
 }
 
+struct ConstNode<'a> {
+    dependencies: Vec<&'a EcoString>,
+    span: Span,
+}
+
 impl InferCtx<'_> {
     pub fn check_const_cycles(&mut self, items_per_file: &[&[Expression]]) {
         let mut consts: Vec<ConstEntry<'_>> = Vec::new();
@@ -39,15 +44,19 @@ impl InferCtx<'_> {
 
         let const_names: HashSet<&EcoString> = consts.iter().map(|c| c.name).collect();
 
-        let mut deps: HashMap<&EcoString, Vec<&EcoString>> = HashMap::default();
-        let mut spans: HashMap<&EcoString, Span> = HashMap::default();
+        let mut nodes: HashMap<&EcoString, ConstNode<'_>> = HashMap::default();
         for entry in &consts {
             let mut refs: Vec<&EcoString> = Vec::new();
             collect_const_refs(entry.body, &const_names, &mut refs);
             refs.sort();
             refs.dedup();
-            deps.insert(entry.name, refs);
-            spans.insert(entry.name, entry.name_span);
+            nodes.insert(
+                entry.name,
+                ConstNode {
+                    dependencies: refs,
+                    span: entry.name_span,
+                },
+            );
         }
 
         let mut color: HashMap<&EcoString, Color> = HashMap::default();
@@ -61,8 +70,7 @@ impl InferCtx<'_> {
                 let mut path: Vec<&EcoString> = Vec::new();
                 dfs(
                     entry.name,
-                    &deps,
-                    &spans,
+                    &nodes,
                     &mut color,
                     &mut path,
                     &mut reported,
@@ -82,8 +90,7 @@ enum Color {
 
 fn dfs<'a>(
     node: &'a EcoString,
-    deps: &HashMap<&'a EcoString, Vec<&'a EcoString>>,
-    spans: &HashMap<&'a EcoString, Span>,
+    nodes: &HashMap<&'a EcoString, ConstNode<'a>>,
     color: &mut HashMap<&'a EcoString, Color>,
     path: &mut Vec<&'a EcoString>,
     reported: &mut HashSet<&'a EcoString>,
@@ -92,18 +99,18 @@ fn dfs<'a>(
     color.insert(node, Color::Gray);
     path.push(node);
 
-    if let Some(neighbors) = deps.get(node) {
-        for next in neighbors {
+    if let Some(current) = nodes.get(node) {
+        for next in &current.dependencies {
             match color.get(next).copied().unwrap_or(Color::White) {
-                Color::White => dfs(next, deps, spans, color, path, reported, sink),
+                Color::White => dfs(next, nodes, color, path, reported, sink),
                 Color::Gray => {
                     let start = path.iter().position(|n| *n == *next).unwrap_or(0);
                     let cycle: Vec<String> = path[start..].iter().map(|n| n.to_string()).collect();
                     let representative = path[start];
                     if reported.insert(representative)
-                        && let Some(span) = spans.get(representative)
+                        && let Some(representative) = nodes.get(representative)
                     {
-                        sink.push(diagnostics::infer::const_cycle(&cycle, *span));
+                        sink.push(diagnostics::infer::const_cycle(&cycle, representative.span));
                     }
                 }
                 Color::Black => {}

--- a/crates/semantics/src/checker/infer/validation/control_flow.rs
+++ b/crates/semantics/src/checker/infer/validation/control_flow.rs
@@ -84,7 +84,7 @@ impl InferCtx<'_> {
 
     pub(crate) fn check_break_in_try_block(&mut self, span: Span) {
         if let Some(ctx) = self.scopes.lookup_try_block_context()
-            && !ctx.loop_depth.is_active()
+            && self.scopes.loop_depth() == ctx.entry_loop_depth
         {
             self.sink.push(diagnostics::infer::break_in_try_block(span));
         }
@@ -92,7 +92,7 @@ impl InferCtx<'_> {
 
     pub(crate) fn check_continue_in_try_block(&mut self, span: Span) {
         if let Some(ctx) = self.scopes.lookup_try_block_context()
-            && !ctx.loop_depth.is_active()
+            && self.scopes.loop_depth() == ctx.entry_loop_depth
         {
             self.sink
                 .push(diagnostics::infer::continue_in_try_block(span));
@@ -108,7 +108,7 @@ impl InferCtx<'_> {
 
     pub(crate) fn check_break_in_recover_block(&mut self, span: Span) {
         if let Some(ctx) = self.scopes.lookup_recover_block_context()
-            && !ctx.loop_depth.is_active()
+            && self.scopes.loop_depth() == ctx.entry_loop_depth
         {
             self.sink
                 .push(diagnostics::infer::break_in_recover_block(span));
@@ -117,7 +117,7 @@ impl InferCtx<'_> {
 
     pub(crate) fn check_continue_in_recover_block(&mut self, span: Span) {
         if let Some(ctx) = self.scopes.lookup_recover_block_context()
-            && !ctx.loop_depth.is_active()
+            && self.scopes.loop_depth() == ctx.entry_loop_depth
         {
             self.sink
                 .push(diagnostics::infer::continue_in_recover_block(span));

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -14,7 +14,7 @@ use crate::facts::{BindingIdAllocator, Facts};
 use crate::store::Store;
 use diagnostics::LocalSink;
 use ecow::EcoString;
-use registration::derived_attributes::DerivedAttribute;
+use registration::derived_attributes::PendingEqualityAttributes;
 use scopes::Scopes;
 use syntax::ast::Visibility as AstVisibility;
 use syntax::ast::{Annotation, Expression, Generic, ImportAlias, Span, StructFieldDefinition};
@@ -120,7 +120,7 @@ pub(crate) enum FileContextKind {
 }
 
 struct SavedFileContext {
-    file_id: Option<u32>,
+    cursor: Cursor,
     scopes: Scopes,
     imports: ImportState,
 }
@@ -134,8 +134,8 @@ pub(crate) struct TaskOutput {
     facts: Facts,
     module_fields: Arc<ModuleFieldMap>,
     ufcs_methods: Arc<HashSet<UfcsMethod>>,
-    typed_files: Vec<(String, File)>,
-    pending_equality_attributes: Vec<DerivedAttribute>,
+    typed_files: Vec<File>,
+    pending_equality_attributes: Vec<PendingEqualityAttributes>,
     pending_generic_bound_checks: Vec<(Type, Type, Span)>,
     pending_interface_bound_checks: Vec<(Type, Type, Span)>,
     sink: LocalSink,
@@ -155,10 +155,12 @@ impl TaskSeed {
             module_fields,
             ufcs_methods,
         } = self;
-        let mut task = TaskState::new(binding_ids.clone(), LocalSink::new());
-        task.module_fields = module_fields.clone();
-        task.ufcs_methods = ufcs_methods.clone();
-        task
+        TaskState::new(
+            binding_ids.clone(),
+            LocalSink::new(),
+            module_fields.clone(),
+            ufcs_methods.clone(),
+        )
     }
 }
 
@@ -182,9 +184,9 @@ pub struct TaskState {
     /// while task-local additions are returned as part of their output.
     ufcs_methods: Arc<HashSet<UfcsMethod>>,
     /// Typed files produced by inference.
-    pub typed_files: Vec<(String, File)>,
+    pub typed_files: Vec<File>,
     /// Equality synthesis waits until registration has discovered all UFCS methods.
-    pub(crate) pending_equality_attributes: Vec<DerivedAttribute>,
+    pub(crate) pending_equality_attributes: Vec<PendingEqualityAttributes>,
     pub(crate) pending_generic_bound_checks: Vec<(Type, Type, Span)>,
     /// Interface bounds on concrete type arguments named in annotations. Drained
     /// once after inference, since body annotations register during it.
@@ -192,7 +194,12 @@ pub struct TaskState {
 }
 
 impl TaskState {
-    fn new(binding_ids: Arc<BindingIdAllocator>, sink: LocalSink) -> Self {
+    fn new(
+        binding_ids: Arc<BindingIdAllocator>,
+        sink: LocalSink,
+        module_fields: Arc<ModuleFieldMap>,
+        ufcs_methods: Arc<HashSet<UfcsMethod>>,
+    ) -> Self {
         Self {
             env: TypeEnv::new(),
             scopes: Scopes::new(),
@@ -202,8 +209,8 @@ impl TaskState {
             facts: Facts::new(binding_ids),
             satisfying_stack: rustc_hash::FxHashSet::default(),
             method_cache: HashMap::default(),
-            module_fields: Arc::default(),
-            ufcs_methods: Arc::default(),
+            module_fields,
+            ufcs_methods,
             typed_files: Vec::new(),
             pending_equality_attributes: Vec::new(),
             pending_generic_bound_checks: Vec::new(),
@@ -212,11 +219,28 @@ impl TaskState {
     }
 
     pub fn with_fresh_allocator() -> Self {
-        Self::new(Arc::new(BindingIdAllocator::new()), LocalSink::new())
+        Self::new(
+            Arc::new(BindingIdAllocator::new()),
+            LocalSink::new(),
+            Arc::default(),
+            Arc::default(),
+        )
     }
 
     pub(crate) fn with_sink(sink: LocalSink) -> Self {
-        Self::new(Arc::new(BindingIdAllocator::new()), sink)
+        Self::new(
+            Arc::new(BindingIdAllocator::new()),
+            sink,
+            Arc::default(),
+            Arc::default(),
+        )
+    }
+
+    pub(crate) fn with_scope<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.scopes.push();
+        let result = f(self);
+        self.scopes.pop();
+        result
     }
 
     pub(crate) fn worker_seed(&self) -> TaskSeed {
@@ -395,10 +419,7 @@ impl TaskState {
     pub(crate) fn put_in_scope(&mut self, generics: &[Generic]) {
         for (index, generic) in generics.iter().enumerate() {
             self.scopes
-                .current_mut()
-                .type_params
-                .get_or_insert_with(HashMap::default)
-                .insert(generic.name.to_string(), index);
+                .insert_type_param(generic.name.to_string(), index);
         }
     }
 
@@ -443,16 +464,7 @@ impl TaskState {
 
     fn record_generic_bound(&mut self, parameter: &str, bound: Type) {
         let qualified_parameter = self.qualify_name(parameter);
-        let bounds = self
-            .scopes
-            .current_mut()
-            .trait_bounds
-            .get_or_insert_with(HashMap::default)
-            .entry(qualified_parameter)
-            .or_default();
-        if !bounds.contains(&bound) {
-            bounds.push(bound);
-        }
+        self.scopes.insert_trait_bound(qualified_parameter, bound);
     }
 
     fn parameter_satisfies_bound(&self, parameter: &str, target: infer::BuiltinBound) -> bool {
@@ -548,7 +560,7 @@ impl TaskState {
     fn current_file_is_test(&self, store: &Store) -> bool {
         self.cursor
             .file_id
-            .is_some_and(|file_id| store.test_file_ids.contains(&file_id))
+            .is_some_and(|file_id| store.is_test_file(file_id))
     }
 
     /// A test-file definition is visible only to test files of the same module.
@@ -801,12 +813,10 @@ impl TaskState {
         kind: FileContextKind,
         f: impl FnOnce(&mut Self, &Store) -> T,
     ) -> T {
-        self.with_module_cursor(module_id, |this| {
-            let saved = this.enter_file_context(store, module_id, file_id, imports, kind);
-            let result = f(this, store);
-            this.exit_file_context(saved);
-            result
-        })
+        let saved = self.enter_file_context(store, module_id, file_id, imports, kind);
+        let result = f(self, store);
+        self.exit_file_context(saved);
+        result
     }
 
     pub(crate) fn with_file_context_mut<T>(
@@ -818,12 +828,10 @@ impl TaskState {
         kind: FileContextKind,
         f: impl FnOnce(&mut Self, &mut Store) -> T,
     ) -> T {
-        self.with_module_cursor(module_id, |this| {
-            let saved = this.enter_file_context(&*store, module_id, file_id, imports, kind);
-            let result = f(this, store);
-            this.exit_file_context(saved);
-            result
-        })
+        let saved = self.enter_file_context(&*store, module_id, file_id, imports, kind);
+        let result = f(self, store);
+        self.exit_file_context(saved);
+        result
     }
 
     fn enter_file_context(
@@ -835,7 +843,13 @@ impl TaskState {
         kind: FileContextKind,
     ) -> SavedFileContext {
         let saved = SavedFileContext {
-            file_id: self.cursor.file_id.replace(file_id),
+            cursor: std::mem::replace(
+                &mut self.cursor,
+                Cursor {
+                    module_id: module_id.into(),
+                    file_id: Some(file_id),
+                },
+            ),
             scopes: std::mem::take(&mut self.scopes),
             imports: std::mem::take(&mut self.imports),
         };
@@ -879,9 +893,9 @@ impl TaskState {
     }
 
     fn exit_file_context(&mut self, saved: SavedFileContext) {
+        self.cursor = saved.cursor;
         self.scopes = saved.scopes;
         self.imports = saved.imports;
-        self.cursor.file_id = saved.file_id;
     }
 
     pub fn failed(&self) -> bool {

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -25,11 +25,7 @@ pub enum MemberKind {
 #[derive(Clone, Debug)]
 pub struct ResolvedMember {
     pub(crate) depth: usize,
-    #[cfg_attr(not(test), expect(dead_code))]
-    embed_path: Vec<EcoString>,
     pub declaring_type: Symbol,
-    #[cfg_attr(not(test), expect(dead_code))]
-    indirect: bool,
     pub kind: MemberKind,
 }
 
@@ -105,14 +101,13 @@ struct Entry {
     indirect: bool,
     /// Reached by more than one path at this depth, so its members collide.
     multiples: bool,
-    embed_path: Vec<EcoString>,
 }
 
 fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
     let mut visited: Vec<Entry> = Vec::new();
     let mut seen: HashSet<String> = HashSet::default();
 
-    let Some(root) = nominal_entry(store, outer.clone(), 0, false, false, Vec::new()) else {
+    let Some(root) = nominal_entry(store, outer.clone(), 0, false, false) else {
         return visited;
     };
     let mut current = vec![root];
@@ -145,15 +140,12 @@ fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
                 let field_ty = instantiate_field(store, &entry.ty, &field.ty);
                 let resolved_field = store.deep_resolve_alias(&field_ty);
                 let (target, is_pointer) = deref_once(&resolved_field);
-                let mut path = entry.embed_path.clone();
-                path.push(field.name.clone());
                 if let Some(child) = nominal_entry(
                     store,
                     target,
                     depth + 1,
                     entry.indirect || is_pointer,
                     entry.multiples,
-                    path,
                 ) {
                     next.push(child);
                 }
@@ -272,9 +264,7 @@ fn build_member(outer: &Type, entry: &Entry, candidate: &Candidate) -> ResolvedM
 
     ResolvedMember {
         depth: entry.depth,
-        embed_path: entry.embed_path.clone(),
         declaring_type: candidate.declaring_type.clone(),
-        indirect: entry.indirect,
         kind,
     }
 }
@@ -309,7 +299,6 @@ fn nominal_entry(
     depth: usize,
     indirect: bool,
     multiples: bool,
-    embed_path: Vec<EcoString>,
 ) -> Option<Entry> {
     let resolved = store.deep_resolve_alias(&target);
     if !matches!(resolved, Type::Nominal { .. }) {
@@ -320,7 +309,6 @@ fn nominal_entry(
         depth,
         indirect,
         multiples,
-        embed_path,
     })
 }
 
@@ -631,8 +619,6 @@ mod tests {
         b.struct_("N1", vec![vembed("N0")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N1"), "m"));
         assert_eq!(member.depth, 1);
-        assert_eq!(member.embed_path, vec![EcoString::from("N0")]);
-        assert!(!member.indirect);
         assert!(!is_pointer_receiver(&member));
     }
 
@@ -642,7 +628,6 @@ mod tests {
         b.struct_("N0", vec![], vec![("pm", pointer_method("N0"))]);
         b.struct_("N1", vec![vembed("N0")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N1"), "pm"));
-        assert!(!member.indirect);
         assert!(is_pointer_receiver(&member));
     }
 
@@ -652,7 +637,6 @@ mod tests {
         b.struct_("N0", vec![], vec![("pm", pointer_method("N0"))]);
         b.struct_("N1", vec![pembed("N0")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N1"), "pm"));
-        assert!(member.indirect);
         assert!(!is_pointer_receiver(&member));
     }
 
@@ -662,7 +646,6 @@ mod tests {
         b.struct_("N0", vec![], vec![("m", value_method("N0"))]);
         b.struct_("N1", vec![pembed("N0")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N1"), "m"));
-        assert!(member.indirect);
         assert!(!is_pointer_receiver(&member));
     }
 
@@ -675,7 +658,6 @@ mod tests {
         b.struct_("N3", vec![vembed("N2")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N3"), "pm"));
         assert_eq!(member.depth, 3);
-        assert!(!member.indirect);
         assert!(is_pointer_receiver(&member));
     }
 
@@ -688,7 +670,6 @@ mod tests {
         b.struct_("N3", vec![vembed("N2")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N3"), "pm"));
         assert_eq!(member.depth, 3);
-        assert!(member.indirect);
         assert!(!is_pointer_receiver(&member));
     }
 
@@ -701,7 +682,6 @@ mod tests {
         b.struct_("N3", vec![vembed("N2")], vec![]);
         let member = found(resolve_selector(&b.store, &nominal("N3"), "m"));
         assert_eq!(member.depth, 3);
-        assert!(!member.indirect);
         assert!(!is_pointer_receiver(&member));
     }
 

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -1,5 +1,3 @@
-use rustc_hash::FxHashMap as HashMap;
-
 use crate::checker::EnvResolve;
 use crate::checker::infer::BuiltinBound;
 use crate::checker::infer::expressions::comparison::{
@@ -13,6 +11,7 @@ use syntax::types::{
 };
 
 use crate::checker::TaskState;
+use crate::checker::scopes::DeferredMapKeyCheck;
 use crate::generics::apply_bounds;
 use crate::prelude::PRELUDE_MODULE_ID;
 use crate::store::Store;
@@ -623,10 +622,7 @@ impl TaskState {
 
         for (i, (name, param_span)) in undeclared.iter().enumerate() {
             self.scopes
-                .current_mut()
-                .type_params
-                .get_or_insert_with(HashMap::default)
-                .insert(name.clone(), generics.len() + i);
+                .insert_type_param(name.clone(), generics.len() + i);
             self.sink
                 .push(diagnostics::infer::undeclared_impl_type_param(
                     name,
@@ -675,14 +671,17 @@ impl TaskState {
     }
 
     pub(crate) fn check_deferred_map_key_bounds(&mut self, store: &Store) {
-        for (key, span, check_concrete) in self.scopes.take_deferred_map_key_checks() {
-            if check_concrete {
-                let resolved = key.resolve_in(&self.env);
-                if !store.resolves_to_unknown(&resolved) {
-                    self.check_map_key_comparable(store, &resolved, span);
+        for check in self.scopes.take_deferred_map_key_checks() {
+            match check {
+                DeferredMapKeyCheck::Comparable { key, span } => {
+                    let resolved = key.resolve_in(&self.env);
+                    if !store.resolves_to_unknown(&resolved) {
+                        self.check_map_key_comparable(store, &resolved, span);
+                    }
                 }
-            } else {
-                self.check_missing_map_key_bounds(store, &key, span);
+                DeferredMapKeyCheck::Bounds { key, span } => {
+                    self.check_missing_map_key_bounds(store, &key, span);
+                }
             }
         }
     }

--- a/crates/semantics/src/checker/registration/derived_attributes.rs
+++ b/crates/semantics/src/checker/registration/derived_attributes.rs
@@ -4,13 +4,6 @@ use syntax::ast::{Attribute, Expression, Span, VariantFields};
 use super::TaskState;
 use crate::store::Store;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DerivedAttributeKind {
-    Display,
-    Equality,
-    Iterate,
-}
-
 #[derive(Debug, Clone)]
 pub(crate) enum DerivedAttributeTarget {
     Struct {
@@ -25,18 +18,38 @@ pub(crate) enum DerivedAttributeTarget {
     Misplaced,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DerivedAttributeKind {
+    Display,
+    Equality,
+    Iterate,
+}
+
 /// One source occurrence of an attribute that synthesizes a type capability.
 ///
 /// Placement is classified once for all three attributes. This keeps additions to
 /// the AST from being accepted or rejected differently by parallel scanners.
 #[derive(Debug, Clone)]
 pub(crate) struct DerivedAttribute {
-    pub(crate) module_id: String,
-    pub(crate) kind: DerivedAttributeKind,
     pub(crate) span: Span,
     pub(crate) has_args: bool,
-    pub(crate) is_d_lis: bool,
     pub(crate) target: DerivedAttributeTarget,
+    kind: DerivedAttributeKind,
+}
+
+pub(crate) struct DerivedAttributeContext {
+    pub(crate) module_id: String,
+    pub(crate) is_d_lis: bool,
+}
+
+struct DerivedAttributes {
+    context: DerivedAttributeContext,
+    candidates: Vec<DerivedAttribute>,
+}
+
+pub(crate) struct PendingEqualityAttributes {
+    pub(crate) context: DerivedAttributeContext,
+    pub(crate) candidates: Vec<DerivedAttribute>,
 }
 
 impl TaskState {
@@ -45,8 +58,13 @@ impl TaskState {
         store: &mut Store,
         items: &[Expression],
     ) {
-        let candidates =
-            collect_derived_attributes(&self.cursor.module_id, self.is_d_lis(store), items);
+        let candidates = collect_derived_attributes(
+            DerivedAttributeContext {
+                module_id: self.cursor.module_id.clone(),
+                is_d_lis: self.is_d_lis(store),
+            },
+            items,
+        );
         self.register_derived_attributes(store, candidates);
     }
 
@@ -60,35 +78,61 @@ impl TaskState {
             module
                 .files
                 .values()
-                .flat_map(|file| {
-                    collect_derived_attributes(module_id, file.is_d_lis(), &file.items)
+                .map(|file| {
+                    collect_derived_attributes(
+                        DerivedAttributeContext {
+                            module_id: module_id.to_string(),
+                            is_d_lis: file.is_d_lis(),
+                        },
+                        &file.items,
+                    )
                 })
-                .collect()
+                .collect::<Vec<_>>()
         };
-        self.register_derived_attributes(store, candidates);
+        for candidates in candidates {
+            self.register_derived_attributes(store, candidates);
+        }
     }
 
-    fn register_derived_attributes(
-        &mut self,
-        store: &mut Store,
-        candidates: Vec<DerivedAttribute>,
-    ) {
-        self.register_iterate(store, &candidates);
-        self.register_display(store, &candidates);
-        self.pending_equality_attributes.extend(
-            candidates
-                .into_iter()
-                .filter(|candidate| candidate.kind == DerivedAttributeKind::Equality),
-        );
+    fn register_derived_attributes(&mut self, store: &mut Store, candidates: DerivedAttributes) {
+        let DerivedAttributes {
+            context,
+            candidates,
+        } = candidates;
+        for candidate in candidates
+            .iter()
+            .filter(|candidate| candidate.kind == DerivedAttributeKind::Iterate)
+        {
+            self.process_iterate_candidate(store, &context, candidate);
+        }
+        for candidate in candidates
+            .iter()
+            .filter(|candidate| candidate.kind == DerivedAttributeKind::Display)
+        {
+            self.process_display_candidate(store, &context, candidate);
+        }
+        let equality: Vec<_> = candidates
+            .into_iter()
+            .filter(|candidate| candidate.kind == DerivedAttributeKind::Equality)
+            .collect();
+        if !equality.is_empty() {
+            self.pending_equality_attributes
+                .push(PendingEqualityAttributes {
+                    context,
+                    candidates: equality,
+                });
+        }
     }
 }
 
 fn collect_derived_attributes(
-    module_id: &str,
-    is_d_lis: bool,
+    context: DerivedAttributeContext,
     items: &[Expression],
-) -> Vec<DerivedAttribute> {
-    let mut out = Vec::new();
+) -> DerivedAttributes {
+    let mut out = DerivedAttributes {
+        context,
+        candidates: Vec::new(),
+    };
     for item in items {
         match item {
             Expression::Struct {
@@ -98,16 +142,12 @@ fn collect_derived_attributes(
                 ..
             } => {
                 collect_attributes(
-                    module_id,
-                    is_d_lis,
                     attributes,
                     DerivedAttributeTarget::Struct { name: name.clone() },
                     &mut out,
                 );
                 for field in fields {
                     collect_attributes(
-                        module_id,
-                        is_d_lis,
                         field.attributes(),
                         DerivedAttributeTarget::Misplaced,
                         &mut out,
@@ -122,8 +162,6 @@ fn collect_derived_attributes(
                 variants,
                 ..
             } => collect_attributes(
-                module_id,
-                is_d_lis,
                 attributes,
                 DerivedAttributeTarget::Enum {
                     name: name.clone(),
@@ -137,13 +175,7 @@ fn collect_derived_attributes(
                 &mut out,
             ),
             Expression::Function { attributes, .. } | Expression::TypeAlias { attributes, .. } => {
-                collect_attributes(
-                    module_id,
-                    is_d_lis,
-                    attributes,
-                    DerivedAttributeTarget::Misplaced,
-                    &mut out,
-                )
+                collect_attributes(attributes, DerivedAttributeTarget::Misplaced, &mut out)
             }
             Expression::ImplBlock { methods, .. }
             | Expression::Interface {
@@ -152,13 +184,7 @@ fn collect_derived_attributes(
             } => {
                 for method in methods {
                     if let Expression::Function { attributes, .. } = method {
-                        collect_attributes(
-                            module_id,
-                            is_d_lis,
-                            attributes,
-                            DerivedAttributeTarget::Misplaced,
-                            &mut out,
-                        );
+                        collect_attributes(attributes, DerivedAttributeTarget::Misplaced, &mut out);
                     }
                 }
             }
@@ -169,29 +195,21 @@ fn collect_derived_attributes(
 }
 
 fn collect_attributes(
-    module_id: &str,
-    is_d_lis: bool,
     attributes: &[Attribute],
     target: DerivedAttributeTarget,
-    out: &mut Vec<DerivedAttribute>,
+    out: &mut DerivedAttributes,
 ) {
-    const DERIVED: [(&str, DerivedAttributeKind); 3] = [
-        ("display", DerivedAttributeKind::Display),
-        ("equality", DerivedAttributeKind::Equality),
-        ("iterate", DerivedAttributeKind::Iterate),
-    ];
-
-    for (name, kind) in DERIVED {
-        let Some(attribute) = attributes.iter().find(|attribute| attribute.name == name) else {
-            continue;
-        };
-        out.push(DerivedAttribute {
-            module_id: module_id.to_string(),
-            kind,
-            span: attribute.span,
-            has_args: !attribute.args.is_empty(),
-            is_d_lis,
-            target: target.clone(),
-        });
-    }
+    let mut collect = |name: &str, kind, target| {
+        if let Some(attribute) = attributes.iter().find(|attribute| attribute.name == name) {
+            out.candidates.push(DerivedAttribute {
+                span: attribute.span,
+                has_args: !attribute.args.is_empty(),
+                target,
+                kind,
+            });
+        }
+    };
+    collect("display", DerivedAttributeKind::Display, target.clone());
+    collect("equality", DerivedAttributeKind::Equality, target.clone());
+    collect("iterate", DerivedAttributeKind::Iterate, target);
 }

--- a/crates/semantics/src/checker/registration/display.rs
+++ b/crates/semantics/src/checker/registration/display.rs
@@ -5,21 +5,17 @@ use syntax::types::{FunctionParameter, Symbol, Type};
 use super::{TaskState, wrap_with_impl_generics};
 use crate::call_classification::is_ufcs_method_type;
 use crate::checker::registration::derived_attributes::{
-    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+    DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
 
 impl TaskState {
-    pub(super) fn register_display(&mut self, store: &mut Store, candidates: &[DerivedAttribute]) {
-        for candidate in candidates
-            .iter()
-            .filter(|candidate| candidate.kind == DerivedAttributeKind::Display)
-        {
-            self.process_display_candidate(store, candidate);
-        }
-    }
-
-    fn process_display_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
+    pub(super) fn process_display_candidate(
+        &mut self,
+        store: &mut Store,
+        context: &DerivedAttributeContext,
+        candidate: &DerivedAttribute,
+    ) {
         let (name, is_struct) = match &candidate.target {
             DerivedAttributeTarget::Misplaced => {
                 self.sink
@@ -39,13 +35,13 @@ impl TaskState {
                 ));
             return;
         }
-        if candidate.is_d_lis {
+        if context.is_d_lis {
             self.sink
                 .push(diagnostics::attribute::display_in_typedef(&candidate.span));
             return;
         }
 
-        let qualified = Symbol::from_parts(&candidate.module_id, name);
+        let qualified = Symbol::from_parts(&context.module_id, name);
         if is_struct
             && let Some(definition) = store.get_definition(qualified.as_str())
             && definition.is_pointer_backed_newtype(|id| store.get_definition(id))
@@ -57,7 +53,7 @@ impl TaskState {
             return;
         }
 
-        self.synthesize_to_string(store, &candidate.module_id, &candidate.span, &qualified);
+        self.synthesize_to_string(store, &context.module_id, &candidate.span, &qualified);
     }
 
     fn synthesize_to_string(

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -8,7 +8,7 @@ use syntax::types::{FunctionParameter, Symbol, Type};
 use super::{TaskState, resolved_generic_bounds, wrap_with_impl_generics};
 use crate::checker::infer::expressions::comparison::{check_not_equatable, param_is_comparable};
 use crate::checker::registration::derived_attributes::{
-    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+    DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
 
@@ -34,15 +34,19 @@ enum UserEquals {
 }
 
 impl TaskState {
-    fn process_equality_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
-        debug_assert_eq!(candidate.kind, DerivedAttributeKind::Equality);
+    fn process_equality_candidate(
+        &mut self,
+        store: &mut Store,
+        context: &DerivedAttributeContext,
+        candidate: &DerivedAttribute,
+    ) -> Option<Symbol> {
         let name = match &candidate.target {
             DerivedAttributeTarget::Misplaced => {
                 self.sink
                     .push(diagnostics::attribute::equality_not_a_struct_or_enum(
                         &candidate.span,
                     ));
-                return;
+                return None;
             }
             DerivedAttributeTarget::Struct { name } | DerivedAttributeTarget::Enum { name, .. } => {
                 name
@@ -54,21 +58,21 @@ impl TaskState {
                 .push(diagnostics::attribute::equality_with_arguments(
                     &candidate.span,
                 ));
-            return;
+            return None;
         }
-        if candidate.is_d_lis {
+        if context.is_d_lis {
             self.sink
                 .push(diagnostics::attribute::equality_in_typedef(&candidate.span));
-            return;
+            return None;
         }
 
-        let qualified = Symbol::from_parts(&candidate.module_id, name);
+        let qualified = Symbol::from_parts(&context.module_id, name);
         if is_tuple_struct(store, &qualified) {
             self.sink
                 .push(diagnostics::attribute::equality_on_tuple_struct(
                     &candidate.span,
                 ));
-            return;
+            return None;
         }
 
         match user_equals(store, &qualified) {
@@ -78,23 +82,23 @@ impl TaskState {
                         .push(diagnostics::attribute::equality_specialized_equals(
                             &candidate.span,
                         ));
-                    return;
+                    return None;
                 }
-                return;
+                return None;
             }
             UserEquals::Conflict => {
                 self.sink
                     .push(diagnostics::attribute::equality_conflicting_equals(
                         &candidate.span,
                     ));
-                return;
+                return None;
             }
             UserEquals::Specialized => {
                 self.sink
                     .push(diagnostics::attribute::equality_specialized_equals(
                         &candidate.span,
                     ));
-                return;
+                return None;
             }
             UserEquals::None => {}
         }
@@ -104,34 +108,40 @@ impl TaskState {
                 .push(diagnostics::attribute::equality_conflicting_equals(
                     &candidate.span,
                 ));
-            return;
+            return None;
         }
 
-        self.synthesize_equals(store, &candidate.module_id, &qualified);
-        self.facts.equality_derivations.push(qualified.to_string());
+        self.synthesize_equals(store, &context.module_id, &qualified);
+        Some(qualified)
     }
 
     /// Synthesize queued equality methods, build the verdict, and gate derivations.
     /// Run once after registration has discovered every UFCS method.
     pub fn finalize_equality(&mut self, store: &mut Store) {
-        let candidates = std::mem::take(&mut self.pending_equality_attributes);
-        for candidate in &candidates {
-            self.process_equality_candidate(store, candidate);
+        let batches = std::mem::take(&mut self.pending_equality_attributes);
+        let mut derivations = Vec::new();
+        for batch in &batches {
+            for candidate in &batch.candidates {
+                if let Some(derivation) =
+                    self.process_equality_candidate(store, &batch.context, candidate)
+                {
+                    derivations.push(derivation);
+                }
+            }
         }
-        self.record_equality_index(store);
-        self.validate_equality_derivations(store);
+        self.record_equality_index(store, &derivations);
+        self.validate_equality_derivations(store, &derivations);
     }
 
-    fn validate_equality_derivations(&mut self, store: &Store) {
-        let derivations = std::mem::take(&mut self.facts.equality_derivations);
-        for id in &derivations {
-            let qualified = Symbol::from_raw(id.as_str());
+    fn validate_equality_derivations(&mut self, store: &Store, derivations: &[Symbol]) {
+        for qualified in derivations {
+            let id = qualified.as_str();
             let module_id = store
                 .module_for_qualified_name(id)
                 .map(str::to_string)
                 .unwrap_or_default();
             let name = syntax::types::unqualified_name(id).to_string();
-            self.gate_equality_derivation(store, &name, &qualified, &module_id);
+            self.gate_equality_derivation(store, &name, qualified, &module_id);
         }
     }
 
@@ -185,28 +195,26 @@ impl TaskState {
             _ => return,
         };
 
-        self.scopes.push();
-        self.put_in_scope(&generics);
-        self.record_resolved_generic_bounds(&generics);
+        self.with_scope(|this| {
+            this.put_in_scope(&generics);
+            this.record_resolved_generic_bounds(&generics);
 
-        for (field_name, field_span, field_ty) in &fields {
-            let reason = check_not_equatable(&self.env, store, field_ty, module_id, &|name| {
-                param_is_comparable(&self.scopes, &self.env, name)
-            });
-            if let Some(reason) = reason {
-                self.sink
-                    .push(diagnostics::attribute::cannot_derive_equality(
-                        type_name, field_name, field_span, reason,
-                    ));
+            for (field_name, field_span, field_ty) in &fields {
+                let reason = check_not_equatable(&this.env, store, field_ty, module_id, &|name| {
+                    param_is_comparable(&this.scopes, &this.env, name)
+                });
+                if let Some(reason) = reason {
+                    this.sink
+                        .push(diagnostics::attribute::cannot_derive_equality(
+                            type_name, field_name, field_span, reason,
+                        ));
+                }
             }
-        }
-
-        self.scopes.pop();
+        });
     }
 
-    fn record_equality_index(&mut self, store: &mut Store) {
-        let synthesized: HashSet<String> =
-            self.facts.equality_derivations.iter().cloned().collect();
+    fn record_equality_index(&mut self, store: &mut Store, derivations: &[Symbol]) {
+        let synthesized: HashSet<&str> = derivations.iter().map(Symbol::as_str).collect();
 
         let ids: Vec<Symbol> = store
             .modules

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -7,6 +7,12 @@ use crate::checker::infer::{BuiltinBound, InferCtx};
 use crate::generics::{apply_bounds, bound_implied, type_argument_children};
 use crate::store::Store;
 
+#[derive(Clone, Copy)]
+enum BoundCheckContext {
+    Declaration,
+    Value,
+}
+
 impl TaskState {
     pub(crate) fn check_transitive_generic_bounds(
         &mut self,
@@ -19,7 +25,13 @@ impl TaskState {
                 .resolved_bounds()
                 .expect("generic bounds were resolved before checking")
             {
-                self.check_bound_type(store, own_generics, declaration_span, bound, true, false);
+                self.check_bound_type(
+                    store,
+                    own_generics,
+                    declaration_span,
+                    bound,
+                    BoundCheckContext::Declaration,
+                );
             }
         }
     }
@@ -33,7 +45,7 @@ impl TaskState {
         let mut seen = rustc_hash::FxHashSet::default();
         for (ty, span) in types {
             if seen.insert(ty.to_string()) {
-                self.check_bound_type(store, own_generics, *span, ty, false, true);
+                self.check_bound_type(store, own_generics, *span, ty, BoundCheckContext::Value);
             }
         }
     }
@@ -44,8 +56,7 @@ impl TaskState {
         own_generics: &[Generic],
         declaration_span: Span,
         ty: &Type,
-        check_map_keys: bool,
-        defer_to_interface_list: bool,
+        context: BoundCheckContext,
     ) {
         if let Type::Nominal { id, params, .. } = ty
             && !params.is_empty()
@@ -56,10 +67,10 @@ impl TaskState {
                 declaration_span,
                 id,
                 params,
-                defer_to_interface_list,
+                context,
             );
         }
-        if check_map_keys
+        if matches!(context, BoundCheckContext::Declaration)
             && let Type::Compound {
                 kind: CompoundKind::Map,
                 args,
@@ -69,14 +80,7 @@ impl TaskState {
             self.check_map_key_comparable(store, key, declaration_span);
         }
         for child in type_argument_children(ty) {
-            self.check_bound_type(
-                store,
-                own_generics,
-                declaration_span,
-                child,
-                check_map_keys,
-                defer_to_interface_list,
-            );
+            self.check_bound_type(store, own_generics, declaration_span, child, context);
         }
     }
 
@@ -87,7 +91,7 @@ impl TaskState {
         declaration_span: Span,
         referenced_id: &str,
         argument_types: &[Type],
-        defer_to_interface_list: bool,
+        context: BoundCheckContext,
     ) {
         let Some(definition) = store.get_definition(referenced_id) else {
             return;
@@ -105,7 +109,7 @@ impl TaskState {
             {
                 continue;
             }
-            if defer_to_interface_list
+            if matches!(context, BoundCheckContext::Value)
                 && resolved_required
                     .get_qualified_id()
                     .and_then(BuiltinBound::from_qualified_id)
@@ -143,15 +147,17 @@ impl TaskState {
                     .get_qualified_id()
                     .is_some_and(|id| store.get_interface(id).is_some())
             {
-                if defer_to_interface_list {
-                    self.pending_interface_bound_checks.push((
+                match context {
+                    BoundCheckContext::Declaration => self.pending_generic_bound_checks.push((
                         argument,
                         required,
                         declaration_span,
-                    ));
-                } else {
-                    self.pending_generic_bound_checks
-                        .push((argument, required, declaration_span));
+                    )),
+                    BoundCheckContext::Value => self.pending_interface_bound_checks.push((
+                        argument,
+                        required,
+                        declaration_span,
+                    )),
                 }
             }
         }

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -3,21 +3,17 @@ use syntax::types::{CompoundKind, Symbol, Type};
 
 use super::TaskState;
 use crate::checker::registration::derived_attributes::{
-    DerivedAttribute, DerivedAttributeKind, DerivedAttributeTarget,
+    DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
 
 impl TaskState {
-    pub(super) fn register_iterate(&mut self, store: &mut Store, candidates: &[DerivedAttribute]) {
-        for candidate in candidates
-            .iter()
-            .filter(|candidate| candidate.kind == DerivedAttributeKind::Iterate)
-        {
-            self.process_iterate_candidate(store, candidate);
-        }
-    }
-
-    fn process_iterate_candidate(&mut self, store: &mut Store, candidate: &DerivedAttribute) {
+    pub(super) fn process_iterate_candidate(
+        &mut self,
+        store: &mut Store,
+        context: &DerivedAttributeContext,
+        candidate: &DerivedAttribute,
+    ) {
         let DerivedAttributeTarget::Enum {
             name,
             name_span,
@@ -30,7 +26,7 @@ impl TaskState {
             return;
         };
 
-        if candidate.is_d_lis {
+        if context.is_d_lis {
             self.sink
                 .push(diagnostics::attribute::iterate_in_typedef(&candidate.span));
             return;
@@ -50,7 +46,7 @@ impl TaskState {
             return;
         }
 
-        let qualified = Symbol::from_parts(&candidate.module_id, name);
+        let qualified = Symbol::from_parts(&context.module_id, name);
         let variants_key = qualified.with_segment("variants");
 
         // A static method or a variant literally named `variants` both register
@@ -86,7 +82,7 @@ impl TaskState {
         let fn_ty = Type::function(vec![], Default::default(), Box::new(slice_ty));
 
         let module = store
-            .get_module_mut(&candidate.module_id)
+            .get_module_mut(&context.module_id)
             .expect("module must exist");
         module.definitions.insert(
             variants_key,

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -134,7 +134,24 @@ impl TaskState {
         functions: &[Expression],
         span: &Span,
     ) {
-        self.scopes.push();
+        let static_methods = self.with_scope(|this| {
+            this.populate_impl_methods_in_scope(store, annotation, generics, functions, span)
+        });
+
+        let scope = self.scopes.current_mut();
+        for (name, ty) in static_methods {
+            scope.insert_value(name, ty);
+        }
+    }
+
+    fn populate_impl_methods_in_scope(
+        &mut self,
+        store: &mut Store,
+        annotation: &Annotation,
+        generics: &[Generic],
+        functions: &[Expression],
+        span: &Span,
+    ) -> Vec<(String, Type)> {
         self.put_in_scope(generics);
         let generics = self.resolve_generic_bounds(&*store, generics, span);
         let impl_bounds = resolved_generic_bounds(&generics);
@@ -142,8 +159,7 @@ impl TaskState {
         self.check_undeclared_impl_type_params(annotation, &generics);
         let receiver_ty = self.convert_receiver_to_type(&*store, annotation, span);
         let Some(type_name) = receiver_ty.get_name() else {
-            self.scopes.pop();
-            return;
+            return Vec::new();
         };
         // Prelude built-ins like `Array` have no qualified name to key methods by.
         let Some(receiver_qualified_name) = receiver_ty.get_qualified_name() else {
@@ -152,8 +168,7 @@ impl TaskState {
                 crate::prelude::PRELUDE_MODULE_ID,
                 *span,
             ));
-            self.scopes.pop();
-            return;
+            return Vec::new();
         };
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
@@ -167,8 +182,7 @@ impl TaskState {
                 type_module,
                 *span,
             ));
-            self.scopes.pop();
-            return;
+            return Vec::new();
         }
 
         if self.current_file_is_test(store)
@@ -181,8 +195,7 @@ impl TaskState {
                     type_name,
                     annotation.get_span(),
                 ));
-            self.scopes.pop();
-            return;
+            return Vec::new();
         }
 
         if !self.is_d_lis(&*store)
@@ -199,8 +212,7 @@ impl TaskState {
                 type_name,
                 annotation.get_span(),
             ));
-            self.scopes.pop();
-            return;
+            return Vec::new();
         }
 
         if self.impl_has_simple_type_params(&receiver_ty, &generics) {
@@ -265,13 +277,13 @@ impl TaskState {
 
             let (method_signature_pairs, method_signature_bounds) =
                 super::function_signature_pairs(&fn_ty, fn_sig.params, fn_span);
-            self.scopes.push();
-            self.put_in_scope(fn_sig.generics);
-            for bound in &method_signature_bounds {
-                self.record_generic_bound(&bound.param_name, bound.ty.clone());
-            }
-            self.check_value_position_bounds(&*store, &[], &method_signature_pairs);
-            self.scopes.pop();
+            self.with_scope(|this| {
+                this.put_in_scope(fn_sig.generics);
+                for bound in &method_signature_bounds {
+                    this.record_generic_bound(&bound.param_name, bound.ty.clone());
+                }
+                this.check_value_position_bounds(&*store, &[], &method_signature_pairs);
+            });
 
             let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
 
@@ -338,12 +350,7 @@ impl TaskState {
             );
         }
 
-        self.scopes.pop();
-
-        let scope = self.scopes.current_mut();
-        for (name, ty) in static_methods {
-            scope.insert_value(name, ty);
-        }
+        static_methods
     }
 
     pub(super) fn populate_interface(&mut self, store: &mut Store, expression: &Expression) {
@@ -360,15 +367,6 @@ impl TaskState {
         else {
             unreachable!("populate_interface called with non-Interface expression");
         };
-        self.scopes.push();
-        self.put_in_scope(generics);
-        let generics = self.resolve_generic_bounds(&*store, generics, span);
-
-        let new_parents = parents
-            .iter()
-            .map(|s| self.convert_to_type(&*store, &s.annotation, &s.span))
-            .collect();
-
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
         struct MethodDef {
@@ -379,92 +377,102 @@ impl TaskState {
             name_span: Span,
             doc: Option<String>,
         }
-        let mut method_defs: Vec<MethodDef> = Vec::new();
-        let mut self_receiver_spans: Vec<Span> = Vec::new();
-        let methods = fn_expressions
-            .iter()
-            .map(|fe| {
-                let (fn_attrs, fn_doc) = if let Expression::Function {
-                    attributes, doc, ..
-                } = fe
-                {
-                    (attributes.as_slice(), doc.clone())
-                } else {
-                    (&[][..], None)
-                };
-                let method_sig = fe.function_definition_view();
-                let method_span = fe.get_span();
-                let fn_ty = self.extract_signature_parts(
-                    &*store,
-                    method_sig.generics,
-                    method_sig.params,
-                    method_sig.annotation,
-                    &method_span,
-                );
-                let fn_ty = match &fn_ty {
-                    Type::Forall { body, .. } => body.as_ref().clone(),
-                    _ => fn_ty,
-                };
+        let (generics, new_parents, methods, method_defs) = self.with_scope(|this| {
+            this.put_in_scope(generics);
+            let generics = this.resolve_generic_bounds(&*store, generics, span);
 
-                // Interface methods declare no receiver: it is always the implementing
-                // type. Reject an explicit `self` and strip it so the rest still checks.
-                let self_receiver_span = method_sig.params.first().and_then(|p| match &p.pattern {
-                    Pattern::Identifier { identifier, span } if identifier == "self" => Some(*span),
-                    _ => None,
-                });
-                if let Some(self_span) = self_receiver_span {
-                    self_receiver_spans.push(self_span);
-                }
-                let fn_ty = if self_receiver_span.is_some() {
-                    match fn_ty {
-                        Type::Function(f) => f.without_receiver(),
-                        other => other,
+            let new_parents = parents
+                .iter()
+                .map(|parent| this.convert_to_type(&*store, &parent.annotation, &parent.span))
+                .collect();
+
+            let mut method_defs = Vec::new();
+            let mut self_receiver_spans = Vec::new();
+            let methods = fn_expressions
+                .iter()
+                .map(|fe| {
+                    let (fn_attrs, fn_doc) = if let Expression::Function {
+                        attributes, doc, ..
+                    } = fe
+                    {
+                        (attributes.as_slice(), doc.clone())
+                    } else {
+                        (&[][..], None)
+                    };
+                    let method_sig = fe.function_definition_view();
+                    let method_span = fe.get_span();
+                    let fn_ty = this.extract_signature_parts(
+                        &*store,
+                        method_sig.generics,
+                        method_sig.params,
+                        method_sig.annotation,
+                        &method_span,
+                    );
+                    let fn_ty = match &fn_ty {
+                        Type::Forall { body, .. } => body.as_ref().clone(),
+                        _ => fn_ty,
+                    };
+
+                    let self_receiver_span =
+                        method_sig.params.first().and_then(|p| match &p.pattern {
+                            Pattern::Identifier { identifier, span } if identifier == "self" => {
+                                Some(*span)
+                            }
+                            _ => None,
+                        });
+                    if let Some(self_span) = self_receiver_span {
+                        self_receiver_spans.push(self_span);
                     }
-                } else {
-                    fn_ty
-                };
+                    let fn_ty = if self_receiver_span.is_some() {
+                        match fn_ty {
+                            Type::Function(f) => f.without_receiver(),
+                            other => other,
+                        }
+                    } else {
+                        fn_ty
+                    };
 
-                let (mut signature_pairs, signature_bounds) =
-                    super::function_signature_pairs(&fn_ty, &[], method_span);
-                if let Type::Function(f) = fn_ty.unwrap_forall() {
-                    signature_pairs.push(((*f.return_type).clone(), method_span));
-                }
-                self.scopes.push();
-                self.put_in_scope(&generics);
-                self.record_resolved_generic_bounds(&generics);
-                self.put_in_scope(method_sig.generics);
-                for bound in &signature_bounds {
-                    self.record_generic_bound(&bound.param_name, bound.ty.clone());
-                }
-                self.check_value_position_bounds(&*store, &[], &signature_pairs);
-                self.scopes.pop();
-
-                let go_hints = extract_attribute_flags(fn_attrs, "go");
-                if go_hints.iter().any(|h| h == "unexported") {
-                    (
-                        super::seal_method_key(is_d_lis, fn_attrs, &module_id, method_sig.name),
-                        fn_ty,
-                    )
-                } else {
-                    method_defs.push(MethodDef {
-                        name: method_sig.name.clone(),
-                        ty: fn_ty.clone(),
-                        go_hints,
-                        allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
-                        name_span: method_sig.name_span,
-                        doc: fn_doc,
+                    let (mut signature_pairs, signature_bounds) =
+                        super::function_signature_pairs(&fn_ty, &[], method_span);
+                    if let Type::Function(f) = fn_ty.unwrap_forall() {
+                        signature_pairs.push(((*f.return_type).clone(), method_span));
+                    }
+                    this.with_scope(|this| {
+                        this.put_in_scope(&generics);
+                        this.record_resolved_generic_bounds(&generics);
+                        this.put_in_scope(method_sig.generics);
+                        for bound in &signature_bounds {
+                            this.record_generic_bound(&bound.param_name, bound.ty.clone());
+                        }
+                        this.check_value_position_bounds(&*store, &[], &signature_pairs);
                     });
-                    (method_sig.name.clone(), fn_ty)
-                }
-            })
-            .collect();
 
-        for self_span in self_receiver_spans {
-            self.sink
-                .push(diagnostics::infer::self_in_interface_method(self_span));
-        }
+                    let go_hints = extract_attribute_flags(fn_attrs, "go");
+                    if go_hints.iter().any(|h| h == "unexported") {
+                        (
+                            super::seal_method_key(is_d_lis, fn_attrs, &module_id, method_sig.name),
+                            fn_ty,
+                        )
+                    } else {
+                        method_defs.push(MethodDef {
+                            name: method_sig.name.clone(),
+                            ty: fn_ty.clone(),
+                            go_hints,
+                            allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
+                            name_span: method_sig.name_span,
+                            doc: fn_doc,
+                        });
+                        (method_sig.name.clone(), fn_ty)
+                    }
+                })
+                .collect();
 
-        self.scopes.pop();
+            for self_span in self_receiver_spans {
+                this.sink
+                    .push(diagnostics::infer::self_in_interface_method(self_span));
+            }
+            (generics, new_parents, methods, method_defs)
+        });
 
         let qualified_name = self.qualify_name(interface_name);
         let interface_ty = store

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -784,12 +784,12 @@ impl TaskState {
                 .unwrap_or_default();
             let value_types = declaration_value_position_types(definition);
 
-            self.scopes.push();
-            self.put_in_scope(&generics);
-            self.record_resolved_generic_bounds(&generics);
-            self.check_transitive_generic_bounds(store, &generics, span);
-            self.check_value_position_bounds(store, &generics, &value_types);
-            self.scopes.pop();
+            self.with_scope(|this| {
+                this.put_in_scope(&generics);
+                this.record_resolved_generic_bounds(&generics);
+                this.check_transitive_generic_bounds(store, &generics, span);
+                this.check_value_position_bounds(store, &generics, &value_types);
+            });
         }
     }
 
@@ -877,26 +877,28 @@ impl TaskState {
 
         let qualified_name = self.qualify_name(name);
 
-        self.scopes.push();
-        self.put_in_scope(generics);
+        let fn_ty = self.with_scope(|this| {
+            this.put_in_scope(generics);
 
-        let test_params;
-        let params: &[Binding] = if syntax::attributes::has_test_attribute(attributes) {
-            test_params = test_functions::normalize_test_params(params.clone(), true);
-            &test_params
-        } else {
-            params
-        };
+            let test_params;
+            let params: &[Binding] = if syntax::attributes::has_test_attribute(attributes) {
+                test_params = test_functions::normalize_test_params(params.clone(), true);
+                &test_params
+            } else {
+                params
+            };
 
-        let fn_ty = self.extract_signature_parts(store, generics, params, return_annotation, span);
+            let fn_ty =
+                this.extract_signature_parts(store, generics, params, return_annotation, span);
 
-        let (signature_pairs, signature_bounds) = function_signature_pairs(&fn_ty, params, *span);
-        for bound in &signature_bounds {
-            self.record_generic_bound(&bound.param_name, bound.ty.clone());
-        }
-        self.check_value_position_bounds(store, &[], &signature_pairs);
-
-        self.scopes.pop();
+            let (signature_pairs, signature_bounds) =
+                function_signature_pairs(&fn_ty, params, *span);
+            for bound in &signature_bounds {
+                this.record_generic_bound(&bound.param_name, bound.ty.clone());
+            }
+            this.check_value_position_bounds(store, &[], &signature_pairs);
+            fn_ty
+        });
 
         let item_visibility =
             self.compute_item_visibility(&*store, syntactic_visibility, visibility);
@@ -1090,30 +1092,30 @@ impl TaskState {
         return_annotation: &Annotation,
         span: &Span,
     ) -> Type {
-        self.scopes.push();
-        self.put_in_scope(generics);
-        let generics = self.resolve_generic_bounds(store, generics, span);
-        self.check_transitive_generic_bounds(store, &generics, *span);
-        let bounds = resolved_generic_bounds(&generics);
+        let (generics, bounds, param_types, return_ty) = self.with_scope(|this| {
+            this.put_in_scope(generics);
+            let generics = this.resolve_generic_bounds(store, generics, span);
+            this.check_transitive_generic_bounds(store, &generics, *span);
+            let bounds = resolved_generic_bounds(&generics);
 
-        let (param_types, return_ty) = self.without_diagnostics(|this| {
-            let param_types: Vec<Type> = params
-                .iter()
-                .map(|binding| match &binding.annotation {
-                    Some(a) => this.convert_variadic_to_type(store, a, span),
-                    None if !binding.ty.is_uninferred() => binding.ty.clone(),
-                    None => this.new_type_var(),
-                })
-                .collect();
+            let (param_types, return_ty) = this.without_diagnostics(|this| {
+                let param_types: Vec<Type> = params
+                    .iter()
+                    .map(|binding| match &binding.annotation {
+                        Some(a) => this.convert_variadic_to_type(store, a, span),
+                        None if !binding.ty.is_uninferred() => binding.ty.clone(),
+                        None => this.new_type_var(),
+                    })
+                    .collect();
 
-            let return_ty = match return_annotation {
-                Annotation::Unknown => this.type_unit(),
-                _ => this.convert_to_type(store, return_annotation, span),
-            };
-            (param_types, return_ty)
+                let return_ty = match return_annotation {
+                    Annotation::Unknown => this.type_unit(),
+                    _ => this.convert_to_type(store, return_annotation, span),
+                };
+                (param_types, return_ty)
+            });
+            (generics, bounds, param_types, return_ty)
         });
-
-        self.scopes.pop();
 
         let function_params = param_types
             .into_iter()

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -34,16 +34,15 @@ impl TaskState {
             .expect("enum type must exist")
             .clone();
 
-        self.scopes.push();
-        self.put_in_scope(generics);
-        let generics = self.resolve_generic_bounds(&*store, generics, span);
-
-        let new_variants: Vec<_> = variants
-            .iter()
-            .map(|v| self.resolve_enum_variant_fields(&*store, v, span))
-            .collect();
-
-        self.scopes.pop();
+        let (generics, new_variants) = self.with_scope(|this| {
+            this.put_in_scope(generics);
+            let generics = this.resolve_generic_bounds(&*store, generics, span);
+            let new_variants: Vec<_> = variants
+                .iter()
+                .map(|variant| this.resolve_enum_variant_fields(&*store, variant, span))
+                .collect();
+            (generics, new_variants)
+        });
 
         self.check_enum_field_type_conflicts(name, &new_variants);
 
@@ -293,33 +292,33 @@ impl TaskState {
             .expect("struct type scheme must exist")
             .clone();
 
-        self.scopes.push();
-        self.put_in_scope(generics);
-        let generics = self.resolve_generic_bounds(&*store, generics, span);
+        let (generics, new_fields) = self.with_scope(|this| {
+            this.put_in_scope(generics);
+            let generics = this.resolve_generic_bounds(&*store, generics, span);
 
-        let new_fields: Vec<StructFieldDefinition> = fields
-            .iter()
-            .map(|f| {
-                let field_ty = self.convert_to_type(&*store, &f.annotation, span);
-                let visibility = if f.is_embedded() {
-                    embed_field_visibility(&*store, &field_ty)
-                } else {
-                    f.visibility
-                };
-                StructFieldDefinition {
-                    ty: field_ty,
-                    visibility,
-                    ..f.clone()
-                }
-            })
-            .collect();
+            let new_fields = fields
+                .iter()
+                .map(|field| {
+                    let field_ty = this.convert_to_type(&*store, &field.annotation, span);
+                    let visibility = if field.is_embedded() {
+                        embed_field_visibility(&*store, &field_ty)
+                    } else {
+                        field.visibility
+                    };
+                    StructFieldDefinition {
+                        ty: field_ty,
+                        visibility,
+                        ..field.clone()
+                    }
+                })
+                .collect();
 
-        let new_fields = match fields {
-            StructFields::Record(_) => StructFields::Record(new_fields),
-            StructFields::Tuple(_) => StructFields::Tuple(new_fields),
-        };
-
-        self.scopes.pop();
+            let new_fields = match fields {
+                StructFields::Record(_) => StructFields::Record(new_fields),
+                StructFields::Tuple(_) => StructFields::Tuple(new_fields),
+            };
+            (generics, new_fields)
+        });
 
         let visibility = self
             .current_module(&*store)
@@ -477,6 +476,10 @@ impl TaskState {
     }
 
     pub(super) fn populate_type_alias(&mut self, store: &mut Store, expression: &Expression) {
+        self.with_scope(|this| this.populate_type_alias_in_scope(store, expression));
+    }
+
+    fn populate_type_alias_in_scope(&mut self, store: &mut Store, expression: &Expression) {
         let Expression::TypeAlias {
             name,
             name_span,
@@ -492,7 +495,6 @@ impl TaskState {
         };
         let qualified_name = self.qualify_name(name);
 
-        self.scopes.push();
         self.put_in_scope(generics);
         let generics = self.resolve_generic_bounds(&*store, generics, span);
 
@@ -556,8 +558,6 @@ impl TaskState {
                 ));
             }
 
-            self.scopes.pop();
-
             self.current_module_mut(store).definitions.insert(
                 qualified_name,
                 Definition {
@@ -607,8 +607,6 @@ impl TaskState {
                 body: Box::new(alias_reference),
             }
         };
-
-        self.scopes.pop();
 
         let visibility = self
             .current_module(&*store)

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -8,9 +8,6 @@ use syntax::types::{Symbol, Type};
 pub struct DepthCounter(usize);
 
 impl DepthCounter {
-    pub(crate) fn new() -> Self {
-        Self(0)
-    }
     fn get(&self) -> usize {
         self.0
     }
@@ -45,30 +42,36 @@ pub enum UseContext {
     AssignmentTarget,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TryCarrier {
-    #[default]
-    Unset,
-    Unknown,
     Result,
     Option,
 }
 
-impl TryCarrier {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TryUsage {
+    #[default]
+    Unused,
+    Unknown,
+    Carrier(TryCarrier),
+}
+
+impl TryUsage {
     /// Record one `?` operand and report whether it conflicts with a carrier
     /// already established by an earlier operand.
-    pub(crate) fn observe(&mut self, observed: Option<Self>) -> bool {
+    pub(crate) fn observe(&mut self, observed: Option<TryCarrier>) -> bool {
         match (*self, observed) {
-            (Self::Unset, None) => *self = Self::Unknown,
-            (Self::Unset | Self::Unknown, Some(carrier)) => *self = carrier,
-            (Self::Result, Some(Self::Option)) | (Self::Option, Some(Self::Result)) => return true,
+            (Self::Unused, None) => *self = Self::Unknown,
+            (Self::Unused | Self::Unknown, Some(carrier)) => *self = Self::Carrier(carrier),
+            (Self::Carrier(TryCarrier::Result), Some(TryCarrier::Option))
+            | (Self::Carrier(TryCarrier::Option), Some(TryCarrier::Result)) => return true,
             _ => {}
         }
         false
     }
 
     pub(crate) fn was_used(self) -> bool {
-        self != Self::Unset
+        self != Self::Unused
     }
 }
 
@@ -76,13 +79,35 @@ impl TryCarrier {
 pub struct TryBlockContext {
     pub(crate) ok_ty: Type,
     pub(crate) err_ty: Type,
-    pub(crate) carrier: TryCarrier,
-    pub(crate) loop_depth: DepthCounter,
+    pub(crate) usage: TryUsage,
+    pub(crate) entry_loop_depth: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct RecoverBlockContext {
-    pub(crate) loop_depth: DepthCounter,
+    pub(crate) entry_loop_depth: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+enum PropagationContext {
+    #[default]
+    None,
+    Try(TryBlockContext),
+    Recover(RecoverBlockContext),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DeferredMapKeyCheck {
+    Comparable { key: Type, span: Span },
+    Bounds { key: Type, span: Span },
+}
+
+#[derive(Debug, Clone, Default)]
+enum TestContext {
+    #[default]
+    None,
+    Handle,
+    Function(EcoString),
 }
 
 /// Traversal state inherited by nested lexical scopes and restored on pop.
@@ -94,8 +119,9 @@ struct InheritedContext {
     negation_depth: DepthCounter,
     invariant_depth: DepthCounter,
     use_context: UseContext,
-    in_test_handle: bool,
-    test_fn_name: Option<EcoString>,
+    dot_access_base: bool,
+    let_binding_rhs: bool,
+    test_context: TestContext,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -111,15 +137,20 @@ struct ScopedValue {
     kind: ScopedValueKind,
 }
 
+#[derive(Debug, Clone, Default)]
+struct GenericContext {
+    type_params: HashMap<String, usize>,
+    trait_bounds: HashMap<Symbol, Vec<Type>>,
+}
+
 #[derive(Debug, Clone)]
 pub struct Scope {
     values: HashMap<String, ScopedValue>,
-    pub(crate) type_params: Option<HashMap<String, usize>>,
-    pub(crate) trait_bounds: Option<HashMap<Symbol, Vec<Type>>>,
+    generics: Option<GenericContext>,
     pub(crate) fn_return_type: Option<Type>,
-    deferred_map_key_checks: Vec<(Type, Span, bool)>,
-    pub(crate) try_block_context: Option<TryBlockContext>,
-    pub(crate) recover_block_context: Option<RecoverBlockContext>,
+    deferred_map_key_checks: Vec<DeferredMapKeyCheck>,
+    propagation_context: PropagationContext,
+    impl_receiver_type: Option<Type>,
     inherited: InheritedContext,
 }
 
@@ -133,12 +164,11 @@ impl Scope {
     fn new() -> Self {
         Scope {
             values: HashMap::default(),
-            type_params: None,
-            trait_bounds: None,
+            generics: None,
             fn_return_type: None,
             deferred_map_key_checks: Vec::new(),
-            try_block_context: None,
-            recover_block_context: None,
+            propagation_context: PropagationContext::None,
+            impl_receiver_type: None,
             inherited: InheritedContext::default(),
         }
     }
@@ -179,22 +209,14 @@ impl Scope {
             },
         );
     }
+
+    fn generics_mut(&mut self) -> &mut GenericContext {
+        self.generics.get_or_insert_with(GenericContext::default)
+    }
 }
 
 pub struct Scopes {
     stack: Vec<Scope>,
-    /// True when inferring the base of a dot-access chain. Suppresses the
-    /// record-struct-as-value error when the struct name is a type qualifier
-    /// (e.g. `lib.Point` in `lib.Point.sum`).
-    dot_access_base: bool,
-    /// True while inferring a `let` binding's right-hand side. Suppresses the generic
-    /// "used as a value" rejection there so `bindings.rs` can raise the specific
-    /// "cannot bind a type or module to a variable" error instead.
-    let_binding_rhs: bool,
-    /// The enclosing impl block's receiver type, used to resolve `self`
-    /// parameter annotations inside the impl's methods. `None` outside impls.
-    /// Singleton because Lisette does not allow nested impl blocks.
-    impl_receiver_type: Option<Type>,
 }
 
 impl Default for Scopes {
@@ -207,9 +229,6 @@ impl Scopes {
     pub(crate) fn new() -> Self {
         Scopes {
             stack: vec![Scope::new()],
-            dot_access_base: false,
-            let_binding_rhs: false,
-            impl_receiver_type: None,
         }
     }
 
@@ -289,11 +308,34 @@ impl Scopes {
     /// Look up a type parameter by walking the scope stack from top to bottom.
     pub(crate) fn lookup_type_param(&self, name: &str) -> Option<usize> {
         for scope in self.stack.iter().rev() {
-            if let Some(idx) = scope.type_params.as_ref().and_then(|tp| tp.get(name)) {
+            if let Some(idx) = scope
+                .generics
+                .as_ref()
+                .and_then(|generics| generics.type_params.get(name))
+            {
                 return Some(*idx);
             }
         }
         None
+    }
+
+    pub(crate) fn insert_type_param(&mut self, name: String, index: usize) {
+        self.current_mut()
+            .generics_mut()
+            .type_params
+            .insert(name, index);
+    }
+
+    pub(crate) fn insert_trait_bound(&mut self, parameter: Symbol, bound: Type) {
+        let bounds = self
+            .current_mut()
+            .generics_mut()
+            .trait_bounds
+            .entry(parameter)
+            .or_default();
+        if !bounds.contains(&bound) {
+            bounds.push(bound);
+        }
     }
 
     /// Look up the enclosing function's return type.
@@ -306,28 +348,26 @@ impl Scopes {
         None
     }
 
-    pub(crate) fn defer_map_key_check(&mut self, key: Type, span: Span, check_concrete: bool) {
+    pub(crate) fn defer_map_key_check(&mut self, check: DeferredMapKeyCheck) {
         if let Some(scope) = self
             .stack
             .iter_mut()
             .rev()
             .find(|scope| scope.fn_return_type.is_some())
         {
-            scope
-                .deferred_map_key_checks
-                .push((key, span, check_concrete));
+            scope.deferred_map_key_checks.push(check);
         }
     }
 
-    pub(crate) fn take_deferred_map_key_checks(&mut self) -> Vec<(Type, Span, bool)> {
+    pub(crate) fn take_deferred_map_key_checks(&mut self) -> Vec<DeferredMapKeyCheck> {
         std::mem::take(&mut self.current_mut().deferred_map_key_checks)
     }
 
     /// Look up the enclosing try block context, stopping at function boundaries.
     pub(crate) fn lookup_try_block_context(&self) -> Option<&TryBlockContext> {
         for scope in self.stack.iter().rev() {
-            if scope.try_block_context.is_some() {
-                return scope.try_block_context.as_ref();
+            if let PropagationContext::Try(context) = &scope.propagation_context {
+                return Some(context);
             }
             if scope.fn_return_type.is_some() {
                 return None;
@@ -338,8 +378,8 @@ impl Scopes {
 
     pub(crate) fn lookup_try_block_context_mut(&mut self) -> Option<&mut TryBlockContext> {
         for scope in self.stack.iter_mut().rev() {
-            if scope.try_block_context.is_some() {
-                return scope.try_block_context.as_mut();
+            if let PropagationContext::Try(context) = &mut scope.propagation_context {
+                return Some(context);
             }
             if scope.fn_return_type.is_some() {
                 return None;
@@ -351,8 +391,8 @@ impl Scopes {
     /// Look up the enclosing recover block context, stopping at function boundaries.
     pub(crate) fn lookup_recover_block_context(&self) -> Option<&RecoverBlockContext> {
         for scope in self.stack.iter().rev() {
-            if scope.recover_block_context.is_some() {
-                return scope.recover_block_context.as_ref();
+            if let PropagationContext::Recover(context) = &scope.propagation_context {
+                return Some(context);
             }
             if scope.fn_return_type.is_some() {
                 return None;
@@ -361,16 +401,19 @@ impl Scopes {
         None
     }
 
-    pub(crate) fn lookup_recover_block_context_mut(&mut self) -> Option<&mut RecoverBlockContext> {
-        for scope in self.stack.iter_mut().rev() {
-            if scope.recover_block_context.is_some() {
-                return scope.recover_block_context.as_mut();
-            }
-            if scope.fn_return_type.is_some() {
-                return None;
-            }
+    pub(crate) fn set_try_block_context(&mut self, context: TryBlockContext) {
+        self.current_mut().propagation_context = PropagationContext::Try(context);
+    }
+
+    pub(crate) fn current_try_block_context(&self) -> Option<&TryBlockContext> {
+        match &self.current().propagation_context {
+            PropagationContext::Try(context) => Some(context),
+            PropagationContext::None | PropagationContext::Recover(_) => None,
         }
-        None
+    }
+
+    pub(crate) fn set_recover_block_context(&mut self, context: RecoverBlockContext) {
+        self.current_mut().propagation_context = PropagationContext::Recover(context);
     }
 
     pub(crate) fn collect_all_value_names(&self) -> Vec<String> {
@@ -385,12 +428,11 @@ impl Scopes {
         let mut all_bounds: HashMap<Symbol, Vec<Type>> = HashMap::default();
         // Walk from bottom to top so inner scopes override outer
         for scope in &self.stack {
-            if let Some(type_params) = &scope.type_params {
-                all_bounds
-                    .retain(|parameter, _| !type_params.contains_key(parameter.last_segment()));
-            }
-            if let Some(ref bounds) = scope.trait_bounds {
-                for (key, value) in bounds {
+            if let Some(generics) = &scope.generics {
+                all_bounds.retain(|parameter, _| {
+                    !generics.type_params.contains_key(parameter.last_segment())
+                });
+                for (key, value) in &generics.trait_bounds {
                     all_bounds.insert(key.clone(), value.clone());
                 }
             }
@@ -401,14 +443,14 @@ impl Scopes {
     pub(crate) fn for_each_bound_on_param<F: FnMut(&Type)>(&self, param_name: &str, mut visit: F) {
         for scope in self.stack.iter().rev() {
             let introduces = scope
-                .type_params
+                .generics
                 .as_ref()
-                .is_some_and(|tp| tp.contains_key(param_name));
+                .is_some_and(|generics| generics.type_params.contains_key(param_name));
             if !introduces {
                 continue;
             }
-            if let Some(ref bounds) = scope.trait_bounds {
-                for (key, types) in bounds {
+            if let Some(generics) = &scope.generics {
+                for (key, types) in &generics.trait_bounds {
                     if key.last_segment() == param_name {
                         for ty in types {
                             visit(ty);
@@ -421,19 +463,24 @@ impl Scopes {
     }
 
     pub(crate) fn mark_test_handle(&mut self) {
-        self.current_mut().inherited.in_test_handle = true;
+        if matches!(self.current().inherited.test_context, TestContext::None) {
+            self.current_mut().inherited.test_context = TestContext::Handle;
+        }
     }
 
     pub(crate) fn has_test_handle(&self) -> bool {
-        self.current().inherited.in_test_handle
+        !matches!(self.current().inherited.test_context, TestContext::None)
     }
 
     pub(crate) fn set_test_fn_name(&mut self, name: EcoString) {
-        self.current_mut().inherited.test_fn_name = Some(name);
+        self.current_mut().inherited.test_context = TestContext::Function(name);
     }
 
     pub(crate) fn test_fn_name(&self) -> Option<&str> {
-        self.current().inherited.test_fn_name.as_deref()
+        match &self.current().inherited.test_context {
+            TestContext::Function(name) => Some(name),
+            TestContext::None | TestContext::Handle => None,
+        }
     }
 
     pub(crate) fn increment_loop_depth(&mut self) {
@@ -448,12 +495,12 @@ impl Scopes {
         self.current().inherited.loop_depth.is_active()
     }
 
-    pub(crate) fn set_loop_break_type(&mut self, ty: Type) {
-        self.current_mut().inherited.loop_break_type = Some(ty);
+    pub(crate) fn loop_depth(&self) -> usize {
+        self.current().inherited.loop_depth.get()
     }
 
-    pub(crate) fn clear_loop_break_type(&mut self) {
-        self.current_mut().inherited.loop_break_type = None;
+    pub(crate) fn replace_loop_break_type(&mut self, ty: Option<Type>) -> Option<Type> {
+        std::mem::replace(&mut self.current_mut().inherited.loop_break_type, ty)
     }
 
     pub(crate) fn loop_break_type(&self) -> Option<&Type> {
@@ -496,15 +543,9 @@ impl Scopes {
         self.current_mut().inherited.loop_depth.restore(depth);
     }
 
-    pub(crate) fn set_value_context(&mut self) -> UseContext {
+    pub(crate) fn replace_use_context(&mut self, context: UseContext) -> UseContext {
         let prev = self.current().inherited.use_context;
-        self.current_mut().inherited.use_context = UseContext::Value;
-        prev
-    }
-
-    pub(crate) fn set_statement_context(&mut self) -> UseContext {
-        let prev = self.current().inherited.use_context;
-        self.current_mut().inherited.use_context = UseContext::Statement;
+        self.current_mut().inherited.use_context = context;
         prev
     }
 
@@ -516,20 +557,8 @@ impl Scopes {
         self.current().inherited.use_context == UseContext::Value
     }
 
-    pub(crate) fn set_callee_context(&mut self) -> UseContext {
-        let prev = self.current().inherited.use_context;
-        self.current_mut().inherited.use_context = UseContext::Callee;
-        prev
-    }
-
     pub(crate) fn is_callee_context(&self) -> bool {
         self.current().inherited.use_context == UseContext::Callee
-    }
-
-    pub(crate) fn set_assignment_target_context(&mut self) -> UseContext {
-        let prev = self.current().inherited.use_context;
-        self.current_mut().inherited.use_context = UseContext::AssignmentTarget;
-        prev
     }
 
     pub(crate) fn is_assignment_target_context(&self) -> bool {
@@ -537,19 +566,19 @@ impl Scopes {
     }
 
     pub(crate) fn is_dot_access_base(&self) -> bool {
-        self.dot_access_base
+        self.current().inherited.dot_access_base
     }
 
-    pub(crate) fn set_dot_access_base(&mut self, value: bool) -> bool {
-        std::mem::replace(&mut self.dot_access_base, value)
+    pub(crate) fn replace_dot_access_base(&mut self, value: bool) -> bool {
+        std::mem::replace(&mut self.current_mut().inherited.dot_access_base, value)
     }
 
     pub(crate) fn is_let_binding_rhs(&self) -> bool {
-        self.let_binding_rhs
+        self.current().inherited.let_binding_rhs
     }
 
-    pub(crate) fn set_let_binding_rhs(&mut self, value: bool) -> bool {
-        std::mem::replace(&mut self.let_binding_rhs, value)
+    pub(crate) fn replace_let_binding_rhs(&mut self, value: bool) -> bool {
+        std::mem::replace(&mut self.current_mut().inherited.let_binding_rhs, value)
     }
 
     pub(crate) fn enter_invariant_position(&mut self) {
@@ -564,12 +593,15 @@ impl Scopes {
         self.current().inherited.invariant_depth.is_active()
     }
 
-    pub(crate) fn set_impl_receiver_type(&mut self, ty: Option<Type>) {
-        self.impl_receiver_type = ty;
+    pub(crate) fn set_impl_receiver_type(&mut self, ty: Type) {
+        self.current_mut().impl_receiver_type = Some(ty);
     }
 
     pub(crate) fn impl_receiver_type(&self) -> Option<&Type> {
-        self.impl_receiver_type.as_ref()
+        self.stack
+            .iter()
+            .rev()
+            .find_map(|scope| scope.impl_receiver_type.as_ref())
     }
 }
 
@@ -617,5 +649,105 @@ mod tests {
 
         assert_eq!(scopes.lookup_binding_id("value"), None);
         assert!(!scopes.binding_crosses_function_boundary("value"));
+    }
+
+    #[test]
+    fn named_test_context_always_provides_a_handle() {
+        let mut scopes = Scopes::new();
+
+        scopes.set_test_fn_name("example".into());
+
+        assert!(scopes.has_test_handle());
+        assert_eq!(scopes.test_fn_name(), Some("example"));
+    }
+
+    #[test]
+    fn known_try_carrier_replaces_an_unknown_observation() {
+        let mut usage = TryUsage::default();
+        usage.observe(None);
+
+        let mismatched = usage.observe(Some(TryCarrier::Result));
+
+        assert_eq!(
+            (usage, mismatched),
+            (TryUsage::Carrier(TryCarrier::Result), false)
+        );
+    }
+
+    #[test]
+    fn conflicting_try_carrier_does_not_replace_the_first_carrier() {
+        let mut usage = TryUsage::Carrier(TryCarrier::Result);
+
+        let mismatched = usage.observe(Some(TryCarrier::Option));
+
+        assert_eq!(
+            (usage, mismatched),
+            (TryUsage::Carrier(TryCarrier::Result), true)
+        );
+    }
+
+    #[test]
+    fn impl_receiver_lifetime_is_tied_to_its_scope() {
+        let mut scopes = Scopes::new();
+        scopes.push();
+        scopes.set_impl_receiver_type(Type::Error);
+        scopes.push();
+
+        assert!(scopes.impl_receiver_type().is_some());
+
+        scopes.pop();
+        scopes.pop();
+        assert!(scopes.impl_receiver_type().is_none());
+    }
+
+    #[test]
+    fn dot_access_base_can_also_be_a_callee() {
+        let mut scopes = Scopes::new();
+        scopes.replace_use_context(UseContext::Callee);
+        scopes.replace_dot_access_base(true);
+
+        assert!(scopes.is_callee_context());
+        assert!(scopes.is_dot_access_base());
+    }
+
+    #[test]
+    fn nested_recover_preserves_enclosing_try_context() {
+        let mut scopes = Scopes::new();
+        scopes.set_try_block_context(TryBlockContext {
+            ok_ty: Type::Error,
+            err_ty: Type::Error,
+            usage: TryUsage::Unused,
+            entry_loop_depth: 1,
+        });
+        scopes.push();
+        scopes.set_recover_block_context(RecoverBlockContext {
+            entry_loop_depth: 2,
+        });
+
+        assert_eq!(
+            scopes
+                .lookup_try_block_context()
+                .map(|ctx| ctx.entry_loop_depth),
+            Some(1)
+        );
+        assert_eq!(
+            scopes
+                .lookup_recover_block_context()
+                .map(|ctx| ctx.entry_loop_depth),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn inner_type_parameter_shadows_outer_bounds_without_declaring_its_own() {
+        let mut scopes = Scopes::new();
+        scopes.insert_type_param("T".into(), 0);
+        scopes.insert_trait_bound(Symbol::from_parts("module", "T"), Type::Error);
+        scopes.push();
+        scopes.insert_type_param("T".into(), 0);
+
+        let bounds = scopes.collect_all_trait_bounds();
+
+        assert!(bounds.is_empty());
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -39,7 +39,6 @@ pub struct Facts {
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<InterfaceSatisfaction>>,
-    pub(crate) equality_derivations: Vec<String>,
     pub(crate) test_functions: Vec<TestFunction>,
 
     pub(crate) deferred: DeferredChecks,
@@ -158,9 +157,15 @@ pub struct StatementTailCheck {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct BranchArm {
+    pub(crate) ty: Type,
+    pub(crate) span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct BranchSubsumption {
     pub(crate) result_ty: Type,
-    pub(crate) arms: Vec<(Type, Span)>,
+    pub(crate) arms: Vec<BranchArm>,
 }
 
 #[derive(Debug, Clone)]
@@ -186,7 +191,6 @@ impl Facts {
             function_spans: Vec::new(),
             usages: HashSet::default(),
             interface_satisfied_methods: HashMap::default(),
-            equality_derivations: Vec::new(),
             test_functions: Vec::new(),
             bound_types: HashMap::default(),
         }
@@ -346,11 +350,9 @@ impl Facts {
             function_spans,
             usages,
             interface_satisfied_methods,
-            equality_derivations,
             test_functions,
             bound_types,
         } = other;
-        self.equality_derivations.extend(equality_derivations);
         self.test_functions.extend(test_functions);
         self.bound_types.extend(bound_types);
 

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -21,7 +21,7 @@ use crate::checker::{TaskOutput, TaskState};
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use crate::facts::Facts;
 use crate::loader::{DiscoveredModules, Loader};
-use crate::module_graph::{ModuleGraphOptions, Roots, build_module_graph};
+use crate::module_graph::{DependencyGraph, ModuleGraphOptions, Roots, build_module_graph};
 use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use crate::store::{ENTRY_MODULE_ID, Store};
 
@@ -30,6 +30,17 @@ pub enum CompilePhase {
     #[default]
     Check,
     Emit,
+    Test,
+}
+
+impl CompilePhase {
+    fn includes_tests(self) -> bool {
+        matches!(self, Self::Check | Self::Test)
+    }
+
+    fn emits(self) -> bool {
+        matches!(self, Self::Emit | Self::Test)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -62,7 +73,6 @@ pub struct AnalyzeInput<'a> {
     pub project_root: Option<PathBuf>,
     pub compile_phase: CompilePhase,
     pub project_kind: ProjectKind,
-    pub emit_tests: bool,
     pub locator: TypedefLocator,
     /// Go module path (from `lisette.toml`); folded into the cache emit-artifact
     /// hash so a project rename invalidates Go outputs.
@@ -81,9 +91,30 @@ struct CacheCandidate {
     expected_artifact_hash: Option<u64>,
 }
 
-struct PendingModule {
-    module_id: String,
-    topo_rank: usize,
+enum PendingModule {
+    Entry {
+        module_id: String,
+        topo_rank: usize,
+    },
+    Compiled {
+        module: CompiledModule,
+        topo_rank: usize,
+    },
+}
+
+impl PendingModule {
+    fn module_id(&self) -> &str {
+        match self {
+            Self::Entry { module_id, .. } => module_id,
+            Self::Compiled { module, .. } => &module.module_id,
+        }
+    }
+
+    fn topo_rank(&self) -> usize {
+        match self {
+            Self::Entry { topo_rank, .. } | Self::Compiled { topo_rank, .. } => *topo_rank,
+        }
+    }
 }
 
 struct CacheBuildJob {
@@ -93,7 +124,7 @@ struct CacheBuildJob {
 }
 
 struct RegistrationOutput {
-    modules: Vec<(String, Arc<Module>)>,
+    modules: Vec<Arc<Module>>,
     task: TaskOutput,
 }
 
@@ -154,7 +185,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
     let sink = LocalSink::new();
 
-    let include_tests = input.compile_phase == CompilePhase::Check || input.emit_tests;
+    let include_tests = input.compile_phase.includes_tests();
 
     store.init_entry_module();
     let entry_filename = input.entry.map(|entry| {
@@ -216,13 +247,13 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         DiscoveredModules::default()
     };
 
-    let include_test_roots = input.compile_phase == CompilePhase::Check || input.emit_tests;
+    let include_test_roots = input.compile_phase.includes_tests();
 
     let roots = match input.project_kind {
         ProjectKind::Binary => {
             let mut additional = match input.compile_phase {
                 CompilePhase::Check => discovered.production_modules.clone(),
-                _ => Vec::new(),
+                CompilePhase::Emit | CompilePhase::Test => Vec::new(),
             };
             if include_test_roots {
                 additional.extend(discovered.test_roots.iter().cloned());
@@ -288,8 +319,13 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     }
     parse_and_register_test_prelude(&mut store, &sink);
 
-    let cache_enabled = input.project_root.is_some() && !cache_disabled && !input.disable_cache;
-    let check_go_files = input.compile_phase == CompilePhase::Emit;
+    let module_cache_root = if cache_disabled || input.disable_cache {
+        None
+    } else {
+        input.project_root.as_deref()
+    };
+    let cache_enabled = module_cache_root.is_some();
+    let check_go_files = input.compile_phase.emits();
 
     let (facts, cached_modules, compiled_modules, ufcs_methods, sink) = {
         let mut checker = TaskState::with_sink(sink);
@@ -297,11 +333,8 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
         let mut module_hashes: HashMap<String, u64> = HashMap::default();
         let mut cached_modules: HashSet<String> = HashSet::default();
-        let mut compiled_modules: Vec<CompiledModule> = vec![];
-
         let order = std::mem::take(&mut graph_result.order);
-        let edges = &graph_result.edges;
-        let production_edges = &graph_result.production_edges;
+        let dependencies = &graph_result.dependencies;
 
         let mut go_cache = LazyGoStdlibCache::new(cache_disabled);
 
@@ -325,7 +358,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
         for (topo_rank, module_id) in order.into_iter().enumerate() {
             if module_id.starts_with("go:") {
-                if graph_result.link_only_modules.contains(&module_id) {
+                if dependencies.is_link_only_module(&module_id) {
                     continue;
                 }
                 register_go_module(
@@ -350,9 +383,12 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
                 .copied()
                 .unwrap_or_else(|| hash_module_source_pair(&files));
 
-            let dep_hashes = get_dependency_module_hashes(&module_id, edges, &module_hashes);
-            let production_dep_hashes =
-                get_dependency_module_hashes(&module_id, production_edges, &module_hashes);
+            let dep_hashes =
+                get_dependency_module_hashes(dependencies.dependencies(&module_id), &module_hashes);
+            let production_dep_hashes = get_dependency_module_hashes(
+                dependencies.production_dependencies(&module_id),
+                &module_hashes,
+            );
             let module_hash = compute_module_hash(production_hash, &production_dep_hashes);
             module_hashes.insert(module_id.clone(), module_hash);
 
@@ -369,64 +405,59 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             let expected_artifact_hash = check_go_files
                 .then(|| compute_emit_artifact_hash(production_hash, &input.go_module));
 
-            match (cache_enabled, compiled) {
-                (true, Some(compiled)) => candidates.push(CacheCandidate {
+            match (module_cache_root, compiled) {
+                (Some(_), Some(compiled)) => candidates.push(CacheCandidate {
                     compiled,
                     files,
                     topo_rank,
                     expected_artifact_hash,
                 }),
-                (_, compiled) => {
+                (None, compiled) | (Some(_), compiled @ None) => {
                     store.store_module(&module_id, files);
-                    if let Some(compiled) = compiled {
-                        compiled_modules.push(compiled);
-                    }
-                    to_infer.push(PendingModule {
-                        module_id,
-                        topo_rank,
-                    });
+                    let pending = match compiled {
+                        Some(module) => PendingModule::Compiled { module, topo_rank },
+                        None => PendingModule::Entry {
+                            module_id,
+                            topo_rank,
+                        },
+                    };
+                    to_infer.push(pending);
                 }
             }
         }
 
         let go_cache_module_ids = go_cache.into_module_ids();
 
-        let cache_load = load_cache_candidates(
-            &mut checker,
-            &mut store,
-            candidates,
-            input.project_root.as_deref(),
-            check_go_files,
-        );
-        compiled_modules.extend(cache_load.compiled);
+        let cache_load = match module_cache_root {
+            Some(root) => load_cache_candidates(&mut checker, &mut store, candidates, root),
+            None => {
+                debug_assert!(candidates.is_empty());
+                CacheLoad::default()
+            }
+        };
         cached_modules.extend(cache_load.cached);
         to_infer.extend(cache_load.to_infer);
 
         for pending in &to_infer {
-            checker.predeclare_module_types(&mut store, &pending.module_id);
+            checker.predeclare_module_types(&mut store, pending.module_id());
         }
         restore_cached_generic_bounds(&mut store, &checker.sink, &cached_modules);
 
-        to_infer.sort_by_key(|pending| pending.topo_rank);
+        to_infer.sort_by_key(PendingModule::topo_rank);
+        let mut compiled_modules = Vec::new();
         let to_infer: Vec<String> = to_infer
             .into_iter()
-            .map(|pending| pending.module_id)
-            .collect();
-
-        let test_ids: Vec<u32> = to_infer
-            .iter()
-            .filter_map(|module_id| store.get_module(module_id))
-            .flat_map(|module| {
-                module
-                    .files
-                    .values()
-                    .filter(|file| file.is_test())
-                    .map(|file| file.id)
+            .map(|pending| match pending {
+                PendingModule::Entry { module_id, .. } => module_id,
+                PendingModule::Compiled { module, .. } => {
+                    let module_id = module.module_id.clone();
+                    compiled_modules.push(module);
+                    module_id
+                }
             })
             .collect();
-        store.test_file_ids.extend(test_ids);
 
-        register_modules(&mut checker, &mut store, &to_infer, edges);
+        register_modules(&mut checker, &mut store, &to_infer, dependencies);
         infer_modules(&mut checker, &mut store, &to_infer);
 
         if !cache_disabled {
@@ -523,7 +554,6 @@ fn register_go_module(
 
 #[derive(Default)]
 struct CacheLoad {
-    compiled: Vec<CompiledModule>,
     cached: HashSet<String>,
     to_infer: Vec<PendingModule>,
 }
@@ -533,20 +563,16 @@ fn load_cache_candidates(
     checker: &mut TaskState,
     store: &mut Store,
     candidates: Vec<CacheCandidate>,
-    project_root: Option<&Path>,
-    check_go_files: bool,
+    project_root: &Path,
 ) -> CacheLoad {
     let load = |c: &CacheCandidate| {
-        project_root.and_then(|root| {
-            try_load_cache(
-                &c.compiled.module_id,
-                c.compiled.full_hash,
-                &c.compiled.dep_hashes,
-                c.expected_artifact_hash,
-                root,
-                check_go_files,
-            )
-        })
+        try_load_cache(
+            &c.compiled.module_id,
+            c.compiled.full_hash,
+            &c.compiled.dep_hashes,
+            c.expected_artifact_hash,
+            project_root,
+        )
     };
     let loaded: Vec<Option<ModuleInterface>> = if candidates.len() < PARALLEL_THRESHOLD {
         candidates.iter().map(load).collect()
@@ -556,22 +582,17 @@ fn load_cache_candidates(
 
     let mut result = CacheLoad::default();
     let mut build_jobs: Vec<CacheBuildJob> = Vec::new();
-    let mut discarded: Vec<Vec<File>> = Vec::new();
     for (candidate, interface) in candidates.into_iter().zip(loaded) {
         let Some(interface) = interface else {
             let module_id = candidate.compiled.module_id.clone();
             store.store_module(&module_id, candidate.files);
-            result.compiled.push(candidate.compiled);
-            result.to_infer.push(PendingModule {
-                module_id,
+            result.to_infer.push(PendingModule::Compiled {
+                module: candidate.compiled,
                 topo_rank: candidate.topo_rank,
             });
             continue;
         };
         let file_id_base = store.reserve_file_ids(interface.files.len() as u32);
-        if !candidate.files.is_empty() {
-            discarded.push(candidate.files);
-        }
         build_jobs.push(CacheBuildJob {
             module_id: candidate.compiled.module_id,
             interface,
@@ -579,10 +600,7 @@ fn load_cache_candidates(
         });
     }
 
-    let Some(root) = project_root else {
-        return result;
-    };
-    let display_base = crate::path::DisplayPathBase::new(&root.join("src"));
+    let display_base = crate::path::DisplayPathBase::new(&project_root.join("src"));
     let build = |job: CacheBuildJob| {
         build_cached_module(
             job.module_id,
@@ -591,23 +609,16 @@ fn load_cache_candidates(
             &display_base,
         )
     };
-    let run_build = || -> Vec<CachedModuleBuild> {
-        if build_jobs.len() < PARALLEL_THRESHOLD {
-            build_jobs.into_iter().map(build).collect()
-        } else {
-            build_jobs.into_par_iter().map(build).collect()
-        }
-    };
-    let built: Vec<CachedModuleBuild> = if discarded.is_empty() {
-        run_build()
+    let built: Vec<CachedModuleBuild> = if build_jobs.len() < PARALLEL_THRESHOLD {
+        build_jobs.into_iter().map(build).collect()
     } else {
-        rayon::join(run_build, move || discarded.into_par_iter().for_each(drop)).0
+        build_jobs.into_par_iter().map(build).collect()
     };
 
     for build in built {
         checker.extend_ufcs_methods(build.ufcs_methods);
-        let module_id = build.module_id;
-        store.insert_prebuilt_module(module_id.clone(), build.module, build.file_map);
+        let module_id = build.module.id.clone();
+        store.insert_prebuilt_module(build.module);
         checker.collect_cached_module_tests(store, &module_id);
         result.cached.insert(module_id);
     }
@@ -619,7 +630,7 @@ fn register_modules(
     checker: &mut TaskState,
     store: &mut Store,
     to_infer: &[String],
-    edges: &HashMap<String, HashSet<String>>,
+    dependencies: &DependencyGraph,
 ) {
     if to_infer.len() < PARALLEL_THRESHOLD {
         for module_id in to_infer {
@@ -630,20 +641,19 @@ fn register_modules(
 
     // Same-wave modules never read each other, so each worker mutates only its
     // own detached module and reads the rest through a snapshot.
-    for wave in registration_waves(to_infer, edges) {
+    for wave in registration_waves(to_infer, dependencies) {
         if wave.len() == 1 {
             checker.register_module(store, &wave[0]);
             continue;
         }
 
-        let detached: Vec<(String, Arc<Module>)> = wave
+        let detached: Vec<Arc<Module>> = wave
             .into_iter()
             .map(|module_id| {
-                let module = store
+                store
                     .modules
                     .remove(&module_id)
-                    .expect("fresh module must be stored before registration");
-                (module_id, module)
+                    .expect("fresh module must be stored before registration")
             })
             .collect();
 
@@ -658,14 +668,15 @@ fn register_modules(
                 let mut worker = seed.spawn();
                 let mut view = store_ref.registration_view();
                 let mut registered = Vec::with_capacity(chunk.len());
-                for (module_id, module) in chunk {
+                for module in chunk {
+                    let module_id = module.id.clone();
                     view.modules.insert(module_id.clone(), module);
                     worker.register_module(&mut view, &module_id);
                     let module = view
                         .modules
                         .remove(&module_id)
                         .expect("registered module must remain in view");
-                    registered.push((module_id, module));
+                    registered.push(module);
                 }
                 RegistrationOutput {
                     modules: registered,
@@ -676,8 +687,8 @@ fn register_modules(
 
         let mut task_outputs = Vec::with_capacity(outputs.len());
         for output in outputs {
-            for (module_id, module) in output.modules {
-                store.modules.insert(module_id, module);
+            for module in output.modules {
+                store.modules.insert(module.id.clone(), module);
             }
             task_outputs.push(output.task);
         }
@@ -718,7 +729,7 @@ fn infer_modules(checker: &mut TaskState, store: &mut Store, to_infer: &[String]
         checker.absorb_outputs(outputs);
     }
 
-    for (_, typed_file) in std::mem::take(&mut checker.typed_files) {
+    for typed_file in std::mem::take(&mut checker.typed_files) {
         store.store_file(typed_file);
     }
 
@@ -727,17 +738,12 @@ fn infer_modules(checker: &mut TaskState, store: &mut Store, to_infer: &[String]
 
 /// Groups topologically ordered modules into dependency waves, so a wave only
 /// reads modules registered in earlier waves.
-fn registration_waves(
-    modules: &[String],
-    edges: &HashMap<String, HashSet<String>>,
-) -> Vec<Vec<String>> {
+fn registration_waves(modules: &[String], dependencies: &DependencyGraph) -> Vec<Vec<String>> {
     let mut wave_of: HashMap<&str, usize> = HashMap::default();
     let mut waves: Vec<Vec<String>> = Vec::new();
     for module_id in modules {
-        let wave = edges
-            .get(module_id)
-            .into_iter()
-            .flatten()
+        let wave = dependencies
+            .dependencies(module_id)
             .filter_map(|dep| wave_of.get(dep.as_str()))
             .map(|dep_wave| dep_wave + 1)
             .max()

--- a/crates/semantics/src/module_graph/kahn.rs
+++ b/crates/semantics/src/module_graph/kahn.rs
@@ -1,16 +1,14 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::ModuleId;
+use super::{DependencyGraph, ModuleId};
 
-pub fn topological_sort(
-    edges: &HashMap<ModuleId, HashSet<ModuleId>>,
-) -> (Vec<ModuleId>, Vec<Vec<ModuleId>>) {
+pub fn topological_sort(edges: &DependencyGraph) -> (Vec<ModuleId>, Vec<Vec<ModuleId>>) {
     let mut in_degree: HashMap<ModuleId, usize> = HashMap::default();
     let mut order = Vec::new();
 
-    for (module, imports) in edges {
+    for module in edges.modules() {
         in_degree.entry(module.clone()).or_insert(0);
-        for import in imports {
+        for import in edges.dependencies(module) {
             *in_degree.entry(import.clone()).or_insert(0) += 1;
         }
     }
@@ -26,14 +24,12 @@ pub fn topological_sort(
     while let Some(module) = queue.pop() {
         order.push(module.clone());
 
-        if let Some(imports) = edges.get(&module) {
-            for import in imports {
-                if let Some(degree) = in_degree.get_mut(import) {
-                    *degree -= 1;
-                    if *degree == 0 {
-                        queue.push(import.clone());
-                        queue.sort();
-                    }
+        for import in edges.dependencies(&module) {
+            if let Some(degree) = in_degree.get_mut(import) {
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push(import.clone());
+                    queue.sort();
                 }
             }
         }
@@ -50,13 +46,10 @@ pub fn topological_sort(
     (order, cycles)
 }
 
-fn find_cycles(
-    edges: &HashMap<ModuleId, HashSet<ModuleId>>,
-    processed: &[ModuleId],
-) -> Vec<Vec<ModuleId>> {
+fn find_cycles(edges: &DependencyGraph, processed: &[ModuleId]) -> Vec<Vec<ModuleId>> {
     let processed_set: HashSet<_> = processed.iter().collect();
     let unprocessed: Vec<_> = edges
-        .keys()
+        .modules()
         .filter(|k| !processed_set.contains(k))
         .collect();
 
@@ -69,26 +62,21 @@ fn find_cycles(
         }
 
         let mut stack = vec![(start, vec![start.clone()])];
-        let mut on_stack: HashSet<ModuleId> = HashSet::default();
 
         while let Some((node, path)) = stack.pop() {
-            if on_stack.contains(node) {
+            if !visited.insert(node.clone()) {
                 continue;
             }
-            on_stack.insert(node.clone());
-            visited.insert(node.clone());
 
-            if let Some(imports) = edges.get(node) {
-                for import in imports {
-                    if let Some(position) = path.iter().position(|p| p == import) {
-                        let mut cycle_path: Vec<_> = path[position..].to_vec();
-                        cycle_path.push(import.clone());
-                        cycles.push(cycle_path);
-                    } else if !visited.contains(import) {
-                        let mut new_path = path.clone();
-                        new_path.push(import.clone());
-                        stack.push((import, new_path));
-                    }
+            for import in edges.dependencies(node) {
+                if let Some(position) = path.iter().position(|p| p == import) {
+                    let mut cycle_path: Vec<_> = path[position..].to_vec();
+                    cycle_path.push(import.clone());
+                    cycles.push(cycle_path);
+                } else if !visited.contains(import) {
+                    let mut new_path = path.clone();
+                    new_path.push(import.clone());
+                    stack.push((import, new_path));
                 }
             }
         }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -14,20 +14,136 @@ use diagnostics::LocalSink;
 
 pub type ModuleId = String;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DependencyKind {
+    Production,
+    TestOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImportUse {
+    LinkOnly,
+    Referenced,
+}
+
+impl ImportUse {
+    fn merge(self, other: Self) -> Self {
+        if self == Self::Referenced || other == Self::Referenced {
+            Self::Referenced
+        } else {
+            Self::LinkOnly
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Dependency {
+    kind: DependencyKind,
+    usage: ImportUse,
+}
+
+/// One canonical classification for every direct module dependency.
+#[derive(Debug, Default)]
+pub struct DependencyGraph {
+    edges: HashMap<ModuleId, HashMap<ModuleId, Dependency>>,
+}
+
+impl DependencyGraph {
+    pub fn contains_module(&self, module_id: &str) -> bool {
+        self.edges.contains_key(module_id)
+    }
+
+    pub fn contains_dependency(&self, module_id: &str, dependency: &str) -> bool {
+        self.edges
+            .get(module_id)
+            .is_some_and(|dependencies| dependencies.contains_key(dependency))
+    }
+
+    pub fn contains_production_dependency(&self, module_id: &str, dependency: &str) -> bool {
+        matches!(
+            self.edges
+                .get(module_id)
+                .and_then(|dependencies| dependencies.get(dependency))
+                .map(|dependency| dependency.kind),
+            Some(DependencyKind::Production)
+        )
+    }
+
+    pub(crate) fn modules(&self) -> impl Iterator<Item = &ModuleId> {
+        self.edges.keys()
+    }
+
+    pub(crate) fn dependencies(&self, module_id: &str) -> impl Iterator<Item = &ModuleId> {
+        self.edges
+            .get(module_id)
+            .into_iter()
+            .flat_map(HashMap::keys)
+    }
+
+    pub(crate) fn production_dependencies(
+        &self,
+        module_id: &str,
+    ) -> impl Iterator<Item = &ModuleId> {
+        self.edges
+            .get(module_id)
+            .into_iter()
+            .flat_map(|dependencies| {
+                dependencies.iter().filter_map(|(module_id, dependency)| {
+                    (dependency.kind == DependencyKind::Production).then_some(module_id)
+                })
+            })
+    }
+
+    pub(crate) fn is_link_only_module(&self, module_id: &str) -> bool {
+        let mut uses = self
+            .edges
+            .values()
+            .filter_map(|dependencies| dependencies.get(module_id))
+            .map(|dependency| dependency.usage);
+        matches!(uses.next(), Some(ImportUse::LinkOnly))
+            && uses.all(|usage| usage == ImportUse::LinkOnly)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.edges.len()
+    }
+
+    fn insert(&mut self, module_id: ModuleId, dependencies: HashMap<ModuleId, Dependency>) {
+        self.edges.insert(module_id, dependencies);
+    }
+}
+
+impl From<HashMap<ModuleId, HashSet<ModuleId>>> for DependencyGraph {
+    fn from(edges: HashMap<ModuleId, HashSet<ModuleId>>) -> Self {
+        Self {
+            edges: edges
+                .into_iter()
+                .map(|(module_id, dependencies)| {
+                    let dependencies = dependencies
+                        .into_iter()
+                        .map(|dependency| {
+                            (
+                                dependency,
+                                Dependency {
+                                    kind: DependencyKind::Production,
+                                    usage: ImportUse::Referenced,
+                                },
+                            )
+                        })
+                        .collect();
+                    (module_id, dependencies)
+                })
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ModuleGraphResult {
     pub order: Vec<ModuleId>,
     pub cycles: Vec<Vec<ModuleId>>,
     pub files: HashMap<ModuleId, Vec<File>>,
-    /// Direct dependencies of each module, test-file imports included. Drives
-    /// reachability, topological order, and a module's own cache validity.
-    pub edges: HashMap<ModuleId, HashSet<ModuleId>>,
-    /// `edges` minus imports that appear only in `.test.lis` files. Drives the
-    /// `module_hash` propagated to dependents, so a test-only import never
-    /// invalidates production importers.
-    pub production_edges: HashMap<ModuleId, HashSet<ModuleId>>,
-    /// `go:` modules that are only ever blank-imported in the visited file set.
-    pub(crate) link_only_modules: HashSet<ModuleId>,
+    pub dependencies: DependencyGraph,
     /// Reachable from the primary roots, snapshotted before `additional` runs.
     pub primary_reachable: HashSet<ModuleId>,
 }
@@ -70,12 +186,10 @@ pub fn build_module_graph(
         standalone_mode,
         locator,
         include_tests,
-        edges: HashMap::default(),
-        production_edges: HashMap::default(),
+        dependencies: DependencyGraph::default(),
         visited: HashSet::default(),
         files: HashMap::default(),
         import_spans: HashMap::default(),
-        blank_tracker: BlankTracker::default(),
     };
     builder.visit(primary);
     let primary_reachable = builder.visited.clone();
@@ -90,12 +204,10 @@ struct GraphBuilder<'a> {
     standalone_mode: bool,
     locator: &'a TypedefLocator,
     include_tests: bool,
-    edges: HashMap<ModuleId, HashSet<ModuleId>>,
-    production_edges: HashMap<ModuleId, HashSet<ModuleId>>,
+    dependencies: DependencyGraph,
     visited: HashSet<ModuleId>,
     files: HashMap<ModuleId, Vec<File>>,
     import_spans: HashMap<ModuleId, Span>,
-    blank_tracker: BlankTracker,
 }
 
 impl<'a> GraphBuilder<'a> {
@@ -138,12 +250,11 @@ impl<'a> GraphBuilder<'a> {
                     .flat_map(|f| f.imports())
                     .map(|import| import.name.to_string())
                     .collect();
-                let imports_with_spans = process_file_imports(
+                let imports = process_file_imports(
                     file_imports,
                     self.sink,
                     self.standalone_mode,
                     self.locator,
-                    &mut self.blank_tracker,
                 );
 
                 let has_production_file = module_files.iter().any(|file| !file.is_test());
@@ -185,81 +296,62 @@ impl<'a> GraphBuilder<'a> {
 
                 self.files.insert(module_id.clone(), module_files);
 
-                let imports: HashSet<_> = imports_with_spans.keys().cloned().collect();
-
-                for (import, span) in imports_with_spans {
-                    if !self.visited.contains(&import) {
+                for (import, resolved) in &imports {
+                    if !self.visited.contains(import) {
                         to_visit.push(import.clone());
                     }
-                    self.import_spans.entry(import).or_insert(span);
+                    self.import_spans
+                        .entry(import.clone())
+                        .or_insert(resolved.span);
                 }
 
-                let production_edge_set: HashSet<ModuleId> = if has_parsed_files {
+                let dependencies: HashMap<ModuleId, Dependency> = if has_parsed_files {
                     imports
-                        .iter()
-                        .filter(|import| production_import_names.contains(import.as_str()))
-                        .cloned()
+                        .into_iter()
+                        .map(|(import, resolved)| {
+                            let kind = if production_import_names.contains(import.as_str()) {
+                                DependencyKind::Production
+                            } else {
+                                DependencyKind::TestOnly
+                            };
+                            (
+                                import,
+                                Dependency {
+                                    kind,
+                                    usage: resolved.usage,
+                                },
+                            )
+                        })
                         .collect()
                 } else {
-                    imports.clone()
+                    imports
+                        .into_iter()
+                        .map(|(import, resolved)| {
+                            (
+                                import,
+                                Dependency {
+                                    kind: DependencyKind::Production,
+                                    usage: resolved.usage,
+                                },
+                            )
+                        })
+                        .collect()
                 };
-                self.production_edges
-                    .insert(module_id.clone(), production_edge_set);
-                self.edges.insert(module_id.clone(), imports);
+                self.dependencies.insert(module_id.clone(), dependencies);
             }
         }
     }
 
     fn finish(self, primary_reachable: HashSet<ModuleId>) -> ModuleGraphResult {
-        let (order, cycles) = kahn::topological_sort(&self.edges);
+        let (order, cycles) = kahn::topological_sort(&self.dependencies);
 
         ModuleGraphResult {
             order,
             cycles,
             files: self.files,
-            edges: self.edges,
-            production_edges: self.production_edges,
-            link_only_modules: self.blank_tracker.into_link_only_modules(),
+            dependencies: self.dependencies,
             primary_reachable,
         }
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ImportUse {
-    LinkOnly,
-    Referenced,
-}
-
-#[derive(Default)]
-struct BlankTracker {
-    modules: HashMap<ModuleId, ImportUse>,
-}
-
-impl BlankTracker {
-    fn record(&mut self, module_id: &str, is_blank: bool) {
-        let use_kind = if is_blank {
-            ImportUse::LinkOnly
-        } else {
-            ImportUse::Referenced
-        };
-        self.modules
-            .entry(module_id.to_string())
-            .and_modify(|prior| {
-                if use_kind == ImportUse::Referenced {
-                    *prior = ImportUse::Referenced;
-                }
-            })
-            .or_insert(use_kind);
-    }
-
-    fn into_link_only_modules(self) -> HashSet<ModuleId> {
-        self.modules
-            .into_iter()
-            .filter_map(|(module_id, use_kind)| {
-                (use_kind == ImportUse::LinkOnly).then_some(module_id)
-            })
-            .collect()
     }
 }
 
@@ -319,8 +411,7 @@ fn batch_parse_modules(
         }
     }
 
-    let parsed: Vec<(ModuleId, File, Vec<syntax::ParseError>)> = if jobs.len() < PARALLEL_THRESHOLD
-    {
+    let parsed: Vec<(File, Vec<syntax::ParseError>)> = if jobs.len() < PARALLEL_THRESHOLD {
         jobs.into_iter().map(parse_one).collect()
     } else {
         use rayon::prelude::*;
@@ -328,9 +419,12 @@ fn batch_parse_modules(
     };
 
     let mut grouped: HashMap<ModuleId, Vec<File>> = HashMap::default();
-    for (module_id, file, errors) in parsed {
+    for (file, errors) in parsed {
         sink.extend_parse_errors(errors);
-        grouped.entry(module_id).or_default().push(file);
+        grouped
+            .entry(file.module_id.clone())
+            .or_default()
+            .push(file);
     }
     grouped
 }
@@ -342,7 +436,7 @@ fn scan_one(fs: &dyn Loader, module_id: &str) -> Vec<(String, semantics_loader::
     entries
 }
 
-fn parse_one(job: ParseJob) -> (ModuleId, File, Vec<syntax::ParseError>) {
+fn parse_one(job: ParseJob) -> (File, Vec<syntax::ParseError>) {
     let result = syntax::build_ast(&job.source, job.file_id);
     let file = File::new(
         &job.module_id,
@@ -353,7 +447,19 @@ fn parse_one(job: ParseJob) -> (ModuleId, File, Vec<syntax::ParseError>) {
         result.file_comment,
         job.file_id,
     );
-    (job.module_id, file, result.errors)
+    (file, result.errors)
+}
+
+#[derive(Clone, Copy)]
+struct ResolvedImport {
+    span: Span,
+    usage: ImportUse,
+}
+
+struct PendingGoImport<'a> {
+    name: &'a str,
+    span: Span,
+    usage: ImportUse,
 }
 
 fn process_file_imports(
@@ -361,17 +467,31 @@ fn process_file_imports(
     sink: &LocalSink,
     standalone_mode: bool,
     locator: &TypedefLocator,
-    blank_tracker: &mut BlankTracker,
-) -> HashMap<ModuleId, Span> {
+) -> HashMap<ModuleId, ResolvedImport> {
     let mut imports = HashMap::default();
-    let referenced_go_imports: HashSet<&str> = file_imports
-        .iter()
-        .filter(|import| {
-            import.name.starts_with("go:") && !matches!(import.alias, Some(ImportAlias::Blank(_)))
-        })
-        .map(|import| import.name.as_str())
-        .collect();
-    let mut go_import_results: HashMap<&str, bool> = HashMap::default();
+    let mut pending_go_imports: Vec<PendingGoImport<'_>> = Vec::new();
+    for file_import in &file_imports {
+        if !file_import.name.starts_with("go:") {
+            continue;
+        }
+        let usage = if matches!(file_import.alias, Some(ImportAlias::Blank(_))) {
+            ImportUse::LinkOnly
+        } else {
+            ImportUse::Referenced
+        };
+        if let Some(pending) = pending_go_imports
+            .iter_mut()
+            .find(|pending| pending.name == file_import.name)
+        {
+            pending.usage = pending.usage.merge(usage);
+        } else {
+            pending_go_imports.push(PendingGoImport {
+                name: &file_import.name,
+                span: file_import.name_span,
+                usage,
+            });
+        }
+    }
 
     for file_import in &file_imports {
         if file_import.name == "prelude" {
@@ -389,42 +509,50 @@ fn process_file_imports(
         }
 
         if let Some(go_pkg) = file_import.name.strip_prefix("go:") {
-            let is_blank = matches!(file_import.alias, Some(ImportAlias::Blank(_)));
-            let ok = *go_import_results
-                .entry(file_import.name.as_str())
-                .or_insert_with(|| {
-                    if referenced_go_imports.contains(file_import.name.as_str()) {
-                        let result = locator.find_typedef_content(go_pkg);
-                        emit_for_locator_result(
-                            &result,
-                            &GoImportSite {
-                                import_name: &file_import.name,
-                                go_pkg,
-                                name_span: Some(file_import.name_span),
-                                target: locator.target(),
-                                standalone_mode,
-                                replace_importer: None,
-                            },
-                            sink,
-                        )
-                    } else {
-                        let status = locator.validate_declaration(go_pkg);
-                        emit_for_declaration_status(
-                            &status,
-                            &file_import.name,
+            let Some(index) = pending_go_imports
+                .iter()
+                .position(|pending| pending.name == file_import.name)
+            else {
+                continue;
+            };
+            let pending = pending_go_imports.remove(index);
+            let ok = match pending.usage {
+                ImportUse::Referenced => {
+                    let result = locator.find_typedef_content(go_pkg);
+                    emit_for_locator_result(
+                        &result,
+                        &GoImportSite {
+                            import_name: pending.name,
                             go_pkg,
-                            file_import.name_span,
-                            locator.target(),
+                            name_span: Some(pending.span),
+                            target: locator.target(),
                             standalone_mode,
-                            sink,
-                        )
-                    }
-                });
+                            replace_importer: None,
+                        },
+                        sink,
+                    )
+                }
+                ImportUse::LinkOnly => {
+                    let status = locator.validate_declaration(go_pkg);
+                    emit_for_declaration_status(
+                        &status,
+                        pending.name,
+                        go_pkg,
+                        pending.span,
+                        locator.target(),
+                        standalone_mode,
+                        sink,
+                    )
+                }
+            };
             if ok {
-                blank_tracker.record(&file_import.name, is_blank);
-                imports
-                    .entry(file_import.name.to_string())
-                    .or_insert(file_import.name_span);
+                imports.insert(
+                    pending.name.to_string(),
+                    ResolvedImport {
+                        span: pending.span,
+                        usage: pending.usage,
+                    },
+                );
             }
             continue;
         }
@@ -459,7 +587,10 @@ fn process_file_imports(
 
         imports
             .entry(file_import.name.to_string())
-            .or_insert(file_import.name_span);
+            .or_insert(ResolvedImport {
+                span: file_import.name_span,
+                usage: ImportUse::Referenced,
+            });
     }
 
     imports
@@ -482,18 +613,12 @@ mod tests {
 
     fn is_link_only(imports: Vec<FileImport>) -> bool {
         let sink = LocalSink::new();
-        let mut tracker = BlankTracker::default();
-        let resolved = process_file_imports(
-            imports,
-            &sink,
-            false,
-            &TypedefLocator::default(),
-            &mut tracker,
-        );
+        let resolved = process_file_imports(imports, &sink, false, &TypedefLocator::default());
 
         assert!(!sink.has_errors());
-        assert!(resolved.contains_key("go:fmt"));
-        tracker.into_link_only_modules().contains("go:fmt")
+        resolved
+            .get("go:fmt")
+            .is_some_and(|resolved| resolved.usage == ImportUse::LinkOnly)
     }
 
     #[test]
@@ -509,5 +634,24 @@ mod tests {
         assert!(!is_link_only(
             vec![go_import(false, 0), go_import(true, 1),]
         ));
+    }
+
+    #[test]
+    fn referenced_edge_wins_across_importing_modules() {
+        let dependency = |usage| Dependency {
+            kind: DependencyKind::Production,
+            usage,
+        };
+        let mut graph = DependencyGraph::default();
+        graph.insert(
+            "blank_importer".into(),
+            HashMap::from_iter([("go:fmt".into(), dependency(ImportUse::LinkOnly))]),
+        );
+        graph.insert(
+            "referencing_importer".into(),
+            HashMap::from_iter([("go:fmt".into(), dependency(ImportUse::Referenced))]),
+        );
+
+        assert!(!graph.is_link_only_module("go:fmt"));
     }
 }

--- a/crates/semantics/src/path.rs
+++ b/crates/semantics/src/path.rs
@@ -8,8 +8,13 @@ pub fn relative_to_cwd(path: &Path) -> Option<String> {
 
 /// Cwd-relative display paths under a fixed base dir, resolving prefixes once.
 pub struct DisplayPathBase {
-    canonical: Option<(PathBuf, PathBuf)>,
-    plain: Option<(PathBuf, PathBuf)>,
+    resolution: DisplayPathResolution,
+}
+
+enum DisplayPathResolution {
+    Unknown,
+    Canonical { base: PathBuf, cwd: PathBuf },
+    Plain { base: PathBuf, cwd: PathBuf },
 }
 
 impl DisplayPathBase {
@@ -20,8 +25,7 @@ impl DisplayPathBase {
     fn with_cwd(base_dir: &Path, cwd: Option<PathBuf>) -> Self {
         let Some(cwd) = cwd else {
             return Self {
-                canonical: None,
-                plain: None,
+                resolution: DisplayPathResolution::Unknown,
             };
         };
         let absolute_base = if base_dir.is_absolute() {
@@ -29,22 +33,23 @@ impl DisplayPathBase {
         } else {
             cwd.join(base_dir)
         };
-        let canonical = match (cwd.canonicalize(), absolute_base.canonicalize()) {
-            (Ok(canonical_cwd), Ok(canonical_base)) => Some((canonical_base, canonical_cwd)),
-            _ => None,
+        let resolution = match (cwd.canonicalize(), absolute_base.canonicalize()) {
+            (Ok(cwd), Ok(base)) => DisplayPathResolution::Canonical { base, cwd },
+            _ => DisplayPathResolution::Plain {
+                base: absolute_base,
+                cwd,
+            },
         };
-        Self {
-            canonical,
-            plain: Some((absolute_base, cwd)),
-        }
+        Self { resolution }
     }
 
     /// Mirrors `relative_to_cwd` on the base dir joined with `rel`.
     pub fn relative(&self, rel: &Path) -> Option<String> {
-        if let Some((base, cwd)) = &self.canonical {
-            return relativize(base.join(rel).strip_prefix(cwd).ok()?);
-        }
-        let (base, cwd) = self.plain.as_ref()?;
+        let (base, cwd) = match &self.resolution {
+            DisplayPathResolution::Canonical { base, cwd }
+            | DisplayPathResolution::Plain { base, cwd } => (base, cwd),
+            DisplayPathResolution::Unknown => return None,
+        };
         relativize(base.join(rel).strip_prefix(cwd).ok()?)
     }
 }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -19,9 +19,18 @@ pub struct ClosedMember {
     /// Qualified the way the user writes it (e.g. `time.Sunday`), for the diagnostic.
     pub display_name: EcoString,
     /// The member's source literal, for rendering the valid-set hint.
-    pub literal: Literal,
-    /// The comparable form, derived once so membership and sort never disagree.
-    pub value: DomainValue,
+    literal: Literal,
+}
+
+impl ClosedMember {
+    pub fn literal(&self) -> &Literal {
+        &self.literal
+    }
+
+    pub fn value(&self, base: SimpleKind) -> DomainValue {
+        DomainValue::from_literal(&self.literal, base)
+            .expect("closed-domain members have a literal compatible with their base")
+    }
 }
 
 /// The curated valid-value set of a `#[go(closed_domain)]` named primitive.
@@ -100,8 +109,6 @@ pub struct Store {
     /// `Arc` so registration workers share a read view; [`Arc::make_mut`]
     /// writes stay zero-copy while a module has a single owner.
     pub modules: HashMap<String, Arc<Module>>,
-    /// file ID -> module ID
-    files: HashMap<u32, String>,
     /// Go module ID -> package name from the typedef `// Package:` directive.
     pub go_package_names: HashMap<String, String>,
     /// File ID -> on-disk path of the `.d.lis` typedef. Lets the LSP map go: typedef
@@ -117,7 +124,7 @@ pub struct Store {
     pub test_index: TestIndex,
     /// File IDs of `.test.lis` files, for detecting test-file context during
     /// inference after a module's `files` have been taken out.
-    pub test_file_ids: HashSet<u32>,
+    test_file_ids: HashSet<u32>,
     /// Read during inference to gate the binary-only `main` signature check.
     pub(crate) project_kind: crate::inference::ProjectKind,
 }
@@ -141,7 +148,6 @@ impl Store {
         .collect();
 
         Self {
-            files: Default::default(),
             modules,
             go_package_names: Default::default(),
             typedef_paths: Default::default(),
@@ -161,10 +167,6 @@ impl Store {
 
     pub(crate) fn reserve_file_ids(&self, count: u32) -> u32 {
         self.next_file_id.fetch_add(count, Ordering::Relaxed)
-    }
-
-    pub fn register_file(&mut self, file_id: u32, module_id: &str) {
-        self.files.insert(file_id, module_id.to_string());
     }
 
     pub(crate) fn entry_module_id(&self) -> &'static str {
@@ -205,10 +207,10 @@ impl Store {
         }
     }
 
-    /// Stores a file in the module and registers the file_id -> module_id mapping.
+    /// Stores a file in its owning module.
     pub fn store_file(&mut self, file: File) {
         let module_id = file.module_id.clone();
-        self.files.insert(file.id, module_id.clone());
+        self.update_test_file_classification(&file);
 
         let module = self
             .get_module_mut(&module_id)
@@ -216,14 +218,27 @@ impl Store {
         module.files.insert(file.id, file);
     }
 
+    fn update_test_file_classification(&mut self, file: &File) {
+        if file.is_test() {
+            self.test_file_ids.insert(file.id);
+        } else {
+            self.test_file_ids.remove(&file.id);
+        }
+    }
+
     pub fn get_file(&self, file_id: u32) -> Option<&File> {
-        let module_id = self.files.get(&file_id)?;
-        let module = self.get_module(module_id)?;
-        module.get_file(file_id)
+        self.modules
+            .values()
+            .find_map(|module| module.get_file(file_id))
     }
 
     pub(crate) fn get_file_mut(&mut self, file_id: u32) -> Option<&mut File> {
-        let module_id = self.files.get(&file_id)?.clone();
+        let module_id = self.modules.iter().find_map(|(module_id, module)| {
+            module
+                .files
+                .contains_key(&file_id)
+                .then(|| module_id.clone())
+        })?;
         let module = Arc::make_mut(self.modules.get_mut(&module_id)?);
         module.files.get_mut(&file_id)
     }
@@ -249,15 +264,16 @@ impl Store {
         self.modules.get_mut(module_id).map(Arc::make_mut)
     }
 
-    /// Inserts a worker-built module (e.g. cache-decoded) and indexes its files.
-    pub(crate) fn insert_prebuilt_module(
-        &mut self,
-        module_id: String,
-        module: Module,
-        file_map: Vec<(u32, String)>,
-    ) {
-        for (file_id, owner) in file_map {
-            self.files.insert(file_id, owner);
+    /// Inserts a worker-built module (e.g. cache-decoded).
+    pub(crate) fn insert_prebuilt_module(&mut self, module: Module) {
+        let module_id = module.id.clone();
+        if let Some(previous) = self.modules.remove(&module_id) {
+            for file_id in previous.files.keys() {
+                self.test_file_ids.remove(file_id);
+            }
+        }
+        for file in module.files.values() {
+            self.update_test_file_classification(file);
         }
         self.modules.insert(module_id.clone(), Arc::new(module));
         self.visited_modules.insert(module_id);
@@ -268,7 +284,6 @@ impl Store {
     pub(crate) fn registration_view(&self) -> Store {
         Store {
             modules: self.modules.clone(),
-            files: self.files.clone(),
             go_package_names: self.go_package_names.clone(),
             typedef_paths: HashMap::default(),
             visited_modules: HashSet::default(),
@@ -303,6 +318,10 @@ impl Store {
         definition
             .name_span
             .is_some_and(|span| self.test_file_ids.contains(&span.file_id))
+    }
+
+    pub(crate) fn is_test_file(&self, file_id: u32) -> bool {
+        self.test_file_ids.contains(&file_id)
     }
 
     pub fn module_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
@@ -374,13 +393,12 @@ impl Store {
                 if module.id != *declaring_module {
                     continue;
                 }
-                let Some(value) = DomainValue::from_literal(const_literal, *base) else {
+                if DomainValue::from_literal(const_literal, *base).is_none() {
                     continue;
-                };
+                }
                 members.entry(id.clone()).or_default().push(ClosedMember {
                     display_name: domain_display_name(qualified_name.as_str()).into(),
                     literal: const_literal.clone(),
-                    value,
                 });
             }
         }
@@ -390,7 +408,7 @@ impl Store {
             let Some(mut domain_members) = members.remove(&type_id) else {
                 continue;
             };
-            domain_members.sort_by(|a, b| a.value.cmp(&b.value));
+            domain_members.sort_by_key(|member| member.value(base));
             domains.insert(
                 type_id.clone(),
                 ClosedDomain {
@@ -716,6 +734,30 @@ mod closed_domain_tests {
             id: Symbol::from_raw(id),
             params: vec![],
         }
+    }
+
+    #[test]
+    fn storing_a_file_owns_its_test_classification() {
+        let mut store = Store::new();
+        store.add_module("m");
+        store.store_file(File::new("m", "sample.test.lis", "", "", vec![], None, 42));
+
+        assert!(store.is_test_file(42));
+
+        store.store_file(File::new("m", "sample.lis", "", "", vec![], None, 42));
+
+        assert!(!store.is_test_file(42));
+    }
+
+    #[test]
+    fn replacing_a_module_removes_its_old_test_classification() {
+        let mut store = Store::new();
+        store.add_module("m");
+        store.store_file(File::new("m", "sample.test.lis", "", "", vec![], None, 42));
+
+        store.insert_prebuilt_module(Module::new("m"));
+
+        assert!(!store.is_test_file(42));
     }
 
     fn struct_def(ty: Type, closed_domain: bool) -> Definition {

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use lisette_semantics::loader::MemoryLoader;
 use lisette_passes::analyze;
-use lisette_semantics::inference::{AnalyzeInput, CompilePhase, SemanticConfig};
+use lisette_semantics::inference::{
+    AnalyzeInput, CompilePhase, EntryFile, ProjectKind, SemanticConfig,
+};
 use lisette_semantics::facts::{BindingIdAllocator, Facts};
 use lisette_syntax::ast::{Expression, Span, StructSpread};
 use lisette_syntax::program::{Definition, DefinitionBody};
@@ -207,15 +209,17 @@ fn run_analysis(code: &str) -> AnalysisResult {
             load_siblings: false,
         },
         loader: &loader,
-        source: code.to_string(),
-        filename: PLAYGROUND_FILE.to_string(),
-        display_path: PLAYGROUND_FILE.to_string(),
-        ast: ast_result.ast,
-        file_comment: ast_result.file_comment,
+        entry: Some(EntryFile {
+            source: code.to_string(),
+            filename: PLAYGROUND_FILE.to_string(),
+            display_path: PLAYGROUND_FILE.to_string(),
+            ast: ast_result.ast,
+            file_comment: ast_result.file_comment,
+        }),
         project_root: None,
         locator: lisette_deps::TypedefLocator::default(),
         compile_phase: CompilePhase::Check,
-        emit_tests: false,
+        project_kind: ProjectKind::Binary,
         go_module: String::new(),
         disable_cache: false,
     };
@@ -265,14 +269,16 @@ fn run_pipeline(
             load_siblings: false,
         },
         loader: &loader,
-        source: code.to_string(),
-        filename: PLAYGROUND_FILE.to_string(),
-        display_path: PLAYGROUND_FILE.to_string(),
-        ast: ast_result.ast,
-        file_comment: ast_result.file_comment,
+        entry: Some(EntryFile {
+            source: code.to_string(),
+            filename: PLAYGROUND_FILE.to_string(),
+            display_path: PLAYGROUND_FILE.to_string(),
+            ast: ast_result.ast,
+            file_comment: ast_result.file_comment,
+        }),
         project_root: None,
         compile_phase: phase.clone(),
-        emit_tests: false,
+        project_kind: ProjectKind::Binary,
         locator: lisette_deps::TypedefLocator::default(),
         go_module: String::new(),
         disable_cache: false,

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -171,7 +171,6 @@ fn check(source: &str) -> Checked {
         locator: TypedefLocator::default(),
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         go_module: String::new(),
         disable_cache: true,
     });

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -205,7 +205,6 @@ fn emit_and_write(
         locator: TypedefLocator::default(),
         compile_phase: CompilePhase::Emit,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         go_module: module.clone(),
         disable_cache: true,
     });

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -39,7 +39,6 @@ fn compile_with(
         locator,
         compile_phase: semantics::inference::CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         go_module: String::new(),
         disable_cache: false,
     })
@@ -92,7 +91,6 @@ pub fn compile_standalone_entry(
         locator: deps::TypedefLocator::default(),
         compile_phase: phase,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         go_module: String::new(),
         disable_cache: true,
     })
@@ -181,9 +179,12 @@ pub fn compile_project_files_with_tests(
         }),
         project_root: None,
         locator: deps::TypedefLocator::default(),
-        compile_phase: semantics::inference::CompilePhase::Emit,
+        compile_phase: if emit_tests {
+            semantics::inference::CompilePhase::Test
+        } else {
+            semantics::inference::CompilePhase::Emit
+        },
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests,
         go_module: go_module.to_string(),
         disable_cache: true,
     });

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -113,23 +113,8 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
 
             let files = graph_result.files.remove(&module_id).unwrap_or_default();
 
-            let prev_module_id = checker.cursor.module_id.clone();
-            checker.cursor.module_id = module_id.to_string();
             store.store_module(&module_id, files);
-            let test_ids: Vec<u32> = store
-                .get_module(&module_id)
-                .map(|module| {
-                    module
-                        .files
-                        .values()
-                        .filter(|file| file.is_test())
-                        .map(|file| file.id)
-                        .collect()
-                })
-                .unwrap_or_default();
-            store.test_file_ids.extend(test_ids);
             checker.register_module(&mut store, &module_id);
-            checker.cursor.module_id = prev_module_id;
 
             to_infer.push(module_id);
         }
@@ -139,14 +124,11 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         checker.finalize_tests(&mut store);
 
         for module_id in &to_infer {
-            let prev_module_id = checker.cursor.module_id.clone();
-            checker.cursor.module_id = module_id.to_string();
             let module_files = checker.take_module_files(&mut store, module_id);
             InferCtx::new(&mut checker, &store).infer_module(module_id, module_files);
-            checker.cursor.module_id = prev_module_id;
         }
 
-        for (_, typed_file) in std::mem::take(&mut checker.typed_files) {
+        for typed_file in std::mem::take(&mut checker.typed_files) {
             store.store_file(typed_file);
         }
 

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -21,10 +21,8 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
 
     init_prelude(&mut store);
 
-    // Parser::new hardcodes file_id=0 in spans, so pin the test file to that id
-    // too; source-based diagnostics rely on span.file_id matching files map key.
+    // Parser::new hardcodes file_id=0 in spans, so pin the test file to that id too.
     let file_id = 0u32;
-    store.register_file(file_id, TEST_MODULE_ID);
 
     let lex_result = Lexer::new(source, file_id).lex();
     if lex_result.failed() {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -2,7 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LocalSink;
 use semantics::module_graph::kahn::topological_sort;
-use semantics::module_graph::{ModuleGraphOptions, Roots, build_module_graph};
+use semantics::module_graph::{DependencyGraph, ModuleGraphOptions, Roots, build_module_graph};
 use semantics::store::Store;
 
 use crate::_harness::filesystem::MockFileSystem;
@@ -50,7 +50,7 @@ fn kahn_simple_dependency_chain() {
     edges.insert("b".to_string(), HashSet::from_iter(["c".to_string()]));
     edges.insert("c".to_string(), HashSet::default());
 
-    let (order, cycles) = topological_sort(&edges);
+    let (order, cycles) = topological_sort(&DependencyGraph::from(edges));
 
     assert!(cycles.is_empty());
     let pos_a = order.iter().position(|x| x == "a").unwrap();
@@ -71,7 +71,7 @@ fn kahn_diamond_dependency() {
     edges.insert("c".to_string(), HashSet::from_iter(["d".to_string()]));
     edges.insert("d".to_string(), HashSet::default());
 
-    let (order, cycles) = topological_sort(&edges);
+    let (order, cycles) = topological_sort(&DependencyGraph::from(edges));
 
     assert!(cycles.is_empty());
     let pos_a = order.iter().position(|x| x == "a").unwrap();
@@ -91,7 +91,7 @@ fn kahn_simple_cycle() {
     edges.insert("b".to_string(), HashSet::from_iter(["c".to_string()]));
     edges.insert("c".to_string(), HashSet::from_iter(["a".to_string()]));
 
-    let (_, cycles) = topological_sort(&edges);
+    let (_, cycles) = topological_sort(&DependencyGraph::from(edges));
 
     assert!(!cycles.is_empty());
 }
@@ -103,7 +103,7 @@ fn kahn_no_dependencies() {
     edges.insert("b".to_string(), HashSet::default());
     edges.insert("c".to_string(), HashSet::default());
 
-    let (order, cycles) = topological_sort(&edges);
+    let (order, cycles) = topological_sort(&DependencyGraph::from(edges));
 
     assert!(cycles.is_empty());
     assert_eq!(order.len(), 3);
@@ -127,16 +127,42 @@ fn test_only_imports_excluded_from_production_edges() {
     );
 
     assert!(
-        result.edges["math"].contains("fixture"),
+        result.dependencies.contains_dependency("math", "fixture"),
         "a test-file import must still be a graph edge for reachability"
     );
     assert!(
-        !result.production_edges["math"].contains("fixture"),
+        !result
+            .dependencies
+            .contains_production_dependency("math", "fixture"),
         "a test-only import must not enter production edges that importers key on"
     );
     assert!(
-        !result.production_edges["main"].contains("fixture"),
+        !result
+            .dependencies
+            .contains_production_dependency("main", "fixture"),
         "the test-only dependency must not propagate to production importers"
+    );
+}
+
+#[test]
+fn production_import_classification_wins_when_tests_import_the_same_module() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.lis", r#"import "fixture""#);
+    fs.add_file("main", "main.test.lis", r#"import "fixture""#);
+    fs.add_file("fixture", "fixture.lis", "pub fn sample() -> int { 2 }");
+
+    let mut store = Store::new();
+    let sink = LocalSink::new();
+    let result = build_module_graph(
+        &mut store,
+        roots("main"),
+        graph_options(&fs, &sink, &default_resolver(), false),
+    );
+
+    assert!(
+        result
+            .dependencies
+            .contains_production_dependency("main", "fixture")
     );
 }
 
@@ -222,7 +248,7 @@ fn additional_roots_widen_graph_but_not_reachable_set() {
     );
 
     assert!(result.order.iter().any(|m| m == "orphan"));
-    assert!(result.edges.contains_key("orphan"));
+    assert!(result.dependencies.contains_module("orphan"));
     assert!(result.files.contains_key("orphan"));
     assert!(
         !result.primary_reachable.contains("orphan"),
@@ -307,7 +333,6 @@ fn check_analyzes_orphan_and_surfaces_its_error() {
         project_root: Some(tmp.path().to_path_buf()),
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         locator: deps::TypedefLocator::default(),
         go_module: String::new(),
         disable_cache: true,
@@ -364,7 +389,6 @@ fn check_analyzes_tests_in_declaration_only_module() {
         project_root: Some(tmp.path().to_path_buf()),
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         locator: deps::TypedefLocator::default(),
         go_module: String::new(),
         disable_cache: true,
@@ -736,7 +760,6 @@ fn main() {
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         locator: resolver,
         go_module: String::new(),
         disable_cache: false,
@@ -831,7 +854,6 @@ fn main() {
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         locator: resolver.clone(),
         go_module: String::new(),
         disable_cache: false,
@@ -862,7 +884,6 @@ fn main() {
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
-        emit_tests: false,
         locator: resolver,
         go_module: String::new(),
         disable_cache: false,

--- a/tests/spec/infer/try.rs
+++ b/tests/spec/infer/try.rs
@@ -340,6 +340,36 @@ fn try_block_with_loop_inside() {
 }
 
 #[test]
+fn try_block_cannot_break_an_enclosing_loop() {
+    infer(
+        r#"{
+    for i in 0..3 {
+      try {
+        break
+        Option.Some(i)?
+      }
+    }
+    }"#,
+    )
+    .assert_infer_code("try_block_break");
+}
+
+#[test]
+fn try_block_cannot_continue_an_enclosing_loop() {
+    infer(
+        r#"{
+    for i in 0..3 {
+      try {
+        continue
+        Option.Some(i)?
+      }
+    }
+    }"#,
+    )
+    .assert_infer_code("try_block_continue");
+}
+
+#[test]
 fn try_block_in_if_condition() {
     infer(
         r#"{


### PR DESCRIPTION
Several pieces of state in `semantics` were split across 2-3 fields that only made sense in particular combinations, with the caller responsible for keeping them in lockstep. Each is now a type that maintains itself, so e.g. a combination like `Check` with test emission, or an edge recorded in one collection and missed in another, cannot be written.
