### PR TITLE
fix: inconsistent escape sequence lexing

### DIFF
--- a/crates/passes/src/passes/checks/constant_cast_overflow.rs
+++ b/crates/passes/src/passes/checks/constant_cast_overflow.rs
@@ -1,6 +1,7 @@
 use crate::passes::comparison::signed_integer_literal;
 use crate::passes::walk::NodeCtx;
 use syntax::ast::{BinaryOperator, Expression, Literal, UnaryOperator};
+use syntax::lex::rune_codepoint;
 use syntax::types::{SimpleKind, Type};
 
 pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
@@ -35,6 +36,10 @@ pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
+    if ctx.store.has_underlying_rune(&operand.get_type()) && ctx.store.has_underlying_byte(ty) {
+        return;
+    }
+
     ctx.sink.push(diagnostics::infer::constant_cast_overflow(
         span,
         &ty.to_string(),
@@ -61,6 +66,10 @@ fn fold(expression: &Expression) -> Option<i128> {
             literal: Literal::Integer { value, text },
             ..
         } if !text.as_deref().is_some_and(|text| text.starts_with('-')) => Some(*value as i128),
+        Expression::Literal {
+            literal: Literal::Char(text),
+            ..
+        } => rune_codepoint(text).map(i128::from),
         Expression::Unary {
             operator,
             expression,

--- a/crates/passes/src/passes/lints/ast_walk/checks/printf_verb_mismatch.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/printf_verb_mismatch.rs
@@ -216,7 +216,7 @@ fn byte_from_octal(chars: &mut Peekable<Chars<'_>>, first: char) -> Option<u8> {
     u8::try_from(value).ok()
 }
 
-/// `\UXXXXXXXX`, which the lexer accepts undocumented and leaves to Go.
+/// `\UXXXXXXXX`, the eight-digit form of the unicode escape.
 fn char_from_eight_hex(chars: &mut Peekable<Chars<'_>>) -> Option<char> {
     let mut value = 0u32;
     for _ in 0..8 {

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -1,6 +1,7 @@
 use crate::checker::EnvResolve;
 use crate::store::Store;
 use syntax::ast::{Expression, FormatStringPart, Literal, Span};
+use syntax::lex::rune_codepoint;
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
@@ -107,8 +108,8 @@ impl InferCtx<'_> {
             Literal::Char(char) => {
                 let resolved = expected_ty.resolve_in(&self.env);
                 let ty = if let Some(numeric) = numeric_adapt_target(&resolved, store) {
-                    if let Some(codepoint) = char_literal_codepoint(&char) {
-                        self.check_integer_literal_overflow(codepoint, &numeric, span);
+                    if let Some(codepoint) = rune_codepoint(&char) {
+                        self.check_integer_literal_overflow(codepoint as u64, &numeric, span);
                     }
                     resolved.clone()
                 } else {
@@ -269,21 +270,4 @@ fn adapts_to_named_type(ty: &Type, store: &Store, kind: SimpleKind) -> bool {
     matches!(&peeled, Type::Nominal { id, .. }
         if store.is_nominal_defined_type(id.as_str())
             && store.underlying_simple_kind(&peeled) == Some(kind))
-}
-
-fn char_literal_codepoint(s: &str) -> Option<u64> {
-    if let Some(rest) = s.strip_prefix('\\') {
-        match rest.as_bytes().first()? {
-            b'n' => Some(10),
-            b't' => Some(9),
-            b'r' => Some(13),
-            b'0' => Some(0),
-            b'\\' => Some(92),
-            b'\'' => Some(39),
-            b'x' => u64::from_str_radix(&rest[1..], 16).ok(),
-            _ => None,
-        }
-    } else {
-        s.chars().next().map(|c| c as u64)
-    }
 }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -5,6 +5,7 @@ use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{EnumVariant, Expression, Literal, StructFieldDefinition};
+use syntax::lex::rune_codepoint;
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, TestIndex,
 };
@@ -73,7 +74,7 @@ impl DomainValue {
         // its two's-complement `u64`, so signed bases reinterpret it as `i64`.
         match base {
             SimpleKind::Rune => match literal {
-                Literal::Char(text) => char_codepoint(text).map(|cp| DomainValue::Int(cp as i128)),
+                Literal::Char(text) => rune_codepoint(text).map(|cp| DomainValue::Int(cp as i128)),
                 Literal::Integer { value, .. } => Some(DomainValue::Int(*value as i64 as i128)),
                 _ => None,
             },
@@ -98,28 +99,6 @@ impl DomainValue {
 /// `SimpleKind::is_unsigned_int`, so it is folded in here.
 fn is_unsigned_base(base: SimpleKind) -> bool {
     base.is_unsigned_int() || base == SimpleKind::Uintptr
-}
-
-/// Decodes a rune literal's inner text to a codepoint, covering the escapes the
-/// lexer accepts (`\a \b \f \n \r \t \v \\ \'`, `\x` hex, and octal `\NNN`).
-fn char_codepoint(text: &str) -> Option<u64> {
-    let Some(rest) = text.strip_prefix('\\') else {
-        return text.chars().next().map(|c| c as u64);
-    };
-    match rest.as_bytes().first()? {
-        b'a' => Some(7),
-        b'b' => Some(8),
-        b'f' => Some(12),
-        b'n' => Some(10),
-        b'r' => Some(13),
-        b't' => Some(9),
-        b'v' => Some(11),
-        b'\\' => Some(92),
-        b'\'' => Some(39),
-        b'x' => u64::from_str_radix(&rest[1..], 16).ok(),
-        b'0'..=b'7' => u64::from_str_radix(rest, 8).ok(),
-        _ => None,
-    }
 }
 
 pub struct Store {

--- a/crates/syntax/src/lex/errors.rs
+++ b/crates/syntax/src/lex/errors.rs
@@ -268,17 +268,30 @@ impl<'source> Lexer<'source> {
         self.errors.push(error);
     }
 
-    pub(super) fn error_invalid_escape(&mut self, ch: char) {
-        let span = self.span((self.current_offset - 1) as u32, 2);
+    pub(super) fn error_invalid_escape(&mut self, ch: char, offset: usize, closing_quote: u8) {
+        let quote_escape = closing_quote as char;
+        let span = self.span(offset as u32, 2);
         let error = ParseError::new(
             "Invalid escape sequence",
             span,
             format!("`\\{ch}` is not a valid escape"),
         )
         .with_lex_code("invalid_escape_sequence")
-        .with_help(
-            "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
-        );
+        .with_help(format!(
+            "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\{quote_escape}`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{{HEX}}` or `\\UHHHHHHHH` (unicode)"
+        ));
+        self.errors.push(error);
+    }
+
+    pub(super) fn error_invalid_hex_escape(&mut self, offset: usize, length: usize, digits: usize) {
+        let span = self.span(offset as u32, length as u32);
+        let error = ParseError::new(
+            "Invalid hex escape",
+            span,
+            format!("expected {digits} hex digits"),
+        )
+        .with_lex_code("invalid_hex_escape")
+        .with_help("Hex escapes are `\\xHH` with 2 digits and `\\UHHHHHHHH` with 8 digits");
         self.errors.push(error);
     }
 

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -632,10 +632,92 @@ impl<'source> Lexer<'source> {
         }
     }
 
-    fn consume_unicode_escape(&mut self, escape_start: usize) {
+    fn consume_escape(&mut self, literal_start: usize, closing_quote: u8) -> bool {
+        let escape_start = self.current_offset;
+        self.next();
+
+        if self.at_eof() {
+            self.error_unterminated_escape(literal_start);
+            return false;
+        }
+
+        match self.current_byte() {
+            first @ b'0'..=b'7' => {
+                self.next();
+                let value = self.consume_octal_escape(first);
+                if value > 255 {
+                    self.error_octal_escape_out_of_range(
+                        escape_start,
+                        self.current_offset - escape_start,
+                    );
+                    return false;
+                }
+                true
+            }
+            b'x' => {
+                self.next();
+                self.consume_hex_escape(escape_start, 2).is_some()
+            }
+            b'u' => {
+                self.next();
+                match self.consume_unicode_escape(escape_start) {
+                    Some(codepoint) => self.check_scalar_value(codepoint, escape_start),
+                    None => false,
+                }
+            }
+            b'U' => {
+                self.next();
+                match self.consume_hex_escape(escape_start, 8) {
+                    Some(codepoint) => self.check_scalar_value(codepoint, escape_start),
+                    None => false,
+                }
+            }
+            b'a' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' | b'\\' => {
+                self.next();
+                true
+            }
+            byte if byte == closing_quote => {
+                self.next();
+                true
+            }
+            _ => {
+                self.error_invalid_escape(self.current_char(), escape_start, closing_quote);
+                self.next();
+                false
+            }
+        }
+    }
+
+    fn check_scalar_value(&mut self, codepoint: u32, escape_start: usize) -> bool {
+        if char::from_u32(codepoint).is_some() {
+            return true;
+        }
+        self.error_unicode_escape_out_of_range(escape_start, self.current_offset - escape_start);
+        false
+    }
+
+    fn consume_hex_escape(&mut self, escape_start: usize, digits: usize) -> Option<u32> {
+        let mut value: u32 = 0;
+        for _ in 0..digits {
+            // At end of input `current_byte` yields 0, which is not a hex digit.
+            let Some(digit) = (self.current_byte() as char).to_digit(16) else {
+                self.error_invalid_hex_escape(
+                    escape_start,
+                    self.current_offset - escape_start,
+                    digits,
+                );
+                return None;
+            };
+            value = value * 16 + digit;
+            self.next();
+        }
+        Some(value)
+    }
+
+    fn consume_unicode_escape(&mut self, escape_start: usize) -> Option<u32> {
         if self.at_eof() || self.current_byte() != b'{' {
             self.error_invalid_unicode_escape(escape_start, self.current_offset - escape_start);
-            return;
+            return None;
         }
         self.next();
 
@@ -643,7 +725,7 @@ impl<'source> Lexer<'source> {
         let mut all_hex = true;
         while !self.at_eof() {
             let byte = self.current_byte();
-            if byte == b'}' || byte == b'"' || byte == b'\n' {
+            if byte == b'}' || byte == b'"' || byte == b'\'' || byte == b'\n' {
                 break;
             }
             if !byte.is_ascii_hexdigit() {
@@ -659,18 +741,16 @@ impl<'source> Lexer<'source> {
         }
 
         let hex_len = hex_end - hex_start;
-        let total_len = self.current_offset - escape_start;
 
         if !closed || !all_hex || hex_len == 0 || hex_len > 6 {
-            self.error_invalid_unicode_escape(escape_start, total_len);
-            return;
+            self.error_invalid_unicode_escape(escape_start, self.current_offset - escape_start);
+            return None;
         }
 
-        let codepoint = u32::from_str_radix(&self.input[hex_start..hex_end], 16)
-            .expect("hex digits validated above");
-        if char::from_u32(codepoint).is_none() {
-            self.error_unicode_escape_out_of_range(escape_start, total_len);
-        }
+        Some(
+            u32::from_str_radix(&self.input[hex_start..hex_end], 16)
+                .expect("hex digits validated above"),
+        )
     }
 
     /// Consume up to 2 more octal digits after the first has already been read.
@@ -696,56 +776,24 @@ impl<'source> Lexer<'source> {
 
         self.next();
 
-        let mut escaped = false;
         let mut terminated = false;
 
-        while !self.at_eof() && !terminated {
+        while !self.at_eof() {
             let byte = self.current_byte();
-            if escaped {
-                match byte {
-                    b'0'..=b'7' => {
-                        let escape_start = self.current_offset - 1;
-                        self.next();
-                        let value = self.consume_octal_escape(byte);
-                        if value > 255 {
-                            let escape_len = self.current_offset - escape_start;
-                            self.error_octal_escape_out_of_range(escape_start, escape_len);
-                        }
-                        escaped = false;
-                        continue;
-                    }
-                    b'u' => {
-                        let escape_start = self.current_offset - 1;
-                        self.next();
-                        self.consume_unicode_escape(escape_start);
-                        escaped = false;
-                        continue;
-                    }
-                    b'a' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' | b'\\' | b'"' | b'x' | b'U' => {
-                    }
-                    b'\'' => {}
-                    _ => {
-                        self.error_invalid_escape(self.current_char());
-                    }
-                }
-                escaped = false;
-            } else if byte == b'\\' {
-                escaped = true;
-            } else if byte == b'"' {
+            if byte == b'\\' {
+                self.consume_escape(start_offset, b'"');
+                continue;
+            }
+            if byte == b'"' {
                 terminated = true;
                 self.next();
                 break;
             }
-
             self.next();
         }
 
         let end_offset = self.current_offset;
         let length = end_offset - start_offset;
-
-        if escaped {
-            self.error_unterminated_escape(start_offset);
-        }
 
         if !terminated {
             self.error_unterminated_string(start_offset, 1);
@@ -1089,22 +1137,8 @@ impl<'source> Lexer<'source> {
             let byte = self.current_byte();
 
             match byte {
-                b'\\' if !self.at_eof() => {
-                    let escape_start = self.current_offset;
-                    self.next();
-                    if !self.at_eof() {
-                        let b = self.current_byte();
-                        self.next();
-                        if matches!(b, b'0'..=b'7') {
-                            let value = self.consume_octal_escape(b);
-                            if value > 255 {
-                                let escape_len = self.current_offset - escape_start;
-                                self.error_octal_escape_out_of_range(escape_start, escape_len);
-                            }
-                        } else if b == b'u' {
-                            self.consume_unicode_escape(escape_start);
-                        }
-                    }
+                b'\\' => {
+                    self.consume_escape(start_offset, b'"');
                 }
                 b'{' if self.peek_byte() == b'{' => {
                     self.skip(2);
@@ -1153,78 +1187,7 @@ impl<'source> Lexer<'source> {
         let start_offset = self.current_offset;
 
         self.next();
-
-        if self.at_eof() || self.current_byte() == b'\'' {
-            self.error_empty_rune_literal(start_offset);
-            let end_offset = self.current_offset;
-            return Token {
-                kind: TokenKind::Char,
-                text: &self.input[start_offset..end_offset],
-                byte_offset: start_offset as u32,
-                byte_length: (end_offset - start_offset) as u32,
-            };
-        }
-
-        if self.current_byte() != b'\\' {
-            self.next();
-        } else {
-            self.next();
-
-            if self.at_eof() {
-                self.error_unterminated_escape(start_offset);
-                let end_offset = self.current_offset;
-                return Token {
-                    kind: TokenKind::Char,
-                    text: &self.input[start_offset..end_offset],
-                    byte_offset: start_offset as u32,
-                    byte_length: (end_offset - start_offset) as u32,
-                };
-            }
-
-            match self.current_byte() {
-                b'0'..=b'7' => {
-                    let escape_start = self.current_offset - 1;
-                    let first = self.current_byte();
-                    self.next();
-                    let value = self.consume_octal_escape(first);
-                    if value > 255 {
-                        let escape_len = self.current_offset - escape_start;
-                        self.error_octal_escape_out_of_range(escape_start, escape_len);
-                    }
-                }
-                b'a' | b'b' | b'f' | b'n' | b'r' | b't' | b'v' | b'\\' | b'\'' | b'x' => {
-                    self.next();
-                }
-                _ => {
-                    self.error_invalid_escape(self.current_char());
-
-                    while !self.at_eof() && self.current_byte() != b'\'' {
-                        self.next();
-                    }
-
-                    if !self.at_eof() && self.current_byte() == b'\'' {
-                        self.next();
-                    }
-
-                    let end_offset = self.current_offset;
-                    return Token {
-                        kind: TokenKind::Char,
-                        text: &self.input[start_offset..end_offset],
-                        byte_offset: start_offset as u32,
-                        byte_length: (end_offset - start_offset) as u32,
-                    };
-                }
-            }
-        }
-
-        if self.at_eof() || self.current_byte() != b'\'' {
-            let length = self.current_offset - start_offset;
-            self.error_unterminated_rune(start_offset, length);
-        }
-
-        if !self.at_eof() && self.current_byte() == b'\'' {
-            self.next();
-        }
+        self.scan_rune_body(start_offset);
 
         let end_offset = self.current_offset;
         Token {
@@ -1232,6 +1195,32 @@ impl<'source> Lexer<'source> {
             text: &self.input[start_offset..end_offset],
             byte_offset: start_offset as u32,
             byte_length: (end_offset - start_offset) as u32,
+        }
+    }
+
+    fn scan_rune_body(&mut self, start_offset: usize) {
+        if self.at_eof() || self.current_byte() == b'\'' {
+            self.error_empty_rune_literal(start_offset);
+            return;
+        }
+
+        if self.current_byte() != b'\\' {
+            self.next();
+        } else if !self.consume_escape(start_offset, b'\'') {
+            // Resync, else a mid-literal cursor also reports unterminated_rune.
+            while !self.at_eof() && self.current_byte() != b'\'' {
+                self.next();
+            }
+            if !self.at_eof() {
+                self.next();
+            }
+            return;
+        }
+
+        if !self.at_eof() && self.current_byte() == b'\'' {
+            self.next();
+        } else {
+            self.error_unterminated_rune(start_offset, self.current_offset - start_offset);
         }
     }
 
@@ -1375,6 +1364,67 @@ impl<'source> Lexer<'source> {
             text: &self.input[start_offset..self.current_offset],
             byte_offset: start_offset as u32,
             byte_length: (self.current_offset - start_offset) as u32,
+        }
+    }
+}
+
+/// Decodes a quote-stripped rune literal, covering every escape the lexer takes.
+pub fn rune_codepoint(text: &str) -> Option<u32> {
+    let Some(rest) = text.strip_prefix('\\') else {
+        return text.chars().next().map(|c| c as u32);
+    };
+    match rest.as_bytes().first()? {
+        b'a' => Some(7),
+        b'b' => Some(8),
+        b'f' => Some(12),
+        b'n' => Some(10),
+        b'r' => Some(13),
+        b't' => Some(9),
+        b'v' => Some(11),
+        b'\\' => Some(92),
+        b'\'' => Some(39),
+        b'x' | b'U' => u32::from_str_radix(&rest[1..], 16).ok(),
+        b'u' => {
+            let braced = rest[1..].strip_prefix('{')?.strip_suffix('}')?;
+            u32::from_str_radix(braced, 16).ok()
+        }
+        b'0'..=b'7' => u32::from_str_radix(rest, 8).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Lexer, rune_codepoint};
+
+    #[test]
+    fn rune_codepoint_decodes_every_escape_the_lexer_accepts() {
+        let cases = [
+            ("'a'", 97),
+            ("'中'", 0x4E2D),
+            ("'\\a'", 7),
+            ("'\\b'", 8),
+            ("'\\f'", 12),
+            ("'\\n'", 10),
+            ("'\\r'", 13),
+            ("'\\t'", 9),
+            ("'\\v'", 11),
+            ("'\\\\'", 92),
+            ("'\\''", 39),
+            ("'\\x41'", 65),
+            ("'\\xFF'", 255),
+            ("'\\101'", 65),
+            ("'\\377'", 255),
+            ("'\\u{41}'", 65),
+            ("'\\u{e9}'", 233),
+            ("'\\U0001F600'", 0x1F600),
+        ];
+
+        for (source, expected) in cases {
+            let result = Lexer::new(source, 0).lex();
+            assert!(result.errors.is_empty(), "{source} should lex cleanly");
+            let inner = &source[1..source.len() - 1];
+            assert_eq!(rune_codepoint(inner), Some(expected), "{source}");
         }
     }
 }

--- a/tests/spec/emit/literals.rs
+++ b/tests/spec/emit/literals.rs
@@ -428,6 +428,46 @@ fn test() -> rune {
 }
 
 #[test]
+fn hex_escape_in_char() {
+    let input = r#"
+fn test() -> rune {
+  '\x41'
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unicode_escape_in_char() {
+    let input = r#"
+fn test() -> rune {
+  '\u{e9}'
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn capital_unicode_escape_in_char() {
+    let input = r#"
+fn test() -> rune {
+  '\U0001F600'
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn capital_unicode_escape_in_string() {
+    let input = r#"
+fn test() -> string {
+  "\U0001F600"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn octal_escape_esc_in_string() {
     let input = r#"
 fn test() -> string {

--- a/tests/spec/emit/snapshots/capital_unicode_escape_in_char.snap
+++ b/tests/spec/emit/snapshots/capital_unicode_escape_in_char.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  fn test() -> rune {
+    '\U0001F600'
+  }
+---
+package main
+
+func test() rune {
+	return '\U0001F600'
+}

--- a/tests/spec/emit/snapshots/capital_unicode_escape_in_string.snap
+++ b/tests/spec/emit/snapshots/capital_unicode_escape_in_string.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  fn test() -> string {
+    "\U0001F600"
+  }
+---
+package main
+
+func test() string {
+	return "\U0001F600"
+}

--- a/tests/spec/emit/snapshots/hex_escape_in_char.snap
+++ b/tests/spec/emit/snapshots/hex_escape_in_char.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  fn test() -> rune {
+    '\x41'
+  }
+---
+package main
+
+func test() rune {
+	return '\x41'
+}

--- a/tests/spec/emit/snapshots/unicode_escape_in_char.snap
+++ b/tests/spec/emit/snapshots/unicode_escape_in_char.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  fn test() -> rune {
+    '\u{e9}'
+  }
+---
+package main
+
+func test() rune {
+	return '\u00E9'
+}

--- a/tests/spec/lex/mod.rs
+++ b/tests/spec/lex/mod.rs
@@ -101,6 +101,24 @@ fn char_escaped_quote() {
 }
 
 #[test]
+fn char_escaped_hex() {
+    let input = "'\\x41'";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn char_escaped_unicode() {
+    let input = "'\\u{e9}'";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
+fn char_escaped_capital_unicode() {
+    let input = "'\\U0001F600'";
+    assert_lex_snapshot!(input);
+}
+
+#[test]
 fn comment() {
     let input = "42; // meaning of life";
     assert_lex_snapshot!(input);

--- a/tests/spec/lex/snapshots/char_escaped_capital_unicode.snap
+++ b/tests/spec/lex/snapshots/char_escaped_capital_unicode.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/lex/mod.rs
+description: "'\\U0001F600'"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Char,
+            text: "'\\U0001F600'",
+            byte_offset: 0,
+            byte_length: 12,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 12,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    blank_lines: [],
+}

--- a/tests/spec/lex/snapshots/char_escaped_hex.snap
+++ b/tests/spec/lex/snapshots/char_escaped_hex.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/lex/mod.rs
+description: "'\\x41'"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Char,
+            text: "'\\x41'",
+            byte_offset: 0,
+            byte_length: 6,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 6,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    blank_lines: [],
+}

--- a/tests/spec/lex/snapshots/char_escaped_unicode.snap
+++ b/tests/spec/lex/snapshots/char_escaped_unicode.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/lex/mod.rs
+description: "'\\u{e9}'"
+---
+LexResult {
+    tokens: [
+        Token {
+            kind: Char,
+            text: "'\\u{e9}'",
+            byte_offset: 0,
+            byte_length: 8,
+        },
+        Token {
+            kind: EOF,
+            text: "",
+            byte_offset: 8,
+            byte_length: 0,
+        },
+    ],
+    errors: [],
+    blank_lines: [],
+}

--- a/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
+++ b/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
@@ -31,7 +31,7 @@ LexResult {
                 ),
             ],
             help: Some(
-                "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\'`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` (unicode)",
+                "Valid escapes are `\\a`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\v`, `\\\\`, `\\\"`, `\\xHH` (hex), `\\ooo` (octal), and `\\u{HEX}` or `\\UHHHHHHHH` (unicode)",
             ),
             note: None,
             code: "lex.invalid_escape_sequence",

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -405,6 +405,90 @@ fn lex_octal_escape_out_of_range() {
 }
 
 #[test]
+fn lex_hex_escape_missing_digit_in_char() {
+    let input = r#"let x = '\x4'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_hex_escape_non_hex_digits_in_char() {
+    let input = r#"let x = '\xZZ'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_hex_escape_missing_digit_in_string() {
+    let input = r#"let x = "\x4""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_hex_escape_non_hex_digits_in_string() {
+    let input = r#"let x = "\xZZ""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_capital_unicode_escape_non_hex_digits() {
+    let input = r#"let x = "\UZZZZZZZZ""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_capital_unicode_escape_above_max() {
+    let input = r#"let x = "\U0011FFFF""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_single_quote_escape_in_string() {
+    let input = r#"let x = "a\'b""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_double_quote_escape_in_char() {
+    let input = r#"let x = '\"'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_unicode_escape_empty_in_char() {
+    let input = r#"let x = '\u{}'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_unicode_escape_above_max_in_char() {
+    let input = r#"let x = '\u{110000}'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_unicode_escape_unterminated_in_char() {
+    let input = r#"let x = '\u{e9'"#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_invalid_escape_in_format_string() {
+    let input = r#"let x = f"a\qb""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_single_quote_escape_in_format_string() {
+    let input = r#"let x = f"a\'b""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
+fn lex_hex_escape_non_hex_digits_in_format_string() {
+    let input = r#"let x = f"\xZZ""#;
+    assert_lex_error_snapshot!(input);
+}
+
+#[test]
 fn lex_unicode_escape_missing_braces() {
     let input = r#"let x = "\u1F600""#;
     assert_lex_error_snapshot!(input);
@@ -8377,6 +8461,36 @@ fn infer_char_literal_overflow_uint8() {
     let input = r#"
 fn test() {
   let x: uint8 = '中';
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_octal_char_literal_overflow_int8() {
+    let input = r#"
+fn test() {
+  let x: int8 = '\377';
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_hex_char_literal_overflow_int8() {
+    let input = r#"
+fn test() {
+  let x: int8 = '\xFF';
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_unicode_char_literal_overflow_uint8() {
+    let input = r#"
+fn test() {
+  let x: uint8 = '\u{1F600}';
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_hex_char_literal_overflow_int8.snap
+++ b/tests/ui/errors/snapshots/infer_hex_char_literal_overflow_int8.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer literal overflow
+   ╭─[test.lis:3:17]
+ 2 │ fn test() {
+ 3 │   let x: int8 = '\xFF';
+   ·                 ───┬──
+   ·                    ╰── overflows `int8`
+ 4 │ }
+   ╰────
+  help: `int8` must be in range `-128` to `127` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/infer_octal_char_literal_overflow_int8.snap
+++ b/tests/ui/errors/snapshots/infer_octal_char_literal_overflow_int8.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer literal overflow
+   ╭─[test.lis:3:17]
+ 2 │ fn test() {
+ 3 │   let x: int8 = '\377';
+   ·                 ───┬──
+   ·                    ╰── overflows `int8`
+ 4 │ }
+   ╰────
+  help: `int8` must be in range `-128` to `127` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/infer_unicode_char_literal_overflow_uint8.snap
+++ b/tests/ui/errors/snapshots/infer_unicode_char_literal_overflow_uint8.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Integer literal overflow
+   ╭─[test.lis:3:18]
+ 2 │ fn test() {
+ 3 │   let x: uint8 = '\u{1F600}';
+   ·                  ─────┬─────
+   ·                       ╰── overflows `uint8`
+ 4 │ }
+   ╰────
+  help: `uint8` must be in range `0` to `255` · code: [infer.integer_literal_overflow]

--- a/tests/ui/errors/snapshots/lex_capital_unicode_escape_above_max.snap
+++ b/tests/ui/errors/snapshots/lex_capital_unicode_escape_above_max.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Unicode escape out of range
+   ╭─[test.lis:1:10]
+ 1 │ let x = "\U0011FFFF"
+   ·          ─────┬────
+   ·               ╰── codepoint exceeds U+10FFFF or is a surrogate (U+D800-U+DFFF)
+   ╰────
+  help: Unicode escapes must be valid scalar values: 0..=0xD7FF or 0xE000..=0x10FFFF · code: [lex.unicode_escape_out_of_range]

--- a/tests/ui/errors/snapshots/lex_capital_unicode_escape_non_hex_digits.snap
+++ b/tests/ui/errors/snapshots/lex_capital_unicode_escape_non_hex_digits.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = "\UZZZZZZZZ"
+   ·          ─┬
+   ·           ╰── expected 8 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_double_quote_escape_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_double_quote_escape_in_char.snap
@@ -3,8 +3,8 @@ source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid escape sequence
    ╭─[test.lis:1:10]
- 1 │ let x = '\q'
+ 1 │ let x = '\"'
    ·          ─┬
-   ·           ╰── `\q` is not a valid escape
+   ·           ╰── `\"` is not a valid escape
    ╰────
   help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` or `\UHHHHHHHH` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_hex_escape_missing_digit_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_hex_escape_missing_digit_in_char.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = '\x4'
+   ·          ─┬─
+   ·           ╰── expected 2 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_hex_escape_missing_digit_in_string.snap
+++ b/tests/ui/errors/snapshots/lex_hex_escape_missing_digit_in_string.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = "\x4"
+   ·          ─┬─
+   ·           ╰── expected 2 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_char.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = '\xZZ'
+   ·          ─┬
+   ·           ╰── expected 2 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_format_string.snap
+++ b/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_format_string.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:11]
+ 1 │ let x = f"\xZZ"
+   ·           ─┬
+   ·            ╰── expected 2 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_string.snap
+++ b/tests/ui/errors/snapshots/lex_hex_escape_non_hex_digits_in_string.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid hex escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = "\xZZ"
+   ·          ─┬
+   ·           ╰── expected 2 hex digits
+   ╰────
+  help: Hex escapes are `\xHH` with 2 digits and `\UHHHHHHHH` with 8 digits · code: [lex.invalid_hex_escape]

--- a/tests/ui/errors/snapshots/lex_invalid_escape_in_format_string.snap
+++ b/tests/ui/errors/snapshots/lex_invalid_escape_in_format_string.snap
@@ -2,11 +2,9 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid escape sequence
-   ╭─[test.lis:3:16]
- 2 │ fn main() {
- 3 │   let s = "test\?string"
-   ·                ─┬
-   ·                 ╰── `\?` is not a valid escape
- 4 │ }
+   ╭─[test.lis:1:12]
+ 1 │ let x = f"a\qb"
+   ·            ─┬
+   ·             ╰── `\q` is not a valid escape
    ╰────
   help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\"`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` or `\UHHHHHHHH` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_invalid_escape_sequence_in_string.snap
+++ b/tests/ui/errors/snapshots/lex_invalid_escape_sequence_in_string.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                  ╰── `\!` is not a valid escape
  4 │ }
    ╰────
-  help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\'`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` (unicode) · code: [lex.invalid_escape_sequence]
+  help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\"`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` or `\UHHHHHHHH` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_single_quote_escape_in_format_string.snap
+++ b/tests/ui/errors/snapshots/lex_single_quote_escape_in_format_string.snap
@@ -2,11 +2,9 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid escape sequence
-   ╭─[test.lis:3:16]
- 2 │ fn main() {
- 3 │   let s = "test\?string"
-   ·                ─┬
-   ·                 ╰── `\?` is not a valid escape
- 4 │ }
+   ╭─[test.lis:1:12]
+ 1 │ let x = f"a\'b"
+   ·            ─┬
+   ·             ╰── `\'` is not a valid escape
    ╰────
   help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\"`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` or `\UHHHHHHHH` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_single_quote_escape_in_string.snap
+++ b/tests/ui/errors/snapshots/lex_single_quote_escape_in_string.snap
@@ -2,11 +2,9 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Invalid escape sequence
-   ╭─[test.lis:3:16]
- 2 │ fn main() {
- 3 │   let s = "test\?string"
-   ·                ─┬
-   ·                 ╰── `\?` is not a valid escape
- 4 │ }
+   ╭─[test.lis:1:11]
+ 1 │ let x = "a\'b"
+   ·           ─┬
+   ·            ╰── `\'` is not a valid escape
    ╰────
   help: Valid escapes are `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\"`, `\xHH` (hex), `\ooo` (octal), and `\u{HEX}` or `\UHHHHHHHH` (unicode) · code: [lex.invalid_escape_sequence]

--- a/tests/ui/errors/snapshots/lex_unicode_escape_above_max_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_unicode_escape_above_max_in_char.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Unicode escape out of range
+   ╭─[test.lis:1:10]
+ 1 │ let x = '\u{110000}'
+   ·          ─────┬────
+   ·               ╰── codepoint exceeds U+10FFFF or is a surrogate (U+D800-U+DFFF)
+   ╰────
+  help: Unicode escapes must be valid scalar values: 0..=0xD7FF or 0xE000..=0x10FFFF · code: [lex.unicode_escape_out_of_range]

--- a/tests/ui/errors/snapshots/lex_unicode_escape_empty_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_unicode_escape_empty_in_char.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid unicode escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = '\u{}'
+   ·          ──┬─
+   ·            ╰── expected `\u{HEX}` with 1-6 hex digits
+   ╰────
+  help: Use the form `\u{1F600}` with 1-6 hexadecimal digits between braces · code: [lex.invalid_unicode_escape]

--- a/tests/ui/errors/snapshots/lex_unicode_escape_unterminated_in_char.snap
+++ b/tests/ui/errors/snapshots/lex_unicode_escape_unterminated_in_char.snap
@@ -1,0 +1,10 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid unicode escape
+   ╭─[test.lis:1:10]
+ 1 │ let x = '\u{e9'
+   ·          ──┬──
+   ·            ╰── expected `\u{HEX}` with 1-6 hex digits
+   ╰────
+  help: Use the form `\u{1F600}` with 1-6 hexadecimal digits between braces · code: [lex.invalid_unicode_escape]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -13426,11 +13426,57 @@ fn main() {
 }
 
 #[test]
-fn constant_cast_overflow_rune_literal_no_warning() {
-    assert_no_lint_warnings!(
+fn constant_cast_overflow_rune_literal() {
+    assert_lint_snapshot!(
         r#"
 fn main() {
   let _ = 'é' as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_escaped_rune_literal() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let _ = '\xFF' as int8
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_unicode_rune_literal_alias_target() {
+    assert_lint_snapshot!(
+        r#"
+type Small = int16
+
+fn main() {
+  let _ = '\u{1F600}' as Small
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_rune_literal_in_range_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = '\377' as uint16
+}
+"#
+    );
+}
+
+#[test]
+fn constant_cast_overflow_rune_to_byte_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _ = '中' as uint8
 }
 "#
     );

--- a/tests/ui/lint/snapshots/constant_cast_overflow_escaped_rune_literal.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_escaped_rune_literal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = '\xFF' as int8
+   ·           ───────┬──────
+   ·                  ╰── constant `255` overflows `int8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `255`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_rune_literal.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_rune_literal.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   let _ = 'é' as int8
+   ·           ─────┬─────
+   ·                ╰── constant `233` overflows `int8`
+ 4 │ }
+   ╰────
+  help: This expression always evaluates to `233`, and `int8` must be in range `-128` to `127` · code: [infer.constant_cast_overflow]

--- a/tests/ui/lint/snapshots/constant_cast_overflow_unicode_rune_literal_alias_target.snap
+++ b/tests/ui/lint/snapshots/constant_cast_overflow_unicode_rune_literal_alias_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ Constant cast overflow
+   ╭─[test.lis:5:11]
+ 4 │ fn main() {
+ 5 │   let _ = '\u{1F600}' as Small
+   ·           ──────────┬─────────
+   ·                     ╰── constant `128512` overflows `Small`
+ 6 │ }
+   ╰────
+  help: This expression always evaluates to `128512`, and `Small` must be in range `-32768` to `32767` · code: [infer.constant_cast_overflow]


### PR DESCRIPTION
Rune literals now accept `\xHH` and `\u{HEX}`, and string and format-string literals reject the same escapes Go rejects.

```rs
fn main() {
  let _ = '\x41' // was "unterminated rune literal"
  let _ = '\u{e9}' // was "invalid escape sequence"

  let _ = "\xZZ" // now rejected, was left for `gofmt` to reject
  let _ = "a\'b" // now rejected, `\'` belongs to rune literals and `\"` to strings
  let _ = f"a\qb" // now rejected, format strings validated no escapes at all
}
```

Rune literals also fold in `constant_cast_overflow`, so `'é' as int8` is caught at compile time.
