### PR TITLE
feat: diagnostic for shadowed lambda captures

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -77,6 +77,30 @@ pub fn written_but_not_read(span: &Span, name: &str) -> LisetteDiagnostic {
         )
 }
 
+pub fn shadowed_capture(
+    span: &Span,
+    outer_span: &Span,
+    name: &str,
+    is_parameter: bool,
+    is_struct_field: bool,
+) -> LisetteDiagnostic {
+    let rename = if is_struct_field {
+        format!("Rename this binding to `{}: <new name>`", name)
+    } else if is_parameter {
+        "Rename this parameter".to_string()
+    } else {
+        "Rename this binding".to_string()
+    };
+    LisetteDiagnostic::warn("Shadowed capture")
+        .with_lint_code("shadowed_capture")
+        .with_span_primary_label(span, "shadows a binding this lambda could capture")
+        .with_span_label(outer_span, "outer binding declared here")
+        .with_help(format!(
+            "{} so the outer `{}` stays readable inside the lambda",
+            rename, name
+        ))
+}
+
 pub fn dead_code(span: &Span, cause: DeadCodeCause) -> LisetteDiagnostic {
     let (code, msg) = match cause {
         DeadCodeCause::Return => ("dead_code_after_return", "Unreachable code after return"),
@@ -918,7 +942,7 @@ pub fn manual_option_zip(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Manual `zip`")
         .with_lint_code("manual_option_zip")
         .with_span_label(span, "can be simpler")
-        .with_help("Replace `a.and_then(|a| b.map(|b| (a, b)))` with `a.zip(b)`")
+        .with_help("Replace `a.and_then(|x| b.map(|y| (x, y)))` with `a.zip(b)`")
 }
 
 pub fn unnecessary_lazy_evaluations(span: &Span, lazy: &str, eager: &str) -> LisetteDiagnostic {

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
@@ -77,6 +77,7 @@ pub(crate) fn run(
         &erroring_functions,
         &mut diagnostics,
     );
+    collect_shadowed_captures(store, facts, &mut diagnostics);
     collect_dead_code(facts, &mut diagnostics);
     diagnostics.extend(pattern_lints);
     collect_overused_references(facts, &mut diagnostics);
@@ -193,6 +194,38 @@ fn collect_bindings(
             out.push(diagnostics::lint::written_but_not_read(&b.span, &b.name));
         }
     }
+}
+
+fn collect_shadowed_captures(store: &Store, facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
+    let produced: Vec<LisetteDiagnostic> = facts
+        .bindings
+        .values()
+        .filter_map(|b| {
+            let outer = b.shadows?;
+            Some(diagnostics::lint::shadowed_capture(
+                &b.span,
+                &outer,
+                &b.name,
+                b.kind.is_param(),
+                b.origin.is_struct_field(),
+            ))
+        })
+        .collect();
+    if produced.is_empty() {
+        return;
+    }
+    let reported: HashSet<u32> = produced
+        .iter()
+        .filter_map(LisetteDiagnostic::file_id)
+        .collect();
+    let allows: Vec<_> = store
+        .modules
+        .values()
+        .flat_map(|module| module.source_files())
+        .filter(|file| reported.contains(&file.id))
+        .flat_map(|file| super::suppression::collect_function_allows(&file.items))
+        .collect();
+    out.extend(super::suppression::filter_allowed(produced, &allows));
 }
 
 fn collect_dead_code(facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -264,6 +264,7 @@ impl InferCtx<'_> {
     ) -> Expression {
         let store = self.store;
         let (new_params, base_fn_ty, new_body) = self.with_scope(|this| {
+            this.scopes.mark_lambda_scope();
             let resolved_expected = expected_ty.resolve_in(&this.env);
             let expected_function = store.resolve_to_function_type(&resolved_expected);
             let expected_params = expected_function

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -193,9 +193,20 @@ impl InferCtx<'_> {
     ) {
         self.check_binding_shadows_import(&name, span, origin.is_typedef());
 
-        let binding_id = self.facts.add_binding(name.clone(), span, kind, origin);
+        let shadows = self.shadowed_capture_span(&name);
+        let binding_id = self
+            .facts
+            .add_binding(name.clone(), span, kind, origin, shadows);
         let scope = self.scopes.current_mut();
         scope.insert_binding(name, ty, binding_id, kind.is_mutable());
+    }
+
+    fn shadowed_capture_span(&self, name: &str) -> Option<Span> {
+        if name.starts_with('_') {
+            return None;
+        }
+        let shadowed = self.scopes.shadowed_capturable_binding(name)?;
+        self.facts.binding_span(shadowed)
     }
 
     fn infer_array_pattern(

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -148,6 +148,7 @@ pub struct Scope {
     values: HashMap<String, ScopedValue>,
     generics: Option<GenericContext>,
     pub(crate) fn_return_type: Option<Type>,
+    is_lambda: bool,
     deferred_map_key_checks: Vec<DeferredMapKeyCheck>,
     propagation_context: PropagationContext,
     impl_receiver_type: Option<Type>,
@@ -166,6 +167,7 @@ impl Scope {
             values: HashMap::default(),
             generics: None,
             fn_return_type: None,
+            is_lambda: false,
             deferred_map_key_checks: Vec::new(),
             propagation_context: PropagationContext::None,
             impl_receiver_type: None,
@@ -282,6 +284,24 @@ impl Scopes {
             ScopedValueKind::Binding { id, .. } => Some(id),
             ScopedValueKind::Value | ScopedValueKind::Const => None,
         }
+    }
+
+    pub(crate) fn mark_lambda_scope(&mut self) {
+        self.current_mut().is_lambda = true;
+    }
+
+    pub(crate) fn shadowed_capturable_binding(&self, name: &str) -> Option<BindingId> {
+        let mut crossed_lambda = false;
+        for scope in self.stack.iter().rev() {
+            if let Some(value) = scope.values.get(name) {
+                return match value.kind {
+                    ScopedValueKind::Binding { id, .. } if crossed_lambda => Some(id),
+                    _ => None,
+                };
+            }
+            crossed_lambda |= scope.is_lambda;
+        }
+        None
     }
 
     /// Whether resolving `name` crosses a function scope, meaning captured.

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -211,6 +211,7 @@ impl Facts {
         span: Span,
         kind: BindingKind,
         origin: BindingOrigin,
+        shadows: Option<Span>,
     ) -> BindingId {
         let id = self.allocator.reserve();
         self.bindings.insert(
@@ -222,9 +223,14 @@ impl Facts {
                 used: false,
                 mutation: None,
                 origin,
+                shadows,
             },
         );
         id
+    }
+
+    pub(crate) fn binding_span(&self, id: BindingId) -> Option<Span> {
+        self.bindings.get(&id).map(|fact| fact.span)
     }
 
     pub(crate) fn mark_used(&mut self, id: BindingId) {
@@ -397,6 +403,7 @@ pub struct BindingFact {
     pub used: bool,
     pub mutation: Option<BindingMutation>,
     pub origin: BindingOrigin,
+    pub shadows: Option<Span>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -478,6 +485,7 @@ mod tests {
                 in_typedef: false,
                 shorthand_field: false,
             },
+            None,
         );
         let b_id = b.add_binding(
             "b".into(),
@@ -487,6 +495,7 @@ mod tests {
                 in_typedef: false,
                 shorthand_field: false,
             },
+            None,
         );
         assert_ne!(a_id, b_id);
 
@@ -508,6 +517,7 @@ mod tests {
                 in_typedef: false,
                 shorthand_field: false,
             },
+            None,
         );
 
         facts.mark_alias_mutated(id);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -21766,7 +21766,7 @@ fn manual_option_zip_fires() {
 fn main() {
   let a: Option<int> = Some(1)
   let b: Option<int> = Some(2)
-  let _ = a.and_then(|a| b.map(|b| (a, b)))
+  let _ = a.and_then(|x| b.map(|y| (x, y)))
 }
 "#
     );
@@ -21779,7 +21779,7 @@ fn manual_option_zip_reversed_arguments_no_warning() {
 fn main() {
   let a: Option<int> = Some(1)
   let b: Option<int> = Some(2)
-  let _ = a.and_then(|a| b.map(|b| (b, a)))
+  let _ = a.and_then(|x| b.map(|y| (y, x)))
 }
 "#
     );
@@ -21795,7 +21795,7 @@ fn makeb() -> Option<int> {
 
 fn main() {
   let a: Option<int> = Some(1)
-  let _ = a.and_then(|a| makeb().map(|b| (a, b)))
+  let _ = a.and_then(|x| makeb().map(|y| (x, y)))
 }
 "#
     );
@@ -21807,7 +21807,7 @@ fn manual_option_zip_captured_second_no_warning() {
         r#"
 fn main() {
   let a: Option<Option<int>> = Some(Some(1))
-  let _ = a.and_then(|a| a.map(|b| (a, b)))
+  let _ = a.and_then(|x| x.map(|y| (x, y)))
 }
 "#
     );
@@ -25608,4 +25608,190 @@ fn infallible_assertion_fires_inside_compound_assert_operand() {
     }, {
         insta::assert_snapshot!(output);
     });
+}
+
+#[test]
+fn shadowed_capture_lambda_param_shadows_outer_let() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let total = 10
+  let xs = [1, 2, 3]
+  let _ = xs.fold(total, |total, x| total + x)
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_lambda_param_shadows_function_parameter() {
+    assert_lint_snapshot!(
+        r#"
+fn tally(total: int, xs: Slice<int>) -> int {
+  xs.fold(total, |total, x| total + x)
+}
+
+fn main() {
+  let _ = tally(0, [1, 2, 3])
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_nested_fold_accumulator() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let outer = [1, 2, 3]
+  let inner = [4, 5, 6]
+  let _ = outer.fold(0, |acc, x| inner.fold(acc, |acc, y| acc + x * y))
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_let_inside_lambda_body() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let scale = 2
+  let xs = [scale, 4, 6]
+  let _ = xs.map(|x| {
+    let scale = x * 10
+    scale + 1
+  })
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_block_shadowing() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let config = 1
+  if config > 0 {
+    let config = 2
+    let _ = config
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_match_arm_shadowing() {
+    assert_no_lint_warnings!(
+        r#"
+enum Shape {
+  Circle(int),
+  Square(int),
+}
+
+fn main() {
+  let size = 2
+  let shape = Shape.Circle(size)
+  let _ = match shape {
+    Shape.Circle(size) => size * 2,
+    Shape.Square(size) => size + 1,
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_same_scope_rebinding() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let used = 1
+  let used = used * 2
+  let _ = used
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_underscore_prefixed_name() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let _total = 10
+  let xs = [1, 2, 3]
+  let _ = xs.map(|_total| _total + 1)
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_top_level_function_name() {
+    assert_no_lint_warnings!(
+        r#"
+fn helper(x: int) -> int {
+  x
+}
+
+fn main() {
+  let xs = [1, 2, 3]
+  let _ = xs.map(|helper| helper + 1)
+  let _ = helper(1)
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_does_not_double_report_an_import_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("util", "util.lis", "pub fn value() -> int { 1 }\n");
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"util\"\n\nfn main() {\n  let xs = [1, 2, 3]\n  let _ = xs.map(|util| util + 1)\n  let _ = util.value()\n}\n",
+    );
+    let result = compile_check(fs);
+    assert!(
+        !result
+            .lints()
+            .iter()
+            .any(|d| d.code_str() == Some("lint.shadowed_capture")),
+        "an import alias is not a capturable binding: {:?}",
+        result.lints()
+    );
+}
+
+#[test]
+fn shadowed_capture_silenced_by_allow_attribute() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(shadowed_capture)]
+fn main() {
+  let total = 10
+  let xs = [1, 2, 3]
+  let _ = xs.fold(total, |total, x| total + x)
+}
+"#
+    );
+}
+
+#[test]
+fn shadowed_capture_silent_for_bare_block_shadowing() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let total = 1
+  {
+    let total = 2
+    let _ = total
+  }
+  let _ = total
+}
+"#
+    );
 }

--- a/tests/ui/lint/snapshots/manual_option_zip_fires.snap
+++ b/tests/ui/lint/snapshots/manual_option_zip_fires.snap
@@ -4,9 +4,9 @@ source: tests/ui/lint/mod.rs
   ● Manual `zip`
    ╭─[test.lis:5:11]
  4 │   let b: Option<int> = Some(2)
- 5 │   let _ = a.and_then(|a| b.map(|b| (a, b)))
+ 5 │   let _ = a.and_then(|x| b.map(|y| (x, y)))
    ·           ────────────────┬────────────────
    ·                           ╰── can be simpler
  6 │ }
    ╰────
-  help: Replace `a.and_then(|a| b.map(|b| (a, b)))` with `a.zip(b)` · code: [lint.manual_option_zip]
+  help: Replace `a.and_then(|x| b.map(|y| (x, y)))` with `a.zip(b)` · code: [lint.manual_option_zip]

--- a/tests/ui/lint/snapshots/shadowed_capture_lambda_param_shadows_function_parameter.snap
+++ b/tests/ui/lint/snapshots/shadowed_capture_lambda_param_shadows_function_parameter.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Shadowed capture
+   ╭─[test.lis:3:19]
+ 1 │ 
+ 2 │ fn tally(total: int, xs: Slice<int>) -> int {
+   ·          ──┬──
+   ·            ╰── outer binding declared here
+ 3 │   xs.fold(total, |total, x| total + x)
+   ·                   ──┬──
+   ·                     ╰── shadows a binding this lambda could capture
+ 4 │ }
+   ╰────
+  help: Rename this parameter so the outer `total` stays readable inside the lambda · code: [lint.shadowed_capture]

--- a/tests/ui/lint/snapshots/shadowed_capture_lambda_param_shadows_outer_let.snap
+++ b/tests/ui/lint/snapshots/shadowed_capture_lambda_param_shadows_outer_let.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Shadowed capture
+   ╭─[test.lis:5:27]
+ 2 │ fn main() {
+ 3 │   let total = 10
+   ·       ──┬──
+   ·         ╰── outer binding declared here
+ 4 │   let xs = [1, 2, 3]
+ 5 │   let _ = xs.fold(total, |total, x| total + x)
+   ·                           ──┬──
+   ·                             ╰── shadows a binding this lambda could capture
+ 6 │ }
+   ╰────
+  help: Rename this parameter so the outer `total` stays readable inside the lambda · code: [lint.shadowed_capture]

--- a/tests/ui/lint/snapshots/shadowed_capture_let_inside_lambda_body.snap
+++ b/tests/ui/lint/snapshots/shadowed_capture_let_inside_lambda_body.snap
@@ -1,0 +1,17 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Shadowed capture
+   ╭─[test.lis:6:9]
+ 2 │ fn main() {
+ 3 │   let scale = 2
+   ·       ──┬──
+   ·         ╰── outer binding declared here
+ 4 │   let xs = [scale, 4, 6]
+ 5 │   let _ = xs.map(|x| {
+ 6 │     let scale = x * 10
+   ·         ──┬──
+   ·           ╰── shadows a binding this lambda could capture
+ 7 │     scale + 1
+   ╰────
+  help: Rename this binding so the outer `scale` stays readable inside the lambda · code: [lint.shadowed_capture]

--- a/tests/ui/lint/snapshots/shadowed_capture_nested_fold_accumulator.snap
+++ b/tests/ui/lint/snapshots/shadowed_capture_nested_fold_accumulator.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Shadowed capture
+   ╭─[test.lis:5:51]
+ 4 │   let inner = [4, 5, 6]
+ 5 │   let _ = outer.fold(0, |acc, x| inner.fold(acc, |acc, y| acc + x * y))
+   ·                          ─┬─                      ─┬─
+   ·                           │                        ╰── shadows a binding this lambda could capture
+   ·                           ╰── outer binding declared here
+ 6 │ }
+   ╰────
+  help: Rename this parameter so the outer `acc` stays readable inside the lambda · code: [lint.shadowed_capture]


### PR DESCRIPTION
Adds a warning for a lambda param (or a binding inside a lambda body) that shadows an outer local the lambda could otherwise capture.

```
▲ Shadowed capture
   ╭─[test.lis:5:27]
 2 │ fn main() {
 3 │   let total = 10
   ·       ──┬──
   ·         ╰── outer binding declared here
 4 │   let xs = [1, 2, 3]
 5 │   let _ = xs.fold(total, |total, x| total + x)
   ·                           ──┬──
   ·                             ╰── shadows a binding this lambda could capture
 6 │ }
   ╰────
  help: Rename this parameter so the outer `total` stays readable inside the lambda · code: [lint.shadowed_capture]
```
