### PR TITLE
refactor: move entry parsing into analysis

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -14,8 +14,6 @@ pub use semantics::inference::ProjectKind;
 use semantics::loader::Loader;
 pub use syntax::program::TestIndex;
 
-const ENTRY_FILE_ID: u32 = 0;
-
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
     pub source: String,
@@ -125,40 +123,14 @@ pub struct CompileResult {
 
 pub fn compile(input: CompileInput<'_>, config: &CompileConfig, fs: &dyn Loader) -> CompileResult {
     let (entry_file, project_kind) = match input {
-        CompileInput::Binary(entry) => {
-            let syntax_result = syntax::build_ast(entry.source, ENTRY_FILE_ID);
-            if syntax_result.failed() {
-                let errors = syntax_result.errors.into_iter().map(Into::into).collect();
-                let mut sources = HashMap::default();
-                sources.insert(
-                    ENTRY_FILE_ID,
-                    SourceInfo {
-                        source: entry.source.to_string(),
-                        filename: entry.display_path.to_string(),
-                    },
-                );
-                return CompileResult {
-                    output: vec![],
-                    errors,
-                    lints: vec![],
-                    sources,
-                    user_file_count: 1,
-                    live_modules: vec![],
-                    emit_stamps: vec![],
-                    test_index: TestIndex::default(),
-                };
-            }
-            (
-                Some(EntryFile {
-                    source: entry.source.to_string(),
-                    filename: entry.filename.to_string(),
-                    display_path: entry.display_path.to_string(),
-                    ast: syntax_result.ast,
-                    file_comment: syntax_result.file_comment,
-                }),
-                ProjectKind::Binary,
-            )
-        }
+        CompileInput::Binary(entry) => (
+            Some(EntryFile::new(
+                entry.source.to_string(),
+                entry.filename.to_string(),
+                entry.display_path.to_string(),
+            )),
+            ProjectKind::Binary,
+        ),
         CompileInput::Library => (None, ProjectKind::Library),
     };
 
@@ -400,6 +372,22 @@ mod tests {
     }
 
     #[test]
+    fn syntax_error_stops_batch_analysis_but_retains_entry_source() {
+        let result =
+            compile_project_source("fn main(", ProjectKind::Binary, CompilePhase::Check, "main");
+
+        assert_eq!(
+            (
+                result.errors.first().and_then(LisetteDiagnostic::code_str),
+                result.user_file_count,
+                result.sources.get(&0).map(|source| source.source.as_str()),
+                result.output.is_empty(),
+            ),
+            (Some("parse.unexpected_token"), 1, Some("fn main("), true)
+        );
+    }
+
+    #[test]
     fn warm_diagnostics_match_cold_for_param_position_leak() {
         let tmp = tempdir().unwrap();
         let root = tmp.path();
@@ -457,7 +445,6 @@ mod tests {
             .and_then(|p| p.to_str())
             .expect("temp project path is valid utf-8");
         let fs_loader = LocalFileSystem::new(working_dir, Some(project_dir));
-        let build_result = syntax::build_ast(&source, ENTRY_FILE_ID);
         let result = analyze(AnalyzeInput {
             config: SemanticConfig {
                 run_lints: true,
@@ -465,13 +452,11 @@ mod tests {
                 load_siblings: true,
             },
             loader: &fs_loader,
-            entry: Some(EntryFile {
+            entry: Some(EntryFile::new(
                 source,
-                filename: "main.lis".to_string(),
-                display_path: "src/main.lis".to_string(),
-                ast: build_result.ast,
-                file_comment: build_result.file_comment,
-            }),
+                "main.lis".to_string(),
+                "src/main.lis".to_string(),
+            )),
             project_root: Some(project_dir.to_path_buf()),
             compile_phase: CompilePhase::Check,
             project_kind: ProjectKind::Binary,
@@ -562,7 +547,6 @@ mod tests {
             .and_then(|p| p.to_str())
             .expect("temp project path is valid utf-8");
         let fs_loader = LocalFileSystem::new(working_dir, Some(project_dir));
-        let build_result = syntax::build_ast(&source, ENTRY_FILE_ID);
         let output = analyze(AnalyzeInput {
             config: SemanticConfig {
                 run_lints: true,
@@ -570,13 +554,11 @@ mod tests {
                 load_siblings: true,
             },
             loader: &fs_loader,
-            entry: Some(EntryFile {
+            entry: Some(EntryFile::new(
                 source,
-                filename: "main.lis".to_string(),
-                display_path: "src/main.lis".to_string(),
-                ast: build_result.ast,
-                file_comment: build_result.file_comment,
-            }),
+                "main.lis".to_string(),
+                "src/main.lis".to_string(),
+            )),
             project_root: Some(project_dir.to_path_buf()),
             compile_phase: CompilePhase::Check,
             project_kind: ProjectKind::Binary,

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -8,8 +8,6 @@ use deps::TypedefLocator;
 use diagnostics::LisetteDiagnostic;
 use passes::analyze;
 use semantics::inference::{AnalyzeInput, CompilePhase, EntryFile, ProjectKind, SemanticConfig};
-use syntax::lex::Lexer;
-use syntax::parse::Parser;
 use syntax::types::{CompoundKind, Type};
 
 use crate::position::LineIndex;
@@ -88,24 +86,6 @@ impl SharedState {
             )]);
         }
 
-        let lex_result = Lexer::new(&source, 0).lex();
-        if lex_result.failed() {
-            let line_index = LineIndex::new(&source);
-            return Err(lex_result
-                .errors
-                .into_iter()
-                .map(|e| {
-                    let diag: LisetteDiagnostic = e.into();
-                    convert_diagnostic(&diag, &line_index)
-                })
-                .collect());
-        }
-
-        let parse_result = Parser::new(lex_result.tokens, &source).parse();
-        let has_parse_errors = !parse_result.errors.is_empty();
-        let parse_errors: Vec<LisetteDiagnostic> =
-            parse_result.errors.into_iter().map(Into::into).collect();
-
         let standalone = config.is_standalone();
         let (locator, manifest_error) = if standalone {
             (TypedefLocator::default(), None)
@@ -138,7 +118,7 @@ impl SharedState {
 
         let analyze_output = analyze(AnalyzeInput {
             config: SemanticConfig {
-                run_lints: !has_parse_errors,
+                run_lints: true,
                 standalone_mode: standalone,
                 load_siblings: true,
             },
@@ -146,13 +126,7 @@ impl SharedState {
             entry: if external_test {
                 None
             } else {
-                Some(EntryFile {
-                    source,
-                    display_path: filename.clone(),
-                    filename,
-                    ast: parse_result.ast,
-                    file_comment: parse_result.file_comment,
-                })
+                Some(EntryFile::recovering(source, filename.clone(), filename))
             },
             project_root: if standalone {
                 None
@@ -165,11 +139,25 @@ impl SharedState {
             go_module: String::new(),
             disable_cache: external_test,
         });
+        let has_parse_errors = analyze_output.has_parse_errors();
+        let entry_parse_failed = analyze_output.entry_parse_failed();
         let mut result = analyze_output.result;
         let facts = analyze_output.facts;
 
-        if has_parse_errors && !external_test {
-            result.prepend_errors(parse_errors);
+        if entry_parse_failed {
+            let line_index = LineIndex::new(
+                result
+                    .emit_input
+                    .files
+                    .get(&0)
+                    .map(|file| file.source.as_str())
+                    .unwrap_or_default(),
+            );
+            return Err(result
+                .errors()
+                .iter()
+                .map(|diagnostic| convert_diagnostic(diagnostic, &line_index))
+                .collect());
         }
 
         if let Some(msg) = manifest_error {

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -20,10 +20,26 @@ pub struct AnalyzeOutput {
     pub facts: Facts,
     pub emit_stamps: Vec<EmitStamp>,
     pub unreachable_modules: Vec<String>,
+    entry_parse_errors: Vec<syntax::ParseError>,
+    entry_parse_status: semantics::inference::EntryParseStatus,
+}
+
+impl AnalyzeOutput {
+    pub fn has_parse_errors(&self) -> bool {
+        self.entry_parse_status != semantics::inference::EntryParseStatus::Clean
+    }
+
+    pub fn entry_parse_failed(&self) -> bool {
+        self.entry_parse_status == semantics::inference::EntryParseStatus::Failed
+    }
+
+    pub fn parse_errors(&self) -> &[syntax::ParseError] {
+        &self.entry_parse_errors
+    }
 }
 
 pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
-    let run_lints = input.config.run_lints;
+    let requested_lints = input.config.run_lints;
 
     let InferenceOutput {
         store,
@@ -34,7 +50,11 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         cached_modules,
         cache_root,
         unreachable_modules,
+        entry_parse_errors,
+        entry_parse_status,
     } = run_inference(input);
+    let run_lints =
+        requested_lints && entry_parse_status == semantics::inference::EntryParseStatus::Clean;
 
     let mut unused = UnusedInfo::default();
     if !has_pre_check_errors {
@@ -51,6 +71,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
     // phase ordering, FxHashMap iteration, or parallel inference scheduling.
     let mut all_diagnostics = sink.into_diagnostics();
     all_diagnostics.sort_by(diagnostics::LisetteDiagnostic::sort_key);
+    all_diagnostics.splice(0..0, entry_parse_errors.iter().cloned().map(Into::into));
 
     let emit_stamps: Vec<EmitStamp> = compiled_modules
         .iter()
@@ -143,5 +164,7 @@ pub fn analyze(input: AnalyzeInput) -> AnalyzeOutput {
         facts,
         emit_stamps,
         unreachable_modules,
+        entry_parse_errors,
+        entry_parse_status,
     }
 }

--- a/crates/semantics/src/inference.rs
+++ b/crates/semantics/src/inference.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use diagnostics::LocalSink;
-use syntax::ast::Expression;
+use syntax::ParseError;
+use syntax::lex::Lexer;
+use syntax::parse::{ParseResult, Parser};
 use syntax::program::{File, Module};
 
 use deps::TypedefLocator;
@@ -23,7 +25,7 @@ use crate::facts::Facts;
 use crate::loader::{DiscoveredModules, Loader};
 use crate::module_graph::{DependencyGraph, ModuleGraphOptions, Roots, build_module_graph};
 use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
-use crate::store::{ENTRY_MODULE_ID, Store};
+use crate::store::{ENTRY_FILE_ID, ENTRY_MODULE_ID, Store};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompilePhase {
@@ -58,11 +60,47 @@ pub struct SemanticConfig {
 }
 
 pub struct EntryFile {
-    pub source: String,
-    pub filename: String,
-    pub display_path: String,
-    pub ast: Vec<Expression>,
-    pub file_comment: Option<String>,
+    source: String,
+    filename: String,
+    display_path: String,
+    parse_mode: EntryParseMode,
+}
+
+impl EntryFile {
+    /// Creates an entry whose syntax errors stop analysis.
+    pub fn new(source: String, filename: String, display_path: String) -> Self {
+        Self {
+            source,
+            filename,
+            display_path,
+            parse_mode: EntryParseMode::Strict,
+        }
+    }
+
+    /// Creates an entry whose parser errors retain the valid partial AST.
+    /// Lexer errors remain fatal.
+    pub fn recovering(source: String, filename: String, display_path: String) -> Self {
+        Self {
+            source,
+            filename,
+            display_path,
+            parse_mode: EntryParseMode::Recover,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryParseMode {
+    Strict,
+    Recover,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EntryParseStatus {
+    #[default]
+    Clean,
+    Recovered,
+    Failed,
 }
 
 pub struct AnalyzeInput<'a> {
@@ -174,17 +212,39 @@ pub struct InferenceOutput {
     pub cached_modules: HashSet<String>,
     pub cache_root: Option<PathBuf>,
     pub unreachable_modules: Vec<String>,
+    pub entry_parse_errors: Vec<ParseError>,
+    pub entry_parse_status: EntryParseStatus,
 }
 
-/// Registers the entry file (`main.lis`, or the library root), returning its
-/// filename so sibling loading can skip re-loading it.
+struct EntryRegistration {
+    filename: Option<String>,
+    errors: Vec<ParseError>,
+    status: EntryParseStatus,
+}
+
+/// Parses and registers the entry file (`main.lis`, or the library root).
 fn register_entry_file(
     store: &mut Store,
     sink: &LocalSink,
     entry: Option<EntryFile>,
     include_tests: bool,
-) -> Option<String> {
-    entry.map(|entry| {
+) -> EntryRegistration {
+    let Some(entry) = entry else {
+        return EntryRegistration {
+            filename: None,
+            errors: Vec::new(),
+            status: EntryParseStatus::Clean,
+        };
+    };
+
+    let (parse_result, status) = parse_entry_file(&entry.source, entry.parse_mode);
+    let ParseResult {
+        ast,
+        errors,
+        file_comment,
+    } = parse_result;
+
+    if status != EntryParseStatus::Failed {
         if entry.filename.ends_with("_test.lis") {
             sink.push(diagnostics::module_graph::wrong_test_file_suffix(
                 &entry.display_path,
@@ -194,15 +254,55 @@ fn register_entry_file(
                 &entry.display_path,
             ));
         }
-        store.store_entry_file(
-            &entry.filename,
-            &entry.display_path,
-            &entry.source,
-            entry.ast,
-            entry.file_comment,
-        );
-        entry.filename
-    })
+    }
+    store.store_entry_file(
+        &entry.filename,
+        &entry.display_path,
+        &entry.source,
+        ast,
+        file_comment,
+    );
+
+    EntryRegistration {
+        filename: Some(entry.filename),
+        errors,
+        status,
+    }
+}
+
+fn parse_entry_file(source: &str, mode: EntryParseMode) -> (ParseResult, EntryParseStatus) {
+    match mode {
+        EntryParseMode::Strict => {
+            let result = syntax::build_ast(source, ENTRY_FILE_ID);
+            let status = if result.failed() {
+                EntryParseStatus::Failed
+            } else {
+                EntryParseStatus::Clean
+            };
+            (result, status)
+        }
+        EntryParseMode::Recover => {
+            let lex_result = Lexer::new(source, ENTRY_FILE_ID).lex();
+            if lex_result.failed() {
+                return (
+                    ParseResult {
+                        ast: Vec::new(),
+                        errors: lex_result.errors,
+                        file_comment: None,
+                    },
+                    EntryParseStatus::Failed,
+                );
+            }
+
+            let result = Parser::new(lex_result.tokens, source).parse();
+            let status = if result.failed() {
+                EntryParseStatus::Recovered
+            } else {
+                EntryParseStatus::Clean
+            };
+            (result, status)
+        }
+    }
 }
 
 /// Loads every other `.lis` file in the entry module's folder as a sibling file.
@@ -536,13 +636,28 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     let include_tests = input.compile_phase.includes_tests();
 
     store.init_entry_module();
-    let entry_filename = register_entry_file(&mut store, &sink, input.entry, include_tests);
+    let entry = register_entry_file(&mut store, &sink, input.entry, include_tests);
+    if entry.status == EntryParseStatus::Failed {
+        let checker = TaskState::with_sink(sink);
+        return InferenceOutput {
+            store,
+            facts: checker.facts,
+            sink: checker.sink,
+            has_pre_check_errors: true,
+            compiled_modules: Vec::new(),
+            cached_modules: HashSet::default(),
+            cache_root: None,
+            unreachable_modules: Vec::new(),
+            entry_parse_errors: entry.errors,
+            entry_parse_status: entry.status,
+        };
+    }
     if input.config.load_siblings {
         load_sibling_files(
             &mut store,
             &sink,
             input.loader,
-            entry_filename.as_deref(),
+            entry.filename.as_deref(),
             include_tests,
         );
     }
@@ -616,6 +731,8 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         cached_modules: module_output.cached_modules,
         cache_root,
         unreachable_modules,
+        entry_parse_errors: entry.errors,
+        entry_parse_status: entry.status,
     }
 }
 
@@ -869,4 +986,48 @@ fn registration_waves(modules: &[String], dependencies: &DependencyGraph) -> Vec
         waves[wave].push(module_id.clone());
     }
     waves
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_entry_parsing_rejects_partial_ast() {
+        let (result, status) =
+            parse_entry_file("fn valid() {}\nfn incomplete(", EntryParseMode::Strict);
+
+        assert_eq!(
+            (status, result.ast.is_empty()),
+            (EntryParseStatus::Failed, true)
+        );
+    }
+
+    #[test]
+    fn recovering_entry_parsing_keeps_partial_ast() {
+        let (result, status) =
+            parse_entry_file("fn valid() {}\nfn incomplete(", EntryParseMode::Recover);
+
+        assert_eq!(
+            (status, result.ast.is_empty()),
+            (EntryParseStatus::Recovered, false)
+        );
+    }
+
+    #[test]
+    fn recovering_entry_parsing_still_rejects_lex_errors() {
+        let (result, status) =
+            parse_entry_file("fn main() { \"unterminated }", EntryParseMode::Recover);
+
+        assert_eq!(
+            (
+                status,
+                result
+                    .errors
+                    .first()
+                    .is_some_and(|error| error.code.starts_with("lex.")),
+            ),
+            (EntryParseStatus::Failed, true)
+        );
+    }
 }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -12,7 +12,7 @@ use syntax::program::{
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
 pub use syntax::ENTRY_MODULE_ID;
-const ENTRY_FILE_ID: u32 = 0;
+pub(crate) const ENTRY_FILE_ID: u32 = 0;
 
 #[derive(Debug, Clone)]
 pub struct ClosedMember {

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -6,14 +6,12 @@
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-use std::sync::Arc;
-
 use lisette_semantics::loader::MemoryLoader;
 use lisette_passes::analyze;
 use lisette_semantics::inference::{
     AnalyzeInput, CompilePhase, EntryFile, ProjectKind, SemanticConfig,
 };
-use lisette_semantics::facts::{BindingIdAllocator, Facts};
+use lisette_semantics::facts::Facts;
 use lisette_syntax::ast::{Expression, IdentifierResolution, Span};
 use lisette_syntax::program::{Definition, DefinitionBody};
 use lisette_syntax::types::{Type, unqualified_name};
@@ -179,26 +177,6 @@ struct AnalysisResult {
 
 /// Run parse + semantic analysis, returning the full result for IDE features.
 fn run_analysis(code: &str) -> AnalysisResult {
-    let ast_result = lisette_syntax::build_ast(code, 0);
-
-    let mut diagnostics: Vec<JsDiagnostic> = ast_result
-        .errors
-        .iter()
-        .map(|e| convert_parse_error(e, code))
-        .collect();
-
-    if ast_result.failed() {
-        return AnalysisResult {
-            sem_result: lisette_diagnostics::SemanticResult::with_parse_errors(
-                ast_result.errors,
-                "_entry_",
-            ),
-            facts: Facts::new(Arc::new(BindingIdAllocator::default())),
-            diagnostics,
-            has_parse_errors: true,
-        };
-    }
-
     let mut loader = MemoryLoader::new();
     loader.add_file("_entry_", PLAYGROUND_FILE, code);
 
@@ -209,13 +187,11 @@ fn run_analysis(code: &str) -> AnalysisResult {
             load_siblings: false,
         },
         loader: &loader,
-        entry: Some(EntryFile {
-            source: code.to_string(),
-            filename: PLAYGROUND_FILE.to_string(),
-            display_path: PLAYGROUND_FILE.to_string(),
-            ast: ast_result.ast,
-            file_comment: ast_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            code.to_string(),
+            PLAYGROUND_FILE.to_string(),
+            PLAYGROUND_FILE.to_string(),
+        )),
         project_root: None,
         locator: lisette_deps::TypedefLocator::default(),
         compile_phase: CompilePhase::Check,
@@ -225,21 +201,29 @@ fn run_analysis(code: &str) -> AnalysisResult {
     };
 
     let analyze_output = analyze(input);
+    let has_parse_errors = analyze_output.has_parse_errors();
+    let mut diagnostics: Vec<JsDiagnostic> = analyze_output
+        .parse_errors()
+        .iter()
+        .map(|error| convert_parse_error(error, code))
+        .collect();
     let sem_result = analyze_output.result;
     let facts = analyze_output.facts;
 
-    for e in sem_result.errors() {
-        diagnostics.push(convert_lisette_diag(e, code));
-    }
-    for w in sem_result.lints() {
-        diagnostics.push(convert_lisette_diag(w, code));
+    if !has_parse_errors {
+        for e in sem_result.errors() {
+            diagnostics.push(convert_lisette_diag(e, code));
+        }
+        for w in sem_result.lints() {
+            diagnostics.push(convert_lisette_diag(w, code));
+        }
     }
 
     AnalysisResult {
         sem_result,
         facts,
         diagnostics,
-        has_parse_errors: false,
+        has_parse_errors,
     }
 }
 
@@ -247,18 +231,6 @@ fn run_pipeline(
     code: &str,
     phase: CompilePhase,
 ) -> (Vec<lisette_emit::OutputFile>, Vec<JsDiagnostic>) {
-    let ast_result = lisette_syntax::build_ast(code, 0);
-
-    let mut diagnostics: Vec<JsDiagnostic> = ast_result
-        .errors
-        .iter()
-        .map(|e| convert_parse_error(e, code))
-        .collect();
-
-    if ast_result.failed() {
-        return (vec![], diagnostics);
-    }
-
     let mut loader = MemoryLoader::new();
     loader.add_file("_entry_", PLAYGROUND_FILE, code);
 
@@ -269,13 +241,11 @@ fn run_pipeline(
             load_siblings: false,
         },
         loader: &loader,
-        entry: Some(EntryFile {
-            source: code.to_string(),
-            filename: PLAYGROUND_FILE.to_string(),
-            display_path: PLAYGROUND_FILE.to_string(),
-            ast: ast_result.ast,
-            file_comment: ast_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            code.to_string(),
+            PLAYGROUND_FILE.to_string(),
+            PLAYGROUND_FILE.to_string(),
+        )),
         project_root: None,
         compile_phase: phase.clone(),
         project_kind: ProjectKind::Binary,
@@ -284,7 +254,16 @@ fn run_pipeline(
         disable_cache: false,
     };
 
-    let sem_result = analyze(input).result;
+    let analyze_output = analyze(input);
+    let mut diagnostics: Vec<JsDiagnostic> = analyze_output
+        .parse_errors()
+        .iter()
+        .map(|error| convert_parse_error(error, code))
+        .collect();
+    if analyze_output.has_parse_errors() {
+        return (Vec::new(), diagnostics);
+    }
+    let sem_result = analyze_output.result;
 
     for e in sem_result.errors() {
         diagnostics.push(convert_lisette_diag(e, code));

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -13,8 +13,6 @@ use semantics::store::ENTRY_MODULE_ID;
 use super::render_lis::{QuestionSpans, render_lis_declarations, render_lis_questions};
 use super::scenario::Scenario;
 
-const ENTRY_FILE_ID: u32 = 0;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
     Resolves,
@@ -142,14 +140,6 @@ struct Checked {
 
 /// Compile a self-contained Lisette source through the real checker.
 fn check(source: &str) -> Checked {
-    let build = syntax::build_ast(source, ENTRY_FILE_ID);
-    if build.failed() {
-        return Checked {
-            parse_failed: true,
-            errors: vec![],
-        };
-    }
-
     let mut loader = MemoryLoader::new();
     loader.add_file(ENTRY_MODULE_ID, "main.lis", source);
 
@@ -160,13 +150,11 @@ fn check(source: &str) -> Checked {
             load_siblings: true,
         },
         loader: &loader,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build.ast,
-            file_comment: build.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         locator: TypedefLocator::default(),
         compile_phase: CompilePhase::Check,
@@ -175,9 +163,14 @@ fn check(source: &str) -> Checked {
         disable_cache: true,
     });
 
+    let parse_failed = output.has_parse_errors();
     Checked {
-        parse_failed: false,
-        errors: output.result.errors().to_vec(),
+        parse_failed,
+        errors: if parse_failed {
+            Vec::new()
+        } else {
+            output.result.errors().to_vec()
+        },
     }
 }
 

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -18,7 +18,6 @@ use super::scenario::{
     EdgeKind, MemberType, NodeId, NodeKind, Question, Receiver, Scenario, Visibility,
 };
 
-const ENTRY_FILE_ID: u32 = 0;
 const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
 
 #[derive(Debug)]
@@ -180,11 +179,6 @@ fn emit_and_write(
 ) -> Result<Emit, String> {
     let module = format!("lisette/embed_emitted_{}", scenario.name);
     let lisette = render_lis_run(scenario, printed);
-    let build = syntax::build_ast(&lisette, ENTRY_FILE_ID);
-    if build.failed() {
-        return Ok(Emit::NotRunnable(vec!["parse".to_string()]));
-    }
-
     let mut loader = MemoryLoader::new();
     loader.add_file(ENTRY_MODULE_ID, "main.lis", &lisette);
     let output = analyze(AnalyzeInput {
@@ -194,13 +188,11 @@ fn emit_and_write(
             load_siblings: true,
         },
         loader: &loader,
-        entry: Some(EntryFile {
-            source: lisette.clone(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build.ast,
-            file_comment: build.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            lisette.clone(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         locator: TypedefLocator::default(),
         compile_phase: CompilePhase::Emit,
@@ -208,6 +200,9 @@ fn emit_and_write(
         go_module: module.clone(),
         disable_cache: true,
     });
+    if output.has_parse_errors() {
+        return Ok(Emit::NotRunnable(vec!["parse".to_string()]));
+    }
     let result = output.result;
     if !result.errors().is_empty() {
         let codes = result

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -7,8 +7,6 @@ use semantics::store::ENTRY_MODULE_ID;
 
 use super::filesystem::MockFileSystem;
 
-const ENTRY_FILE_ID: u32 = 0;
-
 fn compile_with(
     fs: MockFileSystem,
     config: SemanticConfig,
@@ -20,21 +18,14 @@ fn compile_with(
         .map(|c| c.source.clone())
         .expect("main.lis must exist");
 
-    let build_result = syntax::build_ast(&main_source, ENTRY_FILE_ID);
-    if build_result.failed() {
-        return SemanticResult::with_parse_errors(build_result.errors, ENTRY_MODULE_ID);
-    }
-
     analyze(AnalyzeInput {
         config,
         loader: &fs,
-        entry: Some(EntryFile {
-            source: main_source,
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build_result.ast,
-            file_comment: build_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            main_source,
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         locator,
         compile_phase: semantics::inference::CompilePhase::Check,
@@ -68,11 +59,6 @@ pub fn compile_standalone_entry(
         .map(|c| c.source.clone())
         .unwrap_or_else(|| panic!("entry file `{entry_name}` must exist"));
 
-    let build_result = syntax::build_ast(&source, ENTRY_FILE_ID);
-    if build_result.failed() {
-        return SemanticResult::with_parse_errors(build_result.errors, ENTRY_MODULE_ID);
-    }
-
     analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
@@ -80,13 +66,11 @@ pub fn compile_standalone_entry(
             load_siblings: false,
         },
         loader: &fs,
-        entry: Some(EntryFile {
+        entry: Some(EntryFile::new(
             source,
-            filename: entry_name.to_string(),
-            display_path: entry_name.to_string(),
-            ast: build_result.ast,
-            file_comment: build_result.file_comment,
-        }),
+            entry_name.to_string(),
+            entry_name.to_string(),
+        )),
         project_root: None,
         locator: deps::TypedefLocator::default(),
         compile_phase: phase,
@@ -156,13 +140,6 @@ pub fn compile_project_files_with_tests(
         .map(|c| c.source.clone())
         .expect("main.lis must exist");
 
-    let build_result = syntax::build_ast(&main_source, ENTRY_FILE_ID);
-    assert!(
-        !build_result.failed(),
-        "Expected no parse errors, got: {:?}",
-        build_result.errors
-    );
-
     let analyze_output = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
@@ -170,13 +147,11 @@ pub fn compile_project_files_with_tests(
             load_siblings: true,
         },
         loader: &fs,
-        entry: Some(EntryFile {
-            source: main_source,
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build_result.ast,
-            file_comment: build_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            main_source,
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         locator: deps::TypedefLocator::default(),
         compile_phase: if emit_tests {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -316,7 +316,6 @@ fn check_analyzes_orphan_and_surfaces_its_error() {
     );
 
     let source = "import \"lib\"\n\nfn main() {\n  let _ = lib.f()\n}\n";
-    let build = syntax::build_ast(source, 0);
     let output = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
@@ -324,13 +323,11 @@ fn check_analyzes_orphan_and_surfaces_its_error() {
             load_siblings: false,
         },
         loader: &fs,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build.ast,
-            file_comment: build.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: Some(tmp.path().to_path_buf()),
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
@@ -372,7 +369,6 @@ fn check_analyzes_tests_in_declaration_only_module() {
     );
 
     let source = "fn main() {}\n";
-    let build = syntax::build_ast(source, 0);
     let output = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: true,
@@ -380,13 +376,11 @@ fn check_analyzes_tests_in_declaration_only_module() {
             load_siblings: false,
         },
         loader: &fs,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build.ast,
-            file_comment: build.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: Some(tmp.path().to_path_buf()),
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
@@ -732,7 +726,6 @@ fn main() {
 
     let no_loader = MemoryLoader::new();
 
-    let build_result = syntax::build_ast(source, 0);
     let result = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: false,
@@ -740,13 +733,11 @@ fn main() {
             load_siblings: false,
         },
         loader: &no_loader,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build_result.ast,
-            file_comment: build_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
@@ -824,8 +815,6 @@ fn main() {
 
     let no_loader = MemoryLoader::new();
 
-    let build_result = syntax::build_ast(source, 0);
-
     let result1 = analyze(AnalyzeInput {
         config: SemanticConfig {
             run_lints: false,
@@ -833,13 +822,11 @@ fn main() {
             load_siblings: false,
         },
         loader: &no_loader,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build_result.ast.clone(),
-            file_comment: build_result.file_comment.clone(),
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,
@@ -862,13 +849,11 @@ fn main() {
             load_siblings: false,
         },
         loader: &no_loader,
-        entry: Some(EntryFile {
-            source: source.to_string(),
-            filename: "main.lis".to_string(),
-            display_path: "main.lis".to_string(),
-            ast: build_result.ast,
-            file_comment: build_result.file_comment,
-        }),
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
         project_root: None,
         compile_phase: CompilePhase::Check,
         project_kind: semantics::inference::ProjectKind::Binary,


### PR DESCRIPTION
Moves entry-file parsing into the analysis stage of the pipeline. Preserves strict batch parsing and recoverable LSP parsing while removing duplicated parsing logic across the CLI, LSP, playground, and test harness.