### PR TITLE
refactor: decompose complex functions

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -117,27 +117,31 @@ fn parse_path_and_sourcemap(
     Ok((path, sourcemap))
 }
 
-fn try_parse_go_flags(
+/// Matches `arg` against a value-taking flag in both its `--flag value` and
+/// `--flag=value` forms. Returns `Ok(None)` when `arg` is not one of the
+/// given spellings.
+fn flag_value(
     arg: &str,
+    spellings: &[&str],
     arguments: &mut impl Iterator<Item = String>,
-    go_flags: &mut Vec<String>,
     command: &'static str,
-) -> Result<bool, ParseError> {
-    if arg == "--go-flags" {
-        let Some(value) = arguments.next() else {
-            return Err(ParseError::MissingArgument {
-                command,
-                argument: "--go-flags <flags>",
-            });
-        };
-        extend_go_flags(go_flags, &value)?;
-        Ok(true)
-    } else if let Some(value) = arg.strip_prefix("--go-flags=") {
-        extend_go_flags(go_flags, value)?;
-        Ok(true)
-    } else {
-        Ok(false)
+    argument: &'static str,
+) -> Result<Option<String>, ParseError> {
+    for spelling in spellings {
+        if arg == *spelling {
+            return match arguments.next() {
+                Some(value) => Ok(Some(value)),
+                None => Err(ParseError::MissingArgument { command, argument }),
+            };
+        }
+        if let Some(value) = arg
+            .strip_prefix(spelling)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            return Ok(Some(value.to_string()));
+        }
     }
+    Ok(None)
 }
 
 fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseError> {
@@ -156,7 +160,7 @@ fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseErr
     }
 }
 
-fn parse_format(value: &str) -> Result<OutputFormat, ParseError> {
+fn parse_output(value: &str) -> Result<OutputFormat, ParseError> {
     match value {
         "unix" => Ok(OutputFormat::Unix),
         other => Err(ParseError::UnexpectedArgument {
@@ -232,441 +236,29 @@ impl Command {
         }
 
         match command.as_str() {
-            "new" => match arguments.next() {
-                Some(name) => Ok(Command::New { name }),
-                None => Err(ParseError::MissingArgument {
-                    command: "new",
-                    argument: "name",
-                }),
-            },
-
-            "build" | "b" => {
-                let mut path = None;
-                let mut sourcemap = false;
-                let mut go_flags = Vec::new();
-
-                while let Some(arg) = arguments.next() {
-                    if arg == "--sourcemap" {
-                        sourcemap = true;
-                    } else if arg.starts_with('-') {
-                        if !try_parse_go_flags(&arg, &mut arguments, &mut go_flags, "build")? {
-                            return Err(ParseError::UnknownFlag(arg));
-                        }
-                    } else {
-                        path = Some(arg);
-                    }
-                }
-
-                Ok(Command::Build {
-                    path,
-                    sourcemap,
-                    go_flags,
-                })
-            }
-
+            "new" => parse_new(arguments),
+            "build" | "b" => parse_build(arguments),
             "emit" | "e" => {
                 let (path, sourcemap) = parse_path_and_sourcemap(arguments)?;
                 Ok(Command::Emit { path, sourcemap })
             }
-
-            "run" | "r" => {
-                let mut target = None;
-                let mut args = Vec::new();
-                let mut sourcemap = false;
-                let mut go_flags = Vec::new();
-                let mut found_separator = false;
-
-                while let Some(arg) = arguments.next() {
-                    if found_separator {
-                        args.push(arg);
-                    } else if arg == "--" {
-                        found_separator = true;
-                    } else if arg == "--sourcemap" {
-                        sourcemap = true;
-                    } else if arg == "--go-flags" {
-                        let Some(value) = arguments.next() else {
-                            return Err(ParseError::MissingArgument {
-                                command: "run",
-                                argument: "--go-flags <flags>",
-                            });
-                        };
-                        extend_go_flags(&mut go_flags, &value)?;
-                    } else if let Some(value) = arg.strip_prefix("--go-flags=") {
-                        extend_go_flags(&mut go_flags, value)?;
-                    } else if arg.starts_with('-') {
-                        return Err(ParseError::UnknownFlag(arg));
-                    } else {
-                        target = Some(arg);
-                    }
-                }
-
-                if let Some(flag) = go_flags
-                    .iter()
-                    .find(|f| crate::go_cli::is_go_output_flag(f))
-                {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: format!("`{}` cannot be passed to `lis run` via `--go-flags`", flag),
-                        reason: "`run` executes the binary it links at an internal path, so it owns `-o`"
-                            .to_string(),
-                        hint: "Use `lis build --go-flags \"-o <path>\"` to choose the output location"
-                            .to_string(),
-                    });
-                }
-
-                Ok(Command::Run {
-                    target,
-                    args,
-                    sourcemap,
-                    go_flags,
-                })
-            }
-
-            "format" | "f" => {
-                let mut path = None;
-                let mut check = false;
-
-                for arg in arguments {
-                    match arg.as_str() {
-                        "--check" => check = true,
-                        s if s.starts_with('-') => {
-                            return Err(ParseError::UnknownFlag(s.to_string()));
-                        }
-                        s => path = Some(s.to_string()),
-                    }
-                }
-
-                Ok(Command::Format { path, check })
-            }
-
-            "check" | "c" => {
-                let mut path = None;
-                let mut filter = None;
-                let mut deny_warnings = false;
-                let mut format = OutputFormat::Graphical;
-                let mut fix = false;
-
-                while let Some(arg) = arguments.next() {
-                    match arg.as_str() {
-                        "--errors-only" => match filter {
-                            Some(Filter::Warnings) => return Err(check_filter_conflict()),
-                            _ => filter = Some(Filter::Errors),
-                        },
-                        "--warnings-only" => match filter {
-                            Some(Filter::Errors) => return Err(check_filter_conflict()),
-                            _ => filter = Some(Filter::Warnings),
-                        },
-                        "--fix" => fix = true,
-                        "--output" => {
-                            let Some(value) = arguments.next() else {
-                                return Err(ParseError::MissingArgument {
-                                    command: "check",
-                                    argument: "--output <value>",
-                                });
-                            };
-                            format = parse_format(&value)?;
-                        }
-                        s if s.starts_with("--output=") => {
-                            format = parse_format(s.split_once('=').unwrap().1)?;
-                        }
-                        "--deny" => {
-                            let Some(value) = arguments.next() else {
-                                return Err(ParseError::MissingArgument {
-                                    command: "check",
-                                    argument: "--deny <value>",
-                                });
-                            };
-                            deny_warnings = parse_deny(&value)?;
-                        }
-                        s if s.starts_with("--deny=") => {
-                            deny_warnings = parse_deny(s.split_once('=').unwrap().1)?;
-                        }
-                        s if s.starts_with('-') => {
-                            return Err(ParseError::UnknownFlag(s.to_string()));
-                        }
-                        s => path = Some(s.to_string()),
-                    }
-                }
-
-                let filter = filter.unwrap_or_default();
-                if filter == Filter::Errors && deny_warnings {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: "`--errors-only` and `--deny warnings` cannot be used together"
-                            .to_string(),
-                        reason: "`--errors-only` hides warnings, so `--deny warnings` would have nothing to act on"
-                            .to_string(),
-                        hint: "Drop `--errors-only` to make warnings fail the check".to_string(),
-                    });
-                }
-
-                if fix && deny_warnings {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: "`--fix` and `--deny warnings` cannot be used together".to_string(),
-                        reason: "`--fix` reports what it rewrote, not which warnings remain, so it cannot fail on leftover warnings"
-                            .to_string(),
-                        hint: "Run `lis check --fix` first, then `lis check --deny warnings`"
-                            .to_string(),
-                    });
-                }
-
-                Ok(Command::Check {
-                    path,
-                    filter,
-                    action: if fix {
-                        CheckAction::Fix
-                    } else {
-                        CheckAction::Inspect { deny_warnings }
-                    },
-                    format,
-                })
-            }
-
-            "test" | "t" => {
-                let mut path = None;
-                let mut go_flags = Vec::new();
-                let mut selection = TestSelection::All;
-
-                while let Some(arg) = arguments.next() {
-                    if arg == "-f" || arg == "--filter" {
-                        let Some(value) = arguments.next() else {
-                            return Err(ParseError::MissingArgument {
-                                command: "test",
-                                argument: "--filter <pattern>",
-                            });
-                        };
-                        set_test_filter(&mut selection, value)?;
-                    } else if let Some(value) = arg.strip_prefix("--filter=") {
-                        set_test_filter(&mut selection, value.to_string())?;
-                    } else if let Some(value) = arg.strip_prefix("-f=") {
-                        set_test_filter(&mut selection, value.to_string())?;
-                    } else if arg == "--failed" {
-                        set_failed_selection(&mut selection)?;
-                    } else if arg.starts_with('-') {
-                        if !try_parse_go_flags(&arg, &mut arguments, &mut go_flags, "test")? {
-                            return Err(ParseError::UnknownFlag(arg));
-                        }
-                    } else {
-                        path = Some(arg);
-                    }
-                }
-
-                if let Some(flag) = go_flags.iter().find(|f| crate::go_cli::is_go_json_flag(f)) {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: format!(
-                            "`{}` cannot be passed to `lis test` via `--go-flags`",
-                            flag
-                        ),
-                        reason: "`lis test` runs `go test -json` and parses that stream to render the report"
-                            .to_string(),
-                        hint: "Remove `-json`; `lis test` manages it".to_string(),
-                    });
-                }
-
-                if let Some(flag) = go_flags
-                    .iter()
-                    .find(|f| crate::go_cli::is_go_selection_flag(f))
-                {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: format!(
-                            "`{}` cannot be passed to `lis test` via `--go-flags`",
-                            flag
-                        ),
-                        reason: "`lis test` selects which tests run and reconciles the report against them"
-                            .to_string(),
-                        hint: "Use `lis test --filter <pattern>` to select tests".to_string(),
-                    });
-                }
-
-                Ok(Command::Test {
-                    path,
-                    go_flags,
-                    selection,
-                })
-            }
-
+            "run" | "r" => parse_run(arguments),
+            "format" | "f" => parse_format(arguments),
+            "check" | "c" => parse_check(arguments),
+            "test" | "t" => parse_test(arguments),
             "help" | "--help" => Ok(Command::Help {
                 command: arguments.next(),
             }),
-
             "version" | "--version" => Ok(Command::Version),
-
-            "add" => {
-                let mut dependency = None;
-                let mut replace = None;
-
-                while let Some(arg) = arguments.next() {
-                    if arg == "--replace" {
-                        let Some(value) = arguments.next() else {
-                            return Err(ParseError::MissingArgument {
-                                command: "add",
-                                argument: "--replace <module@version>",
-                            });
-                        };
-                        replace = Some(value);
-                    } else if let Some(value) = arg.strip_prefix("--replace=") {
-                        replace = Some(value.to_string());
-                    } else if arg.starts_with('-') {
-                        return Err(ParseError::UnknownFlag(arg));
-                    } else if dependency.is_none() {
-                        dependency = Some(arg);
-                    } else {
-                        return Err(ParseError::UnexpectedArgument {
-                            message: format!("unexpected argument `{}`", arg),
-                            reason: "`lis add` accepts a single dependency".to_string(),
-                            hint: "Run `lis add` once per dep".to_string(),
-                        });
-                    }
-                }
-
-                match dependency {
-                    Some(dependency) => Ok(Command::Add {
-                        dependency,
-                        replace,
-                    }),
-                    None => Err(ParseError::MissingArgument {
-                        command: "add",
-                        argument: "dependency",
-                    }),
-                }
-            }
-
-            "sync" => {
-                if let Some(extra) = arguments.next() {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: format!("unexpected argument `{}`", extra),
-                        reason: "`lis sync` takes no arguments".to_string(),
-                        hint: "Run `lis sync` from the project root".to_string(),
-                    });
-                }
-                Ok(Command::Sync)
-            }
-
+            "add" => parse_add(arguments),
+            "sync" => parse_sync(arguments),
             "lsp" => Ok(Command::Lsp),
-
             "learn" => Ok(Command::Learn),
-
             "complete" => Ok(Command::Completions {
                 shell: arguments.next(),
             }),
-
-            "doc" => {
-                let mut search = false;
-                let mut query = None;
-                let mut extra = None;
-
-                for arg in arguments {
-                    match arg.as_str() {
-                        "-s" | "--search" => search = true,
-                        s if s.starts_with('-') => {
-                            return Err(ParseError::UnknownFlag(s.to_string()));
-                        }
-                        _ if query.is_none() => query = Some(arg),
-                        _ if extra.is_none() => extra = Some(arg),
-                        _ => {}
-                    }
-                }
-
-                if search {
-                    match query {
-                        Some(q) => Ok(Command::DocSearch { query: q }),
-                        None => Err(ParseError::MissingArgument {
-                            command: "doc",
-                            argument: "search query",
-                        }),
-                    }
-                } else {
-                    if let (Some(q), Some(item)) = (&query, &extra) {
-                        return Err(ParseError::UnexpectedArgument {
-                            message: format!("unexpected argument `{}`", item),
-                            reason: "The `doc` command takes a single query argument".to_string(),
-                            hint: format!("Did you mean `lis doc {}.{}`?", q, item),
-                        });
-                    }
-                    Ok(Command::Doc { query })
-                }
-            }
-
-            "bindgen" => {
-                let mut positional = Vec::new();
-                let mut output = None;
-                let mut verbose = false;
-
-                while let Some(arg) = arguments.next() {
-                    match arg.as_str() {
-                        "-v" | "--verbose" => verbose = true,
-                        "-o" | "--output" => {
-                            let Some(value) = arguments.next() else {
-                                return Err(ParseError::MissingArgument {
-                                    command: "bindgen",
-                                    argument: "--output <path>",
-                                });
-                            };
-                            output = Some(value);
-                        }
-                        s if s.starts_with("-o=") || s.starts_with("--output=") => {
-                            let value = s.split_once('=').map(|(_, value)| value).unwrap_or("");
-                            if value.is_empty() {
-                                return Err(ParseError::MissingArgument {
-                                    command: "bindgen",
-                                    argument: "--output <path>",
-                                });
-                            }
-                            output = Some(value.to_string());
-                        }
-                        s if s.starts_with('-') => {
-                            return Err(ParseError::UnknownFlag(s.to_string()));
-                        }
-                        s => positional.push(s.to_string()),
-                    }
-                }
-
-                let Some(package) = positional.first() else {
-                    return Err(ParseError::MissingArgument {
-                        command: "bindgen",
-                        argument: "package",
-                    });
-                };
-                let extra = positional.get(1);
-                let trailing = positional.get(2);
-                if let Some(trailing) = trailing {
-                    return Err(ParseError::UnexpectedArgument {
-                        message: format!("unexpected argument `{trailing}`"),
-                        reason: "`lis bindgen` accepts at most a target and stdlib version"
-                            .to_string(),
-                        hint: "Remove the extra argument".to_string(),
-                    });
-                }
-
-                let target = if package == "stdlib" {
-                    if output.is_some() {
-                        return Err(ParseError::UnexpectedArgument {
-                            message: "`--output` cannot be used when generating stdlib bindings"
-                                .to_string(),
-                            reason:
-                                "stdlib bindings are written to the repository typedef directory"
-                                    .to_string(),
-                            hint: "Remove `--output`".to_string(),
-                        });
-                    }
-                    BindgenTarget::Stdlib {
-                        version: extra.cloned(),
-                    }
-                } else {
-                    if let Some(extra) = extra {
-                        return Err(ParseError::UnexpectedArgument {
-                            message: format!("unexpected argument `{extra}`"),
-                            reason: "package bindgen accepts a single package target".to_string(),
-                            hint: "Remove the extra argument".to_string(),
-                        });
-                    }
-                    BindgenTarget::Package {
-                        name: package.clone(),
-                        output,
-                    }
-                };
-
-                Ok(Command::Bindgen { target, verbose })
-            }
-
+            "doc" => parse_doc(arguments),
+            "bindgen" => parse_bindgen(arguments),
             _ => Err(ParseError::UnknownCommand(command)),
         }
     }
@@ -679,6 +271,408 @@ impl Command {
         let candidates: Vec<String> = COMMANDS.iter().map(|s| s.to_string()).collect();
         diagnostics::infer::find_similar_name(typo, &candidates)
     }
+}
+
+fn parse_new(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    match arguments.next() {
+        Some(name) => Ok(Command::New { name }),
+        None => Err(ParseError::MissingArgument {
+            command: "new",
+            argument: "name",
+        }),
+    }
+}
+
+fn parse_build(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut path = None;
+    let mut sourcemap = false;
+    let mut go_flags = Vec::new();
+
+    while let Some(arg) = arguments.next() {
+        if arg == "--sourcemap" {
+            sourcemap = true;
+        } else if let Some(value) = flag_value(
+            &arg,
+            &["--go-flags"],
+            &mut arguments,
+            "build",
+            "--go-flags <flags>",
+        )? {
+            extend_go_flags(&mut go_flags, &value)?;
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            path = Some(arg);
+        }
+    }
+
+    Ok(Command::Build {
+        path,
+        sourcemap,
+        go_flags,
+    })
+}
+
+fn parse_run(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut target = None;
+    let mut args = Vec::new();
+    let mut sourcemap = false;
+    let mut go_flags = Vec::new();
+    let mut found_separator = false;
+
+    while let Some(arg) = arguments.next() {
+        if found_separator {
+            args.push(arg);
+        } else if arg == "--" {
+            found_separator = true;
+        } else if arg == "--sourcemap" {
+            sourcemap = true;
+        } else if let Some(value) = flag_value(
+            &arg,
+            &["--go-flags"],
+            &mut arguments,
+            "run",
+            "--go-flags <flags>",
+        )? {
+            extend_go_flags(&mut go_flags, &value)?;
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            target = Some(arg);
+        }
+    }
+
+    if let Some(flag) = go_flags
+        .iter()
+        .find(|f| crate::go_cli::is_go_output_flag(f))
+    {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("`{}` cannot be passed to `lis run` via `--go-flags`", flag),
+            reason: "`run` executes the binary it links at an internal path, so it owns `-o`"
+                .to_string(),
+            hint: "Use `lis build --go-flags \"-o <path>\"` to choose the output location"
+                .to_string(),
+        });
+    }
+
+    Ok(Command::Run {
+        target,
+        args,
+        sourcemap,
+        go_flags,
+    })
+}
+
+fn parse_format(arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut path = None;
+    let mut check = false;
+
+    for arg in arguments {
+        match arg.as_str() {
+            "--check" => check = true,
+            s if s.starts_with('-') => {
+                return Err(ParseError::UnknownFlag(s.to_string()));
+            }
+            s => path = Some(s.to_string()),
+        }
+    }
+
+    Ok(Command::Format { path, check })
+}
+
+fn parse_check(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut path = None;
+    let mut filter = None;
+    let mut deny_warnings = false;
+    let mut format = OutputFormat::Graphical;
+    let mut fix = false;
+
+    while let Some(arg) = arguments.next() {
+        if arg == "--errors-only" {
+            match filter {
+                Some(Filter::Warnings) => return Err(check_filter_conflict()),
+                _ => filter = Some(Filter::Errors),
+            }
+        } else if arg == "--warnings-only" {
+            match filter {
+                Some(Filter::Errors) => return Err(check_filter_conflict()),
+                _ => filter = Some(Filter::Warnings),
+            }
+        } else if arg == "--fix" {
+            fix = true;
+        } else if let Some(value) = flag_value(
+            &arg,
+            &["--output"],
+            &mut arguments,
+            "check",
+            "--output <value>",
+        )? {
+            format = parse_output(&value)?;
+        } else if let Some(value) =
+            flag_value(&arg, &["--deny"], &mut arguments, "check", "--deny <value>")?
+        {
+            deny_warnings = parse_deny(&value)?;
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            path = Some(arg);
+        }
+    }
+
+    let filter = filter.unwrap_or_default();
+    if filter == Filter::Errors && deny_warnings {
+        return Err(ParseError::UnexpectedArgument {
+            message: "`--errors-only` and `--deny warnings` cannot be used together".to_string(),
+            reason:
+                "`--errors-only` hides warnings, so `--deny warnings` would have nothing to act on"
+                    .to_string(),
+            hint: "Drop `--errors-only` to make warnings fail the check".to_string(),
+        });
+    }
+
+    if fix && deny_warnings {
+        return Err(ParseError::UnexpectedArgument {
+            message: "`--fix` and `--deny warnings` cannot be used together".to_string(),
+            reason: "`--fix` reports what it rewrote, not which warnings remain, so it cannot fail on leftover warnings"
+                .to_string(),
+            hint: "Run `lis check --fix` first, then `lis check --deny warnings`".to_string(),
+        });
+    }
+
+    Ok(Command::Check {
+        path,
+        filter,
+        action: if fix {
+            CheckAction::Fix
+        } else {
+            CheckAction::Inspect { deny_warnings }
+        },
+        format,
+    })
+}
+
+fn parse_test(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut path = None;
+    let mut go_flags = Vec::new();
+    let mut selection = TestSelection::All;
+
+    while let Some(arg) = arguments.next() {
+        if let Some(value) = flag_value(
+            &arg,
+            &["-f", "--filter"],
+            &mut arguments,
+            "test",
+            "--filter <pattern>",
+        )? {
+            set_test_filter(&mut selection, value)?;
+        } else if arg == "--failed" {
+            set_failed_selection(&mut selection)?;
+        } else if let Some(value) = flag_value(
+            &arg,
+            &["--go-flags"],
+            &mut arguments,
+            "test",
+            "--go-flags <flags>",
+        )? {
+            extend_go_flags(&mut go_flags, &value)?;
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            path = Some(arg);
+        }
+    }
+
+    if let Some(flag) = go_flags.iter().find(|f| crate::go_cli::is_go_json_flag(f)) {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("`{}` cannot be passed to `lis test` via `--go-flags`", flag),
+            reason: "`lis test` runs `go test -json` and parses that stream to render the report"
+                .to_string(),
+            hint: "Remove `-json`; `lis test` manages it".to_string(),
+        });
+    }
+
+    if let Some(flag) = go_flags
+        .iter()
+        .find(|f| crate::go_cli::is_go_selection_flag(f))
+    {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("`{}` cannot be passed to `lis test` via `--go-flags`", flag),
+            reason: "`lis test` selects which tests run and reconciles the report against them"
+                .to_string(),
+            hint: "Use `lis test --filter <pattern>` to select tests".to_string(),
+        });
+    }
+
+    Ok(Command::Test {
+        path,
+        go_flags,
+        selection,
+    })
+}
+
+fn parse_add(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut dependency = None;
+    let mut replace = None;
+
+    while let Some(arg) = arguments.next() {
+        if let Some(value) = flag_value(
+            &arg,
+            &["--replace"],
+            &mut arguments,
+            "add",
+            "--replace <module@version>",
+        )? {
+            replace = Some(value);
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else if dependency.is_none() {
+            dependency = Some(arg);
+        } else {
+            return Err(ParseError::UnexpectedArgument {
+                message: format!("unexpected argument `{}`", arg),
+                reason: "`lis add` accepts a single dependency".to_string(),
+                hint: "Run `lis add` once per dep".to_string(),
+            });
+        }
+    }
+
+    match dependency {
+        Some(dependency) => Ok(Command::Add {
+            dependency,
+            replace,
+        }),
+        None => Err(ParseError::MissingArgument {
+            command: "add",
+            argument: "dependency",
+        }),
+    }
+}
+
+fn parse_sync(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    if let Some(extra) = arguments.next() {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected argument `{}`", extra),
+            reason: "`lis sync` takes no arguments".to_string(),
+            hint: "Run `lis sync` from the project root".to_string(),
+        });
+    }
+    Ok(Command::Sync)
+}
+
+fn parse_doc(arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut search = false;
+    let mut query = None;
+    let mut extra = None;
+
+    for arg in arguments {
+        match arg.as_str() {
+            "-s" | "--search" => search = true,
+            s if s.starts_with('-') => {
+                return Err(ParseError::UnknownFlag(s.to_string()));
+            }
+            _ if query.is_none() => query = Some(arg),
+            _ if extra.is_none() => extra = Some(arg),
+            _ => {}
+        }
+    }
+
+    if search {
+        return match query {
+            Some(q) => Ok(Command::DocSearch { query: q }),
+            None => Err(ParseError::MissingArgument {
+                command: "doc",
+                argument: "search query",
+            }),
+        };
+    }
+
+    if let (Some(q), Some(item)) = (&query, &extra) {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected argument `{}`", item),
+            reason: "The `doc` command takes a single query argument".to_string(),
+            hint: format!("Did you mean `lis doc {}.{}`?", q, item),
+        });
+    }
+    Ok(Command::Doc { query })
+}
+
+fn parse_bindgen(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
+    let mut positional = Vec::new();
+    let mut output = None;
+    let mut verbose = false;
+
+    while let Some(arg) = arguments.next() {
+        if arg == "-v" || arg == "--verbose" {
+            verbose = true;
+        } else if let Some(value) = flag_value(
+            &arg,
+            &["-o", "--output"],
+            &mut arguments,
+            "bindgen",
+            "--output <path>",
+        )? {
+            if value.is_empty() {
+                return Err(ParseError::MissingArgument {
+                    command: "bindgen",
+                    argument: "--output <path>",
+                });
+            }
+            output = Some(value);
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            positional.push(arg);
+        }
+    }
+
+    let target = bindgen_target(&positional, output)?;
+    Ok(Command::Bindgen { target, verbose })
+}
+
+fn bindgen_target(
+    positional: &[String],
+    output: Option<String>,
+) -> Result<BindgenTarget, ParseError> {
+    let Some(package) = positional.first() else {
+        return Err(ParseError::MissingArgument {
+            command: "bindgen",
+            argument: "package",
+        });
+    };
+    let extra = positional.get(1);
+    if let Some(trailing) = positional.get(2) {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected argument `{trailing}`"),
+            reason: "`lis bindgen` accepts at most a target and stdlib version".to_string(),
+            hint: "Remove the extra argument".to_string(),
+        });
+    }
+
+    if package == "stdlib" {
+        if output.is_some() {
+            return Err(ParseError::UnexpectedArgument {
+                message: "`--output` cannot be used when generating stdlib bindings".to_string(),
+                reason: "stdlib bindings are written to the repository typedef directory"
+                    .to_string(),
+                hint: "Remove `--output`".to_string(),
+            });
+        }
+        return Ok(BindgenTarget::Stdlib {
+            version: extra.cloned(),
+        });
+    }
+
+    if let Some(extra) = extra {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected argument `{extra}`"),
+            reason: "package bindgen accepts a single package target".to_string(),
+            hint: "Remove the extra argument".to_string(),
+        });
+    }
+    Ok(BindgenTarget::Package {
+        name: package.clone(),
+        output,
+    })
 }
 
 #[cfg(test)]

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -276,26 +276,115 @@ pub(super) fn build_locked(
     let emit_tests = mode == CompileMode::Test;
     let start = Instant::now();
 
-    if prep.kind == ProjectKind::Library
-        && !emit_tests
-        && let Some(key) = prep
-            .manifest
-            .go_deps()
-            .iter()
-            .find(|(_, dep)| matches!(dep, deps::GoDependency::Replaced { .. }))
-            .map(|(key, _)| key.clone())
-    {
-        cli_error!(
-            "Replaced dependency in a library",
-            format!(
-                "`{}` uses a `replace`, which Go ignores when this library is imported",
-                key
-            ),
-            "Depend on a published version, or keep this project a binary"
-        );
+    reject_library_replace(prep, emit_tests)?;
+    write_initial_go_mod(prep)?;
+    let locator = workspace_locator(prep);
+    let entry = EntryPoint::resolve(prep)?;
+
+    let result = compile_project(prep, mode, &entry, &locator);
+    let counts = render_diagnostics(&result, &entry);
+    if counts.errors > 0 {
         return Err(1);
     }
 
+    let mut emit = write_and_prune_outputs(prep, &result, sourcemap, emit_tests)?;
+    reconcile_target_manifest(prep, &locator, &mut emit)?;
+
+    if !sourcemap {
+        commit_emit_stamps(prep, &result);
+    }
+    // Committed only after gofmt + tidy succeed.
+    go_cli::write_emit_manifest(&prep.target_dir, &emit.new_manifest);
+
+    if let Some(label) = purpose.completion_label() {
+        print_completion(label, prep, &counts, start);
+    }
+
+    Ok(BuildArtifacts {
+        test_index: result.test_index,
+        sources: result.sources,
+    })
+}
+
+enum EntryPoint {
+    Binary { source: String, display: String },
+    Library,
+}
+
+impl EntryPoint {
+    fn resolve(prep: &BuildPrep) -> Result<Self, i32> {
+        match prep.kind {
+            ProjectKind::Binary => {
+                let main_lis = prep.project_path.join("src").join("main.lis");
+                let source = match fs::read_to_string(&main_lis) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        cli_error!(
+                            "Failed to compile Lisette project to Go",
+                            format!("Failed to read `{}`: {}", main_lis.display(), e),
+                            "Check file permissions"
+                        );
+                        return Err(1);
+                    }
+                };
+                let display = relative_to_cwd(&main_lis).unwrap_or_else(|| "main.lis".to_string());
+                Ok(Self::Binary { source, display })
+            }
+            ProjectKind::Library => Ok(Self::Library),
+        }
+    }
+
+    fn compile_input(&self) -> CompileInput<'_> {
+        match self {
+            Self::Binary { source, display } => CompileInput::Binary(CompileEntry {
+                source,
+                filename: "main.lis",
+                display_path: display,
+            }),
+            Self::Library => CompileInput::Library,
+        }
+    }
+
+    fn source(&self) -> &str {
+        match self {
+            Self::Binary { source, .. } => source,
+            Self::Library => "",
+        }
+    }
+
+    fn display(&self) -> &str {
+        match self {
+            Self::Binary { display, .. } => display,
+            Self::Library => "",
+        }
+    }
+}
+
+fn reject_library_replace(prep: &BuildPrep, emit_tests: bool) -> Result<(), i32> {
+    if prep.kind != ProjectKind::Library || emit_tests {
+        return Ok(());
+    }
+    let Some(key) = prep
+        .manifest
+        .go_deps()
+        .iter()
+        .find(|(_, dep)| matches!(dep, deps::GoDependency::Replaced { .. }))
+        .map(|(key, _)| key.clone())
+    else {
+        return Ok(());
+    };
+    cli_error!(
+        "Replaced dependency in a library",
+        format!(
+            "`{}` uses a `replace`, which Go ignores when this library is imported",
+            key
+        ),
+        "Depend on a published version, or keep this project a binary"
+    );
+    Err(1)
+}
+
+fn write_initial_go_mod(prep: &BuildPrep) -> Result<(), i32> {
     if let Err(e) =
         go_cli::write_go_mod(&prep.target_dir, &prep.manifest.project.name, &prep.locator)
     {
@@ -306,7 +395,10 @@ pub(super) fn build_locked(
         );
         return Err(1);
     }
+    Ok(())
+}
 
+fn workspace_locator(prep: &BuildPrep) -> deps::TypedefLocator {
     let typedef_cache_dir = deps::typedef_cache_dir(&prep.project_path);
 
     // Batch-warm the typedef cache so the lazy path during compile is all hits.
@@ -321,62 +413,37 @@ pub(super) fn build_locked(
         typedef_cache_dir,
         prep.locator.target(),
     ));
-    let locator = prep.locator.clone().with_bindgen(bindgen);
+    prep.locator.clone().with_bindgen(bindgen)
+}
 
