### PR TITLE
feat: diagnostic for redundant import alias

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -1191,6 +1191,13 @@ pub fn unused_import(span: &Span) -> LisetteDiagnostic {
         .with_help("Use or remove this import")
 }
 
+pub fn redundant_import_alias(span: &Span, path: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::info("Redundant import alias")
+        .with_lint_code("redundant_import_alias")
+        .with_span_label(span, "alias matches module name exactly")
+        .with_help(format!("Remove the alias: `import \"{path}\"`"))
+}
+
 pub fn unused_type(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Unused type")
         .with_lint_code("unused_type")

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -17,17 +17,15 @@ pub struct AliasMap<'a> {
 }
 
 impl<'a> AliasMap<'a> {
-    pub fn build(files: &HashMap<u32, File>, store: &'a Store) -> Self {
+    pub fn build(file: &File, store: &'a Store) -> Self {
         let mut aliases = HashMap::default();
 
-        for file in files.values().filter(|file| !file.is_d_lis()) {
-            for import in file.imports() {
-                if matches!(import.alias, Some(ImportAlias::Blank(_))) {
-                    continue;
-                }
-                if let Some(effective) = import.effective_alias(&store.go_package_names) {
-                    aliases.insert(effective.clone(), ModuleItemId::new(&effective));
-                }
+        for import in file.imports() {
+            if matches!(import.alias, Some(ImportAlias::Blank(_))) {
+                continue;
+            }
+            if let Some(effective) = import.effective_alias(&store.go_package_names) {
+                aliases.insert(effective.clone(), ModuleItemId::import(file.id, &effective));
             }
         }
 

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -1,4 +1,5 @@
 mod extract;
+mod redundant_import_alias;
 mod reference_graph;
 mod visibility_constraints;
 
@@ -22,6 +23,7 @@ use syntax::program::UnusedInfo;
 use syntax::program::{File, FileImport};
 
 use extract::{AliasMap, is_upper, walk_expression};
+use redundant_import_alias::check_redundant_aliases;
 use reference_graph::{EnumVariantId, ItemKind, ModuleItemId, ReferenceGraph, StructFieldId};
 use syntax::attributes::SERIALIZATION_KEYS;
 use visibility_constraints::check_visibility_constraints;
@@ -107,11 +109,11 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
     let files = &module.files;
     let equality_index = &store.equality_index;
     let mut diagnostics = Vec::new();
-    let mut unused_import_aliases = HashSet::default();
+    let mut unused_import_spans = HashSet::default();
     let mut unused_definition_spans = Vec::new();
     let mut graph = ReferenceGraph::new();
 
-    collect_items(
+    let imports_per_alias = collect_items(
         files,
         &module.id,
         &store.go_package_names,
@@ -119,8 +121,8 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
         &mut graph,
     );
 
-    let alias_map = AliasMap::build(files, store);
     for file in files.values().filter(|file| !file.is_d_lis()) {
+        let alias_map = AliasMap::build(file, store);
         for item in &file.items {
             walk_expression(module, item, &mut graph, &alias_map, None);
         }
@@ -139,10 +141,14 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
         }
     }
 
+    let mut unused_imports_per_alias: HashMap<String, usize> = HashMap::default();
     for item_id in graph.get_unreachable() {
         if let Some(info) = graph.get_item(item_id) {
             if matches!(info.kind, ItemKind::Import { .. }) {
-                unused_import_aliases.insert(item_id.name.to_string());
+                *unused_imports_per_alias
+                    .entry(item_id.name.to_string())
+                    .or_default() += 1;
+                unused_import_spans.insert(info.span);
             }
             if info.kind == ItemKind::Function {
                 unused_definition_spans.push(info.span);
@@ -161,6 +167,15 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
         }
     }
 
+    // Emit drops an import from every file of the module at once.
+    let unused_import_aliases: HashSet<String> = unused_imports_per_alias
+        .into_iter()
+        .filter(|(alias, unused)| imports_per_alias.get(alias) == Some(unused))
+        .map(|(alias, _)| alias)
+        .collect();
+
+    check_redundant_aliases(files, store, &unused_import_spans, &mut diagnostics);
+
     check_visibility_constraints(module, files, &mut diagnostics);
 
     for span in graph.get_unused_struct_fields() {
@@ -178,13 +193,16 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
     }
 }
 
+/// Returns how many files import each alias.
 fn collect_items(
     files: &HashMap<u32, File>,
     module_id: &str,
     go_package_names: &HashMap<String, String>,
     equality_index: &EqualityIndex,
     graph: &mut ReferenceGraph,
-) {
+) -> HashMap<String, usize> {
+    let mut imports_per_alias: HashMap<String, usize> = HashMap::default();
+
     for file in files.values().filter(|file| !file.is_d_lis()) {
         for item in &file.items {
             match item {
@@ -206,8 +224,12 @@ fn collect_items(
                     };
 
                     if let Some(effective) = file_import.effective_alias(go_package_names) {
-                        let id = ModuleItemId::new(&effective);
-                        graph.add_import(id, *name_span, *span);
+                        *imports_per_alias.entry(effective.clone()).or_default() += 1;
+                        graph.add_import(
+                            ModuleItemId::import(file.id, &effective),
+                            *name_span,
+                            *span,
+                        );
                     }
                 }
                 Expression::Function {
@@ -326,6 +348,8 @@ fn collect_items(
             }
         }
     }
+
+    imports_per_alias
 }
 
 fn function_is_entry(name: &str, visibility: Visibility, attributes: &[Attribute]) -> bool {

--- a/crates/passes/src/passes/lints/ref_graph/redundant_import_alias.rs
+++ b/crates/passes/src/passes/lints/ref_graph/redundant_import_alias.rs
@@ -1,0 +1,58 @@
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use diagnostics::{Edit, Fix, LisetteDiagnostic};
+use semantics::store::Store;
+use syntax::ENTRY_MODULE_ID;
+use syntax::ast::{Expression, ImportAlias, Span};
+use syntax::program::{File, Module, unaliased_binding_name};
+
+pub(super) fn check_redundant_aliases(
+    files: &HashMap<u32, File>,
+    store: &Store,
+    unused_import_spans: &HashSet<Span>,
+    diagnostics: &mut Vec<LisetteDiagnostic>,
+) {
+    for file in files.values().filter(|file| !file.is_d_lis()) {
+        for item in &file.items {
+            let Expression::ModuleImport {
+                name,
+                name_span,
+                alias: Some(ImportAlias::Named(alias, alias_span)),
+                ..
+            } = item
+            else {
+                continue;
+            };
+
+            if unused_import_spans.contains(name_span) {
+                continue;
+            }
+
+            // Rewritten from `import "root"`, so this path is not what the file says.
+            if name == ENTRY_MODULE_ID {
+                continue;
+            }
+
+            // Without typedefs, the package clause that names the binding is unknown.
+            if name.starts_with("go:") && store.get_module(name).is_none_or(Module::is_empty_stub) {
+                continue;
+            }
+
+            if unaliased_binding_name(name, &store.go_package_names) != alias.as_str() {
+                continue;
+            }
+
+            let deletion = Span::new(
+                alias_span.file_id,
+                alias_span.byte_offset,
+                name_span.byte_offset - alias_span.byte_offset,
+            );
+            diagnostics.push(
+                diagnostics::lint::redundant_import_alias(alias_span, name).with_fix(Fix::new(
+                    "Remove the redundant alias",
+                    Edit::deletion(deletion),
+                )),
+            );
+        }
+    }
+}

--- a/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
@@ -5,16 +5,28 @@ use syntax::ast::Span;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ModuleItemId {
     pub name: EcoString,
+    pub file_id: Option<u32>,
 }
 
 impl ModuleItemId {
     pub fn new(name: &str) -> Self {
-        Self { name: name.into() }
+        Self {
+            name: name.into(),
+            file_id: None,
+        }
+    }
+
+    pub fn import(file_id: u32, name: &str) -> Self {
+        Self {
+            name: name.into(),
+            file_id: Some(file_id),
+        }
     }
 
     pub fn equals_method(type_name: &str) -> Self {
         Self {
             name: format!("{type_name}#equals").into(),
+            file_id: None,
         }
     }
 

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -40,18 +40,22 @@ impl FileImport {
         match &self.alias {
             Some(ImportAlias::Named(name, _)) => Some(name.to_string()),
             Some(ImportAlias::Blank(_)) => None,
-            None => {
-                if let Some(pkg_name) = go_package_names.get(self.name.as_str()) {
-                    return Some(pkg_name.clone());
-                }
-                let default = match self.name.strip_prefix("go:") {
-                    Some(go_path) => go_import_default_name(go_path),
-                    None => self.name.rsplit('/').next().unwrap_or(&self.name),
-                };
-                Some(default.to_string())
-            }
+            None => Some(unaliased_binding_name(&self.name, go_package_names).to_string()),
         }
     }
+}
+
+pub fn unaliased_binding_name<'a, S: BuildHasher>(
+    path: &'a str,
+    go_package_names: &'a HashMap<String, String, S>,
+) -> &'a str {
+    if let Some(package_name) = go_package_names.get(path) {
+        return package_name;
+    }
+    if path.starts_with("go:") {
+        return go_import_default_name(path);
+    }
+    path.rsplit('/').next().unwrap_or(path)
 }
 
 pub fn go_import_default_name(import_path: &str) -> &str {

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -11,7 +11,7 @@ pub use definition::{
 pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,
 };
-pub use file::{File, FileImport, go_import_default_name};
+pub use file::{File, FileImport, go_import_default_name, unaliased_binding_name};
 pub use module::{Module, ModuleId};
 pub use resolution::{
     CallKind, ChannelOperation, DotAccessKind, DotAccessResolution, NativeTypeKind,

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -1495,3 +1495,16 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn fix_redundant_import_alias() {
+    assert_fix_snapshot!(
+        r#"
+import fmt "go:fmt"
+
+fn main() {
+  fmt.Println("hi")
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -3,6 +3,7 @@ mod fixes;
 use crate::_harness::build::compile_check;
 use crate::_harness::filesystem::MockFileSystem;
 use crate::_harness::formatting::format_result_diagnostic_for_snapshot;
+use crate::_harness::lint::lint;
 use crate::{assert_lint_snapshot, assert_no_lint_warnings};
 use semantics::store::ENTRY_MODULE_ID;
 
@@ -8311,6 +8312,274 @@ fn main() {
 }
 "#
     );
+}
+
+#[test]
+fn redundant_import_alias() {
+    assert_lint_snapshot!(
+        r#"
+import fmt "go:fmt"
+
+fn main() {
+  fmt.Println("hi")
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_import_alias_silent_for_renaming_alias() {
+    assert_no_lint_warnings!(
+        r#"
+import f "go:fmt"
+
+fn main() {
+  f.Println("hi")
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_import_alias_silent_for_unused_import() {
+    let diagnostics = lint(
+        r#"
+import fmt "go:fmt"
+
+fn main() {
+  ()
+}
+"#,
+    );
+    let codes: Vec<&str> = diagnostics
+        .iter()
+        .filter_map(|diagnostic| diagnostic.code_str())
+        .collect();
+    assert!(codes.contains(&"lint.unused_import"), "{codes:?}");
+    assert!(!codes.contains(&"lint.redundant_import_alias"), "{codes:?}");
+}
+
+#[test]
+fn redundant_import_alias_silent_for_go_package_without_typedefs() {
+    assert_no_lint_warnings!(
+        r#"
+import bar "go:example.com/foo/bar"
+
+fn main() {
+  bar.Run()
+}
+"#
+    );
+}
+
+#[test]
+fn redundant_import_alias_on_local_module() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "lib.lis",
+        r#"
+pub struct User {
+  pub name: string,
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import models "models"
+
+fn main() {
+  let _u = models.User { name: "Alice" }
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors().is_empty(),
+        "unexpected errors: {:?}",
+        result.errors()
+    );
+    let codes: Vec<&str> = result.lints().iter().filter_map(|l| l.code_str()).collect();
+    assert!(codes.contains(&"lint.redundant_import_alias"), "{codes:?}");
+}
+
+#[test]
+fn redundant_import_alias_on_nested_module_path() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "routes/admin",
+        "lib.lis",
+        r#"
+pub fn dashboard() -> string {
+  "dashboard"
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import admin "routes/admin"
+
+fn main() {
+  let _page = admin.dashboard()
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors().is_empty(),
+        "unexpected errors: {:?}",
+        result.errors()
+    );
+    let codes: Vec<&str> = result.lints().iter().filter_map(|l| l.code_str()).collect();
+    assert!(codes.contains(&"lint.redundant_import_alias"), "{codes:?}");
+}
+
+#[test]
+fn redundant_import_alias_silent_for_nested_module_renamed_to_its_parent() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "routes/admin",
+        "lib.lis",
+        r#"
+pub fn dashboard() -> string {
+  "dashboard"
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import routes "routes/admin"
+
+fn main() {
+  let _page = routes.dashboard()
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors().is_empty(),
+        "unexpected errors: {:?}",
+        result.errors()
+    );
+    let codes: Vec<&str> = result.lints().iter().filter_map(|l| l.code_str()).collect();
+    assert!(!codes.contains(&"lint.redundant_import_alias"), "{codes:?}");
+}
+
+#[test]
+fn import_unused_in_its_own_file_is_reported_there_not_as_an_alias_advisory() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "lib.lis",
+        r#"
+pub struct User {
+  pub name: string,
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import models "models"
+
+fn main() {
+  let _u = models.User { name: "Alice" }
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "helper.lis",
+        r#"
+import models "models"
+
+pub fn label() -> string {
+  "user"
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+    assert!(
+        result.errors().is_empty(),
+        "unexpected errors: {:?}",
+        result.errors()
+    );
+    let codes: Vec<&str> = result.lints().iter().filter_map(|l| l.code_str()).collect();
+    assert_eq!(
+        codes
+            .iter()
+            .filter(|code| **code == "lint.redundant_import_alias")
+            .count(),
+        1,
+        "{codes:?}"
+    );
+    assert_eq!(
+        codes
+            .iter()
+            .filter(|code| **code == "lint.unused_import")
+            .count(),
+        1,
+        "{codes:?}"
+    );
+}
+
+#[test]
+fn unused_import_is_reported_in_every_file_that_leaves_it_unused() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "models",
+        "lib.lis",
+        r#"
+pub struct User {
+  pub name: string,
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import models "models"
+
+fn main() {
+  ()
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "helper.lis",
+        r#"
+import models "models"
+
+pub fn label() -> string {
+  "user"
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+    let codes: Vec<&str> = result.lints().iter().filter_map(|l| l.code_str()).collect();
+    assert_eq!(
+        codes
+            .iter()
+            .filter(|code| **code == "lint.unused_import")
+            .count(),
+        2,
+        "{codes:?}"
+    );
+    assert!(!codes.contains(&"lint.redundant_import_alias"), "{codes:?}");
 }
 
 #[test]

--- a/tests/ui/lint/snapshots/fix_redundant_import_alias.snap
+++ b/tests/ui/lint/snapshots/fix_redundant_import_alias.snap
@@ -1,0 +1,14 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+import fmt "go:fmt"
+
+fn main() {
+  fmt.Println("hi")
+}
+=== fixed ===
+import "go:fmt"
+
+fn main() {
+  fmt.Println("hi")
+}

--- a/tests/ui/lint/snapshots/redundant_import_alias.snap
+++ b/tests/ui/lint/snapshots/redundant_import_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ● Redundant import alias
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ import fmt "go:fmt"
+   ·        ─┬─
+   ·         ╰── alias matches module name exactly
+ 3 │ 
+   ╰────
+  help: Remove the alias: `import "go:fmt"` · code: [lint.redundant_import_alias]


### PR DESCRIPTION
Adds an advisory for an import alias identical to the name the import already binds, with an autofix that removes the alias.

```
  ● Redundant import alias
   ╭─[src/main.lis:1:8]
 1 │ import models "models"
   ·        ───┬──
   ·           ╰── alias matches module name exactly
 2 │ 
   ╰────
  help: Remove the alias: `import "models"` · code: [lint.redundant_import_alias]
```