### PR TITLE
feat: diagnostic for always-true disjunction

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2760,6 +2760,15 @@ pub fn impossible_comparison(span: &Span) -> LisetteDiagnostic {
         )
 }
 
+pub fn always_true_disjunction(span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Always-true comparison")
+        .with_infer_code("always_true_disjunction")
+        .with_span_label(span, "always `true`")
+        .with_help(
+            "Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`?",
+        )
+}
+
 pub fn nan_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic {
     let result = if always_true { "true" } else { "false" };
 

--- a/crates/passes/src/passes/checks/always_true_disjunction.rs
+++ b/crates/passes/src/passes/checks/always_true_disjunction.rs
@@ -1,0 +1,202 @@
+use crate::passes::comparison::{
+    Bound, expressions_equivalent, flip_comparison, in_scope_comparison, is_side_effect_free,
+    is_skippable_boolean, signed_integer_literal, tighter,
+};
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression, Span};
+
+pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
+    let Expression::Binary {
+        operator: BinaryOperator::Or,
+        span: root_span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    if ctx.claimed_spans.contains(root_span) {
+        return;
+    }
+
+    let mut disjuncts = Vec::new();
+    collect_disjuncts(expression, root_span, &mut disjuncts, ctx);
+
+    // Falsifications combine only across side-effect-free disjuncts: a disjunct
+    // that could mutate state may change the compared operand, ending the run.
+    let mut false_sets: Vec<FalseSet> = Vec::new();
+    let mut always_true = false;
+    for disjunct in disjuncts {
+        if !is_side_effect_free(disjunct) {
+            always_true |= false_sets.iter().any(|set| set.is_empty());
+            false_sets.clear();
+            continue;
+        }
+        if let Some((operand, range, constraint)) = falsifying_constraint(disjunct) {
+            match false_sets
+                .iter_mut()
+                .find(|set| expressions_equivalent(set.operand, operand))
+            {
+                Some(set) => set.add(constraint),
+                None => {
+                    let mut set = FalseSet::new(operand, range);
+                    set.add(constraint);
+                    false_sets.push(set);
+                }
+            }
+        } else if !is_skippable_boolean(disjunct) {
+            // Reasoning across an out-of-scope or type-invalid disjunct is unsound.
+            always_true |= false_sets.iter().any(|set| set.is_empty());
+            false_sets.clear();
+        }
+    }
+    always_true |= false_sets.iter().any(|set| set.is_empty());
+
+    if always_true {
+        ctx.sink
+            .push(diagnostics::infer::always_true_disjunction(root_span));
+    }
+}
+
+/// Flattens an `||` chain, claiming nested spans so sub-chains are not re-reported.
+fn collect_disjuncts<'a>(
+    expression: &'a Expression,
+    root_span: &Span,
+    disjuncts: &mut Vec<&'a Expression>,
+    ctx: &mut NodeCtx,
+) {
+    match expression.unwrap_parens() {
+        Expression::Binary {
+            operator: BinaryOperator::Or,
+            left,
+            right,
+            span,
+            ..
+        } => {
+            if span != root_span {
+                ctx.claimed_spans.insert(*span);
+            }
+            collect_disjuncts(left, root_span, disjuncts, ctx);
+            collect_disjuncts(right, root_span, disjuncts, ctx);
+        }
+        other => disjuncts.push(other),
+    }
+}
+
+enum Constraint {
+    Bounded { low: Bound, high: Bound },
+    Excluded(i128),
+}
+
+/// The constraint under which a comparison is false, with its operand and the
+/// operand type's value range. Floats are excluded: `NaN` falsifies every
+/// ordered comparison at once, so `f < 5 || f >= 5` is not a tautology.
+fn falsifying_constraint(
+    expression: &Expression,
+) -> Option<(&Expression, (i128, i128), Constraint)> {
+    let Expression::Binary {
+        operator,
+        left,
+        right,
+        ..
+    } = expression.unwrap_parens()
+    else {
+        return None;
+    };
+
+    use BinaryOperator::*;
+    let left = left.unwrap_parens();
+    let right = right.unwrap_parens();
+    if !in_scope_comparison(left, right) {
+        return None;
+    }
+    let (operand, operator, bound) =
+        match (signed_integer_literal(left), signed_integer_literal(right)) {
+            (None, Some(bound)) => (left, *operator, bound),
+            (Some(bound), None) => (right, flip_comparison(*operator), bound),
+            _ => return None,
+        };
+    let range = operand
+        .get_type()
+        .as_simple()
+        .and_then(|kind| kind.integer_range())?;
+
+    // Each arm negates its comparison: `x < b` is false exactly when `x >= b`.
+    let constraint = match operator {
+        LessThan => Constraint::Bounded {
+            low: Some((bound, true)),
+            high: None,
+        },
+        LessThanOrEqual => Constraint::Bounded {
+            low: Some((bound, false)),
+            high: None,
+        },
+        GreaterThan => Constraint::Bounded {
+            low: None,
+            high: Some((bound, true)),
+        },
+        GreaterThanOrEqual => Constraint::Bounded {
+            low: None,
+            high: Some((bound, false)),
+        },
+        Equal => Constraint::Excluded(bound),
+        NotEqual => Constraint::Bounded {
+            low: Some((bound, true)),
+            high: Some((bound, true)),
+        },
+        _ => return None,
+    };
+
+    Some((operand, range, constraint))
+}
+
+/// The integer values falsifying every disjunct in a run, seeded with the
+/// operand type's range: values outside the domain cannot falsify anything.
+struct FalseSet<'a> {
+    operand: &'a Expression,
+    low: (i128, bool),
+    high: (i128, bool),
+    excluded: Vec<i128>,
+}
+
+impl<'a> FalseSet<'a> {
+    fn new(operand: &'a Expression, (min, max): (i128, i128)) -> Self {
+        FalseSet {
+            operand,
+            low: (min, true),
+            high: (max, true),
+            excluded: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, constraint: Constraint) {
+        match constraint {
+            Constraint::Bounded { low, high } => {
+                self.low = tighter(Some(self.low), low, |a, b| a > b).unwrap_or(self.low);
+                self.high = tighter(Some(self.high), high, |a, b| a < b).unwrap_or(self.high);
+            }
+            Constraint::Excluded(value) => self.excluded.push(value),
+        }
+    }
+
+    // Integer operands, so exclusive bounds shrink to the nearest integer.
+    fn is_empty(&self) -> bool {
+        let (low_value, low_inclusive) = self.low;
+        let (high_value, high_inclusive) = self.high;
+        let low = if low_inclusive {
+            low_value
+        } else {
+            low_value + 1
+        };
+        let high = if high_inclusive {
+            high_value
+        } else {
+            high_value - 1
+        };
+        if low > high {
+            return true;
+        }
+        high - low < self.excluded.len() as i128
+            && (low..=high).all(|value| self.excluded.contains(&value))
+    }
+}

--- a/crates/passes/src/passes/checks/impossible_comparison.rs
+++ b/crates/passes/src/passes/checks/impossible_comparison.rs
@@ -1,9 +1,9 @@
 use crate::passes::comparison::{
     Bound, expressions_equivalent, flip_comparison, in_scope_comparison, is_side_effect_free,
-    signed_integer_literal, tighter,
+    is_skippable_boolean, signed_integer_literal, tighter,
 };
 use crate::passes::walk::NodeCtx;
-use syntax::ast::{BinaryOperator, Expression, Span, UnaryOperator};
+use syntax::ast::{BinaryOperator, Expression, Span};
 
 pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
     let Expression::Binary {
@@ -84,26 +84,6 @@ fn collect_conjuncts<'a>(
             collect_conjuncts(right, root_span, conjuncts, ctx);
         }
         other => conjuncts.push(other),
-    }
-}
-
-/// Whether `expression` is a value-stable boolean safe to skip in the chain: a
-/// boolean identifier, field read, literal, or `!` of one. These cannot be a
-/// rejected comparison, so a run of constraints may carry across them.
-fn is_skippable_boolean(expression: &Expression) -> bool {
-    if !expression.get_type().is_boolean() {
-        return false;
-    }
-    match expression.unwrap_parens() {
-        Expression::Identifier { .. }
-        | Expression::DotAccess { .. }
-        | Expression::Literal { .. } => true,
-        Expression::Unary {
-            operator: UnaryOperator::Not,
-            expression: inner,
-            ..
-        } => is_skippable_boolean(inner),
-        _ => false,
     }
 }
 

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod always_true_disjunction;
 pub(crate) mod cast_nan_to_int;
 pub(crate) mod const_naming;
 pub(crate) mod decimal_file_mode;

