### PR TITLE
fix: derive equality for generics bound by custom interfaces

### DIFF
--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -7,10 +7,10 @@ use crate::control_flow::fallible;
 use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
 use crate::definitions::structs::is_raw_function_type;
 use crate::names::go_name;
-use syntax::ast::{Pattern, RestPattern, StructFields};
+use syntax::ast::{Generic, Pattern, RestPattern, StructFields};
 use syntax::containment::enum_payload_pointer_wrapped;
 use syntax::program::{Definition, DefinitionBody};
-use syntax::types::{Type, substitute};
+use syntax::types::{Type, build_substitution_map, substitute};
 
 impl Planner<'_> {
     pub(crate) fn go_name_for_binding(&self, pattern: &Pattern) -> Option<String> {
@@ -106,12 +106,69 @@ impl Planner<'_> {
         self.field_is_public(ty, field) || self.type_uses_exported_members(ty)
     }
 
-    pub(crate) fn type_has_equals(&self, ty: &Type) -> bool {
+    pub(crate) fn type_has_equals(&self, ty: &Type, generics: &[Generic]) -> bool {
         let peeled = self.facts.peel_alias(ty);
+        if let Type::Parameter(name) = &peeled {
+            return self.generic_param_has_equals_bound(generics, name.as_str());
+        }
         let Some(id) = peeled.get_qualified_id() else {
             return false;
         };
         self.facts.usable_equals_from(id)
+    }
+
+    fn generic_param_has_equals_bound(&self, generics: &[Generic], param_name: &str) -> bool {
+        let Some(generic) = generics.iter().find(|g| g.name.as_str() == param_name) else {
+            return false;
+        };
+        let Some(bounds) = generic.resolved_bounds() else {
+            return false;
+        };
+        bounds.into_iter().any(|bound| {
+            self.interface_bound_provides_equals(&self.facts.peel_alias(bound), param_name)
+        })
+    }
+
+    fn interface_bound_provides_equals(&self, bound: &Type, param_name: &str) -> bool {
+        let mut stack = vec![(bound.clone(), Vec::<String>::new())];
+        let mut seen: Vec<Type> = Vec::new();
+        while let Some((current, mut path)) = stack.pop() {
+            if seen.contains(&current) {
+                continue;
+            }
+            seen.push(current.clone());
+            let Type::Nominal { id, .. } = &current else {
+                continue;
+            };
+            if path.iter().any(|seen_id| seen_id == id.as_str()) {
+                continue;
+            }
+            let Some(Definition {
+                body: DefinitionBody::Interface { definition },
+                ..
+            }) = self.facts.definition(id.as_str())
+            else {
+                continue;
+            };
+            path.push(id.to_string());
+            let map = build_substitution_map(
+                &definition.generics,
+                current.get_type_params().unwrap_or_default(),
+            );
+            let provides_equals = definition.methods.get("equals").is_some_and(|equals_ty| {
+                substitute(equals_ty, &map).is_equals_bound_signature(param_name)
+            });
+            if provides_equals {
+                return true;
+            }
+            for parent in &definition.parents {
+                stack.push((
+                    self.facts.peel_alias(&substitute(parent, &map)),
+                    path.clone(),
+                ));
+            }
+        }
+        false
     }
 
     pub(crate) fn has_field(&self, struct_ty: &Type, field_name: &str) -> bool {

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -10,7 +10,7 @@ use crate::plan::values::{CaptureBoundary, EvaluationEffect, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
 use crate::utils::reads_mutable_operand;
-use syntax::ast::{Expression, Literal, UnaryOperator};
+use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
 use syntax::program::{CallKind, DotAccessKind, NativeTypeKind};
 use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
@@ -446,7 +446,7 @@ impl Planner<'_> {
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let (setup, receiver, emitted_args, effect, contains_deferred_evaluation) =
                     self.stage_native_dot_access_call(ctx);
-                let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty);
+                let body = self.render_equality(&receiver, &emitted_args[0], &receiver_ty, &[]);
                 return NativeCallResult::new(setup, body, effect, contains_deferred_evaluation);
             }
         }
