### PR TITLE
perf: scan project sources once per check

### DIFF
--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -15,6 +15,7 @@ pub use semantics::path::relative_to_cwd;
 
 pub struct LocalFileSystem {
     search_paths: Vec<(PathBuf, DisplayPathBase)>,
+    scanned_sources: Option<Vec<PathBuf>>,
 }
 
 impl LocalFileSystem {
@@ -32,7 +33,16 @@ impl LocalFileSystem {
                     (path, display_base)
                 })
                 .collect(),
+            scanned_sources: None,
         }
+    }
+
+    /// Build a loader rooted at `src_dir` whose module discovery reuses `sources`,
+    /// which must be the `.lis` files under that same directory.
+    pub fn with_scanned_sources(src_dir: &Path, sources: Vec<PathBuf>) -> Self {
+        let mut fs = Self::new(src_dir.to_str().unwrap_or("."));
+        fs.scanned_sources = Some(sources);
+        fs
     }
 
     fn collect_files(&self, folder_path: &Path, fs_name: &str, base: &DisplayPathBase) -> Files {
@@ -373,7 +383,15 @@ impl Loader for LocalFileSystem {
         let mut with_test: HashSet<PathBuf> = HashSet::default();
         let mut with_test_root_file: HashSet<PathBuf> = HashSet::default();
         let mut with_production_module: HashSet<PathBuf> = HashSet::default();
-        for path in collect_lis_filepaths_recursive(root) {
+        let walked;
+        let sources = match &self.scanned_sources {
+            Some(sources) => sources.as_slice(),
+            None => {
+                walked = collect_lis_filepaths_recursive(root);
+                &walked
+            }
+        };
+        for path in sources {
             let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -149,8 +149,8 @@ pub(super) fn link_project_binary(
 fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
     crate::go_cli::require_go()?;
 
-    let kind = match validate_project(project_path) {
-        Some(kind) => kind,
+    let layout = match validate_project(project_path) {
+        Some(layout) => layout,
         None => return Err(1),
     };
 
@@ -181,7 +181,8 @@ fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
         target_dir,
         manifest,
         locator,
-        kind,
+        kind: layout.kind,
+        sources: layout.sources,
     })
 }
 
@@ -191,6 +192,7 @@ pub(super) struct BuildPrep {
     pub manifest: deps::Manifest,
     pub locator: deps::TypedefLocator,
     pub kind: ProjectKind,
+    pub sources: Vec<PathBuf>,
 }
 
 pub(super) struct LockedProject {
@@ -360,8 +362,7 @@ pub(super) fn build_locked(
         locator: locator.clone(),
     };
 
-    let source_dir = src_dir.to_str().unwrap_or(".");
-    let local_fs = LocalFileSystem::new(source_dir);
+    let local_fs = LocalFileSystem::with_scanned_sources(&src_dir, prep.sources.clone());
 
     let input = match entry_bits.as_ref() {
         Some((source, display)) => CompileInput::Binary(CompileEntry {
@@ -538,7 +539,12 @@ pub(super) fn build_locked(
     })
 }
 
-pub(super) fn resolve_project_kind(project_path: &Path) -> Option<ProjectKind> {
+pub(super) struct ProjectLayout {
+    pub kind: ProjectKind,
+    pub sources: Vec<PathBuf>,
+}
+
+pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayout> {
     if project_path.join("main.lis").exists() {
         cli_error!(
             "Misplaced entrypoint",
@@ -557,7 +563,10 @@ pub(super) fn resolve_project_kind(project_path: &Path) -> Option<ProjectKind> {
     }
 
     if src.join("main.lis").exists() {
-        return Some(ProjectKind::Binary);
+        return Some(ProjectLayout {
+            kind: ProjectKind::Binary,
+            sources,
+        });
     }
 
     let has_production = sources.iter().any(|p| {
@@ -578,7 +587,10 @@ pub(super) fn resolve_project_kind(project_path: &Path) -> Option<ProjectKind> {
         return None;
     }
 
-    Some(ProjectKind::Library)
+    Some(ProjectLayout {
+        kind: ProjectKind::Library,
+        sources,
+    })
 }
 
 const GO_OS_NAMES: &[&str] = &[
@@ -717,7 +729,7 @@ fn go_ignored_shape(src: &Path, sources: &[PathBuf]) -> Option<(&'static str, St
     None
 }
 
-fn validate_project(project_path: &Path) -> Option<ProjectKind> {
+fn validate_project(project_path: &Path) -> Option<ProjectLayout> {
     if !project_path.exists() {
         cli_error!(
             "Project not found",
@@ -739,5 +751,5 @@ fn validate_project(project_path: &Path) -> Option<ProjectKind> {
         return None;
     }
 
-    resolve_project_kind(project_path)
+    resolve_project_layout(project_path)
 }

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -16,6 +16,7 @@ use lisette::pipeline::{
 
 use crate::cli_error;
 use crate::command::CheckAction;
+use crate::handlers::build::ProjectLayout;
 use crate::lock::acquire_target_lock;
 use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 
@@ -79,6 +80,7 @@ pub fn check(
             CompileScope::Standalone,
             TypedefLocator::default(),
             "main",
+            None,
         );
     }
 
@@ -90,8 +92,8 @@ pub fn check(
 }
 
 fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
-    let kind = match super::build::resolve_project_kind(project_path) {
-        Some(kind) => kind,
+    let layout = match super::build::resolve_project_layout(project_path) {
+        Some(layout) => layout,
         None => return 1,
     };
 
@@ -143,6 +145,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
     let locator = locator.with_bindgen(bindgen);
 
     let go_module = manifest.project.name.clone();
+    let ProjectLayout { kind, sources } = layout;
     let result = match kind {
         ProjectKind::Binary => {
             let src_main = project_path.join("src").join("main.lis");
@@ -152,6 +155,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
                 CompileScope::Project(project_path.to_path_buf()),
                 locator,
                 &go_module,
+                Some(sources),
             )
         }
         ProjectKind::Library => {
@@ -163,6 +167,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
                 CompileScope::Project(project_path.to_path_buf()),
                 locator,
                 &go_module,
+                Some(sources),
             );
             report_check(&result, "", "", options, start)
         }
@@ -177,9 +182,10 @@ fn check_single_file(
     scope: CompileScope,
     locator: TypedefLocator,
     go_module: &str,
+    sources: Option<Vec<PathBuf>>,
 ) -> i32 {
     let start = Instant::now();
-    let compiled = match compile_single_file(file_path, scope, locator, go_module) {
+    let compiled = match compile_single_file(file_path, scope, locator, go_module, sources) {
         Ok(compiled) => compiled,
         Err(ReadFailure) => return 1,
     };
@@ -256,6 +262,7 @@ fn compile_single_file(
     scope: CompileScope,
     locator: TypedefLocator,
     go_module: &str,
+    sources: Option<Vec<PathBuf>>,
 ) -> Result<CompiledFile, ReadFailure> {
     let source = match fs::read_to_string(file_path) {
         Ok(s) => s,
@@ -288,6 +295,7 @@ fn compile_single_file(
         scope,
         locator,
         go_module,
+        sources,
     );
 
     Ok(CompiledFile {
@@ -303,6 +311,7 @@ fn compile_project_entry(
     scope: CompileScope,
     locator: TypedefLocator,
     go_module: &str,
+    sources: Option<Vec<PathBuf>>,
 ) -> CompileResult {
     let config = CompileConfig {
         mode: CompileMode::Check,
@@ -312,7 +321,10 @@ fn compile_project_entry(
         locator,
     };
 
-    let fs = LocalFileSystem::new(dir.to_str().unwrap_or("."));
+    let fs = match sources {
+        Some(sources) => LocalFileSystem::with_scanned_sources(dir, sources),
+        None => LocalFileSystem::new(dir.to_str().unwrap_or(".")),
+    };
     compile(input, &config, &fs)
 }
 
@@ -358,6 +370,7 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
                 CompileScope::Directory,
                 TypedefLocator::default(),
                 "main",
+                None,
             ) {
                 compiled = Some(result);
                 break;


### PR DESCRIPTION
`lis check` no longer walks `src/` twice per run, introduced at #1094. Warm `lis check` had regressed ~10% percent against v0.9.0 depending on project size, and is now again within measurement noise of it.