--- a/crates/passes/src/passes/checks/node_walk.rs
+++ b/crates/passes/src/passes/checks/node_walk.rs
@@ -5,11 +5,11 @@ use crate::passes::walk::{
 };
 
 use super::{
-    cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop,
-    empty_range, enum_variant_value, impossible_comparison, index_out_of_bounds,
-    irrefutable_patterns, map_key, min_max, nan_comparison, newtype, oversized_shift,
-    pub_type_export, receivers, repeated_if_condition, stringer_signature, temp_producing,
-    unchanging_loop_condition,
+    always_true_disjunction, cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings,
+    empty_infinite_loop, empty_range, enum_variant_value, impossible_comparison,
+    index_out_of_bounds, irrefutable_patterns, map_key, min_max, nan_comparison, newtype,
+    oversized_shift, pub_type_export, receivers, repeated_if_condition, stringer_signature,
+    temp_producing, unchanging_loop_condition,
 };
 
 fn run_expression_checks(expression: &Expression, ctx: &mut NodeCtx<'_>, _role: FunctionRole<'_>) {
@@ -20,6 +20,7 @@ fn run_expression_checks(expression: &Expression, ctx: &mut NodeCtx<'_>, _role: 
         (min_max::check, &[Call]),
         (cast_nan_to_int::check, &[Cast]),
         (impossible_comparison::check, &[Binary]),
+        (always_true_disjunction::check, &[Binary]),
         (empty_range::check, &[Range]),
         (empty_infinite_loop::check, &[Loop]),
         (oversized_shift::check, &[Binary]),

--- a/crates/passes/src/passes/comparison.rs
+++ b/crates/passes/src/passes/comparison.rs
@@ -172,6 +172,25 @@ pub(crate) fn negate_comparison(operator: BinaryOperator) -> Option<&'static str
     })
 }
 
