### PR TITLE
refactor: tailor comparable-bound diagnostic to equatable types

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1293,14 +1293,35 @@ pub fn not_orderable_bound(span: Span) -> LisetteDiagnostic {
         )
 }
 
-pub fn not_comparable_bound(span: Span) -> LisetteDiagnostic {
+pub struct EquatableFieldHint<'a> {
+    pub type_name: &'a str,
+    pub param_name: &'a str,
+}
+
+pub fn not_comparable_bound(
+    reason: &str,
+    hint: Option<EquatableFieldHint<'_>>,
+    span: Span,
+) -> LisetteDiagnostic {
+    let help = match hint {
+        Some(EquatableFieldHint {
+            type_name,
+            param_name,
+        }) => format!(
+            "`Comparable` requires `==`, and {reason} cannot be compared with `==` in Go. \
+             `{type_name}` already has its own `equals`, so declare `{param_name}`'s bound as an \
+             interface holding `fn equals(other: {param_name}) -> bool`"
+        ),
+        None => format!(
+            "`Comparable` requires `==`, and {reason} cannot be compared with `==` in Go. \
+             If you own this bound, relax it, or accept the comparison as an explicit argument \
+             instead"
+        ),
+    };
     LisetteDiagnostic::error("Bound not satisfied")
         .with_infer_code("not_comparable_bound")
         .with_span_label(&span, "does not satisfy `Comparable`")
-        .with_help(
-            "The parameter must be `Comparable` but the argument is not comparable. \
-             Relax the bound or pass an argument that satisfies it",
-        )
+        .with_help(help)
 }
 
 pub fn bound_only_in_value_position(name: &str, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/generic_obligations.rs
+++ b/crates/semantics/src/checker/infer/generic_obligations.rs
@@ -12,9 +12,13 @@ impl InferCtx<'_> {
         constructed_ty: &Type,
         span: Span,
     ) {
+        let has_equals_method = constructed_ty
+            .get_qualified_id()
+            .is_some_and(|id| self.store.definition_has_equals_method(id));
         let origin = GenericBoundOrigin::Construction {
             name: unqualified_name(written_name).into(),
             enclosing_return_type: self.scopes.lookup_fn_return_type().cloned(),
+            has_equals_method,
         };
         for bound in type_obligations(self.store, constructed_ty) {
             self.register_generic_bound_obligation(bound, &origin, span);

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -643,7 +643,7 @@ impl InferCtx<'_> {
             return Dispatched::Fallthrough;
         };
 
-        self.check_builtin_bound_argument(store, resolved_generic, builtin, *span);
+        self.check_builtin_bound_argument(store, resolved_generic, builtin, *span, None);
         Dispatched::Handled
     }
 

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -687,6 +687,7 @@ impl TaskState {
             return;
         };
         let generics = definition.body.generics().unwrap_or_default();
