### PR TITLE
refactor: remove and forbid `too_many_arguments` exemptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ repository = "https://github.com/ivov/lisette"
 homepage = "https://lisette.run"
 description = "Little language inspired by Rust that compiles to Go"
 
+[workspace.lints.clippy]
+too_many_arguments = "forbid"
+
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 6

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -38,3 +38,6 @@ rustc-hash.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -1,6 +1,6 @@
 use super::project::MutationProject;
 use super::reconciliation::{
-    ReplacedRoot, ReplacedRootMode, ReplacementIdentity, ResolvedDependency,
+    ReplacedRoot, ReplacedRootMode, ReplacementIdentity, ResolvedDependency, RootWrite,
     apply_graph_to_manifest, declared_replacements, finalize_manifest_via, reconcile_root,
 };
 use crate::go_cli;
@@ -159,17 +159,22 @@ fn run_add_pipeline(plan: AddPlan) -> i32 {
         Err(code) => return code,
     };
 
+    let root_write = match replacement {
+        Some(identity) => RootWrite::Replaced(ReplacedRoot {
+            identity,
+            mode: ReplacedRootMode::AddDirect,
+        }),
+        None => RootWrite::Remote {
+            fallback_version: &plan.resolved_version,
+        },
+    };
     let upgraded = match apply_graph_to_manifest(
         &resolved_dep.canonical_module,
         &project.root,
         &project.manifest,
-        &plan.resolved_version,
         &workspace,
         &module_graph,
-        replacement.map(|identity| ReplacedRoot {
-            identity,
-            mode: ReplacedRootMode::AddDirect,
-        }),
+        root_write,
     ) {
         Ok(u) => u,
         Err(code) => return code,

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -379,16 +379,18 @@ pub(super) fn build_locked(
     let counts = render::render_all(
         &result.errors,
         &result.lints,
-        |file_id| {
-            result
-                .sources
-                .get(&file_id)
-                .map(|info| (info.source.clone(), info.filename.clone()))
-        },
+        render::SourceCache::new(
+            |file_id| {
+                result
+                    .sources
+                    .get(&file_id)
+                    .map(|info| (info.source.clone(), info.filename.clone()))
+            },
+            entry_bits.as_ref().map(|(s, _)| s.as_str()).unwrap_or(""),
+            entry_bits.as_ref().map(|(_, d)| d.as_str()).unwrap_or(""),
+        ),
         result.user_file_count,
         &filter,
-        entry_bits.as_ref().map(|(s, _)| s.as_str()).unwrap_or(""),
-        entry_bits.as_ref().map(|(_, d)| d.as_str()).unwrap_or(""),
     );
 
     if counts.errors > 0 {

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -223,11 +223,9 @@ fn report_check(
         let (output, counts) = render::render_unix(
             &result.errors,
             &result.lints,
-            get_source,
+            render::SourceCache::new(get_source, source, filename),
             result.user_file_count,
             &options.filter,
-            source,
-            filename,
         );
         print!("{}", output);
         counts
@@ -235,11 +233,9 @@ fn report_check(
         render::render_all(
             &result.errors,
             &result.lints,
-            get_source,
+            render::SourceCache::new(get_source, source, filename),
             result.user_file_count,
             &options.filter,
-            source,
-            filename,
         )
     };
     if !unix {
@@ -399,11 +395,9 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
             let (output, counts) = render::render_unix(
                 &compiled.result.errors,
                 &compiled.result.lints,
-                get_source,
+                render::SourceCache::new(get_source, &compiled.source, &compiled.display_path),
                 compiled.result.user_file_count,
                 &options.filter,
-                &compiled.source,
-                &compiled.display_path,
             );
             print!("{}", output);
             counts
@@ -411,11 +405,9 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
             render::render_all(
                 &compiled.result.errors,
                 &compiled.result.lints,
-                get_source,
+                render::SourceCache::new(get_source, &compiled.source, &compiled.display_path),
                 compiled.result.user_file_count,
                 &options.filter,
-                &compiled.source,
-                &compiled.display_path,
             )
         };
         total_errors += counts.errors;

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -194,6 +194,11 @@ pub(crate) struct ReplacedRoot<'a> {
     pub(crate) mode: ReplacedRootMode,
 }
 
+pub(crate) enum RootWrite<'a> {
+    Remote { fallback_version: &'a str },
+    Replaced(ReplacedRoot<'a>),
+}
+
 /// Re-walk every declared replacement's closure and reconcile the manifest, for `lis sync`.
 pub(crate) fn reconcile_declared_replacements(
     project_root: &Path,
@@ -266,10 +271,9 @@ pub(crate) fn reconcile_declared_replacements(
             original,
             project_root,
             &current,
-            &replacement.replacement_version,
             &workspace,
             graph,
-            Some(ReplacedRoot {
+            RootWrite::Replaced(ReplacedRoot {
                 identity: replacement,
                 mode: ReplacedRootMode::SyncPreserveVia,
             }),
@@ -836,18 +840,16 @@ pub(crate) fn apply_graph_to_manifest(
     added_dep: &str,
     project_root: &Path,
     manifest: &deps::Manifest,
-    fallback_version: &str,
     workspace: &GoWorkspace,
     graph: &GraphResult,
-    replaced_root: Option<ReplacedRoot>,
+    root: RootWrite<'_>,
 ) -> Result<Vec<DirectUpgrade>, i32> {
     let existing_deps = manifest.go_deps();
     let transitives = graph.transitive_map(added_dep);
-    let added_dep_version = graph.version(added_dep).unwrap_or(fallback_version);
     let mut upgraded: Vec<DirectUpgrade> = Vec::new();
 
-    let root_result = match replaced_root {
-        Some(replaced_root) => {
+    let root_result = match root {
+        RootWrite::Replaced(replaced_root) => {
             let via = match replaced_root.mode {
                 ReplacedRootMode::SyncPreserveVia => existing_deps
                     .get(added_dep)
@@ -864,14 +866,17 @@ pub(crate) fn apply_graph_to_manifest(
                 },
             )
         }
-        None => upsert_go_dependency(
-            project_root,
-            added_dep,
-            &deps::GoDependency::Remote {
-                version: added_dep_version.to_string(),
-                via: None,
-            },
-        ),
+        RootWrite::Remote { fallback_version } => {
+            let added_dep_version = graph.version(added_dep).unwrap_or(fallback_version);
+            upsert_go_dependency(
+                project_root,
+                added_dep,
+                &deps::GoDependency::Remote {
+                    version: added_dep_version.to_string(),
+                    via: None,
+                },
+            )
+        }
     };
     if let Err(msg) = root_result {
         error!("failed to update manifest", msg);

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -167,16 +167,18 @@ fn run_standalone(file: &str, args: Vec<String>, sourcemap: bool, go_flags: &[St
     let counts = render::render_all(
         &result.errors,
         &result.lints,
-        |file_id| {
-            result
-                .sources
-                .get(&file_id)
-                .map(|info| (info.source.clone(), info.filename.clone()))
-        },
+        render::SourceCache::new(
+            |file_id| {
+                result
+                    .sources
+                    .get(&file_id)
+                    .map(|info| (info.source.clone(), info.filename.clone()))
+            },
+            &source,
+            &entry_display,
+        ),
         result.user_file_count,
         &filter,
-        &source,
-        &entry_display,
     );
 
     if counts.errors > 0 {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -210,79 +210,66 @@ pub fn print_add_success(
         None => eprintln!("  ✓ Added {} {}", module_path, version),
     }
 
-    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
-    visited.insert(module_path.to_string());
-
-    let empty: Vec<String> = Vec::new();
-    let children = edges.get(module_path).unwrap_or(&empty);
-    let mut sorted: Vec<&String> = children.iter().collect();
-    sorted.sort();
-    for (i, child) in sorted.iter().enumerate() {
-        let is_last = i == sorted.len() - 1;
-        print_tree_node(
-            child,
-            "    ",
-            is_last,
-            edges,
-            versions,
-            colored,
-            &mut visited,
-        );
-    }
+    let mut printer = TreePrinter {
+        edges,
+        versions,
+        colored,
+        visited: std::collections::HashSet::new(),
+    };
+    printer.visited.insert(module_path.to_string());
+    printer.print_children(module_path, "    ");
 }
 
-fn print_tree_node(
-    node: &str,
-    prefix: &str,
-    is_last: bool,
-    edges: &std::collections::HashMap<String, Vec<String>>,
-    versions: &std::collections::HashMap<String, String>,
+struct TreePrinter<'a> {
+    edges: &'a std::collections::HashMap<String, Vec<String>>,
+    versions: &'a std::collections::HashMap<String, String>,
     colored: bool,
-    visited: &mut std::collections::HashSet<String>,
-) {
-    let branch = if is_last { "└─ " } else { "├─ " };
-    let version = versions.get(node).map(String::as_str).unwrap_or("");
-    let already_seen = !visited.insert(node.to_string());
+    visited: std::collections::HashSet<String>,
+}
 
-    if colored {
-        if already_seen {
-            eprintln!(
-                "{}{}{} {} {}",
-                prefix,
-                branch,
-                node.green(),
-                version.blue(),
-                "(*)".dimmed()
-            );
-        } else {
-            eprintln!("{}{}{} {}", prefix, branch, node.green(), version.blue());
+impl TreePrinter<'_> {
+    fn print_children(&mut self, node: &str, prefix: &str) {
+        let Some(children) = self.edges.get(node) else {
+            return;
+        };
+        let mut sorted: Vec<&String> = children.iter().collect();
+        sorted.sort();
+        for (i, child) in sorted.iter().enumerate() {
+            let is_last = i == sorted.len() - 1;
+            self.print_node(child, prefix, is_last);
         }
-    } else if already_seen {
-        eprintln!("{}{}{} {} (*)", prefix, branch, node, version);
-    } else {
-        eprintln!("{}{}{} {}", prefix, branch, node, version);
     }
 
-    if already_seen {
-        return;
-    }
+    fn print_node(&mut self, node: &str, prefix: &str, is_last: bool) {
+        let branch = if is_last { "└─ " } else { "├─ " };
+        let version = self.versions.get(node).map(String::as_str).unwrap_or("");
+        let already_seen = !self.visited.insert(node.to_string());
 
-    let empty: Vec<String> = Vec::new();
-    let children = edges.get(node).unwrap_or(&empty);
-    let mut sorted: Vec<&String> = children.iter().collect();
-    sorted.sort();
-    let child_prefix = format!("{}{}", prefix, if is_last { "   " } else { "│  " });
-    for (i, child) in sorted.iter().enumerate() {
-        let child_is_last = i == sorted.len() - 1;
-        print_tree_node(
-            child,
-            &child_prefix,
-            child_is_last,
-            edges,
-            versions,
-            colored,
-            visited,
-        );
+        if self.colored {
+            if already_seen {
+                eprintln!(
+                    "{}{}{} {} {}",
+                    prefix,
+                    branch,
+                    node.green(),
+                    version.blue(),
+                    "(*)".dimmed()
+                );
+            } else {
+                eprintln!("{}{}{} {}", prefix, branch, node.green(), version.blue());
+            }
+        } else if already_seen {
+            eprintln!("{}{}{} {} (*)", prefix, branch, node, version);
+        } else {
+            eprintln!("{}{}{} {}", prefix, branch, node, version);
+        }
+
+        if already_seen {
+            return;
+        }
+
+        let child_prefix = format!("{}{}", prefix, if is_last { "   " } else { "│  " });
+        self.print_children(node, &child_prefix);
     }
 }
 

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -19,3 +19,6 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -16,3 +16,6 @@ syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
 miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true
+
+[lints]
+workspace = true

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -1321,17 +1321,14 @@ pub fn manual_replace_all(
 pub fn needless_splitn(
     span: &Span,
     member: &str,
-    target: &str,
-    namespace: &str,
-    s: &str,
-    sep: &str,
-    count: &str,
+    original: &str,
+    replacement: &str,
 ) -> LisetteDiagnostic {
     LisetteDiagnostic::info(format!("Needless `{member}`"))
         .with_lint_code("needless_splitn")
         .with_span_label(span, "splits with no limit")
         .with_help(format!(
-            "`{namespace}.{member}({s}, {sep}, {count})` splits with no limit. Use `{namespace}.{target}({s}, {sep})`"
+            "`{original}` splits with no limit. Use `{replacement}`"
         ))
 }
 

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -247,7 +247,7 @@ pub struct Counts {
 }
 
 /// Resolves a `file_id` to its source, falling back to the entry file.
-struct SourceCache<F> {
+pub struct SourceCache<F> {
     get_source: F,
     default_source: IndexedSource,
     default_filename: String,
@@ -255,7 +255,7 @@ struct SourceCache<F> {
 }
 
 impl<F: Fn(u32) -> Option<(String, String)>> SourceCache<F> {
-    fn new(get_source: F, default_source: &str, default_filename: &str) -> Self {
+    pub fn new(get_source: F, default_source: &str, default_filename: &str) -> Self {
         Self {
             get_source,
             default_source: IndexedSource::new(default_source),
@@ -329,11 +329,9 @@ impl DiagnosticGroups<'_> {
 pub fn render_all(
     errors: &[LisetteDiagnostic],
     lints: &[LisetteDiagnostic],
-    get_source: impl Fn(u32) -> Option<(String, String)>,
+    mut sources: SourceCache<impl Fn(u32) -> Option<(String, String)>>,
     file_count: usize,
     filter: &Filter,
-    default_source: &str,
-    default_filename: &str,
 ) -> Counts {
     let groups = partition_diagnostics(errors, lints, filter);
 
@@ -342,7 +340,6 @@ pub fn render_all(
     }
 
     let use_color = std::env::var("NO_COLOR").is_err();
-    let mut sources = SourceCache::new(get_source, default_source, default_filename);
 
     render_group(&groups.errors, Style::new().red(), use_color, &mut sources);
     render_group(
@@ -377,15 +374,12 @@ pub fn unix_line(diagnostic: &LisetteDiagnostic, source: &IndexedSource, filenam
 pub fn render_unix(
     errors: &[LisetteDiagnostic],
     lints: &[LisetteDiagnostic],
-    get_source: impl Fn(u32) -> Option<(String, String)>,
+    mut sources: SourceCache<impl Fn(u32) -> Option<(String, String)>>,
     file_count: usize,
     filter: &Filter,
-    default_source: &str,
-    default_filename: &str,
 ) -> (String, Counts) {
     let groups = partition_diagnostics(errors, lints, filter);
 
-    let mut sources = SourceCache::new(get_source, default_source, default_filename);
     let mut output = String::new();
     for diagnostic in groups
         .errors
@@ -447,7 +441,13 @@ mod tests {
     fn unix_counts_and_labels_info_separately() {
         let empty: Vec<LisetteDiagnostic> = Vec::new();
         let lints = vec![LisetteDiagnostic::info("advisory")];
-        let (output, counts) = render_unix(&empty, &lints, |_| None, 1, &show_all(), "", "f.lis");
+        let (output, counts) = render_unix(
+            &empty,
+            &lints,
+            SourceCache::new(|_| None, "", "f.lis"),
+            1,
+            &show_all(),
+        );
         assert_eq!(counts.errors, 0);
         assert_eq!(counts.warnings, 0);
         assert_eq!(counts.info, 1);

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -18,3 +18,6 @@ diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true
+
+[lints]
+workspace = true

--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -38,23 +38,19 @@ pub(crate) enum BridgeDirection {
 pub(crate) enum LayoutBridge {
     Identity,
     UnwrapNullableOption {
-        option_type: Type,
         target_payload: Box<ValueLayout>,
         payload: Box<LayoutBridge>,
     },
     UnwrapPointerOption {
-        option_type: Type,
         target_payload: Box<ValueLayout>,
         payload: Box<LayoutBridge>,
     },
     WrapNullableOption {
         option_type: Type,
-        source_payload: Box<ValueLayout>,
         payload: Box<LayoutBridge>,
     },
     WrapPointerOption {
         option_type: Type,
-        source_payload: Box<ValueLayout>,
         payload: Box<LayoutBridge>,
     },
     Reference {
@@ -261,15 +257,14 @@ pub(crate) fn resolve_layout_bridge(
     match (source, target) {
         (
             TaggedOption {
-                option_type,
                 payload: source_payload,
+                ..
             },
             NullableOption {
                 payload: target_payload,
                 ..
             },
         ) => LayoutBridge::UnwrapNullableOption {
-            option_type: option_type.clone(),
             target_payload: target_payload.clone(),
             payload: Box::new(resolve_layout_bridge(
                 planner,
@@ -279,15 +274,14 @@ pub(crate) fn resolve_layout_bridge(
         },
         (
             TaggedOption {
-                option_type,
                 payload: source_payload,
+                ..
             },
             PointerOption {
                 payload: target_payload,
                 ..
             },
         ) => LayoutBridge::UnwrapPointerOption {
-            option_type: option_type.clone(),
             target_payload: target_payload.clone(),
             payload: Box::new(resolve_layout_bridge(
                 planner,
@@ -306,7 +300,6 @@ pub(crate) fn resolve_layout_bridge(
             },
         ) => LayoutBridge::WrapNullableOption {
             option_type: option_type.clone(),
-            source_payload: source_payload.clone(),
             payload: Box::new(resolve_layout_bridge(
                 planner,
                 source_payload,
@@ -324,7 +317,6 @@ pub(crate) fn resolve_layout_bridge(
             },
         ) => LayoutBridge::WrapPointerOption {
             option_type: option_type.clone(),
-            source_payload: source_payload.clone(),
             payload: Box::new(resolve_layout_bridge(
                 planner,
                 source_payload,
@@ -333,13 +325,12 @@ pub(crate) fn resolve_layout_bridge(
         },
         (
             TaggedOption {
-                option_type,
                 payload: source_payload,
+                ..
             },
             target,
         ) if is_go_interface_slot(planner, target.logical_type()) => {
             LayoutBridge::UnwrapNullableOption {
-                option_type: option_type.clone(),
                 target_payload: Box::new(target.clone()),
                 payload: Box::new(resolve_layout_bridge(planner, source_payload, target)),
             }

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -23,6 +23,13 @@ enum CollectPayloadFields {
     No,
 }
 
+struct CollisionSinks<'a> {
+    package_block: &'a mut SpanMap,
+    selectors: &'a mut HashMap<String, SpanMap>,
+    interfaces: &'a mut HashMap<String, SpanMap>,
+    diagnostics: &'a mut Vec<LisetteDiagnostic>,
+}
+
 impl Planner<'_> {
     pub(crate) fn detect_name_collisions(&self, files: &[&File]) -> Vec<LisetteDiagnostic> {
         let mut package_block: SpanMap = HashMap::default();
@@ -34,10 +41,12 @@ impl Planner<'_> {
             for item in &file.items {
                 self.collect_item(
                     item,
-                    &mut package_block,
-                    &mut selectors,
-                    &mut interfaces,
-                    &mut diagnostics,
+                    &mut CollisionSinks {
+                        package_block: &mut package_block,
+                        selectors: &mut selectors,
+                        interfaces: &mut interfaces,
+                        diagnostics: &mut diagnostics,
+                    },
                     CollectPayloadFields::Yes,
                 );
             }
@@ -66,10 +75,12 @@ impl Planner<'_> {
             for item in &file.items {
                 self.collect_item(
                     item,
-                    &mut package_block,
-                    &mut selectors,
-                    &mut interfaces,
-                    &mut diagnostics,
+                    &mut CollisionSinks {
+                        package_block: &mut package_block,
+                        selectors: &mut selectors,
+                        interfaces: &mut interfaces,
+                        diagnostics: &mut diagnostics,
+                    },
                     CollectPayloadFields::No,
                 );
             }
@@ -85,12 +96,15 @@ impl Planner<'_> {
     fn collect_item(
         &self,
         item: &Expression,
-        package_block: &mut SpanMap,
-        selectors: &mut HashMap<String, SpanMap>,
-        interfaces: &mut HashMap<String, SpanMap>,
-        diagnostics: &mut Vec<LisetteDiagnostic>,
+        sinks: &mut CollisionSinks<'_>,
         payload_fields: CollectPayloadFields,
     ) {
+        let CollisionSinks {
+            package_block,
+            selectors,
+            interfaces,
+            diagnostics,
+        } = sinks;
         match item {
             Expression::Function { .. } => self.collect_function(item, package_block, diagnostics),
             Expression::Const { .. } => self.collect_const(item, package_block, diagnostics),

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -233,9 +233,9 @@ impl Planner<'_> {
         match bridge {
             LayoutBridge::Identity => value.to_string(),
             LayoutBridge::UnwrapNullableOption {
-                option_type,
                 target_payload,
                 payload,
+                ..
             } => {
                 if payload.is_identity() {
                     let slot_type = target_payload.go_type(self);
@@ -244,7 +244,6 @@ impl Planner<'_> {
                     self.plan_option_projection_with_bridge(
                         statements,
                         value,
-                        option_type,
                         target_payload,
                         payload,
                         false,
@@ -252,9 +251,9 @@ impl Planner<'_> {
                 }
             }
             LayoutBridge::UnwrapPointerOption {
-                option_type,
                 target_payload,
                 payload,
+                ..
             } => {
                 if payload.is_identity() {
                     let slot_type = format!("*{}", target_payload.go_type(self));
@@ -263,7 +262,6 @@ impl Planner<'_> {
                     self.plan_option_projection_with_bridge(
                         statements,
                         value,
-                        option_type,
                         target_payload,
                         payload,
                         true,
@@ -272,8 +270,8 @@ impl Planner<'_> {
             }
             LayoutBridge::WrapNullableOption {
                 option_type,
-                source_payload,
                 payload,
+                ..
             } => {
                 if payload.is_identity() {
                     self.plan_nil_check_option_wrap(statements, value, option_type)
@@ -282,7 +280,6 @@ impl Planner<'_> {
                         statements,
                         value,
                         option_type,
-                        source_payload,
                         payload,
                         false,
                     )
@@ -290,20 +287,13 @@ impl Planner<'_> {
             }
             LayoutBridge::WrapPointerOption {
                 option_type,
-                source_payload,
                 payload,
+                ..
             } => {
                 if payload.is_identity() {
                     self.plan_pointer_to_option_wrap(statements, value, option_type)
                 } else {
-                    self.plan_option_wrap_with_bridge(
-                        statements,
-                        value,
-                        option_type,
-                        source_payload,
-                        payload,
-                        true,
-                    )
+                    self.plan_option_wrap_with_bridge(statements, value, option_type, payload, true)
                 }
             }
             LayoutBridge::Reference { pointee } => {
@@ -314,19 +304,9 @@ impl Planner<'_> {
             LayoutBridge::Function { source, target, .. } => {
                 self.plan_function_layout_bridge(statements, value, source, target)
             }
-            LayoutBridge::Aggregate {
-                source,
-                target,
-                key,
-                element,
-            } => self.plan_aggregate_layout_bridge(
-                statements,
-                value,
-                source,
-                target,
-                key.as_deref(),
-                element,
-            ),
+            LayoutBridge::Aggregate { .. } => {
+                self.plan_aggregate_layout_bridge(statements, value, bridge)
+            }
         }
     }
 
@@ -334,7 +314,6 @@ impl Planner<'_> {
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         option_value: &str,
-        _option_type: &Type,
         target_payload: &ValueLayout,
         payload_bridge: &LayoutBridge,
         address: bool,
@@ -383,7 +362,6 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         raw_value: &str,
         option_type: &Type,
-        _source_payload: &ValueLayout,
         payload_bridge: &LayoutBridge,
         pointer: bool,
     ) -> String {
@@ -443,11 +421,21 @@ impl Planner<'_> {
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         value: &str,
-        source_layout: &ValueLayout,
-        target_layout: &ValueLayout,
-        key_bridge: Option<&LayoutBridge>,
-        element_bridge: &LayoutBridge,
+        bridge: &LayoutBridge,
     ) -> String {
+        let LayoutBridge::Aggregate {
+            source,
+            target,
+            key,
+            element,
+        } = bridge
+        else {
+            unreachable!("plan_aggregate_layout_bridge requires an Aggregate bridge");
+        };
+        let source_layout: &ValueLayout = source;
+        let target_layout: &ValueLayout = target;
+        let element_bridge: &LayoutBridge = element;
+        let key_bridge = key.as_deref();
         self.require_stdlib();
         let source = self.hoist_tmp_value_statement(statements, "src", value);
         let direction = key_bridge

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -213,9 +213,13 @@ impl<'a> Planner<'a> {
                 value_count: args.len(),
                 has_spread: spread.is_some(),
             },
-            &mut function_string,
             expression_ctx,
         );
+        if !type_args_string.is_empty()
+            && let Some(bracket_start) = function_string.find('[')
+        {
+            function_string.truncate(bracket_start);
+        }
 
         let args_ctx = CallArgsContext {
             plan: call_plan,
@@ -369,7 +373,6 @@ impl<'a> Planner<'a> {
         self.reconstruct_collapsed_type_args(recipe, &mapping)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn resolve_call_type_args(
         &mut self,
         function: &Expression,
@@ -377,7 +380,6 @@ impl<'a> Planner<'a> {
         type_args: ResolvedCallTypeArguments<'_>,
         call_ty: Option<&Type>,
         arg_shape: CallArgShape,
-        function_string: &mut String,
         ctx: ExpressionContext<'_>,
     ) -> String {
         if callee_curries_receiver(callee) {
@@ -414,12 +416,6 @@ impl<'a> Planner<'a> {
                 candidate = slot_ty.and_then(|t| self.prelude_container_type_args(t));
             }
             type_args_string = candidate.unwrap_or_default();
-        }
-
-        if !type_args_string.is_empty()
-            && let Some(bracket_start) = function_string.find('[')
-        {
-            function_string.truncate(bracket_start);
         }
 
         type_args_string

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -9,7 +9,7 @@ use crate::abi::coercion::CoercionPlan;
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
-use crate::expressions::staging::VariadicCombine;
+use crate::expressions::staging::{SpreadSequenceOptions, VariadicCombine};
 use crate::names::generics::extract_type_mapping;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
@@ -20,6 +20,15 @@ use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::types::Type;
+
+struct CallTypeArgsRequest<'e, 'c> {
+    function: &'e Expression,
+    callee: &'e ResolvedCallee<'c>,
+    type_args: ResolvedCallTypeArguments<'e>,
+    call_ty: Option<&'e Type>,
+    arg_shape: CallArgShape,
+    ctx: ExpressionContext<'e>,
+}
 
 struct CallArgsContext<'plan, 'facts> {
     plan: &'plan CallPlan<'facts>,
@@ -178,10 +187,11 @@ impl<'a> Planner<'a> {
             let sequenced = self.sequence_with_spread_values(
                 stages,
                 spread,
-                wrap_to_any,
-                "_arg",
-                combine,
-                expression_ctx.capture_boundary(),
+                SpreadSequenceOptions {
+                    wrap_to_any,
+                    combine,
+                    boundary: expression_ctx.capture_boundary(),
+                },
             );
             let effect = self.regular_call_effect(function, sequenced.effect);
             let (setup, args_strings) = sequenced.into_rendered();
@@ -204,17 +214,17 @@ impl<'a> Planner<'a> {
             function_string = format!("({})", function_string);
         }
 
-        let type_args_string = self.resolve_call_type_args(
+        let type_args_string = self.resolve_call_type_args(CallTypeArgsRequest {
             function,
-            &call_plan.resolved,
-            resolved_type_args,
+            callee: &call_plan.resolved,
+            type_args: resolved_type_args,
             call_ty,
-            CallArgShape {
+            arg_shape: CallArgShape {
                 value_count: args.len(),
                 has_spread: spread.is_some(),
             },
-            expression_ctx,
-        );
+            ctx: expression_ctx,
+        });
         if !type_args_string.is_empty()
             && let Some(bracket_start) = function_string.find('[')
         {
@@ -373,15 +383,15 @@ impl<'a> Planner<'a> {
         self.reconstruct_collapsed_type_args(recipe, &mapping)
     }
 
-    fn resolve_call_type_args(
-        &mut self,
-        function: &Expression,
-        callee: &ResolvedCallee<'_>,
-        type_args: ResolvedCallTypeArguments<'_>,
-        call_ty: Option<&Type>,
-        arg_shape: CallArgShape,
-        ctx: ExpressionContext<'_>,
-    ) -> String {
+    fn resolve_call_type_args(&mut self, request: CallTypeArgsRequest<'_, '_>) -> String {
+        let CallTypeArgsRequest {
+            function,
+            callee,
+            type_args,
+            call_ty,
+            arg_shape,
+            ctx,
+        } = request;
         if callee_curries_receiver(callee) {
             return String::new();
         }
@@ -458,9 +468,11 @@ impl<'a> Planner<'a> {
                 .resolved
                 .declared_type()
                 .and_then(|ty| ty.unwrap_forall().get_function_params()),
-            ctx.wrap_spread_to_any,
-            ctx.combine_variadic.clone(),
-            ctx.capture_boundary,
+            SpreadSequenceOptions {
+                wrap_to_any: ctx.wrap_spread_to_any,
+                combine: ctx.combine_variadic.clone(),
+                boundary: ctx.capture_boundary,
+            },
         )
     }
 

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+use crate::expressions::staging::SpreadSequenceOptions;
 use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -14,6 +15,12 @@ use crate::types::native::NativeGoType;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
+
+#[derive(Clone, Copy)]
+struct UfcsCallSite<'e, 'c> {
+    function: &'e Expression,
+    callee: &'e ResolvedCallee<'c>,
+}
 
 impl Planner<'_> {
     fn ufcs_type_args(
@@ -106,16 +113,13 @@ impl Planner<'_> {
 
         let coercion = resolution.receiver_coercion();
         let receiver_ty = self.facts.strip_and_peel(&receiver.get_type());
+        let site = UfcsCallSite {
+            function,
+            callee: &call_plan.resolved,
+        };
 
-        let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) = self
-            .lower_ufcs_call_args(
-                function,
-                receiver,
-                args,
-                spread,
-                &call_plan.resolved,
-                coercion,
-            );
+        let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) =
+            self.lower_ufcs_call_args(site, receiver, args, spread, coercion);
         let receiver_arg = match coercion {
             Some(ReceiverCoercion::AutoDeref) => format!("*{receiver_arg}"),
             Some(ReceiverCoercion::AutoAddress) | None => receiver_arg,
@@ -154,8 +158,7 @@ impl Planner<'_> {
         new_args.extend(emitted_args);
 
         let fn_name = self.build_ufcs_qualified_call(
-            function,
-            &call_plan.resolved,
+            site,
             &receiver_ty,
             member,
             type_args,
@@ -177,13 +180,13 @@ impl Planner<'_> {
 
     fn lower_ufcs_call_args(
         &mut self,
-        function: &Expression,
+        site: UfcsCallSite<'_, '_>,
         receiver: &Expression,
         args: &[Expression],
         spread: Option<&Expression>,
-        callee: &ResolvedCallee<'_>,
         coercion: Option<ReceiverCoercion>,
     ) -> (Vec<LoweredStatement>, String, Vec<String>, bool) {
+        let UfcsCallSite { function, callee } = site;
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
         // suppresses the Go-fn-value identity short-circuit before dispatch
@@ -223,9 +226,11 @@ impl Planner<'_> {
                         .and_then(|ty| ty.unwrap_forall().get_function_params())
                 })
                 .flatten(),
-            false,
-            combine,
-            CaptureBoundary::SiblingSequence,
+            SpreadSequenceOptions {
+                wrap_to_any: false,
+                combine,
+                boundary: CaptureBoundary::SiblingSequence,
+            },
         );
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (setup, all_values) = sequenced.into_rendered();
@@ -257,13 +262,13 @@ impl Planner<'_> {
 
     fn build_ufcs_qualified_call(
         &mut self,
-        function: &Expression,
-        callee: &ResolvedCallee<'_>,
+        site: UfcsCallSite<'_, '_>,
         receiver_ty: &Type,
         member: &str,
         type_args: ResolvedCallTypeArguments<'_>,
         arg_shape: CallArgShape,
     ) -> String {
+        let UfcsCallSite { function, callee } = site;
         let Type::Nominal {
             id: qualified_name, ..
         } = receiver_ty
@@ -332,10 +337,11 @@ impl Planner<'_> {
         let sequenced = self.sequence_with_spread_values(
             stages,
             spread,
-            false,
-            "_arg",
-            combine,
-            CaptureBoundary::SiblingSequence,
+            SpreadSequenceOptions {
+                wrap_to_any: false,
+                combine,
+                boundary: CaptureBoundary::SiblingSequence,
+            },
         );
         let (setup, emitted_all) = sequenced.into_rendered();
 

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -16,7 +16,6 @@ use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
 
 impl Planner<'_> {
-    #[allow(clippy::too_many_arguments)]
     fn ufcs_type_args(
         &mut self,
         function: &Expression,
@@ -107,12 +106,6 @@ impl Planner<'_> {
 
         let coercion = resolution.receiver_coercion();
         let receiver_ty = self.facts.strip_and_peel(&receiver.get_type());
-        let Type::Nominal {
-            id: qualified_name, ..
-        } = &receiver_ty
-        else {
-            unreachable!("UFCS receiver must be a constructor type");
-        };
 
         let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) = self
             .lower_ufcs_call_args(
@@ -164,7 +157,6 @@ impl Planner<'_> {
             function,
             &call_plan.resolved,
             &receiver_ty,
-            qualified_name,
             member,
             type_args,
             CallArgShape {
@@ -263,17 +255,21 @@ impl Planner<'_> {
         self.stage_composite(arg, ExpressionContext::value())
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn build_ufcs_qualified_call(
         &mut self,
         function: &Expression,
         callee: &ResolvedCallee<'_>,
         receiver_ty: &Type,
-        qualified_name: &str,
         member: &str,
         type_args: ResolvedCallTypeArguments<'_>,
         arg_shape: CallArgShape,
     ) -> String {
+        let Type::Nominal {
+            id: qualified_name, ..
+        } = receiver_ty
+        else {
+            unreachable!("UFCS receiver must be a constructor type");
+        };
         let type_args_string = self
             .ufcs_type_args(function, callee, receiver_ty, type_args, arg_shape)
             .unwrap_or_default();

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -288,7 +288,6 @@ impl Planner<'_> {
 
     /// Compound map-tuple element pattern: capture key/value into fresh vars,
     /// destructure at the top of the body, discard the temp when unused.
-    #[allow(clippy::too_many_arguments)]
     fn lower_map_tuple_compound_body(
         &mut self,
         first: &Pattern,

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -530,9 +530,11 @@ impl Planner<'_> {
                     some_arm,
                     match_arms,
                     receiver_var_pattern,
-                    &case_var,
+                    TypedSubject {
+                        var: &case_var,
+                        ty: element_ty,
+                    },
                     needs_receiver_destructure,
-                    element_ty,
                     place,
                 );
                 let none_block = this.capture_scoped_block(|this| {
@@ -570,15 +572,13 @@ impl Planner<'_> {
 
     /// Lower the Some arm body (with payload destructure) so the caller can
     /// wrap it in `if ok` alongside the None arm. `None` if it renders empty.
-    #[allow(clippy::too_many_arguments)]
     fn lower_receive_some_arm(
         &mut self,
         some_arm: &MatchArm,
         match_arms: &[MatchArm],
         receiver_var_pattern: &Pattern,
-        case_var: &str,
+        subject: TypedSubject<'_>,
         needs_receiver_destructure: bool,
-        element_ty: &syntax::types::Type,
         place: &PlacePlan,
     ) -> Option<LoweredBlock> {
         self.capture_scoped_block(|this| {
@@ -587,10 +587,7 @@ impl Planner<'_> {
             }
             LoweredBlock {
                 statements: this.lower_select_match_receive_some_site(
-                    TypedSubject {
-                        var: case_var,
-                        ty: element_ty,
-                    },
+                    subject,
                     AnnotatedPattern {
                         pattern: receiver_var_pattern,
                     },

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -529,7 +529,6 @@ impl Planner<'_> {
                 let some_block = this.lower_receive_some_arm(
                     some_arm,
                     match_arms,
-                    receiver_var_pattern,
                     TypedSubject {
                         var: &case_var,
                         ty: element_ty,
@@ -576,7 +575,6 @@ impl Planner<'_> {
         &mut self,
         some_arm: &MatchArm,
         match_arms: &[MatchArm],
-        receiver_var_pattern: &Pattern,
         subject: TypedSubject<'_>,
         needs_receiver_destructure: bool,
         place: &PlacePlan,
@@ -585,11 +583,14 @@ impl Planner<'_> {
             if !needs_receiver_destructure {
                 return this.lower_block_to_place(&some_arm.expression, place);
             }
+            let Pattern::EnumVariant { fields, .. } = &some_arm.pattern else {
+                unreachable!("Some arm must carry an EnumVariant pattern");
+            };
             LoweredBlock {
                 statements: this.lower_select_match_receive_some_site(
                     subject,
                     AnnotatedPattern {
-                        pattern: receiver_var_pattern,
+                        pattern: &fields[0],
                     },
                     &some_arm.expression,
                     match_arms,

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -12,6 +12,14 @@ use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
 
+struct NullableFieldAccess<'a> {
+    expression_string: &'a str,
+    member: &'a str,
+    field: &'a str,
+    expression_ty: &'a Type,
+    result_ty: &'a Type,
+}
+
 impl Planner<'_> {
     pub(crate) fn plan_dot_access(
         &mut self,
@@ -81,11 +89,13 @@ impl Planner<'_> {
 
         if let Some(s) = self.plan_nullable_field_access(
             &mut setup,
-            &expression_string,
-            member,
-            &field,
-            &expression_ty,
-            result_ty,
+            NullableFieldAccess {
+                expression_string: &expression_string,
+                member,
+                field: &field,
+                expression_ty: &expression_ty,
+                result_ty,
+            },
         ) {
             return ValuePlan::computed(setup, GoExpression::opaque(s), effect);
         }
@@ -212,12 +222,15 @@ impl Planner<'_> {
     fn plan_nullable_field_access(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
-        expression_string: &str,
-        member: &str,
-        field: &str,
-        expression_ty: &Type,
-        result_ty: &Type,
+        access: NullableFieldAccess<'_>,
     ) -> Option<String> {
+        let NullableFieldAccess {
+            expression_string,
+            member,
+            field,
+            expression_ty,
+            result_ty,
+        } = access;
         let source_layout = self.field_slot_layout(expression_ty, member, result_ty)?;
         let target_layout = self.value_layout(result_ty, SlotOrigin::Lisette);
         let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -15,7 +15,9 @@ use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::utils::is_order_sensitive;
 
-struct StructCallContext {
+struct StructCallContext<'a> {
+    name: &'a str,
+    ty: &'a Type,
     go_type: String,
     enum_ctx: Option<EnumCallContext>,
 }
@@ -69,7 +71,7 @@ impl Planner<'_> {
         let mut field_names: Vec<String> = Vec::new();
         let mut field_values: Vec<String> = Vec::new();
         for (slot, f) in field_assignments.iter().enumerate() {
-            let field_name = self.resolve_struct_call_field_name(&f.name, ty, &ctx);
+            let field_name = self.resolve_struct_call_field_name(&f.name, &ctx);
             let mut value = emitted_values[slot].clone();
             value = self.wrap_recursive_enum_field(&mut setup, value, f, &ctx);
             let value_ty = f.value.get_type();
@@ -108,35 +110,28 @@ impl Planner<'_> {
                 } else {
                     let base_staged = self.stage_operand(base, ExpressionContext::value());
                     effect = effect.combine(base_staged.evaluation.effect);
-                    if ctx.enum_ctx.is_some() {
-                        let (value, contains_deferred_evaluation) = self.lower_enum_variant_spread(
-                            &mut setup,
-                            base,
-                            base_staged,
-                            name,
-                            ty,
-                            &ctx,
-                            field_pairs,
-                            &field_side_effects,
-                            field_assignments,
-                            expression_ctx,
-                        );
-                        base_contains_deferred_evaluation = contains_deferred_evaluation;
-                        value
-                    } else {
-                        let (value, contains_deferred_evaluation) = self.lower_struct_update(
-                            &mut setup,
-                            base_staged,
-                            &field_pairs,
-                            &field_side_effects,
-                        );
-                        base_contains_deferred_evaluation = contains_deferred_evaluation;
-                        value
-                    }
+                    let field_pairs =
+                        self.hoist_observable_fields(&mut setup, field_pairs, &field_side_effects);
+                    let (spread_setup, value, contains_deferred_evaluation) =
+                        if ctx.enum_ctx.is_some() {
+                            self.lower_enum_variant_spread(
+                                base,
+                                base_staged,
+                                &ctx,
+                                field_pairs,
+                                field_assignments,
+                                expression_ctx,
+                            )
+                        } else {
+                            self.lower_struct_update(base_staged, &field_pairs)
+                        };
+                    setup.extend(spread_setup);
+                    base_contains_deferred_evaluation = contains_deferred_evaluation;
+                    value
                 }
             }
             StructSpread::Autofill { .. } if !is_go_struct => {
-                self.append_autofills(&mut field_pairs, field_assignments, ty, name, &ctx);
+                self.append_autofills(&mut field_pairs, field_assignments, &ctx);
                 emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
             }
             StructSpread::Autofill { .. } | StructSpread::None => {
@@ -187,13 +182,11 @@ impl Planner<'_> {
         &mut self,
         field_pairs: &mut Vec<(String, String)>,
         field_assignments: &[StructFieldAssignment],
-        ty: &Type,
-        name: &str,
-        ctx: &StructCallContext,
+        ctx: &StructCallContext<'_>,
     ) {
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let Some(unspecified) =
-            self.lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned)
+            self.lookup_unspecified_fields(ctx.ty, ctx.name, ctx.enum_ctx.as_ref(), &assigned)
         else {
             return;
         };
@@ -201,7 +194,7 @@ impl Planner<'_> {
             if field_ty.is_slice() {
                 continue;
             }
-            let go_field_name = self.resolve_struct_call_field_name(&field_name, ty, ctx);
+            let go_field_name = self.resolve_struct_call_field_name(&field_name, ctx);
             let zero = self.lisette_zero(&field_ty);
             field_pairs.push((go_field_name, zero));
         }
@@ -419,7 +412,7 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
         value: String,
         field: &StructFieldAssignment,
-        ctx: &StructCallContext,
+        ctx: &StructCallContext<'_>,
     ) -> String {
         let needs_pointer = ctx
             .enum_ctx
@@ -433,7 +426,7 @@ impl Planner<'_> {
     }
 
     /// Analyze a struct call to determine Go type and enum context.
-    fn analyze_struct_call(&mut self, name: &str, ty: &Type) -> StructCallContext {
+    fn analyze_struct_call<'t>(&mut self, name: &'t str, ty: &'t Type) -> StructCallContext<'t> {
         let is_prelude = is_from_prelude(ty);
         let enum_id = self.as_enum(ty);
 
@@ -445,7 +438,12 @@ impl Planner<'_> {
 
         let enum_ctx = enum_id.map(|id| self.compute_enum_call_context(name, &id));
 
-        StructCallContext { go_type, enum_ctx }
+        StructCallContext {
+            name,
+            ty,
+            go_type,
+            enum_ctx,
+        }
     }
 
     /// Compute the Go type string for a struct call.
@@ -549,117 +547,102 @@ impl Planner<'_> {
     fn resolve_struct_call_field_name(
         &mut self,
         field_name: &str,
-        ty: &Type,
-        ctx: &StructCallContext,
+        ctx: &StructCallContext<'_>,
     ) -> String {
         if let Some(ref enum_ctx) = ctx.enum_ctx {
             self.enum_struct_field_name(&enum_ctx.enum_id, &enum_ctx.variant_name, field_name)
                 .unwrap_or_else(|| go_name::make_exported(field_name))
-        } else if self.field_is_embedded(ty, field_name) {
+        } else if self.field_is_embedded(ctx.ty, field_name) {
             go_name::escape_keyword(field_name).into_owned()
-        } else if self.struct_field_is_exported(ty, field_name) {
+        } else if self.struct_field_is_exported(ctx.ty, field_name) {
             go_name::make_exported(field_name)
         } else {
             go_name::unexported_method_go_name(field_name)
         }
     }
 
-    fn lower_struct_update(
+    fn hoist_observable_fields(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
+        field_pairs: Vec<(String, String)>,
+        field_side_effects: &[bool],
+    ) -> Vec<(String, String)> {
+        field_pairs
+            .into_iter()
+            .enumerate()
+            .map(|(i, (name, value))| {
+                if field_side_effects.get(i).copied().unwrap_or(false) {
+                    let temp = self.hoist_tmp_value_statement(statements, "field", &value);
+                    (name, temp)
+                } else {
+                    (name, value)
+                }
+            })
+            .collect()
+    }
+
+    fn lower_struct_update(
+        &mut self,
         base_staged: ValuePlan,
         fields: &[(String, String)],
-        field_side_effects: &[bool],
-    ) -> (String, bool) {
+    ) -> (Vec<LoweredStatement>, String, bool) {
         if fields.is_empty() {
             let contains_deferred_evaluation =
                 base_staged.expression.contains_deferred_evaluation();
             let (setup, value) = base_staged.into_parts();
-            statements.extend(setup);
-            return (value, contains_deferred_evaluation);
+            return (setup, value, contains_deferred_evaluation);
         }
 
-        let fields: Vec<(String, String)> = fields
-            .iter()
-            .enumerate()
-            .map(|(i, (name, value))| {
-                if field_side_effects.get(i).copied().unwrap_or(false) {
-                    let temp = self.hoist_tmp_value_statement(statements, "field", value);
-                    (name.clone(), temp)
-                } else {
-                    (name.clone(), value.clone())
-                }
-            })
-            .collect();
+        let (mut statements, base_value) = base_staged.into_parts();
+        let tmp = self.hoist_tmp_value_statement(&mut statements, "copy", &base_value);
 
-        let (base_setup, base_value) = base_staged.into_parts();
-        statements.extend(base_setup);
-        let tmp = self.hoist_tmp_value_statement(statements, "copy", &base_value);
-
-        for (name, value) in &fields {
+        for (name, value) in fields {
             statements.push(LoweredStatement::RawGo(format!(
                 "{}.{} = {}\n",
                 tmp, name, value
             )));
         }
 
-        (tmp, false)
+        (statements, tmp, false)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn lower_enum_variant_spread(
         &mut self,
-        statements: &mut Vec<LoweredStatement>,
         base: &Expression,
         base_staged: ValuePlan,
-        name: &str,
-        ty: &Type,
-        ctx: &StructCallContext,
-        field_pairs: Vec<(String, String)>,
-        field_side_effects: &[bool],
+        ctx: &StructCallContext<'_>,
+        mut field_pairs: Vec<(String, String)>,
         field_assignments: &[StructFieldAssignment],
         expression_ctx: ExpressionContext<'_>,
-    ) -> (String, bool) {
-        let mut pairs: Vec<(String, String)> = field_pairs
-            .into_iter()
-            .enumerate()
-            .map(|(i, (field_name, value))| {
-                if field_side_effects.get(i).copied().unwrap_or(false) {
-                    let temp = self.hoist_tmp_value_statement(statements, "field", &value);
-                    (field_name, temp)
-                } else {
-                    (field_name, value)
-                }
-            })
-            .collect();
-
+    ) -> (Vec<LoweredStatement>, String, bool) {
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let carried = self
-            .lookup_unspecified_fields(ty, name, ctx.enum_ctx.as_ref(), &assigned)
+            .lookup_unspecified_fields(ctx.ty, ctx.name, ctx.enum_ctx.as_ref(), &assigned)
             .unwrap_or_default();
 
-        let (base_setup, base_value) = base_staged.into_parts();
-        statements.extend(base_setup);
+        let (mut statements, base_value) = base_staged.into_parts();
 
         if carried.is_empty() {
             statements.push(LoweredStatement::RawGo(format!("_ = {}\n", base_value)));
             return (
-                emit_struct_literal(&ctx.go_type, &pairs, expression_ctx),
+                statements,
+                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
                 false,
             );
         }
 
         let source = if is_order_sensitive(base) {
-            self.hoist_tmp_value_statement(statements, "spread", &base_value)
+            self.hoist_tmp_value_statement(&mut statements, "spread", &base_value)
         } else {
             base_value
         };
         for (field_name, _) in carried {
-            let slot = self.resolve_struct_call_field_name(&field_name, ty, ctx);
-            pairs.push((slot.clone(), format!("{}.{}", source, slot)));
+            let slot = self.resolve_struct_call_field_name(&field_name, ctx);
+            field_pairs.push((slot.clone(), format!("{}.{}", source, slot)));
         }
         (
-            emit_struct_literal(&ctx.go_type, &pairs, expression_ctx),
+            statements,
+            emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
             false,
         )
     }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -15,6 +15,12 @@ use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::utils::is_order_sensitive;
 
+struct SpreadInput<'a> {
+    base: &'a Expression,
+    base_staged: ValuePlan,
+    field_pairs: Vec<(String, String)>,
+}
+
 struct StructCallContext<'a> {
     name: &'a str,
     ty: &'a Type,
@@ -115,10 +121,12 @@ impl Planner<'_> {
                     let (spread_setup, value, contains_deferred_evaluation) =
                         if ctx.enum_ctx.is_some() {
                             self.lower_enum_variant_spread(
-                                base,
-                                base_staged,
+                                SpreadInput {
+                                    base,
+                                    base_staged,
+                                    field_pairs,
+                                },
                                 &ctx,
-                                field_pairs,
                                 field_assignments,
                                 expression_ctx,
                             )
@@ -608,13 +616,16 @@ impl Planner<'_> {
 
     fn lower_enum_variant_spread(
         &mut self,
-        base: &Expression,
-        base_staged: ValuePlan,
+        input: SpreadInput<'_>,
         ctx: &StructCallContext<'_>,
-        mut field_pairs: Vec<(String, String)>,
         field_assignments: &[StructFieldAssignment],
         expression_ctx: ExpressionContext<'_>,
     ) -> (Vec<LoweredStatement>, String, bool) {
+        let SpreadInput {
+            base,
+            base_staged,
+            mut field_pairs,
+        } = input;
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let carried = self
             .lookup_unspecified_fields(ctx.ty, ctx.name, ctx.enum_ctx.as_ref(), &assigned)

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -19,6 +19,12 @@ pub(crate) struct VariadicCombine {
     pub fixed_count: usize,
 }
 
+pub(crate) struct SpreadSequenceOptions {
+    pub(crate) wrap_to_any: bool,
+    pub(crate) combine: Option<VariadicCombine>,
+    pub(crate) boundary: CaptureBoundary,
+}
+
 impl Planner<'_> {
     pub(crate) fn stage_or_capture(&mut self, expression: &Expression, prefix: &str) -> ValuePlan {
         if matches!(
@@ -375,18 +381,20 @@ impl Planner<'_> {
         &mut self,
         mut stages: Vec<ValuePlan>,
         spread: Option<&Expression>,
-        wrap_to_any: bool,
-        prefix: &str,
-        combine: Option<VariadicCombine>,
-        boundary: CaptureBoundary,
+        options: SpreadSequenceOptions,
     ) -> SequencedValues {
         let spread_index = spread.map(|s| {
             stages.push(self.stage_operand(s, ExpressionContext::value()));
             stages.len() - 1
         });
-        let mut sequenced = self.sequence_values(stages, boundary, prefix);
+        let mut sequenced = self.sequence_values(stages, options.boundary, "_arg");
         if let Some(i) = spread_index {
-            self.finalize_spread_stage(&mut sequenced.values, i, wrap_to_any, combine);
+            self.finalize_spread_stage(
+                &mut sequenced.values,
+                i,
+                options.wrap_to_any,
+                options.combine,
+            );
         }
         sequenced
     }
@@ -396,9 +404,7 @@ impl Planner<'_> {
         mut stages: Vec<ValuePlan>,
         spread: Option<&Expression>,
         adapter_params: Option<&[FunctionParameter]>,
-        wrap_to_any: bool,
-        combine: Option<VariadicCombine>,
-        boundary: CaptureBoundary,
+        options: SpreadSequenceOptions,
     ) -> SequencedValues {
         if let Some(spread) = spread
             && let Some(adapter_stage) =
@@ -406,10 +412,15 @@ impl Planner<'_> {
         {
             stages.push(adapter_stage);
             let spread_index = stages.len() - 1;
-            let mut sequenced = self.sequence_values(stages, boundary, "_arg");
-            self.finalize_spread_stage(&mut sequenced.values, spread_index, wrap_to_any, combine);
+            let mut sequenced = self.sequence_values(stages, options.boundary, "_arg");
+            self.finalize_spread_stage(
+                &mut sequenced.values,
+                spread_index,
+                options.wrap_to_any,
+                options.combine,
+            );
             return sequenced;
         }
-        self.sequence_with_spread_values(stages, spread, wrap_to_any, "_arg", combine, boundary)
+        self.sequence_with_spread_values(stages, spread, options)
     }
 }

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -191,18 +191,11 @@ pub(crate) fn with_tree_bindings<R>(
     statements: &mut Vec<LoweredStatement>,
     bindings: &[PatternBinding],
     subject_var: &str,
-    consumers: &[&syntax::ast::Expression],
-    inline_blockers: &[&syntax::ast::Expression],
+    body: &syntax::ast::Expression,
     f: impl FnOnce(&mut Planner, &mut Vec<LoweredStatement>) -> R,
 ) -> R {
-    let overlays = tree_binding_statements(
-        planner,
-        statements,
-        bindings,
-        subject_var,
-        consumers,
-        inline_blockers,
-    );
+    let overlays =
+        tree_binding_statements(planner, statements, bindings, subject_var, &[body], &[]);
     let result = f(planner, statements);
     drop_inline_overlays(planner, &overlays);
     result

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1315,7 +1315,6 @@ fn collect_struct_checks(
     let Pattern::Struct {
         fields,
         ty,
-        identifier,
         resolution,
         ..
     } = pattern
@@ -1323,9 +1322,8 @@ fn collect_struct_checks(
         return;
     };
 
-    let (enum_info, child_path) = resolve_struct_child_path(
-        planner, path, ty, identifier, resolution, path_ty, collector,
-    );
+    let (enum_info, child_path) =
+        resolve_struct_child_path(planner, path, pattern, path_ty, collector);
     let variant_fields = record_variant_fields(planner, resolution);
 
     for field in fields {
@@ -1356,12 +1354,19 @@ fn collect_struct_checks(
 fn resolve_struct_child_path(
     planner: &Planner,
     path: &AccessPath,
-    ty: &Type,
-    identifier: &str,
-    resolution: &RecordPatternResolution,
+    pattern: &Pattern,
     path_ty: Option<&Type>,
     collector: &mut PatternCollector,
 ) -> (Option<(String, String)>, AccessPath) {
+    let Pattern::Struct {
+        ty,
+        identifier,
+        resolution,
+        ..
+    } = pattern
+    else {
+        unreachable!("resolve_struct_child_path requires a Struct pattern");
+    };
     if let Some(asserted) = interface_assert_child_path(planner, path, ty, path_ty, collector) {
         return (None, asserted);
     }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -602,8 +602,7 @@ impl Planner<'_> {
                     &mut branch,
                     &info.bindings,
                     effective,
-                    &[body],
-                    &[],
+                    body,
                     |this, branch| {
                         branch.extend(this.lower_block_as_body(body).statements);
                     },
@@ -677,8 +676,7 @@ impl Planner<'_> {
                 &mut statements,
                 &info.bindings,
                 &effective,
-                &[body],
-                &[],
+                body,
                 |this, statements| {
                     let block = this.lower_block_to_place(body, place);
                     statements.extend(block.statements);
@@ -697,8 +695,7 @@ impl Planner<'_> {
             &mut then_body,
             &info.bindings,
             &effective,
-            &[body],
-            &[],
+            body,
             |this, then_body| {
                 let block = this.lower_block_to_place(body, place);
                 then_body.extend(block.statements);

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -17,6 +17,13 @@ use crate::plan::bodies::{
 use crate::plan::placement::unreachable_panic_if_needed;
 use crate::utils::wrap_if_struct_literal;
 
+#[derive(Clone, Copy)]
+struct ChainGroup<'a> {
+    indices: &'a [usize],
+    tests: &'a [ChainTest],
+    conditions: &'a [Option<String>],
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum WalkRole {
     SwitchCase,
@@ -372,12 +379,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     statements.extend(leaf);
                 }
             }
-            Decision::Guard {
-                arm_index,
-                bindings,
-                success,
-                failure,
-            } => self.walk_guard(statements, *arm_index, bindings, success, failure, ctx),
+            Decision::Guard { .. } => self.walk_guard(statements, decision, ctx),
             Decision::Switch { .. } => self.walk_switch(statements, decision, ctx),
             Decision::Chain { tests, fallback } => {
                 if ctx.is_grouped_retry() {
@@ -508,12 +510,19 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn walk_guard(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        arm_index: usize,
-        bindings: &[PatternBinding],
-        success: &Decision,
-        failure: &Decision,
+        decision: &Decision,
         ctx: &WalkCtx,
     ) {
+        let Decision::Guard {
+            arm_index,
+            bindings,
+            success,
+            failure,
+        } = decision
+        else {
+            unreachable!("walk_guard requires a Guard decision");
+        };
+        let arm_index = *arm_index;
         let needs_pre_scope = ctx.leaf_scope_explicit() && !bindings.is_empty();
         let arm = &self.arms[arm_index];
         let arm_body = &*arm.expression;
@@ -720,9 +729,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             let collapse_as_catchall = is_last_group && last_is_catchall && indices.len() == 1;
             self.emit_chain_group(
                 statements,
-                indices,
-                tests,
-                &conditions,
+                ChainGroup {
+                    indices,
+                    tests,
+                    conditions: &conditions,
+                },
                 &inner_ctx,
                 collapse_as_catchall,
             );
@@ -736,12 +747,15 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     fn emit_chain_group(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        indices: &[usize],
-        tests: &[ChainTest],
-        conditions: &[Option<String>],
+        group: ChainGroup<'_>,
         ctx: &WalkCtx,
         collapse_as_catchall: bool,
     ) {
+        let ChainGroup {
+            indices,
+            tests,
+            conditions,
+        } = group;
         if collapse_as_catchall {
             self.walk(statements, &tests[indices[0]].decision, ctx);
             return;

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -389,7 +389,6 @@ impl Planner<'_> {
     /// Lower a block (or single expression) that assigns its tail into `var`.
     /// `has_go_braces` selects the scope discipline: a full Go-brace scope when
     /// the caller wraps the result in `{ }`, otherwise a binding frame.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn lower_block_to_var(
         &mut self,
         expression: &Expression,

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -4,6 +4,7 @@ use crate::calls::native::{clip_shared_capacity, is_clip_safe_path};
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
+use crate::expressions::staging::SpreadSequenceOptions;
 use crate::plan::bodies::{
     AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, LoopTransfer, LoweredBlock,
     LoweredStatement, PlacePlan,
@@ -587,10 +588,11 @@ impl Planner<'_> {
         let sequenced = self.sequence_with_spread_values(
             stages,
             spread,
-            false,
-            "_arg",
-            combine,
-            CaptureBoundary::SiblingSequence,
+            SpreadSequenceOptions {
+                wrap_to_any: false,
+                combine,
+                boundary: CaptureBoundary::SiblingSequence,
+            },
         );
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -631,7 +631,6 @@ fn extract_simple_tuple_vars(pattern: &Pattern) -> Option<Vec<String>> {
 
 impl Planner<'_> {
     /// Build a `LetPlan` by classifying the binding into a `LetForm`.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_let_plan(
         &mut self,
         binding: &Binding,

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -15,3 +15,6 @@ test = false
 [dependencies]
 syntax = { package = "lisette-syntax", version = "=0.9.0", path = "../syntax" }
 unicode-segmentation = "1.11"
+
+[lints]
+workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -34,3 +34,6 @@ serde_json.workspace = true
 stdlib = { package = "lisette-stdlib", path = "../stdlib" }
 tempfile = "3"
 tokio-util = { version = "0.7", features = ["codec"] }
+
+[lints]
+workspace = true

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -65,21 +65,7 @@ fn walk(
             ..
         } => collect_parameter_hints(callee, args, range, line_index, hints),
 
-        Expression::Lambda {
-            params,
-            return_annotation,
-            body,
-            ty,
-            ..
-        } => lambda_hints(
-            params,
-            return_annotation,
-            body,
-            ty,
-            range,
-            line_index,
-            hints,
-        ),
+        Expression::Lambda { .. } => lambda_hints(expression, range, line_index, hints),
 
         _ => {}
     }
@@ -160,21 +146,28 @@ fn collect_identifier_spans(pattern: &Pattern, out: &mut Vec<Span>) {
 
 /// `: T` hints for a lambda's un-annotated params, plus `-> T` when the return is omitted.
 fn lambda_hints(
-    params: &[Binding],
-    return_annotation: &Annotation,
-    body: &Expression,
-    ty: &Type,
+    lambda: &Expression,
     range: (u32, u32),
     line_index: &LineIndex,
     hints: &mut Vec<InlayHint>,
 ) {
+    let Expression::Lambda {
+        params,
+        return_annotation,
+        body,
+        ty,
+        ..
+    } = lambda
+    else {
+        return;
+    };
     for param in params {
         binding_type_hint(param, range, line_index, hints);
     }
 
     // Skip a curried lambda's return; the inner lambda's own hints convey the shape.
     if matches!(return_annotation, Annotation::Unknown)
-        && !matches!(body, Expression::Lambda { .. })
+        && !matches!(body.as_ref(), Expression::Lambda { .. })
         && let Some(ret) = ty.get_function_ret()
         && !ret.is_unit()
         && !ret.is_variable()

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -18,3 +18,6 @@ diagnostics = { package = "lisette-diagnostics", version = "=0.9.0", path = "../
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true
+
+[lints]
+workspace = true

--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -1,7 +1,7 @@
 //! Hard errors over generic-parameter shapes.
 
 use diagnostics::LocalSink;
-use syntax::ast::{Annotation, Expression, Generic, Span};
+use syntax::ast::{Expression, Generic, Span};
 use syntax::types::{Bound, Type};
 
 use semantics::generics::{
@@ -57,22 +57,8 @@ fn visit_expression(
             }
             return;
         }
-        Expression::Function {
-            name,
-            generics,
-            return_annotation,
-            return_type,
-            ..
-        } => {
-            check_constrained_return_type(
-                return_type,
-                generics,
-                enclosing,
-                return_annotation,
-                name,
-                store,
-                sink,
-            );
+        Expression::Function { .. } => {
+            check_constrained_return_type(expression, enclosing, store, sink);
         }
         Expression::Call {
             expression: callee,
@@ -105,14 +91,21 @@ fn check_unconstrained_bounded(bounds: &[Bound], span: &Span, sink: &LocalSink) 
 }
 
 fn check_constrained_return_type(
-    return_ty: &Type,
-    generics: &[Generic],
+    function: &Expression,
     enclosing: Option<GenericContext<'_>>,
-    return_annotation: &Annotation,
-    fn_name: &str,
     store: &Store,
     sink: &LocalSink,
 ) {
+    let Expression::Function {
+        name: fn_name,
+        generics,
+        return_annotation,
+        return_type: return_ty,
+        ..
+    } = function
+    else {
+        return;
+    };
     let span = return_annotation.get_span();
     let mut seen = rustc_hash::FxHashSet::default();
     for applied in nested_type_obligations(store, return_ty) {

--- a/crates/passes/src/passes/checks/generics.rs
+++ b/crates/passes/src/passes/checks/generics.rs
@@ -104,7 +104,6 @@ fn check_unconstrained_bounded(bounds: &[Bound], span: &Span, sink: &LocalSink) 
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn check_constrained_return_type(
     return_ty: &Type,
     generics: &[Generic],

--- a/crates/passes/src/passes/checks/native_value_usage.rs
+++ b/crates/passes/src/passes/checks/native_value_usage.rs
@@ -1,5 +1,5 @@
 use diagnostics::LocalSink;
-use syntax::ast::{Expression, Span, StructKind};
+use syntax::ast::{Expression, StructKind};
 use syntax::program::{Definition, DefinitionBody, NativeTypeKind};
 use syntax::types::{Symbol, Type, unqualified_name};
 
@@ -25,12 +25,8 @@ fn visit_expression(
     store: &Store,
     sink: &LocalSink,
 ) {
-    if let Expression::Identifier {
-        value, ty, span, ..
-    } = expression
-        && position != Position::Callee
-    {
-        check_one(value, ty, *span, position, module_id, store, sink);
+    if matches!(expression, Expression::Identifier { .. }) && position != Position::Callee {
+        check_one(expression, position, module_id, store, sink);
     }
 
     match expression {
@@ -67,14 +63,20 @@ fn visit_expression(
 }
 
 fn check_one(
-    value: &str,
-    ty: &Type,
-    span: Span,
+    identifier: &Expression,
     position: Position,
     module_id: &str,
     store: &Store,
     sink: &LocalSink,
 ) {
+    let Expression::Identifier {
+        value, ty, span, ..
+    } = identifier
+    else {
+        return;
+    };
+    let value = value.as_str();
+    let span = *span;
     if matches!(
         value,
         "imaginary" | "assert_type" | "complex" | "real" | "panic"

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
@@ -52,20 +52,13 @@ pub fn check_needless_splitn(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
+    let original = format!("{namespace_text}.{member}({s_text}, {sep_text}, {count_text})");
     let replacement = format!("{namespace_text}.{target}({s_text}, {sep_text})");
     ctx.sink.push(
-        diagnostics::lint::needless_splitn(
-            span,
-            member.as_str(),
-            target,
-            namespace_text,
-            s_text,
-            sep_text,
-            count_text,
-        )
-        .with_fix(Fix::new(
-            format!("Replace with `{replacement}`"),
-            Edit::replacement(*span, replacement.clone()),
-        )),
+        diagnostics::lint::needless_splitn(span, member.as_str(), &original, &replacement)
+            .with_fix(Fix::new(
+                format!("Replace with `{replacement}`"),
+                Edit::replacement(*span, replacement.clone()),
+            )),
     );
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
@@ -32,7 +32,7 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
             _ => container.is_result(),
         };
         if confirmed && reorder_safe(payload, mapper, ctx.store) {
-            push_map_on_constructor(ctx, span, receiver, variant, "map", payload, mapper);
+            push_map_on_constructor(ctx, span, receiver, variant, payload, mapper);
         }
         return;
     }
@@ -46,7 +46,7 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
             return;
         };
         if receiver.get_type().is_result() && reorder_safe(payload, mapper, ctx.store) {
-            push_map_on_constructor(ctx, span, receiver, "Err", "map_err", payload, mapper);
+            push_map_on_constructor(ctx, span, receiver, "Err", payload, mapper);
         }
     }
 }
@@ -56,10 +56,10 @@ fn push_map_on_constructor(
     span: &Span,
     receiver: &Expression,
     variant: &str,
-    method: &str,
     payload: &Expression,
     mapper: &Expression,
 ) {
+    let method = if variant == "Err" { "map_err" } else { "map" };
     let mut diagnostic = diagnostics::lint::unnecessary_map_on_constructor(span, variant, method);
     // A lambda mapper needs beta-reduction to inline, so it reports without a fix.
     if !matches!(mapper.unwrap_parens(), Expression::Lambda { .. })

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
@@ -32,7 +32,7 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
             _ => container.is_result(),
         };
         if confirmed && reorder_safe(payload, mapper, ctx.store) {
-            push_map_on_constructor(ctx, span, receiver, args, variant, "map", payload, mapper);
+            push_map_on_constructor(ctx, span, receiver, variant, "map", payload, mapper);
         }
         return;
     }
@@ -46,17 +46,15 @@ pub fn check_unnecessary_map_on_constructor(expression: &Expression, ctx: &NodeC
             return;
         };
         if receiver.get_type().is_result() && reorder_safe(payload, mapper, ctx.store) {
-            push_map_on_constructor(ctx, span, receiver, args, "Err", "map_err", payload, mapper);
+            push_map_on_constructor(ctx, span, receiver, "Err", "map_err", payload, mapper);
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn push_map_on_constructor(
     ctx: &NodeCtx,
     span: &Span,
     receiver: &Expression,
-    args: &[Expression],
     variant: &str,
     method: &str,
     payload: &Expression,
@@ -65,7 +63,7 @@ fn push_map_on_constructor(
     let mut diagnostic = diagnostics::lint::unnecessary_map_on_constructor(span, variant, method);
     // A lambda mapper needs beta-reduction to inline, so it reports without a fix.
     if !matches!(mapper.unwrap_parens(), Expression::Lambda { .. })
-        && reads_as_method_call(receiver, args)
+        && reads_as_method_call(receiver, std::slice::from_ref(mapper))
         && let (Some(mapper_text), Some(payload_text)) = (
             span_text(ctx.source, mapper),
             span_text(ctx.source, payload),

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -3,8 +3,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use semantics::checker::promotion::{self, MemberKind, Resolution};
 use semantics::store::Store;
 use syntax::ast::{
-    Annotation, Attribute, Binding, CallTypeArguments, Expression, Generic, ImportAlias, Pattern,
-    SelectArm, StructSpread,
+    Annotation, Attribute, Expression, ImportAlias, Pattern, SelectArm, StructSpread,
 };
 use syntax::program::File;
 use syntax::program::{DefinitionBody, DotAccessKind, EqualityIndex, Module};
@@ -64,23 +63,8 @@ pub(super) fn walk_expression(
             walk_identifier(module, value, graph, alias_map, ctx);
         }
 
-        Expression::Call {
-            expression: callee,
-            args,
-            spread,
-            type_arguments,
-            ..
-        } => {
-            walk_call(
-                module,
-                callee,
-                args,
-                spread,
-                type_arguments,
-                graph,
-                alias_map,
-                ctx,
-            );
+        Expression::Call { .. } => {
+            walk_call(module, expression, graph, alias_map, ctx);
         }
 
         Expression::StructCall { .. } => {
@@ -114,25 +98,9 @@ pub(super) fn walk_expression(
             }
         }
 
-        Expression::Function {
-            name,
-            generics,
-            params,
-            return_annotation,
-            body,
-            ..
-        } => {
+        Expression::Function { name, .. } => {
             let fn_ctx = ctx.cloned().unwrap_or_else(|| ModuleItemId::new(name));
-            walk_callable_body(
-                module,
-                generics,
-                params,
-                return_annotation,
-                body.definition(),
-                graph,
-                alias_map,
-                &fn_ctx,
-            );
+            walk_callable_body(module, expression, graph, alias_map, &fn_ctx);
         }
 
         Expression::Const {
@@ -274,26 +242,9 @@ pub(super) fn walk_expression(
                 }
             }
             for m in methods {
-                if let Expression::Function {
-                    name,
-                    generics,
-                    params,
-                    return_annotation,
-                    body,
-                    ..
-                } = m
-                {
+                if let Expression::Function { name, .. } = m {
                     let method_ctx = ModuleItemId::method(name, receiver_name);
-                    walk_callable_body(
-                        module,
-                        generics,
-                        params,
-                        return_annotation,
-                        body.definition(),
-                        graph,
-                        alias_map,
-                        &method_ctx,
-                    );
+                    walk_callable_body(module, m, graph, alias_map, &method_ctx);
                 } else {
                     walk_expression(module, m, graph, alias_map, ctx);
                 }
@@ -396,18 +347,24 @@ fn walk_identifier(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_call(
     module: &Module,
-    callee: &Expression,
-    args: &[Expression],
-    spread: &Option<Box<Expression>>,
-    type_arguments: &CallTypeArguments,
+    expression: &Expression,
     graph: &mut ReferenceGraph,
     alias_map: &AliasMap,
     ctx: Option<&ModuleItemId>,
 ) {
-    if let Expression::Identifier { value, .. } = callee {
+    let Expression::Call {
+        expression: callee,
+        args,
+        spread,
+        type_arguments,
+        ..
+    } = expression
+    else {
+        return;
+    };
+    if let Expression::Identifier { value, .. } = callee.as_ref() {
         let mut segments = value.split('.');
         let first = segments.next().unwrap_or("");
         if segments.next().is_some() && is_upper(first) {
@@ -771,17 +728,23 @@ fn is_method_access(kind: Option<DotAccessKind>) -> bool {
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_callable_body(
     module: &Module,
-    generics: &[Generic],
-    params: &[Binding],
-    return_annotation: &Annotation,
-    body: Option<&Expression>,
+    function: &Expression,
     graph: &mut ReferenceGraph,
     alias_map: &AliasMap,
     fn_ctx: &ModuleItemId,
 ) {
+    let Expression::Function {
+        generics,
+        params,
+        return_annotation,
+        body,
+        ..
+    } = function
+    else {
+        return;
+    };
     for g in generics {
         for bound in g.bounds() {
             walk_annotation(module, bound, graph, alias_map, fn_ctx);
@@ -799,7 +762,7 @@ fn walk_callable_body(
         );
     }
     walk_annotation(module, return_annotation, graph, alias_map, fn_ctx);
-    if let Some(body) = body {
+    if let Some(body) = body.definition() {
         walk_expression(module, body, graph, alias_map, Some(fn_ctx));
     }
 }

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -25,3 +25,6 @@ rayon.workspace = true
 [dev-dependencies]
 tempfile = "3"
 
+
+[lints]
+workspace = true

--- a/crates/semantics/src/cache/bounds.rs
+++ b/crates/semantics/src/cache/bounds.rs
@@ -4,7 +4,7 @@ use syntax::ast::{Expression, Generic};
 use syntax::program::{FileImport, Visibility};
 use syntax::types::Symbol;
 
-use crate::checker::{FileContextKind, TaskState};
+use crate::checker::{FileContextKind, FileContextSpec, TaskState};
 use crate::prelude::PRELUDE_MODULE_ID;
 use crate::store::Store;
 
@@ -100,10 +100,12 @@ fn restore_module_bounds(
         }
         checker.with_file_context_mut(
             store,
-            module_id,
-            file.file_id,
-            &file.imports,
-            file_context_kind(module_id),
+            FileContextSpec {
+                module_id,
+                file_id: file.file_id,
+                imports: &file.imports,
+                kind: file_context_kind(module_id),
+            },
             |checker, store| {
                 checker.register_type_names(store, &file.missing_types, &Visibility::Private);
             },
@@ -116,10 +118,12 @@ fn restore_module_bounds(
         }
         checker.with_file_context_mut(
             store,
-            module_id,
-            file.file_id,
-            &file.imports,
-            file_context_kind(module_id),
+            FileContextSpec {
+                module_id,
+                file_id: file.file_id,
+                imports: &file.imports,
+                kind: file_context_kind(module_id),
+            },
             |checker, store| checker.register_type_definitions(store, &file.missing_types),
         );
     }
@@ -131,10 +135,12 @@ fn restore_module_bounds(
         let definitions = file.bounds_to_restore;
         checker.with_file_context_mut(
             store,
-            module_id,
-            file.file_id,
-            &file.imports,
-            file_context_kind(module_id),
+            FileContextSpec {
+                module_id,
+                file_id: file.file_id,
+                imports: &file.imports,
+                kind: file_context_kind(module_id),
+            },
             |checker, store| {
                 for (name, generics) in definitions {
                     let Some(span) = generics.first().map(|generic| generic.span) else {

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -794,22 +794,18 @@ mod tests {
 
     #[test]
     fn hash_module_sources_independent_of_display_path() {
-        let cli_file = File::new(
+        let cli_file = File::new_cached(
             "greet",
             "greet.lis",
             "src/greet/greet.lis",
             "pub fn x() -> int { 1 }",
-            vec![],
-            None,
             1,
         );
-        let lsp_file = File::new(
+        let lsp_file = File::new_cached(
             "greet",
             "greet.lis",
             "greet.lis",
             "pub fn x() -> int { 1 }",
-            vec![],
-            None,
             1,
         );
 

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -19,6 +19,24 @@ enum IterSeqKind {
     Seq2,
 }
 
+enum MatchArmsKind {
+    Match,
+    IfLet { without_else: bool },
+}
+
+impl MatchArmsKind {
+    fn binding_kind(&self) -> BindingKind {
+        match self {
+            MatchArmsKind::Match => BindingKind::MatchArm,
+            MatchArmsKind::IfLet { .. } => BindingKind::IfLet,
+        }
+    }
+
+    fn is_if_let_without_else(&self) -> bool {
+        matches!(self, MatchArmsKind::IfLet { without_else: true })
+    }
+}
+
 fn iter_seq_kind(ty: &Type) -> Option<IterSeqKind> {
     let Type::Nominal { id, .. } = ty else {
         return None;
@@ -307,14 +325,8 @@ impl InferCtx<'_> {
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
-        let (new_subject, new_arms, result_ty) = self.infer_match_arms(
-            subject,
-            arms,
-            BindingKind::MatchArm,
-            false,
-            span,
-            expected_ty,
-        );
+        let (new_subject, new_arms, result_ty) =
+            self.infer_match_arms(subject, arms, MatchArmsKind::Match, span, expected_ty);
 
         Expression::Match {
             subject: new_subject.into(),
@@ -372,8 +384,9 @@ impl InferCtx<'_> {
         let (new_scrutinee, mut new_arms, result_ty) = self.infer_match_arms(
             scrutinee,
             arms,
-            BindingKind::IfLet,
-            is_if_let_without_else,
+            MatchArmsKind::IfLet {
+                without_else: is_if_let_without_else,
+            },
             span,
             expected_ty,
         );
@@ -401,11 +414,12 @@ impl InferCtx<'_> {
         &mut self,
         subject: Box<Expression>,
         arms: Vec<MatchArm>,
-        arm_kind: BindingKind,
-        is_if_let_without_else: bool,
+        kind: MatchArmsKind,
         span: Span,
         expected_ty: &Type,
     ) -> (Expression, Vec<MatchArm>, Type) {
+        let arm_kind = kind.binding_kind();
+        let is_if_let_without_else = kind.is_if_let_without_else();
         let result_ty = self.new_type_var();
         let subject_ty = self.new_type_var();
         let new_subject = self.infer_expression(*subject, &subject_ty);

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -22,6 +22,15 @@ struct ConformanceTraversal<'a> {
     visiting: rustc_hash::FxHashSet<String>,
 }
 
+struct ConformanceSite<'a> {
+    ty: &'a Type,
+    symbol_methods: &'a MethodSignatures,
+    interface_qualified_id: &'a str,
+    interface_is_public: bool,
+    map: &'a SubstitutionMap,
+    receiver_id: Option<&'a str>,
+}
+
 fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
     fn walk(
         store: &Store,
@@ -552,15 +561,17 @@ impl InferCtx<'_> {
             .get_definition(interface_qualified_id)
             .is_some_and(|d| d.visibility.is_public());
 
+        let site = ConformanceSite {
+            ty,
+            symbol_methods: &symbol_methods,
+            interface_qualified_id,
+            interface_is_public,
+            map: &map,
+            receiver_id: receiver_id.as_ref().map(|id| id.as_str()),
+        };
+
         for (method_name, method_ty) in &interface.methods {
-            let selected = self.select_impl_method(
-                ty,
-                &symbol_methods,
-                interface_qualified_id,
-                interface_is_public,
-                method_name.as_str(),
-                receiver_id.as_ref().map(|id| id.as_str()),
-            );
+            let selected = self.select_impl_method(&site, method_name.as_str());
             let (impl_method_name, symbol_method) = match selected {
                 SelectedMethod::Found(name, method) => (name, method),
                 SelectedMethod::UfcsOnly => {
@@ -586,14 +597,8 @@ impl InferCtx<'_> {
                     continue;
                 }
                 SelectedMethod::Missing => {
-                    let private_candidate = self.private_method_hint(
-                        ty,
-                        &symbol_methods,
-                        interface_qualified_id,
-                        method_name.as_str(),
-                        method_ty,
-                        &map,
-                    );
+                    let private_candidate =
+                        self.private_method_hint(&site, method_name.as_str(), method_ty);
                     method_violations.push(InterfaceMethodViolation::Missing(MissingMethod {
                         name: method_name.to_string(),
                         signature: method_ty.clone(),
@@ -603,14 +608,8 @@ impl InferCtx<'_> {
                 }
             };
 
-            let signature = self.check_method_signature(
-                ty,
-                interface_qualified_id,
-                method_name.as_str(),
-                method_ty,
-                &symbol_method,
-                &map,
-            );
+            let signature =
+                self.check_method_signature(&site, method_name.as_str(), method_ty, &symbol_method);
 
             match signature {
                 SignatureCheck::Matched => {
@@ -675,27 +674,22 @@ impl InferCtx<'_> {
         check.visiting.remove(interface_qualified_id);
     }
 
-    fn select_impl_method(
-        &self,
-        ty: &Type,
-        symbol_methods: &MethodSignatures,
-        interface_qualified_id: &str,
-        interface_is_public: bool,
-        method_name: &str,
-        receiver_id: Option<&str>,
-    ) -> SelectedMethod {
+    fn select_impl_method(&self, site: &ConformanceSite<'_>, method_name: &str) -> SelectedMethod {
         let selected = syntax::go_names::conformance_method(
-            symbol_methods,
-            interface_qualified_id,
-            interface_is_public,
+            site.symbol_methods,
+            site.interface_qualified_id,
+            site.interface_is_public,
             method_name,
-            &|name| self.conformance_candidate(ty, name),
+            &|name| self.conformance_candidate(site.ty, name),
         );
         let ufcs_probe = match &selected {
             Some((name, _)) => name.as_str(),
             None => method_name,
         };
-        if receiver_id.is_some_and(|id| self.is_ufcs_method(id, ufcs_probe)) {
+        if site
+            .receiver_id
+            .is_some_and(|id| self.is_ufcs_method(id, ufcs_probe))
+        {
             return SelectedMethod::UfcsOnly;
         }
         match selected {
@@ -706,48 +700,32 @@ impl InferCtx<'_> {
 
     fn private_method_hint(
         &mut self,
-        ty: &Type,
-        symbol_methods: &MethodSignatures,
-        interface_qualified_id: &str,
+        site: &ConformanceSite<'_>,
         method_name: &str,
         method_ty: &Type,
-        map: &SubstitutionMap,
     ) -> Option<String> {
-        let interface_is_public = self
-            .store
-            .get_definition(interface_qualified_id)
-            .is_some_and(|d| d.visibility.is_public());
         let (impl_name, impl_method) = syntax::go_names::conformance_method_if_public(
-            symbol_methods,
-            interface_qualified_id,
-            interface_is_public,
+            site.symbol_methods,
+            site.interface_qualified_id,
+            site.interface_is_public,
             method_name,
-            &|name| self.conformance_candidate(ty, name),
+            &|name| self.conformance_candidate(site.ty, name),
         )?;
         let impl_name = impl_name.to_string();
         let impl_method = impl_method.clone();
-        let signature = self.check_method_signature(
-            ty,
-            interface_qualified_id,
-            method_name,
-            method_ty,
-            &impl_method,
-            map,
-        );
+        let signature = self.check_method_signature(site, method_name, method_ty, &impl_method);
         matches!(signature, SignatureCheck::Matched).then_some(impl_name)
     }
 
     fn check_method_signature(
         &mut self,
-        ty: &Type,
-        interface_qualified_id: &str,
+        site: &ConformanceSite<'_>,
         method_name: &str,
         method_ty: &Type,
         symbol_method: &Type,
-        map: &SubstitutionMap,
     ) -> SignatureCheck {
         let store = self.store;
-        let substituted_method = substitute(method_ty, map);
+        let substituted_method = substitute(method_ty, site.map);
 
         let instantiated_method = match symbol_method {
             Type::Forall { .. } => self.instantiate(symbol_method).0,
@@ -773,7 +751,7 @@ impl InferCtx<'_> {
         };
 
         let impl_for_unify = covariant_return_adjustment(
-            interface_qualified_id,
+            site.interface_qualified_id,
             method_name,
             &substituted_method,
             &impl_method_without_receiver,
@@ -786,7 +764,7 @@ impl InferCtx<'_> {
             Signature,
         }
 
-        let candidate_ty = ty.strip_refs().resolve_in(&self.env);
+        let candidate_ty = site.ty.strip_refs().resolve_in(&self.env);
         let mut resolved_impl_method = None;
         let sig_match = self.in_invariant_position(|ctx| {
             ctx.speculatively(|this| {

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use unify::BuiltinBound;
 use rustc_hash::FxHashMap as HashMap;
 
 use super::freeze::FreezeFolder;
-use super::{FileContextKind, TaskState};
+use super::{FileContextKind, FileContextSpec, TaskState};
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
 use syntax::program::{File, FileImport};
@@ -52,10 +52,12 @@ impl InferCtx<'_> {
 
         self.with_file_context(
             store,
-            module_id,
-            file_id,
-            &imports,
-            FileContextKind::Standard,
+            FileContextSpec {
+                module_id,
+                file_id,
+                imports: &imports,
+                kind: FileContextKind::Standard,
+            },
             |this, store| {
                 let mut ctx = InferCtx::new(this, store);
                 ctx.check_definition_module_collisions(&file.items, &imports);

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -119,6 +119,13 @@ pub(crate) enum FileContextKind {
     TestPrelude,
 }
 
+pub(crate) struct FileContextSpec<'a> {
+    pub(crate) module_id: &'a str,
+    pub(crate) file_id: u32,
+    pub(crate) imports: &'a [FileImport],
+    pub(crate) kind: FileContextKind,
+}
+
 struct SavedFileContext {
     cursor: Cursor,
     scopes: Scopes,
@@ -807,13 +814,10 @@ impl TaskState {
     fn with_file_context<T>(
         &mut self,
         store: &Store,
-        module_id: &str,
-        file_id: u32,
-        imports: &[FileImport],
-        kind: FileContextKind,
+        spec: FileContextSpec<'_>,
         f: impl FnOnce(&mut Self, &Store) -> T,
     ) -> T {
-        let saved = self.enter_file_context(store, module_id, file_id, imports, kind);
+        let saved = self.enter_file_context(store, spec);
         let result = f(self, store);
         self.exit_file_context(saved);
         result
@@ -822,26 +826,22 @@ impl TaskState {
     pub(crate) fn with_file_context_mut<T>(
         &mut self,
         store: &mut Store,
-        module_id: &str,
-        file_id: u32,
-        imports: &[FileImport],
-        kind: FileContextKind,
+        spec: FileContextSpec<'_>,
         f: impl FnOnce(&mut Self, &mut Store) -> T,
     ) -> T {
-        let saved = self.enter_file_context(&*store, module_id, file_id, imports, kind);
+        let saved = self.enter_file_context(&*store, spec);
         let result = f(self, store);
         self.exit_file_context(saved);
         result
     }
 
-    fn enter_file_context(
-        &mut self,
-        store: &Store,
-        module_id: &str,
-        file_id: u32,
-        imports: &[FileImport],
-        kind: FileContextKind,
-    ) -> SavedFileContext {
+    fn enter_file_context(&mut self, store: &Store, spec: FileContextSpec<'_>) -> SavedFileContext {
+        let FileContextSpec {
+            module_id,
+            file_id,
+            imports,
+            kind,
+        } = spec;
         let saved = SavedFileContext {
             cursor: std::mem::replace(
                 &mut self.cursor,

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -42,6 +42,23 @@ impl TypeArgumentChecks {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ConvertMode {
+    variadic_allowed: bool,
+    type_argument_checks: TypeArgumentChecks,
+    position: TypePosition,
+}
+
+impl ConvertMode {
+    fn nested(self) -> Self {
+        ConvertMode {
+            variadic_allowed: false,
+            type_argument_checks: self.type_argument_checks.nested(),
+            position: TypePosition::Value,
+        }
+    }
+}
+
 impl TaskState {
     /// Resolves a generic-bound annotation. Bound-only markers like
     /// `Comparable` are admitted here; the same names in value position
@@ -56,9 +73,11 @@ impl TaskState {
             store,
             annotation,
             span,
-            false,
-            TypeArgumentChecks::Deferred,
-            TypePosition::Bound,
+            ConvertMode {
+                variadic_allowed: false,
+                type_argument_checks: TypeArgumentChecks::Deferred,
+                position: TypePosition::Bound,
+            },
         );
         if !result.contains_error() {
             self.facts
@@ -78,9 +97,11 @@ impl TaskState {
             store,
             annotation,
             span,
-            false,
-            TypeArgumentChecks::All,
-            TypePosition::Value,
+            ConvertMode {
+                variadic_allowed: false,
+                type_argument_checks: TypeArgumentChecks::All,
+                position: TypePosition::Value,
+            },
         )
     }
 
@@ -94,9 +115,11 @@ impl TaskState {
             store,
             annotation,
             span,
-            true,
-            TypeArgumentChecks::All,
-            TypePosition::Value,
+            ConvertMode {
+                variadic_allowed: true,
+                type_argument_checks: TypeArgumentChecks::All,
+                position: TypePosition::Value,
+            },
         )
     }
 
@@ -110,9 +133,11 @@ impl TaskState {
             store,
             annotation,
             span,
-            false,
-            TypeArgumentChecks::Descendants,
-            TypePosition::Value,
+            ConvertMode {
+                variadic_allowed: false,
+                type_argument_checks: TypeArgumentChecks::Descendants,
+                position: TypePosition::Value,
+            },
         )
     }
 
@@ -121,10 +146,13 @@ impl TaskState {
         store: &Store,
         annotation: &Annotation,
         span: &Span,
-        variadic_allowed: bool,
-        type_argument_checks: TypeArgumentChecks,
-        position: TypePosition,
+        mode: ConvertMode,
     ) -> Type {
+        let ConvertMode {
+            variadic_allowed,
+            type_argument_checks,
+            position,
+        } = mode;
         match annotation {
             Annotation::Unknown => self.new_type_var(),
 
@@ -142,9 +170,10 @@ impl TaskState {
                             store,
                             &param.annotation,
                             span,
-                            index == last_param,
-                            type_argument_checks.nested(),
-                            TypePosition::Value,
+                            ConvertMode {
+                                variadic_allowed: index == last_param,
+                                ..mode.nested()
+                            },
                         )
                     })
                     .collect();
@@ -153,14 +182,7 @@ impl TaskState {
                 let new_return_type = if matches!(return_type.as_ref(), Annotation::Unknown) {
                     self.type_unit()
                 } else {
-                    self.convert_to_type_mode(
-                        store,
-                        return_type,
-                        span,
-                        false,
-                        type_argument_checks.nested(),
-                        TypePosition::Value,
-                    )
+                    self.convert_to_type_mode(store, return_type, span, mode.nested())
                 };
 
                 Type::function(
@@ -214,7 +236,7 @@ impl TaskState {
                         params,
                         *annotation_span,
                         span,
-                        type_argument_checks,
+                        mode,
                     );
                 }
 
@@ -274,16 +296,7 @@ impl TaskState {
 
                 let concrete_args: Vec<Type> = params
                     .iter()
-                    .map(|arg| {
-                        self.convert_to_type_mode(
-                            store,
-                            arg,
-                            span,
-                            false,
-                            type_argument_checks.nested(),
-                            TypePosition::Value,
-                        )
-                    })
+                    .map(|arg| self.convert_to_type_mode(store, arg, span, mode.nested()))
                     .collect();
 
                 if generics.len() != params.len() {
@@ -347,16 +360,7 @@ impl TaskState {
             Annotation::Tuple { elements, .. } => {
                 let element_types = elements
                     .iter()
-                    .map(|element| {
-                        self.convert_to_type_mode(
-                            store,
-                            element,
-                            span,
-                            false,
-                            type_argument_checks.nested(),
-                            TypePosition::Value,
-                        )
-                    })
+                    .map(|element| self.convert_to_type_mode(store, element, span, mode.nested()))
                     .collect();
                 Type::Tuple(element_types)
             }
@@ -381,17 +385,10 @@ impl TaskState {
         params: &[Annotation],
         annotation_span: Span,
         span: &Span,
-        type_argument_checks: TypeArgumentChecks,
+        mode: ConvertMode,
     ) -> Type {
         if params.len() == 1 && self.cursor.module_id == PRELUDE_MODULE_ID {
-            let element = self.convert_to_type_mode(
-                store,
-                &params[0],
-                span,
-                false,
-                type_argument_checks.nested(),
-                TypePosition::Value,
-            );
+            let element = self.convert_to_type_mode(store, &params[0], span, mode.nested());
             return Type::Nominal {
                 id: Symbol::from_parts("prelude", "Array"),
                 params: vec![element],
@@ -404,26 +401,12 @@ impl TaskState {
                 annotation_span,
             ));
             for param in params {
-                let _ = self.convert_to_type_mode(
-                    store,
-                    param,
-                    span,
-                    false,
-                    type_argument_checks.nested(),
-                    TypePosition::Value,
-                );
+                let _ = self.convert_to_type_mode(store, param, span, mode.nested());
             }
             return Type::Error;
         }
 
-        let element = self.convert_to_type_mode(
-            store,
-            &params[0],
-            span,
-            false,
-            type_argument_checks.nested(),
-            TypePosition::Value,
-        );
+        let element = self.convert_to_type_mode(store, &params[0], span, mode.nested());
         if element.contains_error() {
             return Type::Error;
         }

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -13,6 +13,13 @@ enum BoundCheckContext {
     Value,
 }
 
+#[derive(Clone, Copy)]
+struct BoundsCheckSite<'a> {
+    store: &'a Store,
+    own_generics: &'a [Generic],
+    declaration_span: Span,
+}
+
 impl TaskState {
     pub(crate) fn check_transitive_generic_bounds(
         &mut self,
@@ -20,18 +27,17 @@ impl TaskState {
         own_generics: &[Generic],
         declaration_span: Span,
     ) {
+        let site = BoundsCheckSite {
+            store,
+            own_generics,
+            declaration_span,
+        };
         for generic in own_generics {
             for bound in generic
                 .resolved_bounds()
                 .expect("generic bounds were resolved before checking")
             {
-                self.check_bound_type(
-                    store,
-                    own_generics,
-                    declaration_span,
-                    bound,
-                    BoundCheckContext::Declaration,
-                );
+                self.check_bound_type(&site, bound, BoundCheckContext::Declaration);
             }
         }
     }
@@ -45,30 +51,26 @@ impl TaskState {
         let mut seen = rustc_hash::FxHashSet::default();
         for (ty, span) in types {
             if seen.insert(ty.to_string()) {
-                self.check_bound_type(store, own_generics, *span, ty, BoundCheckContext::Value);
+                let site = BoundsCheckSite {
+                    store,
+                    own_generics,
+                    declaration_span: *span,
+                };
+                self.check_bound_type(&site, ty, BoundCheckContext::Value);
             }
         }
     }
 
     fn check_bound_type(
         &mut self,
-        store: &Store,
-        own_generics: &[Generic],
-        declaration_span: Span,
+        site: &BoundsCheckSite<'_>,
         ty: &Type,
         context: BoundCheckContext,
     ) {
         if let Type::Nominal { id, params, .. } = ty
             && !params.is_empty()
         {
-            self.check_nominal_arguments(
-                store,
-                own_generics,
-                declaration_span,
-                id,
-                params,
-                context,
-            );
+            self.check_nominal_arguments(site, id, params, context);
         }
         if matches!(context, BoundCheckContext::Declaration)
             && let Type::Compound {
@@ -77,22 +79,25 @@ impl TaskState {
             } = ty
             && let Some(key) = args.first()
         {
-            self.check_map_key_comparable(store, key, declaration_span);
+            self.check_map_key_comparable(site.store, key, site.declaration_span);
         }
         for child in type_argument_children(ty) {
-            self.check_bound_type(store, own_generics, declaration_span, child, context);
+            self.check_bound_type(site, child, context);
         }
     }
 
     fn check_nominal_arguments(
         &mut self,
-        store: &Store,
-        own_generics: &[Generic],
-        declaration_span: Span,
+        site: &BoundsCheckSite<'_>,
         referenced_id: &str,
         argument_types: &[Type],
         context: BoundCheckContext,
     ) {
+        let BoundsCheckSite {
+            store,
+            own_generics,
+            declaration_span,
+        } = *site;
         let Some(definition) = store.get_definition(referenced_id) else {
             return;
         };

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -26,7 +26,7 @@ use syntax::program::{
 };
 use syntax::types::{Bound, FunctionParameter, Symbol, Type};
 
-use super::{FileContextKind, TaskState, resolved_generic_bounds};
+use super::{FileContextKind, FileContextSpec, TaskState, resolved_generic_bounds};
 use crate::store::Store;
 
 pub(crate) fn extract_package_directive(source: &str) -> Option<String> {
@@ -422,10 +422,12 @@ impl TaskState {
 
         self.with_file_context_mut(
             store,
-            module_id,
-            file_id,
-            &imports,
-            FileContextKind::ImportedTypedef,
+            FileContextSpec {
+                module_id,
+                file_id,
+                imports: &imports,
+                kind: FileContextKind::ImportedTypedef,
+            },
             |this, store| {
                 let items = std::mem::take(
                     &mut store
@@ -498,10 +500,12 @@ impl TaskState {
     ) {
         self.with_file_context_mut(
             store,
-            module_id,
-            file_id,
-            imports,
-            FileContextKind::Standard,
+            FileContextSpec {
+                module_id,
+                file_id,
+                imports,
+                kind: FileContextKind::Standard,
+            },
             |this, store| {
                 let items = std::mem::take(
                     &mut store

--- a/crates/semantics/src/diagnostics.rs
+++ b/crates/semantics/src/diagnostics.rs
@@ -85,30 +85,28 @@ pub(crate) fn emit_for_locator_result(
 /// Emit a diagnostic for a non-OK `DeclarationStatus`; returns `true` if OK.
 pub(crate) fn emit_for_declaration_status(
     status: &DeclarationStatus,
-    import_name: &str,
-    go_pkg: &str,
-    name_span: Span,
-    target: Target,
-    standalone_mode: bool,
+    site: &GoImportSite,
     sink: &LocalSink,
 ) -> bool {
+    let GoImportSite {
+        import_name,
+        go_pkg,
+        name_span,
+        target,
+        standalone_mode,
+        ..
+    } = *site;
+    let span = name_span.unwrap_or_else(|| Span::new(0, 0, 0));
     match status {
         DeclarationStatus::Stdlib
         | DeclarationStatus::DeclaredThirdParty { .. }
         | DeclarationStatus::DeclaredReplacement { .. } => true,
         DeclarationStatus::UnknownStdlib => {
-            emit_unknown_stdlib(
-                import_name,
-                go_pkg,
-                name_span,
-                target,
-                standalone_mode,
-                sink,
-            );
+            emit_unknown_stdlib(import_name, go_pkg, span, target, standalone_mode, sink);
             false
         }
         DeclarationStatus::UndeclaredImport => {
-            emit_undeclared(import_name, go_pkg, name_span, standalone_mode, None, sink);
+            emit_undeclared(import_name, go_pkg, span, standalone_mode, None, sink);
             false
         }
     }

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -228,15 +228,15 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             let file_id = store.new_file_id();
             let result = syntax::build_ast(&content.source, file_id);
             sink.extend_parse_errors(result.errors);
-            store.store_file(File::new(
-                ENTRY_MODULE_ID,
-                &filename,
-                &content.display_path,
-                &content.source,
-                result.ast,
-                result.file_comment,
-                file_id,
-            ));
+            store.store_file(File {
+                id: file_id,
+                module_id: ENTRY_MODULE_ID.to_string(),
+                name: filename,
+                display_path: content.display_path,
+                source: content.source,
+                items: result.ast,
+                file_comment: result.file_comment,
+            });
         }
     }
 

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -438,15 +438,15 @@ fn scan_one(fs: &dyn Loader, module_id: &str) -> Vec<(String, semantics_loader::
 
 fn parse_one(job: ParseJob) -> (File, Vec<syntax::ParseError>) {
     let result = syntax::build_ast(&job.source, job.file_id);
-    let file = File::new(
-        &job.module_id,
-        &job.filename,
-        &job.display_path,
-        &job.source,
-        result.ast,
-        result.file_comment,
-        job.file_id,
-    );
+    let file = File {
+        id: job.file_id,
+        module_id: job.module_id,
+        name: job.filename,
+        display_path: job.display_path,
+        source: job.source,
+        items: result.ast,
+        file_comment: result.file_comment,
+    };
     (file, result.errors)
 }
 
@@ -536,11 +536,14 @@ fn process_file_imports(
                     let status = locator.validate_declaration(go_pkg);
                     emit_for_declaration_status(
                         &status,
-                        pending.name,
-                        go_pkg,
-                        pending.span,
-                        locator.target(),
-                        standalone_mode,
+                        &GoImportSite {
+                            import_name: pending.name,
+                            go_pkg,
+                            name_span: Some(pending.span),
+                            target: locator.target(),
+                            standalone_mode,
+                            replace_importer: None,
+                        },
                         sink,
                     )
                 }

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -3,7 +3,7 @@ use stdlib::{LIS_PRELUDE_SOURCE, LIS_TEST_PRELUDE_SOURCE};
 use syntax::program::{File, Visibility};
 
 use crate::call_classification::compute_module_ufcs;
-use crate::checker::{FileContextKind, TaskState};
+use crate::checker::{FileContextKind, FileContextSpec, TaskState};
 use crate::store::Store;
 
 pub(crate) const PRELUDE_MODULE_ID: &str = "prelude";
@@ -41,10 +41,12 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
 
     checker.with_file_context_mut(
         store,
-        PRELUDE_MODULE_ID,
-        PRELUDE_FILE_ID,
-        &[],
-        FileContextKind::Prelude,
+        FileContextSpec {
+            module_id: PRELUDE_MODULE_ID,
+            file_id: PRELUDE_FILE_ID,
+            imports: &[],
+            kind: FileContextKind::Prelude,
+        },
         |checker, store| {
             for file in module.typedef_files() {
                 checker.register_type_names(store, &file.items, &Visibility::Public);
@@ -89,10 +91,12 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
 
     checker.with_file_context_mut(
         store,
-        TEST_PRELUDE_MODULE_ID,
-        file_id,
-        &[],
-        FileContextKind::TestPrelude,
+        FileContextSpec {
+            module_id: TEST_PRELUDE_MODULE_ID,
+            file_id,
+            imports: &[],
+            kind: FileContextKind::TestPrelude,
+        },
         |checker, store| {
             for file in module.typedef_files() {
                 checker.register_type_names(store, &file.items, &Visibility::Public);

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -740,11 +740,11 @@ mod closed_domain_tests {
     fn storing_a_file_owns_its_test_classification() {
         let mut store = Store::new();
         store.add_module("m");
-        store.store_file(File::new("m", "sample.test.lis", "", "", vec![], None, 42));
+        store.store_file(File::new_cached("m", "sample.test.lis", "", "", 42));
 
         assert!(store.is_test_file(42));
 
-        store.store_file(File::new("m", "sample.lis", "", "", vec![], None, 42));
+        store.store_file(File::new_cached("m", "sample.lis", "", "", 42));
 
         assert!(!store.is_test_file(42));
     }
@@ -753,7 +753,7 @@ mod closed_domain_tests {
     fn replacing_a_module_removes_its_old_test_classification() {
         let mut store = Store::new();
         store.add_module("m");
-        store.store_file(File::new("m", "sample.test.lis", "", "", vec![], None, 42));
+        store.store_file(File::new_cached("m", "sample.test.lis", "", "", 42));
 
         store.insert_prebuilt_module(Module::new("m"));
 

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -11,3 +11,6 @@ repository.workspace = true
 [lib]
 doctest = false
 test = false
+
+[lints]
+workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -19,3 +19,6 @@ serde = ["dep:serde", "ecow/serde"]
 ecow.workspace = true
 rustc-hash.workspace = true
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+
+[lints]
+workspace = true

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -11,7 +11,36 @@ use crate::lex::TokenKind::*;
 use crate::parse::error::ParseError;
 use crate::types::Type;
 
+struct DefinitionHeader<'source> {
+    doc: Option<std::string::String>,
+    attributes: Vec<Attribute>,
+    name: EcoString,
+    name_span: Span,
+    generics: Vec<Generic>,
+    start: Token<'source>,
+}
+
 impl<'source> Parser<'source> {
+    fn parse_definition_header(
+        &mut self,
+        doc: Option<std::string::String>,
+        attributes: Vec<Attribute>,
+        start: Token<'source>,
+    ) -> DefinitionHeader<'source> {
+        let name_token = self.current_token();
+        let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
+        let name = self.read_identifier();
+        let generics = self.parse_generics();
+        DefinitionHeader {
+            doc,
+            attributes,
+            name,
+            name_span,
+            generics,
+            start,
+        }
+    }
+
     pub(crate) fn parse_attributes(&mut self) -> Vec<Attribute> {
         let mut attributes = vec![];
         loop {
@@ -148,10 +177,7 @@ impl<'source> Parser<'source> {
 
         self.ensure(Enum);
 
-        let name_token = self.current_token();
-        let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
-        let name = self.read_identifier();
-        let generics = self.parse_generics();
+        let header = self.parse_definition_header(doc, attributes, start);
 
         let underlying_start = self.current_token();
         if self.advance_if(Colon) {
@@ -175,18 +201,10 @@ impl<'source> Parser<'source> {
 
         self.ensure(LeftCurlyBrace);
 
-        self.parse_regular_enum_body(doc, attributes, name, name_span, generics, start)
+        self.parse_regular_enum_body(header)
     }
 
-    fn parse_regular_enum_body(
-        &mut self,
-        doc: Option<std::string::String>,
-        attributes: Vec<Attribute>,
-        name: EcoString,
-        name_span: Span,
-        generics: Vec<Generic>,
-        start: Token<'source>,
-    ) -> Expression {
+    fn parse_regular_enum_body(&mut self, header: DefinitionHeader<'source>) -> Expression {
         let mut variants = vec![];
         let mut seen_variants: Vec<(EcoString, Span)> = vec![];
 
@@ -214,6 +232,14 @@ impl<'source> Parser<'source> {
 
         self.ensure(RightCurlyBrace);
 
+        let DefinitionHeader {
+            doc,
+            attributes,
+            name,
+            name_span,
+            generics,
+            start,
+        } = header;
         Expression::Enum {
             doc,
             attributes,
@@ -376,27 +402,16 @@ impl<'source> Parser<'source> {
 
         self.ensure(Struct);
 
-        let name_token = self.current_token();
-        let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
-        let name = self.read_identifier();
-        let generics = self.parse_generics();
+        let header = self.parse_definition_header(doc, attributes, start);
 
         if self.is(LeftParen) {
-            return self.parse_tuple_struct(doc, attributes, name, name_span, generics, start);
+            return self.parse_tuple_struct(header);
         }
 
-        self.parse_named_struct(doc, attributes, name, name_span, generics, start)
+        self.parse_named_struct(header)
     }
 
-    fn parse_named_struct(
-        &mut self,
-        doc: Option<std::string::String>,
-        attributes: Vec<Attribute>,
-        name: EcoString,
-        name_span: Span,
-        generics: Vec<Generic>,
-        start: Token<'source>,
-    ) -> Expression {
+    fn parse_named_struct(&mut self, header: DefinitionHeader<'source>) -> Expression {
         let mut fields = vec![];
         let mut seen_fields: Vec<(EcoString, Span)> = vec![];
 
@@ -421,6 +436,14 @@ impl<'source> Parser<'source> {
 
         self.ensure(RightCurlyBrace);
 
+        let DefinitionHeader {
+            doc,
+            attributes,
+            name,
+            name_span,
+            generics,
+            start,
+        } = header;
         Expression::Struct {
             doc,
             attributes,
@@ -433,15 +456,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_tuple_struct(
-        &mut self,
-        doc: Option<std::string::String>,
-        attributes: Vec<Attribute>,
-        name: EcoString,
-        name_span: Span,
-        generics: Vec<Generic>,
-        start: Token<'source>,
-    ) -> Expression {
+    fn parse_tuple_struct(&mut self, header: DefinitionHeader<'source>) -> Expression {
         self.ensure(LeftParen);
 
         let mut fields = vec![];
@@ -472,6 +487,14 @@ impl<'source> Parser<'source> {
 
         self.ensure(RightParen);
 
+        let DefinitionHeader {
+            doc,
+            attributes,
+            name,
+            name_span,
+            generics,
+            start,
+        } = header;
         Expression::Struct {
             doc,
             attributes,

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -70,26 +70,6 @@ fn is_major_version_segment(segment: &str) -> bool {
 }
 
 impl File {
-    pub fn new(
-        module_id: &str,
-        name: &str,
-        display_path: &str,
-        source: &str,
-        items: Vec<Expression>,
-        file_comment: Option<String>,
-        id: u32,
-    ) -> Self {
-        File {
-            id,
-            module_id: module_id.to_string(),
-            name: name.to_string(),
-            display_path: display_path.to_string(),
-            source: source.to_string(),
-            items,
-            file_comment,
-        }
-    }
-
     pub fn new_cached(
         module_id: &str,
         name: &str,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -53,3 +53,6 @@ path = "embed_diff.rs"
 [[test]]
 name = "manifest_pins"
 path = "manifest_pins.rs"
+
+[lints]
+workspace = true

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -156,15 +156,15 @@ impl CompiledTest {
             InferCtx::new(&mut checker, &store).check_const_cycles(&[self.ast.as_slice()]);
 
             let test_file_id = store.new_file_id();
-            store.store_file(File::new(
-                TEST_MODULE_ID,
-                "test.lis",
-                "test.lis",
-                "",
-                self.ast.clone(),
-                None,
-                test_file_id,
-            ));
+            store.store_file(File {
+                id: test_file_id,
+                module_id: TEST_MODULE_ID.to_string(),
+                name: "test.lis".to_string(),
+                display_path: "test.lis".to_string(),
+                source: String::new(),
+                items: self.ast.clone(),
+                file_comment: None,
+            });
             checker.finalize_equality(&mut store);
             checker.check_pending_generic_bounds(&store);
 
@@ -200,15 +200,15 @@ impl CompiledTest {
             if !checker.failed() {
                 // Overwrite the stored file with the typed AST so passes::run
                 // sees post-inference items when iterating store.modules.
-                store.store_file(File::new(
-                    TEST_MODULE_ID,
-                    "test.lis",
-                    "test.lis",
-                    "",
-                    typed_ast.clone(),
-                    None,
-                    test_file_id,
-                ));
+                store.store_file(File {
+                    id: test_file_id,
+                    module_id: TEST_MODULE_ID.to_string(),
+                    name: "test.lis".to_string(),
+                    display_path: "test.lis".to_string(),
+                    source: String::new(),
+                    items: typed_ast.clone(),
+                    file_comment: None,
+                });
                 store.build_closed_domains();
                 let ufcs_methods = checker.shared_ufcs_methods();
                 let analysis = semantics::context::AnalysisContext::new(&store, &ufcs_methods);

--- a/tests/spec/representation.rs
+++ b/tests/spec/representation.rs
@@ -486,16 +486,8 @@ fn nonliteral_constants_remain_distinguishable_from_runtime_values() {
 #[test]
 fn module_derives_file_classification_from_each_file() {
     let mut module = Module::new("example");
-    let source = File::new("example", "main.lis", "main.lis", "", vec![], None, 1);
-    let typedef = File::new(
-        "example",
-        "native.d.lis",
-        "native.d.lis",
-        "",
-        vec![],
-        None,
-        2,
-    );
+    let source = File::new_cached("example", "main.lis", "main.lis", "", 1);
+    let typedef = File::new_cached("example", "native.d.lis", "native.d.lis", "", 2);
     module.files.insert(source.id, source);
     module.files.insert(typedef.id, typedef);
 

--- a/tests/ui/unix.rs
+++ b/tests/ui/unix.rs
@@ -97,11 +97,9 @@ fn test() {
     let (output, counts) = render::render_unix(
         &result.errors,
         &[],
-        |_| None,
+        render::SourceCache::new(|_| None, source, "src/main.lis"),
         1,
         &unfiltered(),
-        source,
-        "src/main.lis",
     );
 
     assert!(!output.contains('\u{1b}'));


### PR DESCRIPTION
Removes every `#[allow(clippy::too_many_arguments)]` in the codebase and lowers the threshold from the default 7 to 6, enforced via `forbid` so a new exemption cannot be added.