### PR TITLE
fix: extend SSA mutation derivation to interface dispatch

### DIFF
--- a/bindgen/internal/convert/mutation.go
+++ b/bindgen/internal/convert/mutation.go
@@ -290,8 +290,12 @@ func (a *MutationAnalysis) recordCallWrites(fn *ssa.Function, common *ssa.CallCo
 		}
 		return
 	}
-	// A dynamic call has no body to consult, and a bodiless callee summarizes as
-	// writing nothing. Assuming otherwise for either was measured and rejected.
+	if common.IsInvoke() {
+		if isReceiverMutationAxiom(common.Method) {
+			markRoots(fn, common.Value, summary)
+		}
+		return
+	}
 	callee := common.StaticCallee()
 	if callee == nil {
 		return
@@ -302,6 +306,13 @@ func (a *MutationAnalysis) recordCallWrites(fn *ssa.Function, common *ssa.CallCo
 			resumeWalk(fn, common.Args[index], summary, mode)
 		}
 	}
+}
+
+func isReceiverMutationAxiom(method *types.Func) bool {
+	if method == nil || method.Pkg() == nil {
+		return false
+	}
+	return method.Pkg().Path() == "sort" && qualifiedFunctionName(method) == "Interface.Swap"
 }
 
 func markRoots(fn *ssa.Function, value ssa.Value, summary *mutationSummary) {

--- a/bindgen/internal/convert/mutation_test.go
+++ b/bindgen/internal/convert/mutation_test.go
@@ -406,6 +406,28 @@ func (h *Holder) Absorb(src []int)   { h.items = src }
 	assertMutates(t, verdicts["Absorb"])
 }
 
