### PR TITLE
feat: diagnostic for constant cast overflow

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2925,6 +2925,21 @@ pub fn integer_literal_overflow(
         ))
 }
 
+pub fn constant_cast_overflow(
+    span: &Span,
+    target_ty: &str,
+    value: i128,
+    min: i128,
+    max: i128,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Constant cast overflow")
+        .with_infer_code("constant_cast_overflow")
+        .with_span_label(span, format!("constant `{value}` overflows `{target_ty}`"))
+        .with_help(format!(
+            "This expression always evaluates to `{value}`, and `{target_ty}` must be in range `{min}` to `{max}`"
+        ))
+}
+
 pub fn float_literal_overflow(target_ty: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Float literal overflow")
         .with_infer_code("float_literal_overflow")

--- a/crates/passes/src/passes/checks/constant_cast_overflow.rs
+++ b/crates/passes/src/passes/checks/constant_cast_overflow.rs
@@ -1,0 +1,109 @@
+use crate::passes::comparison::signed_integer_literal;
+use crate::passes::walk::NodeCtx;
+use syntax::ast::{BinaryOperator, Expression, Literal, UnaryOperator};
+use syntax::types::{SimpleKind, Type};
+
+pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
+    let Expression::Cast {
+        expression: operand,
+        ty,
+        span,
+        ..
+    } = expression
+    else {
+        return;
+    };
+
+    let Some(value) = fold(operand) else {
+        return;
+    };
+
+    let Some(kind) = ctx.store.underlying_simple_kind(ty) else {
+        return;
+    };
+    let Some((min, max)) = kind.integer_range() else {
+        return;
+    };
+
+    if (min..=max).contains(&value) {
+        return;
+    }
+
+    // The checker reports a lone literal as integer_literal_overflow, but only
+    // for primitive target names, leaving alias and newtype targets to us.
+    if names_primitive_integer(ty) && signed_integer_literal(operand.unwrap_parens()).is_some() {
+        return;
+    }
+
+    ctx.sink.push(diagnostics::infer::constant_cast_overflow(
+        span,
+        &ty.to_string(),
+        value,
+        min,
+        max,
+    ));
+}
+
+fn names_primitive_integer(ty: &Type) -> bool {
+    ty.get_name()
+        .and_then(SimpleKind::from_name)
+        .and_then(SimpleKind::integer_range)
+        .is_some()
+}
+
+/// Literals only, because a named constant carries a Go type whose arithmetic
+/// and `^` mask differ from the untyped semantics `i128` models here.
+fn fold(expression: &Expression) -> Option<i128> {
+    match expression.unwrap_parens() {
+        // Negative literal text occurs only in patterns, so bail rather than
+        // misread the magnitude.
+        Expression::Literal {
+            literal: Literal::Integer { value, text },
+            ..
+        } if !text.as_deref().is_some_and(|text| text.starts_with('-')) => Some(*value as i128),
+        Expression::Unary {
+            operator,
+            expression,
+            ..
+        } => {
+            let value = fold(expression)?;
+            match operator {
+                UnaryOperator::Negative => value.checked_neg(),
+                UnaryOperator::BitwiseNot => Some(!value),
+                _ => None,
+            }
+        }
+        Expression::Binary {
+            operator,
+            left,
+            right,
+            ..
+        } => fold_binary(*operator, fold(left)?, fold(right)?),
+        _ => None,
+    }
+}
+
+fn fold_binary(operator: BinaryOperator, left: i128, right: i128) -> Option<i128> {
+    match operator {
+        BinaryOperator::Addition => left.checked_add(right),
+        BinaryOperator::Subtraction => left.checked_sub(right),
+        BinaryOperator::Multiplication => left.checked_mul(right),
+        BinaryOperator::Division => left.checked_div(right),
+        BinaryOperator::Remainder => left.checked_rem(right),
+        BinaryOperator::BitwiseAnd => Some(left & right),
+        BinaryOperator::BitwiseOr => Some(left | right),
+        BinaryOperator::BitwiseXor => Some(left ^ right),
+        BinaryOperator::BitwiseAndNot => Some(left & !right),
+        BinaryOperator::ShiftLeft => {
+            let amount = shift_amount(right)?;
+            let shifted = left << amount;
+            (shifted >> amount == left).then_some(shifted)
+        }
+        BinaryOperator::ShiftRight => Some(left >> shift_amount(right)?),
+        _ => None,
+    }
+}
+
+fn shift_amount(amount: i128) -> Option<u32> {
+    (0..128).contains(&amount).then_some(amount as u32)
+}

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cast_nan_to_int;
 pub(crate) mod const_naming;
+pub(crate) mod constant_cast_overflow;
 pub(crate) mod decimal_file_mode;
 pub(crate) mod duplicate_bindings;
 pub(crate) mod empty_infinite_loop;