+        let has_equals_method = store.definition_has_equals_method(definition_name);
         for applied in apply_bounds(generics, arguments) {
             match applied
                 .required
@@ -694,7 +695,11 @@ impl TaskState {
                 .and_then(BuiltinBound::from_qualified_id)
             {
                 Some(builtin) => {
-                    self.check_builtin_bound_argument(store, &applied.argument, builtin, span)
+                    let hint = has_equals_method.then(|| diagnostics::infer::EquatableFieldHint {
+                        type_name: unqualified_name(definition_name),
+                        param_name: applied.parameter_name.as_str(),
+                    });
+                    self.check_builtin_bound_argument(store, &applied.argument, builtin, span, hint)
                 }
                 None => self.check_interface_type_argument(
                     store,
@@ -741,6 +746,7 @@ impl TaskState {
         argument: &Type,
         required: BuiltinBound,
         span: Span,
+        equals_hint: Option<diagnostics::infer::EquatableFieldHint<'_>>,
     ) {
         let resolved = store.deep_resolve_alias(&argument.resolve_in(&self.env));
         if resolved.is_variable() {
@@ -779,9 +785,12 @@ impl TaskState {
                         required.label(),
                         span,
                     ));
-                } else if reason.is_some() {
-                    self.sink
-                        .push(diagnostics::infer::not_comparable_bound(span));
+                } else if let Some(reason) = reason {
+                    self.sink.push(diagnostics::infer::not_comparable_bound(
+                        reason,
+                        equals_hint,
+                        span,
+                    ));
                 }
             }
             BuiltinBound::Ordered if !store.satisfies_ordered_constraint(&resolved) => {

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -144,7 +144,13 @@ impl TaskState {
                 .get_qualified_id()
                 .and_then(BuiltinBound::from_qualified_id)
             {
-                self.check_builtin_bound_argument(store, &argument, required, declaration_span);
+                self.check_builtin_bound_argument(
+                    store,
+                    &argument,
+                    required,
+                    declaration_span,
+                    None,
+                );
             } else if !argument.contains_error()
                 && !store.contains_unknown(&argument)
                 && !argument.is_variable()

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -121,6 +121,7 @@ pub enum GenericBoundOrigin {
     Construction {
         name: EcoString,
         enclosing_return_type: Option<Type>,
+        has_equals_method: bool,
     },
     FunctionReference {
         name: EcoString,

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -198,7 +198,24 @@ impl TaskState {
                 .get_qualified_id()
                 .and_then(BuiltinBound::from_qualified_id)
             {
-                self.check_builtin_bound_argument(store, &argument, builtin, obligation.span);
+                let equals_hint = match &obligation.origin {
+                    GenericBoundOrigin::Construction {
+                        name,
+                        has_equals_method: true,
+                        ..
+                    } => Some(diagnostics::infer::EquatableFieldHint {
+                        type_name: name.as_str(),
+                        param_name: obligation.param_name.as_str(),
+                    }),
+                    _ => None,
+                };
+                self.check_builtin_bound_argument(
+                    store,
+                    &argument,
+                    builtin,
+                    obligation.span,
+                    equals_hint,
+                );
             } else {
                 InferCtx::new(self, store).check_concrete_bound(
                     &argument,

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -382,6 +382,14 @@ impl Store {
         }
     }
 
+    pub(crate) fn definition_has_equals_method(&self, qualified_id: &str) -> bool {
+        matches!(
+            self.get_definition(qualified_id).map(|d| &d.body),
+            Some(DefinitionBody::Struct { methods, .. } | DefinitionBody::Enum { methods, .. })
+                if methods.contains_key("equals")
+        )
+    }
+
     pub(crate) fn is_interface(&self, ty: &Type) -> bool {
         matches!(ty, Type::Nominal { id, .. } if self.get_interface(id.as_str()).is_some())
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9143,6 +9143,19 @@ fn test() {
 }
 
 #[test]
+fn infer_comparable_bound_on_equatable_struct_suggests_interface() {
+    let input = r#"
+#[equality]
+struct Wrap<T: Comparable> { value: T }
+
+fn test() {
+  let one = Wrap { value: [1] }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_ordered_bound_rejects_bool() {
     let input = r#"
 import "go:cmp"

--- a/tests/ui/errors/snapshots/infer_comparable_bound_on_equatable_struct_suggests_interface.snap
+++ b/tests/ui/errors/snapshots/infer_comparable_bound_on_equatable_struct_suggests_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Bound not satisfied
+   ╭─[test.lis:6:13]
+ 5 │ fn test() {
+ 6 │   let one = Wrap { value: [1] }
+   ·             ─────────┬─────────
+   ·                      ╰── does not satisfy `Comparable`
+ 7 │ }
+   ╰────
+  help: `Comparable` requires `==`, and slices cannot be compared with `==` in Go. `Wrap` already has its own `equals`, so declare `T`'s bound as an interface holding `fn equals(other: T) -> bool` · code: [infer.not_comparable_bound]

--- a/tests/ui/errors/snapshots/infer_comparable_bound_rejects_slice.snap
+++ b/tests/ui/errors/snapshots/infer_comparable_bound_rejects_slice.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                           ╰── does not satisfy `Comparable`
  6 │ }
    ╰────
-  help: The parameter must be `Comparable` but the argument is not comparable. Relax the bound or pass an argument that satisfies it · code: [infer.not_comparable_bound]
+  help: `Comparable` requires `==`, and slices cannot be compared with `==` in Go. If you own this bound, relax it, or accept the comparison as an explicit argument instead · code: [infer.not_comparable_bound]


### PR DESCRIPTION
When a `Comparable` bound fails on a generic field of a type that already derives equality, the diagnostic now points at declaring the field's bound as an interface requiring `equals` instead of leaving the reader to guess how to relax it.