+func receiverMutations(t *testing.T, analysis *MutationAnalysis, pkg *packages.Package, typeName string) map[string]bool {
+	t.Helper()
+	named := pkg.Types.Scope().Lookup(typeName).(*types.TypeName).Type().(*types.Named)
+	out := map[string]bool{}
+	for i := 0; i < named.NumMethods(); i++ {
+		method := named.Method(i)
+		facts, ok := analysis.Function(method)
+		if !ok {
+			t.Fatalf("no verdict for %q", method.Name())
+		}
+		out[method.Name()] = facts.ReceiverMutates
+	}
+	return out
+}
+
+func assertReceiverMutates(t *testing.T, mutates map[string]bool, method string, want bool) {
+	t.Helper()
+	if mutates[method] != want {
+		t.Errorf("%s: ReceiverMutates = %v, want %v", method, mutates[method], want)
+	}
+}
+
 func TestMutationReportsReceiverMutates(t *testing.T) {
 	analysis, pkg := analyzeSource(t, `
 type Values map[string][]string
@@ -413,22 +435,43 @@ type Values map[string][]string
 func (v Values) Set(key, value string) { v[key] = []string{value} }
 func (v Values) Get(key string) string { return v[key][0] }
 `)
-	named := pkg.Types.Scope().Lookup("Values").(*types.TypeName).Type().(*types.Named)
-	receiverMutates := map[string]bool{}
-	for i := 0; i < named.NumMethods(); i++ {
-		method := named.Method(i)
-		facts, ok := analysis.Function(method)
-		if !ok {
-			t.Fatalf("no verdict for %q", method.Name())
-		}
-		receiverMutates[method.Name()] = facts.ReceiverMutates
-	}
-	if !receiverMutates["Set"] {
-		t.Errorf("Set: ReceiverMutates = false, want true")
-	}
-	if receiverMutates["Get"] {
-		t.Errorf("Get: ReceiverMutates = true, want false")
-	}
+	mutates := receiverMutations(t, analysis, pkg, "Values")
+	assertReceiverMutates(t, mutates, "Set", true)
+	assertReceiverMutates(t, mutates, "Get", false)
+}
+
+func TestMutationSeesSortInterfaceDelegation(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+import "sort"
+
+type Numbers []int
+
+func (x Numbers) Len() int           { return len(x) }
+func (x Numbers) Less(i, j int) bool { return x[i] < x[j] }
+func (x Numbers) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+func (x Numbers) Sort()              { sort.Sort(x) }
+func (x Numbers) Stable()            { sort.Stable(x) }
+func (x Numbers) Sorted() bool       { return sort.IsSorted(x) }
+`)
+	mutates := receiverMutations(t, analysis, pkg, "Numbers")
+	assertReceiverMutates(t, mutates, "Sort", true)
+	assertReceiverMutates(t, mutates, "Stable", true)
+	assertReceiverMutates(t, mutates, "Sorted", false)
+	assertReceiverMutates(t, mutates, "Len", false)
+}
+
+func TestMutationKeepsUncuratedDispatchOpaque(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Sink interface{ Absorb([]int) }
+
+type Batch []int
+
+func (b Batch) Drain(s Sink) { s.Absorb(b) }
+
+func Forward(s Sink, xs []int) { s.Absorb(xs) }
+`)
+	assertReceiverMutates(t, receiverMutations(t, analysis, pkg, "Batch"), "Drain", false)
+	assertMutates(t, mutatedParams(t, analysis, pkg, "Forward"))
 }
 
 func TestIsMutableParamCombinesSignals(t *testing.T) {

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -457,6 +457,9 @@ func (e *Emitter) emitMethodInImpl(result convert.ConvertResult, recvName string
 	if result.CommaOk {
 		e.buf.WriteString("  #[go(comma_ok)]\n")
 	}
+	if result.Receiver != nil && result.Receiver.Mutable && !result.Receiver.IsPointer {
+		e.buf.WriteString("  #[go(value_method_set)]\n")
+	}
 	if result.SentinelInt != nil {
 		e.buf.WriteString("  " + sentinelFlag(*result.SentinelInt) + "\n")
 	}

--- a/bindgen/tests/testdata/fixtures/receiver_mutation/receiver_mutation.go
+++ b/bindgen/tests/testdata/fixtures/receiver_mutation/receiver_mutation.go
@@ -1,5 +1,7 @@
 package receivermutation
 
+import "sort"
+
 type Values map[string][]string
 
 func (v Values) Set(key, value string) { v[key] = []string{value} }
@@ -13,3 +15,11 @@ func (c Counter) Value() int { return c.n }
 type Buffer struct{ data []byte }
 
 func (b *Buffer) Append(p []byte) { b.data = append(b.data, p...) }
+
+type Numbers []int
+
+func (x Numbers) Len() int           { return len(x) }
+func (x Numbers) Less(i, j int) bool { return x[i] < x[j] }
+func (x Numbers) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+func (x Numbers) Sort()              { sort.Sort(x) }
+func (x Numbers) Sorted() bool       { return sort.IsSorted(x) }

--- a/bindgen/tests/testdata/snapshots/receiver_mutation.d.lis
+++ b/bindgen/tests/testdata/snapshots/receiver_mutation.d.lis
@@ -8,6 +8,8 @@ pub type Buffer
 
 pub type Counter
 
+pub struct Numbers(Slice<int>)
+
 pub struct Values(Map<string, Slice<string>>)
 
 impl Buffer {
@@ -19,7 +21,18 @@ impl Counter {
   fn Value(self) -> int
 }
 
+impl Numbers {
+  fn Len(self) -> int
+  fn Less(self, i: int, j: int) -> bool
+  #[go(value_method_set)]
+  fn Sort(self: Ref<Numbers>)
+  fn Sorted(self) -> bool
+  #[go(value_method_set)]
+  fn Swap(self: Ref<Numbers>, i: int, j: int)
+}
+
 impl Values {
   fn Get(self, key: string) -> string
+  #[go(value_method_set)]
   fn Set(self: Ref<Values>, key: string, value: string)
 }

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -61,6 +61,30 @@ fn method_comma_ok(store: &Store, type_id: &str, method: &str) -> bool {
 }
 
 impl InferCtx<'_> {
+    fn method_in_value_method_set(&self, receiver: &Type, method: &str) -> bool {
+        let store = self.store;
+        let resolved = store.deep_resolve_alias(&receiver.strip_refs().resolve_in(&self.env));
+        let Some(id) = resolved.get_qualified_id() else {
+            return false;
+        };
+        let owner = if store.get_definition(&format!("{id}.{method}")).is_some() {
+            id.to_string()
+        } else {
+            match crate::checker::promotion::resolve_selector(store, &resolved, method) {
+                crate::checker::promotion::Resolution::Found(member) => {
+                    member.declaring_type.to_string()
+                }
+                _ => return false,
+            }
+        };
+        if !owner.starts_with(GO_IMPORT_PREFIX) {
+            return false;
+        }
+        store
+            .get_definition(&format!("{owner}.{method}"))
+            .is_some_and(|def| def.go_hints().iter().any(|h| h == "value_method_set"))
+    }
+
     pub(crate) fn check_concrete_bound(&mut self, ty: &Type, bound: &Type, span: &Span) {
         let bound = self.store.deep_resolve_alias(bound);
         let Type::Nominal { id, params, .. } = bound else {
@@ -306,6 +330,7 @@ impl InferCtx<'_> {
                 };
                 if let Type::Function(f) = func
                     && f.params.first().is_some_and(|param| param.ty.is_ref())
+                    && !self.method_in_value_method_set(check.receiver, impl_name)
                 {
                     check.found.push(impl_name.to_string());
                 }

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -213,6 +213,7 @@ const KNOWN_GO_HINTS: &[&str] = &[
     "hidden_fields",
     "sentinel_minus_one",
     "unexported",
+    "value_method_set",
     "zero_safe",
 ];
 

--- a/crates/stdlib/typedefs/go/ast.d.lis
+++ b/crates/stdlib/typedefs/go/ast.d.lis
@@ -1002,6 +1002,7 @@ impl CommentMap {
   /// Update replaces an old node in the comment map with the new node
   /// and returns the new node. Comments that were associated with the
   /// old node are associated with the new node.
+  #[go(value_method_set)]
   fn Update(self: Ref<CommentMap>, old: Node, new: Node) -> Node
 }
 

--- a/crates/stdlib/typedefs/go/scanner.d.lis
+++ b/crates/stdlib/typedefs/go/scanner.d.lis
@@ -74,8 +74,10 @@ impl ErrorList {
   /// Sort sorts an [ErrorList]. *[Error] entries are sorted by position,
   /// other errors are sorted by error message, and before any *[Error]
   /// entry.
-  fn Sort(self)
+  #[go(value_method_set)]
+  fn Sort(self: Ref<ErrorList>)
 
+  #[go(value_method_set)]
   fn Swap(self: Ref<ErrorList>, i: int, j: int)
 }
 

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -1732,6 +1732,7 @@ impl Header {
   /// It appends to any existing values associated with key.
   /// The key is case insensitive; it is canonicalized by
   /// [CanonicalHeaderKey].
+  #[go(value_method_set)]
   fn Add(self: Ref<Header>, key: string, value: string)
 
   /// Clone returns a copy of h or nil if h is nil.
@@ -1740,6 +1741,7 @@ impl Header {
   /// Del deletes the values associated with key.
   /// The key is case insensitive; it is canonicalized by
   /// [CanonicalHeaderKey].
+  #[go(value_method_set)]
   fn Del(self: Ref<Header>, key: string)
 
   /// Get gets the first value associated with the given key. If
@@ -1755,6 +1757,7 @@ impl Header {
   /// associated with key. The key is case insensitive; it is
   /// canonicalized by [textproto.CanonicalMIMEHeaderKey].
   /// To use non-canonical keys, assign to the map directly.
+  #[go(value_method_set)]
   fn Set(self: Ref<Header>, key: string, value: string)
 
   /// Values returns all values associated with the given key.

--- a/crates/stdlib/typedefs/net/textproto.d.lis
+++ b/crates/stdlib/typedefs/net/textproto.d.lis
@@ -137,9 +137,11 @@ impl Error {
 impl MIMEHeader {
   /// Add adds the key, value pair to the header.
   /// It appends to any existing values associated with key.
+  #[go(value_method_set)]
   fn Add(self: Ref<MIMEHeader>, key: string, value: string)
 
   /// Del deletes the values associated with key.
+  #[go(value_method_set)]
   fn Del(self: Ref<MIMEHeader>, key: string)
 
   /// Get gets the first value associated with the given key.
@@ -152,6 +154,7 @@ impl MIMEHeader {
   /// Set sets the header entries associated with key to
   /// the single element value. It replaces any existing
   /// values associated with key.
+  #[go(value_method_set)]
   fn Set(self: Ref<MIMEHeader>, key: string, value: string)
 
   /// Values returns all values associated with the given key.

--- a/crates/stdlib/typedefs/net/url.d.lis
+++ b/crates/stdlib/typedefs/net/url.d.lis
@@ -268,9 +268,11 @@ impl Userinfo {
 impl Values {
   /// Add adds the value to key. It appends to any existing
   /// values associated with key.
+  #[go(value_method_set)]
   fn Add(self: Ref<Values>, key: string, value: string)
 
   /// Del deletes the values associated with key.
+  #[go(value_method_set)]
   fn Del(self: Ref<Values>, key: string)
 
   /// Encode encodes the values into “URL encoded” form
@@ -288,5 +290,6 @@ impl Values {
 
   /// Set sets the key to value. It replaces any existing
   /// values.
+  #[go(value_method_set)]
   fn Set(self: Ref<Values>, key: string, value: string)
 }

--- a/crates/stdlib/typedefs/reflect.d.lis
+++ b/crates/stdlib/typedefs/reflect.d.lis
@@ -690,6 +690,7 @@ impl Value {
   /// 
   /// It panics if v's Kind is not a [Slice], or if n is negative or too large to
   /// allocate the memory, or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn Grow(self: Ref<Value>, n: int)
 
   /// Index returns v's i'th element.
@@ -874,36 +875,43 @@ impl Value {
   /// It panics if [Value.CanSet] returns false.
   /// As in Go, x's value must be assignable to v's type and
   /// must not be derived from an unexported field.
+  #[go(value_method_set)]
   fn Set(self: Ref<Value>, x: Value)
 
   /// SetBool sets v's underlying value.
   /// It panics if v's Kind is not [Bool] or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetBool(self: Ref<Value>, x: bool)
 
   /// SetBytes sets v's underlying value.
   /// It panics if v's underlying value is not a slice of bytes
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetBytes(self: Ref<Value>, x: Slice<byte>)
 
   /// SetCap sets v's capacity to n.
   /// It panics if v's Kind is not [Slice], or if n is smaller than the length or
   /// greater than the capacity of the slice,
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetCap(self: Ref<Value>, n: int)
 
   /// SetComplex sets v's underlying value to x.
   /// It panics if v's Kind is not [Complex64] or [Complex128],
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetComplex(self: Ref<Value>, x: complex128)
 
   /// SetFloat sets v's underlying value to x.
   /// It panics if v's Kind is not [Float32] or [Float64],
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetFloat(self: Ref<Value>, x: float64)
 
   /// SetInt sets v's underlying value to x.
   /// It panics if v's Kind is not [Int], [Int8], [Int16], [Int32], or [Int64],
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetInt(self: Ref<Value>, x: int64)
 
   /// SetIterKey assigns to v the key of iter's current map entry.
@@ -911,6 +919,7 @@ impl Value {
   /// As in Go, the key must be assignable to v's type and
   /// must not be derived from an unexported field.
   /// It panics if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetIterKey(self: Ref<Value>, iter: Ref<MapIter>)
 
   /// SetIterValue assigns to v the value of iter's current map entry.
@@ -918,12 +927,14 @@ impl Value {
   /// As in Go, the value must be assignable to v's type and
   /// must not be derived from an unexported field.
   /// It panics if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetIterValue(self: Ref<Value>, iter: Ref<MapIter>)
 
   /// SetLen sets v's length to n.
   /// It panics if v's Kind is not [Slice], or if n is negative or
   /// greater than the capacity of the slice,
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetLen(self: Ref<Value>, n: int)
 
   /// SetMapIndex sets the element associated with key in the map v to elem.
@@ -937,19 +948,23 @@ impl Value {
   /// SetPointer sets the [unsafe.Pointer] value v to x.
   /// It panics if v's Kind is not [UnsafePointer]
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetPointer(self: Ref<Value>, x: Unknown)
 
   /// SetString sets v's underlying value to x.
   /// It panics if v's Kind is not [String] or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetString(self: Ref<Value>, x: string)
 
   /// SetUint sets v's underlying value to x.
   /// It panics if v's Kind is not [Uint], [Uintptr], [Uint8], [Uint16], [Uint32], or [Uint64],
   /// or if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetUint(self: Ref<Value>, x: uint64)
 
   /// SetZero sets v to be the zero value of v's type.
   /// It panics if [Value.CanSet] returns false.
+  #[go(value_method_set)]
   fn SetZero(self: Ref<Value>)
 
   /// Slice returns v[i:j].

--- a/crates/stdlib/typedefs/sort.d.lis
+++ b/crates/stdlib/typedefs/sort.d.lis
@@ -222,8 +222,10 @@ impl Float64Slice {
   fn Search(self, x: float64) -> int
 
   /// Sort is a convenience method: x.Sort() calls Sort(x).
-  fn Sort(self)
+  #[go(value_method_set)]
+  fn Sort(self: Ref<Float64Slice>)
 
+  #[go(value_method_set)]
   fn Swap(self: Ref<Float64Slice>, i: int, j: int)
 }
 
@@ -236,8 +238,10 @@ impl IntSlice {
   fn Search(self, x: int) -> int
 
   /// Sort is a convenience method: x.Sort() calls Sort(x).
-  fn Sort(self)
+  #[go(value_method_set)]
+  fn Sort(self: Ref<IntSlice>)
 
+  #[go(value_method_set)]
   fn Swap(self: Ref<IntSlice>, i: int, j: int)
 }
 
@@ -250,7 +254,9 @@ impl StringSlice {
   fn Search(self, x: string) -> int
 
   /// Sort is a convenience method: x.Sort() calls Sort(x).
-  fn Sort(self)
+  #[go(value_method_set)]
+  fn Sort(self: Ref<StringSlice>)
 
+  #[go(value_method_set)]
   fn Swap(self: Ref<StringSlice>, i: int, j: int)
 }

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -3435,6 +3435,207 @@ fn main() {
 }
 
 #[test]
+fn go_value_receiver_satisfies_interface_by_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "go:sort"
+
+fn sort_it(i: sort.Interface) {
+  sort.Sort(i)
+}
+
+fn main() {
+  let s = sort.IntSlice([3, 1, 2])
+  sort_it(s)
+  fmt.Println(s)
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn go_pointer_receiver_still_needs_ref_for_interface() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:bytes"
+import "go:io"
+
+fn write_to(w: io.Writer) {
+  let _ = w
+}
+
+fn main() {
+  let b = bytes.Buffer {}
+  write_to(b)
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| e.code_str() == Some("infer.interface_not_implemented")),
+        "Expected interface_not_implemented error, got: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn go_promoted_value_receiver_satisfies_interface_by_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "go:sort"
+
+struct Ranking {
+  embed sort.IntSlice,
+}
+
+fn sort_it(i: sort.Interface) {
+  sort.Sort(i)
+}
+
+fn main() {
+  let r = Ranking { IntSlice: sort.IntSlice([3, 1, 2]) }
+  sort_it(r)
+  fmt.Println(r.IntSlice)
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
+fn go_promoted_pointer_receiver_still_needs_ref_for_interface() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:bytes"
+import "go:io"
+
+struct Sink {
+  embed bytes.Buffer,
+}
+
+fn write_to(w: io.Writer) {
+  let _ = w
+}
+
+fn main() {
+  let s = Sink { Buffer: bytes.Buffer {} }
+  write_to(s)
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| e.code_str() == Some("infer.interface_not_implemented")),
+        "Expected interface_not_implemented error, got: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn value_method_set_hint_ignored_outside_go_typedefs() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+pub struct Counter { pub n: int }
+
+impl Counter {
+  #[go(value_method_set)]
+  fn bump(self: Ref<Counter>) { self.n += 1 }
+}
+
+interface Bumper {
+  fn bump()
+}
+
+fn use_it(b: Bumper) { b.bump() }
+
+fn main() {
+  let mut c = Counter { n: 0 }
+  use_it(c)
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| e.code_str() == Some("infer.interface_not_implemented")),
+        "Expected interface_not_implemented error, got: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn go_delegated_receiver_mutation_rejected_with_immutable_binding() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:sort"
+
+fn main() {
+  let s = sort.IntSlice([3, 1, 2])
+  s.Sort()
+}
+"#,
+    );
+    let result = compile_check(fs);
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| e.code_str() == Some("infer.immutable")),
+        "Expected immutable error, got: {:?}",
+        result.errors()
+    );
+}
+
+#[test]
+fn go_delegated_receiver_mutation_accepted_with_let_mut() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+import "go:sort"
+
+fn main() {
+  let mut s = sort.IntSlice([3, 1, 2])
+  s.Sort()
+  fmt.Println(s)
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn unused_method_with_go_import_not_emitted() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/build/snapshots/go_delegated_receiver_mutation_accepted_with_let_mut.snap
+++ b/tests/spec/build/snapshots/go_delegated_receiver_mutation_accepted_with_let_mut.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func main() {
+	s := sort.IntSlice([]int{3, 1, 2})
+	s.Sort()
+	fmt.Println(s)
+}

--- a/tests/spec/build/snapshots/go_promoted_value_receiver_satisfies_interface_by_value.snap
+++ b/tests/spec/build/snapshots/go_promoted_value_receiver_satisfies_interface_by_value.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Ranking struct {
+	sort.IntSlice
+}
+
+func sortIt(i sort.Interface) {
+	sort.Sort(i)
+}
+
+func main() {
+	r := Ranking{IntSlice: sort.IntSlice([]int{3, 1, 2})}
+	sortIt(r)
+	fmt.Println(r.IntSlice)
+}

--- a/tests/spec/build/snapshots/go_value_receiver_satisfies_interface_by_value.snap
+++ b/tests/spec/build/snapshots/go_value_receiver_satisfies_interface_by_value.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+func sortIt(i sort.Interface) {
+	sort.Sort(i)
+}
+
+func main() {
+	s := sort.IntSlice([]int{3, 1, 2})
+	sortIt(s)
+	fmt.Println(s)
+}


### PR DESCRIPTION
Calling a Go method that mutates through a value receiver now correctly requires a `let mut` binding even when the mutation happens one call deeper, through interface dispatch.

```rs
import "go:sort"

fn main() {
  let s = sort.IntSlice([3, 1, 2])
  s.Sort() // now rejected, previously sorted an immutable
}
```

The same change also stops Lisette from mistaking a mutating value receiver for a Go pointer receiver, so a Go type whose methods Go accepts by value satisfies its interfaces by value again:

```rs
fn sort_it(i: sort.Interface) {
  sort.Sort(i)
}

fn main() {
  let mut s = sort.IntSlice([3, 1, 2])
  sort_it(s) // no longer demands &s
}
```

`bytes.Buffer` and other genuine pointer receivers keep needing `&`, as Go requires.

Follow-up to #1158