--- a/crates/passes/src/passes/checks/node_walk.rs
+++ b/crates/passes/src/passes/checks/node_walk.rs
@@ -5,11 +5,11 @@ use crate::passes::walk::{
 };
 
 use super::{
-    cast_nan_to_int, const_naming, decimal_file_mode, duplicate_bindings, empty_infinite_loop,
-    empty_range, enum_variant_value, impossible_comparison, index_out_of_bounds,
-    irrefutable_patterns, map_key, min_max, nan_comparison, newtype, oversized_shift,
-    pub_type_export, receivers, repeated_if_condition, stringer_signature, temp_producing,
-    unchanging_loop_condition,
+    cast_nan_to_int, const_naming, constant_cast_overflow, decimal_file_mode, duplicate_bindings,
+    empty_infinite_loop, empty_range, enum_variant_value, impossible_comparison,
+    index_out_of_bounds, irrefutable_patterns, map_key, min_max, nan_comparison, newtype,
+    oversized_shift, pub_type_export, receivers, repeated_if_condition, stringer_signature,
+    temp_producing, unchanging_loop_condition,
 };
 
 fn run_expression_checks(expression: &Expression, ctx: &mut NodeCtx<'_>, _role: FunctionRole<'_>) {
@@ -19,6 +19,7 @@ fn run_expression_checks(expression: &Expression, ctx: &mut NodeCtx<'_>, _role: 
         (nan_comparison::check, &[Binary]),
         (min_max::check, &[Call]),
         (cast_nan_to_int::check, &[Cast]),
+        (constant_cast_overflow::check, &[Cast]),
         (impossible_comparison::check, &[Binary]),
         (empty_range::check, &[Range]),
         (empty_infinite_loop::check, &[Loop]),

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -12892,6 +12892,191 @@ fn main() {
 }
 
 #[test]
+fn constant_cast_overflow_folded_addition() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (200 + 100) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_folded_shift() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (1 << 40) as int32
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_negative_to_unsigned() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (10 - 20) as uint8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_bitwise_not() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (^0) as uint8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_negated_compound() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (-(200 + 100)) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_multiplication_boundary() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = (2 * 64) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_in_range_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = (100 + 27) as int8
+  let _ = (0 - 128) as int8
+  let _ = (200 + 100) as int64
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_variable_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let x = 5
+  let _ = (x + 100) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_float_operand_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = (1.5 * 200.0) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_bare_literal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = 300 as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_negated_literal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = (-129) as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_newtype_target() {
+    assert_lint_snapshot!(
+        r#"
+struct Small(int8)
+
+fn main() {
+  let _ = 300 as Small
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_alias_target() {
+    assert_lint_snapshot!(
+        r#"
+type Tiny = int8
+
+fn main() {
+  let _ = 300 as Tiny
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_named_constant_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+const N = 300
+
+fn main() {
+  let _ = N as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_rune_literal_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = 'é' as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_cast_in_arithmetic_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = ((5 as int8) + 3) as int16
+}
+"#
+    );
+}
+
+#[test]
 fn empty_infinite_loop_fires() {
     assert_lint_snapshot!(
         r#"

--- a/tests/ui/lint/snapshots/constant_cast_overflow_alias_target.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_alias_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let _ = 300 as Tiny
+   ·           ─────┬─────
+   ·                ╰── constant `300` overflows `Tiny`
+ 6 │ }
+   ╰────
+  help: This expression always evaluates to `300`, and `Tiny` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_bitwise_not.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_bitwise_not.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (^0) as uint8
+   ·           ──────┬──────
+   ·                 ╰── constant `-1` overflows `uint8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `-1`, and `uint8` must be in range `0` to `255` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_folded_addition.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_folded_addition.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (200 + 100) as int8
+   ·           ─────────┬─────────
+   ·                    ╰── constant `300` overflows `int8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `300`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_folded_shift.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_folded_shift.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (1 << 40) as int32
+   ·           ─────────┬────────
+   ·                    ╰── constant `1099511627776` overflows `int32`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `1099511627776`, and `int32` must be in range `-2147483648` to `2147483647` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_multiplication_boundary.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_multiplication_boundary.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (2 * 64) as int8
+   ·           ────────┬───────
+   ·                   ╰── constant `128` overflows `int8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `128`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_negated_compound.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_negated_compound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (-(200 + 100)) as int8
+   ·           ───────────┬──────────
+   ·                      ╰── constant `-300` overflows `int8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `-300`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_negative_to_unsigned.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_negative_to_unsigned.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = (10 - 20) as uint8
+   ·           ─────────┬────────
+   ·                    ╰── constant `-10` overflows `uint8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `-10`, and `uint8` must be in range `0` to `255` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_newtype_target.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_newtype_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let _ = 300 as Small
+   ·           ──────┬─────
+   ·                 ╰── constant `300` overflows `Small`
+ 6 │ }
+   ╰────
+  help: This expression always evaluates to `300`, and `Small` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]


### PR DESCRIPTION
Adds `constant_cast_overflow`, an error for casting a literal integer expression whose value does not fit the target type.

```
  ✕ Constant cast overflow
   ╭─[test.lis:3:11]
 2 │ fn main() {
 3 │   let _ = (2 * 64) as int8
   ·           ────────┬───────
   ·                   ╰── constant `128` overflows `int8`
 4 │ }
   ╰────
  help: This expression always evaluates to `128`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]
```