+/// A value-stable boolean (identifier, field read, literal, or `!` of one),
+/// safe to carry a constraint run across in a `&&`/`||` chain.
+pub(crate) fn is_skippable_boolean(expression: &Expression) -> bool {
+    if !expression.get_type().is_boolean() {
+        return false;
+    }
+    match expression.unwrap_parens() {
+        Expression::Identifier { .. }
+        | Expression::DotAccess { .. }
+        | Expression::Literal { .. } => true,
+        Expression::Unary {
+            operator: UnaryOperator::Not,
+            expression: inner,
+            ..
+        } => is_skippable_boolean(inner),
+        _ => false,
+    }
+}
+
 pub(crate) fn is_side_effect_free(expression: &Expression) -> bool {
     match expression.unwrap_parens() {
         Expression::Identifier { .. } | Expression::Literal { .. } => true,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3854,6 +3854,279 @@ fn main() {
 }
 
 #[test]
+fn always_true_disjunction_two_inequalities() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x != 1 || x != 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_overlapping_ranges() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x > 0 || x < 10
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_literal_on_left() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = 5 > x || 4 < x
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_boundary_meet() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x < 5 || x >= 5
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_integer_gap() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x <= 0 || x >= 1
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_equality_covers_gap() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x <= 0 || x == 1 || x >= 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_equality_inequality() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x == 5 || x != 5
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_negative_bounds() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 0;
+  let _ = x >= -3 || x <= 0
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_unsigned_type_boundary() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: uint8 = 5
+  let _ = x > 0 || x == 0
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_signed_type_boundary() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x: int8 = 5
+  let _ = x > -128 || x == -128
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_single_tautological_disjunct() {
+    let diagnostics = crate::_harness::lint::lint(
+        r#"
+fn main() {
+  let x: uint8 = 5
+  let flag = true
+  let _ = x >= 0 || flag
+}
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code_str() == Some("infer.always_true_disjunction")),
+        "an unsigned `>= 0` disjunct alone covers the domain: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn always_true_disjunction_type_boundary_gap_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x: uint8 = 5
+  let _ = x > 1 || x == 0
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_chain_with_unrelated_disjunct() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let flag = true;
+  let _ = x != 1 || flag || x != 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_chain_with_negated_disjunct() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let x = 5;
+  let flag = true;
+  let _ = x != 1 || !flag || x != 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_single_diagnostic_for_chain() {
+    let diagnostics = crate::_harness::lint::lint(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x != 1 || x != 2 || x != 3
+}
+"#,
+    );
+    let count = diagnostics
+        .iter()
+        .filter(|d| d.code_str() == Some("infer.always_true_disjunction"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "a nested `||` chain must report once: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn always_true_disjunction_integer_gap_value_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x <= 0 || x >= 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_float_operand_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let f: float64 = 1.0
+  let _ = f < 5 || f >= 5
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_satisfiable_exclusions_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5;
+  let _ = x == 1 || x == 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_side_effecting_operand_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn pick() -> int { 7 }
+
+fn main() {
+  let _ = pick() != 1 || pick() != 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_side_effecting_disjunct_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn step() -> bool { true }
+
+fn main() {
+  let x = 0;
+  let _ = x != 1 || step() || x != 2
+}
+"#
+    );
+}
+
+#[test]
+fn always_true_disjunction_distinct_operands_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let a = 1;
+  let b = 2;
+  let _ = a != 1 || b != 2
+}
+"#
+    );
+}
+
+#[test]
 fn redundant_comparison_disjunction_narrower() {
     assert_lint_snapshot!(
         r#"
@@ -4164,6 +4437,103 @@ fn main() {
 }
 
 #[test]
+fn always_true_disjunction_skips_type_invalid_operand() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let x = "a";
+  let _ = x != 1 || x != 2
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the type mismatch to still be reported: {:?}",
+        result.errors()
+    );
+    assert!(
+        !result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message() == "Always-true comparison"),
+        "must not flag a type-invalid comparison as always true: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn always_true_disjunction_non_boolean_disjunct_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let x = 0
+  let _ = x != 1 || 3 || x != 2
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the non-boolean disjunct type error to still be reported: {:?}",
+        result.errors()
+    );
+    assert!(
+        !result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message() == "Always-true comparison"),
+        "must not reason across a non-boolean disjunct in a type-invalid chain: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn always_true_disjunction_invalid_comparison_disjunct_no_diagnostic() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+fn main() {
+  let x = 0
+  let s = "a"
+  let _ = x != 1 || s < 5 || x != 2
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message().contains("Type mismatch")),
+        "expected the invalid-comparison type error to still be reported: {:?}",
+        result.errors()
+    );
+    assert!(
+        !result
+            .errors()
+            .iter()
+            .any(|d| d.plain_message() == "Always-true comparison"),
+        "must not reason across an out-of-scope or invalid comparison disjunct: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
 fn redundant_comparison_skips_type_invalid_operand() {
     let mut fs = MockFileSystem::new();
     fs.add_file(
@@ -4316,6 +4686,7 @@ fn assert_no_chain_comparison_lints(source: &str) {
     let codes: Vec<&str> = diagnostics.iter().filter_map(|d| d.code_str()).collect();
     for code in [
         "infer.impossible_comparison",
+        "infer.always_true_disjunction",
         "lint.redundant_comparison",
         "lint.double_comparison",
     ] {

--- a/tests/ui/lint/snapshots/always_true_disjunction_boundary_meet.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_boundary_meet.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x < 5 || x >= 5
+   ·           ───────┬───────
+   ·                  ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_chain_with_negated_disjunct.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_chain_with_negated_disjunct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:5:11]
+ 4 │   let flag = true;
+ 5 │   let _ = x != 1 || !flag || x != 2
+   ·           ────────────┬────────────
+   ·                       ╰── always `true`
+ 6 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_chain_with_unrelated_disjunct.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_chain_with_unrelated_disjunct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:5:11]
+ 4 │   let flag = true;
+ 5 │   let _ = x != 1 || flag || x != 2
+   ·           ────────────┬───────────
+   ·                       ╰── always `true`
+ 6 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_equality_covers_gap.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_equality_covers_gap.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x <= 0 || x == 1 || x >= 2
+   ·           ─────────────┬────────────
+   ·                        ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_equality_inequality.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_equality_inequality.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x == 5 || x != 5
+   ·           ────────┬───────
+   ·                   ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_integer_gap.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_integer_gap.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x <= 0 || x >= 1
+   ·           ────────┬───────
+   ·                   ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_literal_on_left.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = 5 > x || 4 < x
+   ·           ───────┬──────
+   ·                  ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_negative_bounds.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_negative_bounds.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 0;
+ 4 │   let _ = x >= -3 || x <= 0
+   ·           ────────┬────────
+   ·                   ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_overlapping_ranges.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_overlapping_ranges.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x > 0 || x < 10
+   ·           ───────┬───────
+   ·                  ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_signed_type_boundary.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_signed_type_boundary.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x: int8 = 5
+ 4 │   let _ = x > -128 || x == -128
+   ·           ──────────┬──────────
+   ·                     ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_two_inequalities.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_two_inequalities.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x = 5;
+ 4 │   let _ = x != 1 || x != 2
+   ·           ────────┬───────
+   ·                   ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]

--- a/tests/ui/lint/snapshots/always_true_disjunction_unsigned_type_boundary.snap
+++ b/tests/ui/lint/snapshots/always_true_disjunction_unsigned_type_boundary.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Always-true comparison
+   ╭─[test.lis:4:11]
+ 3 │   let x: uint8 = 5
+ 4 │   let _ = x > 0 || x == 0
+   ·           ───────┬───────
+   ·                  ╰── always `true`
+ 5 │ }
+   ╰────
+  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]


### PR DESCRIPTION
Adds `always_true_disjunction`, an error for `||` chains that are `true` for every input, mirroring the existing `impossible_comparison` error for `&&` chains that are always `false`.

```
  ✕ Always-true comparison
   ╭─[test.lis:4:11]
 3 │   let x = 5;
 4 │   let _ = x < 5 || x >= 5
   ·           ───────┬───────
   ·                  ╰── always `true`
 5 │ }
   ╰────
  help: Every value satisfies at least one side, so this `||` is always `true`. Check the bounds, or did you mean `&&`? · code: [infer.always_true_disjunction]
```