@@ -743,7 +743,7 @@ impl Planner<'_> {
                     self.stage_native_identifier_args(ctx);
                 if emitted_args.len() >= 2 {
                     let body =
-                        self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty);
+                        self.render_equality(&emitted_args[0], &emitted_args[1], &receiver_ty, &[]);
                     return NativeCallResult::new(
                         setup,
                         body,
@@ -960,7 +960,13 @@ impl Planner<'_> {
         )
     }
 
-    pub(crate) fn render_equality(&mut self, lhs: &str, rhs: &str, ty: &Type) -> String {
+    pub(crate) fn render_equality(
+        &mut self,
+        lhs: &str,
+        rhs: &str,
+        ty: &Type,
+        generics: &[Generic],
+    ) -> String {
         let peeled = self.facts.peel_alias(ty);
         if peeled.is_ref() {
             return format!("{lhs} == {rhs}");
@@ -968,8 +974,8 @@ impl Planner<'_> {
         if peeled.is_slice() {
             self.require_slices();
             return match peeled.inner() {
-                Some(elem) if self.needs_custom_equality(&elem) => {
-                    let eq = self.equality_closure(&elem);
+                Some(elem) if self.needs_custom_equality(&elem, generics) => {
+                    let eq = self.equality_closure(&elem, generics);
                     format!("slices.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("slices.Equal({lhs}, {rhs})"),
@@ -981,29 +987,29 @@ impl Planner<'_> {
                 .as_compound()
                 .and_then(|(_, args)| args.get(1).cloned());
             return match value {
-                Some(value) if self.needs_custom_equality(&value) => {
-                    let eq = self.equality_closure(&value);
+                Some(value) if self.needs_custom_equality(&value, generics) => {
+                    let eq = self.equality_closure(&value, generics);
                     format!("maps.EqualFunc({lhs}, {rhs}, {eq})")
                 }
                 _ => format!("maps.Equal({lhs}, {rhs})"),
             };
         }
-        if self.type_has_equals(&peeled) {
+        if self.type_has_equals(&peeled, generics) {
             return format!("{lhs}.{}({rhs})", self.equals_method_go_name());
         }
         format!("{lhs} == {rhs}")
     }
 
-    fn equality_closure(&mut self, ty: &Type) -> String {
+    fn equality_closure(&mut self, ty: &Type, generics: &[Generic]) -> String {
         let go_ty = self.go_type_string(ty);
         let a = self.fresh_var(Some("a"));
         let b = self.fresh_var(Some("b"));
-        let body = self.render_equality(&a, &b, ty);
+        let body = self.render_equality(&a, &b, ty, generics);
         format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
     }
 
-    fn needs_custom_equality(&self, ty: &Type) -> bool {
-        self.is_container(ty) || self.type_has_equals(ty)
+    fn needs_custom_equality(&self, ty: &Type, generics: &[Generic]) -> bool {
+        self.is_container(ty) || self.type_has_equals(ty, generics)
     }
 
     fn is_container(&self, ty: &Type) -> bool {

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -122,6 +122,7 @@ impl Planner<'_> {
         let Some(Definition {
             body:
                 DefinitionBody::Enum {
+                    generics: sem_generics,
                     variants: sem_variants,
                     ..
                 },
@@ -130,6 +131,7 @@ impl Planner<'_> {
         else {
             return;
         };
+        let sem_generics = sem_generics.clone();
         let sem_variants = sem_variants.clone();
         let layout = self.enum_layout(enum_id).expect("enum layout should exist");
 
@@ -155,7 +157,7 @@ impl Planner<'_> {
                         lhs = format!("(*{lhs})");
                         rhs = format!("(*{rhs})");
                     }
-                    self.render_equality(&lhs, &rhs, &sem_field.ty)
+                    self.render_equality(&lhs, &rhs, &sem_field.ty, &sem_generics)
                 })
                 .collect();
             cases.push(format!(

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -68,7 +68,7 @@ impl Planner<'_> {
         };
         self.append_struct_debug_method(&mut result, name, &receiver_generics, &stringer_fields);
         self.append_to_string_method(&mut result, name, &receiver_generics, struct_attrs);
-        self.append_equals_method(&mut result, name, &receiver_generics, fields, struct_attrs);
+        self.append_equals_method(&mut result, name, generics, fields, struct_attrs);
         self.append_embedded_stringer_shadow(
             &mut result,
             name,
@@ -439,22 +439,23 @@ impl Planner<'_> {
         &mut self,
         out: &mut String,
         name: &str,
-        receiver_generics: &str,
+        generics: &[Generic],
         fields: &[StructFieldDefinition],
         attributes: &[Attribute],
     ) {
         if !self.should_synthesize_equals(name) {
             return;
         }
-        let receiver = synthesized_receiver_name(name, receiver_generics);
-        let other = synthesized_local_name("other", &receiver, receiver_generics);
+        let receiver_generics = self.receiver_generics_string(generics);
+        let receiver = synthesized_receiver_name(name, &receiver_generics);
+        let other = synthesized_local_name("other", &receiver, &receiver_generics);
         let comparisons: Vec<String> = fields
             .iter()
             .map(|f| {
                 let go_field = struct_field_go_name(f, attributes);
                 let lhs = format!("{receiver}.{go_field}");
                 let rhs = format!("{other}.{go_field}");
-                self.render_equality(&lhs, &rhs, &f.ty)
+                self.render_equality(&lhs, &rhs, &f.ty, generics)
             })
             .collect();
         let body = if comparisons.is_empty() {

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -554,7 +554,7 @@ impl Planner<'_> {
         let recv_ty = recv.get_type();
         let lhs = self.stage_assert_operand(recv, "assertLeft", statements);
         let rhs = self.stage_assert_operand(arg, "assertRight", statements);
-        let condition = self.render_equality(&lhs, &rhs, &recv_ty);
+        let condition = self.render_equality(&lhs, &rhs, &recv_ty, &[]);
         AssertShape {
             condition,
             kind: "labeled",
@@ -631,7 +631,7 @@ impl Planner<'_> {
             return None;
         }
         let recv_ty = self.facts.peel_alias(&recv.get_type());
-        (recv_ty.is_slice() || recv_ty.is_map() || self.type_has_equals(&recv_ty))
+        (recv_ty.is_slice() || recv_ty.is_map() || self.type_has_equals(&recv_ty, &[]))
             .then(|| (recv.unwrap_parens(), &args[0]))
     }
 

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -363,12 +363,13 @@ pub(crate) fn check_not_equatable(
     store: &Store,
     ty: &Type,
     current_module: &str,
+    equatable_param: &dyn Fn(&str) -> bool,
     comparable_param: &dyn Fn(&str) -> bool,
 ) -> Option<&'static str> {
     let resolved = store.deep_resolve_alias(&ty.resolve_in(env));
 
     if let Type::Parameter(name) = &resolved
-        && comparable_param(name)
+        && equatable_param(name)
     {
         return None;
     }
@@ -385,14 +386,26 @@ pub(crate) fn check_not_equatable(
     };
 
     match resolved.as_compound() {
-        Some((CompoundKind::Slice, args)) => {
-            check_not_equatable(env, store, args.first()?, current_module, comparable_param)
-        }
+        Some((CompoundKind::Slice, args)) => check_not_equatable(
+            env,
+            store,
+            args.first()?,
+            current_module,
+            equatable_param,
+            comparable_param,
+        ),
         Some((CompoundKind::Map, args)) => {
             if map_key_not_comparable(env, store, args.first()?, comparable_param) {
                 return Some("a map with a non-comparable key");
             }
-            check_not_equatable(env, store, args.get(1)?, current_module, comparable_param)
+            check_not_equatable(
+                env,
+                store,
+                args.get(1)?,
+                current_module,
+                equatable_param,
+                comparable_param,
+            )
         }
         _ => Some(reason),
     }
@@ -491,6 +504,45 @@ pub(crate) fn param_is_comparable(scopes: &Scopes, env: &TypeEnv, param_name: &s
     found
 }
 
+fn interface_bound_guarantees_equals(store: &Store, bound: &Type, param_name: &str) -> bool {
+    interface_closure_any(store, bound, |current| {
+        let Some(id) = current.get_qualified_id() else {
+            return false;
+        };
+        let Some(interface) = store.get_interface(id) else {
+            return false;
+        };
+        let map = build_substitution_map(
+            &interface.generics,
+            current.get_type_params().unwrap_or_default(),
+        );
+        interface.methods.get("equals").is_some_and(|equals_ty| {
+            substitute(equals_ty, &map).is_equals_bound_signature(param_name)
+        })
+    })
+}
+
+pub(crate) fn param_is_equatable(
+    scopes: &Scopes,
+    env: &TypeEnv,
+    store: &Store,
+    param_name: &str,
+) -> bool {
+    if param_is_comparable(scopes, env, param_name) {
+        return true;
+    }
+    let mut found = false;
+    scopes.for_each_bound_on_param(param_name, |bound_ty| {
+        if found {
+            return;
+        }
+        if interface_bound_guarantees_equals(store, &bound_ty.resolve_in(env), param_name) {
+            found = true;
+        }
+    });
+    found
+}
+
 impl InferCtx<'_> {
     fn is_comparable_with_param_bounds(&self, ty: &Type) -> bool {
         let resolved = ty.resolve_in(&self.env);
@@ -555,14 +607,16 @@ impl InferCtx<'_> {
     }
 
     fn not_equatable_reason(&self, ty: &Type) -> Option<&'static str> {
+        let is_comparable = |name: &str| {
+            self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+        };
         check_not_equatable(
             &self.env,
             self.store,
             ty,
             self.cursor.module_id.as_str(),
-            &|name| {
-                self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
-            },
+            &is_comparable,
+            &is_comparable,
         )
     }
 
@@ -617,17 +671,16 @@ impl InferCtx<'_> {
             if field_resolved.get_qualified_id() == Some(name) {
                 return true;
             }
+            let is_comparable = |name: &str| {
+                self.parameter_satisfies_bound(name, super::super::unify::BuiltinBound::Comparable)
+            };
             check_not_equatable(
                 &self.env,
                 self.store,
                 &substituted,
                 self.cursor.module_id.as_str(),
-                &|name| {
-                    self.parameter_satisfies_bound(
-                        name,
-                        super::super::unify::BuiltinBound::Comparable,
-                    )
-                },
+                &is_comparable,
+                &is_comparable,
             )
             .is_none()
         })

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -6,7 +6,9 @@ use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{FunctionParameter, Symbol, Type};
 
 use super::{TaskState, resolved_generic_bounds, wrap_with_impl_generics};
-use crate::checker::infer::expressions::comparison::{check_not_equatable, param_is_comparable};
+use crate::checker::infer::expressions::comparison::{
+    check_not_equatable, param_is_comparable, param_is_equatable,
+};
 use crate::checker::registration::derived_attributes::{
     DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
@@ -200,9 +202,14 @@ impl TaskState {
             this.record_resolved_generic_bounds(&generics);
 
             for (field_name, field_span, field_ty) in &fields {
-                let reason = check_not_equatable(&this.env, store, field_ty, module_id, &|name| {
-                    param_is_comparable(&this.scopes, &this.env, name)
-                });
+                let reason = check_not_equatable(
+                    &this.env,
+                    store,
+                    field_ty,
+                    module_id,
+                    &|name| param_is_equatable(&this.scopes, &this.env, store, name),
+                    &|name| param_is_comparable(&this.scopes, &this.env, name),
+                );
                 if let Some(reason) = reason {
                     this.sink
                         .push(diagnostics::attribute::cannot_derive_equality(

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -868,6 +868,20 @@ impl Type {
         )
     }
 
+    pub fn is_equals_bound_signature(&self, param_name: &str) -> bool {
+        let func = match self {
+            Type::Forall { body, .. } => body.as_ref(),
+            other => other,
+        };
+        matches!(
+            func,
+            Type::Function(f)
+                if f.params.len() == 1
+                    && f.return_type.is_boolean()
+                    && matches!(&f.params[0].ty, Type::Parameter(name) if name.as_str() == param_name)
+        )
+    }
+
     pub fn equals_receiver_vars(&self, owner_id: &str, arity: usize) -> Option<Vec<EcoString>> {
         if !self.is_equals_signature() {
             return None;

--- a/docs/reference/15-attributes.md
+++ b/docs/reference/15-attributes.md
@@ -313,6 +313,38 @@ let b = Fraction { numerator: 2, denominator: 4 }
 a.equals(b) // true
 ```
 
+`#[equality]` works on generic structs and enums, as long as the type parameter is bound by `Comparable` or `Ordered`.
+
+```rs
+#[equality]
+struct Cart<T: Comparable> {
+  items: Slice<T>
+}
+
+let a = Cart { items: [1, 2, 3] }
+let b = Cart { items: [1, 2, 3] }
+
+a.equals(b) // true
+```
+
+The bound can also be a custom interface instead, as long as the interface declares an `equals` method.
+
+```rs
+interface Equatable<T> {
+  fn equals(other: T) -> bool
+}
+
+#[equality]
+struct Batch<T: Equatable<T>> {
+  item: T
+}
+
+let a = Batch { item: Order { id: 1, tags: ["a"] } }
+let b = Batch { item: Order { id: 1, tags: ["a"] } }
+
+a.equals(b) // true
+```
+
 <br>
 
 <table><tr>

--- a/tests/spec/emit/snapshots/equality_generic_enum_custom_equatable_bound.snap
+++ b/tests/spec/emit/snapshots/equality_generic_enum_custom_equatable_bound.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Equatable<T> {
+    fn equals(other: T) -> bool
+  }
+  
+  #[equality]
+  enum Pair<T: Equatable<T>> { Both(T, T) }
+---
+package main
+
+func MakePairBoth[T Equatable[T]](arg0 T, arg1 T) Pair[T] {
+	return Pair[T]{Tag: PairBoth, Both0: arg0, Both1: arg1}
+}
+
+type Equatable[T any] interface {
+	equals(T) bool
+}
+
+type PairTag int
+
+const (
+	PairBoth PairTag = iota
+)
+
+type Pair[T Equatable[T]] struct {
+	Tag   PairTag
+	Both0 T
+	Both1 T
+}
+
+func (p Pair[T]) equals(other Pair[T]) bool {
+	if p.Tag != other.Tag {
+		return false
+	}
+	switch p.Tag {
+	case PairBoth:
+		return p.Both0.equals(other.Both0) && p.Both1.equals(other.Both1)
+	default:
+		return true
+	}
+}

--- a/tests/spec/emit/snapshots/equality_generic_struct_custom_equatable_bound.snap
+++ b/tests/spec/emit/snapshots/equality_generic_struct_custom_equatable_bound.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Equatable<T> {
+    fn equals(other: T) -> bool
+  }
+  
+  #[equality]
+  struct Box<T: Equatable<T>> { value: T }
+---
+package main
+
+type Equatable[T any] interface {
+	equals(T) bool
+}
+
+type Box[T Equatable[T]] struct {
+	value T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return b.value.equals(other.value)
+}

--- a/tests/spec/emit/snapshots/equality_generic_struct_slice_of_custom_equatable_bound.snap
+++ b/tests/spec/emit/snapshots/equality_generic_struct_slice_of_custom_equatable_bound.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  interface Equatable<T> {
+    fn equals(other: T) -> bool
+  }
+  
+  #[equality]
+  struct Box<T: Equatable<T>> { values: Slice<T> }
+---
+package main
+
+import "slices"
+
+type Equatable[T any] interface {
+	equals(T) bool
+}
+
+type Box[T Equatable[T]] struct {
+	values []T
+}
+
+func (b Box[T]) equals(other Box[T]) bool {
+	return slices.EqualFunc(b.values, other.values, func(a_1 T, b_2 T) bool { return a_1.equals(b_2) })
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -748,6 +748,45 @@ struct Box<T: Comparable> { value: T }
 }
 
 #[test]
+fn equality_generic_struct_custom_equatable_bound() {
+    let input = r#"
+interface Equatable<T> {
+  fn equals(other: T) -> bool
+}
+
+#[equality]
+struct Box<T: Equatable<T>> { value: T }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_generic_enum_custom_equatable_bound() {
+    let input = r#"
+interface Equatable<T> {
+  fn equals(other: T) -> bool
+}
+
+#[equality]
+enum Pair<T: Equatable<T>> { Both(T, T) }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn equality_generic_struct_slice_of_custom_equatable_bound() {
+    let input = r#"
+interface Equatable<T> {
+  fn equals(other: T) -> bool
+}
+
+#[equality]
+struct Box<T: Equatable<T>> { values: Slice<T> }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn equality_user_equals_suppresses_synthesis() {
     let input = r#"
 #[equality]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -12056,6 +12056,25 @@ struct Pair {
 }
 
 #[test]
+fn equality_derivation_terminates_on_transforming_interface_cycle() {
+    let input = r#"
+interface A<T> {
+  embed B<Slice<T>>
+}
+
+interface B<T> {
+  embed A<Slice<T>>
+}
+
+#[equality]
+struct Wrap<T: A<T>> {
+  value: T
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn equality_enum_rejects_function_payload() {
     let input = r#"
 #[equality]
@@ -12657,6 +12676,19 @@ struct Key { tags: Slice<int> }
 
 #[equality]
 struct Index { values: Map<Key, int> }
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn equality_map_key_bound_by_custom_equatable_interface_rejected() {
+    let input = r#"
+interface Equatable<T> {
+  fn equals(other: T) -> bool
+}
+
+#[equality]
+struct Index<T: Equatable<T>> { values: Map<T, int> }
 "#;
     assert_infer_error_snapshot!(input);
 }

--- a/tests/ui/errors/snapshots/equality_derivation_terminates_on_transforming_interface_cycle.snap
+++ b/tests/ui/errors/snapshots/equality_derivation_terminates_on_transforming_interface_cycle.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Recursive interface embedding
+   ╭─[test.lis:6:11]
+ 5 │ 
+ 6 │ interface B<T> {
+   ·           ┬
+   ·           ╰── creates a cycle
+ 7 │   embed A<Slice<T>>
+   ╰────
+  help: Interface embedding cycle detected: B → A → B. Break the cycle by removing one of the embeddings · code: [infer.interface_cycle]

--- a/tests/ui/errors/snapshots/equality_map_key_bound_by_custom_equatable_interface_rejected.snap
+++ b/tests/ui/errors/snapshots/equality_map_key_bound_by_custom_equatable_interface_rejected.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing map key bound
+   ╭─[test.lis:7:41]
+ 6 │ #[equality]
+ 7 │ struct Index<T: Equatable<T>> { values: Map<T, int> }
+   ·                                         ─────┬─────
+   ·                                              ╰── `T` reaches this map key without `Comparable`
+   ╰────
+  help: Map keys must be comparable. Add the bound where `T` is declared: `<T: Comparable>` · code: [infer.missing_map_key_bound]


### PR DESCRIPTION
The `#[equality]` attribute now derives equality for a generic field whose type param is bound by a custom interface having its own `equals` method, i.e. not only the built-in `Comparable`/`Ordered` bounds.

```rs
interface Equatable<T> {
  fn equals(other: T) -> bool
}

#[equality]
struct Order {
  id: int,
  tags: Slice<string>,
}

#[equality]
struct Batch<T: Equatable<T>> {
  item: T
}

let a = Batch { item: Order { id: 1, tags: ["a"] } }
let b = Batch { item: Order { id: 1, tags: ["a"] } }

a.equals(b) // true
```

Close #1152
