### PR TITLE
perf: remove eager Go version check

### DIFF
--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -24,26 +24,22 @@ pub fn go_command(target: Target) -> Command {
     c
 }
 
-pub fn require_go() -> Result<(), i32> {
+pub fn toolchain_failure() -> Option<GoCliError> {
     match go_status() {
-        GoStatus::Ready => Ok(()),
-        GoStatus::Absent => {
-            crate::cli_error!(
-                "Go is not installed",
-                "`go` is not in PATH",
-                "Install Go from https://go.dev/dl/"
-            );
-            Err(1)
-        }
-        GoStatus::Outdated { found, required } => {
-            crate::cli_error!(
-                "Go version is outdated",
-                format!("Found Go {}, but {} or later is required", found, required),
-                "Upgrade Go at https://go.dev/dl/"
-            );
-            Err(1)
-        }
+        GoStatus::Ready => None,
+        GoStatus::Absent => Some(GoCliError {
+            message: "Go is not installed: `go` is not in PATH".to_string(),
+            hint: "Install Go from https://go.dev/dl/",
+        }),
+        GoStatus::Outdated { found, required } => Some(GoCliError {
+            message: format!("Found Go {}, but {} or later is required", found, required),
+            hint: "Upgrade Go at https://go.dev/dl/",
+        }),
     }
+}
+
+pub fn toolchain_failure_message() -> Option<String> {
+    toolchain_failure().map(|failure| format!("{}. {}", failure.message, failure.hint))
 }
 
 pub fn is_go_present() -> bool {
@@ -417,17 +413,17 @@ pub fn finalize_go_dir(
     import_set_hash: u64,
 ) -> Result<(), GoCliError> {
     if let Err(e) = go_fmt_paths(changed_paths) {
-        return Err(GoCliError {
+        return Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: format!("Go format failed: {}", e),
             hint: "Check Go installation with `go version`",
-        });
+        }));
     }
 
     if let Err(e) = ensure_go_sum(dir, target, import_set_hash) {
-        return Err(GoCliError {
+        return Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: format!("Failed to resolve Go dependencies: {}", e),
             hint: "Check Go installation and network connectivity",
-        });
+        }));
     }
 
     Ok(())
@@ -591,14 +587,14 @@ pub fn build_binary(
 
     match cmd.status() {
         Ok(status) if status.success() => Ok(()),
-        Ok(_) => Err(GoCliError {
+        Ok(_) => Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: "`go build` failed".to_string(),
             hint: "Review the Go compiler output above",
-        }),
-        Err(e) => Err(GoCliError {
+        })),
+        Err(e) => Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: format!("Failed to execute `go build`: {}", e),
             hint: "Check Go installation with `go version`",
-        }),
+        })),
     }
 }
 
@@ -616,14 +612,14 @@ pub fn verify_go_packages(
 
     match cmd.status() {
         Ok(status) if status.success() => Ok(()),
-        Ok(_) => Err(GoCliError {
+        Ok(_) => Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: "`go build ./...` failed".to_string(),
             hint: "Review the Go compiler output above",
-        }),
-        Err(e) => Err(GoCliError {
+        })),
+        Err(e) => Err(toolchain_failure().unwrap_or_else(|| GoCliError {
             message: format!("Failed to execute `go build`: {}", e),
             hint: "Check Go installation with `go version`",
-        }),
+        })),
     }
 }
 
