### PR TITLE
perf: inline terminal width detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -232,7 +232,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "terminal_size",
  "tokio",
 ]
 
@@ -370,7 +369,7 @@ checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -466,7 +465,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -559,17 +558,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
-dependencies = [
- "rustix",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -712,86 +701,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,7 +30,6 @@ stdlib = { package = "lisette-stdlib", version = "=0.10.0", path = "../stdlib" }
 deps = { package = "lisette-deps", version = "=0.10.0", path = "../deps" }
 lsp = { package = "lisette-lsp", version = "=0.10.0", path = "../lsp" }
 tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
-terminal_size = "0.4"
 owo-colors.workspace = true
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -11,9 +11,107 @@ pub fn use_color() -> bool {
 }
 
 pub fn terminal_width() -> usize {
-    terminal_size::terminal_size_of(std::io::stderr())
-        .map(|(w, _)| w.0 as usize)
-        .unwrap_or(100)
+    normalize_terminal_width(platform_terminal_width())
+}
+
+fn normalize_terminal_width(width: Option<u16>) -> usize {
+    width.filter(|width| *width > 0).map_or(100, usize::from)
+}
+
+// Platform implementations adapted from terminal_size 0.4.3:
+// https://github.com/eminence/terminal-size
+// Copyright (c) 2015 The terminal-size Developers.
+// Licensed under MIT
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn platform_terminal_width() -> Option<u16> {
+    use std::os::fd::AsRawFd;
+    use std::os::raw::{c_int, c_ulong};
+
+    #[derive(Default)]
+    #[repr(C)]
+    struct WindowSize {
+        rows: u16,
+        columns: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    }
+
+    unsafe extern "C" {
+        fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
+    }
+
+    #[cfg(target_os = "linux")]
+    const GET_WINDOW_SIZE: c_ulong = 0x5413;
+    #[cfg(target_os = "macos")]
+    const GET_WINDOW_SIZE: c_ulong = 0x4008_7468;
+
+    let mut size = WindowSize::default();
+    let stderr = std::io::stderr();
+    // SAFETY: stderr supplies a live file descriptor for the duration of the
+    // call, and `size` is the C-compatible buffer required by TIOCGWINSZ.
+    let result = unsafe { ioctl(stderr.as_raw_fd(), GET_WINDOW_SIZE, &mut size) };
+    (result == 0).then_some(size.columns)
+}
+
+#[cfg(windows)]
+fn platform_terminal_width() -> Option<u16> {
+    use std::ffi::c_void;
+    use std::os::windows::io::{AsHandle, AsRawHandle};
+
+    #[derive(Clone, Copy, Default)]
+    #[repr(C)]
+    struct Coordinate {
+        x: i16,
+        y: i16,
+    }
+
+    #[derive(Clone, Copy, Default)]
+    #[repr(C)]
+    struct SmallRectangle {
+        left: i16,
+        top: i16,
+        right: i16,
+        bottom: i16,
+    }
+
+    #[derive(Default)]
+    #[repr(C)]
+    struct ConsoleScreenBufferInfo {
+        size: Coordinate,
+        cursor_position: Coordinate,
+        attributes: u16,
+        window: SmallRectangle,
+        maximum_window_size: Coordinate,
+    }
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        #[link_name = "GetConsoleScreenBufferInfo"]
+        fn get_console_screen_buffer_info(
+            output: *mut c_void,
+            info: *mut ConsoleScreenBufferInfo,
+        ) -> i32;
+    }
+
+    let stderr = std::io::stderr();
+    let mut info = ConsoleScreenBufferInfo::default();
+    // SAFETY: the borrowed stderr handle remains live for the call, and
+    // `info` exactly matches the Windows CONSOLE_SCREEN_BUFFER_INFO layout.
+    let result = unsafe {
+        get_console_screen_buffer_info(stderr.as_handle().as_raw_handle().cast(), &mut info)
+    };
+    if result == 0 {
+        return None;
+    }
+
+    let width = i32::from(info.window.right) - i32::from(info.window.left) + 1;
+    u16::try_from(width).ok()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn platform_terminal_width() -> Option<u16> {
+    None
 }
 
 pub fn format_elapsed(elapsed: std::time::Duration) -> String {
@@ -460,4 +558,24 @@ macro_rules! cli_error {
             eprintln!(" · help: {}", hint);
         }
     }};
+}
+
+#[cfg(test)]
+mod terminal_width_tests {
+    use super::normalize_terminal_width;
+
+    #[test]
+    fn uses_detected_width() {
+        assert_eq!(normalize_terminal_width(Some(132)), 132);
+    }
+
+    #[test]
+    fn falls_back_when_detection_fails() {
+        assert_eq!(normalize_terminal_width(None), 100);
+    }
+
+    #[test]
+    fn falls_back_when_terminal_reports_zero() {
+        assert_eq!(normalize_terminal_width(Some(0)), 100);
+    }
 }


### PR DESCRIPTION
Removes the `terminal_size` dep by inlining a minimal terminal-width detection for Linux, macOS, and Windows, reducing the production graph from 54 to 48 pkgs and the lockfile from 91 to 80 pkgs.