### PR TITLE
feat: SSA parameter mutability analysis for bindgen

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -172,8 +172,8 @@ func ParseTargets(s string) ([]Target, error) {
 	return targets, nil
 }
 
-func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goVersion string, cfg *config.Config, nilness *convert.NilnessAnalysis) GeneratePkgResult {
-	converter := convert.NewConverter(pkg.PkgPath, pkg, cfg, nilness)
+func generateFromPackage(pkg *packages.Package, displayPath, lisetteVersion, goVersion string, cfg *config.Config, nilness *convert.NilnessAnalysis, mutation *convert.MutationAnalysis) GeneratePkgResult {
+	converter := convert.NewConverter(pkg.PkgPath, pkg, cfg, nilness, mutation)
 	exports := extract.ExtractExports(pkg, converter.EmbedIsFaithful)
 	converted := converter.ConvertAll(exports)
 

--- a/bindgen/internal/cli/generate_pkg.go
+++ b/bindgen/internal/cli/generate_pkg.go
@@ -25,7 +25,8 @@ func GeneratePkg(pkgPath, lisetteVersion, goVersion string, cfg *config.Config) 
 	}
 
 	nilness := convert.NewNilnessAnalysis([]*packages.Package{pkg}, cfg)
-	return generateFromPackage(pkg, pkgPath, lisetteVersion, goVersion, cfg, nilness), nil
+	mutation := convert.NewMutationAnalysis(nilness, []*packages.Package{pkg})
+	return generateFromPackage(pkg, pkgPath, lisetteVersion, goVersion, cfg, nilness, mutation), nil
 }
 
 // generateUnloadableStub returns a header-only typedef with zero exports for

--- a/bindgen/internal/cli/generate_pkgs.go
+++ b/bindgen/internal/cli/generate_pkgs.go
@@ -139,6 +139,7 @@ func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *conf
 		}
 	}
 	nilness := convert.NewNilnessAnalysis(analysisRoots, cfg)
+	mutation := convert.NewMutationAnalysis(nilness, analysisRoots)
 
 	visited := make(map[string]bool)
 	frontier := make([]string, 0, len(pkgPaths))