+fn compile_project(
+    prep: &BuildPrep,
+    mode: CompileMode,
+    entry: &EntryPoint,
+    locator: &deps::TypedefLocator,
+) -> lisette::pipeline::CompileResult {
     let go_module_name = &prep.manifest.project.name;
-    let version = &prep.manifest.project.version;
-
-    let src_dir = prep.project_path.join("src");
-    let entry_bits = match prep.kind {
-        ProjectKind::Binary => {
-            let main_lis = src_dir.join("main.lis");
-            let source = match fs::read_to_string(&main_lis) {
-                Ok(s) => s,
-                Err(e) => {
-                    cli_error!(
-                        "Failed to compile Lisette project to Go",
-                        format!("Failed to read `{}`: {}", main_lis.display(), e),
-                        "Check file permissions"
-                    );
-                    return Err(1);
-                }
-            };
-            let display = relative_to_cwd(&main_lis).unwrap_or_else(|| "main.lis".to_string());
-            Some((source, display))
-        }
-        ProjectKind::Library => None,
-    };
-
-    let entry_package_name = match prep.kind {
-        ProjectKind::Binary => "main".to_string(),
-        ProjectKind::Library => emit::root_package_name(go_module_name),
-    };
-
-    let project_name = go_module_name.rsplit('/').next().unwrap_or(go_module_name);
-
     let compile_config = CompileConfig {
         mode,
         go_module: go_module_name.to_string(),
-        entry_package_name,
+        entry_package_name: match prep.kind {
+            ProjectKind::Binary => "main".to_string(),
+            ProjectKind::Library => emit::root_package_name(go_module_name),
+        },
         scope: CompileScope::Project(prep.project_path.clone()),
         locator: locator.clone(),
     };
 
+    let src_dir = prep.project_path.join("src");
     let local_fs = LocalFileSystem::with_scanned_sources(&src_dir, prep.sources.clone());
+    compile(entry.compile_input(), &compile_config, &local_fs)
+}
 
-    let input = match entry_bits.as_ref() {
-        Some((source, display)) => CompileInput::Binary(CompileEntry {
-            source,
-            filename: "main.lis",
-            display_path: display,
-        }),
-        None => CompileInput::Library,
-    };
-    let result = compile(input, &compile_config, &local_fs);
-
-    let filter = Filter::All;
-
-    let counts = render::render_all(
+fn render_diagnostics(
+    result: &lisette::pipeline::CompileResult,
+    entry: &EntryPoint,
+) -> render::Counts {
+    render::render_all(
         &result.errors,
         &result.lints,
         |file_id| {
@@ -386,15 +453,18 @@ pub(super) fn build_locked(
                 .map(|info| (info.source.clone(), info.filename.clone()))
         },
         result.user_file_count,
-        &filter,
-        entry_bits.as_ref().map(|(s, _)| s.as_str()).unwrap_or(""),
-        entry_bits.as_ref().map(|(_, d)| d.as_str()).unwrap_or(""),
-    );
+        &Filter::All,
+        entry.source(),
+        entry.display(),
+    )
+}
 
-    if counts.errors > 0 {
-        return Err(1);
-    }
-
+fn write_and_prune_outputs(
+    prep: &BuildPrep,
+    result: &lisette::pipeline::CompileResult,
+    sourcemap: bool,
+    emit_tests: bool,
+) -> Result<go_cli::EmitWriteResult, i32> {
     let heading = "Failed to compile Lisette project to Go";
     let produced: Vec<&str> = result.output.iter().map(|f| f.name.as_str()).collect();
 
@@ -433,7 +503,7 @@ pub(super) fn build_locked(
         prune_orphan_go_files(&prep.target_dir, &produced, &emitted, &result.live_modules)
     {
         cli_error!(
-            "Failed to compile Lisette project to Go",
+            heading,
             format!("Failed to prune stale Go files: {}", e),
             "Check file permissions"
         );
@@ -444,7 +514,7 @@ pub(super) fn build_locked(
         && let Err(e) = prune_stale_root_go(&prep.target_dir, &produced)
     {
         cli_error!(
-            "Failed to compile Lisette project to Go",
+            heading,
             format!("Failed to prune stale Go files: {}", e),
             "Check file permissions"
         );
@@ -455,12 +525,22 @@ pub(super) fn build_locked(
         && let Err(e) = remove_stale_test_outputs(&prep.target_dir, &mut emit.new_manifest)
     {
         cli_error!(
-            "Failed to compile Lisette project to Go",
+            heading,
             format!("Failed to remove stale test file: {}", e),
             "Check file permissions"
         );
         return Err(1);
     }
+
+    Ok(emit)
+}
+
+fn reconcile_target_manifest(
+    prep: &BuildPrep,
+    locator: &deps::TypedefLocator,
+    emit: &mut go_cli::EmitWriteResult,
+) -> Result<(), i32> {
+    let heading = "Failed to compile Lisette project to Go";
 
     // Drop manifest entries whose files pruning removed, so the import-set hash
     // below reflects only surviving output.
@@ -475,8 +555,7 @@ pub(super) fn build_locked(
         && prior != import_set_hash
     {
         go_cli::invalidate_go_mod_stamp(&prep.target_dir);
-        if let Err(e) =
-            go_cli::write_go_mod(&prep.target_dir, &prep.manifest.project.name, &locator)
+        if let Err(e) = go_cli::write_go_mod(&prep.target_dir, &prep.manifest.project.name, locator)
         {
             cli_error!(heading, e, "Check file permissions on `target/go.mod`");
             return Err(1);
@@ -492,51 +571,47 @@ pub(super) fn build_locked(
         cli_error!(heading, e.message, e.hint);
         return Err(1);
     }
+    Ok(())
+}
 
-    if !sourcemap
-        && let Err(e) = semantics::cache::apply_emit_stamps(
-            &prep.project_path,
-            &result
-                .emit_stamps
-                .iter()
-                .map(|s| (s.clone(), Some(s.artifact_hash)))
-                .collect::<Vec<_>>(),
-        )
-    {
+fn commit_emit_stamps(prep: &BuildPrep, result: &lisette::pipeline::CompileResult) {
+    if let Err(e) = semantics::cache::apply_emit_stamps(
+        &prep.project_path,
+        &result
+            .emit_stamps
+            .iter()
+            .map(|s| (s.clone(), Some(s.artifact_hash)))
+            .collect::<Vec<_>>(),
+    ) {
         eprintln!("warning: failed to write emit stamps: {e}");
     }
+}
 
-    // Committed only after gofmt + tidy succeed.
-    go_cli::write_emit_manifest(&prep.target_dir, &emit.new_manifest);
-
-    if let Some(label) = purpose.completion_label() {
-        if counts.errors + counts.warnings + counts.info == 0 {
-            eprintln!();
-        }
-        if use_color() {
-            use owo_colors::OwoColorize;
-            eprintln!(
-                "  ✓ {} {} v{} {}",
-                label,
-                project_name.bright_magenta(),
-                version,
-                format_elapsed(start.elapsed())
-            );
-        } else {
-            eprintln!(
-                "  ✓ {} `{}` v{} {}",
-                label,
-                project_name,
-                version,
-                format_elapsed(start.elapsed())
-            );
-        }
+fn print_completion(label: &str, prep: &BuildPrep, counts: &render::Counts, start: Instant) {
+    if counts.errors + counts.warnings + counts.info == 0 {
+        eprintln!();
     }
-
-    Ok(BuildArtifacts {
-        test_index: result.test_index,
-        sources: result.sources,
-    })
+    let go_module_name = &prep.manifest.project.name;
+    let project_name = go_module_name.rsplit('/').next().unwrap_or(go_module_name);
+    let version = &prep.manifest.project.version;
+    if use_color() {
+        use owo_colors::OwoColorize;
+        eprintln!(
+            "  ✓ {} {} v{} {}",
+            label,
+            project_name.bright_magenta(),
+            version,
+            format_elapsed(start.elapsed())
+        );
+    } else {
+        eprintln!(
+            "  ✓ {} `{}` v{} {}",
+            label,
+            project_name,
+            version,
+            format_elapsed(start.elapsed())
+        );
+    }
 }
 
 pub(super) struct ProjectLayout {

--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -328,11 +328,45 @@ fn interface_definition(name: &str, gen_str: &str, method_signatures: &[Expressi
     )
 }
 
-fn build_index_from_source(source: &str) -> PreludeIndex {
+#[derive(Clone, Copy, PartialEq)]
+enum IndexStyle {
+    Prelude,
+    GoPackage,
+}
+
+struct SourceIndex {
+    types: Vec<TypeInfo>,
+    functions: Vec<FunctionInfo>,
+    constants: Vec<ConstInfo>,
+    variables: Vec<VarInfo>,
+}
+
+fn type_entry(
+    name: &str,
+    generics: &[Generic],
+    doc: &Option<String>,
+    definition: String,
+    kind: TypeKind,
+) -> TypeInfo {
+    TypeInfo {
+        name: name.to_string(),
+        generics: generics.iter().map(|g| g.name.to_string()).collect(),
+        definition,
+        doc: doc.clone(),
+        methods: Vec::new(),
+        kind,
+    }
+}
+
+fn index_source(source: &str, style: IndexStyle) -> SourceIndex {
     let parse_result = syntax::parse::Parser::lex_and_parse_file(source, 0);
 
-    let mut types: Vec<TypeInfo> = Vec::new();
-    let mut functions: Vec<FunctionInfo> = Vec::new();
+    let mut index = SourceIndex {
+        types: Vec::new(),
+        functions: Vec::new(),
+        constants: Vec::new(),
+        variables: Vec::new(),
+    };
 
     for expression in &parse_result.ast {
         match expression {
@@ -340,19 +374,29 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
                 doc,
                 name,
                 generics,
+                annotation,
                 ..
             } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
                 let gen_str = generics_to_string(generics);
-                let definition = format!("type {}{}", name, gen_str);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
+                let shows_underlying = style == IndexStyle::GoPackage
+                    && !matches!(annotation, Annotation::Opaque { .. });
+                let definition = if shows_underlying {
+                    format!(
+                        "type {}{} = {}",
+                        name,
+                        gen_str,
+                        annotation_to_string(annotation)
+                    )
+                } else {
+                    format!("type {}{}", name, gen_str)
+                };
+                index.types.push(type_entry(
+                    name,
+                    generics,
+                    doc,
                     definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Primitive,
-                });
+                    TypeKind::Primitive,
+                ));
             }
 
             Expression::Struct {
@@ -362,17 +406,20 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
                 fields,
                 ..
             } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = struct_definition(name, &gen_str, fields, true);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
+                let show_private_fields = style == IndexStyle::Prelude;
+                let definition = struct_definition(
+                    name,
+                    &generics_to_string(generics),
+                    fields,
+                    show_private_fields,
+                );
+                index.types.push(type_entry(
+                    name,
+                    generics,
+                    doc,
                     definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Struct,
-                });
+                    TypeKind::Struct,
+                ));
             }
 
             Expression::Enum {
@@ -382,17 +429,10 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
                 variants,
                 ..
             } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = enum_definition(name, &gen_str, variants);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
-                    definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Enum,
-                });
+                let definition = enum_definition(name, &generics_to_string(generics), variants);
+                index
+                    .types
+                    .push(type_entry(name, generics, doc, definition, TypeKind::Enum));
             }
 
             Expression::Interface {
@@ -402,76 +442,15 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
                 method_signatures,
                 ..
             } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = interface_definition(name, &gen_str, method_signatures);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
+                let definition =
+                    interface_definition(name, &generics_to_string(generics), method_signatures);
+                index.types.push(type_entry(
+                    name,
+                    generics,
+                    doc,
                     definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Interface,
-                });
-            }
-
-            Expression::ImplBlock {
-                receiver_name,
-                methods,
-                generics,
-                annotation,
-                ..
-            } => {
-                let base_name = annotation
-                    .get_name()
-                    .unwrap_or_else(|| receiver_name.to_string());
-
-                let impl_annotation_str = annotation_to_string(annotation);
-
-                let is_specialized =
-                    impl_annotation_str != base_name && !impl_annotation_str.is_empty() && {
-                        match annotation {
-                            Annotation::Constructor { params, .. } => {
-                                params.len() != generics.len()
-                                    || params.iter().zip(generics.iter()).any(|(p, g)| {
-                                        p.get_name().map(|n| n != g.name.as_str()).unwrap_or(true)
-                                    })
-                            }
-                            _ => false,
-                        }
-                    };
-
-                let suffix = if is_specialized {
-                    format!(" (on {})", impl_annotation_str)
-                } else {
-                    String::new()
-                };
-
-                for method in methods {
-                    if let Expression::Function {
-                        doc,
-                        name,
-                        generics: mgen,
-                        params,
-                        return_annotation,
-                        ..
-                    } = method
-                    {
-                        let sig = function_signature(name, mgen, params, return_annotation);
-                        if let Some(type_info) = types.iter_mut().find(|t| t.name == base_name) {
-                            type_info.methods.push(MethodInfo {
-                                name: name.to_string(),
-                                signature: sig,
-                                doc: doc.clone(),
-                            });
-                            if !suffix.is_empty()
-                                && let Some(last) = type_info.methods.last_mut()
-                            {
-                                last.signature = format!("{}{}", last.signature, suffix);
-                            }
-                        }
-                    }
-                }
+                    TypeKind::Interface,
+                ));
             }
 
             Expression::Function {
@@ -482,19 +461,130 @@ fn build_index_from_source(source: &str) -> PreludeIndex {
                 return_annotation,
                 ..
             } => {
-                let sig = function_signature(name, generics, params, return_annotation);
-                functions.push(FunctionInfo {
+                index.functions.push(FunctionInfo {
                     name: name.to_string(),
-                    signature: sig,
+                    signature: function_signature(name, generics, params, return_annotation),
                     doc: doc.clone(),
                 });
+            }
+
+            Expression::Const {
+                doc,
+                identifier,
+                annotation,
+                ..
+            } if style == IndexStyle::GoPackage => {
+                let signature = match annotation {
+                    Some(annotation) => {
+                        format!("const {}: {}", identifier, annotation_to_string(annotation))
+                    }
+                    None => format!("const {}", identifier),
+                };
+                index.constants.push(ConstInfo {
+                    name: identifier.to_string(),
+                    signature,
+                    doc: doc.clone(),
+                });
+            }
+
+            Expression::VariableDeclaration {
+                doc,
+                name,
+                annotation,
+                ..
+            } if style == IndexStyle::GoPackage => {
+                index.variables.push(VarInfo {
+                    name: name.to_string(),
+                    signature: format!("var {}: {}", name, annotation_to_string(annotation)),
+                    doc: doc.clone(),
+                });
+            }
+
+            Expression::ImplBlock {
+                receiver_name,
+                methods,
+                generics,
+                annotation,
+                ..
+            } => {
+                attach_impl_methods(
+                    &mut index.types,
+                    receiver_name,
+                    methods,
+                    generics,
+                    annotation,
+                );
             }
 
             _ => {}
         }
     }
 
-    PreludeIndex { types, functions }
+    index
+}
+
+fn attach_impl_methods(
+    types: &mut [TypeInfo],
+    receiver_name: &str,
+    methods: &[Expression],
+    generics: &[Generic],
+    annotation: &Annotation,
+) {
+    let base_name = annotation
+        .get_name()
+        .unwrap_or_else(|| receiver_name.to_string());
+
+    let impl_annotation_str = annotation_to_string(annotation);
+
+    let is_specialized = impl_annotation_str != base_name && !impl_annotation_str.is_empty() && {
+        match annotation {
+            Annotation::Constructor { params, .. } => {
+                params.len() != generics.len()
+                    || params
+                        .iter()
+                        .zip(generics.iter())
+                        .any(|(p, g)| p.get_name().map(|n| n != g.name.as_str()).unwrap_or(true))
+            }
+            _ => false,
+        }
+    };
+
+    let suffix = if is_specialized {
+        format!(" (on {})", impl_annotation_str)
+    } else {
+        String::new()
+    };
+
+    let Some(type_info) = types.iter_mut().find(|t| t.name == base_name) else {
+        return;
+    };
+
+    for method in methods {
+        if let Expression::Function {
+            doc,
+            name,
+            generics: method_generics,
+            params,
+            return_annotation,
+            ..
+        } = method
+        {
+            let signature = function_signature(name, method_generics, params, return_annotation);
+            type_info.methods.push(MethodInfo {
+                name: name.to_string(),
+                signature: format!("{}{}", signature, suffix),
+                doc: doc.clone(),
+            });
+        }
+    }
+}
+
+fn build_index_from_source(source: &str) -> PreludeIndex {
+    let index = index_source(source, IndexStyle::Prelude);
+    PreludeIndex {
+        types: index.types,
+        functions: index.functions,
+    }
 }
 
 fn build_prelude_index() -> PreludeIndex {
@@ -529,221 +619,13 @@ fn build_test_prelude_index() -> PreludeIndex {
 }
 
 fn build_go_package_index(source: &str, package: &str) -> GoPackageIndex {
-    let parse_result = syntax::parse::Parser::lex_and_parse_file(source, 0);
-
-    let mut types: Vec<TypeInfo> = Vec::new();
-    let mut functions: Vec<FunctionInfo> = Vec::new();
-    let mut constants: Vec<ConstInfo> = Vec::new();
-    let mut variables: Vec<VarInfo> = Vec::new();
-
-    for expression in &parse_result.ast {
-        match expression {
-            Expression::TypeAlias {
-                doc,
-                name,
-                generics,
-                annotation,
-                ..
-            } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = if let Annotation::Opaque { .. } = annotation {
-                    format!("type {}{}", name, gen_str)
-                } else {
-                    format!(
-                        "type {}{} = {}",
-                        name,
-                        gen_str,
-                        annotation_to_string(annotation)
-                    )
-                };
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
-                    definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Primitive,
-                });
-            }
-
-            Expression::Struct {
-                doc,
-                name,
-                generics,
-                fields,
-                ..
-            } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = struct_definition(name, &gen_str, fields, false);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
-                    definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Struct,
-                });
-            }
-
-            Expression::Enum {
-                doc,
-                name,
-                generics,
-                variants,
-                ..
-            } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = enum_definition(name, &gen_str, variants);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
-                    definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Enum,
-                });
-            }
-
-            Expression::Interface {
-                doc,
-                name,
-                generics,
-                method_signatures,
-                ..
-            } => {
-                let gen_names: Vec<String> = generics.iter().map(|g| g.name.to_string()).collect();
-                let gen_str = generics_to_string(generics);
-                let definition = interface_definition(name, &gen_str, method_signatures);
-                types.push(TypeInfo {
-                    name: name.to_string(),
-                    generics: gen_names,
-                    definition,
-                    doc: doc.clone(),
-                    methods: Vec::new(),
-                    kind: TypeKind::Interface,
-                });
-            }
-
-            Expression::Function {
-                doc,
-                name,
-                generics,
-                params,
-                return_annotation,
-                ..
-            } => {
-                let sig = function_signature(name, generics, params, return_annotation);
-                functions.push(FunctionInfo {
-                    name: name.to_string(),
-                    signature: sig,
-                    doc: doc.clone(),
-                });
-            }
-
-            Expression::Const {
-                doc,
-                identifier,
-                annotation,
-                ..
-            } => {
-                let sig = if let Some(ann) = annotation {
-                    format!("const {}: {}", identifier, annotation_to_string(ann))
-                } else {
-                    format!("const {}", identifier)
-                };
-                constants.push(ConstInfo {
-                    name: identifier.to_string(),
-                    signature: sig,
-                    doc: doc.clone(),
-                });
-            }
-
-            Expression::VariableDeclaration {
-                doc,
-                name,
-                annotation,
-                ..
-            } => {
-                let sig = format!("var {}: {}", name, annotation_to_string(annotation));
-                variables.push(VarInfo {
-                    name: name.to_string(),
-                    signature: sig,
-                    doc: doc.clone(),
-                });
-            }
-
-            Expression::ImplBlock {
-                receiver_name,
-                methods,
-                annotation,
-                generics,
-                ..
-            } => {
-                let base_name = annotation
-                    .get_name()
-                    .unwrap_or_else(|| receiver_name.to_string());
-
-                let impl_annotation_str = annotation_to_string(annotation);
-
-                let is_specialized =
-                    impl_annotation_str != base_name && !impl_annotation_str.is_empty() && {
-                        match annotation {
-                            Annotation::Constructor { params, .. } => {
-                                params.len() != generics.len()
-                                    || params.iter().zip(generics.iter()).any(|(p, g)| {
-                                        p.get_name().map(|n| n != g.name.as_str()).unwrap_or(true)
-                                    })
-                            }
-                            _ => false,
-                        }
-                    };
-
-                let suffix = if is_specialized {
-                    format!(" (on {})", impl_annotation_str)
-                } else {
-                    String::new()
-                };
-
-                for method in methods {
-                    if let Expression::Function {
-                        doc,
-                        name,
-                        generics: mgen,
-                        params,
-                        return_annotation,
-                        ..
-                    } = method
-                    {
-                        let sig = function_signature(name, mgen, params, return_annotation);
-                        if let Some(type_info) = types.iter_mut().find(|t| t.name == base_name) {
-                            type_info.methods.push(MethodInfo {
-                                name: name.to_string(),
-                                signature: sig,
-                                doc: doc.clone(),
-                            });
-                            if !suffix.is_empty()
-                                && let Some(last) = type_info.methods.last_mut()
-                            {
-                                last.signature = format!("{}{}", last.signature, suffix);
-                            }
-                        }
-                    }
-                }
-            }
-
-            _ => {}
-        }
-    }
-
+    let index = index_source(source, IndexStyle::GoPackage);
     GoPackageIndex {
         package: package.to_string(),
-        types,
-        functions,
-        constants,
-        variables,
+        types: index.types,
+        functions: index.functions,
+        constants: index.constants,
+        variables: index.variables,
     }
 }
 
@@ -1741,73 +1623,11 @@ pub fn doc_search(query: &str) -> i32 {
     }
 
     let query_lower = query.to_lowercase();
-
     let prelude_index = build_prelude_index();
-    let mut prelude_matches: Vec<SearchMatch> = Vec::new();
-
-    for ti in &prelude_index.types {
-        let type_qual = format_type_with_generics_plain(&ti.name, &ti.generics);
-        for mi in &ti.methods {
-            if mi.name.to_lowercase().contains(&query_lower) {
-                prelude_matches.push(SearchMatch {
-                    name: mi.name.clone(),
-                    display: format_search_line(&type_qual, &mi.name, &mi.signature),
-                    doc_path: format!("{}.{}", ti.name, mi.name),
-                });
-            }
-        }
-    }
-    for fi in &prelude_index.functions {
-        if fi.name.to_lowercase().contains(&query_lower) {
-            prelude_matches.push(SearchMatch {
-                name: fi.name.clone(),
-                display: format_search_line("", &fi.name, &fi.signature),
-                doc_path: fi.name.clone(),
-            });
-        }
-    }
-
-    let mut go_matches: Vec<SearchMatch> = Vec::new();
     let target = Target::host();
-    let go_cache = try_load_go_stdlib_cache(target);
 
