### PR TITLE
fix: adjust formatting for long control-flow headers

### DIFF
--- a/crates/format/src/formatter/expression.rs
+++ b/crates/format/src/formatter/expression.rs
@@ -360,7 +360,7 @@ impl<'a> Formatter<'a> {
         alternative: Option<&'a Expression>,
     ) -> Document<'a> {
         let if_doc = Document::str("if ")
-            .append(self.expression(condition))
+            .append(self.header_expression(condition))
             .append(" ")
             .append(self.as_inline_block(consequence));
 
@@ -387,7 +387,7 @@ impl<'a> Formatter<'a> {
         let if_let_doc = Document::str("if let ")
             .append(self.pattern(pattern))
             .append(" = ")
-            .append(self.expression(scrutinee))
+            .append(self.header_expression(scrutinee))
             .append(" ")
             .append(self.as_inline_block(consequence));
 
@@ -468,7 +468,7 @@ impl<'a> Formatter<'a> {
     ) -> Document<'a> {
         let entries = self.match_arm_entries(arms);
 
-        let header = Document::str("match ").append(self.expression(subject));
+        let header = Document::str("match ").append(self.header_expression(subject));
         let body = self.join_sibling_body(entries, span.end());
         Self::braced_body(header, body)
     }
@@ -479,7 +479,7 @@ impl<'a> Formatter<'a> {
 
     fn while_(&mut self, condition: &'a Expression, body: &'a Expression) -> Document<'a> {
         Document::str("while ")
-            .append(self.expression(condition))
+            .append(self.header_expression(condition))
             .append(" ")
             .append(self.as_block(body))
     }
@@ -493,7 +493,7 @@ impl<'a> Formatter<'a> {
         Document::str("while let ")
             .append(self.pattern(pattern))
             .append(" = ")
-            .append(self.expression(scrutinee))
+            .append(self.header_expression(scrutinee))
             .append(" ")
             .append(self.as_block(body))
     }
@@ -507,7 +507,7 @@ impl<'a> Formatter<'a> {
         Document::str("for ")
             .append(self.binding(binding))
             .append(" in ")
-            .append(self.expression(iterable))
+            .append(self.header_expression(iterable))
             .append(" ")
             .append(self.as_block(body))
     }
@@ -518,13 +518,23 @@ impl<'a> Formatter<'a> {
         left_operand: &'a Expression,
         right_operand: &'a Expression,
     ) -> Document<'a> {
