### PR TITLE
refactor: tailor type-mismatch diagnostic to container widening

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -58,6 +58,59 @@ enum ClosureAdapter {
     Narrows,
 }
 
+/// A built-in container that holds values which can be widened into an interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WideningContainer {
+    Slice,
+    Option,
+    Result,
+    Partial,
+    Map,
+}
+
+/// What a container has to widen, and how.
+#[derive(Debug, Clone, Copy)]
+enum Widening {
+    /// `map` over every element.
+    Elements,
+    /// `map` over the single held value.
+    Value,
+    /// `map_err` over the held error.
+    Error,
+    /// No method does it, so the entries are copied over by hand.
+    Entries,
+}
+
+impl WideningContainer {
+    fn of(ty: &Type) -> Option<Self> {
+        if ty.is_slice() {
+            Some(Self::Slice)
+        } else if ty.is_option() {
+            Some(Self::Option)
+        } else if ty.is_result() {
+            Some(Self::Result)
+        } else if ty.is_partial() {
+            Some(Self::Partial)
+        } else if ty.is_map() {
+            Some(Self::Map)
+        } else {
+            None
+        }
+    }
+
+    /// How the type argument at `position` is widened, if it can be.
+    fn widening(self, position: usize) -> Option<Widening> {
+        match self {
+            Self::Slice => Some(Widening::Elements),
+            Self::Option => Some(Widening::Value),
+            Self::Result | Self::Partial if position == 0 => Some(Widening::Value),
+            Self::Result | Self::Partial => Some(Widening::Error),
+            Self::Map if position == 1 => Some(Widening::Entries),
+            Self::Map => None,
+        }
+    }
+}
+
 impl InferCtx<'_> {
     /// Make two types equal. Returns `false` when they do not match.
     ///
@@ -825,10 +878,57 @@ impl InferCtx<'_> {
             None => {}
         }
 
+        if let Some(widening) = self.container_widening_help(expected, actual) {
+            return widening;
+        }
+
         format!(
             "Change the type annotation to `{}` or convert the value to `{}`",
             actual, expected
         )
+    }
+
+    fn container_widening_help(&self, expected: &Type, actual: &Type) -> Option<String> {
+        let container = WideningContainer::of(expected)?;
+        if WideningContainer::of(actual) != Some(container) {
+            return None;
+        }
+
+        let (expected_args, actual_args) = (expected.get_type_params()?, actual.get_type_params()?);
+        if expected_args.len() != actual_args.len() {
+            return None;
+        }
+
+        let mut differing = expected_args
+            .iter()
+            .zip(actual_args)
+            .enumerate()
+            .filter(|(_, (expected_arg, actual_arg))| expected_arg != actual_arg);
+        let (position, (expected_element, actual_element)) = differing.next()?;
+        if differing.next().is_some() {
+            return None;
+        }
+
+        if !self.store.is_interface(expected_element) || !self.widens_into_interface(actual_element)
+        {
+            return None;
+        }
+
+        let cast = format!("|value| value as {expected_element}");
+        Some(match container.widening(position)? {
+            Widening::Elements => format!("Use `.map({cast})` to widen each element"),
+            Widening::Value => format!("Use `.map({cast})` to widen the value"),
+            Widening::Error => format!("Use `.map_err({cast})` to widen the error"),
+            Widening::Entries => format!(
+                "Copy the entries into a new `{expected}`, widening each value: `widened[key] = value as {expected_element}`"
+            ),
+        })
+    }
+
+    fn widens_into_interface(&self, ty: &Type) -> bool {
+        !matches!(ty, Type::Parameter(_))
+            && !self.store.is_interface(ty)
+            && !self.store.resolves_to_unknown(ty)
     }
 
     fn closure_adapter(&self, expected: &Type, actual: &Type) -> Option<ClosureAdapter> {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -2095,6 +2095,117 @@ fn unwrap(e: error) -> FooError { e }
 }
 
 #[test]
