### PR TITLE
perf: reduce binary size 20% by skipping stack unwinding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ inherits = "release"
 lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
+panic = "abort"


### PR DESCRIPTION
Distributed binaries no longer carry stack unwinding machinery, cutting the release artifact from 13.8 to 10.9 MB, a 20.8% reduction, measured on `aarch64-apple-darwin`.

Nothing meaningful is lost. `lis` already terminated through `std::process::exit`, so destructors never ran at teardown, and no code path recovers from a panic. ICE report is unchanged, symbol-resolved backtrace included.

Two side effects: an ICE exits 134 (SIGABRT) rather than 101, and a panic in the LSP server's background diagnostics task now stops the server instead of being silently swallowed and leaving that file's diagnostics stale.