-        use BinaryOperator::*;
-
-        if matches!(operator, Pipeline) {
+        if matches!(operator, BinaryOperator::Pipeline) {
             return self.pipeline(left_operand, right_operand);
         }
 
-        let operator_string = match operator {
+        self.expression(left_operand)
+            .append(" ")
+            .append(Self::binary_operator_symbol(operator))
+            .append(strict_break("", " "))
+            .append(self.expression(right_operand))
+            .group()
+            .measure_flat()
+    }
+
+    fn binary_operator_symbol(operator: &BinaryOperator) -> &'static str {
+        use BinaryOperator::*;
+
+        match operator {
             Addition => "+",
             Subtraction => "-",
             Multiplication => "*",
@@ -545,15 +555,37 @@ impl<'a> Formatter<'a> {
             And => "&&",
             Or => "||",
             Pipeline => unreachable!(),
+        }
+    }
+
+    fn header_expression(&mut self, expression: &'a Expression) -> Document<'a> {
+        let Expression::Binary {
+            operator,
+            left,
+            right,
+            ..
+        } = expression
+        else {
+            return self.expression(expression);
         };
 
-        self.expression(left_operand)
+        if matches!(operator, BinaryOperator::Pipeline) {
+            return self.expression(expression);
+        }
+
+        let start = expression.get_span().byte_offset;
+        let comments = self.comments.take_comments_before(start);
+
+        let doc = self
+            .header_expression(left)
             .append(" ")
-            .append(operator_string)
-            .append(strict_break("", " "))
-            .append(self.expression(right_operand))
+            .append(Self::binary_operator_symbol(operator))
+            .append(" ")
+            .append(self.header_expression(right))
             .group()
-            .measure_flat()
+            .measure_flat();
+
+        prepend_comments(doc, comments)
     }
 
     fn pipeline(&mut self, left: &'a Expression, right: &'a Expression) -> Document<'a> {

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -635,6 +635,55 @@ fn line_breaking_long_binary_chain() {
 }
 
 #[test]
+fn line_breaking_long_if_condition() {
+    assert_format_snapshot!(
+        "fn check(n: int, label: string) -> string { if n > 10 && n < 100 && label != \"\" && n % 2 == 0 && n != 42 && n != 7 && n > 0 { return \"yes\" } \"no\" }"
+    );
+}
+
+#[test]
+fn line_breaking_long_while_condition() {
+    assert_format_snapshot!(
+        "fn test(n: int) { while n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 { n = n + 1 } }"
+    );
+}
+
+#[test]
+fn line_breaking_long_else_if_condition() {
+    assert_format_snapshot!(
+        "fn test(n: int, m: int) -> string { if n == 1 { \"one\" } else if n > 10 && n < 100 && m != 42 && n % 2 == 0 && m != 7 && n > 0 && m > 3 { \"two\" } else { \"three\" } }"
+    );
+}
+
+#[test]
+fn line_breaking_long_if_let_scrutinee() {
+    assert_format_snapshot!(
+        "fn test() -> int { if let Some(v) = first_value + second_value + third_value + fourth_value + fifth_value { v } else { 0 } }"
+    );
+}
+
+#[test]
+fn line_breaking_long_match_subject() {
+    assert_format_snapshot!(
+        "fn test(n: int) -> string { match n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 { true => \"t\", false => \"f\" } }"
+    );
+}
+
+#[test]
+fn line_breaking_long_for_iterable() {
+    assert_format_snapshot!(
+        "fn test() { for x in first_sequence + second_sequence + third_sequence + fourth_sequence_here { print(x) } }"
+    );
+}
+
+#[test]
+fn line_breaking_long_if_condition_call_still_breaks() {
+    assert_format_snapshot!(
+        "fn test() -> int { if some_function(first_argument, second_argument, third_argument, fourth_argument) { 1 } else { 2 } }"
+    );
+}
+
+#[test]
 fn line_breaking_long_slice() {
     assert_format_snapshot!(
         "fn test() { [first_element, second_element, third_element, fourth_element, fifth_element, sixth_element] }"

--- a/tests/spec/format/snapshots/line_breaking_long_else_if_condition.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_else_if_condition.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test(n: int, m: int) -> string { if n == 1 { \"one\" } else if n > 10 && n < 100 && m != 42 && n % 2 == 0 && m != 7 && n > 0 && m > 3 { \"two\" } else { \"three\" } }"
+---
+fn test(n: int, m: int) -> string {
+  if n == 1 {
+    "one"
+  } else if n > 10 && n < 100 && m != 42 && n % 2 == 0 && m != 7 && n > 0 && m > 3 {
+    "two"
+  } else {
+    "three"
+  }
+}

--- a/tests/spec/format/snapshots/line_breaking_long_for_iterable.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_for_iterable.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() { for x in first_sequence + second_sequence + third_sequence + fourth_sequence_here { print(x) } }"
+---
+fn test() {
+  for x in first_sequence + second_sequence + third_sequence + fourth_sequence_here {
+    print(x)
+  }
+}

--- a/tests/spec/format/snapshots/line_breaking_long_if_condition.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_if_condition.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn check(n: int, label: string) -> string { if n > 10 && n < 100 && label != \"\" && n % 2 == 0 && n != 42 && n != 7 && n > 0 { return \"yes\" } \"no\" }"
+---
+fn check(n: int, label: string) -> string {
+  if n > 10 && n < 100 && label != "" && n % 2 == 0 && n != 42 && n != 7 && n > 0 {
+    return "yes"
+  }
+  "no"
+}

--- a/tests/spec/format/snapshots/line_breaking_long_if_condition_call_still_breaks.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_if_condition_call_still_breaks.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() -> int { if some_function(first_argument, second_argument, third_argument, fourth_argument) { 1 } else { 2 } }"
+---
+fn test() -> int {
+  if some_function(
+    first_argument,
+    second_argument,
+    third_argument,
+    fourth_argument,
+  ) {
+    1
+  } else {
+    2
+  }
+}

--- a/tests/spec/format/snapshots/line_breaking_long_if_let_scrutinee.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_if_let_scrutinee.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test() -> int { if let Some(v) = first_value + second_value + third_value + fourth_value + fifth_value { v } else { 0 } }"
+---
+fn test() -> int {
+  if let Some(v) = first_value + second_value + third_value + fourth_value + fifth_value {
+    v
+  } else {
+    0
+  }
+}

--- a/tests/spec/format/snapshots/line_breaking_long_match_subject.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_match_subject.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test(n: int) -> string { match n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 { true => \"t\", false => \"f\" } }"
+---
+fn test(n: int) -> string {
+  match n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 {
+    true => "t",
+    false => "f",
+  }
+}

--- a/tests/spec/format/snapshots/line_breaking_long_while_condition.snap
+++ b/tests/spec/format/snapshots/line_breaking_long_while_condition.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn test(n: int) { while n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 { n = n + 1 } }"
+---
+fn test(n: int) {
+  while n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 {
+    n = n + 1
+  }
+}


### PR DESCRIPTION
`lis format` no longer wraps the operator chain in a long control flow header, allowing the the opening brace to stay on the line that carries the keyword.

Before:

```rs
fn loops(n: int) {
  while n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 &&
  n < 9999 {
    print(n)
  }
}
```

After:

```rs
fn loops(n: int) {
  while n > 10 && n < 100 && n % 2 == 0 && n != 42 && n != 7 && n > 0 && n < 9999 {
    print(n)
  }
}
```

Such a long header may now exceed 80 cols, as it does in `gofmt`. Only the operator chain is affected, so a header that is a long call still breaks across its args.