### PR TITLE
test: reuse prelude setup across tests

### DIFF
--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -115,6 +115,19 @@ pub struct Store {
     pub(crate) project_kind: crate::inference::ProjectKind,
 }
 
+impl Clone for Store {
+    fn clone(&self) -> Self {
+        Self {
+            modules: self.modules.clone(),
+            go_package_names: self.go_package_names.clone(),
+            next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
+            equality_index: self.equality_index.clone(),
+            test_index: self.test_index.clone(),
+            project_kind: self.project_kind,
+        }
+    }
+}
+
 impl Default for Store {
     fn default() -> Self {
         Self::new()
@@ -647,6 +660,30 @@ fn method_lookup_key(ty: &Type) -> Option<Symbol> {
         // Array methods live on the prelude `Array` impl.
         Type::Array { .. } => Some(Symbol::from_parts("prelude", "Array")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod clone_tests {
+    use super::*;
+
+    #[test]
+    fn clone_has_an_independent_file_id_counter() {
+        let store = Store::new();
+        let cloned = store.clone();
+
+        assert_eq!(store.new_file_id(), cloned.new_file_id());
+    }
+
+    #[test]
+    fn clone_detaches_a_module_before_mutation() {
+        let mut store = Store::new();
+        store.add_module("m");
+        let mut cloned = store.clone();
+
+        cloned.store_file(File::new_cached("m", "cloned.lis", "", "", 42));
+
+        assert!(store.get_file(42).is_none());
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -24,12 +24,15 @@ grammar:
     npm --prefix editors/tree-sitter-lisette run build
 
 test:
-    cargo test -p tests --test suite
-    cargo test -p lisette-lsp --test lsp
-    cargo test -p tests --test manifest_pins
+    cargo test -p tests --test suite -- --format terse
+    cargo test -p lisette-lsp --test lsp -- --format terse
+    cargo test -p tests --test manifest_pins -- --format terse
 
 test-unit:
-    cargo test --workspace --lib --bins
+    cargo test --workspace --lib --bins -- --format terse
+
+_test-check:
+    cargo test --workspace --lib --bins --test suite --test lsp --test manifest_pins -- --format terse
 
 test-infer:
     cargo test -p tests --test suite infer_tests
@@ -74,7 +77,7 @@ lintfix:
 run file:
     cargo run -p lisette -- {{file}}
 
-check: format-check test test-unit lint
+check: format-check _test-check lint
 
 perf-flamegraph:
     cargo build --profile flamegraph -p lisette

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -5,7 +5,6 @@ use semantics::{
     checker::TaskState,
     module_graph::Roots,
     module_graph::{ModuleGraphOptions, build_module_graph},
-    store::Store,
 };
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
@@ -14,13 +13,11 @@ use syntax::{
     types::{Symbol, Type},
 };
 
-use super::init_prelude;
+use super::new_test_store;
 
 use super::builders::*;
 use super::filesystem::MockFileSystem;
 use super::pipeline::TestPipeline;
-use super::register_test_builtins;
-
 pub fn checker_errors(raw_source: &str, typedefs: &[(&str, &str)]) -> Vec<LisetteDiagnostic> {
     let mut pipeline = TestPipeline::new(raw_source);
     for (name, source) in typedefs {
@@ -57,7 +54,7 @@ pub fn infer_with_go_typedefs(raw_source: &str, typedefs: &[(&str, &str)]) -> In
 }
 
 pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
-    let mut store = Store::new();
+    let mut store = new_test_store();
 
     let sink = LocalSink::new();
 
@@ -90,11 +87,8 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         };
     }
 
-    init_prelude(&mut store);
-
     let ast = {
         let mut checker = TaskState::with_fresh_allocator();
-        register_test_builtins(&mut store, &mut checker);
         checker.put_prelude_in_scope(&store);
 
         let order = std::mem::take(&mut graph_result.order);

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -1,5 +1,5 @@
 use diagnostics::{Fix, LisetteDiagnostic, apply_fixes};
-use semantics::{checker::TaskState, checker::infer::InferCtx, store::Store};
+use semantics::{checker::TaskState, checker::infer::InferCtx};
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
     ast::Expression,
@@ -9,17 +9,13 @@ use syntax::{
     program::{File, FileImport, UnusedInfo, Visibility},
 };
 
-use super::init_prelude;
-
-use crate::_harness::register_test_builtins;
+use super::new_test_store;
 
 use super::TEST_MODULE_ID;
 
 pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
-    let mut store = Store::new();
+    let mut store = new_test_store();
     store.add_module(TEST_MODULE_ID);
-
-    init_prelude(&mut store);
 
     // Parser::new hardcodes file_id=0 in spans, so pin the test file to that id too.
     let file_id = 0u32;
@@ -45,7 +41,6 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
 
     let mut checker = TaskState::with_fresh_allocator();
     checker.cursor.module_id = TEST_MODULE_ID.to_string();
-    register_test_builtins(&mut store, &mut checker);
     checker.put_prelude_in_scope(&store);
 
     let locator = deps::TypedefLocator::default();

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -17,20 +17,30 @@ pub use infer::{InferResult, infer, infer_module, infer_with_go_typedefs};
 
 pub const TEST_MODULE_ID: &str = "test";
 
+use std::sync::OnceLock;
+
 use diagnostics::LocalSink;
-use semantics::checker::TaskState;
 use semantics::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use semantics::store::Store;
 use syntax::program::{Definition, DefinitionBody, Visibility};
 use syntax::types::{CompoundKind, FunctionParameter, Type};
 
-pub fn init_prelude(store: &mut Store) {
-    let sink = LocalSink::new();
-    parse_and_register_prelude(store, &sink);
-    parse_and_register_test_prelude(store, &sink);
+pub fn new_test_store() -> Store {
+    static TEMPLATE: OnceLock<Store> = OnceLock::new();
+
+    TEMPLATE
+        .get_or_init(|| {
+            let mut store = Store::new();
+            let sink = LocalSink::new();
+            parse_and_register_prelude(&mut store, &sink);
+            parse_and_register_test_prelude(&mut store, &sink);
+            register_test_builtins(&mut store);
+            store
+        })
+        .clone()
 }
 
-pub fn register_test_builtins(store: &mut Store, _checker: &mut TaskState) {
+fn register_test_builtins(store: &mut Store) {
     let module = store
         .get_module_mut("prelude")
         .expect("prelude module must exist");

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, LocalSink};
-use semantics::{checker::TaskState, checker::infer::InferCtx, store::Store};
+use semantics::{checker::TaskState, checker::infer::InferCtx};
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::{
     ast::{Expression, FunctionBody},
@@ -12,9 +12,7 @@ use syntax::{
     types::Symbol,
 };
 
-use super::init_prelude;
-
-use crate::_harness::register_test_builtins;
+use super::new_test_store;
 
 use super::TEST_MODULE_ID;
 use super::wrap::{TEST_WRAPPER_NAME, wrap};
@@ -91,12 +89,10 @@ pub struct CompiledTest {
 
 impl CompiledTest {
     pub fn run_inference(self) -> InferenceResult {
-        let mut store = Store::new();
+        let mut store = new_test_store();
         store.add_module(TEST_MODULE_ID);
 
         let sink = LocalSink::new();
-
-        init_prelude(&mut store);
 
         let (
             typed_ast,
@@ -109,7 +105,6 @@ impl CompiledTest {
         ) = {
             let mut checker = TaskState::with_fresh_allocator();
             checker.cursor.module_id = TEST_MODULE_ID.to_string();
-            register_test_builtins(&mut store, &mut checker);
             checker.put_prelude_in_scope(&store);
 
             let locator = deps::TypedefLocator::default();


### PR DESCRIPTION
This PR adds a prelude store that can be reused across tests, to avoid re-parsing and re-registration for the suite of 7.4k tests. This reduces the `just check` run from 26s to 16s median on my MBP M1.