### PR TITLE
perf: shed more dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,19 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "ecow"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,12 +158,6 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -188,7 +169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -213,12 +194,6 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itoa"
@@ -304,7 +279,6 @@ dependencies = [
 name = "lisette-lsp"
 version = "0.10.0"
 dependencies = [
- "dashmap",
  "lisette-deps",
  "lisette-diagnostics",
  "lisette-format",
@@ -362,15 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,10 +349,6 @@ checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
 ]
@@ -432,19 +393,6 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -497,15 +445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,12 +474,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -604,33 +537,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ too_many_arguments = "forbid"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-miette = { version = "7.6", default-features = false, features = ["fancy-no-backtrace"] }
+miette = { version = "7.6", default-features = false, features = ["fancy-no-syscall"] }
 owo-colors = "4.0"
 insta = "1.48.0"
 ecow = "0.2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,7 +29,7 @@ emit = { package = "lisette-emit", version = "=0.10.0", path = "../emit" }
 stdlib = { package = "lisette-stdlib", version = "=0.10.0", path = "../stdlib" }
 deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
 lsp = { package = "lisette-lsp", version = "=0.10.0", path = "../lsp" }
-tokio = { version = "1", features = ["rt-multi-thread", "io-std", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
 terminal_size = "0.4"
 owo-colors.workspace = true
 rustc-hash.workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -18,8 +18,7 @@ passes = { package = "lisette-passes", version = "=0.10.0", path = "../passes" }
 diagnostics = { package = "lisette-diagnostics", version = "=0.10.0", path = "../diagnostics" }
 deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
 format = { package = "lisette-format", version = "=0.10.0", path = "../format" }
-tokio = { version = "1", features = ["rt", "macros", "sync", "time", "io-util"] }
-dashmap = "5.5"
+tokio = { version = "1", features = ["rt", "sync", "time", "io-util"] }
 miette.workspace = true
 rustc-hash.workspace = true
 serde.workspace = true
@@ -28,6 +27,7 @@ serde_json.workspace = true
 [dev-dependencies]
 stdlib = { package = "lisette-stdlib", path = "../stdlib" }
 tempfile = "3"
+tokio = { version = "1", features = ["macros"] }
 
 [lints]
 workspace = true

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -15,7 +15,7 @@ use syntax::types::{CompoundKind, Type};
 
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
-use crate::state::{AnalysisRequest, SharedState};
+use crate::state::{AnalysisRequest, DocumentState, SharedState};
 
 enum AnalysisError {
     Diagnostics(Vec<Diagnostic>),
@@ -67,6 +67,8 @@ impl SharedState {
 
         let source = self
             .documents
+            .read()
+            .await
             .get(uri)
             .map(|document| document.content().to_string())
             .ok_or_else(Vec::new)?;
@@ -205,9 +207,10 @@ impl SharedState {
     }
 
     async fn run_analysis_cached(&self, uri: &Url) -> Result<Arc<AnalysisSnapshot>, AnalysisError> {
-        let document = self.documents.get(uri).ok_or(AnalysisError::Superseded)?;
+        let documents = self.documents.read().await;
+        let document = documents.get(uri).ok_or(AnalysisError::Superseded)?;
         let request = document.request_analysis();
-        drop(document);
+        drop(documents);
 
         let revision = match request {
             AnalysisRequest::Cached(snapshot) => return Ok(snapshot),
@@ -220,7 +223,7 @@ impl SharedState {
                 .map_err(AnalysisError::Diagnostics)?,
         );
 
-        if let Some(mut document) = self.documents.get_mut(uri)
+        if let Some(document) = self.documents.write().await.get_mut(uri)
             && document.cache_analysis(&revision, Arc::clone(&snapshot))
         {
             return Ok(snapshot);
@@ -255,16 +258,22 @@ impl SharedState {
     }
 
     pub(crate) async fn get_snapshot(&self, uri: &Url) -> Option<Arc<AnalysisSnapshot>> {
-        self.run_analysis_cached(uri).await.ok().or_else(|| {
-            self.documents
+        match self.run_analysis_cached(uri).await {
+            Ok(snapshot) => Some(snapshot),
+            Err(_) => self
+                .documents
+                .read()
+                .await
                 .get(uri)
-                .and_then(|document| document.last_valid_analysis())
-        })
+                .and_then(DocumentState::last_valid_analysis),
+        }
     }
 
-    pub(crate) fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
+    pub(crate) async fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
         self.documents
-            .iter()
+            .read()
+            .await
+            .values()
             .filter_map(|document| match document.request_analysis() {
                 AnalysisRequest::Cached(snapshot) => Some(snapshot),
                 AnalysisRequest::Required(_) => None,

--- a/crates/lsp/src/document.rs
+++ b/crates/lsp/src/document.rs
@@ -9,11 +9,11 @@ impl SharedState {
     pub(crate) async fn update_document(&self, uri: Url, content: String, version: i32) {
         self.project.update_overlay(&uri, content.clone()).await;
 
-        if let Some(mut document) = self.documents.get_mut(&uri) {
+        let mut documents = self.documents.write().await;
+        if let Some(document) = documents.get_mut(&uri) {
             document.update(content, version);
         } else {
-            self.documents
-                .insert(uri, DocumentState::new(content, version));
+            documents.insert(uri, DocumentState::new(content, version));
         }
     }
 
@@ -26,13 +26,23 @@ impl SharedState {
             return;
         }
 
-        let version = self.documents.get(&uri).map(|document| document.version());
+        let version = self
+            .documents
+            .read()
+            .await
+            .get(&uri)
+            .map(DocumentState::version);
 
         let Some(diagnostics) = self.analyze_and_convert(&uri).await else {
             return;
         };
 
-        let current_version = self.documents.get(&uri).map(|document| document.version());
+        let current_version = self
+            .documents
+            .read()
+            .await
+            .get(&uri)
+            .map(DocumentState::version);
         if version != current_version {
             return; // Discard stale results
         }
@@ -43,18 +53,21 @@ impl SharedState {
     }
 
     pub(crate) async fn recheck_open_documents(self: &Arc<Self>) {
-        let mut uris = Vec::with_capacity(self.documents.len());
-        for mut document in self.documents.iter_mut() {
+        let mut documents = self.documents.write().await;
+        let mut uris = Vec::with_capacity(documents.len());
+        for (uri, document) in documents.iter_mut() {
             document.invalidate_analysis();
-            uris.push(document.key().clone());
+            uris.push(uri.clone());
         }
+        drop(documents);
         for uri in uris {
             self.schedule_diagnostics(uri).await;
         }
     }
 
     async fn schedule_diagnostics(self: &Arc<Self>, uri: Url) {
-        let Some(mut document) = self.documents.get_mut(&uri) else {
+        let mut documents = self.documents.write().await;
+        let Some(document) = documents.get_mut(&uri) else {
             return;
         };
 
@@ -64,7 +77,7 @@ impl SharedState {
             let task_id = tokio::task::id();
             tokio::time::sleep(Duration::from_millis(300)).await;
             state.publish_diagnostics(diagnostics_uri.clone()).await;
-            if let Some(mut document) = state.documents.get_mut(&diagnostics_uri) {
+            if let Some(document) = state.documents.write().await.get_mut(&diagnostics_uri) {
                 document.finish_diagnostics(task_id);
             }
         });

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -131,7 +131,7 @@ impl Backend {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = &params.text_document.uri;
-        self.documents.remove(uri);
+        self.documents.write().await.remove(uri);
 
         let overlay_removed = self.project.remove_overlay(uri).await;
 
@@ -147,7 +147,8 @@ impl Backend {
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let uri = &params.text_document.uri;
         let (source, end_position) = {
-            let Some(doc) = self.documents.get(uri) else {
+            let documents = self.documents.read().await;
+            let Some(doc) = documents.get(uri) else {
                 return Ok(None);
             };
             let end = doc
@@ -576,7 +577,7 @@ impl Backend {
         }
 
         locations.extend(usage_locations(
-            self.open_document_snapshots(),
+            self.open_document_snapshots().await,
             &definition_uri,
             definition_span,
         ));
@@ -845,7 +846,7 @@ impl Backend {
             });
 
         for location in usage_locations(
-            self.open_document_snapshots(),
+            self.open_document_snapshots().await,
             &definition_uri,
             definition_span,
         ) {

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::protocol::{Client, Url};
-use dashmap::DashMap;
 use deps::BindgenSetup;
+use tokio::sync::RwLock;
 use tokio::task::AbortHandle;
 
 use crate::loader::ProjectState;
@@ -12,7 +13,7 @@ use crate::snapshot::AnalysisSnapshot;
 pub struct SharedState {
     pub(crate) client: Client,
     pub(crate) project: ProjectState,
-    pub(crate) documents: DashMap<Url, DocumentState>,
+    pub(crate) documents: RwLock<HashMap<Url, DocumentState>>,
     pub(crate) bindgen_setup: Option<Arc<dyn BindgenSetup>>,
 }
 
@@ -212,7 +213,7 @@ impl Backend {
             shared_state: Arc::new(SharedState {
                 client,
                 project: ProjectState::new(),
-                documents: DashMap::new(),
+                documents: RwLock::new(HashMap::new()),
                 bindgen_setup,
             }),
         }


### PR DESCRIPTION
Replaces `dashmap` with `tokio::sync::RwLock<HashMap>` for the LSP's document map, and trims unused `tokio` and `miette` feature flags, continuing the dep reduction effort from in #1155 and #1159.