@@ -179,7 +180,7 @@ func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *conf
 					stub := generateUnloadableStub(pkgPath, pkg, lisetteVersion, goVersion)
 					wave[i] = waveResult{ok: ManifestOk{Package: pkgPath, Content: stub.Content, Stubbed: true}}
 				} else {
-					result := generateFromPackage(pkg, pkgPath, lisetteVersion, goVersion, cfg, nilness)
+					result := generateFromPackage(pkg, pkgPath, lisetteVersion, goVersion, cfg, nilness, mutation)
 					wave[i] = waveResult{
 						ok:      ManifestOk{Package: pkgPath, Content: result.Content, Stubbed: false},
 						imports: result.ExternalImports,

--- a/bindgen/internal/cli/generate_std.go
+++ b/bindgen/internal/cli/generate_std.go
@@ -60,6 +60,7 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 			fmt.Fprintf(os.Stderr, "[%s] loaded %d packages in %.1fs\n", target, len(pkgs), time.Since(loadStart).Seconds())
 
 			nilness := convert.NewNilnessAnalysis(pkgs, cfg)
+			mutation := convert.NewMutationAnalysis(nilness, pkgs)
 
 			var generated atomic.Int32
 			total := len(pkgs)
@@ -78,7 +79,7 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 					default:
 					}
 
-					result := generateFromPackage(pkg, pkg.PkgPath, lisetteVersion, goVersion, cfg, nilness)
+					result := generateFromPackage(pkg, pkg.PkgPath, lisetteVersion, goVersion, cfg, nilness, mutation)
 
 					resultsMu.Lock()
 					results[pkg.PkgPath] = result.Content

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -116,7 +116,7 @@ func (c *Converter) convertFunction(result *ConvertResult, symbolExport extract.
 	liftedSpecs, paramOverrides := c.liftReflectionDecodeParams(signature, result.Name, result.TypeParams)
 	result.TypeParams = liftedSpecs
 
-	params, skip := c.convertParams(signature, result.Name, result.Name, paramOverrides, true, substitutions)
+	params, skip := c.convertParams(signature, symbolExport.Obj, result.Name, result.Name, paramOverrides, true, substitutions)
 	if skip != nil {
 		result.SkipReason = skip
 		return
@@ -164,9 +164,10 @@ func (c *Converter) applySentinelInt(result *ConvertResult, qualifiedName string
 	result.SentinelInt = &value
 }
 
-func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName string, paramOverrides map[int]string, directEligible bool, substitutions map[string]string) ([]FunctionParameter, *SkipReason) {
+func (c *Converter) convertParams(sig *types.Signature, obj types.Object, lookupName, methodName string, paramOverrides map[int]string, directEligible bool, substitutions map[string]string) ([]FunctionParameter, *SkipReason) {
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, lookupName)
 	nilableParams := c.cfg.NilableParams(c.currentPkgPath, lookupName)
+	mutation, _ := c.mutation.Function(obj)
 
 	params := sig.Params()
 	usedNames := collectNamedParams(params)
@@ -202,7 +203,7 @@ func (c *Converter) convertParams(sig *types.Signature, lookupName, methodName s
 		out = append(out, FunctionParameter{
 			Name:    name,
 			Type:    typeStr,
-			Mutable: isMutableParam(mutParams, name, typeStr, methodName),
+			Mutable: isMutableParam(mutation.Mutates(i), mutParams, name, typeStr, methodName),
 		})
 	}
 	return out, nil
@@ -371,7 +372,7 @@ func (c *Converter) convertMethod(result *ConvertResult, symbolExport extract.Sy
 	}
 	liftedSpecs, paramOverrides := c.liftReflectionDecodeParams(signature, qualifiedName, methodSpecs)
 
-	params, skip := c.convertParams(signature, qualifiedName, result.Name, paramOverrides, true, nil)
+	params, skip := c.convertParams(signature, symbolExport.Obj, qualifiedName, result.Name, paramOverrides, true, nil)
 	if skip != nil {
 		result.SkipReason = skip
 		return
@@ -1138,14 +1139,15 @@ func describeConstraint(constraint *types.Interface) string {
 	return "complex"
 }
 
-func isMutableParam(mutParams []string, name, typeStr, funcName string) bool {
+// isMutableParam combines the three signals additively rather than ranking them:
+// a missing `mut` corrupts caller data, a spurious one only asks for a `let mut`.
+func isMutableParam(derivedMutates bool, mutParams []string, name, typeStr, funcName string) bool {
 	if !isReferenceType(typeStr) {
 		return false
 	}
-	if mutParams != nil {
-		return slices.Contains(mutParams, name)
-	}
-	return looksLikeMutableParam(name, typeStr, funcName)
+	return slices.Contains(mutParams, name) ||
+		derivedMutates ||
+		looksLikeMutableParam(name, typeStr, funcName)
 }
 
 // looksLikeMutableParam returns true if the parameter is likely written into.
@@ -1830,7 +1832,7 @@ func (c *Converter) extractInterfaceMethods(_interface *types.Interface, typeNam
 		}
 
 		qualifiedName := typeName + "." + method.Name()
-		params, skip := c.convertParams(signature, qualifiedName, method.Name(), nil, false, nil)
+		params, skip := c.convertParams(signature, method, qualifiedName, method.Name(), nil, false, nil)
 		if skip != nil {
 			return nil, false
 		}

--- a/bindgen/internal/convert/dispatch.go
+++ b/bindgen/internal/convert/dispatch.go
@@ -146,6 +146,7 @@ type Converter struct {
 	pkg                      *packages.Package
 	cfg                      config.Config
 	nilness                  *NilnessAnalysis             // nil falls back to name heuristics
+	mutation                 *MutationAnalysis            // nil falls back to the curated map and name heuristics
 	uniformPointerTypes      map[string]bool              // lazily computed; types with 10+ single-pointer-return methods
 	manyToOneTypes           map[string]bool              // lazily computed; return types with 10+ free functions
 	majorityPointerTypes     map[string]bool              // lazily computed; types where ≥20 methods return same *T (>90%)
@@ -161,7 +162,7 @@ type Converter struct {
 	synth []syntheticStruct
 }
 
-func NewConverter(pkgPath string, pkg *packages.Package, cfg *config.Config, nilness *NilnessAnalysis) *Converter {
+func NewConverter(pkgPath string, pkg *packages.Package, cfg *config.Config, nilness *NilnessAnalysis, mutation *MutationAnalysis) *Converter {
 	var effectiveConfig config.Config
 	if cfg != nil {
 		effectiveConfig = *cfg
@@ -172,6 +173,7 @@ func NewConverter(pkgPath string, pkg *packages.Package, cfg *config.Config, nil
 		pkg:            pkg,
 		cfg:            effectiveConfig,
 		nilness:        nilness,
+		mutation:       mutation,
 	}
 }
 

--- a/bindgen/internal/convert/mutation.go
+++ b/bindgen/internal/convert/mutation.go
@@ -1,0 +1,576 @@
+// SSA parameter-mutation analysis: which parameters a function writes through.
+package convert
+
+import (
+	"go/constant"
+	"go/token"
+	"go/types"
+	"sort"
+
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/ssa"
+)
+
+// FunctionMutation is indexed by Go signature parameter, so a receiver is not counted.
+type FunctionMutation struct {
+	Params []bool
+}
+
+func (m FunctionMutation) Mutates(index int) bool {
+	return index < len(m.Params) && m.Params[index]
+}
+
+// MutationAnalysis is precomputed at construction and read-only afterwards,
+// since `generate_std` converts packages concurrently.
+type MutationAnalysis struct {
+	program    *ssa.Program
+	verdicts   map[*types.Func]FunctionMutation
+	summaries  map[*ssa.Function]*mutationSummary
+	inProgress map[*ssa.Function]bool
+	// sawCycle: a summary was read before it was finished, so settle must run.
+	sawCycle bool
+}
+
+// mutationSummary is keyed by SSA parameter index (a receiver is 0), and by
+// free-variable index for closures.
+type mutationSummary struct {
+	params   map[int]reachMode
+	freeVars map[int]reachMode
+}
+
+// reachMode says whether a write replaced what the parameter points at or wrote
+// inside it. A parameter can be reached both ways on different paths.
+type reachMode uint8
+
+const (
+	reachDirect reachMode = 1 << iota
+	reachThroughLoad
+)
+
+func modeFor(throughLoad bool) reachMode {
+	if throughLoad {
+		return reachThroughLoad
+	}
+	return reachDirect
+}
+
+// weight sums the modes, so a parameter that gains a second mode counts as
+// growth and not only a newly found parameter.
+func (m *mutationSummary) weight() int {
+	total := 0
+	for _, mode := range m.params {
+		total += int(mode)
+	}
+	for _, mode := range m.freeVars {
+		total += int(mode)
+	}
+	return total
+}
+
+// NewMutationAnalysis reuses the SSA program the nilability analysis built.
+func NewMutationAnalysis(nilness *NilnessAnalysis, roots []*packages.Package) *MutationAnalysis {
+	if nilness == nil || nilness.program == nil {
+		return nil
+	}
+	analysis := &MutationAnalysis{
+		program:    nilness.program,
+		verdicts:   make(map[*types.Func]FunctionMutation),
+		summaries:  make(map[*ssa.Function]*mutationSummary),
+		inProgress: make(map[*ssa.Function]bool),
+	}
+
+	wellTyped := make([]*packages.Package, 0, len(roots))
+	for _, pkg := range roots {
+		if pkg != nil && pkg.Types != nil && len(pkg.Errors) == 0 {
+			wellTyped = append(wellTyped, pkg)
+		}
+	}
+	sort.Slice(wellTyped, func(i, j int) bool { return wellTyped[i].PkgPath < wellTyped[j].PkgPath })
+
+	var bound []*types.Func
+	for _, pkg := range wellTyped {
+		scope := pkg.Types.Scope()
+		for _, name := range scope.Names() {
+			switch obj := scope.Lookup(name).(type) {
+			case *types.Func:
+				bound = append(bound, obj)
+			case *types.TypeName:
+				named, ok := obj.Type().(*types.Named)
+				if !ok {
+					continue
+				}
+				for sel := range analysis.program.MethodSets.MethodSet(types.NewPointer(named)).Methods() {
+					if fn, ok := sel.Obj().(*types.Func); ok {
+						bound = append(bound, fn)
+					}
+				}
+			}
+		}
+	}
+
+	// Read verdicts only after settling, so a function bound early does not
+	// freeze an answer a later pass grows.
+	for _, fn := range bound {
+		if ssaFn := analysis.program.FuncValue(fn); ssaFn != nil && functionBody(ssaFn) != nil {
+			analysis.summarize(ssaFn)
+		}
+	}
+	analysis.settle()
+	for _, fn := range bound {
+		analysis.record(fn)
+	}
+	return analysis
+}
+
+func (a *MutationAnalysis) Function(obj types.Object) (FunctionMutation, bool) {
+	if a == nil {
+		return FunctionMutation{}, false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return FunctionMutation{}, false
+	}
+	facts, ok := a.verdicts[fn]
+	return facts, ok
+}
+
+func (a *MutationAnalysis) record(fn *types.Func) {
+	if _, done := a.verdicts[fn]; done {
+		return
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return
+	}
+	paramCount := sig.Params().Len()
+	facts := FunctionMutation{Params: make([]bool, paramCount)}
+
+	ssaFn := a.program.FuncValue(fn)
+	if ssaFn == nil || functionBody(ssaFn) == nil {
+		a.verdicts[fn] = facts // the curated map and the name heuristic decide
+		return
+	}
+
+	// An SSA method carries its receiver as parameter 0.
+	offset := 0
+	if sig.Recv() != nil {
+		offset = 1
+	}
+	for index := range a.summarize(ssaFn).params {
+		if signatureIndex := index - offset; signatureIndex >= 0 && signatureIndex < paramCount {
+			facts.Params[signatureIndex] = true
+		}
+	}
+	a.verdicts[fn] = facts
+}
+
+func (a *MutationAnalysis) summarize(fn *ssa.Function) *mutationSummary {
+	if s, ok := a.summaries[fn]; ok {
+		if a.inProgress[fn] {
+			a.sawCycle = true // s holds only what has been found so far
+		}
+		return s
+	}
+	summary := &mutationSummary{params: map[int]reachMode{}, freeVars: map[int]reachMode{}}
+	a.summaries[fn] = summary
+	a.walk(fn, summary)
+	return summary
+}
+
+// walk grows `summary` in place, so re-running it only adds.
+func (a *MutationAnalysis) walk(fn *ssa.Function, summary *mutationSummary) {
+	body := functionBody(fn)
+	if body == nil {
+		return
+	}
+	a.inProgress[fn] = true
+	defer delete(a.inProgress, fn)
+	for _, block := range body.Blocks {
+		for _, instruction := range block.Instrs {
+			a.recordWrites(body, instruction, summary)
+		}
+	}
+}
+
+// settle re-walks every summary until none grows, which is what makes two
+// mutually recursive functions agree: whichever was summarized first read the
+// other while it was still empty. It runs until nothing changes rather than for
+// a fixed number of passes, since stopping early would leave the answer
+// depending on which function was walked first. Findings are only ever added,
+// so this terminates.
+func (a *MutationAnalysis) settle() {
+	if !a.sawCycle {
+		return
+	}
+	for grew := true; grew; {
+		grew = false
+		for _, fn := range a.summarized() {
+			summary := a.summaries[fn]
+			before := summary.weight()
+			a.walk(fn, summary)
+			if summary.weight() != before {
+				grew = true
+			}
+		}
+	}
+}
+
+// summarized snapshots the keys, since a walk can add a callee to the map.
+func (a *MutationAnalysis) summarized() []*ssa.Function {
+	out := make([]*ssa.Function, 0, len(a.summaries))
+	for fn := range a.summaries {
+		out = append(out, fn)
+	}
+	return out
+}
+
+func (a *MutationAnalysis) recordWrites(fn *ssa.Function, instruction ssa.Instruction, summary *mutationSummary) {
+	switch typed := instruction.(type) {
+	case *ssa.Store:
+		// Overwriting a local or captured variable is not a write the caller can
+		// see. SSA stores every captured parameter into one of these.
+		if isVariableSlot(typed.Addr) {
+			return
+		}
+		markRoots(fn, typed.Addr, summary)
+	case *ssa.MapUpdate:
+		markRoots(fn, typed.Map, summary)
+	case *ssa.MakeClosure:
+		a.recordClosureWrites(fn, typed, summary)
+	case ssa.CallInstruction:
+		a.recordCallWrites(fn, typed.Common(), summary)
+	}
+}
+
+// recordClosureWrites assumes the closure runs, since it cannot know who calls it.
+func (a *MutationAnalysis) recordClosureWrites(fn *ssa.Function, closure *ssa.MakeClosure, summary *mutationSummary) {
+	target, ok := closure.Fn.(*ssa.Function)
+	if !ok {
+		return
+	}
+	inner := a.summarize(target)
+	for index, mode := range inner.freeVars {
+		if index < len(closure.Bindings) {
+			resumeWalk(fn, closure.Bindings[index], summary, mode)
+		}
+	}
+}
+
+// resumeWalk continues the way the callee reached its own parameter, so
+// `write(&local)` reaches what `local` holds while `advance(&cursor)` does not.
+func resumeWalk(fn *ssa.Function, value ssa.Value, summary *mutationSummary, mode reachMode) {
+	if mode&reachDirect != 0 {
+		markRoots(fn, value, summary)
+	}
+	if mode&reachThroughLoad != 0 {
+		markRootsThroughLoad(fn, value, summary)
+	}
+}
+
+func (a *MutationAnalysis) recordCallWrites(fn *ssa.Function, common *ssa.CallCommon, summary *mutationSummary) {
+	if builtin, ok := common.Value.(*ssa.Builtin); ok {
+		switch builtin.Name() {
+		case "copy", "delete", "clear":
+			if len(common.Args) > 0 {
+				markRoots(fn, common.Args[0], summary)
+			}
+		case "append":
+			// Writes past the length of its first argument when capacity
+			// allowed, so `append(s[:0], v)` overwrites `s[0]`.
+			if len(common.Args) > 0 && !appendMustReallocate(common.Args[0]) {
+				markRoots(fn, common.Args[0], summary)
+			}
+		}
+		return
+	}
+	// A dynamic call has no body to consult, and a bodiless callee summarizes as
+	// writing nothing. Assuming otherwise for either was measured and rejected.
+	callee := common.StaticCallee()
+	if callee == nil {
+		return
+	}
+	inner := a.summarize(callee)
+	for index, mode := range inner.params {
+		if index < len(common.Args) {
+			resumeWalk(fn, common.Args[index], summary, mode)
+		}
+	}
+}
+
+func markRoots(fn *ssa.Function, value ssa.Value, summary *mutationSummary) {
+	markRootsSeen(fn, value, summary, false, make(map[rootVisit]bool))
+}
+
+// markRootsThroughLoad starts as though a load stood before `value`.
+func markRootsThroughLoad(fn *ssa.Function, value ssa.Value, summary *mutationSummary) {
+	markRootsSeen(fn, value, summary, true, make(map[rootVisit]bool))
+}
+
+// rootVisit keys the visited set, since the two modes give different answers.
+type rootVisit struct {
+	value       ssa.Value
+	throughLoad bool
+}
+
+// markRootsSeen walks back from a written location to the parameters and
+// captured variables that the write actually lands in.
+func markRootsSeen(fn *ssa.Function, value ssa.Value, summary *mutationSummary, throughLoad bool, seen map[rootVisit]bool) {
+	visit := rootVisit{value, throughLoad}
+	if value == nil || seen[visit] {
+		return
+	}
+	seen[visit] = true
+	descend := func(next ssa.Value, loaded bool) {
+		markRootsSeen(fn, next, summary, loaded, seen)
+	}
+
+	switch typed := value.(type) {
+	case *ssa.Parameter:
+		for index, param := range fn.Params {
+			if param == typed {
+				summary.params[index] |= modeFor(throughLoad)
+				return
+			}
+		}
+	case *ssa.FreeVar:
+		for index, free := range fn.FreeVars {
+			if free == typed {
+				summary.freeVars[index] |= modeFor(throughLoad)
+				return
+			}
+		}
+	case *ssa.Slice:
+		descend(typed.X, throughLoad)
+	case *ssa.IndexAddr:
+		descend(typed.X, throughLoad)
+	case *ssa.FieldAddr:
+		descend(typed.X, throughLoad)
+	case *ssa.Field:
+		// Copying a struct or array copies the slice headers inside it. SSA uses this
+		// value form only where it cannot take an address, such as a call result, so
+		// nothing reaches it until call results are tracked.
+		if !isIndirection(typed.Type()) {
+			descend(typed.X, throughLoad)
+		}
+	case *ssa.Index:
+		if !isIndirection(typed.Type()) {
+			descend(typed.X, throughLoad)
+		}
+	case *ssa.ChangeType:
+		descend(typed.X, throughLoad)
+	case *ssa.Convert:
+		// A string conversion allocates, so `[]byte(string(src))` is storage
+		// of its own. Pointer and numeric conversions keep it.
+		if !convertCopies(typed.X.Type(), typed.Type()) {
+			descend(typed.X, throughLoad)
+		}
+	case *ssa.SliceToArrayPointer:
+		descend(typed.X, throughLoad)
+	case *ssa.Lookup:
+		if !typed.CommaOk && !isIndirection(typed.Type()) {
+			descend(typed.X, throughLoad)
+		}
+	case *ssa.MakeInterface:
+		descend(typed.X, throughLoad)
+	case *ssa.ChangeInterface:
+		descend(typed.X, throughLoad)
+	case *ssa.TypeAssert:
+		descend(typed.X, throughLoad)
+	case *ssa.Extract:
+		// The comma-ok and range forms hand back a tuple whose value still points at
+		// the map or interface it came out of.
+		switch tuple := typed.Tuple.(type) {
+		case *ssa.TypeAssert:
+			if typed.Index == 0 {
+				descend(tuple.X, throughLoad)
+			}
+		case *ssa.Lookup:
+			if typed.Index == 0 && !isIndirection(typed.Type()) {
+				descend(tuple.X, throughLoad)
+			}
+		case *ssa.Next:
+			if rang, ok := tuple.Iter.(*ssa.Range); ok &&
+				typed.Index == 2 && !isIndirection(typed.Type()) {
+				descend(rang.X, throughLoad)
+			}
+		}
+	case *ssa.Phi:
+		for _, edge := range typed.Edges {
+			descend(edge, throughLoad)
+		}
+	case *ssa.UnOp:
+		if typed.Op != token.MUL {
+			return
+		}
+		// A pointer or interface read out of a slice or map ends the trail, since the
+		// slice holds only the pointer and the write lands on what it points at. Read
+		// out of a local variable it does not, which keeps `v := any(s)` reaching `s`.
+		if isIndirection(typed.Type()) && !isVariableSlot(typed.X) {
+			return
+		}
+		descend(typed.X, true)
+	case *ssa.Alloc:
+		// Arriving through a load means the write went inside whatever the local
+		// holds, so keep going. Arriving directly means the local itself was
+		// overwritten, which says nothing about where its value came from.
+		if !throughLoad {
+			return
+		}
+		for _, stored := range storesInto(typed) {
+			descend(stored, false)
+		}
+	case *ssa.Call:
+		// An append result shares the argument's backing array, which is how
+		// `slices.Delete` becomes visible: it shifts elements down, then clears the
+		// leftover tail. Only the zero-capacity form breaks that, since appending
+		// nothing to a full slice hands the same slice straight back.
+		if builtin, ok := typed.Common().Value.(*ssa.Builtin); ok &&
+			builtin.Name() == "append" && len(typed.Common().Args) > 0 &&
+			!isZeroCapacity(typed.Common().Args[0]) {
+			descend(typed.Common().Args[0], throughLoad)
+		}
+	}
+}
+
+func convertCopies(from, to types.Type) bool {
+	return isStringType(from) || isStringType(to)
+}
+
+func isStringType(t types.Type) bool {
+	basic, ok := t.Underlying().(*types.Basic)
+	return ok && basic.Info()&types.IsString != 0
+}
+
+// isIndirection reports the types that refer to a separate object rather than
+// holding one. A type parameter needs its core type first, since `Underlying` on
+// one yields the constraint interface, which would stop every generic slice.
+func isIndirection(t types.Type) bool {
+	if parameter, ok := t.(*types.TypeParam); ok {
+		core := coreType(parameter)
+		if core == nil {
+			return false // several shapes admitted: keep walking
+		}
+		t = core
+	}
+	switch t.Underlying().(type) {
+	case *types.Pointer, *types.Interface:
+		return true
+	}
+	return false
+}
+
+// coreType returns the underlying type a constraint's members share, or nil.
+func coreType(parameter *types.TypeParam) types.Type {
+	return constraintCore(parameter.Constraint(), make(map[types.Type]bool))
+}
+
+// constraintCore recurses, since a constraint may embed another named interface
+// rather than stating its terms directly.
+func constraintCore(constraint types.Type, seen map[types.Type]bool) types.Type {
+	iface, ok := constraint.Underlying().(*types.Interface)
+	if !ok {
+		return constraint.Underlying()
+	}
+	if seen[constraint] {
+		return nil
+	}
+	seen[constraint] = true
+
+	var core types.Type
+	for i := range iface.NumEmbeddeds() {
+		for _, term := range unionTerms(iface.EmbeddedType(i)) {
+			resolved := constraintCore(term, seen)
+			if resolved == nil {
+				return nil
+			}
+			if core == nil {
+				core = resolved
+				continue
+			}
+			if !types.Identical(core, resolved) {
+				return nil
+			}
+		}
+	}
+	return core // nil when only methods are listed, as `any` does
+}
+
+func unionTerms(embedded types.Type) []types.Type {
+	union, ok := embedded.(*types.Union)
+	if !ok {
+		return []types.Type{embedded}
+	}
+	out := make([]types.Type, 0, union.Len())
+	for i := range union.Len() {
+		out = append(out, union.Term(i).Type())
+	}
+	return out
+}
+
+// appendMustReallocate reports the two idioms with no spare room: zero-capacity
+// `s[:0:0]`, and the filled-to-capacity `s[:cap(s)]` that `slices.Grow` uses.
+func appendMustReallocate(value ssa.Value) bool {
+	return isZeroCapacity(value) || isFilledToCapacity(value)
+}
+
+func isFilledToCapacity(value ssa.Value) bool {
+	sliced, ok := value.(*ssa.Slice)
+	if !ok || sliced.Max != nil || sliced.High == nil {
+		return false
+	}
+	call, ok := sliced.High.(*ssa.Call)
+	if !ok {
+		return false
+	}
+	builtin, ok := call.Common().Value.(*ssa.Builtin)
+	return ok && builtin.Name() == "cap" &&
+		len(call.Common().Args) == 1 && call.Common().Args[0] == sliced.X
+}
+
+func isZeroCapacity(value ssa.Value) bool {
+	sliced, ok := value.(*ssa.Slice)
+	if !ok || sliced.Max == nil {
+		return false
+	}
+	max, ok := constantIndex(sliced.Max)
+	if !ok {
+		return false
+	}
+	if sliced.Low == nil {
+		return max == 0
+	}
+	low, ok := constantIndex(sliced.Low)
+	return ok && low == max
+}
+
+func constantIndex(value ssa.Value) (int64, bool) {
+	konst, ok := value.(*ssa.Const)
+	if !ok || konst.Value == nil || konst.Value.Kind() != constant.Int {
+		return 0, false
+	}
+	return constant.Int64Val(konst.Value)
+}
+
+// isVariableSlot reports an address where writing overwrites a local or captured
+// variable, rather than writing inside the value it holds.
+func isVariableSlot(address ssa.Value) bool {
+	switch address.(type) {
+	case *ssa.Alloc, *ssa.FreeVar:
+		return true
+	}
+	return false
+}
+
+func storesInto(alloc *ssa.Alloc) []ssa.Value {
+	referrers := alloc.Referrers()
+	if referrers == nil {
+		return nil
+	}
+	var out []ssa.Value
+	for _, ref := range *referrers {
+		if store, ok := ref.(*ssa.Store); ok && store.Addr == alloc {
+			out = append(out, store.Val)
+		}
+	}
+	return out
+}

--- a/bindgen/internal/convert/mutation_test.go
+++ b/bindgen/internal/convert/mutation_test.go
@@ -1,0 +1,434 @@
+package convert
+
+import (
+	"os"
+	"path/filepath"
+
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func analyzeSource(t *testing.T, source string) (*MutationAnalysis, *packages.Package) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module probe\n\ngo 1.25\n")
+	write("probe.go", "package probe\n\n"+source)
+
+	cfg := &packages.Config{Mode: packages.LoadAllSyntax, Dir: dir}
+	pkgs, err := packages.Load(cfg, "probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || len(pkgs[0].Errors) > 0 {
+		t.Fatalf("load failed: %v", pkgs)
+	}
+	nilness := NewNilnessAnalysis(pkgs, nil)
+	if nilness == nil {
+		t.Fatal("SSA build failed")
+	}
+	analysis := NewMutationAnalysis(nilness, pkgs)
+	if analysis == nil {
+		t.Fatal("mutation analysis unavailable")
+	}
+	return analysis, pkgs[0]
+}
+
+func mutatedParams(t *testing.T, analysis *MutationAnalysis, pkg *packages.Package, name string) []string {
+	t.Helper()
+	obj, _ := pkg.Types.Scope().Lookup(name).(*types.Func)
+	if obj == nil {
+		t.Fatalf("no function %q", name)
+	}
+	facts, ok := analysis.Function(obj)
+	if !ok {
+		t.Fatalf("no verdict for %q", name)
+	}
+	sig := obj.Type().(*types.Signature)
+	var out []string
+	for i := 0; i < sig.Params().Len(); i++ {
+		if facts.Mutates(i) {
+			out = append(out, sig.Params().At(i).Name())
+		}
+	}
+	return out
+}
+
+func assertMutates(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("mutated params: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mutated params: got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMutationDetectsDirectWrites(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func ElementWrite(s []int)          { s[0] = 1 }
+func MapWrite(m map[string]int)     { m["k"] = 1 }
+func MapDelete(m map[string]int)    { delete(m, "k") }
+func SliceClear(s []int)            { clear(s) }
+func CopyInto(dst, src []int)       { copy(dst, src) }
+func ReadOnly(s []int) int          { return s[0] }
+func Reassign(s []int) []int        { s = nil; return s }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ElementWrite"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "MapWrite"), "m")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "MapDelete"), "m")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "SliceClear"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "CopyInto"), "dst")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ReadOnly"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Reassign"))
+}
+
+// `slices.Sort` stores nothing itself and reaches its write several frames
+// down, so depth matters.
+func TestMutationPropagatesThroughCallees(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func deep3(s []int)      { s[0] = 1 }
+func deep2(s []int)      { deep3(s) }
+func deep1(s []int)      { deep2(s) }
+func Shallow(s []int)    { deep1(s) }
+func Sub(s []int)        { deep1(s[1:]) }
+func NotPassed(s []int)  { deep1(nil) }
+func Recursive(s []int)  { if len(s) > 0 { Recursive(s[1:]) }; s[0] = 1 }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Shallow"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Sub"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "NotPassed"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Recursive"), "s")
+}
+
+// A closure may run wherever it is handed to, as `maps.Insert` does.
+func TestMutationSeesClosureWrites(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func run(f func()) { f() }
+
+func ThroughClosure(s []int)  { run(func() { s[0] = 1 }) }
+func EscapingClosure(s []int) func() { return func() { s[0] = 1 } }
+func ReadingClosure(s []int)  { run(func() { _ = s[0] }) }
+func ReassignInClosure(s []int) { run(func() { s = nil }) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ThroughClosure"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "EscapingClosure"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ReadingClosure"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ReassignInClosure"))
+}
+
+// Without these the whole `slices` package is invisible.
+func TestMutationSeesGenericSliceParams(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func GenericWrite[S ~[]E, E any](s S)     { var zero E; s[0] = zero }
+func GenericRead[S ~[]E, E any](s S) int  { return len(s) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "GenericWrite"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "GenericRead"))
+}
+
+// Both halves matter: the write catches `s = append(s[:0], v)`, the
+// provenance catches `slices.Delete`.
+func TestMutationFollowsAppend(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Reset(s []int)                 { s = append(s[:0], 42); _ = s }
+func AppendAndReturn(s []int) []int { return append(s, 1) }
+
+func DeleteShape(s []int, i, j int) []int {
+	oldlen := len(s)
+	s = append(s[:i], s[j:]...)
+	clear(s[len(s):oldlen])
+	return s
+}
+
+func FreshBuilder(s []int) []int { out := []int{}; for _, v := range s { out = append(out, v) }; return out }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Reset"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "AppendAndReturn"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "DeleteShape"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "FreshBuilder"))
+}
+
+// The shapes `slices.Clone` and `slices.Grow` use to force a fresh allocation.
+func TestMutationSkipsReallocatingAppend(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func CloneShape(s []int) []int { return append(s[:0:0], s...) }
+
+func GrowShape(s []int, n int) []int {
+	if n -= cap(s) - len(s); n > 0 { s = append(s[:cap(s)], make([]int, n)...)[:len(s)] }
+	return s
+}
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "CloneShape"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "GrowShape"))
+}
+
+// A filled-to-capacity append hands its argument straight back when it appends
+// nothing, so only the zero-capacity form breaks the chain.
+func TestMutationBreaksProvenanceOnlyForZeroCapacityAppend(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func CloneThenClear(s []int) { out := append(s[:0:0], s...); clear(out) }
+func FullThenClear(s []int, xs []int) { out := append(s[:cap(s)], xs...); clear(out) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "CloneThenClear"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "FullThenClear"), "s")
+}
+
+// `cycA` writes after its recursive call, so `cycB` reads an empty in-progress
+// summary and must not keep it.
+func TestMutationSettlesMutualRecursion(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func cycA(s []int, n int) { if n > 0 { cycB(s, n-1) }; s[0] = 1 }
+func cycB(s []int, n int) { if n > 0 { cycA(s, n-1) } }
+
+func EntryA(s []int) { cycA(s, 1) }
+func EntryB(s []int) { cycB(s, 1) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "EntryA"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "EntryB"), "s")
+}
+
+// Repair walks backwards one link per pass in the worst ordering, so a settle
+// that stopped early would leave entries disagreeing.
+func TestMutationSettlesLongCycleFromEveryEntry(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func cyc1(s []int, n int)  { if n > 0 { cyc2(s, n-1) }; s[0] = 1 }
+func cyc2(s []int, n int)  { if n > 0 { cyc3(s, n-1) } }
+func cyc3(s []int, n int)  { if n > 0 { cyc4(s, n-1) } }
+func cyc4(s []int, n int)  { if n > 0 { cyc5(s, n-1) } }
+func cyc5(s []int, n int)  { if n > 0 { cyc6(s, n-1) } }
+func cyc6(s []int, n int)  { if n > 0 { cyc7(s, n-1) } }
+func cyc7(s []int, n int)  { if n > 0 { cyc8(s, n-1) } }
+func cyc8(s []int, n int)  { if n > 0 { cyc9(s, n-1) } }
+func cyc9(s []int, n int)  { if n > 0 { cyc10(s, n-1) } }
+func cyc10(s []int, n int) { if n > 0 { cyc11(s, n-1) } }
+func cyc11(s []int, n int) { if n > 0 { cyc12(s, n-1) } }
+func cyc12(s []int, n int) { if n > 0 { cyc1(s, n-1) } }
+
+func Entry2(s []int)  { cyc2(s, 1) }
+func Entry7(s []int)  { cyc7(s, 1) }
+func Entry12(s []int) { cyc12(s, 1) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Entry2"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Entry7"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Entry12"), "s")
+}
+
+func TestMutationStopsAtIndirectElements(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type box struct{ n int }
+type node interface{ node() }
+func (b *box) node() {}
+
+func WriteThroughElement(list []*box)  { for _, b := range list { b.n = 1 } }
+func WriteThroughUnboxed(list []node)  { for _, e := range list { if b, ok := e.(*box); ok { b.n = 1 } } }
+func WriteValueElement(list []box)     { for i := range list { list[i].n = 1 } }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "WriteThroughElement"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "WriteThroughUnboxed"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "WriteValueElement"), "list")
+}
+
+// Boxing shares the backing store, so unboxing and writing reaches the caller.
+func TestMutationFollowsInterfaceBoxing(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func unbox(v any)        { v.([]int)[0] = 1 }
+func unboxCommaOk(v any) { if got, ok := v.([]int); ok { got[0] = 1 } }
+func readUnboxed(v any) int { return len(v.([]int)) }
+
+func Boxed(s []int)        { unbox(s) }
+func BoxedCommaOk(s []int) { unboxCommaOk(s) }
+func BoxedRead(s []int)    { readUnboxed(s) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Boxed"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "BoxedCommaOk"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "BoxedRead"))
+}
+
+// A slot is not a container element, so the cutoff turns on provenance rather
+// than on the loaded type alone.
+func TestMutationFollowsInterfaceThroughVariableSlots(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Captured(s []int) { v := any(s); func() { v.([]int)[0] = 1 }() }
+func Local(s []int)    { v := any(s); v.([]int)[0] = 1 }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Captured"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Local"), "s")
+}
+
+// A type parameter reports its constraint as its underlying type, and that
+// constraint may itself be named or embed another named one.
+func TestMutationResolvesTypeParameterCore(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+import "iter"
+
+type sliceish interface{ ~[]int }
+type nested interface{ sliceish }
+type withMethod interface{ ~[]int; Len() int }
+
+func AppendSeqShape[S ~[]E, E any](s S, seq iter.Seq[E]) S {
+	for v := range seq { s = append(s, v) }
+	return s
+}
+
+func InlineConstraint[S ~[]int](s S)     { func() { s[0] = 1 }() }
+func NamedConstraint[S sliceish](s S)    { func() { s[0] = 1 }() }
+func NestedConstraint[S nested](s S)     { func() { s[0] = 1 }() }
+func MethodConstraint[S withMethod](s S) { func() { s[0] = 1 }() }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "AppendSeqShape"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "InlineConstraint"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "NamedConstraint"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "NestedConstraint"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "MethodConstraint"), "s")
+}
+
+// Each case writes through a loaded element, so the assertion turns on how the
+// walk classifies that load rather than on a direct write.
+func TestMutationLeavesOpenConstraintsUnresolved(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type sliceish interface{ ~[]int }
+
+func OpenConstraintElement[T any](list []T) {
+	for _, e := range list {
+		if s, ok := any(e).([]int); ok { s[0] = 1 }
+	}
+}
+
+func OpenConstraintPointer[T any](list []*T) { for _, p := range list { var zero T; *p = zero } }
+
+func ResolvedConstraint[S sliceish](s S) { func() { s[0] = 1 }() }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "OpenConstraintElement"), "list")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "OpenConstraintPointer"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ResolvedConstraint"), "s")
+}
+
+// Reassigning a local says nothing about what it was seeded from.
+// `crypto/x509` parses this way, walking a cursor over a copy of its input.
+func TestMutationStopsAtLocalReassignment(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func advance(cursor *[]byte) { *cursor = (*cursor)[1:] }
+
+func WalkCursor(der []byte)  { cursor := der; advance(&cursor) }
+func WriteCursor(der []byte) { cursor := der; cursor[0] = 1 }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "WalkCursor"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "WriteCursor"), "der")
+}
+
+// `writeThrough` reaches its parameter through a load and `replace` does not,
+// so a caller passing `&local` has to resume differently for each.
+func TestMutationResumesCalleeWalkInTheSameMode(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func writeThrough(p *[]int) { (*p)[0] = 42 }
+func replace(p *[]int)      { *p = nil }
+
+func ThroughLocal(s []int) { local := s; writeThrough(&local) }
+func ReplaceLocal(s []int) { local := s; replace(&local); _ = local }
+func ThroughDirect(s []int) { writeThrough(&s) }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ThroughLocal"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ReplaceLocal"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ThroughDirect"), "s")
+}
+
+// A map element read reaches the map's own storage, in all three forms.
+func TestMutationFollowsMapLookups(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type node interface{ node() }
+type boxed struct{ n int }
+func (b *boxed) node() {}
+
+func Direct(m map[string][]int)  { m["x"][0] = 1 }
+func CommaOk(m map[string][]int) { if v, ok := m["x"]; ok { v[0] = 1 } }
+func Ranged(m map[string][]int)  { for _, s := range m { s[0] = 1 } }
+func ReadOnly(m map[string][]int) int { return len(m["x"]) }
+
+func IndirectElement(m map[string]node) {
+	for _, e := range m {
+		if b, ok := e.(*boxed); ok { b.n = 1 }
+	}
+}
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Direct"), "m")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "CommaOk"), "m")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Ranged"), "m")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ReadOnly"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "IndirectElement"))
+}
+
+// A string conversion allocates. A slice-to-array-pointer one does not.
+func TestMutationTracksConversionStorage(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func StringRoundTrip(src []byte) { dst := []byte(string(src)); clear(dst) }
+func ToArrayPointer(s []int)     { a := (*[1]int)(s); a[0] = 1 }
+func NamedConversion(s []int)    { type ints []int; a := ints(s); a[0] = 1 }
+`)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "StringRoundTrip"))
+	assertMutates(t, mutatedParams(t, analysis, pkg, "ToArrayPointer"), "s")
+	assertMutates(t, mutatedParams(t, analysis, pkg, "NamedConversion"), "s")
+}
+
+func TestMutationReportsMethodReceiverOffset(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Holder struct{ items []int }
+
+func (h *Holder) Fill(dst []int)     { copy(dst, h.items) }
+func (h *Holder) Absorb(src []int)   { h.items = src }
+`)
+	named := pkg.Types.Scope().Lookup("Holder").(*types.TypeName).Type().(*types.Named)
+	verdicts := map[string][]string{}
+	for i := 0; i < named.NumMethods(); i++ {
+		method := named.Method(i)
+		facts, ok := analysis.Function(method)
+		if !ok {
+			t.Fatalf("no verdict for %q", method.Name())
+		}
+		sig := method.Type().(*types.Signature)
+		var mutated []string
+		for j := 0; j < sig.Params().Len(); j++ {
+			if facts.Mutates(j) {
+				mutated = append(mutated, sig.Params().At(j).Name())
+			}
+		}
+		verdicts[method.Name()] = mutated
+	}
+	assertMutates(t, verdicts["Fill"], "dst")
+	assertMutates(t, verdicts["Absorb"])
+}
+
+func TestIsMutableParamCombinesSignals(t *testing.T) {
+	cases := []struct {
+		name      string
+		derived   bool
+		curated   []string
+		paramName string
+		typeStr   string
+		funcName  string
+		want      bool
+	}{
+		{"derived only", true, nil, "s", "Slice<int>", "Sort", true},
+		{"curated only", false, []string{"buf"}, "buf", "Slice<byte>", "Buffer", true},
+		{"heuristic only", false, nil, "p", "Slice<byte>", "Read", true},
+		{"curated omits, derived finds", true, []string{"other"}, "s", "Slice<int>", "Sort", true},
+		{"no signal", false, nil, "s", "Slice<int>", "Sort", false},
+		{"not a reference type", true, []string{"n"}, "n", "int", "Read", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isMutableParam(c.derived, c.curated, c.paramName, c.typeStr, c.funcName)
+			if got != c.want {
+				t.Errorf("isMutableParam = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/crates/stdlib/typedefs/crypto/rsa.d.lis
+++ b/crates/stdlib/typedefs/crypto/rsa.d.lis
@@ -78,7 +78,7 @@ pub fn DecryptPKCS1v15SessionKey(
   random: io.Reader,
   priv: Ref<PrivateKey>,
   ciphertext: Slice<byte>,
-  key: Slice<byte>,
+  mut key: Slice<byte>,
 ) -> Result<(), error>
 
 /// EncryptOAEP encrypts the given message with RSA-OAEP.

--- a/crates/stdlib/typedefs/go/ast.d.lis
+++ b/crates/stdlib/typedefs/go/ast.d.lis
@@ -202,7 +202,7 @@ pub fn Preorder(root: Node) -> iter.Seq<Node>
 /// stack, and it is surprisingly tricky to do this correctly.)
 pub fn PreorderStack(
   root: Node,
-  stack: Slice<Node>,
+  mut stack: Slice<Node>,
   f: fn(Node, Slice<Node>) -> bool,
 )
 

--- a/crates/stdlib/typedefs/go/types.d.lis
+++ b/crates/stdlib/typedefs/go/types.d.lis
@@ -422,7 +422,7 @@ pub fn NewFunc(
 /// by setting missing receivers.
 /// 
 /// Deprecated: Use NewInterfaceType instead which allows arbitrary embedded types.
-pub fn NewInterface(methods: Slice<Ref<Func>>, embeddeds: Slice<Ref<Named>>) -> Ref<Interface>
+pub fn NewInterface(mut methods: Slice<Ref<Func>>, embeddeds: Slice<Ref<Named>>) -> Ref<Interface>
 
 /// NewInterfaceType returns a new interface for the given methods and embedded
 /// types. NewInterfaceType takes ownership of the provided methods and may
@@ -430,7 +430,7 @@ pub fn NewInterface(methods: Slice<Ref<Func>>, embeddeds: Slice<Ref<Named>>) -> 
 /// 
 /// To avoid race conditions, the interface's type set should be computed before
 /// concurrent use of the interface, by explicitly calling Complete.
-pub fn NewInterfaceType(methods: Slice<Ref<Func>>, embeddeds: Slice<Type>) -> Ref<Interface>
+pub fn NewInterfaceType(mut methods: Slice<Ref<Func>>, embeddeds: Slice<Type>) -> Ref<Interface>
 
 /// NewLabel returns a new label.
 pub fn NewLabel(pos: token.Pos, pkg: Ref<Package>, name: string) -> Ref<Label>

--- a/crates/stdlib/typedefs/slices.d.lis
+++ b/crates/stdlib/typedefs/slices.d.lis
@@ -15,7 +15,7 @@ pub fn All<E>(s: Slice<E>) -> iter.Seq2<int, E>
 /// returns the extended slice.
 /// If seq is empty, the result preserves the nilness of s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn AppendSeq<E>(s: Slice<E>, seq: iter.Seq<E>) -> Slice<E>
+pub fn AppendSeq<E>(mut s: Slice<E>, seq: iter.Seq<E>) -> Slice<E>
 
 /// Backward returns an iterator over index-value pairs in the slice,
 /// traversing it backward with descending indices.
@@ -70,14 +70,14 @@ pub fn Collect<E>(seq: iter.Seq<E>) -> Slice<E>
 /// Compact zeroes the elements between the new length and the original length.
 /// The result preserves the nilness of s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Compact<E: Comparable>(s: Slice<E>) -> Slice<E>
+pub fn Compact<E: Comparable>(mut s: Slice<E>) -> Slice<E>
 
 /// CompactFunc is like [Compact] but uses an equality function to compare elements.
 /// For runs of elements that compare equal, CompactFunc keeps the first one.
 /// CompactFunc zeroes the elements between the new length and the original length.
 /// The result preserves the nilness of s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn CompactFunc<E>(s: Slice<E>, eq: fn(E, E) -> bool) -> Slice<E>
+pub fn CompactFunc<E>(mut s: Slice<E>, eq: fn(E, E) -> bool) -> Slice<E>
 
 /// Compare compares the elements of s1 and s2, using [cmp.Compare] on each pair
 /// of elements. The elements are compared sequentially, starting at index 0,
@@ -118,14 +118,14 @@ pub fn ContainsFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> bool
 /// Delete zeroes the elements s[len(s)-(j-i):len(s)].
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Delete<E>(s: Slice<E>, i: int, j: int) -> Slice<E>
+pub fn Delete<E>(mut s: Slice<E>, i: int, j: int) -> Slice<E>
 
 /// DeleteFunc removes any elements from s for which del returns true,
 /// returning the modified slice.
 /// DeleteFunc zeroes the elements between the new length and the original length.
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn DeleteFunc<E>(s: Slice<E>, del: fn(E) -> bool) -> Slice<E>
+pub fn DeleteFunc<E>(mut s: Slice<E>, del: fn(E) -> bool) -> Slice<E>
 
 /// Equal reports whether two slices are equal: the same length and all
 /// elements equal. If the lengths are different, Equal returns false.
@@ -171,7 +171,7 @@ pub fn IndexFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> int
 /// This function is O(len(s) + len(v)).
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Insert<E>(s: Slice<E>, i: int, v: VarArgs<E>) -> Slice<E>
+pub fn Insert<E>(mut s: Slice<E>, i: int, v: VarArgs<E>) -> Slice<E>
 
 /// IsSorted reports whether x is sorted in ascending order.
 #[go(collapsed_type_params, "Slice<E>, E")]
@@ -220,16 +220,16 @@ pub fn Repeat<E>(x: Slice<E>, count: int) -> Slice<E>
 /// When len(v) < (j-i), Replace zeroes the elements between the new length and the original length.
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Replace<E>(s: Slice<E>, i: int, j: int, v: VarArgs<E>) -> Slice<E>
+pub fn Replace<E>(mut s: Slice<E>, i: int, j: int, v: VarArgs<E>) -> Slice<E>
 
 /// Reverse reverses the elements of the slice in place.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Reverse<E>(s: Slice<E>)
+pub fn Reverse<E>(mut s: Slice<E>)
 
 /// Sort sorts a slice of any ordered type in ascending order.
 /// When sorting floating-point numbers, NaNs are ordered before other values.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Sort<E: cmp.Ordered>(x: Slice<E>)
+pub fn Sort<E: cmp.Ordered>(mut x: Slice<E>)
 
 /// SortFunc sorts the slice x in ascending order as determined by the cmp
 /// function. This sort is not guaranteed to be stable.
@@ -241,12 +241,12 @@ pub fn Sort<E: cmp.Ordered>(x: Slice<E>)
 /// See https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings.
 /// The function should return 0 for incomparable items.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn SortFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int)
+pub fn SortFunc<E>(mut x: Slice<E>, cmp: fn(E, E) -> int)
 
 /// SortStableFunc sorts the slice x while keeping the original order of equal
 /// elements, using cmp to compare elements in the same way as [SortFunc].
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn SortStableFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int)
+pub fn SortStableFunc<E>(mut x: Slice<E>, cmp: fn(E, E) -> int)
 
 /// Sorted collects values from seq into a new slice, sorts the slice,
 /// and returns it.

--- a/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
@@ -668,7 +668,7 @@ pub fn Open(path: string, mode: int, perm: uint32) -> Result<int, error>
 /// appending the names to names. It returns the number of
 /// bytes consumed from buf, the number of entries added
 /// to names, and the new names slice.
-pub fn ParseDirent(buf: Slice<byte>, max: int, names: Slice<string>) -> (int, int, Slice<string>)
+pub fn ParseDirent(buf: Slice<byte>, max: int, mut names: Slice<string>) -> (int, int, Slice<string>)
 
 /// ParseRoutingMessage parses b as routing messages and returns the
 /// slice containing the [RoutingMessage] interfaces.

--- a/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
@@ -671,7 +671,7 @@ pub fn Open(path: string, mode: int, perm: uint32) -> Result<int, error>
 /// appending the names to names. It returns the number of
 /// bytes consumed from buf, the number of entries added
 /// to names, and the new names slice.
-pub fn ParseDirent(buf: Slice<byte>, max: int, names: Slice<string>) -> (int, int, Slice<string>)
+pub fn ParseDirent(buf: Slice<byte>, max: int, mut names: Slice<string>) -> (int, int, Slice<string>)
 
 /// ParseRoutingMessage parses b as routing messages and returns the
 /// slice containing the [RoutingMessage] interfaces.

--- a/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
@@ -821,7 +821,7 @@ pub fn Openat(dirfd: int, path: string, flags: int, mode: uint32) -> Result<int,
 /// appending the names to names. It returns the number of
 /// bytes consumed from buf, the number of entries added
 /// to names, and the new names slice.
-pub fn ParseDirent(buf: Slice<byte>, max: int, names: Slice<string>) -> (int, int, Slice<string>)
+pub fn ParseDirent(buf: Slice<byte>, max: int, mut names: Slice<string>) -> (int, int, Slice<string>)
 
 /// ParseNetlinkMessage parses b as an array of netlink messages and
 /// returns the slice containing the NetlinkMessage structures.
@@ -849,7 +849,7 @@ pub fn Pause() -> Result<(), error>
 
 pub fn Pipe(mut p: Slice<int>) -> Result<(), error>
 
-pub fn Pipe2(p: Slice<int>, flags: int) -> Result<(), error>
+pub fn Pipe2(mut p: Slice<int>, flags: int) -> Result<(), error>
 
 pub fn PivotRoot(newroot: string, putold: string) -> Result<(), error>
 
@@ -865,9 +865,9 @@ pub fn PtraceGetEventMsg(pid: int) -> Result<uint, error>
 
 pub fn PtraceGetRegs(pid: int, regsout: Ref<PtraceRegs>) -> Result<(), error>
 
-pub fn PtracePeekData(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekData(pid: int, addr: uintptr, mut out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePeekText(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekText(pid: int, addr: uintptr, mut out: Slice<byte>) -> Result<int, error>
 
 pub fn PtracePokeData(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 

--- a/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
@@ -820,7 +820,7 @@ pub fn Openat(dirfd: int, path: string, flags: int, mode: uint32) -> Result<int,
 /// appending the names to names. It returns the number of
 /// bytes consumed from buf, the number of entries added
 /// to names, and the new names slice.
-pub fn ParseDirent(buf: Slice<byte>, max: int, names: Slice<string>) -> (int, int, Slice<string>)
+pub fn ParseDirent(buf: Slice<byte>, max: int, mut names: Slice<string>) -> (int, int, Slice<string>)
 
 /// ParseNetlinkMessage parses b as an array of netlink messages and
 /// returns the slice containing the NetlinkMessage structures.
@@ -848,7 +848,7 @@ pub fn Pause() -> Result<(), error>
 
 pub fn Pipe(mut p: Slice<int>) -> Result<(), error>
 
-pub fn Pipe2(p: Slice<int>, flags: int) -> Result<(), error>
+pub fn Pipe2(mut p: Slice<int>, flags: int) -> Result<(), error>
 
 pub fn PivotRoot(newroot: string, putold: string) -> Result<(), error>
 
@@ -864,9 +864,9 @@ pub fn PtraceGetEventMsg(pid: int) -> Result<uint, error>
 
 pub fn PtraceGetRegs(pid: int, regsout: Ref<PtraceRegs>) -> Result<(), error>
 
-pub fn PtracePeekData(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekData(pid: int, addr: uintptr, mut out: Slice<byte>) -> Result<int, error>
 
-pub fn PtracePeekText(pid: int, addr: uintptr, out: Slice<byte>) -> Result<int, error>
+pub fn PtracePeekText(pid: int, addr: uintptr, mut out: Slice<byte>) -> Result<int, error>
 
 pub fn PtracePokeData(pid: int, addr: uintptr, data: Slice<byte>) -> Result<int, error>
 

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -3316,6 +3316,75 @@ fn main() {
 }
 
 #[test]
+fn go_derived_mut_param_rejected_with_immutable_arg() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:slices"
+
+fn main() {
+  let nums = [3, 1, 2];
+  slices.Sort(nums)
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| e.code_str() == Some("infer.immutable_arg_to_mut_param")),
+        "Expected immutable_arg_to_mut_param error, got: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn go_derived_mut_param_accepted_with_let_mut() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:slices"
+
+fn main() {
+  let mut nums = [3, 1, 2];
+  slices.Sort(nums)
+  let mut items = [1, 1, 2];
+  slices.Reverse(items)
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+/// `Clone` and `Clip` read their argument, so they stay callable on an
+/// immutable binding.
+#[test]
+fn go_non_mutating_slices_helpers_accept_immutable_arg() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "go:slices"
+
+fn main() {
+  let nums = [3, 1, 2];
+  let copied = slices.Clone(nums)
+  let clipped = slices.Clip(nums)
+  fmt.Println(copied, clipped)
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn go_mut_param_selective_only_dst() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/build/snapshots/go_derived_mut_param_accepted_with_let_mut.snap
+++ b/tests/spec/build/snapshots/go_derived_mut_param_accepted_with_let_mut.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import "slices"
+
+func main() {
+	nums := []int{3, 1, 2}
+	slices.Sort(nums)
+	items := []int{1, 1, 2}
+	slices.Reverse(items)
+}

--- a/tests/spec/build/snapshots/go_non_mutating_slices_helpers_accept_immutable_arg.snap
+++ b/tests/spec/build/snapshots/go_non_mutating_slices_helpers_accept_immutable_arg.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+func main() {
+	nums := []int{3, 1, 2}
+	copied := slices.Clone(nums)
+	clipped := slices.Clip(nums)
+	fmt.Println(copied, clipped)
+}


### PR DESCRIPTION
Derives bindgen's `mut` param annotations from [SSA analysis](https://pkg.go.dev/golang.org/x/tools/go/ssa).

Lisette requires a Go function that writes through a slice or map arg to declare that param `mut`, so the caller has to pass a `let mut` binding. Until now bindgen decided this from a hand-maintained list, falling back to name-based heuristics.

Bindgen now compiles each Go function to its SSA form (reusing work from #1133) and walks backwards from each write to find which param's storage it lands in, following calls across pkg boundaries, closures, and generic instantiations, to determine param mutability.

```diff
-pub fn Sort<E: cmp.Ordered>(x: Slice<E>)
+pub fn Sort<E: cmp.Ordered>(mut x: Slice<E>)
```

19 stdlib signatures gain `mut`, 11 of them in `slices`, and none lose it. Callers passing an immutable binding to any of them now need `let mut`. The override list is retained for what no body reveals, such as assembly implementations and writes behind an interface call. The benefit extends to third-party typedefs as well.