-    for pkg in get_go_stdlib_packages(target) {
-        if let Some(ref cache) = go_cache {
-            let module_id = format!("go:{}", pkg);
-            if let Some(module_cache) = cache.modules.get(&module_id)
-                && !has_go_module_matches(module_cache, &query_lower)
-            {
-                continue;
-            }
-        }
-
-        let Some(source) = get_go_stdlib_typedef(pkg, target) else {
-            continue;
-        };
-        let index = build_go_package_index(source, pkg);
-
-        for fi in &index.functions {
-            if fi.name.to_lowercase().contains(&query_lower) {
-                go_matches.push(SearchMatch {
-                    name: fi.name.clone(),
-                    display: format_search_line(pkg, &fi.name, &fi.signature),
-                    doc_path: format!("{}.{}", pkg, fi.name),
-                });
-            }
-        }
-        for ti in &index.types {
-            let type_qual = format!("{}.{}", pkg, ti.name);
-            for mi in &ti.methods {
-                if mi.name.to_lowercase().contains(&query_lower) {
-                    go_matches.push(SearchMatch {
-                        name: mi.name.clone(),
-                        display: format_search_line(&type_qual, &mi.name, &mi.signature),
-                        doc_path: format!("{}.{}.{}", pkg, ti.name, mi.name),
-                    });
-                }
-            }
-        }
-    }
+    let mut prelude_matches = collect_prelude_matches(&prelude_index, &query_lower);
+    let mut go_matches = collect_go_matches(target, &query_lower);
 
     let rank = |name: &str| -> u8 {
         let lower = name.to_lowercase();
@@ -1825,81 +1645,164 @@ pub fn doc_search(query: &str) -> i32 {
     if prelude_matches.is_empty() && go_matches.is_empty() {
         println!();
         println!("  No matches found.");
-
-        let mut best_name = String::new();
-        let mut best_dist = usize::MAX;
-
-        for ti in &prelude_index.types {
-            for mi in &ti.methods {
-                let d = levenshtein_distance(&query_lower, &mi.name.to_lowercase());
-                if d <= 2 && d < best_dist {
-                    best_name = mi.name.clone();
-                    best_dist = d;
-                }
-            }
-        }
-        for fi in &prelude_index.functions {
-            let d = levenshtein_distance(&query_lower, &fi.name.to_lowercase());
-            if d <= 2 && d < best_dist {
-                best_name = fi.name.clone();
-                best_dist = d;
-            }
-        }
-
-        if best_dist > 0 {
-            'outer: for pkg in get_go_stdlib_packages(target) {
-                let Some(source) = get_go_stdlib_typedef(pkg, target) else {
-                    continue;
-                };
-                let index = build_go_package_index(source, pkg);
-                for fi in &index.functions {
-                    let d = levenshtein_distance(&query_lower, &fi.name.to_lowercase());
-                    if d <= 2 && d < best_dist {
-                        best_name = fi.name.clone();
-                        best_dist = d;
-                        if d == 0 {
-                            break 'outer;
-                        }
-                    }
-                }
-                for ti in &index.types {
-                    for mi in &ti.methods {
-                        let d = levenshtein_distance(&query_lower, &mi.name.to_lowercase());
-                        if d <= 2 && d < best_dist {
-                            best_name = mi.name.clone();
-                            best_dist = d;
-                            if d == 0 {
-                                break 'outer;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if best_dist <= 2 {
-            println!();
-            println!(
+        println!();
+        match nearest_symbol(&query_lower, &prelude_index, target) {
+            Some(best_name) => println!(
                 "  hint: Did you mean {}?",
                 format_method_name(&format!("lis doc -s {}", best_name))
-            );
-        } else {
-            println!();
-            println!(
+            ),
+            None => println!(
                 "  hint: Run {} to browse prelude types, or {} to list Go packages",
                 format_method_name("lis doc"),
                 format_method_name("lis doc go:")
-            );
+            ),
         }
         return 0;
     }
 
+    render_search_results(&prelude_matches, &go_matches);
+    0
+}
+
+fn collect_prelude_matches(prelude_index: &PreludeIndex, query_lower: &str) -> Vec<SearchMatch> {
+    let mut matches = Vec::new();
+    for type_info in &prelude_index.types {
+        let type_qualifier = format_type_with_generics_plain(&type_info.name, &type_info.generics);
+        for method_info in &type_info.methods {
+            if method_info.name.to_lowercase().contains(query_lower) {
+                matches.push(SearchMatch {
+                    name: method_info.name.clone(),
+                    display: format_search_line(
+                        &type_qualifier,
+                        &method_info.name,
+                        &method_info.signature,
+                    ),
+                    doc_path: format!("{}.{}", type_info.name, method_info.name),
+                });
+            }
+        }
+    }
+    for function_info in &prelude_index.functions {
+        if function_info.name.to_lowercase().contains(query_lower) {
+            matches.push(SearchMatch {
+                name: function_info.name.clone(),
+                display: format_search_line("", &function_info.name, &function_info.signature),
+                doc_path: function_info.name.clone(),
+            });
+        }
+    }
+    matches
+}
+
+fn collect_go_matches(target: Target, query_lower: &str) -> Vec<SearchMatch> {
+    let mut matches = Vec::new();
+    let go_cache = try_load_go_stdlib_cache(target);
+
+    for package in get_go_stdlib_packages(target) {
+        if let Some(ref cache) = go_cache {
+            let module_id = format!("go:{}", package);
+            if let Some(module_cache) = cache.modules.get(&module_id)
+                && !has_go_module_matches(module_cache, query_lower)
+            {
+                continue;
+            }
+        }
+
+        let Some(source) = get_go_stdlib_typedef(package, target) else {
+            continue;
+        };
+        let index = build_go_package_index(source, package);
+
+        for function_info in &index.functions {
+            if function_info.name.to_lowercase().contains(query_lower) {
+                matches.push(SearchMatch {
+                    name: function_info.name.clone(),
+                    display: format_search_line(
+                        package,
+                        &function_info.name,
+                        &function_info.signature,
+                    ),
+                    doc_path: format!("{}.{}", package, function_info.name),
+                });
+            }
+        }
+        for type_info in &index.types {
+            let type_qualifier = format!("{}.{}", package, type_info.name);
+            for method_info in &type_info.methods {
+                if method_info.name.to_lowercase().contains(query_lower) {
+                    matches.push(SearchMatch {
+                        name: method_info.name.clone(),
+                        display: format_search_line(
+                            &type_qualifier,
+                            &method_info.name,
+                            &method_info.signature,
+                        ),
+                        doc_path: format!("{}.{}.{}", package, type_info.name, method_info.name),
+                    });
+                }
+            }
+        }
+    }
+    matches
+}
+
+/// Finds the closest symbol name within edit distance 2, for a did-you-mean hint.
+fn nearest_symbol(
+    query_lower: &str,
+    prelude_index: &PreludeIndex,
+    target: Target,
+) -> Option<String> {
+    let mut best_name = String::new();
+    let mut best_distance = usize::MAX;
+    let consider = |name: &str, best_name: &mut String, best_distance: &mut usize| -> usize {
+        let distance = levenshtein_distance(query_lower, &name.to_lowercase());
+        if distance <= 2 && distance < *best_distance {
+            *best_name = name.to_string();
+            *best_distance = distance;
+        }
+        distance
+    };
+
+    for type_info in &prelude_index.types {
+        for method_info in &type_info.methods {
+            consider(&method_info.name, &mut best_name, &mut best_distance);
+        }
+    }
+    for function_info in &prelude_index.functions {
+        consider(&function_info.name, &mut best_name, &mut best_distance);
+    }
+
+    if best_distance > 0 {
+        'packages: for package in get_go_stdlib_packages(target) {
+            let Some(source) = get_go_stdlib_typedef(package, target) else {
+                continue;
+            };
+            let index = build_go_package_index(source, package);
+            for function_info in &index.functions {
+                if consider(&function_info.name, &mut best_name, &mut best_distance) == 0 {
+                    break 'packages;
+                }
+            }
+            for type_info in &index.types {
+                for method_info in &type_info.methods {
+                    if consider(&method_info.name, &mut best_name, &mut best_distance) == 0 {
+                        break 'packages;
+                    }
+                }
+            }
+        }
+    }
+
+    (best_distance <= 2).then_some(best_name)
+}
+
+fn render_search_results(prelude_matches: &[SearchMatch], go_matches: &[SearchMatch]) {
     println!();
     println!("  Prelude:");
     if prelude_matches.is_empty() {
         println!("    {}", format_dim("(no matches)"));
     } else {
-        for m in &prelude_matches {
+        for m in prelude_matches {
             println!("{}", m.display);
         }
     }
@@ -1942,7 +1845,6 @@ pub fn doc_search(query: &str) -> i32 {
     }
 
     println!();
-    0
 }
 
 pub fn doc(query: Option<String>) -> i32 {

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -306,6 +306,26 @@ pub(crate) fn reconcile_root(
     Ok(graph)
 }
 
+fn handle_module_failure(
+    context: &str,
+    module_path: &str,
+    message: &str,
+    is_explicit: bool,
+    failed_transitives: &mut HashSet<String>,
+) -> Result<(), i32> {
+    if is_explicit {
+        match import_compat_hint(message) {
+            Some(hint) => cli_error!(context, message, hint),
+            None => error!(context, message),
+        }
+        return Err(1);
+    }
+    if failed_transitives.insert(module_path.to_string()) {
+        print_warning(&format!("skipping transitive {}: {}", module_path, message));
+    }
+    Ok(())
+}
+
 /// Manifest walk: BFS the third-party module subgraph from `dep.canonical_module`
 /// via `go list -json M/...`. Module-grained so the manifest declares every
 /// module a future subpackage import could reach; the outer loop converges
@@ -325,20 +345,15 @@ fn reconcile_module_graph(
             let is_explicit = module_path == canonical_module;
 
             let module_version = match workspace.query_version(&module_path) {
-                Ok(v) => v,
-                Err(msg) => {
-                    if is_explicit {
-                        match import_compat_hint(&msg) {
-                            Some(hint) => {
-                                cli_error!("failed to resolve module version", msg, hint)
-                            }
-                            None => error!("failed to resolve module version", msg),
-                        }
-                        return Err(1);
-                    }
-                    if failed_transitives.insert(module_path.clone()) {
-                        print_warning(&format!("skipping transitive {}: {}", module_path, msg));
-                    }
+                Ok(version) => version,
+                Err(message) => {
+                    handle_module_failure(
+                        "failed to resolve module version",
+                        &module_path,
+                        &message,
+                        is_explicit,
+                        &mut failed_transitives,
+                    )?;
                     continue;
                 }
             };
@@ -352,20 +367,15 @@ fn reconcile_module_graph(
             }
 
             let listed = match workspace.find_third_party_modules(&module_path) {
-                Ok(l) => l,
-                Err(msg) => {
-                    if is_explicit {
-                        match import_compat_hint(&msg) {
-                            Some(hint) => {
-                                cli_error!("failed to scan transitive modules", msg, hint)
-                            }
-                            None => error!("failed to scan transitive modules", msg),
-                        }
-                        return Err(1);
-                    }
-                    if failed_transitives.insert(module_path.clone()) {
-                        print_warning(&format!("skipping transitive {}: {}", module_path, msg));
-                    }
+                Ok(listed) => listed,
+                Err(message) => {
+                    handle_module_failure(
+                        "failed to scan transitive modules",
+                        &module_path,
+                        &message,
+                        is_explicit,
+                        &mut failed_transitives,
+                    )?;
                     continue;
                 }
             };
@@ -462,6 +472,29 @@ pub(crate) fn declared_replacements(
         .collect()
 }
 
+/// A package waiting to be bindgenned, pinned to its module's version.
+struct QueuedPackage {
+    module: String,
+    version: String,
+    package: String,
+}
+
+/// The identity the cache walk dedupes on: a package within its module.
+#[derive(PartialEq, Eq, Hash)]
+struct PackageKey {
+    module: String,
+    package: String,
+}
+
+impl QueuedPackage {
+    fn key(&self) -> PackageKey {
+        PackageKey {
+            module: self.module.clone(),
+            package: self.package.clone(),
+        }
+    }
+}
+
 /// Cache walk: bindgen the requested package, then recurse into each
 /// typedef's own `go:` imports. Sibling subpackages stay cache misses for
 /// the locator to handle on first access. Returns each bindgenned
@@ -473,8 +506,8 @@ fn walk_typedef_cache(
     module_graph: &mut GraphResult,
     replacements: &HashMap<String, ReplacementIdentity>,
 ) -> Result<Vec<BindgennedPackage>, i32> {
-    let mut visited: HashSet<(String, String)> = HashSet::new();
-    let mut queue: Vec<(String, String, String)> = Vec::new();
+    let mut visited: HashSet<PackageKey> = HashSet::new();
+    let mut queue: Vec<QueuedPackage> = Vec::new();
     let mut bindgenned: Vec<BindgennedPackage> = Vec::new();
 
     let seed_packages = seed_cache_walk(
@@ -484,105 +517,139 @@ fn walk_typedef_cache(
         &mut queue,
     )?;
 
-    while let Some((module_path, version, package_path)) = queue.pop() {
-        if !visited.insert((module_path.clone(), package_path.clone())) {
+    while let Some(entry) = queue.pop() {
+        if !visited.insert(entry.key()) {
             continue;
         }
 
-        let is_seed = seed_packages.contains(&(module_path.clone(), package_path.clone()));
+        let is_seed = seed_packages.contains(&entry.key());
         let module = GoModule {
-            path: &module_path,
-            version: &version,
-            replacement: replacement_for(&module_path, replacements),
+            path: &entry.module,
+            version: &entry.version,
+            replacement: replacement_for(&entry.module, replacements),
         };
 
-        match workspace.reconcile_package(module, &package_path) {
+        match workspace.reconcile_package(module, &entry.package) {
             Ok(stubs) => {
                 warn_stubbed(&stubs);
                 bindgenned.push(BindgennedPackage {
-                    module: module_path.clone(),
-                    version: version.clone(),
-                    package: package_path.clone(),
+                    module: entry.module.clone(),
+                    version: entry.version.clone(),
+                    package: entry.package.clone(),
                 });
             }
-            Err(msg) => {
+            Err(message) => {
                 if is_seed {
-                    error!("failed to bindgen package", msg);
+                    error!("failed to bindgen package", message);
                     return Err(1);
                 }
-                print_warning(&format!("skipping transitive {}: {}", package_path, msg));
+                print_warning(&format!(
+                    "skipping transitive {}: {}",
+                    entry.package, message
+                ));
                 continue;
             }
         }
 
-        let imports = match workspace.imports_of(module, &package_path) {
-            Ok(i) => i,
-            Err(msg) => {
+        let imports = match workspace.imports_of(module, &entry.package) {
+            Ok(imports) => imports,
+            Err(message) => {
                 print_warning(&format!(
                     "skipping import-walk for {}: {}",
-                    package_path, msg
+                    entry.package, message
                 ));
                 continue;
             }
         };
 
         for import in imports {
-            if deps::is_stdlib(&import) {
+            let Some(next) = classify_import(import, &entry, workspace, module_graph) else {
                 continue;
-            }
-            let containing = match workspace.find_containing_module(&import) {
-                Ok(info) if !info.path.is_empty() => info,
-                _ => {
-                    print_warning(&format!(
-                        "could not resolve containing module for `{}` (referenced by {})",
-                        import, package_path
-                    ));
-                    continue;
-                }
             };
-            if containing.path == module_path {
-                let key = (containing.path, import);
-                if !visited.contains(&key) {
-                    queue.push((key.0, version.clone(), key.1));
-                }
-                continue;
+            if !visited.contains(&next.key()) {
+                queue.push(next);
             }
-
-            // Record cache-walk-discovered modules so the manifest declares
-            // every module whose typedef ends up in the cache.
-            let next_version = if let Some(version) = module_graph.version(&containing.path) {
-                version.to_string()
-            } else {
-                let resolved = if !containing.version.is_empty() {
-                    containing.version
-                } else {
-                    match workspace.query_version(&containing.path) {
-                        Ok(v) => v,
-                        Err(msg) => {
-                            print_warning(&format!("skipping transitive {}: {}", import, msg));
-                            continue;
-                        }
-                    }
-                };
-                module_graph.discover(containing.path.clone(), resolved.clone());
-                resolved
-            };
-
-            module_graph.record_dependency(
-                module_path.clone(),
-                version.clone(),
-                containing.path.clone(),
-            );
-
-            let key = (containing.path.clone(), import.clone());
-            if visited.contains(&key) {
-                continue;
-            }
-            queue.push((containing.path, next_version, import));
         }
     }
 
     Ok(bindgenned)
+}
+
+/// Where one typedef import sends the cache walk next, if anywhere.
+fn classify_import(
+    import: String,
+    current: &QueuedPackage,
+    workspace: &GoWorkspace,
+    module_graph: &mut GraphResult,
+) -> Option<QueuedPackage> {
+    if deps::is_stdlib(&import) {
+        return None;
+    }
+    let containing = match workspace.find_containing_module(&import) {
+        Ok(info) if !info.path.is_empty() => info,
+        _ => {
+            print_warning(&format!(
+                "could not resolve containing module for `{}` (referenced by {})",
+                import, current.package
+            ));
+            return None;
+        }
+    };
+    if containing.path == current.module {
+        return Some(QueuedPackage {
+            module: containing.path,
+            version: current.version.clone(),
+            package: import,
+        });
+    }
+
+    // Record cache-walk-discovered modules so the manifest declares
+    // every module whose typedef ends up in the cache.
+    let next_version = resolve_discovered_version(
+        &containing.path,
+        containing.version,
+        &import,
+        workspace,
+        module_graph,
+    )?;
+
+    module_graph.record_dependency(
+        current.module.clone(),
+        current.version.clone(),
+        containing.path.clone(),
+    );
+
+    Some(QueuedPackage {
+        module: containing.path,
+        version: next_version,
+        package: import,
+    })
+}
+
+/// The graph's pin, else the version `go list` reported, else a fresh query.
+fn resolve_discovered_version(
+    containing_module: &str,
+    listed_version: String,
+    import: &str,
+    workspace: &GoWorkspace,
+    module_graph: &mut GraphResult,
+) -> Option<String> {
+    if let Some(version) = module_graph.version(containing_module) {
+        return Some(version.to_string());
+    }
+    let resolved = if !listed_version.is_empty() {
+        listed_version
+    } else {
+        match workspace.query_version(containing_module) {
+            Ok(version) => version,
+            Err(message) => {
+                print_warning(&format!("skipping transitive {}: {}", import, message));
+                return None;
+            }
+        }
+    };
+    module_graph.discover(containing_module.to_string(), resolved.clone());
+    Some(resolved)
 }
 
 pub(crate) struct BindgennedPackage {
@@ -717,22 +784,29 @@ fn seed_cache_walk(
     canonical_module: &str,
     requested_package: &str,
     workspace: &GoWorkspace,
-    queue: &mut Vec<(String, String, String)>,
-) -> Result<HashSet<(String, String)>, i32> {
+    queue: &mut Vec<QueuedPackage>,
+) -> Result<HashSet<PackageKey>, i32> {
     let version = match workspace.query_version(canonical_module) {
-        Ok(v) => v,
-        Err(msg) => {
-            error!("failed to resolve module version", msg);
+        Ok(version) => version,
+        Err(message) => {
+            error!("failed to resolve module version", message);
             return Err(1);
         }
     };
 
     let push_seed = |queue: &mut Vec<_>, seeds: &mut HashSet<_>, package: String| {
-        seeds.insert((canonical_module.to_string(), package.clone()));
-        queue.push((canonical_module.to_string(), version.clone(), package));
+        seeds.insert(PackageKey {
+            module: canonical_module.to_string(),
+            package: package.clone(),
+        });
+        queue.push(QueuedPackage {
+            module: canonical_module.to_string(),
+            version: version.clone(),
+            package,
+        });
     };
 
-    let mut seeds: HashSet<(String, String)> = HashSet::new();
+    let mut seeds: HashSet<PackageKey> = HashSet::new();
 
     if canonical_module != requested_package {
         push_seed(queue, &mut seeds, requested_package.to_string());
@@ -815,6 +889,18 @@ impl ManifestChanges {
     }
 }
 
+/// Upsert one manifest entry, mapping a write failure to the exit code.
+fn write_manifest_dependency(
+    project_root: &Path,
+    module: &str,
+    dependency: &deps::GoDependency,
+) -> Result<(), i32> {
+    upsert_go_dependency(project_root, module, dependency).map_err(|message| {
+        error!("failed to update manifest", message);
+        1
+    })
+}
+
 /// Update `lisette.toml` to reflect the newly reconciled `added_dep` subgraph,
 /// leaving every other direct dep and its transitives untouched.
 ///
@@ -846,37 +932,26 @@ pub(crate) fn apply_graph_to_manifest(
     let added_dep_version = graph.version(added_dep).unwrap_or(fallback_version);
     let mut upgraded: Vec<DirectUpgrade> = Vec::new();
 
-    let root_result = match replaced_root {
+    let root_dependency = match replaced_root {
         Some(replaced_root) => {
             let via = match replaced_root.mode {
                 ReplacedRootMode::SyncPreserveVia => existing_deps
                     .get(added_dep)
-                    .and_then(|d| d.via().map(<[String]>::to_vec)),
+                    .and_then(|dependency| dependency.via().map(<[String]>::to_vec)),
                 ReplacedRootMode::AddDirect => None,
             };
-            upsert_go_dependency(
-                project_root,
-                added_dep,
-                &deps::GoDependency::Replaced {
-                    replacement_path: replaced_root.identity.replacement_path.clone(),
-                    replacement_version: replaced_root.identity.replacement_version.clone(),
-                    via,
-                },
-            )
+            deps::GoDependency::Replaced {
+                replacement_path: replaced_root.identity.replacement_path.clone(),
+                replacement_version: replaced_root.identity.replacement_version.clone(),
+                via,
+            }
         }
-        None => upsert_go_dependency(
-            project_root,
-            added_dep,
-            &deps::GoDependency::Remote {
-                version: added_dep_version.to_string(),
-                via: None,
-            },
-        ),
+        None => deps::GoDependency::Remote {
+            version: added_dep_version.to_string(),
+            via: None,
+        },
     };
-    if let Err(msg) = root_result {
-        error!("failed to update manifest", msg);
-        return Err(1);
-    }
+    write_manifest_dependency(project_root, added_dep, &root_dependency)?;
 
     let mut sorted_transitives: Vec<(&String, &Vec<String>)> = transitives.iter().collect();
     sorted_transitives.sort_by(|a, b| a.0.cmp(b.0));
@@ -898,18 +973,14 @@ pub(crate) fn apply_graph_to_manifest(
             } = existing
                 && existing_version != version
             {
-                upsert_go_dependency(
+                write_manifest_dependency(
                     project_root,
                     module_path,
                     &deps::GoDependency::Remote {
                         version: version.to_string(),
                         via: None,
                     },
-                )
-                .map_err(|msg| {
-                    error!("failed to update manifest", msg);
-                    1
-                })?;
+                )?;
                 upgraded.push(DirectUpgrade {
                     path: (*module_path).clone(),
                     old_version: existing_version.clone(),
@@ -934,23 +1005,19 @@ pub(crate) fn apply_graph_to_manifest(
         via.sort();
 
         // A replaced transitive keeps its `replace` shape, only its `via` is reconciled.
-        let result = match existing {
+        match existing {
             Some(replaced @ deps::GoDependency::Replaced { .. }) => {
-                upsert_go_dependency(project_root, module_path, &replaced.with_via(Some(via)))
+                write_manifest_dependency(project_root, module_path, &replaced.with_via(Some(via)))?
             }
-            _ => upsert_go_dependency(
+            _ => write_manifest_dependency(
                 project_root,
                 module_path,
                 &deps::GoDependency::Remote {
                     version: version.to_string(),
                     via: Some(via),
                 },
-            ),
+            )?,
         };
-        if let Err(msg) = result {
-            error!("failed to update manifest", msg);
-            return Err(1);
-        }
     }
 
     let mut sorted_existing: Vec<(&String, &deps::GoDependency)> = existing_deps.iter().collect();
@@ -975,40 +1042,27 @@ pub(crate) fn apply_graph_to_manifest(
         filtered.sort();
 
         if filtered.is_empty() {
-            upsert_go_dependency(project_root, dep_path, &dep.with_via(Some(Vec::new()))).map_err(
-                |msg| {
-                    error!("failed to update manifest", msg);
-                    1
-                },
-            )?;
+            write_manifest_dependency(project_root, dep_path, &dep.with_via(Some(Vec::new())))?;
             continue;
         }
 
         match dep {
             deps::GoDependency::Replaced { .. } => {
-                upsert_go_dependency(project_root, dep_path, &dep.with_via(Some(filtered)))
-                    .map_err(|msg| {
-                        error!("failed to update manifest", msg);
-                        1
-                    })?;
+                write_manifest_dependency(project_root, dep_path, &dep.with_via(Some(filtered)))?;
             }
             deps::GoDependency::Remote { .. } => {
                 let dep_version = workspace.query_version(dep_path).map_err(|msg| {
                     error!("failed to resolve module version", msg);
                     1
                 })?;
-                upsert_go_dependency(
+                write_manifest_dependency(
                     project_root,
                     dep_path,
                     &deps::GoDependency::Remote {
                         version: dep_version,
                         via: Some(filtered),
                     },
-                )
-                .map_err(|msg| {
-                    error!("failed to update manifest", msg);
-                    1
-                })?;
+                )?;
             }
         }
     }

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -5,6 +5,7 @@ use owo_colors::OwoColorize;
 use semantics::store::ENTRY_MODULE_ID;
 use serde::Deserialize;
 use syntax::ast::Span;
+use syntax::program::TestFunction;
 
 use crate::go_cli::GoTestEvent;
 use crate::output::{format_backticks, format_elapsed};
@@ -60,6 +61,21 @@ impl TestEvents {
     fn failure(&self) -> Option<FailureRecord> {
         let (count, parts) = self.failure_chunks.as_ref()?;
         reassemble_one(*count, parts)
+    }
+
+    fn record_attribute(&mut self, attribute: TestAttribute) {
+        match attribute {
+            TestAttribute::FailureChunk(envelope) => {
+                let chunks = self
+                    .failure_chunks
+                    .get_or_insert_with(|| (envelope.n, Vec::new()));
+                chunks.0 = envelope.n;
+                chunks.1.push((envelope.i, envelope.d));
+            }
+            TestAttribute::SkipReason(reason) => self.skip_reason = Some(reason),
+            TestAttribute::SubtestName(name) => self.subtest_name = Some(name),
+            TestAttribute::Log(record) => self.logs.push(record),
+        }
     }
 
     fn outcome(&self) -> TestOutcome {
@@ -283,25 +299,31 @@ fn name_or_title_contains(fn_name: &str, title: Option<&str>, pattern: &str) -> 
     fn_name.contains(pattern) || title.is_some_and(|t| t.contains(pattern))
 }
 
+fn test_function_name(test: &TestFunction) -> &str {
+    let prefix = format!("{}.", test.module_id);
+    test.qualified_name
+        .strip_prefix(&prefix)
+        .unwrap_or(&test.qualified_name)
+}
+
+fn test_key(test: &TestFunction, go_module: &str) -> TestKey {
+    let package = if test.module_id == ENTRY_MODULE_ID {
+        go_module.to_string()
+    } else {
+        format!("{}/{}", go_module, test.module_id)
+    };
+    (package, go_test_name(test_function_name(test)))
+}
+
 pub fn matching_tests(index: &TestIndex, go_module: &str, filter: &str) -> Vec<(String, String)> {
     index
         .tests()
         .iter()
         .filter_map(|test| {
-            let prefix = format!("{}.", test.module_id);
-            let fn_name = test
-                .qualified_name
-                .strip_prefix(&prefix)
-                .unwrap_or(&test.qualified_name);
-            if !name_or_title_contains(fn_name, test.title.as_deref(), filter) {
+            if !name_or_title_contains(test_function_name(test), test.title.as_deref(), filter) {
                 return None;
             }
-            let package = if test.module_id == ENTRY_MODULE_ID {
-                go_module.to_string()
-            } else {
-                format!("{}/{}", go_module, test.module_id)
-            };
-            Some((package, go_test_name(fn_name)))
+            Some(test_key(test, go_module))
         })
         .collect()
 }
@@ -310,19 +332,7 @@ pub fn all_test_keys(index: &TestIndex, go_module: &str) -> HashSet<(String, Str
     index
         .tests()
         .iter()
-        .map(|test| {
-            let prefix = format!("{}.", test.module_id);
-            let fn_name = test
-                .qualified_name
-                .strip_prefix(&prefix)
-                .unwrap_or(&test.qualified_name);
-            let package = if test.module_id == ENTRY_MODULE_ID {
-                go_module.to_string()
-            } else {
-                format!("{}/{}", go_module, test.module_id)
-            };
-            (package, go_test_name(fn_name))
-        })
+        .map(|test| test_key(test, go_module))
         .collect()
 }
 
@@ -344,143 +354,29 @@ pub fn build_report_filtered(
 
     for event in events {
         if event.action == "attr"
-            && event.key.as_deref() == Some(FAIL_ATTR_KEY)
-            && let (Some(test), Some(value)) = (&event.test, &event.value)
-            && let Ok(envelope) = serde_json::from_str::<FailEnvelope>(value)
-        {
-            let entry = tests
-                .entry((event.package.clone(), test.clone()))
-                .or_default()
-                .failure_chunks
-                .get_or_insert_with(|| (envelope.n, Vec::new()));
-            entry.0 = envelope.n;
-            entry.1.push((envelope.i, envelope.d));
-            continue;
-        }
-        if event.action == "attr"
-            && event.key.as_deref() == Some(SKIP_ATTR_KEY)
-            && let (Some(test), Some(value)) = (&event.test, &event.value)
-            && let Some(reason) = decode_hex(value).and_then(|b| String::from_utf8(b).ok())
+            && let (Some(key), Some(test), Some(value)) =
+                (event.key.as_deref(), &event.test, &event.value)
+            && let Some(attribute) = decode_test_attribute(key, value)
         {
             tests
                 .entry((event.package.clone(), test.clone()))
                 .or_default()
-                .skip_reason = Some(reason);
-            continue;
-        }
-        if event.action == "attr"
-            && event.key.as_deref() == Some(SUBTEST_ATTR_KEY)
-            && let (Some(test), Some(value)) = (&event.test, &event.value)
-            && let Some(name) = decode_hex(value).and_then(|b| String::from_utf8(b).ok())
-        {
-            tests
-                .entry((event.package.clone(), test.clone()))
-                .or_default()
-                .subtest_name = Some(name);
-            continue;
-        }
-        if event.action == "attr"
-            && event.key.as_deref() == Some(LOG_ATTR_KEY)
-            && let (Some(test), Some(value)) = (&event.test, &event.value)
-            && let Some(record) =
-                decode_hex(value).and_then(|b| serde_json::from_slice::<LogRecord>(&b).ok())
-        {
-            tests
-                .entry((event.package.clone(), test.clone()))
-                .or_default()
-                .logs
-                .push(record);
+                .record_attribute(attribute);
             continue;
         }
         let Some(test) = &event.test else {
-            match event.action.as_str() {
-                "build-output" => {
-                    if let Some(text) = &event.output {
-                        build_output.push_str(text);
-                    }
-                    if let Some(path) = &event.import_path {
-                        packages
-                            .entry(package_of_import_path(path).to_string())
-                            .or_default()
-                            .record_build_failure();
-                    }
-                }
-                "build-fail" => {
-                    if let Some(path) = &event.import_path {
-                        packages
-                            .entry(package_of_import_path(path).to_string())
-                            .or_default()
-                            .record_build_failure();
-                    }
-                }
-                "output" => {
-                    if let Some(text) = &event.output {
-                        packages
-                            .entry(event.package.clone())
-                            .or_default()
-                            .output
-                            .push_str(text);
-                    }
-                }
-                "pass" => {
-                    test_elapsed = test_elapsed.max(event.elapsed.unwrap_or(0.0));
-                }
-                "fail" => {
-                    packages
-                        .entry(event.package.clone())
-                        .or_default()
-                        .record_test_failure();
-                    test_elapsed = test_elapsed.max(event.elapsed.unwrap_or(0.0));
-                }
-                _ => {}
-            }
+            handle_package_event(event, &mut build_output, &mut packages, &mut test_elapsed);
             continue;
         };
         let state = tests
             .entry((event.package.clone(), test.clone()))
             .or_default();
-        match event.action.as_str() {
-            "run" => {
-                state.execution.start();
-            }
-            "pass" => {
-                state
-                    .execution
-                    .finish(TerminalStatus::Passed, event.elapsed);
-            }
-            "fail" => {
-                state
-                    .execution
-                    .finish(TerminalStatus::Failed, event.elapsed);
-            }
-            "skip" => {
-                state
-                    .execution
-                    .finish(TerminalStatus::Skipped, event.elapsed);
-            }
-            "output" => {
-                if let Some(text) = &event.output {
-                    state.output.push_str(text);
-                }
-            }
-            _ => {}
-        }
+        handle_test_event(event, state);
     }
 
     let mut rows = Vec::new();
     for test in index.tests() {
-        let prefix = format!("{}.", test.module_id);
-        let fn_name = test
-            .qualified_name
-            .strip_prefix(&prefix)
-            .unwrap_or(&test.qualified_name);
-        let package = if test.module_id == ENTRY_MODULE_ID {
-            go_module.to_string()
-        } else {
-            format!("{}/{}", go_module, test.module_id)
-        };
-        let go_name = go_test_name(fn_name);
-        let key = (package.clone(), go_name.clone());
+        let key = test_key(test, go_module);
         if let Some(set) = selected
             && !set.contains(&key)
         {
@@ -490,11 +386,15 @@ pub fn build_report_filtered(
         let outcome = state
             .map(TestEvents::outcome)
             .unwrap_or(TestOutcome::Unreached);
+        let (package, go_name) = key;
         let children = collect_children(&package, &go_name, &tests);
         rows.push(TestRow {
             package,
-            go_name: go_name.clone(),
-            name: test.title.clone().unwrap_or_else(|| fn_name.to_string()),
+            go_name,
+            name: test
+                .title
+                .clone()
+                .unwrap_or_else(|| test_function_name(test).to_string()),
             description: test.doc.clone(),
             outcome,
             output: state.map(|state| state.output.clone()).unwrap_or_default(),
@@ -509,6 +409,106 @@ pub fn build_report_filtered(
         packages,
         go_module: go_module.to_string(),
         test_elapsed,
+    }
+}
+
+/// A decoded `attr` event addressed to one test.
+enum TestAttribute {
+    FailureChunk(FailEnvelope),
+    SkipReason(String),
+    SubtestName(String),
+    Log(LogRecord),
+}
+
+fn decode_test_attribute(key: &str, value: &str) -> Option<TestAttribute> {
+    match key {
+        FAIL_ATTR_KEY => serde_json::from_str(value)
+            .ok()
+            .map(TestAttribute::FailureChunk),
+        SKIP_ATTR_KEY => decode_hex_utf8(value).map(TestAttribute::SkipReason),
+        SUBTEST_ATTR_KEY => decode_hex_utf8(value).map(TestAttribute::SubtestName),
+        LOG_ATTR_KEY => decode_hex(value)
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            .map(TestAttribute::Log),
+        _ => None,
+    }
+}
+
+fn handle_package_event(
+    event: &GoTestEvent,
+    build_output: &mut String,
+    packages: &mut HashMap<String, PackageEvents>,
+    test_elapsed: &mut f64,
+) {
+    match event.action.as_str() {
+        "build-output" => {
+            if let Some(text) = &event.output {
+                build_output.push_str(text);
+            }
+            if let Some(path) = &event.import_path {
+                packages
+                    .entry(package_of_import_path(path).to_string())
+                    .or_default()
+                    .record_build_failure();
+            }
+        }
+        "build-fail" => {
+            if let Some(path) = &event.import_path {
+                packages
+                    .entry(package_of_import_path(path).to_string())
+                    .or_default()
+                    .record_build_failure();
+            }
+        }
+        "output" => {
+            if let Some(text) = &event.output {
+                packages
+                    .entry(event.package.clone())
+                    .or_default()
+                    .output
+                    .push_str(text);
+            }
+        }
+        "pass" => {
+            *test_elapsed = test_elapsed.max(event.elapsed.unwrap_or(0.0));
+        }
+        "fail" => {
+            packages
+                .entry(event.package.clone())
+                .or_default()
+                .record_test_failure();
+            *test_elapsed = test_elapsed.max(event.elapsed.unwrap_or(0.0));
+        }
+        _ => {}
+    }
+}
+
+fn handle_test_event(event: &GoTestEvent, state: &mut TestEvents) {
+    match event.action.as_str() {
+        "run" => {
+            state.execution.start();
+        }
+        "pass" => {
+            state
+                .execution
+                .finish(TerminalStatus::Passed, event.elapsed);
+        }
+        "fail" => {
+            state
+                .execution
+                .finish(TerminalStatus::Failed, event.elapsed);
+        }
+        "skip" => {
+            state
+                .execution
+                .finish(TerminalStatus::Skipped, event.elapsed);
+        }
+        "output" => {
+            if let Some(text) = &event.output {
+                state.output.push_str(text);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -531,6 +531,10 @@ fn reassemble_one(n: usize, parts: &[(usize, String)]) -> Option<FailureRecord> 
     }
     let bytes = decode_hex(&joined)?;
     serde_json::from_slice::<FailureRecord>(&bytes).ok()
+}
+
+fn decode_hex_utf8(value: &str) -> Option<String> {
+    decode_hex(value).and_then(|bytes| String::from_utf8(bytes).ok())
 }
 
 fn decode_hex(hex: &str) -> Option<Vec<u8>> {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -376,8 +376,8 @@ pub fn print_dimmed(text: &str) {
 
 #[macro_export]
 macro_rules! error {
-    ($msg:literal, $reason:expr) => {{
-        let msg = $crate::output::capitalize_first($msg);
+    ($msg:expr, $reason:expr) => {{
+        let msg = $crate::output::capitalize_first(&$msg);
         let reason = $reason;
         if $crate::output::use_color() {
             use owo_colors::OwoColorize;

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -302,32 +302,17 @@ impl TypedefLocator {
         let cache_dir = typedef_cache_dir(project_root);
         let typedef_path = pkg.typedef_path(&cache_dir, self.target);
 
-        match read_typedef(&typedef_path) {
-            ReadOutcome::Found(content) => TypedefLocatorResult::Found {
-                content: Cow::Owned(content),
-                origin: TypedefOrigin::Cache(typedef_path),
-            },
-            ReadOutcome::Unreadable(error) => TypedefLocatorResult::UnreadableTypedef {
-                path: typedef_path,
-                error,
-            },
-            ReadOutcome::Missing => match &self.bindgen {
+        match read_cached_typedef(&typedef_path) {
+            Some(found) => found,
+            None => match &self.bindgen {
                 None => TypedefLocatorResult::MissingTypedef {
                     module: module_path,
                     version: display_version,
                     replacement_path,
                 },
                 Some(runner) => match runner.run(&pkg) {
-                    Ok(()) => match read_typedef(&typedef_path) {
-                        ReadOutcome::Found(content) => TypedefLocatorResult::Found {
-                            content: Cow::Owned(content),
-                            origin: TypedefOrigin::Cache(typedef_path),
-                        },
-                        ReadOutcome::Unreadable(error) => TypedefLocatorResult::UnreadableTypedef {
-                            path: typedef_path,
-                            error,
-                        },
-                        ReadOutcome::Missing => TypedefLocatorResult::BindgenFailed {
+                    Ok(()) => read_cached_typedef(&typedef_path).unwrap_or_else(|| {
+                        TypedefLocatorResult::BindgenFailed {
                             module: module_path,
                             version: display_version,
                             package: package_path.to_string(),
@@ -337,8 +322,8 @@ impl TypedefLocator {
                                     typedef_path.display()
                                 ),
                             },
-                        },
-                    },
+                        }
+                    }),
                     Err(kind) => TypedefLocatorResult::BindgenFailed {
                         module: module_path,
                         version: display_version,
@@ -362,6 +347,21 @@ fn read_typedef(path: &Path) -> ReadOutcome {
         Ok(s) => ReadOutcome::Found(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReadOutcome::Missing,
         Err(e) => ReadOutcome::Unreadable(e.to_string()),
+    }
+}
+
+/// Reads a cached typedef file, wrapping a hit or a read error; `None` on a cache miss.
+fn read_cached_typedef(path: &Path) -> Option<TypedefLocatorResult> {
+    match read_typedef(path) {
+        ReadOutcome::Found(content) => Some(TypedefLocatorResult::Found {
+            content: Cow::Owned(content),
+            origin: TypedefOrigin::Cache(path.to_path_buf()),
+        }),
+        ReadOutcome::Unreadable(error) => Some(TypedefLocatorResult::UnreadableTypedef {
+            path: path.to_path_buf(),
+            error,
+        }),
+        ReadOutcome::Missing => None,
     }
 }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -36,6 +36,7 @@ use crate::definition::{
 use crate::project::find_project_root;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
+use syntax::program::File;
 
 pub use crate::service::{ProtocolAdapter, build_service};
 pub use crate::state::{Backend, SharedState};
@@ -286,6 +287,11 @@ impl LanguageServer for Backend {
                 .find(|b| b.span.file_id == file_id && offset_in_span(offset, &b.span))
                 .map(|b| b.span)
         };
+        let binding_or_word_fallback = |resolved: Option<syntax::ast::Span>| {
+            resolved
+                .or_else(&find_binding)
+                .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
+        };
 
         let definition_span = match expression {
             syntax::ast::Expression::Identifier {
@@ -410,59 +416,21 @@ impl LanguageServer for Backend {
                     .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
             }
 
-            syntax::ast::Expression::Match { arms, .. } => {
-                resolve_match_pattern_definition(arms, offset, file, &snapshot)
-                    .or_else(&find_binding)
-                    .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
-            }
+            syntax::ast::Expression::Match { arms, .. } => binding_or_word_fallback(
+                resolve_match_pattern_definition(arms, offset, file, &snapshot),
+            ),
 
             syntax::ast::Expression::IfLet { pattern, .. }
             | syntax::ast::Expression::WhileLet { pattern, .. } => {
-                resolve_enum_in_pattern(pattern, offset, file, &snapshot)
-                    .or_else(&find_binding)
-                    .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
+                binding_or_word_fallback(resolve_enum_in_pattern(pattern, offset, file, &snapshot))
             }
 
-            _ => find_binding()
-                .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot)),
+            _ => binding_or_word_fallback(None),
         };
 
-        let Some(definition_span) = definition_span else {
-            return Ok(None);
-        };
-
-        // A dummy span (zero length) would resolve to offset 0 of file_id 0;
-        // refuse rather than jump there.
-        if definition_span.is_dummy() {
-            return Ok(None);
-        }
-
-        if let Some(target_file) = snapshot.files().get(&definition_span.file_id) {
-            let end = (definition_span.byte_offset as usize)
-                .saturating_add(definition_span.byte_length as usize);
-            if end > target_file.source.len() {
-                return Ok(None);
-            }
-        }
-
-        // The typedef file may be absent (cache cleared, or pruned by another lis
-        // version); decline instead of returning a dangling Location.
-        if let Some(path) = snapshot.typedef_path(definition_span.file_id)
-            && !path.exists()
-        {
-            return Ok(None);
-        }
-
-        let Some(target) = snapshot.source(definition_span.file_id) else {
-            return Ok(None);
-        };
-
-        let range = target.line_index.span_to_range(definition_span);
-
-        Ok(Some(GotoDefinitionResponse::Scalar(Location {
-            uri: target.uri.clone(),
-            range,
-        })))
+        Ok(definition_span
+            .and_then(|span| location_for(span, &snapshot))
+            .map(GotoDefinitionResponse::Scalar))
     }
 
     async fn document_symbol(
@@ -651,13 +619,29 @@ impl LanguageServer for Backend {
         let line_index = cursor.document.line_index;
         let offset = cursor.offset;
 
+        let rename_response =
+            |span: syntax::ast::Span, placeholder: &str| -> Result<Option<PrepareRenameResponse>> {
+                Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
+                    range: line_index.span_to_range(span),
+                    placeholder: placeholder.to_string(),
+                }))
+            };
+        let rename_word_if_resolved =
+            |resolved: Option<syntax::ast::Span>| -> Result<Option<PrepareRenameResponse>> {
+                if let Some(definition_span) = resolved
+                    && !is_generated_typedef_span(&snapshot, &definition_span)
+                    && let Some((word, start, end)) = word_at_offset(&file.source, offset)
+                {
+                    let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
+                    return rename_response(span, word);
+                }
+                Ok(None)
+            };
+
         for binding in snapshot.facts().bindings.values() {
             let span = binding.span;
             if span.file_id == file_id && offset_in_span(offset, &span) {
-                return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                    range: line_index.span_to_range(span),
-                    placeholder: binding.name.clone(),
-                }));
+                return rename_response(span, &binding.name);
             }
         }
 
@@ -677,10 +661,7 @@ impl LanguageServer for Backend {
                 .and_then(|type_id| find_struct_field_span(&type_id, &fa.name, &snapshot))
                 .is_some()
         {
-            return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                range: line_index.span_to_range(fa.name_span),
-                placeholder: fa.name.to_string(),
-            }));
+            return rename_response(fa.name_span, &fa.name);
         }
 
         match expression {
@@ -693,10 +674,7 @@ impl LanguageServer for Backend {
                 if let Some(binding) = snapshot.facts().bindings.get(id)
                     && binding.span.file_id == file_id
                 {
-                    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(*span),
-                        placeholder: value.to_string(),
-                    }))
+                    rename_response(*span, value)
                 } else {
                     Ok(None)
                 }
@@ -710,11 +688,7 @@ impl LanguageServer for Backend {
             } => {
                 validation::check_rename_guards(qname.as_str())?;
                 if snapshot.definitions().contains_key(qname.as_str()) {
-                    let short_name = syntax::types::unqualified_name(value);
-                    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(*span),
-                        placeholder: short_name.to_string(),
-                    }))
+                    rename_response(*span, syntax::types::unqualified_name(value))
                 } else {
                     Ok(None)
                 }
@@ -731,10 +705,7 @@ impl LanguageServer for Backend {
             } => {
                 let qname = format!("{}.{}", file.module_id, name);
                 validation::check_rename_guards(&qname)?;
-                Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                    range: line_index.span_to_range(*name_span),
-                    placeholder: name.to_string(),
-                }))
+                rename_response(*name_span, name)
             }
 
             syntax::ast::Expression::Struct {
@@ -748,16 +719,10 @@ impl LanguageServer for Backend {
                     && find_struct_field_span(&qname, &field.name, &snapshot).is_some()
                 {
                     validation::check_rename_guards(&qname)?;
-                    return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(field.name_span),
-                        placeholder: field.name.to_string(),
-                    }));
+                    return rename_response(field.name_span, &field.name);
                 }
                 validation::check_rename_guards(&qname)?;
-                Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                    range: line_index.span_to_range(*name_span),
-                    placeholder: name.to_string(),
-                }))
+                rename_response(*name_span, name)
             }
 
             syntax::ast::Expression::Enum {
@@ -772,25 +737,16 @@ impl LanguageServer for Backend {
                 {
                     let qname = format!("{}.{}.{}", file.module_id, name, variant.name);
                     validation::check_rename_guards(&qname)?;
-                    return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(variant.name_span),
-                        placeholder: variant.name.to_string(),
-                    }));
+                    return rename_response(variant.name_span, &variant.name);
                 }
                 let qualified_name = format!("{}.{}", file.module_id, name);
                 validation::check_rename_guards(&qualified_name)?;
-                Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                    range: line_index.span_to_range(*name_span),
-                    placeholder: name.to_string(),
-                }))
+                rename_response(*name_span, name)
             }
 
             syntax::ast::Expression::VariableDeclaration {
                 name, name_span, ..
-            } => Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                range: line_index.span_to_range(*name_span),
-                placeholder: name.to_string(),
-            })),
+            } => rename_response(*name_span, name),
 
             syntax::ast::Expression::Const {
                 identifier,
@@ -799,10 +755,7 @@ impl LanguageServer for Backend {
             } => {
                 let qname = format!("{}.{}", file.module_id, identifier);
                 validation::check_rename_guards(&qname)?;
-                Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                    range: line_index.span_to_range(*identifier_span),
-                    placeholder: identifier.to_string(),
-                }))
+                rename_response(*identifier_span, identifier)
             }
 
             syntax::ast::Expression::DotAccess {
@@ -821,59 +774,25 @@ impl LanguageServer for Backend {
                         span.byte_offset + span.byte_length - member.len() as u32,
                         member.len() as u32,
                     );
-                    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(member_span),
-                        placeholder: member.to_string(),
-                    }))
+                    rename_response(member_span, member)
                 } else {
                     Ok(None)
                 }
             }
 
-            syntax::ast::Expression::Match { arms, .. } => {
-                if let Some(def_span) =
-                    resolve_match_pattern_definition(arms, offset, file, &snapshot)
-                    && !is_generated_typedef_span(&snapshot, &def_span)
-                    && let Some((word, start, end)) = word_at_offset(&file.source, offset)
-                {
-                    let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
-                    return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(span),
-                        placeholder: word.to_string(),
-                    }));
-                }
-                Ok(None)
-            }
+            syntax::ast::Expression::Match { arms, .. } => rename_word_if_resolved(
+                resolve_match_pattern_definition(arms, offset, file, &snapshot),
+            ),
 
             syntax::ast::Expression::IfLet { pattern, .. }
             | syntax::ast::Expression::WhileLet { pattern, .. } => {
-                if let Some(def_span) = resolve_enum_in_pattern(pattern, offset, file, &snapshot)
-                    && !is_generated_typedef_span(&snapshot, &def_span)
-                    && let Some((word, start, end)) = word_at_offset(&file.source, offset)
-                {
-                    let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
-                    return Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(span),
-                        placeholder: word.to_string(),
-                    }));
-                }
-                Ok(None)
+                rename_word_if_resolved(resolve_enum_in_pattern(pattern, offset, file, &snapshot))
             }
 
-            _ => {
-                if let Some((word, start, end)) = word_at_offset(&file.source, offset)
-                    && let Some(def_span) = lookup_definition_span(word, file, &snapshot)
-                    && !is_generated_typedef_span(&snapshot, &def_span)
-                {
-                    let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
-                    Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
-                        range: line_index.span_to_range(span),
-                        placeholder: word.to_string(),
-                    }))
-                } else {
-                    Ok(None)
-                }
-            }
+            _ => rename_word_if_resolved(
+                word_at_offset(&file.source, offset)
+                    .and_then(|(word, _, _)| lookup_definition_span(word, file, &snapshot)),
+            ),
         }
     }
 
@@ -1030,174 +949,32 @@ impl LanguageServer for Backend {
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        if let Some(module_name) = get_module_prefix(&file.source, offset as usize)
-            && let Some(imp) = file.imports().iter().find(|imp| {
-                imp.effective_alias(&snapshot.result.emit_input.go_package_names)
-                    .as_deref()
-                    == Some(module_name)
-            })
+        let module_prefix = get_module_prefix(&file.source, offset as usize);
+
+        if let Some(module_name) = module_prefix
+            && let Some(items) = imported_module_completions(module_name, file, &snapshot)
         {
-            let mut items = Vec::new();
-            for (qname, definition) in snapshot.definitions().iter() {
-                if let Some(rest) = qname.strip_prefix(imp.name.as_str())
-                    && let Some(name) = rest.strip_prefix('.')
-                    && !name.contains('.')
-                    && definition.visibility.is_public()
-                {
-                    items.push(CompletionItem {
-                        label: name.to_string(),
-                        kind: Some(definition_to_completion_kind(definition)),
-                        detail: Some(definition.ty.to_string()),
-                        ..Default::default()
-                    });
-                }
-            }
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        if let Some(ctx) = detect_dot_context(file, offset, &snapshot) {
-            let items = match ctx {
-                DotContext::Instance(type_id) => {
-                    let same_module = id_is_in_module(&type_id, &file.module_id);
-                    get_instance_completions(&type_id, &snapshot, same_module)
-                }
-                DotContext::TypeLevel(type_id) => {
-                    get_type_completions(&type_id, &snapshot, &file.module_id)
-                }
-            };
+        if let Some(items) = dot_context_completions(file, offset, &snapshot) {
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        if let Some(prefix) = get_module_prefix(&file.source, offset as usize) {
-            if prefix == "self" {
-                if let Some(impl_type) = traversal::find_enclosing_impl_type(&file.items, offset) {
-                    let type_id = format!("{}.{}", file.module_id, impl_type);
-                    let items = get_instance_completions(&type_id, &snapshot, true);
-                    return Ok(Some(CompletionResponse::Array(items)));
-                }
-            } else {
-                for module in [file.module_id.as_str(), "prelude"] {
-                    let qualified = format!("{module}.{prefix}");
-                    if let Some(definition) = snapshot.definitions().get(qualified.as_str())
-                        && definition.is_type_definition()
-                    {
-                        let items = get_type_completions(&qualified, &snapshot, &file.module_id);
-                        return Ok(Some(CompletionResponse::Array(items)));
-                    }
-                }
-
-                for import in file.imports() {
-                    let qualified = format!("{}.{}", import.name, prefix);
-                    if let Some(definition) = snapshot.definitions().get(qualified.as_str())
-                        && definition.is_type_definition()
-                        && definition.visibility.is_public()
-                    {
-                        let items = get_type_completions(&qualified, &snapshot, &file.module_id);
-                        return Ok(Some(CompletionResponse::Array(items)));
-                    }
-                }
-
-                let indexed =
-                    offset as usize >= 2 && file.source.as_bytes()[offset as usize - 2] == b']';
-                if let Some(type_id) =
-                    resolve_variable_type(prefix, file, offset, &snapshot, indexed)
-                {
-                    let same_module = id_is_in_module(&type_id, &file.module_id);
-                    let items = get_instance_completions(&type_id, &snapshot, same_module);
-                    return Ok(Some(CompletionResponse::Array(items)));
-                }
-            }
-
-            return Ok(Some(CompletionResponse::Array(vec![])));
-        }
-
-        // In a struct literal's field-name position, offer the unassigned fields.
-        if let Some((name, ty, assigned)) = detect_struct_literal_field_context(file, offset)
-            && let Some(type_id) = type_name(ty, &snapshot)
-        {
-            let same_module = id_is_in_module(&type_id, &file.module_id);
-            let items = get_struct_literal_completions(
-                &type_id,
-                name,
-                &snapshot,
-                same_module,
-                assigned,
-                offset,
-            );
+        if let Some(prefix) = module_prefix {
+            // A prefix that resolves to nothing still returns here: a `foo.`
+            // cursor must never fall through to the general completions below.
+            let items = module_prefix_completions(prefix, file, offset, &snapshot);
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        let mut items = Vec::new();
-
-        for kw in validation::KEYWORDS {
-            items.push(CompletionItem {
-                label: kw.to_string(),
-                kind: Some(CompletionItemKind::KEYWORD),
-                ..Default::default()
-            });
+        if let Some(items) = struct_literal_field_completions(file, offset, &snapshot) {
+            return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        const PRELUDE_TYPES: &[&str] = &[
-            "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32",
-            "uint64", "float32", "float64", "string", "bool", "rune", "byte", "Option", "Result",
-            "Slice", "Map", "Channel", "Array",
-        ];
-        for ty in PRELUDE_TYPES {
-            items.push(CompletionItem {
-                label: ty.to_string(),
-                kind: Some(CompletionItemKind::TYPE_PARAMETER),
-                ..Default::default()
-            });
-        }
-
-        const PRELUDE_VALUES: &[&str] = &[
-            "Some", "None", "Ok", "Err", "Unit", "println", "print", "panic", "len", "cap", "make",
-            "append", "copy",
-        ];
-        for val in PRELUDE_VALUES {
-            items.push(CompletionItem {
-                label: val.to_string(),
-                kind: Some(CompletionItemKind::FUNCTION),
-                ..Default::default()
-            });
-        }
-
-        let module_prefix = format!("{}.", file.module_id);
-        for (qname, definition) in snapshot.definitions().iter() {
-            if let Some(name) = qname.strip_prefix(&module_prefix)
-                && !name.contains('.')
-            {
-                items.push(CompletionItem {
-                    label: name.to_string(),
-                    kind: Some(definition_to_completion_kind(definition)),
-                    detail: Some(definition.ty.to_string()),
-                    ..Default::default()
-                });
-            }
-        }
-
-        for binding in snapshot.facts().bindings.values() {
-            if binding.span.file_id == file_id && binding.span.byte_offset < offset {
-                items.push(CompletionItem {
-                    label: binding.name.clone(),
-                    kind: Some(CompletionItemKind::VARIABLE),
-                    ..Default::default()
-                });
-            }
-        }
-
-        for import in file.imports() {
-            let alias = import
-                .effective_alias(&snapshot.result.emit_input.go_package_names)
-                .unwrap_or_else(|| import.name.to_string());
-            items.push(CompletionItem {
-                label: alias,
-                kind: Some(CompletionItemKind::MODULE),
-                ..Default::default()
-            });
-        }
-
-        Ok(Some(CompletionResponse::Array(items)))
+        Ok(Some(CompletionResponse::Array(general_completions(
+            file, file_id, offset, &snapshot,
+        ))))
     }
 
     async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
@@ -1219,6 +996,218 @@ impl LanguageServer for Backend {
     async fn shutdown(&self) -> Result<()> {
         Ok(())
     }
+}
+
+fn location_for(span: syntax::ast::Span, snapshot: &AnalysisSnapshot) -> Option<Location> {
+    if span.is_dummy() {
+        return None;
+    }
+
+    if let Some(target_file) = snapshot.files().get(&span.file_id) {
+        let end = (span.byte_offset as usize).saturating_add(span.byte_length as usize);
+        if end > target_file.source.len() {
+            return None;
+        }
+    }
+
+    if let Some(path) = snapshot.typedef_path(span.file_id)
+        && !path.exists()
+    {
+        return None;
+    }
+
+    let target = snapshot.source(span.file_id)?;
+    Some(Location {
+        uri: target.uri.clone(),
+        range: target.line_index.span_to_range(span),
+    })
+}
+
+fn imported_module_completions(
+    module_name: &str,
+    file: &File,
+    snapshot: &AnalysisSnapshot,
+) -> Option<Vec<CompletionItem>> {
+    let imports = file.imports();
+    let imp = imports.iter().find(|imp| {
+        imp.effective_alias(&snapshot.result.emit_input.go_package_names)
+            .as_deref()
+            == Some(module_name)
+    })?;
+
+    let mut items = Vec::new();
+    for (qname, definition) in snapshot.definitions().iter() {
+        if let Some(rest) = qname.strip_prefix(imp.name.as_str())
+            && let Some(name) = rest.strip_prefix('.')
+            && !name.contains('.')
+            && definition.visibility.is_public()
+        {
+            items.push(CompletionItem {
+                label: name.to_string(),
+                kind: Some(definition_to_completion_kind(definition)),
+                detail: Some(definition.ty.to_string()),
+                ..Default::default()
+            });
+        }
+    }
+    Some(items)
+}
+
+fn dot_context_completions(
+    file: &File,
+    offset: u32,
+    snapshot: &AnalysisSnapshot,
+) -> Option<Vec<CompletionItem>> {
+    let ctx = detect_dot_context(file, offset, snapshot)?;
+    Some(match ctx {
+        DotContext::Instance(type_id) => {
+            let same_module = id_is_in_module(&type_id, &file.module_id);
+            get_instance_completions(&type_id, snapshot, same_module)
+        }
+        DotContext::TypeLevel(type_id) => get_type_completions(&type_id, snapshot, &file.module_id),
+    })
+}
+
+/// A `foo.` prefix that resolves to nothing still returns an (empty) result
+/// here: it must never fall through to the general completions below.
+fn module_prefix_completions(
+    prefix: &str,
+    file: &File,
+    offset: u32,
+    snapshot: &AnalysisSnapshot,
+) -> Vec<CompletionItem> {
+    if prefix == "self" {
+        if let Some(impl_type) = traversal::find_enclosing_impl_type(&file.items, offset) {
+            let type_id = format!("{}.{}", file.module_id, impl_type);
+            return get_instance_completions(&type_id, snapshot, true);
+        }
+        return Vec::new();
+    }
+
+    for module in [file.module_id.as_str(), "prelude"] {
+        let qualified = format!("{module}.{prefix}");
+        if let Some(definition) = snapshot.definitions().get(qualified.as_str())
+            && definition.is_type_definition()
+        {
+            return get_type_completions(&qualified, snapshot, &file.module_id);
+        }
+    }
+
+    for import in file.imports() {
+        let qualified = format!("{}.{}", import.name, prefix);
+        if let Some(definition) = snapshot.definitions().get(qualified.as_str())
+            && definition.is_type_definition()
+            && definition.visibility.is_public()
+        {
+            return get_type_completions(&qualified, snapshot, &file.module_id);
+        }
+    }
+
+    let indexed = offset as usize >= 2 && file.source.as_bytes()[offset as usize - 2] == b']';
+    if let Some(type_id) = resolve_variable_type(prefix, file, offset, snapshot, indexed) {
+        let same_module = id_is_in_module(&type_id, &file.module_id);
+        return get_instance_completions(&type_id, snapshot, same_module);
+    }
+
+    Vec::new()
+}
+
+/// In a struct literal's field-name position, offers the unassigned fields.
+fn struct_literal_field_completions(
+    file: &File,
+    offset: u32,
+    snapshot: &AnalysisSnapshot,
+) -> Option<Vec<CompletionItem>> {
+    let (name, ty, assigned) = detect_struct_literal_field_context(file, offset)?;
+    let type_id = type_name(ty, snapshot)?;
+    let same_module = id_is_in_module(&type_id, &file.module_id);
+    Some(get_struct_literal_completions(
+        &type_id,
+        name,
+        snapshot,
+        same_module,
+        assigned,
+        offset,
+    ))
+}
+
+fn general_completions(
+    file: &File,
+    file_id: u32,
+    offset: u32,
+    snapshot: &AnalysisSnapshot,
+) -> Vec<CompletionItem> {
+    let mut items = Vec::new();
+
+    for kw in validation::KEYWORDS {
+        items.push(CompletionItem {
+            label: kw.to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            ..Default::default()
+        });
+    }
+
+    const PRELUDE_TYPES: &[&str] = &[
+        "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64",
+        "float32", "float64", "string", "bool", "rune", "byte", "Option", "Result", "Slice", "Map",
+        "Channel", "Array",
+    ];
+    for ty in PRELUDE_TYPES {
+        items.push(CompletionItem {
+            label: ty.to_string(),
+            kind: Some(CompletionItemKind::TYPE_PARAMETER),
+            ..Default::default()
+        });
+    }
+
+    const PRELUDE_VALUES: &[&str] = &[
+        "Some", "None", "Ok", "Err", "Unit", "println", "print", "panic", "len", "cap", "make",
+        "append", "copy",
+    ];
+    for val in PRELUDE_VALUES {
+        items.push(CompletionItem {
+            label: val.to_string(),
+            kind: Some(CompletionItemKind::FUNCTION),
+            ..Default::default()
+        });
+    }
+
+    let module_prefix = format!("{}.", file.module_id);
+    for (qname, definition) in snapshot.definitions().iter() {
+        if let Some(name) = qname.strip_prefix(&module_prefix)
+            && !name.contains('.')
+        {
+            items.push(CompletionItem {
+                label: name.to_string(),
+                kind: Some(definition_to_completion_kind(definition)),
+                detail: Some(definition.ty.to_string()),
+                ..Default::default()
+            });
+        }
+    }
+
+    for binding in snapshot.facts().bindings.values() {
+        if binding.span.file_id == file_id && binding.span.byte_offset < offset {
+            items.push(CompletionItem {
+                label: binding.name.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                ..Default::default()
+            });
+        }
+    }
+
+    for import in file.imports() {
+        let alias = import
+            .effective_alias(&snapshot.result.emit_input.go_package_names)
+            .unwrap_or_else(|| import.name.to_string());
+        items.push(CompletionItem {
+            label: alias,
+            kind: Some(CompletionItemKind::MODULE),
+            ..Default::default()
+        });
+    }
+
+    items
 }
 
 fn ranges_overlap(a: Range, b: Range) -> bool {

--- a/crates/passes/src/passes/checks/native_value_usage.rs
+++ b/crates/passes/src/passes/checks/native_value_usage.rs
@@ -1,7 +1,7 @@
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, Span, StructKind};
 use syntax::program::{Definition, DefinitionBody, NativeTypeKind};
-use syntax::types::{Symbol, Type, unqualified_name};
+use syntax::types::{FunctionType, Symbol, Type, unqualified_name};
 
 use semantics::store::Store;
 
@@ -139,14 +139,7 @@ fn check_one(
     if NativeTypeKind::is_constructor_method(method_part)
         && !is_user_type(type_part, module_id, store)
     {
-        let ret_ty = match ty {
-            Type::Function(f) => Some(f.return_type.as_ref()),
-            Type::Forall { body, .. } => match body.as_ref() {
-                Type::Function(f) => Some(f.return_type.as_ref()),
-                _ => None,
-            },
-            _ => None,
-        };
+        let ret_ty = fn_signature(ty).map(|f| f.return_type.as_ref());
         if let Some(ret) = ret_ty {
             let is_native_ret = matches!(ret.get_name(), Some("Channel" | "Map" | "Slice"));
             if is_native_ret {
@@ -156,19 +149,10 @@ fn check_one(
         }
     }
 
-    let is_fn = matches!(ty, Type::Function(_) | Type::Forall { .. });
-    if !is_fn {
+    let Some(signature) = fn_signature(ty) else {
         return;
-    }
-    let fn_params = match ty {
-        Type::Function(f) => f.params.as_slice(),
-        Type::Forall { body, .. } => match body.as_ref() {
-            Type::Function(f) => f.params.as_slice(),
-            _ => return,
-        },
-        _ => return,
     };
-    let Some(first) = fn_params.first() else {
+    let Some(first) = signature.params.first() else {
         return;
     };
     let stripped = first.ty.strip_refs();
@@ -186,6 +170,17 @@ fn check_one(
 
     if !is_public {
         sink.push(diagnostics::infer::private_method_expression(span));
+    }
+}
+
+fn fn_signature(ty: &Type) -> Option<&FunctionType> {
+    match ty {
+        Type::Function(f) => Some(f),
+        Type::Forall { body, .. } => match body.as_ref() {
+            Type::Function(f) => Some(f),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
@@ -1,7 +1,7 @@
 use semantics::store::Store;
 use syntax::ast::{
-    ConstructorPatternResolution, Literal, MatchArm, Pattern, RecordPatternResolution,
-    SequencePatternResolution,
+    ConstructorPatternResolution, EnumVariant, Generic, Literal, MatchArm, Pattern,
+    RecordPatternResolution, SequencePatternResolution, StructFieldPattern,
 };
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{Type, build_substitution_map, substitute, unqualified_name};
@@ -145,292 +145,14 @@ pub fn normalize_pattern(
             resolution,
             ty,
             ..
-        } => match resolution {
-            ConstructorPatternResolution::Unresolved => Wildcard,
-            ConstructorPatternResolution::Const { qualified_name } => {
-                NormalizedPattern::OpaqueConst(qualified_name.to_string())
-            }
-            ConstructorPatternResolution::ConstValue { value, .. } => match value {
-                Literal::Boolean(b) => normalize_boolean(*b, unions),
-                literal => NormalizedPattern::Literal(literal.clone()),
-            },
-            ConstructorPatternResolution::EnumVariant {
-                enum_name,
-                variant_name,
-            } => {
-                let type_args = pattern_type_args(ctx, ty);
-                let enum_def = ctx.store.get_definition(enum_name);
-                let field_types = match enum_def.map(|definition| &definition.body) {
-                    Some(DefinitionBody::Struct {
-                        fields, generics, ..
-                    }) => {
-                        let substitution = build_substitution_map(generics, &type_args);
-                        fields
-                            .iter()
-                            .map(|field| substitute(&field.ty, &substitution))
-                            .collect::<Vec<_>>()
-                    }
-                    Some(DefinitionBody::Enum {
-                        variants, generics, ..
-                    }) => {
-                        let Some(variant) = variants
-                            .iter()
-                            .find(|variant| variant.name == unqualified_name(variant_name))
-                        else {
-                            return Wildcard;
-                        };
-                        let substitution = build_substitution_map(generics, &type_args);
-                        variant
-                            .fields
-                            .iter()
-                            .map(|field| substitute(&field.ty, &substitution))
-                            .collect()
-                    }
-                    _ => return Wildcard,
-                };
-                let patterns: Vec<NormalizedPattern> = fields
-                    .iter()
-                    .enumerate()
-                    .map(|(i, f)| {
-                        let child = ctx.at_position(field_types.get(i).cloned());
-                        normalize_pattern(f, unions, &child, cache)
-                    })
-                    .collect();
-
-                let mut patterns = patterns;
-                if *rest && patterns.len() < field_types.len() {
-                    patterns.resize(field_types.len(), Wildcard);
-                }
-
-                if let Some(Definition {
-                    body:
-                        DefinitionBody::Struct {
-                            fields: struct_fields,
-                            ..
-                        },
-                    ..
-                }) = enum_def
-                {
-                    let arity = struct_fields.len();
-                    let mut args = patterns.clone();
-                    while args.len() < arity {
-                        args.push(Wildcard);
-                    }
-                    if let Some(normalized) =
-                        try_normalize_interface_implementer(ctx, enum_name, arity, args, unions)
-                    {
-                        return normalized;
-                    }
-                }
-
-                let type_name = make_type_key(enum_name, &type_args);
-                let enum_body = enum_def.map(|d| &d.body);
-
-                // Tuple struct / newtype tags are the bare type name (like record
-                // structs); enum variants are `Type.Variant`.
-                let is_struct_def = matches!(enum_body, Some(DefinitionBody::Struct { .. }));
-                let tag = if is_struct_def {
-                    enum_name.to_string()
-                } else {
-                    format!("{}.{}", enum_name, unqualified_name(variant_name))
-                };
-
-                if unions.get(&type_name).is_none() {
-                    let alternatives = match enum_body {
-                        Some(DefinitionBody::Enum {
-                            variants, generics, ..
-                        }) => variants
-                            .iter()
-                            .filter(|v| {
-                                is_variant_inhabited(v, &type_args, generics, ctx.store, cache)
-                            })
-                            .map(|v| Constructor {
-                                tag_id: format!("{}.{}", enum_name, v.name),
-                                arity: v.fields.len(),
-                            })
-                            .collect(),
-                        Some(DefinitionBody::Struct {
-                            fields: struct_fields,
-                            generics,
-                            ..
-                        }) if super::inhabitance::is_struct_inhabited(
-                            struct_fields,
-                            &type_args,
-                            generics,
-                            ctx.store,
-                            cache,
-                        ) =>
-                        {
-                            vec![Constructor {
-                                tag_id: tag.clone(),
-                                arity: struct_fields.len(),
-                            }]
-                        }
-                        _ => vec![],
-                    };
-
-                    unions.insert(type_name.clone(), alternatives);
-                }
-
-                NormalizedPattern::Constructor {
-                    type_name,
-                    tag,
-                    args: patterns,
-                }
-            }
-        },
+        } => normalize_enum_variant_pattern(fields, *rest, resolution, ty, unions, ctx, cache),
 
         Pattern::Struct {
             fields,
             ty,
-            resolution:
-                RecordPatternResolution::EnumVariant {
-                    enum_name,
-                    variant_name,
-                },
+            resolution,
             ..
-        } => {
-            let type_args = pattern_type_args(ctx, ty);
-            let Some(Definition {
-                body:
-                    DefinitionBody::Enum {
-                        variants, generics, ..
-                    },
-                ..
-            }) = ctx.store.get_definition(enum_name)
-            else {
-                return Wildcard;
-            };
-            let Some(variant) = variants
-                .iter()
-                .find(|variant| variant.name == unqualified_name(variant_name))
-            else {
-                return Wildcard;
-            };
-            let substitution = build_substitution_map(generics, &type_args);
-            let patterns = variant
-                .fields
-                .iter()
-                .map(|f| {
-                    fields
-                        .iter()
-                        .find_map(|field| {
-                            if field.name == f.name {
-                                let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
-                                Some(normalize_pattern(&field.value, unions, &child, cache))
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or(Wildcard)
-                })
-                .collect();
-
-            let type_name = make_type_key(enum_name, &type_args);
-
-            if unions.get(&type_name).is_none() {
-                let alternatives = variants
-                    .iter()
-                    .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, cache))
-                    .map(|v| Constructor {
-                        tag_id: format!("{}.{}", enum_name, v.name),
-                        arity: v.fields.len(),
-                    })
-                    .collect();
-
-                unions.insert(type_name.clone(), alternatives);
-            }
-
-            let variant_name = unqualified_name(variant_name);
-            let tag = format!("{}.{}", enum_name, variant_name);
-
-            NormalizedPattern::Constructor {
-                type_name,
-                tag,
-                args: patterns,
-            }
-        }
-
-        Pattern::Struct {
-            fields,
-            ty,
-            resolution: RecordPatternResolution::Struct { struct_name },
-            ..
-        } => {
-            let type_args = pattern_type_args(ctx, ty);
-            let Some(Definition {
-                body:
-                    DefinitionBody::Struct {
-                        fields: struct_fields,
-                        generics,
-                        ..
-                    },
-                ..
-            }) = ctx.store.get_definition(struct_name)
-            else {
-                return Wildcard;
-            };
-            let substitution = build_substitution_map(generics, &type_args);
-            let patterns: Vec<NormalizedPattern> = struct_fields
-                .iter()
-                .map(|f| {
-                    fields
-                        .iter()
-                        .find_map(|field| {
-                            if field.name == f.name {
-                                let child = ctx.at_position(Some(substitute(&f.ty, &substitution)));
-                                Some(normalize_pattern(&field.value, unions, &child, cache))
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or(Wildcard)
-                })
-                .collect();
-
-            if let Some(normalized) = try_normalize_interface_implementer(
-                ctx,
-                struct_name,
-                struct_fields.len(),
-                patterns.clone(),
-                unions,
-            ) {
-                return normalized;
-            }
-
-            let type_name = make_type_key(struct_name, &type_args);
-
-            if unions.get(&type_name).is_none() {
-                let is_inhabited = super::inhabitance::is_struct_inhabited(
-                    struct_fields,
-                    &type_args,
-                    generics,
-                    ctx.store,
-                    cache,
-                );
-
-                if is_inhabited {
-                    let constructor = Constructor {
-                        tag_id: struct_name.to_string(),
-                        arity: struct_fields.len(),
-                    };
-                    unions.insert(type_name.clone(), vec![constructor]);
-                } else {
-                    unions.insert(type_name.clone(), vec![]);
-                }
-            }
-
-            NormalizedPattern::Constructor {
-                type_name,
-                tag: struct_name.to_string(),
-                args: patterns,
-            }
-        }
-
-        Pattern::Struct {
-            resolution: RecordPatternResolution::Unresolved,
-            ..
-        } => Wildcard,
+        } => normalize_record_pattern(fields, ty, resolution, unions, ctx, cache),
 
         Pattern::Slice {
             prefix,
@@ -462,6 +184,307 @@ pub fn normalize_pattern(
     }
 }
 
+fn normalize_enum_variant_pattern(
+    fields: &[Pattern],
+    rest: bool,
+    resolution: &ConstructorPatternResolution,
+    ty: &Type,
+    unions: &mut UnionTable,
+    ctx: &NormalizationContext,
+    cache: &mut InhabitanceCache,
+) -> NormalizedPattern {
+    match resolution {
+        ConstructorPatternResolution::Unresolved => Wildcard,
+        ConstructorPatternResolution::Const { qualified_name } => {
+            NormalizedPattern::OpaqueConst(qualified_name.to_string())
+        }
+        ConstructorPatternResolution::ConstValue { value, .. } => match value {
+            Literal::Boolean(b) => normalize_boolean(*b, unions),
+            literal => NormalizedPattern::Literal(literal.clone()),
+        },
+        ConstructorPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } => {
+            let type_args = pattern_type_args(ctx, ty);
+            let enum_def = ctx.store.get_definition(enum_name);
+            let field_types = match enum_def.map(|definition| &definition.body) {
+                Some(DefinitionBody::Struct {
+                    fields, generics, ..
+                }) => substituted_field_types(
+                    generics,
+                    fields.iter().map(|field| &field.ty),
+                    &type_args,
+                ),
+                Some(DefinitionBody::Enum {
+                    variants, generics, ..
+                }) => {
+                    let Some(variant) = find_variant(variants, variant_name) else {
+                        return Wildcard;
+                    };
+                    substituted_field_types(
+                        generics,
+                        variant.fields.iter().map(|field| &field.ty),
+                        &type_args,
+                    )
+                }
+                _ => return Wildcard,
+            };
+            let patterns: Vec<NormalizedPattern> = fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| {
+                    let child = ctx.at_position(field_types.get(i).cloned());
+                    normalize_pattern(f, unions, &child, cache)
+                })
+                .collect();
+
+            let mut patterns = patterns;
+            if rest && patterns.len() < field_types.len() {
+                patterns.resize(field_types.len(), Wildcard);
+            }
+
+            if let Some(Definition {
+                body:
+                    DefinitionBody::Struct {
+                        fields: struct_fields,
+                        ..
+                    },
+                ..
+            }) = enum_def
+            {
+                let arity = struct_fields.len();
+                let mut args = patterns.clone();
+                while args.len() < arity {
+                    args.push(Wildcard);
+                }
+                if let Some(normalized) =
+                    try_normalize_interface_implementer(ctx, enum_name, arity, args, unions)
+                {
+                    return normalized;
+                }
+            }
+
+            let type_name = make_type_key(enum_name, &type_args);
+            let enum_body = enum_def.map(|d| &d.body);
+
+            // Tuple struct / newtype tags are the bare type name (like record
+            // structs); enum variants are `Type.Variant`.
+            let is_struct_def = matches!(enum_body, Some(DefinitionBody::Struct { .. }));
+            let tag = if is_struct_def {
+                enum_name.to_string()
+            } else {
+                format!("{}.{}", enum_name, unqualified_name(variant_name))
+            };
+
+            register_union(unions, &type_name, || match enum_body {
+                Some(DefinitionBody::Enum {
+                    variants, generics, ..
+                }) => variants
+                    .iter()
+                    .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, cache))
+                    .map(|v| Constructor {
+                        tag_id: format!("{}.{}", enum_name, v.name),
+                        arity: v.fields.len(),
+                    })
+                    .collect(),
+                Some(DefinitionBody::Struct {
+                    fields: struct_fields,
+                    generics,
+                    ..
+                }) if super::inhabitance::is_struct_inhabited(
+                    struct_fields,
+                    &type_args,
+                    generics,
+                    ctx.store,
+                    cache,
+                ) =>
+                {
+                    vec![Constructor {
+                        tag_id: tag.clone(),
+                        arity: struct_fields.len(),
+                    }]
+                }
+                _ => vec![],
+            });
+
+            NormalizedPattern::Constructor {
+                type_name,
+                tag,
+                args: patterns,
+            }
+        }
+    }
+}
+
+fn normalize_record_pattern(
+    fields: &[StructFieldPattern],
+    ty: &Type,
+    resolution: &RecordPatternResolution,
+    unions: &mut UnionTable,
+    ctx: &NormalizationContext,
+    cache: &mut InhabitanceCache,
+) -> NormalizedPattern {
+    match resolution {
+        RecordPatternResolution::Unresolved => Wildcard,
+
+        RecordPatternResolution::EnumVariant {
+            enum_name,
+            variant_name,
+        } => {
+            let type_args = pattern_type_args(ctx, ty);
+            let Some(Definition {
+                body:
+                    DefinitionBody::Enum {
+                        variants, generics, ..
+                    },
+                ..
+            }) = ctx.store.get_definition(enum_name)
+            else {
+                return Wildcard;
+            };
+            let Some(variant) = find_variant(variants, variant_name) else {
+                return Wildcard;
+            };
+            let field_types =
+                substituted_field_types(generics, variant.fields.iter().map(|f| &f.ty), &type_args);
+            let patterns = variant
+                .fields
+                .iter()
+                .zip(field_types)
+                .map(|(f, field_type)| {
+                    field_pattern_or_wildcard(fields, &f.name, field_type, unions, ctx, cache)
+                })
+                .collect();
+
+            let type_name = make_type_key(enum_name, &type_args);
+
+            register_union(unions, &type_name, || {
+                variants
+                    .iter()
+                    .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, cache))
+                    .map(|v| Constructor {
+                        tag_id: format!("{}.{}", enum_name, v.name),
+                        arity: v.fields.len(),
+                    })
+                    .collect()
+            });
+
+            let tag = format!("{}.{}", enum_name, unqualified_name(variant_name));
+
+            NormalizedPattern::Constructor {
+                type_name,
+                tag,
+                args: patterns,
+            }
+        }
+
+        RecordPatternResolution::Struct { struct_name } => {
+            let type_args = pattern_type_args(ctx, ty);
+            let Some(Definition {
+                body:
+                    DefinitionBody::Struct {
+                        fields: struct_fields,
+                        generics,
+                        ..
+                    },
+                ..
+            }) = ctx.store.get_definition(struct_name)
+            else {
+                return Wildcard;
+            };
+            let field_types =
+                substituted_field_types(generics, struct_fields.iter().map(|f| &f.ty), &type_args);
+            let patterns: Vec<NormalizedPattern> = struct_fields
+                .iter()
+                .zip(field_types)
+                .map(|(f, field_type)| {
+                    field_pattern_or_wildcard(fields, &f.name, field_type, unions, ctx, cache)
+                })
+                .collect();
+
+            if let Some(normalized) = try_normalize_interface_implementer(
+                ctx,
+                struct_name,
+                struct_fields.len(),
+                patterns.clone(),
+                unions,
+            ) {
+                return normalized;
+            }
+
+            let type_name = make_type_key(struct_name, &type_args);
+
+            register_union(unions, &type_name, || {
+                if super::inhabitance::is_struct_inhabited(
+                    struct_fields,
+                    &type_args,
+                    generics,
+                    ctx.store,
+                    cache,
+                ) {
+                    vec![Constructor {
+                        tag_id: struct_name.to_string(),
+                        arity: struct_fields.len(),
+                    }]
+                } else {
+                    vec![]
+                }
+            });
+
+            NormalizedPattern::Constructor {
+                type_name,
+                tag: struct_name.to_string(),
+                args: patterns,
+            }
+        }
+    }
+}
+
+fn field_pattern_or_wildcard(
+    written_fields: &[StructFieldPattern],
+    field_name: &str,
+    field_type: Type,
+    unions: &mut UnionTable,
+    ctx: &NormalizationContext,
+    cache: &mut InhabitanceCache,
+) -> NormalizedPattern {
+    written_fields
+        .iter()
+        .find_map(|field| {
+            if field.name == field_name {
+                let child = ctx.at_position(Some(field_type.clone()));
+                Some(normalize_pattern(&field.value, unions, &child, cache))
+            } else {
+                None
+            }
+        })
+        .unwrap_or(Wildcard)
+}
+
+fn substituted_field_types<'a>(
+    generics: &[Generic],
+    field_types: impl Iterator<Item = &'a Type>,
+    type_args: &[Type],
+) -> Vec<Type> {
+    let substitution = build_substitution_map(generics, type_args);
+    field_types
+        .map(|ty| substitute(ty, &substitution))
+        .collect()
+}
+
+fn find_variant<'a>(variants: &'a [EnumVariant], variant_name: &str) -> Option<&'a EnumVariant> {
+    variants
+        .iter()
+        .find(|variant| variant.name == unqualified_name(variant_name))
+}
+
+fn register_union(unions: &mut UnionTable, type_name: &str, alternatives: impl FnOnce() -> Union) {
+    if unions.get(type_name).is_none() {
+        unions.insert(type_name.to_string(), alternatives());
+    }
+}
+
 fn normalize_slice(
     prefix: &[Pattern],
     has_rest: bool,
@@ -471,23 +494,21 @@ fn normalize_slice(
     cache: &mut InhabitanceCache,
 ) -> NormalizedPattern {
     let type_name = make_type_key("Slice", std::slice::from_ref(element_type));
-    if unions.get(&type_name).is_none() {
-        let element_inhabited = is_inhabited(element_type, ctx.store, cache);
-
+    register_union(unions, &type_name, || {
         let mut constructors = vec![Constructor {
             tag_id: "EmptySlice".to_string(),
             arity: 0,
         }];
 
-        if element_inhabited {
+        if is_inhabited(element_type, ctx.store, cache) {
             constructors.push(Constructor {
                 tag_id: "NonEmptySlice".to_string(),
                 arity: 2, // head and tail
             });
         }
 
-        unions.insert(type_name.clone(), constructors);
-    }
+        constructors
+    });
 
     if prefix.is_empty() && has_rest {
         return Wildcard;
@@ -534,13 +555,12 @@ fn normalize_tuple(
     let arity = elements.len();
     let type_name = format!("Tuple{}", arity);
 
-    if unions.get(&type_name).is_none() {
-        let constructor = Constructor {
+    register_union(unions, &type_name, || {
+        vec![Constructor {
             tag_id: type_name.clone(),
             arity,
-        };
-        unions.insert(type_name.clone(), vec![constructor]);
-    }
+        }]
+    });
 
     let element_types = match ctx.scrutinee_type.as_ref().map(|t| ctx.store.peel_alias(t)) {
         Some(Type::Tuple(types)) => Some(types),
@@ -577,15 +597,12 @@ fn normalize_array(
     );
 
     if length == 0 {
-        if unions.get(&type_name).is_none() {
-            unions.insert(
-                type_name.clone(),
-                vec![Constructor {
-                    tag_id: "ArrayNil".to_string(),
-                    arity: 0,
-                }],
-            );
-        }
+        register_union(unions, &type_name, || {
+            vec![Constructor {
+                tag_id: "ArrayNil".to_string(),
+                arity: 0,
+            }]
+        });
         return NormalizedPattern::Constructor {
             type_name,
             tag: "ArrayNil".to_string(),
@@ -593,17 +610,16 @@ fn normalize_array(
         };
     }
 
-    if unions.get(&type_name).is_none() {
-        let constructors = if is_inhabited(element_type, ctx.store, cache) {
+    register_union(unions, &type_name, || {
+        if is_inhabited(element_type, ctx.store, cache) {
             vec![Constructor {
                 tag_id: "ArrayCons".to_string(),
                 arity: 2,
             }]
         } else {
             vec![]
-        };
-        unions.insert(type_name.clone(), constructors);
-    }
+        }
+    });
 
     let Some((first, rest)) = prefix.split_first() else {
         return Wildcard;
@@ -623,14 +639,14 @@ fn normalize_array(
 fn normalize_boolean(boolean: bool, unions: &mut UnionTable) -> NormalizedPattern {
     let type_name = "Bool".to_string();
 
-    if unions.get(&type_name).is_none() {
+    register_union(unions, &type_name, || {
         let make_alt = |b: bool| Constructor {
             tag_id: b.to_string(),
             arity: 0,
         };
 
-        unions.insert(type_name.clone(), vec![make_alt(true), make_alt(false)]);
-    }
+        vec![make_alt(true), make_alt(false)]
+    });
 
     NormalizedPattern::Constructor {
         type_name,

--- a/crates/passes/src/passes/diagnostic_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/diagnostic_producers/unused_expressions.rs
@@ -33,8 +33,7 @@ fn visit_expression(
         Expression::Block { items, ty, .. }
         | Expression::TryBlock { items, ty, .. }
         | Expression::RecoverBlock { items, ty, .. } => {
-            let tail_is_discarded =
-                tail_ctx.is_some() || ty.is_unit() || ty.is_ignored() || ty.is_never();
+            let tail_is_discarded = tail_ctx.is_some() || discards_value(ty);
             visit_block_items(items, tail_is_discarded, tail_ctx, module_id, store, facts);
         }
         Expression::Function {
@@ -46,14 +45,7 @@ fn visit_expression(
             let Some(body) = body.definition() else {
                 return;
             };
-            let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
-            let body_ty = body.get_type();
-            let tail_is_discarded = is_implicit_return
-                && (return_type.is_unit() || body_ty.is_ignored() || body_ty.is_never());
-            let ctx = tail_is_discarded.then(|| TailContext {
-                expected_span: signature_marker_span(body.get_span()),
-                expected_ty: return_type,
-            });
+            let ctx = tail_context_for_function(body, return_type, return_annotation);
             visit_expression(body, ctx.as_ref(), module_id, store, facts);
             return;
         }
@@ -64,24 +56,10 @@ fn visit_expression(
             return_annotation,
             ..
         } => {
-            let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
-            let lambda_returns_unit = matches!(ty, Type::Function(f) if f.return_type.is_unit());
             let body_ty = body.get_type();
-            let tail_is_discarded = is_implicit_return
-                && (lambda_returns_unit
-                    || body_ty.is_unit()
-                    || body_ty.is_ignored()
-                    || body_ty.is_never());
-            let lambda_return_ty: &Type = match ty {
-                Type::Function(f) => &f.return_type,
-                _ => &body_ty,
-            };
-            let ctx = tail_is_discarded.then(|| TailContext {
-                expected_span: signature_marker_span(*span),
-                expected_ty: lambda_return_ty,
-            });
+            let ctx = tail_context_for_lambda(ty, *span, return_annotation, &body_ty);
 
-            if tail_is_discarded && !matches!(body.as_ref(), Expression::Block { .. }) {
+            if ctx.is_some() && !matches!(body.as_ref(), Expression::Block { .. }) {
                 descend_discarded(
                     body,
                     &DiscardMode::Tail(ctx.as_ref().into()),
@@ -94,22 +72,22 @@ fn visit_expression(
             visit_expression(body, ctx.as_ref(), module_id, store, facts);
             return;
         }
-        Expression::For { iterable, body, .. } => {
-            visit_expression(iterable, None, module_id, store, facts);
-            visit_loop_body(body, module_id, store, facts);
-            return;
+        Expression::For {
+            iterable: pre_child,
+            body,
+            ..
         }
-        Expression::While {
-            condition, body, ..
-        } => {
-            visit_expression(condition, None, module_id, store, facts);
-            visit_loop_body(body, module_id, store, facts);
-            return;
+        | Expression::While {
+            condition: pre_child,
+            body,
+            ..
         }
-        Expression::WhileLet {
-            scrutinee, body, ..
+        | Expression::WhileLet {
+            scrutinee: pre_child,
+            body,
+            ..
         } => {
-            visit_expression(scrutinee, None, module_id, store, facts);
+            visit_expression(pre_child, None, module_id, store, facts);
             visit_loop_body(body, module_id, store, facts);
             return;
         }
@@ -123,6 +101,45 @@ fn visit_expression(
     for child in expression.children() {
         visit_expression(child, None, module_id, store, facts);
     }
+}
+
+fn discards_value(ty: &Type) -> bool {
+    ty.is_unit() || ty.is_ignored() || ty.is_never()
+}
+
+fn tail_context_for_function<'a>(
+    body: &Expression,
+    return_type: &'a Type,
+    return_annotation: &Annotation,
+) -> Option<TailContext<'a>> {
+    let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
+    let body_ty = body.get_type();
+    // Deliberately tests return_type.is_unit(), not body_ty.is_unit(), unlike the lambda case.
+    let tail_is_discarded =
+        is_implicit_return && (return_type.is_unit() || body_ty.is_ignored() || body_ty.is_never());
+    tail_is_discarded.then(|| TailContext {
+        expected_span: signature_marker_span(body.get_span()),
+        expected_ty: return_type,
+    })
+}
+
+fn tail_context_for_lambda<'a>(
+    ty: &'a Type,
+    span: Span,
+    return_annotation: &Annotation,
+    body_ty: &'a Type,
+) -> Option<TailContext<'a>> {
+    let is_implicit_return = matches!(return_annotation, Annotation::Unknown);
+    let lambda_returns_unit = matches!(ty, Type::Function(f) if f.return_type.is_unit());
+    let tail_is_discarded = is_implicit_return && (lambda_returns_unit || discards_value(body_ty));
+    let lambda_return_ty: &'a Type = match ty {
+        Type::Function(f) => &f.return_type,
+        _ => body_ty,
+    };
+    tail_is_discarded.then(|| TailContext {
+        expected_span: signature_marker_span(span),
+        expected_ty: lambda_return_ty,
+    })
 }
 
 fn visit_loop_body(

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -7,7 +7,7 @@ use syntax::ast::{
     SelectArm, StructSpread,
 };
 use syntax::program::File;
-use syntax::program::{DefinitionBody, DotAccessKind, EqualityIndex, Module};
+use syntax::program::{DefinitionBody, DotAccessKind, DotAccessResolution, EqualityIndex, Module};
 use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 
 use super::reference_graph::{EnumVariantId, ModuleItemId, ReferenceGraph, StructFieldId};
@@ -52,6 +52,12 @@ fn deref_for_keying(ty: &Type, aliases: &AliasMap) -> Type {
     aliases.store.peel_refs_and_aliases(ty).0
 }
 
+// ctx is `None` at the top level. Function/Const nest inside an enclosing item and inherit
+// it when present; every other item kind below always self-derives from its own name.
+fn item_ctx(ctx: Option<&ModuleItemId>, name: &str) -> ModuleItemId {
+    ctx.cloned().unwrap_or_else(|| ModuleItemId::new(name))
+}
+
 pub(super) fn walk_expression(
     module: &Module,
     expression: &Expression,
@@ -93,46 +99,14 @@ pub(super) fn walk_expression(
             resolution,
             ..
         } => {
-            walk_expression(module, expression, graph, alias_map, ctx);
-            let receiver_ty = expression.get_type();
-            if let Some(ty_name) = qualified_type_name(&receiver_ty, alias_map) {
-                graph.mark_struct_field_used(StructFieldId::new(ty_name.as_str(), member));
-            }
-            mark_promoted_field_read(&receiver_ty, member, graph, alias_map);
-            if let Some(from) = ctx
-                && is_method_access(resolution.kind())
-                && credits_local_method(&expression.get_type(), module, alias_map)
-            {
-                let to = method_node(member, &expression.get_type(), alias_map);
-                graph.add_reference(from, to);
-            }
-            if let Some(from) = ctx
-                && member == "equals"
-                && is_container_receiver(&expression.get_type(), alias_map)
-            {
-                add_equals_references(graph, from, &expression.get_type(), module, alias_map);
-            }
+            walk_dot_access(
+                module, expression, member, resolution, graph, alias_map, ctx,
+            );
         }
 
-        Expression::Function {
-            name,
-            generics,
-            params,
-            return_annotation,
-            body,
-            ..
-        } => {
-            let fn_ctx = ctx.cloned().unwrap_or_else(|| ModuleItemId::new(name));
-            walk_callable_body(
-                module,
-                generics,
-                params,
-                return_annotation,
-                body.definition(),
-                graph,
-                alias_map,
-                &fn_ctx,
-            );
+        Expression::Function { name, .. } => {
+            let fn_ctx = item_ctx(ctx, name);
+            walk_function_like(module, expression, graph, alias_map, &fn_ctx);
         }
 
         Expression::Const {
@@ -141,9 +115,7 @@ pub(super) fn walk_expression(
             expression,
             ..
         } => {
-            let const_ctx = ctx
-                .cloned()
-                .unwrap_or_else(|| ModuleItemId::new(identifier));
+            let const_ctx = item_ctx(ctx, identifier);
             if let Some(ann) = annotation {
                 walk_annotation(module, ann, graph, alias_map, &const_ctx);
             }
@@ -159,12 +131,12 @@ pub(super) fn walk_expression(
             ..
         } => {
             let enum_ctx = ModuleItemId::new(name);
-            let owner = format!("{}.{}", module.id, name);
-            let has_equality = has_equality_attr(attributes);
+            let synthesizes_equality =
+                has_synthesized_equality(module, name, attributes, alias_map);
             for v in variants {
                 for f in &v.fields {
                     walk_annotation(module, &f.annotation, graph, alias_map, &enum_ctx);
-                    if has_equality && alias_map.store.equality_index.is_synthesized(&owner) {
+                    if synthesizes_equality {
                         mark_equals_roots(graph, &f.ty, module, alias_map);
                     }
                 }
@@ -184,11 +156,11 @@ pub(super) fn walk_expression(
                     walk_annotation(module, bound, graph, alias_map, &struct_ctx);
                 }
             }
-            let owner = format!("{}.{}", module.id, name);
-            let has_equality = has_equality_attr(attributes);
+            let synthesizes_equality =
+                has_synthesized_equality(module, name, attributes, alias_map);
             for f in fields {
                 walk_annotation(module, &f.annotation, graph, alias_map, &struct_ctx);
-                if has_equality && alias_map.store.equality_index.is_synthesized(&owner) {
+                if synthesizes_equality {
                     mark_equals_roots(graph, &f.ty, module, alias_map);
                 }
             }
@@ -274,26 +246,9 @@ pub(super) fn walk_expression(
                 }
             }
             for m in methods {
-                if let Expression::Function {
-                    name,
-                    generics,
-                    params,
-                    return_annotation,
-                    body,
-                    ..
-                } = m
-                {
+                if let Expression::Function { name, .. } = m {
                     let method_ctx = ModuleItemId::method(name, receiver_name);
-                    walk_callable_body(
-                        module,
-                        generics,
-                        params,
-                        return_annotation,
-                        body.definition(),
-                        graph,
-                        alias_map,
-                        &method_ctx,
-                    );
+                    walk_function_like(module, m, graph, alias_map, &method_ctx);
                 } else {
                     walk_expression(module, m, graph, alias_map, ctx);
                 }
@@ -512,6 +467,36 @@ fn walk_struct_call(
                 }
             }
         }
+    }
+}
+
+fn walk_dot_access(
+    module: &Module,
+    expression: &Expression,
+    member: &str,
+    resolution: &DotAccessResolution,
+    graph: &mut ReferenceGraph,
+    alias_map: &AliasMap,
+    ctx: Option<&ModuleItemId>,
+) {
+    walk_expression(module, expression, graph, alias_map, ctx);
+    let receiver_ty = expression.get_type();
+    if let Some(ty_name) = qualified_type_name(&receiver_ty, alias_map) {
+        graph.mark_struct_field_used(StructFieldId::new(ty_name.as_str(), member));
+    }
+    mark_promoted_field_read(&receiver_ty, member, graph, alias_map);
+    if let Some(from) = ctx
+        && is_method_access(resolution.kind())
+        && credits_local_method(&receiver_ty, module, alias_map)
+    {
+        let to = method_node(member, &receiver_ty, alias_map);
+        graph.add_reference(from, to);
+    }
+    if let Some(from) = ctx
+        && member == "equals"
+        && is_container_receiver(&receiver_ty, alias_map)
+    {
+        add_equals_references(graph, from, &receiver_ty, module, alias_map);
     }
 }
 
@@ -771,6 +756,35 @@ fn is_method_access(kind: Option<DotAccessKind>) -> bool {
     )
 }
 
+fn walk_function_like(
+    module: &Module,
+    expr: &Expression,
+    graph: &mut ReferenceGraph,
+    alias_map: &AliasMap,
+    ctx_id: &ModuleItemId,
+) {
+    let Expression::Function {
+        generics,
+        params,
+        return_annotation,
+        body,
+        ..
+    } = expr
+    else {
+        return;
+    };
+    walk_callable_body(
+        module,
+        generics,
+        params,
+        return_annotation,
+        body.definition(),
+        graph,
+        alias_map,
+        ctx_id,
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 fn walk_callable_body(
     module: &Module,
@@ -824,6 +838,16 @@ fn credits_local_method(receiver_ty: &Type, module: &Module, aliases: &AliasMap)
 
 fn has_equality_attr(attributes: &[Attribute]) -> bool {
     attributes.iter().any(|a| a.name == "equality")
+}
+
+fn has_synthesized_equality(
+    module: &Module,
+    name: &str,
+    attributes: &[Attribute],
+    alias_map: &AliasMap,
+) -> bool {
+    let owner = format!("{}.{}", module.id, name);
+    has_equality_attr(attributes) && alias_map.store.equality_index.is_synthesized(&owner)
 }
 
 fn add_equals_references(

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -14,7 +14,9 @@ use diagnostics::{Edit, Fix};
 use semantics::context::AnalysisContext;
 use semantics::facts::Facts;
 use semantics::store::Store;
-use syntax::ast::{Attribute, AttributeArg, Expression, ImportAlias, Span, Visibility};
+use syntax::ast::{
+    Attribute, AttributeArg, Expression, ImportAlias, Span, StructFieldDefinition, Visibility,
+};
 use syntax::program::EqualityIndex;
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
@@ -221,8 +223,7 @@ fn collect_items(
                     ..
                 } => {
                     let id = ModuleItemId::new(name);
-                    let is_test = syntax::attributes::has_test_attribute(attributes);
-                    let is_entry = *visibility == Visibility::Public || name == "main" || is_test;
+                    let is_entry = function_is_entry(name, *visibility, attributes);
                     graph.add_item(id, *name_span, ItemKind::Function, is_entry);
                 }
                 Expression::Const {
@@ -272,25 +273,17 @@ fn collect_items(
                     let is_public = *visibility == Visibility::Public;
                     graph.add_item(id, *name_span, ItemKind::Type, is_public);
 
-                    let has_serialization_attr = has_serialization_attr(attributes);
-
-                    let has_display_attr = attributes.iter().any(|a| a.name == "display");
                     let qualified_name = format!("{module_id}.{name}");
-                    let synthesizes_equals = equality_index.is_synthesized(&qualified_name);
+                    let flags = StructLintFlags {
+                        is_public,
+                        has_serialization_attr: has_serialization_attr(attributes),
+                        has_display_attr: attributes.iter().any(|a| a.name == "display"),
+                        synthesizes_equals: equality_index.is_synthesized(&qualified_name),
+                    };
 
                     for struct_field in fields {
-                        let field_id = StructFieldId::new(&qualified_name, &struct_field.name);
-                        let has_tag_attribute =
-                            struct_field.attributes().iter().any(|a| a.name == "tag");
-                        let lint_candidate = struct_field.visibility != Visibility::Public
-                            && !is_public
-                            && !has_serialization_attr
-                            && !has_display_attr
-                            && !synthesizes_equals
-                            && !has_tag_attribute
-                            && !struct_field.is_embedded()
-                            && !struct_field.name.starts_with('_');
-                        if lint_candidate {
+                        if field_is_lint_candidate(struct_field, &flags) {
+                            let field_id = StructFieldId::new(&qualified_name, &struct_field.name);
                             graph.add_struct_field(field_id, struct_field.name_span);
                         }
                     }
@@ -300,16 +293,8 @@ fn collect_items(
                     name_span,
                     visibility,
                     ..
-                } => {
-                    let id = ModuleItemId::new(name);
-                    graph.add_item(
-                        id,
-                        *name_span,
-                        ItemKind::Type,
-                        *visibility == Visibility::Public,
-                    );
                 }
-                Expression::Interface {
+                | Expression::Interface {
                     name,
                     name_span,
                     visibility,
@@ -337,9 +322,7 @@ fn collect_items(
                         } = method
                         {
                             let id = ModuleItemId::method(name, receiver_name);
-                            let is_entry = *visibility == Visibility::Public
-                                || is_upper(name)
-                                || matches!(name.as_str(), "string" | "goString" | "error");
+                            let is_entry = method_is_entry(name, *visibility);
                             graph.add_item(id, *name_span, ItemKind::Function, is_entry);
                         }
                     }
@@ -348,6 +331,35 @@ fn collect_items(
             }
         }
     }
+}
+
+fn function_is_entry(name: &str, visibility: Visibility, attributes: &[Attribute]) -> bool {
+    let is_test = syntax::attributes::has_test_attribute(attributes);
+    visibility == Visibility::Public || name == "main" || is_test
+}
+
+fn method_is_entry(name: &str, visibility: Visibility) -> bool {
+    visibility == Visibility::Public
+        || is_upper(name)
+        || matches!(name, "string" | "goString" | "error")
+}
+
+struct StructLintFlags {
+    is_public: bool,
+    has_serialization_attr: bool,
+    has_display_attr: bool,
+    synthesizes_equals: bool,
+}
+
+fn field_is_lint_candidate(field: &StructFieldDefinition, flags: &StructLintFlags) -> bool {
+    field.visibility != Visibility::Public
+        && !flags.is_public
+        && !flags.has_serialization_attr
+        && !flags.has_display_attr
+        && !flags.synthesizes_equals
+        && !field.attributes().iter().any(|a| a.name == "tag")
+        && !field.is_embedded()
+        && !field.name.starts_with('_')
 }
 
 fn has_serialization_attr(attributes: &[Attribute]) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -587,118 +587,8 @@ impl InferCtx<'_> {
         let iterable_ty = self.new_type_var();
         let new_iterable = self.infer_expression(*iterable, &iterable_ty);
 
-        let resolved_unpeeled = iterable_ty.resolve_in(&self.env);
-        let iter_seq = iter_seq_kind(&resolved_unpeeled);
-
-        // `iter.Seq<V>` / `iter.Seq2<K, V>` are Go range-over-func iterators
-        // stored as function aliases. Keep the nominal so its name and type args
-        // stay available; peeling expands it to an unnamed `fn(...)` shape.
-        let resolved_iterable_ty = if iter_seq.is_some() {
-            resolved_unpeeled
-        } else {
-            store.peel_alias(&resolved_unpeeled)
-        };
-
-        let iterable_is_error = resolved_iterable_ty.is_error();
-
-        let iterable_ty_name = match resolved_iterable_ty.get_name() {
-            Some(name) => name,
-            None => {
-                if !iterable_is_error {
-                    self.sink.push(diagnostics::infer::unknown_iterable_type(
-                        new_iterable.get_span(),
-                    ));
-                }
-                "Slice"
-            }
-        };
-
-        let fallback_args;
-        let iterable_ty_args = match resolved_iterable_ty.get_type_params() {
-            Some(args) => args,
-            None => {
-                let element = if iterable_is_error {
-                    Type::Error
-                } else {
-                    self.new_type_var()
-                };
-                fallback_args = [element.clone(), element];
-                &fallback_args
-            }
-        };
-
-        let element_ty = match iterable_ty_name {
-            "string" => {
-                let receiver = new_iterable.root_identifier().unwrap_or("s");
-                self.sink.push(diagnostics::infer::string_not_iterable(
-                    new_iterable.get_span(),
-                    receiver,
-                ));
-                Type::Error
-            }
-            "Slice" | "EnumeratedSlice" | "Receiver" | "Channel"
-                if !iterable_ty_args.is_empty() =>
-            {
-                if iterable_ty_name == "EnumeratedSlice" {
-                    Type::Tuple(vec![self.type_int(), iterable_ty_args[0].clone()])
-                } else {
-                    iterable_ty_args[0].clone()
-                }
-            }
-
-            // Array yields its element directly (not via `get_type_params`).
-            // A `Ref<Array>` peers to "Array" here but must be deref'd first.
-            "Array" => match &resolved_iterable_ty {
-                Type::Array { element, .. } => element.as_ref().clone(),
-                _ => {
-                    self.sink.push(diagnostics::infer::not_iterable(
-                        &resolved_iterable_ty,
-                        new_iterable.get_span(),
-                    ));
-                    Type::Error
-                }
-            },
-            "Map" if iterable_ty_args.len() >= 2 => Type::Tuple(vec![
-                iterable_ty_args[0].clone(),
-                iterable_ty_args[1].clone(),
-            ]),
-
-            "Seq" if iter_seq.is_some() && !iterable_ty_args.is_empty() => {
-                iterable_ty_args[0].clone()
-            }
-            "Seq2" if iter_seq.is_some() && iterable_ty_args.len() >= 2 => Type::Tuple(vec![
-                iterable_ty_args[0].clone(),
-                iterable_ty_args[1].clone(),
-            ]),
-
-            "Range" | "RangeInclusive" | "RangeFrom" if !iterable_ty_args.is_empty() => {
-                let elem_ty = &iterable_ty_args[0];
-                if elem_ty.get_name() != Some("int") && !elem_ty.is_variable() {
-                    self.sink
-                        .push(diagnostics::infer::non_int_range_not_iterable(
-                            elem_ty,
-                            new_iterable.get_span(),
-                        ));
-                }
-                elem_ty.clone()
-            }
-
-            "RangeTo" | "RangeToInclusive" => {
-                self.sink.push(diagnostics::infer::range_not_iterable(
-                    iterable_ty_name,
-                    new_iterable.get_span(),
-                ));
-                Type::Error
-            }
-
-            _ => {
-                self.sink.push(diagnostics::infer::not_iterable(
-                    &resolved_iterable_ty,
-                    new_iterable.get_span(),
-                ));
-                Type::Error
-            }
-        };
+        let (element_ty, iterable_ty_name, iter_seq) =
+            self.for_element_type(&iterable_ty, &new_iterable);
 
         if let Some(annotation) = &binding.annotation {
             let annotated_ty = self.convert_to_type(store, annotation, &span);
@@ -720,7 +610,7 @@ impl InferCtx<'_> {
             };
 
             let requires_tuple_destructuring =
-                matches!(iterable_ty_name, "Map" | "EnumeratedSlice")
+                matches!(iterable_ty_name.as_str(), "Map" | "EnumeratedSlice")
                     || matches!(iter_seq, Some(IterSeqKind::Seq2));
             if requires_tuple_destructuring && element_ty.is_tuple() {
                 match &new_binding.pattern {
@@ -744,6 +634,128 @@ impl InferCtx<'_> {
             body: new_body.into(),
             span,
         }
+    }
+
+    /// Derives a for-loop's element type, name, and `iter.Seq` kind from its iterable type.
+    fn for_element_type(
+        &mut self,
+        iterable_ty: &Type,
+        iterable_expr: &Expression,
+    ) -> (Type, String, Option<IterSeqKind>) {
+        let store = self.store;
+
+        let resolved_unpeeled = iterable_ty.resolve_in(&self.env);
+        let iter_seq = iter_seq_kind(&resolved_unpeeled);
+
+        let resolved_iterable_ty = if iter_seq.is_some() {
+            resolved_unpeeled
+        } else {
+            store.peel_alias(&resolved_unpeeled)
+        };
+
+        let iterable_is_error = resolved_iterable_ty.is_error();
+
+        let iterable_ty_name = match resolved_iterable_ty.get_name() {
+            Some(name) => name,
+            None => {
+                if !iterable_is_error {
+                    self.sink.push(diagnostics::infer::unknown_iterable_type(
+                        iterable_expr.get_span(),
+                    ));
+                }
+                "Slice"
+            }
+        };
+
+        let fallback_args;
+        let iterable_ty_args = match resolved_iterable_ty.get_type_params() {
+            Some(args) => args,
+            None => {
+                let element = if iterable_is_error {
+                    Type::Error
+                } else {
+                    self.new_type_var()
+                };
+                fallback_args = [element.clone(), element];
+                &fallback_args
+            }
+        };
+
+        let element_ty = match iterable_ty_name {
+            "string" => {
+                let receiver = iterable_expr.root_identifier().unwrap_or("s");
+                self.sink.push(diagnostics::infer::string_not_iterable(
+                    iterable_expr.get_span(),
+                    receiver,
+                ));
+                Type::Error
+            }
+
+            "Slice" | "EnumeratedSlice" | "Receiver" | "Channel"
+                if !iterable_ty_args.is_empty() =>
+            {
+                if iterable_ty_name == "EnumeratedSlice" {
+                    Type::Tuple(vec![self.type_int(), iterable_ty_args[0].clone()])
+                } else {
+                    iterable_ty_args[0].clone()
+                }
+            }
+
+            "Array" => match &resolved_iterable_ty {
+                Type::Array { element, .. } => element.as_ref().clone(),
+                _ => {
+                    self.sink.push(diagnostics::infer::not_iterable(
+                        &resolved_iterable_ty,
+                        iterable_expr.get_span(),
+                    ));
+                    Type::Error
+                }
+            },
+
+            "Map" if iterable_ty_args.len() >= 2 => Type::Tuple(vec![
+                iterable_ty_args[0].clone(),
+                iterable_ty_args[1].clone(),
+            ]),
+
+            "Seq" if iter_seq.is_some() && !iterable_ty_args.is_empty() => {
+                iterable_ty_args[0].clone()
+            }
+
+            "Seq2" if iter_seq.is_some() && iterable_ty_args.len() >= 2 => Type::Tuple(vec![
+                iterable_ty_args[0].clone(),
+                iterable_ty_args[1].clone(),
+            ]),
+
+            "Range" | "RangeInclusive" | "RangeFrom" if !iterable_ty_args.is_empty() => {
+                let elem_ty = &iterable_ty_args[0];
+                if elem_ty.get_name() != Some("int") && !elem_ty.is_variable() {
+                    self.sink
+                        .push(diagnostics::infer::non_int_range_not_iterable(
+                            elem_ty,
+                            iterable_expr.get_span(),
+                        ));
+                }
+                elem_ty.clone()
+            }
+
+            "RangeTo" | "RangeToInclusive" => {
+                self.sink.push(diagnostics::infer::range_not_iterable(
+                    iterable_ty_name,
+                    iterable_expr.get_span(),
+                ));
+                Type::Error
+            }
+
+            _ => {
+                self.sink.push(diagnostics::infer::not_iterable(
+                    &resolved_iterable_ty,
+                    iterable_expr.get_span(),
+                ));
+                Type::Error
+            }
+        };
+
+        (element_ty, iterable_ty_name.to_string(), iter_seq)
     }
 
     pub(super) fn infer_return_statement(

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -613,94 +613,13 @@ impl InferCtx<'_> {
             self.facts.add_usage(*args.span, definition_span);
         }
 
-        // Reject cross-module tuple-struct constructors used as values
-        if !self.scopes.is_callee_context()
-            && matches!(
-                store.get_definition(&resolved_definition).map(|d| &d.body),
-                Some(DefinitionBody::Struct {
-                    fields: StructFields::Tuple(_),
-                    ..
-                })
-            )
-        {
-            let display_name = format!("{}.{}", type_name, args.member_name);
-            self.sink.push(diagnostics::infer::native_constructor_value(
-                &display_name,
-                *args.span,
-            ));
-        }
-
-        if !self.scopes.is_callee_context()
-            && !self.scopes.is_dot_access_base()
-            && matches!(
-                store.get_definition(&resolved_definition).map(|d| &d.body),
-                Some(DefinitionBody::Struct {
-                    fields: StructFields::Record(_),
-                    ..
-                })
-            )
-        {
-            let display_name = format!("{}.{}", type_name, args.member_name);
-            self.sink.push(diagnostics::infer::record_struct_value(
-                &display_name,
-                *args.span,
-            ));
-        }
-
-        if !self.scopes.is_callee_context()
-            && !self.scopes.is_dot_access_base()
-            && !self.scopes.is_let_binding_rhs()
-            && matches!(
-                store.get_definition(&resolved_definition).map(|d| &d.body),
-                Some(DefinitionBody::Enum { .. })
-            )
-        {
-            self.sink
-                .push(diagnostics::infer::namespace_alias_used_as_value(
-                    *args.span,
-                ));
-        }
-
-        if !self.scopes.is_callee_context()
-            && !self.scopes.is_dot_access_base()
-            && let Some(definition) = store.get_definition(&resolved_definition)
-        {
-            let display_name = format!("{}.{}", type_name, args.member_name);
-            match &definition.body {
-                DefinitionBody::TypeAlias { .. } => {
-                    let diagnostic = match store.deep_struct_kind(definition.ty.unwrap_forall()) {
-                        Some(StructKind::Record) => {
-                            diagnostics::infer::record_struct_value(&display_name, *args.span)
-                        }
-                        Some(StructKind::Tuple) => {
-                            diagnostics::infer::native_constructor_value(&display_name, *args.span)
-                        }
-                        None => diagnostics::infer::type_used_as_value(&display_name, *args.span),
-                    };
-                    self.sink.push(diagnostic);
-                }
-                DefinitionBody::Interface { .. } => {
-                    self.sink.push(diagnostics::infer::type_used_as_value(
-                        &display_name,
-                        *args.span,
-                    ));
-                }
-                _ => {}
-            }
-        }
-
-        if !self.scopes.is_callee_context() && !self.scopes.is_dot_access_base() {
-            let phantom = phantom_type_params(&member_type);
-            if !phantom.is_empty() {
-                let display_name = format!("{}.{}", type_name, args.member_name);
-                self.sink
-                    .push(diagnostics::infer::uninferable_generic_reference(
-                        &display_name,
-                        &phantom,
-                        *args.span,
-                    ));
-            }
-        }
+        self.check_module_member_in_value_position(
+            store,
+            &resolved_definition,
+            &member_type,
+            type_name,
+            args,
+        );
 
         let (module_ty, _) = self.instantiate(&module_ty);
         let (member_ty, _) = self.instantiate(&member_type);
@@ -723,6 +642,100 @@ impl InferCtx<'_> {
                 definition: Some(resolved_definition),
             },
         ))
+    }
+
+    /// Rejects module members used in value position rather than called or used as a type.
+    fn check_module_member_in_value_position(
+        &mut self,
+        store: &crate::store::Store,
+        resolved_definition: &Symbol,
+        member_type: &Type,
+        type_name: &str,
+        args: &DotAccessResolutionArgs,
+    ) {
+        let is_callee_context = self.scopes.is_callee_context();
+        let is_dot_access_base = self.scopes.is_dot_access_base();
+        let display_name = format!("{}.{}", type_name, args.member_name);
+
+        if let Some(definition) = store.get_definition(resolved_definition) {
+            match &definition.body {
+                DefinitionBody::Struct {
+                    fields: StructFields::Tuple(_),
+                    ..
+                } => {
+                    // Deliberately omits `is_dot_access_base`, unlike the other arms below.
+                    if !is_callee_context {
+                        self.sink.push(diagnostics::infer::native_constructor_value(
+                            &display_name,
+                            *args.span,
+                        ));
+                    }
+                }
+                DefinitionBody::Struct {
+                    fields: StructFields::Record(_),
+                    ..
+                } => {
+                    if !is_callee_context && !is_dot_access_base {
+                        self.sink.push(diagnostics::infer::record_struct_value(
+                            &display_name,
+                            *args.span,
+                        ));
+                    }
+                }
+                DefinitionBody::Enum { .. } => {
+                    if !is_callee_context
+                        && !is_dot_access_base
+                        && !self.scopes.is_let_binding_rhs()
+                    {
+                        self.sink
+                            .push(diagnostics::infer::namespace_alias_used_as_value(
+                                *args.span,
+                            ));
+                    }
+                }
+                DefinitionBody::TypeAlias { .. } => {
+                    if !is_callee_context && !is_dot_access_base {
+                        let diagnostic = match store.deep_struct_kind(definition.ty.unwrap_forall())
+                        {
+                            Some(StructKind::Record) => {
+                                diagnostics::infer::record_struct_value(&display_name, *args.span)
+                            }
+                            Some(StructKind::Tuple) => {
+                                diagnostics::infer::native_constructor_value(
+                                    &display_name,
+                                    *args.span,
+                                )
+                            }
+                            None => {
+                                diagnostics::infer::type_used_as_value(&display_name, *args.span)
+                            }
+                        };
+                        self.sink.push(diagnostic);
+                    }
+                }
+                DefinitionBody::Interface { .. } => {
+                    if !is_callee_context && !is_dot_access_base {
+                        self.sink.push(diagnostics::infer::type_used_as_value(
+                            &display_name,
+                            *args.span,
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !is_callee_context && !is_dot_access_base {
+            let phantom = phantom_type_params(member_type);
+            if !phantom.is_empty() {
+                self.sink
+                    .push(diagnostics::infer::uninferable_generic_reference(
+                        &display_name,
+                        &phantom,
+                        *args.span,
+                    ));
+            }
+        }
     }
 
     fn as_instance_method(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -43,6 +43,11 @@ struct VariadicParameter {
     first_index: usize,
 }
 
+enum DeferredCallCheckTarget {
+    GenericCall,
+    SliceMake,
+}
+
 impl InferCtx<'_> {
     fn check_call_arity(
         &mut self,
@@ -343,27 +348,14 @@ impl InferCtx<'_> {
             return self.infer_array_new_call(&expression, args, type_args, span, expected_ty);
         }
 
-        if let Some(diagnostic) = match callee_path.as_deref() {
+        let pseudo_constructor_diagnostic = match callee_path.as_deref() {
             Some("Map.make") => Some(diagnostics::infer::map_no_make_constructor(span)),
             Some("Channel.make") => Some(diagnostics::infer::channel_no_make_constructor(span)),
             _ => None,
-        } {
-            self.sink.push(diagnostic);
-            let new_args: Vec<Expression> = args
-                .into_iter()
-                .map(|arg| self.with_value_context(|s| s.infer_expression(arg, &Type::Error)))
-                .collect();
-            let new_spread = spread
-                .map(|s| self.with_value_context(|state| state.infer_expression(*s, &Type::Error)));
-            return Expression::Call {
-                expression,
-                args: new_args,
-                spread: new_spread.map(Box::new),
-                type_arguments: CallTypeArguments::checked_without_types(type_args),
-                ty: Type::Error,
-                span,
-                call_kind: CallKind::Unresolved,
-            };
+        };
+        if let Some(diagnostic) = pseudo_constructor_diagnostic {
+            return self
+                .reject_pseudo_constructor(diagnostic, expression, args, spread, type_args, span);
         }
 
         let store = self.store;
@@ -454,33 +446,14 @@ impl InferCtx<'_> {
             .resolve_in(&self.env)
             .is_error();
 
-        let new_spread = spread.map(|spread_expr| match &variadic {
-            Some(variadic) => {
-                let expected = if variadic.parameter.ty.is_unknown() {
-                    let var = self.new_type_var();
-                    self.type_slice(var)
-                } else {
-                    self.type_slice(variadic.parameter.ty.clone())
-                };
-                let inferred =
-                    self.with_value_context(|s| s.infer_expression(*spread_expr, &expected));
-                if variadic.parameter.mutable {
-                    let callee_label = callee_label(&callee_expression);
-                    self.check_arg_against_mut_param(
-                        &inferred,
-                        &variadic.parameter.ty,
-                        &callee_label,
-                    );
-                }
-                inferred
-            }
-            None => {
-                if !callee_is_unresolved {
-                    self.sink
-                        .push(diagnostics::infer::spread_on_non_variadic(span));
-                }
-                self.with_value_context(|s| s.infer_expression(*spread_expr, &Type::Error))
-            }
+        let new_spread = spread.map(|spread_expr| {
+            self.infer_spread_argument(
+                spread_expr,
+                variadic.as_ref(),
+                &callee_expression,
+                callee_is_unresolved,
+                span,
+            )
         });
 
         let resolved_expected = store.deep_resolve_alias(&expected_ty.resolve_in(&self.env));
@@ -528,15 +501,11 @@ impl InferCtx<'_> {
             && type_args.is_empty()
             && !self.is_enum_type(store, &resolved_return);
         if return_check_recorded {
-            let module_id = self.cursor.module_id.clone();
-            self.facts
-                .deferred
-                .generic_calls
-                .push(crate::facts::GenericCallCheck {
-                    ty: return_ty.clone(),
-                    span,
-                    module_id,
-                });
+            self.record_generic_call_check(
+                return_ty.clone(),
+                span,
+                DeferredCallCheckTarget::GenericCall,
+            );
         }
 
         // A zero-variadic-arg call can't infer its `VarArgs<T>` parameter from args.
@@ -550,15 +519,11 @@ impl InferCtx<'_> {
             let already_covered = return_check_recorded
                 && resolved_return.contains_type(&variadic.parameter.ty.resolve_in(&self.env));
             if !already_covered {
-                let module_id = self.cursor.module_id.clone();
-                self.facts
-                    .deferred
-                    .generic_calls
-                    .push(crate::facts::GenericCallCheck {
-                        ty: variadic.parameter.ty.clone(),
-                        span,
-                        module_id,
-                    });
+                self.record_generic_call_check(
+                    variadic.parameter.ty.clone(),
+                    span,
+                    DeferredCallCheckTarget::GenericCall,
+                );
             }
         }
 
@@ -582,15 +547,11 @@ impl InferCtx<'_> {
         }
 
         if callee_path.as_deref() == Some("Slice.make") {
-            let module_id = self.cursor.module_id.clone();
-            self.facts
-                .deferred
-                .slice_makes
-                .push(crate::facts::SliceMakeCheck {
-                    ty: call_ty.clone(),
-                    span,
-                    module_id,
-                });
+            self.record_generic_call_check(
+                call_ty.clone(),
+                span,
+                DeferredCallCheckTarget::SliceMake,
+            );
         }
 
         self.check_negative_size_literal(
@@ -608,6 +569,98 @@ impl InferCtx<'_> {
             ty: call_ty,
             span,
             call_kind,
+        }
+    }
+
+    /// Error-recovery rebuild for `Map.make`/`Channel.make`, which have no constructor.
+    fn reject_pseudo_constructor(
+        &mut self,
+        diagnostic: diagnostics::LisetteDiagnostic,
+        expression: Box<Expression>,
+        args: Vec<Expression>,
+        spread: Option<Box<Expression>>,
+        type_args: Vec<Annotation>,
+        span: Span,
+    ) -> Expression {
+        self.sink.push(diagnostic);
+        let new_args: Vec<Expression> = args
+            .into_iter()
+            .map(|arg| self.with_value_context(|s| s.infer_expression(arg, &Type::Error)))
+            .collect();
+        let new_spread = spread
+            .map(|s| self.with_value_context(|state| state.infer_expression(*s, &Type::Error)));
+        Expression::Call {
+            expression,
+            args: new_args,
+            spread: new_spread.map(Box::new),
+            type_arguments: CallTypeArguments::checked_without_types(type_args),
+            ty: Type::Error,
+            span,
+            call_kind: CallKind::Unresolved,
+        }
+    }
+
+    fn infer_spread_argument(
+        &mut self,
+        spread_expr: Box<Expression>,
+        variadic: Option<&VariadicParameter>,
+        callee_expression: &Expression,
+        callee_is_unresolved: bool,
+        span: Span,
+    ) -> Expression {
+        match variadic {
+            Some(variadic) => {
+                let expected = if variadic.parameter.ty.is_unknown() {
+                    let var = self.new_type_var();
+                    self.type_slice(var)
+                } else {
+                    self.type_slice(variadic.parameter.ty.clone())
+                };
+                let inferred =
+                    self.with_value_context(|s| s.infer_expression(*spread_expr, &expected));
+                if variadic.parameter.mutable {
+                    let callee_label = callee_label(callee_expression);
+                    self.check_arg_against_mut_param(
+                        &inferred,
+                        &variadic.parameter.ty,
+                        &callee_label,
+                    );
+                }
+                inferred
+            }
+            None => {
+                if !callee_is_unresolved {
+                    self.sink
+                        .push(diagnostics::infer::spread_on_non_variadic(span));
+                }
+                self.with_value_context(|s| s.infer_expression(*spread_expr, &Type::Error))
+            }
+        }
+    }
+
+    fn record_generic_call_check(&mut self, ty: Type, span: Span, target: DeferredCallCheckTarget) {
+        let module_id = self.cursor.module_id.clone();
+        match target {
+            DeferredCallCheckTarget::GenericCall => {
+                self.facts
+                    .deferred
+                    .generic_calls
+                    .push(crate::facts::GenericCallCheck {
+                        ty,
+                        span,
+                        module_id,
+                    });
+            }
+            DeferredCallCheckTarget::SliceMake => {
+                self.facts
+                    .deferred
+                    .slice_makes
+                    .push(crate::facts::SliceMakeCheck {
+                        ty,
+                        span,
+                        module_id,
+                    });
+            }
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/mod.rs
+++ b/crates/semantics/src/checker/infer/expressions/mod.rs
@@ -15,7 +15,7 @@ pub mod propagate;
 pub mod select;
 pub mod struct_call;
 
-use syntax::ast::Expression;
+use syntax::ast::{Expression, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
@@ -231,24 +231,14 @@ impl InferCtx<'_> {
             Expression::Task {
                 expression, span, ..
             } => {
-                // Only fire the generic ban when the dedicated
-                // `task_in_expression_position` check won't — avoids duplicates.
-                if is_subexpression && !self.scopes.is_value_context() {
-                    self.sink
-                        .push(diagnostics::infer::control_flow_in_expression("task", span));
-                }
+                self.check_control_flow_in_expression("task", span, is_subexpression);
                 self.infer_task(expression, span, expected_ty)
             }
 
             Expression::Defer {
                 expression, span, ..
             } => {
-                if is_subexpression && !self.scopes.is_value_context() {
-                    self.sink
-                        .push(diagnostics::infer::control_flow_in_expression(
-                            "defer", span,
-                        ));
-                }
+                self.check_control_flow_in_expression("defer", span, is_subexpression);
                 self.infer_defer(expression, span, expected_ty)
             }
 
@@ -288,6 +278,14 @@ impl InferCtx<'_> {
             Expression::Break { value, span } => self.infer_break(value, span, is_subexpression),
             Expression::Continue { span } => self.infer_continue(span, is_subexpression),
             Expression::RawGo { text } => Expression::RawGo { text },
+        }
+    }
+
+    /// Bans `task`/`defer` as a bare subexpression, skipped when the dedicated check already fires.
+    fn check_control_flow_in_expression(&mut self, kind: &str, span: Span, is_subexpression: bool) {
+        if is_subexpression && !self.scopes.is_value_context() {
+            self.sink
+                .push(diagnostics::infer::control_flow_in_expression(kind, span));
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -29,6 +29,19 @@ struct BinaryOperands<'a> {
     right: BinaryOperand<'a>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NumericCompat {
+    SameAliased,
+    DifferentCompatible,
+    Neither,
+}
+
+impl NumericCompat {
+    fn is_compatible(self) -> bool {
+        !matches!(self, NumericCompat::Neither)
+    }
+}
+
 impl InferCtx<'_> {
     pub(super) fn infer_unary(
         &mut self,
@@ -310,33 +323,19 @@ impl InferCtx<'_> {
         let right_operand_ty = operands.right.ty;
         let left_span = &operands.left.span;
         let right_span = &operands.right.span;
+        let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
+        let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
         match operator {
             Equal | NotEqual => {
-                let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
-                let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
-
                 if !self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
                     span,
-                ) {
-                    let same_aliased_numeric = resolved_left_operand == resolved_right_operand
-                        && self.store.is_aliased_numeric_type(&resolved_left_operand);
-
-                    let different_but_compatible = resolved_left_operand != resolved_right_operand
-                        && self.store.is_numeric_compatible_with(
-                            &resolved_left_operand,
-                            &resolved_right_operand,
-                        );
-
-                    if !same_aliased_numeric && !different_but_compatible {
-                        self.unify_binary_operands(
-                            operator,
-                            left_operand_ty,
-                            right_operand_ty,
-                            &span,
-                        );
-                    }
+                ) && !self
+                    .numeric_compat(&resolved_left_operand, &resolved_right_operand)
+                    .is_compatible()
+                {
+                    self.unify_binary_operands(operator, left_operand_ty, right_operand_ty, &span);
                 }
                 let operands_match =
                     left_operand_ty.resolve_in(&self.env) == right_operand_ty.resolve_in(&self.env);
@@ -347,9 +346,6 @@ impl InferCtx<'_> {
             }
 
             And | Or => {
-                let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
-                let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
-
                 if self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
@@ -372,9 +368,6 @@ impl InferCtx<'_> {
             }
 
             LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => {
-                let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
-                let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
-
                 if self.report_named_type_boundary(
                     &resolved_left_operand,
                     &resolved_right_operand,
@@ -383,16 +376,9 @@ impl InferCtx<'_> {
                     return self.type_bool();
                 }
 
-                let same_aliased_numeric = resolved_left_operand == resolved_right_operand
-                    && self.store.is_aliased_numeric_type(&resolved_left_operand);
-
-                let different_but_compatible = resolved_left_operand != resolved_right_operand
-                    && self.store.is_numeric_compatible_with(
-                        &resolved_left_operand,
-                        &resolved_right_operand,
-                    );
-
-                if (same_aliased_numeric || different_but_compatible)
+                if self
+                    .numeric_compat(&resolved_left_operand, &resolved_right_operand)
+                    .is_compatible()
                     && self.store.is_orderable(&resolved_left_operand)
                     && self.store.is_orderable(&resolved_right_operand)
                 {
@@ -406,9 +392,6 @@ impl InferCtx<'_> {
             }
 
             Addition => {
-                let resolved_left_operand = left_operand_ty.resolve_in(&self.env);
-                let resolved_right_operand = right_operand_ty.resolve_in(&self.env);
-
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
                     operator,
                     &resolved_left_operand,
@@ -452,11 +435,8 @@ impl InferCtx<'_> {
             }
 
             Subtraction | Multiplication | Division | Remainder => {
-                let left_resolved = left_operand_ty.resolve_in(&self.env);
-                let right_resolved = right_operand_ty.resolve_in(&self.env);
-
                 if matches!(operator, Remainder)
-                    && (left_resolved.is_float() || right_resolved.is_float())
+                    && (resolved_left_operand.is_float() || resolved_right_operand.is_float())
                 {
                     self.sink
                         .push(diagnostics::infer::float_modulo_not_supported(span));
@@ -464,12 +444,13 @@ impl InferCtx<'_> {
 
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
                     operator,
-                    &left_resolved,
-                    &right_resolved,
+                    &resolved_left_operand,
+                    &resolved_right_operand,
                     &span,
                 ) {
                     result_ty
-                } else if left_resolved.is_complex() || right_resolved.is_complex() {
+                } else if resolved_left_operand.is_complex() || resolved_right_operand.is_complex()
+                {
                     self.type_complex128()
                 } else {
                     let left_ok =
@@ -489,13 +470,10 @@ impl InferCtx<'_> {
             }
 
             BitwiseAnd | BitwiseOr | BitwiseXor | BitwiseAndNot => {
-                let left_resolved = left_operand_ty.resolve_in(&self.env);
-                let right_resolved = right_operand_ty.resolve_in(&self.env);
-
                 if let Some(result_ty) = self.try_operation_with_numeric_alias(
                     operator,
-                    &left_resolved,
-                    &right_resolved,
+                    &resolved_left_operand,
+                    &resolved_right_operand,
                     &span,
                 ) {
                     result_ty
@@ -525,6 +503,17 @@ impl InferCtx<'_> {
             Pipeline => {
                 panic!("Pipeline operator should have been desugared before type inference")
             }
+        }
+    }
+
+    /// Classifies whether two resolved operand types are numerically compatible.
+    fn numeric_compat(&self, left: &Type, right: &Type) -> NumericCompat {
+        if left == right && self.store.is_aliased_numeric_type(left) {
+            NumericCompat::SameAliased
+        } else if left != right && self.store.is_numeric_compatible_with(left, right) {
+            NumericCompat::DifferentCompatible
+        } else {
+            NumericCompat::Neither
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -396,26 +396,8 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::non_addressable_assignment(kind, span));
         }
 
-        // Propagates type information to the RHS (e.g., lambda params
-        // get their types from a Map's value type).
-        let value_expected = target_ty.resolve_in(&self.env);
-        let (new_value, value_ty) = if let Some(operator) = compound_operator {
-            let inferred = self.infer_binary_with_left(
-                operator,
-                InferredOperand::new(new_target.clone(), target_ty.clone()),
-                value,
-                &value_expected,
-                span,
-            );
-            let Expression::Binary { right, .. } = inferred.expression else {
-                unreachable!("infer_binary_with_left always returns a binary")
-            };
-            (*right, inferred.ty)
-        } else {
-            let new_value = self.infer_expression(*value, &value_expected);
-            let value_ty = new_value.get_type();
-            (new_value, value_ty)
-        };
+        let (new_value, value_ty) =
+            self.infer_assignment_value(&new_target, &target_ty, value, compound_operator, span);
 
         // Track mutation for binding-rooted targets. Call-based lvalues
         // (e.g., `get().*.x = ...`) have no local binding to track.
@@ -448,25 +430,7 @@ impl InferCtx<'_> {
             let can_mutate = is_mutable || is_deref || binding_is_ref;
 
             if !can_mutate && self.imports.namespace(&var_name).is_none() {
-                let self_type_name = if var_name == "self" {
-                    self.lookup_type(store, "self")
-                        .and_then(|t| t.get_name().map(str::to_owned))
-                } else {
-                    None
-                };
-                let is_pattern_binding = self
-                    .scopes
-                    .lookup_binding_id(&var_name)
-                    .and_then(|id| self.facts.bindings.get(&id))
-                    .is_some_and(|b| b.kind.is_pattern_position());
-                let is_const = self.is_const_var(store, &var_name);
-                self.sink.push(diagnostics::infer::disallowed_mutation(
-                    &var_name,
-                    span,
-                    self_type_name.as_deref(),
-                    is_pattern_binding,
-                    is_const,
-                ));
+                self.report_disallowed_mutation(store, &var_name, span);
             }
 
             // Check for self-referential assignment: x = Expr { field: &x }
@@ -501,6 +465,63 @@ impl InferCtx<'_> {
             compound_operator,
             span,
         }
+    }
+
+    fn infer_assignment_value(
+        &mut self,
+        new_target: &Expression,
+        target_ty: &Type,
+        value: Box<Expression>,
+        compound_operator: Option<BinaryOperator>,
+        span: Span,
+    ) -> (Expression, Type) {
+        // Propagates type information to the RHS (e.g., lambda params
+        // get their types from a Map's value type).
+        let value_expected = target_ty.resolve_in(&self.env);
+        if let Some(operator) = compound_operator {
+            let inferred = self.infer_binary_with_left(
+                operator,
+                InferredOperand::new(new_target.clone(), target_ty.clone()),
+                value,
+                &value_expected,
+                span,
+            );
+            let Expression::Binary { right, .. } = inferred.expression else {
+                unreachable!("infer_binary_with_left always returns a binary")
+            };
+            (*right, inferred.ty)
+        } else {
+            let new_value = self.infer_expression(*value, &value_expected);
+            let value_ty = new_value.get_type();
+            (new_value, value_ty)
+        }
+    }
+
+    fn report_disallowed_mutation(
+        &mut self,
+        store: &crate::store::Store,
+        var_name: &str,
+        span: Span,
+    ) {
+        let self_type_name = if var_name == "self" {
+            self.lookup_type(store, "self")
+                .and_then(|t| t.get_name().map(str::to_owned))
+        } else {
+            None
+        };
+        let is_pattern_binding = self
+            .scopes
+            .lookup_binding_id(var_name)
+            .and_then(|id| self.facts.bindings.get(&id))
+            .is_some_and(|b| b.kind.is_pattern_position());
+        let is_const = self.is_const_var(store, var_name);
+        self.sink.push(diagnostics::infer::disallowed_mutation(
+            var_name,
+            span,
+            self_type_name.as_deref(),
+            is_pattern_binding,
+            is_const,
+        ));
     }
 
     pub(super) fn infer_tuple(

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -76,167 +76,36 @@ impl InferCtx<'_> {
             span,
         };
         let store = self.store;
-        if let Some(qualified_name) = self.lookup_qualified_name(store, &literal.name)
-            && let Some(Definition {
-                ty: struct_ty,
-                body:
-                    DefinitionBody::Struct {
-                        fields: struct_fields,
-                        ..
-                    },
-                ..
-            }) = store.get_definition(&qualified_name)
-        {
-            let struct_ty = struct_ty.clone();
-            let struct_fields = struct_fields.clone();
 
-            self.track_name_usage(
-                store,
-                &qualified_name,
-                &literal.span,
-                literal.name.len() as u32,
-            );
-            return self.infer_struct_call_for_struct(
-                literal,
-                ResolvedStruct {
-                    qualified_name,
-                    ty: struct_ty,
-                    fields: struct_fields,
-                    alias_underlying: None,
-                },
-                expected_ty,
-            );
+        if let Some(resolved) = self
+            .as_struct(store, &literal)
+            .or_else(|| self.as_alias_struct(store, &literal.name))
+        {
+            return self.infer_struct_call_for_struct(literal, resolved, expected_ty);
         }
 
+        // Opaque types (e.g., Go's sync.WaitGroup) can be zero-value instantiated
+        // with T{} even though they have no struct definition.
         if let Some(qualified_name) = self.lookup_qualified_name(store, &literal.name)
             && let Some(Definition {
                 ty: alias_ty,
                 body: DefinitionBody::TypeAlias { alias, .. },
                 ..
             }) = store.get_definition(&qualified_name)
+            && matches!(alias, syntax::program::AliasKind::Opaque(_))
+            && literal.fields.is_empty()
         {
             let alias_ty = alias_ty.clone();
-            let is_opaque = matches!(alias, syntax::program::AliasKind::Opaque(_));
-
-            let underlying = (!is_opaque).then(|| store.peel_alias(&alias_ty));
-            if let Some(Type::Nominal { id: struct_id, .. }) = &underlying
-                && let Some(Definition {
-                    ty: struct_ty,
-                    body:
-                        DefinitionBody::Struct {
-                            fields: struct_fields,
-                            ..
-                        },
-                    ..
-                }) = store.get_definition(struct_id)
-            {
-                let struct_ty = struct_ty.clone();
-                let struct_fields = struct_fields.clone();
-                let struct_id_str: EcoString = struct_id.into();
-                let alias_underlying = if matches!(&alias_ty, Type::Forall { .. }) {
-                    None
-                } else {
-                    underlying
-                };
-                return self.infer_struct_call_for_struct(
-                    literal,
-                    ResolvedStruct {
-                        qualified_name: struct_id_str,
-                        ty: struct_ty,
-                        fields: struct_fields,
-                        alias_underlying,
-                    },
-                    expected_ty,
-                );
-            }
-
-            // Opaque types (e.g., Go's sync.WaitGroup) can be zero-value instantiated
-            // with T{} even though they have no struct definition.
-            if is_opaque && literal.fields.is_empty() {
-                let (instantiated_ty, _) = self.instantiate(&alias_ty);
-                self.unify(expected_ty, &instantiated_ty, &literal.span);
-                return literal.with_type(instantiated_ty);
-            }
+            let (instantiated_ty, _) = self.instantiate(&alias_ty);
+            self.unify(expected_ty, &instantiated_ty, &literal.span);
+            return literal.with_type(instantiated_ty);
         }
 
-        if let Some((type_part, variant_name)) = literal.name.rsplit_once('.')
-            && let Some(qualified_name) = self.lookup_qualified_name(store, type_part)
-            && let Some(Definition {
-                ty: alias_ty,
-                body:
-                    DefinitionBody::TypeAlias {
-                        alias: syntax::program::AliasKind::Transparent { .. },
-                        ..
-                    },
-                ..
-            }) = store.get_definition(&qualified_name)
+        if let Some(resolved) = self
+            .as_alias_variant(store, &literal.name)
+            .or_else(|| self.as_variant(store, &literal.name))
         {
-            let alias_ty = alias_ty.clone();
-            let underlying = store.peel_alias(&alias_ty);
-            let variant_fields = if let Type::Nominal { id: enum_id, .. } = &underlying
-                && let Some(variants) = store.variants_of(enum_id)
-                && let Some(variant) = variants.iter().find(|v| v.name == variant_name)
-                && variant.fields.is_struct()
-            {
-                Some(variant.fields.iter().cloned().collect::<Vec<_>>())
-            } else {
-                None
-            };
-
-            if let Some(variant_fields) = variant_fields {
-                let (instantiated_ty, map) = self.instantiate(&alias_ty);
-                let instantiated_target = store.peel_alias(&instantiated_ty);
-                let enum_ty = match instantiated_target {
-                    Type::Function(f) => (*f.return_type).clone(),
-                    other => other,
-                };
-                return self.infer_struct_call_for_enum_variant(
-                    literal,
-                    ResolvedVariant {
-                        fields: variant_fields,
-                        substitutions: map,
-                        ty: enum_ty,
-                    },
-                    expected_ty,
-                );
-            }
-        }
-
-        if let Some(ty) = self.lookup_type(store, &literal.name) {
-            let (value_constructor_type, map) = self.instantiate(&ty);
-
-            let pattern_ty = match value_constructor_type {
-                Type::Function(f) => (*f.return_type).clone(),
-                Type::Nominal { .. } => value_constructor_type,
-                _ => {
-                    self.sink.push(diagnostics::infer::struct_not_found(
-                        &literal.name,
-                        literal.span,
-                    ));
-                    self.unify(expected_ty, &Type::Error, &literal.span);
-                    return literal.with_type(Type::Error);
-                }
-            };
-
-            let resolved_ty = pattern_ty.resolve_in(&self.env);
-            let variant_name = unqualified_name(&literal.name);
-
-            if let Type::Nominal { id, .. } = &resolved_ty
-                && let Some(variants) = store.variants_of(id)
-                && let Some(variant) = variants.iter().find(|v| v.name == variant_name)
-                && variant.fields.is_struct()
-            {
-                let variant_fields: Vec<_> = variant.fields.iter().cloned().collect();
-                return self.infer_struct_call_for_enum_variant(
-                    literal,
-                    ResolvedVariant {
-                        fields: variant_fields,
-                        substitutions: map,
-                        ty: pattern_ty,
-                    },
-                    expected_ty,
-                );
-            }
+            return self.infer_struct_call_for_enum_variant(literal, resolved, expected_ty);
         }
 
         self.sink.push(diagnostics::infer::struct_not_found(
@@ -245,6 +114,161 @@ impl InferCtx<'_> {
         ));
         self.unify(expected_ty, &Type::Error, &literal.span);
         literal.with_type(Type::Error)
+    }
+
+    fn as_struct(
+        &mut self,
+        store: &crate::store::Store,
+        literal: &StructLiteral,
+    ) -> Option<ResolvedStruct> {
+        let qualified_name = self.lookup_qualified_name(store, &literal.name)?;
+        let Definition {
+            ty: struct_ty,
+            body:
+                DefinitionBody::Struct {
+                    fields: struct_fields,
+                    ..
+                },
+            ..
+        } = store.get_definition(&qualified_name)?
+        else {
+            return None;
+        };
+        let struct_ty = struct_ty.clone();
+        let struct_fields = struct_fields.clone();
+
+        self.track_name_usage(
+            store,
+            &qualified_name,
+            &literal.span,
+            literal.name.len() as u32,
+        );
+        Some(ResolvedStruct {
+            qualified_name,
+            ty: struct_ty,
+            fields: struct_fields,
+            alias_underlying: None,
+        })
+    }
+
+    /// Resolve a `type Alias = Struct` name to its underlying struct.
+    fn as_alias_struct(&self, store: &crate::store::Store, name: &str) -> Option<ResolvedStruct> {
+        let qualified_name = self.lookup_qualified_name(store, name)?;
+        let Definition {
+            ty: alias_ty,
+            body: DefinitionBody::TypeAlias { alias, .. },
+            ..
+        } = store.get_definition(&qualified_name)?
+        else {
+            return None;
+        };
+        let alias_ty = alias_ty.clone();
+        let is_opaque = matches!(alias, syntax::program::AliasKind::Opaque(_));
+
+        let underlying = (!is_opaque).then(|| store.peel_alias(&alias_ty));
+        let Some(Type::Nominal { id: struct_id, .. }) = &underlying else {
+            return None;
+        };
+        let Definition {
+            ty: struct_ty,
+            body:
+                DefinitionBody::Struct {
+                    fields: struct_fields,
+                    ..
+                },
+            ..
+        } = store.get_definition(struct_id)?
+        else {
+            return None;
+        };
+        let struct_ty = struct_ty.clone();
+        let struct_fields = struct_fields.clone();
+        let struct_id_str: EcoString = struct_id.into();
+        // Deliberately None for a `Type::Forall` alias.
+        let alias_underlying = if matches!(&alias_ty, Type::Forall { .. }) {
+            None
+        } else {
+            underlying
+        };
+        Some(ResolvedStruct {
+            qualified_name: struct_id_str,
+            ty: struct_ty,
+            fields: struct_fields,
+            alias_underlying,
+        })
+    }
+
+    fn as_alias_variant(
+        &mut self,
+        store: &crate::store::Store,
+        name: &str,
+    ) -> Option<ResolvedVariant> {
+        let (type_part, variant_name) = name.rsplit_once('.')?;
+        let qualified_name = self.lookup_qualified_name(store, type_part)?;
+        let Definition {
+            ty: alias_ty,
+            body:
+                DefinitionBody::TypeAlias {
+                    alias: syntax::program::AliasKind::Transparent { .. },
+                    ..
+                },
+            ..
+        } = store.get_definition(&qualified_name)?
+        else {
+            return None;
+        };
+        let alias_ty = alias_ty.clone();
+        let underlying = store.peel_alias(&alias_ty);
+        let Type::Nominal { id: enum_id, .. } = &underlying else {
+            return None;
+        };
+        let variants = store.variants_of(enum_id)?;
+        let variant = variants.iter().find(|v| v.name == variant_name)?;
+        if !variant.fields.is_struct() {
+            return None;
+        }
+        let variant_fields: Vec<_> = variant.fields.iter().cloned().collect();
+
+        let (instantiated_ty, map) = self.instantiate(&alias_ty);
+        let instantiated_target = store.peel_alias(&instantiated_ty);
+        let enum_ty = match instantiated_target {
+            Type::Function(f) => (*f.return_type).clone(),
+            other => other,
+        };
+        Some(ResolvedVariant {
+            fields: variant_fields,
+            substitutions: map,
+            ty: enum_ty,
+        })
+    }
+
+    fn as_variant(&mut self, store: &crate::store::Store, name: &str) -> Option<ResolvedVariant> {
+        let ty = self.lookup_type(store, name)?;
+        let (value_constructor_type, map) = self.instantiate(&ty);
+
+        let pattern_ty = match value_constructor_type {
+            Type::Function(f) => (*f.return_type).clone(),
+            Type::Nominal { .. } => value_constructor_type,
+            _ => return None,
+        };
+
+        let resolved_ty = pattern_ty.resolve_in(&self.env);
+        let variant_name = unqualified_name(name);
+
+        let Type::Nominal { id, .. } = &resolved_ty else {
+            return None;
+        };
+        let variants = store.variants_of(id)?;
+        let variant = variants.iter().find(|v| v.name == variant_name)?;
+        if !variant.fields.is_struct() {
+            return None;
+        }
+        let variant_fields: Vec<_> = variant.fields.iter().cloned().collect();
+        Some(ResolvedVariant {
+            fields: variant_fields,
+            substitutions: map,
+            ty: pattern_ty,
+        })
     }
 
     fn infer_struct_call_for_struct(

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -178,171 +178,16 @@ impl TaskState {
                 name: type_name,
                 params,
                 span: annotation_span,
-            } => {
-                if type_name == "VarArgs" && !variadic_allowed {
-                    self.sink
-                        .push(diagnostics::infer::variadic_type_not_allowed(
-                            *annotation_span,
-                        ));
-                    return Type::Error;
-                }
-
-                // Unit is internal — `()` desugars to Constructor { name: "Unit" }.
-                // Return the interned unit type directly, unless a user-defined
-                // type named `Unit` exists in scope.
-                if type_name == "Unit"
-                    && params.is_empty()
-                    && self.resolve_type_name(store, "Unit").is_none()
-                {
-                    return Type::unit();
-                }
-
-                if self.lookup_generic_index(type_name).is_some() {
-                    if !params.is_empty() {
-                        self.sink.push(diagnostics::infer::type_param_with_args(
-                            params.len(),
-                            *annotation_span,
-                        ));
-                    }
-                    return Type::Parameter(type_name.into());
-                }
-
-                // `Array` carries a const-integer size, so it needs its own path.
-                if type_name == "Array" {
-                    return self.convert_array_annotation(
-                        store,
-                        params,
-                        *annotation_span,
-                        span,
-                        type_argument_checks,
-                    );
-                }
-
-                let Some((qualified_name, ty)) =
-                    self.resolve_type_with_arity(store, type_name, params.len())
-                else {
-                    if type_name == "Self" {
-                        let receiver = self.scopes.impl_receiver_type().map(|ty| ty.stringify());
-                        self.sink.push(diagnostics::infer::self_type_not_supported(
-                            *annotation_span,
-                            receiver.as_deref(),
-                        ));
-                    } else {
-                        self.sink.push(diagnostics::infer::type_not_found(
-                            type_name,
-                            *annotation_span,
-                        ));
-                    }
-                    return Type::Error;
-                };
-
-                if let Some((kind, help)) =
-                    self.classify_non_type_name(store, &qualified_name, type_name)
-                {
-                    self.sink.push(diagnostics::infer::value_in_type_position(
-                        type_name,
-                        kind,
-                        *annotation_span,
-                        help,
-                    ));
-                    return Type::Error;
-                }
-
-                self.track_name_usage(
-                    store,
-                    &qualified_name,
-                    annotation_span,
-                    type_name.len() as u32,
-                );
-
-                if position == TypePosition::Value
-                    && let Some(builtin) =
-                        crate::checker::infer::BuiltinBound::from_qualified_id(&qualified_name)
-                {
-                    self.sink
-                        .push(diagnostics::infer::bound_only_in_value_position(
-                            builtin.label(),
-                            *annotation_span,
-                        ));
-                    return Type::Error;
-                }
-
-                let (generics, body) = match ty {
-                    Type::Forall { vars, body } => (vars, *body),
-                    other => (vec![], other),
-                };
-
-                let concrete_args: Vec<Type> = params
-                    .iter()
-                    .map(|arg| {
-                        self.convert_to_type_mode(
-                            store,
-                            arg,
-                            span,
-                            false,
-                            type_argument_checks.nested(),
-                            TypePosition::Value,
-                        )
-                    })
-                    .collect();
-
-                if generics.len() != params.len() {
-                    let generics_as_str: Vec<String> =
-                        generics.iter().map(|s| s.to_string()).collect();
-                    self.sink.push(diagnostics::infer::generics_arity_mismatch(
-                        &generics_as_str,
-                        params,
-                        &concrete_args,
-                        *span,
-                    ));
-                }
-                if type_argument_checks.current() && qualified_name != "prelude.Map" {
-                    self.check_type_argument_bounds(
-                        store,
-                        &qualified_name,
-                        &concrete_args,
-                        *annotation_span,
-                    );
-                }
-                let resolved_ty = if generics.is_empty() && concrete_args.is_empty() {
-                    body
-                } else {
-                    let map: SubstitutionMap = generics
-                        .iter()
-                        .cloned()
-                        .zip(concrete_args.iter().cloned())
-                        .collect();
-                    substitute(&body, &map)
-                };
-
-                // Reject Ref<InterfaceType> — Go pointer-to-interface is invalid
-                if self.is_lis(store)
-                    && qualified_name == "prelude.Ref"
-                    && params.len() == 1
-                    && let Some(inner) = resolved_ty.inner()
-                {
-                    let peeled_inner = store.peel_alias(&inner.resolve_in(&self.env));
-                    if let Some(inner_id) = peeled_inner.get_qualified_id()
-                        && store.get_interface(inner_id).is_some()
-                    {
-                        self.sink.push(diagnostics::infer::ref_of_interface_type(
-                            &inner,
-                            *annotation_span,
-                        ));
-                    }
-                }
-
-                if type_argument_checks.current()
-                    && qualified_name == "prelude.Map"
-                    && let Some(key_ty) = resolved_ty
-                        .get_type_params()
-                        .and_then(|parameters| parameters.first())
-                {
-                    self.check_map_key_comparable(store, key_ty, *annotation_span);
-                }
-
-                resolved_ty
-            }
+            } => self.convert_constructor_annotation(
+                store,
+                type_name,
+                params,
+                *annotation_span,
+                span,
+                variadic_allowed,
+                type_argument_checks,
+                position,
+            ),
 
             Annotation::Tuple { elements, .. } => {
                 let element_types = elements
@@ -373,6 +218,180 @@ impl TaskState {
                 unreachable!("Annotation::Opaque should not be converted to a type")
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn convert_constructor_annotation(
+        &mut self,
+        store: &Store,
+        type_name: &EcoString,
+        params: &[Annotation],
+        annotation_span: Span,
+        span: &Span,
+        variadic_allowed: bool,
+        type_argument_checks: TypeArgumentChecks,
+        position: TypePosition,
+    ) -> Type {
+        if type_name == "VarArgs" && !variadic_allowed {
+            self.sink
+                .push(diagnostics::infer::variadic_type_not_allowed(
+                    annotation_span,
+                ));
+            return Type::Error;
+        }
+
+        // Unit is internal — `()` desugars to Constructor { name: "Unit" }.
+        // Return the interned unit type directly, unless a user-defined
+        // type named `Unit` exists in scope.
+        if type_name == "Unit"
+            && params.is_empty()
+            && self.resolve_type_name(store, "Unit").is_none()
+        {
+            return Type::unit();
+        }
+
+        if self.lookup_generic_index(type_name).is_some() {
+            if !params.is_empty() {
+                self.sink.push(diagnostics::infer::type_param_with_args(
+                    params.len(),
+                    annotation_span,
+                ));
+            }
+            return Type::Parameter(type_name.into());
+        }
+
+        // `Array` carries a const-integer size, so it needs its own path.
+        if type_name == "Array" {
+            return self.convert_array_annotation(
+                store,
+                params,
+                annotation_span,
+                span,
+                type_argument_checks,
+            );
+        }
+
+        let Some((qualified_name, ty)) =
+            self.resolve_type_with_arity(store, type_name, params.len())
+        else {
+            if type_name == "Self" {
+                let receiver = self.scopes.impl_receiver_type().map(|ty| ty.stringify());
+                self.sink.push(diagnostics::infer::self_type_not_supported(
+                    annotation_span,
+                    receiver.as_deref(),
+                ));
+            } else {
+                self.sink.push(diagnostics::infer::type_not_found(
+                    type_name,
+                    annotation_span,
+                ));
+            }
+            return Type::Error;
+        };
+
+        if let Some((kind, help)) = self.classify_non_type_name(store, &qualified_name, type_name) {
+            self.sink.push(diagnostics::infer::value_in_type_position(
+                type_name,
+                kind,
+                annotation_span,
+                help,
+            ));
+            return Type::Error;
+        }
+
+        self.track_name_usage(
+            store,
+            &qualified_name,
+            &annotation_span,
+            type_name.len() as u32,
+        );
+
+        if position == TypePosition::Value
+            && let Some(builtin) =
+                crate::checker::infer::BuiltinBound::from_qualified_id(&qualified_name)
+        {
+            self.sink
+                .push(diagnostics::infer::bound_only_in_value_position(
+                    builtin.label(),
+                    annotation_span,
+                ));
+            return Type::Error;
+        }
+
+        let (generics, body) = match ty {
+            Type::Forall { vars, body } => (vars, *body),
+            other => (vec![], other),
+        };
+
+        let concrete_args: Vec<Type> = params
+            .iter()
+            .map(|arg| {
+                self.convert_to_type_mode(
+                    store,
+                    arg,
+                    span,
+                    false,
+                    type_argument_checks.nested(),
+                    TypePosition::Value,
+                )
+            })
+            .collect();
+
+        if generics.len() != params.len() {
+            let generics_as_str: Vec<String> = generics.iter().map(|s| s.to_string()).collect();
+            self.sink.push(diagnostics::infer::generics_arity_mismatch(
+                &generics_as_str,
+                params,
+                &concrete_args,
+                *span,
+            ));
+        }
+        if type_argument_checks.current() && qualified_name != "prelude.Map" {
+            self.check_type_argument_bounds(
+                store,
+                &qualified_name,
+                &concrete_args,
+                annotation_span,
+            );
+        }
+        let resolved_ty = if generics.is_empty() && concrete_args.is_empty() {
+            body
+        } else {
+            let map: SubstitutionMap = generics
+                .iter()
+                .cloned()
+                .zip(concrete_args.iter().cloned())
+                .collect();
+            substitute(&body, &map)
+        };
+
+        // Reject Ref<InterfaceType> — Go pointer-to-interface is invalid
+        if self.is_lis(store)
+            && qualified_name == "prelude.Ref"
+            && params.len() == 1
+            && let Some(inner) = resolved_ty.inner()
+        {
+            let peeled_inner = store.peel_alias(&inner.resolve_in(&self.env));
+            if let Some(inner_id) = peeled_inner.get_qualified_id()
+                && store.get_interface(inner_id).is_some()
+            {
+                self.sink.push(diagnostics::infer::ref_of_interface_type(
+                    &inner,
+                    annotation_span,
+                ));
+            }
+        }
+
+        if type_argument_checks.current()
+            && qualified_name == "prelude.Map"
+            && let Some(key_ty) = resolved_ty
+                .get_type_params()
+                .and_then(|parameters| parameters.first())
+        {
+            self.check_map_key_comparable(store, key_ty, annotation_span);
+        }
+
+        resolved_ty
     }
 
     fn convert_array_annotation(

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -4,7 +4,8 @@ use syntax::ast::{
 };
 use syntax::program::{Definition, DefinitionBody, Interface, Visibility};
 use syntax::types::{
-    Symbol, Type, build_substitution_map, substitute, type_args_match_params, unqualified_name,
+    Bound, Symbol, Type, build_substitution_map, substitute, type_args_match_params,
+    unqualified_name,
 };
 
 use super::{extract_attribute_flags, has_recursive_instantiation, wrap_with_impl_generics};
@@ -15,6 +16,16 @@ struct ImplReceiver<'a> {
     module_id: &'a str,
     qualified_name: &'a str,
     display_name: &'a str,
+    receiver_ty: &'a Type,
+}
+
+/// Receiver type resolved from an `impl` block's annotation, with its generics' bounds registered.
+struct ResolvedImplReceiver {
+    receiver_ty: Type,
+    qualified_name: Symbol,
+    module_id: String,
+    generics: Vec<Generic>,
+    impl_bounds: Vec<Bound>,
 }
 
 impl TaskState {
@@ -152,15 +163,52 @@ impl TaskState {
         functions: &[Expression],
         span: &Span,
     ) -> Vec<(String, Type)> {
+        let Some(resolved) = self.resolve_impl_receiver(store, annotation, generics, span) else {
+            return Vec::new();
+        };
+        let type_name = resolved
+            .receiver_ty
+            .get_name()
+            .expect("a resolved receiver always has a name");
+        let receiver = ImplReceiver {
+            module_id: &resolved.module_id,
+            qualified_name: resolved.qualified_name.as_str(),
+            display_name: type_name,
+            receiver_ty: &resolved.receiver_ty,
+        };
+
+        // Static methods land in the parent scope, since this impl's generics scope drops here.
+        let mut static_methods: Vec<(String, Type)> = Vec::new();
+        for function in functions {
+            if let Some(entry) = self.register_impl_method(
+                store,
+                &receiver,
+                function,
+                &resolved.generics,
+                &resolved.impl_bounds,
+            ) {
+                static_methods.push(entry);
+            }
+        }
+
+        static_methods
+    }
+
+    /// Resolve an `impl` block's receiver annotation to a type, or `None` if it should be skipped.
+    fn resolve_impl_receiver(
+        &mut self,
+        store: &mut Store,
+        annotation: &Annotation,
+        generics: &[Generic],
+        span: &Span,
+    ) -> Option<ResolvedImplReceiver> {
         self.put_in_scope(generics);
         let generics = self.resolve_generic_bounds(&*store, generics, span);
         let impl_bounds = resolved_generic_bounds(&generics);
 
         self.check_undeclared_impl_type_params(annotation, &generics);
         let receiver_ty = self.convert_receiver_to_type(&*store, annotation, span);
-        let Some(type_name) = receiver_ty.get_name() else {
-            return Vec::new();
-        };
+        let type_name = receiver_ty.get_name()?;
         // Prelude built-ins like `Array` have no qualified name to key methods by.
         let Some(receiver_qualified_name) = receiver_ty.get_qualified_name() else {
             self.sink.push(diagnostics::infer::impl_on_foreign_type(
@@ -168,7 +216,7 @@ impl TaskState {
                 crate::prelude::PRELUDE_MODULE_ID,
                 *span,
             ));
-            return Vec::new();
+            return None;
         };
         let module_id = self.cursor.module_id.clone();
         let is_d_lis = self.is_d_lis(&*store);
@@ -182,7 +230,7 @@ impl TaskState {
                 type_module,
                 *span,
             ));
-            return Vec::new();
+            return None;
         }
 
         if self.current_file_is_test(store)
@@ -195,7 +243,7 @@ impl TaskState {
                     type_name,
                     annotation.get_span(),
                 ));
-            return Vec::new();
+            return None;
         }
 
         if !self.is_d_lis(&*store)
@@ -212,7 +260,7 @@ impl TaskState {
                 type_name,
                 annotation.get_span(),
             ));
-            return Vec::new();
+            return None;
         }
 
         if self.impl_has_simple_type_params(&receiver_ty, &generics) {
@@ -228,129 +276,141 @@ impl TaskState {
         }
         self.check_transitive_generic_bounds(&*store, &generics, *span);
 
-        let receiver = ImplReceiver {
-            module_id: &module_id,
-            qualified_name: receiver_qualified_name.as_str(),
-            display_name: type_name,
+        Some(ResolvedImplReceiver {
+            receiver_ty,
+            qualified_name: receiver_qualified_name,
+            module_id,
+            generics,
+            impl_bounds,
+        })
+    }
+
+    /// Register one impl function as a method, returning the static-method entry (if any) for the caller.
+    fn register_impl_method(
+        &mut self,
+        store: &mut Store,
+        receiver: &ImplReceiver<'_>,
+        function: &Expression,
+        generics: &[Generic],
+        impl_bounds: &[Bound],
+    ) -> Option<(String, Type)> {
+        let is_d_lis = self.is_d_lis(&*store);
+        let (fn_attrs, fn_doc) = if let Expression::Function {
+            attributes, doc, ..
+        } = function
+        {
+            (attributes.as_slice(), doc.clone())
+        } else {
+            (&[][..], None)
         };
-        let mut static_methods: Vec<(String, Type)> = Vec::new();
+        let fn_visibility = if let Expression::Function { visibility, .. } = function
+            && (*visibility == SyntacticVisibility::Public || is_d_lis)
+        {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        };
+        let fn_sig = function.function_definition_view();
+        let fn_span = function.get_span();
+        let mut fn_ty = self.extract_signature_parts(
+            &*store,
+            fn_sig.generics,
+            fn_sig.params,
+            fn_sig.annotation,
+            &fn_span,
+        );
+        let qualified_name = format!("{}.{}", receiver.display_name, fn_sig.name);
+        let module_qualified_name = Symbol::from_parts(receiver.module_id, &qualified_name);
+        let is_instance_method = fn_sig.params.first().is_some_and(|p| {
+            matches!(p.pattern, Pattern::Identifier { ref identifier, .. } if identifier == "self")
+        });
 
-        for function in functions {
-            let (fn_attrs, fn_doc) = if let Expression::Function {
-                attributes, doc, ..
-            } = function
-            {
-                (attributes.as_slice(), doc.clone())
-            } else {
-                (&[][..], None)
-            };
-            let fn_visibility = if let Expression::Function { visibility, .. } = function
-                && (*visibility == SyntacticVisibility::Public || self.is_d_lis(&*store))
-            {
-                Visibility::Public
-            } else {
-                Visibility::Private
-            };
-            let fn_sig = function.function_definition_view();
-            let fn_span = function.get_span();
-            let mut fn_ty = self.extract_signature_parts(
-                &*store,
-                fn_sig.generics,
-                fn_sig.params,
-                fn_sig.annotation,
-                &fn_span,
-            );
-            let qualified_name = format!("{}.{}", type_name, fn_sig.name);
-            let module_qualified_name = Symbol::from_parts(&module_id, &qualified_name);
-            let is_instance_method = fn_sig.params.first().is_some_and(|p| {
-                matches!(p.pattern, Pattern::Identifier { ref identifier, .. } if identifier == "self")
-            });
+        let has_unannotated_self = fn_sig
+            .params
+            .first()
+            .is_some_and(|p| p.annotation.is_none());
 
-            let has_unannotated_self = fn_sig
-                .params
-                .first()
-                .is_some_and(|p| p.annotation.is_none());
-
-            if is_instance_method && has_unannotated_self {
-                fn_ty = fn_ty.with_replaced_first_param(&receiver_ty);
-            }
-
-            let (method_signature_pairs, method_signature_bounds) =
-                super::function_signature_pairs(&fn_ty, fn_sig.params, fn_span);
-            self.with_scope(|this| {
-                this.put_in_scope(fn_sig.generics);
-                for bound in &method_signature_bounds {
-                    this.record_generic_bound(&bound.param_name, bound.ty.clone());
-                }
-                this.check_value_position_bounds(&*store, &[], &method_signature_pairs);
-            });
-
-            let method_ty = wrap_with_impl_generics(&fn_ty, &generics, &impl_bounds);
-
-            let go_hints = extract_attribute_flags(fn_attrs, "go");
-            let method_key: EcoString =
-                if is_instance_method && go_hints.iter().any(|h| h == "unexported") {
-                    super::seal_method_key(is_d_lis, fn_attrs, &module_id, fn_sig.name)
-                } else {
-                    fn_sig.name.clone()
-                };
-
-            if !generics.is_empty()
-                && self.impl_has_simple_type_params(&receiver_ty, &generics)
-                && has_recursive_instantiation(&receiver_qualified_name, &fn_ty)
-            {
-                self.sink
-                    .push(diagnostics::infer::recursive_generic_instantiation(
-                        type_name,
-                        fn_sig.name_span,
-                    ));
-            }
-
-            if is_instance_method {
-                if !self.try_register_instance_method(
-                    store,
-                    &receiver,
-                    &method_key,
-                    fn_sig.name_span,
-                    &method_ty,
-                ) {
-                    continue;
-                }
-            } else {
-                static_methods.push((qualified_name, method_ty.clone()));
-            }
-
-            self.check_duplicate_method(
-                &*store,
-                &receiver,
-                fn_sig.name,
-                fn_sig.name_span,
-                generics.is_empty(),
-            );
-
-            let module = store
-                .get_module_mut(&module_id)
-                .expect("current module must exist in store");
-            module.definitions.insert(
-                module_qualified_name,
-                Definition {
-                    visibility: fn_visibility.clone(),
-                    ty: method_ty,
-                    name: None,
-                    name_span: Some(fn_sig.name_span),
-                    doc: fn_doc,
-                    body: DefinitionBody::Value {
-                        kind: syntax::program::ValueKind::Runtime,
-                        allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
-                        go_hints,
-                        go_name: None,
-                        go_type_param_recipe: None,
-                    },
-                },
-            );
+        if is_instance_method && has_unannotated_self {
+            fn_ty = fn_ty.with_replaced_first_param(receiver.receiver_ty);
         }
 
-        static_methods
+        let (method_signature_pairs, method_signature_bounds) =
+            super::function_signature_pairs(&fn_ty, fn_sig.params, fn_span);
+        self.with_scope(|this| {
+            this.put_in_scope(fn_sig.generics);
+            for bound in &method_signature_bounds {
+                this.record_generic_bound(&bound.param_name, bound.ty.clone());
+            }
+            this.check_value_position_bounds(&*store, &[], &method_signature_pairs);
+        });
+
+        let method_ty = wrap_with_impl_generics(&fn_ty, generics, impl_bounds);
+
+        let go_hints = extract_attribute_flags(fn_attrs, "go");
+        let method_key: EcoString =
+            if is_instance_method && go_hints.iter().any(|h| h == "unexported") {
+                super::seal_method_key(is_d_lis, fn_attrs, receiver.module_id, fn_sig.name)
+            } else {
+                fn_sig.name.clone()
+            };
+
+        if !generics.is_empty()
+            && self.impl_has_simple_type_params(receiver.receiver_ty, generics)
+            && has_recursive_instantiation(receiver.qualified_name, &fn_ty)
+        {
+            self.sink
+                .push(diagnostics::infer::recursive_generic_instantiation(
+                    receiver.display_name,
+                    fn_sig.name_span,
+                ));
+        }
+
+        let mut static_entry = None;
+        if is_instance_method {
+            if !self.try_register_instance_method(
+                store,
+                receiver,
+                &method_key,
+                fn_sig.name_span,
+                &method_ty,
+            ) {
+                // Receiver not found: skip the duplicate check and the definition insert below.
+                return None;
+            }
+        } else {
+            static_entry = Some((qualified_name, method_ty.clone()));
+        }
+
+        self.check_duplicate_method(
+            &*store,
+            receiver,
+            fn_sig.name,
+            fn_sig.name_span,
+            generics.is_empty(),
+        );
+
+        let module = store
+            .get_module_mut(receiver.module_id)
+            .expect("current module must exist in store");
+        module.definitions.insert(
+            module_qualified_name,
+            Definition {
+                visibility: fn_visibility.clone(),
+                ty: method_ty,
+                name: None,
+                name_span: Some(fn_sig.name_span),
+                doc: fn_doc,
+                body: DefinitionBody::Value {
+                    kind: syntax::program::ValueKind::Runtime,
+                    allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
+                    go_hints,
+                    go_name: None,
+                    go_type_param_recipe: None,
+                },
+            },
+        );
+
+        static_entry
     }
 
     pub(super) fn populate_interface(&mut self, store: &mut Store, expression: &Expression) {

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -177,18 +177,15 @@ pub struct InferenceOutput {
     pub unreachable_modules: Vec<String>,
 }
 
-/// Loads, registers, and infers every module, returning the artifacts the
-/// post-inference passes consume. Internal, unstable API.
-pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
-    let mut store = Store::new();
-    store.project_kind = input.project_kind;
-
-    let sink = LocalSink::new();
-
-    let include_tests = input.compile_phase.includes_tests();
-
-    store.init_entry_module();
-    let entry_filename = input.entry.map(|entry| {
+/// Registers the entry file (`main.lis`, or the library root), returning its
+/// filename so sibling loading can skip re-loading it.
+fn register_entry_file(
+    store: &mut Store,
+    sink: &LocalSink,
+    entry: Option<EntryFile>,
+    include_tests: bool,
+) -> Option<String> {
+    entry.map(|entry| {
         if entry.filename.ends_with("_test.lis") {
             sink.push(diagnostics::module_graph::wrong_test_file_suffix(
                 &entry.display_path,
@@ -206,52 +203,58 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             entry.file_comment,
         );
         entry.filename
-    });
+    })
+}
 
-    if input.config.load_siblings {
-        for (filename, content) in input.loader.scan_folder(ENTRY_MODULE_ID) {
-            if Some(&filename) == entry_filename.as_ref() {
-                continue;
-            }
-            if filename.ends_with("_test.lis") {
-                sink.push(diagnostics::module_graph::wrong_test_file_suffix(
-                    &content.display_path,
-                ));
-                continue;
-            }
-            if !filename.ends_with(".lis")
-                || filename.ends_with(".d.lis")
-                || (filename.ends_with(".test.lis") && !include_tests)
-            {
-                continue;
-            }
-            let file_id = store.new_file_id();
-            let result = syntax::build_ast(&content.source, file_id);
-            sink.extend_parse_errors(result.errors);
-            store.store_file(File::new(
-                ENTRY_MODULE_ID,
-                &filename,
-                &content.display_path,
-                &content.source,
-                result.ast,
-                result.file_comment,
-                file_id,
-            ));
+/// Loads every other `.lis` file in the entry module's folder as a sibling file.
+fn load_sibling_files(
+    store: &mut Store,
+    sink: &LocalSink,
+    loader: &dyn Loader,
+    entry_filename: Option<&str>,
+    include_tests: bool,
+) {
+    for (filename, content) in loader.scan_folder(ENTRY_MODULE_ID) {
+        if Some(filename.as_str()) == entry_filename {
+            continue;
         }
+        if filename.ends_with("_test.lis") {
+            sink.push(diagnostics::module_graph::wrong_test_file_suffix(
+                &content.display_path,
+            ));
+            continue;
+        }
+        if !filename.ends_with(".lis")
+            || filename.ends_with(".d.lis")
+            || (filename.ends_with(".test.lis") && !include_tests)
+        {
+            continue;
+        }
+        let file_id = store.new_file_id();
+        let result = syntax::build_ast(&content.source, file_id);
+        sink.extend_parse_errors(result.errors);
+        store.store_file(File::new(
+            ENTRY_MODULE_ID,
+            &filename,
+            &content.display_path,
+            &content.source,
+            result.ast,
+            result.file_comment,
+            file_id,
+        ));
     }
+}
 
-    let entry_module = store.entry_module_id().to_string();
-    let discovered = if input.project_root.is_some() {
-        input.loader.discover_modules()
-    } else {
-        DiscoveredModules::default()
-    };
-
-    let include_test_roots = input.compile_phase.includes_tests();
-
-    let roots = match input.project_kind {
+fn compute_roots(
+    project_kind: ProjectKind,
+    compile_phase: CompilePhase,
+    discovered: &DiscoveredModules,
+    entry_module: String,
+) -> Roots {
+    let include_test_roots = compile_phase.includes_tests();
+    match project_kind {
         ProjectKind::Binary => {
-            let mut additional = match input.compile_phase {
+            let mut additional = match compile_phase {
                 CompilePhase::Check => discovered.production_modules.clone(),
                 CompilePhase::Emit | CompilePhase::Test => Vec::new(),
             };
@@ -275,9 +278,268 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
                 additional,
             }
         }
+    }
+}
+
+/// Production modules the primary roots never reached.
+fn find_unreachable_modules(
+    discovered: &DiscoveredModules,
+    graph_result: &crate::module_graph::ModuleGraphResult,
+) -> Vec<String> {
+    let mut unreachable: Vec<String> = discovered
+        .production_modules
+        .iter()
+        .filter(|m| !graph_result.primary_reachable.contains(m.as_str()))
+        .cloned()
+        .collect();
+    unreachable.sort();
+    unreachable
+}
+
+/// Loads the prelude from cache when possible, else parses and registers it fresh.
+fn load_prelude(store: &mut Store, sink: &LocalSink, cache_disabled: bool) -> bool {
+    let prelude_cache_hit = !cache_disabled
+        && prelude_cache::try_load_prelude_cache().is_some_and(|cached| {
+            prelude_cache::register_cached_prelude(store, cached);
+            true
+        });
+    if !prelude_cache_hit {
+        parse_and_register_prelude(store, sink);
+    }
+    prelude_cache_hit
+}
+
+struct ModuleInferenceInput<'a> {
+    graph_result: crate::module_graph::ModuleGraphResult,
+    sink: LocalSink,
+    module_cache_root: Option<&'a Path>,
+    check_go_files: bool,
+    cache_disabled: bool,
+    prelude_cache_hit: bool,
+    go_module: &'a str,
+    locator: &'a TypedefLocator,
+    standalone_mode: bool,
+}
+
+struct ModuleInferenceOutput {
+    facts: Facts,
+    cached_modules: HashSet<String>,
+    compiled_modules: Vec<CompiledModule>,
+    ufcs_methods: HashSet<(String, String)>,
+    sink: LocalSink,
+}
+
+/// Classifies every topo-ordered module as a `go:` import, a cache candidate,
+/// or pending registration, then registers and infers whatever was not
+/// served from cache.
+fn infer_all_modules(store: &mut Store, mut input: ModuleInferenceInput) -> ModuleInferenceOutput {
+    let mut checker = TaskState::with_sink(input.sink);
+    checker.extend_ufcs_methods(crate::prelude::compute_prelude_ufcs(store));
+
+    let mut module_hashes: HashMap<String, u64> = HashMap::default();
+    let mut cached_modules: HashSet<String> = HashSet::default();
+    let order = std::mem::take(&mut input.graph_result.order);
+    let dependencies = &input.graph_result.dependencies;
+
+    let mut go_cache = LazyGoStdlibCache::new(input.cache_disabled);
+
+    let mut to_infer: Vec<PendingModule> = Vec::new();
+    let mut candidates: Vec<CacheCandidate> = Vec::new();
+
+    let source_hashes: HashMap<String, (u64, u64)> =
+        if input.graph_result.files.len() < PARALLEL_THRESHOLD {
+            input
+                .graph_result
+                .files
+                .iter()
+                .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                .collect()
+        } else {
+            input
+                .graph_result
+                .files
+                .par_iter()
+                .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                .collect()
+        };
+
+    for (topo_rank, module_id) in order.into_iter().enumerate() {
+        if module_id.starts_with("go:") {
+            if dependencies.is_link_only_module(&module_id) {
+                continue;
+            }
+            register_go_module(
+                &mut checker,
+                store,
+                &module_id,
+                input.locator,
+                input.standalone_mode,
+                &mut go_cache,
+            );
+            continue;
+        }
+
+        if store.is_visited(&module_id) {
+            continue;
+        }
+
+        let files = input
+            .graph_result
+            .files
+            .remove(&module_id)
+            .unwrap_or_default();
+        // Production-only hash drives dependents/emit; all-files hash drives own validity.
+        let (production_hash, full_hash) = source_hashes
+            .get(&module_id)
+            .copied()
+            .unwrap_or_else(|| hash_module_source_pair(&files));
+
+        let dep_hashes =
+            get_dependency_module_hashes(dependencies.dependencies(&module_id), &module_hashes);
+        let production_dep_hashes = get_dependency_module_hashes(
+            dependencies.production_dependencies(&module_id),
+            &module_hashes,
+        );
+        let module_hash = compute_module_hash(production_hash, &production_dep_hashes);
+        module_hashes.insert(module_id.clone(), module_hash);
+
+        let is_entry = module_id == ENTRY_MODULE_ID;
+
+        let compiled = (!is_entry).then(|| CompiledModule {
+            module_id: module_id.clone(),
+            module_hash,
+            production_hash,
+            full_hash,
+            dep_hashes,
+        });
+
+        let expected_artifact_hash = input
+            .check_go_files
+            .then(|| compute_emit_artifact_hash(production_hash, input.go_module));
+
+        match (input.module_cache_root, compiled) {
+            (Some(_), Some(compiled)) => candidates.push(CacheCandidate {
+                compiled,
+                files,
+                topo_rank,
+                expected_artifact_hash,
+            }),
+            (None, compiled) | (Some(_), compiled @ None) => {
+                store.store_module(&module_id, files);
+                let pending = match compiled {
+                    Some(module) => PendingModule::Compiled { module, topo_rank },
+                    None => PendingModule::Entry {
+                        module_id,
+                        topo_rank,
+                    },
+                };
+                to_infer.push(pending);
+            }
+        }
+    }
+
+    let go_cache_module_ids = go_cache.into_module_ids();
+
+    let cache_load = match input.module_cache_root {
+        Some(root) => load_cache_candidates(&mut checker, store, candidates, root),
+        None => {
+            debug_assert!(candidates.is_empty());
+            CacheLoad::default()
+        }
+    };
+    cached_modules.extend(cache_load.cached);
+    to_infer.extend(cache_load.to_infer);
+
+    for pending in &to_infer {
+        checker.predeclare_module_types(store, pending.module_id());
+    }
+    restore_cached_generic_bounds(store, &checker.sink, &cached_modules);
+
+    to_infer.sort_by_key(PendingModule::topo_rank);
+    let mut compiled_modules = Vec::new();
+    let to_infer: Vec<String> = to_infer
+        .into_iter()
+        .map(|pending| match pending {
+            PendingModule::Entry { module_id, .. } => module_id,
+            PendingModule::Compiled { module, .. } => {
+                let module_id = module.module_id.clone();
+                compiled_modules.push(module);
+                module_id
+            }
+        })
+        .collect();
+
+    register_modules(&mut checker, store, &to_infer, dependencies);
+    infer_modules(&mut checker, store, &to_infer);
+
+    if !input.cache_disabled {
+        let all_go_modules: Vec<String> = store
+            .modules
+            .keys()
+            .filter(|id| id.strip_prefix("go:").is_some_and(deps::is_stdlib))
+            .cloned()
+            .collect();
+        // A non-empty list implies the lazy cache load was attempted.
+        let needs_save = !all_go_modules.is_empty()
+            && go_cache_module_ids.as_ref().is_none_or(|ids| {
+                all_go_modules.len() != ids.len()
+                    || all_go_modules.iter().any(|id| !ids.contains(id))
+            });
+        if needs_save {
+            go_stdlib::save_go_stdlib_cache(store, &all_go_modules, input.locator.target());
+        }
+    }
+
+    if !input.cache_disabled && !input.prelude_cache_hit {
+        prelude_cache::save_prelude_cache(store);
+    }
+
+    let ufcs_methods = checker.take_ufcs_methods();
+    ModuleInferenceOutput {
+        facts: checker.facts,
+        cached_modules,
+        compiled_modules,
+        ufcs_methods,
+        sink: checker.sink,
+    }
+}
+
+/// Loads, registers, and infers every module, returning the artifacts the
+/// post-inference passes consume. Internal, unstable API.
+pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
+    let mut store = Store::new();
+    store.project_kind = input.project_kind;
+
+    let sink = LocalSink::new();
+    let include_tests = input.compile_phase.includes_tests();
+
+    store.init_entry_module();
+    let entry_filename = register_entry_file(&mut store, &sink, input.entry, include_tests);
+    if input.config.load_siblings {
+        load_sibling_files(
+            &mut store,
+            &sink,
+            input.loader,
+            entry_filename.as_deref(),
+            include_tests,
+        );
+    }
+
+    let entry_module = store.entry_module_id().to_string();
+    let discovered = if input.project_root.is_some() {
+        input.loader.discover_modules()
+    } else {
+        DiscoveredModules::default()
     };
 
-    let mut graph_result = build_module_graph(
+    let roots = compute_roots(
+        input.project_kind,
+        input.compile_phase,
+        &discovered,
+        entry_module,
+    );
+
+    let graph_result = build_module_graph(
         &mut store,
         roots,
         ModuleGraphOptions {
@@ -292,215 +554,43 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     for cycle in &graph_result.cycles {
         sink.push(diagnostics::module_graph::import_cycle(cycle));
     }
-
-    let mut unreachable_modules: Vec<String> = discovered
-        .production_modules
-        .iter()
-        .filter(|m| !graph_result.primary_reachable.contains(m.as_str()))
-        .cloned()
-        .collect();
-    unreachable_modules.sort();
+    let unreachable_modules = find_unreachable_modules(&discovered, &graph_result);
 
     let has_pre_check_errors = sink.has_errors();
 
     let cache_disabled = is_cache_disabled();
-
-    let prelude_cache_hit = if cache_disabled {
-        false
-    } else if let Some(cached) = prelude_cache::try_load_prelude_cache() {
-        prelude_cache::register_cached_prelude(&mut store, cached);
-        true
-    } else {
-        false
-    };
-
-    if !prelude_cache_hit {
-        parse_and_register_prelude(&mut store, &sink);
-    }
+    let prelude_cache_hit = load_prelude(&mut store, &sink, cache_disabled);
     parse_and_register_test_prelude(&mut store, &sink);
 
-    let module_cache_root = if cache_disabled || input.disable_cache {
-        None
-    } else {
-        input.project_root.as_deref()
-    };
+    let module_cache_root = (!cache_disabled && !input.disable_cache)
+        .then_some(input.project_root.as_deref())
+        .flatten();
     let cache_enabled = module_cache_root.is_some();
     let check_go_files = input.compile_phase.emits();
 
-    let (facts, cached_modules, compiled_modules, ufcs_methods, sink) = {
-        let mut checker = TaskState::with_sink(sink);
-        checker.extend_ufcs_methods(crate::prelude::compute_prelude_ufcs(&store));
-
-        let mut module_hashes: HashMap<String, u64> = HashMap::default();
-        let mut cached_modules: HashSet<String> = HashSet::default();
-        let order = std::mem::take(&mut graph_result.order);
-        let dependencies = &graph_result.dependencies;
-
-        let mut go_cache = LazyGoStdlibCache::new(cache_disabled);
-
-        let mut to_infer: Vec<PendingModule> = Vec::new();
-        let mut candidates: Vec<CacheCandidate> = Vec::new();
-
-        let source_hashes: HashMap<String, (u64, u64)> =
-            if graph_result.files.len() < PARALLEL_THRESHOLD {
-                graph_result
-                    .files
-                    .iter()
-                    .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
-                    .collect()
-            } else {
-                graph_result
-                    .files
-                    .par_iter()
-                    .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
-                    .collect()
-            };
-
-        for (topo_rank, module_id) in order.into_iter().enumerate() {
-            if module_id.starts_with("go:") {
-                if dependencies.is_link_only_module(&module_id) {
-                    continue;
-                }
-                register_go_module(
-                    &mut checker,
-                    &mut store,
-                    &module_id,
-                    &input.locator,
-                    input.config.standalone_mode,
-                    &mut go_cache,
-                );
-                continue;
-            }
-
-            if store.is_visited(&module_id) {
-                continue;
-            }
-
-            let files = graph_result.files.remove(&module_id).unwrap_or_default();
-            // Production-only hash drives dependents/emit; all-files hash drives own validity.
-            let (production_hash, full_hash) = source_hashes
-                .get(&module_id)
-                .copied()
-                .unwrap_or_else(|| hash_module_source_pair(&files));
-
-            let dep_hashes =
-                get_dependency_module_hashes(dependencies.dependencies(&module_id), &module_hashes);
-            let production_dep_hashes = get_dependency_module_hashes(
-                dependencies.production_dependencies(&module_id),
-                &module_hashes,
-            );
-            let module_hash = compute_module_hash(production_hash, &production_dep_hashes);
-            module_hashes.insert(module_id.clone(), module_hash);
-
-            let is_entry = module_id == ENTRY_MODULE_ID;
-
-            let compiled = (!is_entry).then(|| CompiledModule {
-                module_id: module_id.clone(),
-                module_hash,
-                production_hash,
-                full_hash,
-                dep_hashes,
-            });
-
-            let expected_artifact_hash = check_go_files
-                .then(|| compute_emit_artifact_hash(production_hash, &input.go_module));
-
-            match (module_cache_root, compiled) {
-                (Some(_), Some(compiled)) => candidates.push(CacheCandidate {
-                    compiled,
-                    files,
-                    topo_rank,
-                    expected_artifact_hash,
-                }),
-                (None, compiled) | (Some(_), compiled @ None) => {
-                    store.store_module(&module_id, files);
-                    let pending = match compiled {
-                        Some(module) => PendingModule::Compiled { module, topo_rank },
-                        None => PendingModule::Entry {
-                            module_id,
-                            topo_rank,
-                        },
-                    };
-                    to_infer.push(pending);
-                }
-            }
-        }
-
-        let go_cache_module_ids = go_cache.into_module_ids();
-
-        let cache_load = match module_cache_root {
-            Some(root) => load_cache_candidates(&mut checker, &mut store, candidates, root),
-            None => {
-                debug_assert!(candidates.is_empty());
-                CacheLoad::default()
-            }
-        };
-        cached_modules.extend(cache_load.cached);
-        to_infer.extend(cache_load.to_infer);
-
-        for pending in &to_infer {
-            checker.predeclare_module_types(&mut store, pending.module_id());
-        }
-        restore_cached_generic_bounds(&mut store, &checker.sink, &cached_modules);
-
-        to_infer.sort_by_key(PendingModule::topo_rank);
-        let mut compiled_modules = Vec::new();
-        let to_infer: Vec<String> = to_infer
-            .into_iter()
-            .map(|pending| match pending {
-                PendingModule::Entry { module_id, .. } => module_id,
-                PendingModule::Compiled { module, .. } => {
-                    let module_id = module.module_id.clone();
-                    compiled_modules.push(module);
-                    module_id
-                }
-            })
-            .collect();
-
-        register_modules(&mut checker, &mut store, &to_infer, dependencies);
-        infer_modules(&mut checker, &mut store, &to_infer);
-
-        if !cache_disabled {
-            let all_go_modules: Vec<String> = store
-                .modules
-                .keys()
-                .filter(|id| id.strip_prefix("go:").is_some_and(deps::is_stdlib))
-                .cloned()
-                .collect();
-            // A non-empty list implies the lazy cache load was attempted.
-            let needs_save = !all_go_modules.is_empty()
-                && go_cache_module_ids.as_ref().is_none_or(|ids| {
-                    all_go_modules.len() != ids.len()
-                        || all_go_modules.iter().any(|id| !ids.contains(id))
-                });
-            if needs_save {
-                go_stdlib::save_go_stdlib_cache(&store, &all_go_modules, input.locator.target());
-            }
-        }
-
-        if !cache_disabled && !prelude_cache_hit {
-            prelude_cache::save_prelude_cache(&store);
-        }
-
-        let ufcs_methods = checker.take_ufcs_methods();
-
-        (
-            checker.facts,
-            cached_modules,
-            compiled_modules,
-            ufcs_methods,
-            checker.sink,
-        )
-    };
+    let module_output = infer_all_modules(
+        &mut store,
+        ModuleInferenceInput {
+            graph_result,
+            sink,
+            module_cache_root,
+            check_go_files,
+            cache_disabled,
+            prelude_cache_hit,
+            go_module: &input.go_module,
+            locator: &input.locator,
+            standalone_mode: input.config.standalone_mode,
+        },
+    );
 
     InferenceOutput {
         store,
-        facts,
-        ufcs_methods,
-        sink,
+        facts: module_output.facts,
+        ufcs_methods: module_output.ufcs_methods,
+        sink: module_output.sink,
         has_pre_check_errors,
-        compiled_modules,
-        cached_modules,
+        compiled_modules: module_output.compiled_modules,
+        cached_modules: module_output.cached_modules,
         cache_enabled,
         unreachable_modules,
     }

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -392,32 +392,10 @@ impl<'source> Lexer<'source> {
 
         let mut kind = TokenKind::Integer;
 
-        while !self.at_eof() {
-            let byte = self.current_byte();
-            if byte.is_ascii_digit() || byte == b'_' {
-                if byte == b'_' && self.previous_char() == '_' {
-                    let underscore_start = self.current_offset - 1;
-                    self.error_consecutive_underscores(underscore_start);
-                }
-                self.next();
-            } else {
-                break;
-            }
-        }
+        self.scan_digits(|byte| byte.is_ascii_digit());
+        self.check_trailing_underscore();
 
-        if self.previous_char() == '_' {
-            self.error_number_trailing_underscore(
-                self.current_offset - self.previous_char().len_utf8(),
-            );
-        }
-
-        // Skip decimal part if preceded by single `.` (e.g., `tuple.0.0` — don't lex `0.0` as float).
-        // Don't skip if preceded by `..` (range operator), e.g. `0..1.5` should lex `1.5` as float.
-        let preceded_by_dot = start_offset > 0
-            && self.input.as_bytes()[start_offset - 1] == b'.'
-            && !(start_offset > 1 && self.input.as_bytes()[start_offset - 2] == b'.');
-
-        if !preceded_by_dot
+        if !self.preceded_by_single_dot(start_offset)
             && self.current_byte() == b'.'
             && self.peek_byte() != b'.'
             && (self.peek_byte().is_ascii_digit() || self.peek_byte() == b'_')
@@ -429,24 +407,8 @@ impl<'source> Lexer<'source> {
                 self.error_decimal_leading_underscore(self.current_offset);
             }
 
-            while !self.at_eof() {
-                let byte = self.current_byte();
-                if byte.is_ascii_digit() || byte == b'_' {
-                    if byte == b'_' && self.previous_char() == '_' {
-                        let underscore_start = self.current_offset - 1;
-                        self.error_consecutive_underscores(underscore_start);
-                    }
-                    self.next();
-                } else {
-                    break;
-                }
-            }
-
-            if self.previous_char() == '_' {
-                self.error_number_trailing_underscore(
-                    self.current_offset - self.previous_char().len_utf8(),
-                );
-            }
+            self.scan_digits(|byte| byte.is_ascii_digit());
+            self.check_trailing_underscore();
         }
 
         if self.current_byte() == b'e' || self.current_byte() == b'E' {
@@ -465,24 +427,8 @@ impl<'source> Lexer<'source> {
                 );
             }
 
-            while !self.at_eof() {
-                let byte = self.current_byte();
-                if byte.is_ascii_digit() || byte == b'_' {
-                    if byte == b'_' && self.previous_char() == '_' {
-                        let underscore_start = self.current_offset - 1;
-                        self.error_consecutive_underscores(underscore_start);
-                    }
-                    self.next();
-                } else {
-                    break;
-                }
-            }
-
-            if self.previous_char() == '_' {
-                self.error_number_trailing_underscore(
-                    self.current_offset - self.previous_char().len_utf8(),
-                );
-            }
+            self.scan_digits(|byte| byte.is_ascii_digit());
+            self.check_trailing_underscore();
         }
 
         if self.current_byte() == b'i' && !self.peek_byte().is_ascii_alphanumeric() {
@@ -505,12 +451,11 @@ impl<'source> Lexer<'source> {
         }
     }
 
-    fn lex_hex_number(&mut self, start_offset: usize) -> Token<'source> {
-        let digits_start = self.current_offset;
-
+    /// Consume digit and underscore bytes, reporting consecutive underscores.
+    fn scan_digits(&mut self, is_digit: impl Fn(u8) -> bool) {
         while !self.at_eof() {
             let byte = self.current_byte();
-            if byte.is_ascii_hexdigit() || byte == b'_' {
+            if is_digit(byte) || byte == b'_' {
                 if byte == b'_' && self.previous_char() == '_' {
                     let underscore_start = self.current_offset - 1;
                     self.error_consecutive_underscores(underscore_start);
@@ -520,21 +465,41 @@ impl<'source> Lexer<'source> {
                 break;
             }
         }
+    }
 
-        if self.current_offset == digits_start {
-            self.error_missing_hex_digits(start_offset, 2);
-        }
-
+    fn check_trailing_underscore(&mut self) {
         if self.previous_char() == '_' {
             self.error_number_trailing_underscore(
                 self.current_offset - self.previous_char().len_utf8(),
             );
         }
+    }
+
+    // A single preceding `.` is field access (e.g. `tuple.0.0`), so do not lex `0.0` as float.
+    // A preceding `..` is the range operator, so e.g. `0..1.5` should lex `1.5` as float.
+    fn preceded_by_single_dot(&self, start_offset: usize) -> bool {
+        start_offset > 0
+            && self.input.as_bytes()[start_offset - 1] == b'.'
+            && !(start_offset > 1 && self.input.as_bytes()[start_offset - 2] == b'.')
+    }
+
+    fn finish_radix_number(
+        &mut self,
+        start_offset: usize,
+        digits_start: usize,
+        base: &str,
+        error_missing_digits: fn(&mut Self, usize, usize),
+    ) -> Token<'source> {
+        if self.current_offset == digits_start {
+            error_missing_digits(self, start_offset, 2);
+        }
+
+        self.check_trailing_underscore();
 
         if self.current_byte() == b'i' && !self.peek_byte().is_ascii_alphanumeric() {
-            self.next(); // consume 'i'
+            self.next();
             let end_offset = self.current_offset;
-            self.error_non_decimal_imaginary("hex", start_offset, end_offset - start_offset);
+            self.error_non_decimal_imaginary(base, start_offset, end_offset - start_offset);
             return Token {
                 kind: TokenKind::Imaginary,
                 text: &self.input[start_offset..end_offset],
@@ -552,18 +517,25 @@ impl<'source> Lexer<'source> {
         }
     }
 
+    fn lex_hex_number(&mut self, start_offset: usize) -> Token<'source> {
+        let digits_start = self.current_offset;
+
+        self.scan_digits(|byte| byte.is_ascii_hexdigit());
+
+        self.finish_radix_number(
+            start_offset,
+            digits_start,
+            "hex",
+            Self::error_missing_hex_digits,
+        )
+    }
+
     fn lex_octal_number(&mut self, start_offset: usize) -> Token<'source> {
         let digits_start = self.current_offset;
 
-        while !self.at_eof() {
-            let byte = self.current_byte();
-            if (b'0'..=b'7').contains(&byte) || byte == b'_' {
-                if byte == b'_' && self.previous_char() == '_' {
-                    let underscore_start = self.current_offset - 1;
-                    self.error_consecutive_underscores(underscore_start);
-                }
-                self.next();
-            } else if byte == b'8' || byte == b'9' {
+        loop {
+            self.scan_digits(|byte| (b'0'..=b'7').contains(&byte));
+            if matches!(self.current_byte(), b'8' | b'9') {
                 self.error_invalid_octal_digit(self.current_offset);
                 self.next();
             } else {
@@ -571,49 +543,20 @@ impl<'source> Lexer<'source> {
             }
         }
 
-        if self.current_offset == digits_start {
-            self.error_missing_octal_digits(start_offset, 2);
-        }
-
-        if self.previous_char() == '_' {
-            self.error_number_trailing_underscore(
-                self.current_offset - self.previous_char().len_utf8(),
-            );
-        }
-
-        if self.current_byte() == b'i' && !self.peek_byte().is_ascii_alphanumeric() {
-            self.next(); // consume 'i'
-            let end_offset = self.current_offset;
-            self.error_non_decimal_imaginary("octal", start_offset, end_offset - start_offset);
-            return Token {
-                kind: TokenKind::Imaginary,
-                text: &self.input[start_offset..end_offset],
-                byte_offset: start_offset as u32,
-                byte_length: (end_offset - start_offset) as u32,
-            };
-        }
-
-        let end_offset = self.current_offset;
-        Token {
-            kind: TokenKind::Integer,
-            text: &self.input[start_offset..end_offset],
-            byte_offset: start_offset as u32,
-            byte_length: (end_offset - start_offset) as u32,
-        }
+        self.finish_radix_number(
+            start_offset,
+            digits_start,
+            "octal",
+            Self::error_missing_octal_digits,
+        )
     }
 
     fn lex_binary_number(&mut self, start_offset: usize) -> Token<'source> {
         let digits_start = self.current_offset;
 
-        while !self.at_eof() {
-            let byte = self.current_byte();
-            if byte == b'0' || byte == b'1' || byte == b'_' {
-                if byte == b'_' && self.previous_char() == '_' {
-                    let underscore_start = self.current_offset - 1;
-                    self.error_consecutive_underscores(underscore_start);
-                }
-                self.next();
-            } else if (b'2'..=b'9').contains(&byte) {
+        loop {
+            self.scan_digits(|byte| byte == b'0' || byte == b'1');
+            if (b'2'..=b'9').contains(&self.current_byte()) {
                 self.error_invalid_binary_digit(self.current_offset);
                 self.next();
             } else {
@@ -621,35 +564,12 @@ impl<'source> Lexer<'source> {
             }
         }
 
-        if self.current_offset == digits_start {
-            self.error_missing_binary_digits(start_offset, 2);
-        }
-
-        if self.previous_char() == '_' {
-            self.error_number_trailing_underscore(
-                self.current_offset - self.previous_char().len_utf8(),
-            );
-        }
-
-        if self.current_byte() == b'i' && !self.peek_byte().is_ascii_alphanumeric() {
-            self.next();
-            let end_offset = self.current_offset;
-            self.error_non_decimal_imaginary("binary", start_offset, end_offset - start_offset);
-            return Token {
-                kind: TokenKind::Imaginary,
-                text: &self.input[start_offset..end_offset],
-                byte_offset: start_offset as u32,
-                byte_length: (end_offset - start_offset) as u32,
-            };
-        }
-
-        let end_offset = self.current_offset;
-        Token {
-            kind: TokenKind::Integer,
-            text: &self.input[start_offset..end_offset],
-            byte_offset: start_offset as u32,
-            byte_length: (end_offset - start_offset) as u32,
-        }
+        self.finish_radix_number(
+            start_offset,
+            digits_start,
+            "binary",
+            Self::error_missing_binary_digits,
+        )
     }
 
     fn lex_identifier(&mut self) -> Token<'source> {


### PR DESCRIPTION
Decomposes the codebase's most complex functions into smaller, single-purpose ones.

- `Command::parse` and the `cli` handlers `build.rs`, `reconciliation.rs`, etc. split per subcommand.
- `run_inference` and the type checker's largest inference functions split along phases.
- The LSP's `completion`, `goto_definition`, and `prepare_rename` handlers split into one function per context.
- The lint ref-graph walker and the pattern-exhaustiveness normalizer in `passes` split along variant boundaries.
- The lexer's number-scanning code is deduplicated across the hex, octal, binary, and decimal paths.