+fn infer_slice_of_concrete_where_slice_of_interface_expected() {
+    let input = r#"
+interface Animal {
+  fn speak() -> string
+}
+
+struct Cat {}
+
+impl Cat {
+  fn speak(self) -> string { "meow" }
+}
+
+fn take(animals: Slice<Animal>) -> int { animals.length() }
+
+fn test() -> int {
+  let cats: Slice<Cat> = [Cat {}]
+  take(cats)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_option_of_concrete_where_option_of_interface_expected() {
+    let input = r#"
+interface Animal {
+  fn speak() -> string
+}
+
+struct Cat {}
+
+impl Cat {
+  fn speak(self) -> string { "meow" }
+}
+
+fn take(animal: Option<Animal>) -> bool { animal.is_some() }
+
+fn test() -> bool {
+  let cat: Option<Cat> = Some(Cat {})
+  take(cat)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_result_with_concrete_error_where_error_interface_expected() {
+    let input = r#"
+struct FooError {}
+
+impl FooError {
+  fn Error(self) -> string { "foo failed" }
+}
+
+fn take(outcome: Result<int, error>) -> bool { outcome.is_ok() }
+
+fn test() -> bool {
+  let outcome: Result<int, FooError> = Ok(1)
+  take(outcome)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_of_concrete_values_where_map_of_interface_values_expected() {
+    let input = r#"
+interface Animal {
+  fn speak() -> string
+}
+
+struct Cat {}
+
+impl Cat {
+  fn speak(self) -> string { "meow" }
+}
+
+fn take(animals: Map<string, Animal>) -> int { animals.length() }
+
+fn test() -> int {
+  let cats: Map<string, Cat> = Map.new()
+  take(cats)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_slice_of_interface_where_slice_of_concrete_expected() {
+    let input = r#"
+interface Animal {
+  fn speak() -> string
+}
+
+struct Cat {}
+
+impl Cat {
+  fn speak(self) -> string { "meow" }
+}
+
+fn take(cats: Slice<Cat>) -> int { cats.length() }
+
+fn test() -> int {
+  let animals: Slice<Animal> = [Cat {}]
+  take(animals)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_called_function_when_function_alias_expected() {
     let input = r#"
 type Cmd = fn() -> int

--- a/tests/ui/errors/snapshots/infer_map_of_concrete_values_where_map_of_interface_values_expected.snap
+++ b/tests/ui/errors/snapshots/infer_map_of_concrete_values_where_map_of_interface_values_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:16:8]
+ 15 │   let cats: Map<string, Cat> = Map.new()
+ 16 │   take(cats)
+    ·        ──┬─
+    ·          ╰── expected `Map<string, Animal>`, found `Map<string, Cat>`
+ 17 │ }
+    ╰────
+  help: Copy the entries into a new `Map<string, Animal>`, widening each value: `widened[key] = value as Animal` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_option_of_concrete_where_option_of_interface_expected.snap
+++ b/tests/ui/errors/snapshots/infer_option_of_concrete_where_option_of_interface_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:16:8]
+ 15 │   let cat: Option<Cat> = Some(Cat {})
+ 16 │   take(cat)
+    ·        ─┬─
+    ·         ╰── expected `Option<Animal>`, found `Option<Cat>`
+ 17 │ }
+    ╰────
+  help: Use `.map(|value| value as Animal)` to widen the value · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_result_with_concrete_error_where_error_interface_expected.snap
+++ b/tests/ui/errors/snapshots/infer_result_with_concrete_error_where_error_interface_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:12:8]
+ 11 │   let outcome: Result<int, FooError> = Ok(1)
+ 12 │   take(outcome)
+    ·        ───┬───
+    ·           ╰── expected `Result<int, error>`, found `Result<int, FooError>`
+ 13 │ }
+    ╰────
+  help: Use `.map_err(|value| value as error)` to widen the error · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_slice_of_concrete_where_slice_of_interface_expected.snap
+++ b/tests/ui/errors/snapshots/infer_slice_of_concrete_where_slice_of_interface_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:16:8]
+ 15 │   let cats: Slice<Cat> = [Cat {}]
+ 16 │   take(cats)
+    ·        ──┬─
+    ·          ╰── expected `Slice<Animal>`, found `Slice<Cat>`
+ 17 │ }
+    ╰────
+  help: Use `.map(|value| value as Animal)` to widen each element · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_slice_of_interface_where_slice_of_concrete_expected.snap
+++ b/tests/ui/errors/snapshots/infer_slice_of_interface_where_slice_of_concrete_expected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:16:8]
+ 15 │   let animals: Slice<Animal> = [Cat {}]
+ 16 │   take(animals)
+    ·        ───┬───
+    ·           ╰── expected `Slice<Cat>`, found `Slice<Animal>`
+ 17 │ }
+    ╰────
+  help: Change the type annotation to `Slice<Animal>` or convert the value to `Slice<Cat>` · code: [infer.type_mismatch]


### PR DESCRIPTION
Type args are invariant, so passing `Slice<Cat>` where `Slice<Animal>` is expected fails. This is solvable via conversion, but the diagnostic's helptext did not name it. This makes the helptext content-sensitive:

| Container | Help |
| --- | --- |
| `Slice` | `.map(...)` to widen each element |
| `Option`, `Result`, `Partial` | `.map(...)` to widen the value |
| `Result`, `Partial` error | `.map_err(...)` to widen the error |
| `Map` | copy the entries into a new map, widening each value |