@@ -689,9 +685,11 @@ fn run_go_test(
         .current_dir(build_dir)
         .stdout(Stdio::piped());
 
-    let spawn_error = || GoCliError {
-        message: "Failed to execute `go test`".to_string(),
-        hint: "Check Go installation with `go version`",
+    let spawn_error = || {
+        toolchain_failure().unwrap_or_else(|| GoCliError {
+            message: "Failed to execute `go test`".to_string(),
+            hint: "Check Go installation with `go version`",
+        })
     };
 
     let mut child = cmd.spawn().map_err(|_| spawn_error())?;

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -31,10 +31,6 @@ enum DependencySource {
 }
 
 pub fn add(dep_string: Option<&str>, replace: Option<&str>, path: Option<&str>) -> i32 {
-    if let Err(code) = go_cli::require_go() {
-        return code;
-    }
-
     if let Some(path) = path {
         return add_local(path);
     }

--- a/crates/cli/src/handlers/bindgen.rs
+++ b/crates/cli/src/handlers/bindgen.rs
@@ -7,10 +7,6 @@ use crate::cli_error;
 use crate::command::BindgenTarget;
 
 pub fn bindgen(target: BindgenTarget, verbose: bool) -> i32 {
-    if let Err(code) = crate::go_cli::require_go() {
-        return code;
-    }
-
     match target {
         BindgenTarget::Stdlib { version } => {
             let source_dir = Path::new("bindgen");
@@ -60,11 +56,11 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
             0
         }
         Err(msg) => {
-            cli_error!(
-                "Failed to generate bindings",
-                msg,
-                "Check Go installation with `go version`"
-            );
+            let (detail, hint) = match crate::go_cli::toolchain_failure() {
+                Some(failure) => (failure.message, failure.hint),
+                None => (msg, "Check Go installation with `go version`"),
+            };
+            cli_error!("Failed to generate bindings", detail, hint);
             1
         }
     }
@@ -129,11 +125,14 @@ fn bindgen_std(source_dir: &Path, version: Option<String>, verbose: bool) -> i32
             1
         }
         Err(e) => {
-            cli_error!(
-                "Failed to generate std bindings",
-                format!("Failed to run bindgen: {}", e),
-                "Check Go installation with `go version`"
-            );
+            let (detail, hint) = match crate::go_cli::toolchain_failure() {
+                Some(failure) => (failure.message, failure.hint),
+                None => (
+                    format!("Failed to run bindgen: {}", e),
+                    "Check Go installation with `go version`",
+                ),
+            };
+            cli_error!("Failed to generate std bindings", detail, hint);
             1
         }
     }

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -151,8 +151,6 @@ pub(super) fn link_project_binary(
 }
 
 fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
-    crate::go_cli::require_go()?;
-
     let layout = match validate_project(project_path) {
         Some(layout) => layout,
         None => return Err(1),

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -211,8 +211,6 @@ pub(crate) fn reconcile_declared_replacements(
         return Ok(());
     }
 
-    go_cli::require_go()?;
-
     // Seed every declared dep so MVS picks the versions the real build sees.
     go_cli::invalidate_go_mod_stamp(target_dir);
     let locator = deps::TypedefLocator::new(

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -32,10 +32,6 @@ pub fn run(
     sourcemap: bool,
     go_flags: Vec<String>,
 ) -> i32 {
-    if let Err(code) = crate::go_cli::require_go() {
-        return code;
-    }
-
     let target = target.unwrap_or_else(|| ".".to_string());
 
     if target.ends_with(".lis") {

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -81,11 +81,15 @@ impl<'a> GoWorkspace<'a> {
             .args(args)
             .current_dir(self.root)
             .output()
-            .map_err(|e| format!("Failed to run `{}`: {}", cmd_display, e))?;
+            .map_err(|e| {
+                crate::go_cli::toolchain_failure_message()
+                    .unwrap_or_else(|| format!("Failed to run `{}`: {}", cmd_display, e))
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(translate_go_error(args, stderr.trim()));
+            return Err(crate::go_cli::toolchain_failure_message()
+                .unwrap_or_else(|| translate_go_error(args, stderr.trim())));
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())


### PR DESCRIPTION
CLI commands no longer probe `go version` before doing any work. Enforcement of the minimum Go version already comes from the `go` directive Lis writes into the generated `go.mod`, so we now report a missing or outdated Go only once a Go command has actually failed.

With an installed Go older than Lisette requires and the default `GOTOOLCHAIN=auto`, Go fetches the matching toolchain and the build succeeds, where before Lisette refused outright. With `GOTOOLCHAIN=local`, or with no Go on `PATH`, the same "Go is not installed" and "Found Go 1.19.0, but 1.25 or later is required" errors still appear, now attached to the step that failed rather than to a preflight check.
