### PR TITLE
feat: expand `lis check --output unix`

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -440,6 +440,16 @@ fn parse_check(mut arguments: impl Iterator<Item = String>) -> Result<Command, P
         });
     }
 
+    if fix && format == OutputFormat::Unix {
+        return Err(ParseError::UnexpectedArgument {
+            message: "`--fix` and `--output unix` cannot be used together".to_string(),
+            reason:
+                "`--fix` reports what it rewrote, not which diagnostics remain, so it has no per-diagnostic lines to emit"
+                    .to_string(),
+            hint: "Run `lis check --fix` first, then `lis check --output unix`".to_string(),
+        });
+    }
+
     Ok(Command::Check {
         path,
         filter,

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -289,7 +289,7 @@ fn compile_single_file(
         .unwrap_or("main.lis")
         .to_string();
     let entry_display =
-        lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| entry_name.clone());
+        lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
     let working_dir = file_path.parent().unwrap_or_else(|| Path::new("."));
 
     let result = compile_project_entry(

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -155,10 +155,10 @@ pub fn compile(
     };
 
     let mut diagnostics = analysis.take_diagnostics();
-    if !analysis.unreachable_modules.is_empty() && !emit_tests {
-        diagnostics.push(diagnostics::module_graph::unreachable_modules(
-            &analysis.unreachable_modules,
-        ));
+    if !emit_tests {
+        for module_id in &analysis.unreachable_modules {
+            diagnostics.push(diagnostics::module_graph::unreachable_module(module_id));
+        }
     }
 
     let mut sources = Sources::default();

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -95,6 +95,15 @@ fn strip_period(s: &str, strip: bool) -> &str {
     }
 }
 
+fn combine_help_and_note(help: Option<&str>, note: Option<&str>, has_code: bool) -> Option<String> {
+    match (help, note) {
+        (Some(help), Some(note)) => Some(format!("{} {}", help, strip_period(note, has_code))),
+        (Some(help), None) => Some(strip_period(help, has_code).to_string()),
+        (None, Some(note)) => Some(strip_period(note, has_code).to_string()),
+        (None, None) => None,
+    }
+}
+
 #[derive(Debug, Clone)]
 struct Label {
     span: Span,
@@ -195,6 +204,7 @@ pub struct LisetteDiagnostic {
     severity: Severity,
     code: Option<String>,
     fix: Option<crate::Fix>,
+    file_location: Option<String>,
 }
 
 impl fmt::Display for LisetteDiagnostic {
@@ -239,12 +249,7 @@ impl fmt::Display for HelpText<'_> {
         let use_color = self.use_color;
         let has_code = self.diagnostic_code.is_some();
 
-        let combined = match (self.help, self.note) {
-            (Some(h), Some(n)) => format!("{} {}", h, strip_period(n, has_code)),
-            (Some(h), None) => strip_period(h, has_code).to_string(),
-            (None, Some(n)) => strip_period(n, has_code).to_string(),
-            (None, None) => String::new(),
-        };
+        let combined = combine_help_and_note(self.help, self.note, has_code).unwrap_or_default();
 
         if !combined.is_empty() {
             if use_color {
@@ -319,6 +324,14 @@ impl LisetteDiagnostic {
         self.note.as_deref()
     }
 
+    pub fn help_and_note(&self) -> Option<String> {
+        combine_help_and_note(
+            self.help.as_deref(),
+            self.note.as_deref(),
+            self.code.is_some(),
+        )
+    }
+
     fn new(message: impl Into<String>, severity: Severity) -> Self {
         Self {
             message: message.into(),
@@ -328,6 +341,7 @@ impl LisetteDiagnostic {
             severity,
             code: None,
             fix: None,
+            file_location: None,
         }
     }
 
@@ -480,14 +494,34 @@ impl LisetteDiagnostic {
             .collect()
     }
 
-    pub fn location_offset(&self) -> Option<usize> {
+    fn location_label(&self) -> Option<&Label> {
         let file_id = self.file_id()?;
         self.labels
             .iter()
             .filter(|label| label.span.file_id == file_id)
             .find(|label| label.primary)
             .or_else(|| self.labels.first())
+    }
+
+    pub fn location_offset(&self) -> Option<usize> {
+        self.location_label()
             .map(|label| label.span.byte_offset as usize)
+    }
+
+    pub fn with_file_location(mut self, display_path: impl Into<String>) -> Self {
+        self.file_location = Some(display_path.into());
+        self
+    }
+
+    pub fn file_location(&self) -> Option<&str> {
+        self.file_location.as_deref()
+    }
+
+    pub fn located_label(&self) -> Option<&str> {
+        self.location_label()
+            .map(|label| label.text.as_str())
+            .filter(|text| !text.is_empty())
+            .or_else(|| self.plain_label())
     }
 
     pub(crate) fn severity_word(&self) -> &'static str {

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -124,12 +124,14 @@ pub fn wrong_test_file_suffix(display_path: &str) -> LisetteDiagnostic {
         display_path
     ))
     .with_resolve_code("wrong_test_file_suffix")
+    .with_file_location(display_path)
     .with_help(help)
 }
 
 pub fn non_test_file_under_tests(display_path: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("`{}` is not a test file", display_path))
         .with_resolve_code("non_test_file_under_tests")
+        .with_file_location(display_path)
         .with_help("Files under `tests/` must use the `.test.lis` suffix. Rename this file or move it into `src/`")
 }
 
@@ -139,6 +141,7 @@ pub fn cannot_emit_test_file(display_path: &str) -> LisetteDiagnostic {
         display_path
     ))
     .with_resolve_code("cannot_emit_test_file")
+    .with_file_location(display_path)
     .with_help("Test files are not entry points. Use `lis check` to type-check this file.")
 }
 
@@ -288,79 +291,14 @@ pub fn bindgen_failed(
     ))
 }
 
-pub fn unreachable_modules(module_ids: &[String]) -> LisetteDiagnostic {
-    let list = module_ids.join("` · `");
-    let (message, help) = if module_ids.len() == 1 {
-        (
-            format!("Unreachable module: `{list}`"),
-            "This module is never imported. Use or remove it.",
-        )
-    } else {
-        (
-            format!("Unreachable modules: `{list}`"),
-            "These modules are never imported. Use or remove them.",
-        )
-    };
-    LisetteDiagnostic::warn(message).with_help(help)
+pub fn unreachable_module(module_id: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn(format!("Unreachable module: `{}`", module_id))
+        .with_resolve_code("unreachable_module")
+        .with_help("This module is never imported. Use or remove it.")
 }
 
 pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
-    let modules: Vec<_> = path[..path.len() - 1].to_vec();
-
-    let is_self_import = modules.len() == 1;
-
-    let chain = if is_self_import {
-        format!("{} -> {}", modules[0], modules[0])
-    } else {
-        modules.join(" -> ")
-    };
-
-    let first_module = &modules[0];
-    let first_end = first_module.len();
-    let first_center = first_module.len() / 2;
-
-    let last_module = if is_self_import {
-        &modules[0]
-    } else {
-        modules.last().expect("cycle must have at least one module")
-    };
-    let last_start = chain.len() - last_module.len();
-    let last_end = chain.len();
-    let last_center = last_start + last_module.len() / 2;
-
-    let mut underline = String::new();
-    for i in 0..chain.len() {
-        if i < first_end {
-            if i == first_center {
-                underline.push('┬');
-            } else {
-                underline.push('─');
-            }
-        } else if i >= last_start && i < last_end {
-            if i == last_center {
-                underline.push('┬');
-            } else {
-                underline.push('─');
-            }
-        } else {
-            underline.push(' ');
-        }
-    }
-
-    let mut connect_line = String::new();
-    for i in 0..=last_center {
-        if i < first_center {
-            connect_line.push(' ');
-        } else if i == first_center {
-            connect_line.push('╰');
-        } else if i < last_center {
-            connect_line.push('─');
-        } else {
-            connect_line.push('╯');
-        }
-    }
-
-    let art = format!("{}\n{}\n{}", chain, underline, connect_line);
+    let is_self_import = path.len() == 2;
 
     let help = if is_self_import {
         "Remove the self-import"
@@ -368,7 +306,7 @@ pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
         "To break the cycle, remove one of the imports or extract common dependencies into a separate module"
     };
 
-    LisetteDiagnostic::error(format!("Import cycle detected\n\n{}", art))
+    LisetteDiagnostic::error(format!("Import cycle detected: {}", path.join(" -> ")))
         .with_resolve_code("import_cycle")
         .with_help(help)
 }
@@ -378,21 +316,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unreachable_modules_singular_is_a_spanless_warning() {
-        let diagnostic = unreachable_modules(&["orphan".to_string()]);
+    fn unreachable_module_names_one_module_and_carries_a_code() {
+        let diagnostic = unreachable_module("orphan");
         assert!(diagnostic.is_warning());
         assert_eq!(diagnostic.plain_message(), "Unreachable module: `orphan`");
-        assert_eq!(diagnostic.file_id(), None);
-        assert_eq!(diagnostic.code_str(), None);
+        assert_eq!(diagnostic.code_str(), Some("resolve.unreachable_module"));
     }
 
     #[test]
-    fn unreachable_modules_plural_joins_ids() {
-        let diagnostic = unreachable_modules(&["alpha".to_string(), "beta".to_string()]);
-        assert!(diagnostic.is_warning());
+    fn import_cycle_names_the_whole_chain_on_one_line() {
+        let cycle = ["alpha".to_string(), "beta".to_string(), "alpha".to_string()];
+
+        let diagnostic = import_cycle(&cycle);
+
         assert_eq!(
             diagnostic.plain_message(),
-            "Unreachable modules: `alpha` · `beta`"
+            "Import cycle detected: alpha -> beta -> alpha"
         );
+        assert!(!diagnostic.plain_message().contains('\n'));
+    }
+
+    #[test]
+    fn import_cycle_calls_out_a_self_import() {
+        let cycle = ["alpha".to_string(), "alpha".to_string()];
+
+        let diagnostic = import_cycle(&cycle);
+
+        assert_eq!(
+            diagnostic.plain_message(),
+            "Import cycle detected: alpha -> alpha"
+        );
+        assert_eq!(diagnostic.plain_help(), Some("Remove the self-import"));
     }
 }

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::time::Duration;
 
 use rustc_hash::FxHashMap;
@@ -351,19 +352,79 @@ pub fn render_all(
     groups.counts(file_count)
 }
 
-/// Renders one diagnostic as `file:line:col: severity: message [code]`.
+fn breaks_line(character: char) -> bool {
+    matches!(character, '\n' | '\r' | '\u{b}' | '\u{c}')
+}
+
+fn flatten_to_one_line(text: &str) -> Cow<'_, str> {
+    if !text.contains(breaks_line) {
+        return Cow::Borrowed(text);
+    }
+
+    let mut flattened = String::with_capacity(text.len());
+    let mut chars = text.char_indices().peekable();
+    while let Some((start, character)) = chars.next() {
+        if !character.is_whitespace() {
+            flattened.push(character);
+            continue;
+        }
+
+        let mut end = start + character.len_utf8();
+        while let Some(&(index, next)) = chars.peek() {
+            if !next.is_whitespace() {
+                break;
+            }
+            end = index + next.len_utf8();
+            chars.next();
+        }
+
+        let run = &text[start..end];
+        if run.contains(breaks_line) {
+            flattened.push(' ');
+        } else {
+            flattened.push_str(run);
+        }
+    }
+
+    Cow::Owned(flattened.trim().to_string())
+}
+
+/// Renders one diagnostic as `file:line:col: severity: message: label · help [code flags]`.
 pub fn unix_line(diagnostic: &LisetteDiagnostic, source: &IndexedSource, filename: &str) -> String {
     let mut line = String::new();
     if let Some(offset) = diagnostic.location_offset() {
-        let (lineno, col) = source.line_col(offset);
-        line.push_str(&format!("{}:{}:{}: ", filename, lineno, col));
+        let (lineno, column) = source.line_col(offset);
+        line.push_str(&format!(
+            "{}:{}:{}: ",
+            flatten_to_one_line(filename),
+            lineno,
+            column
+        ));
+    } else if let Some(path) = diagnostic.file_location() {
+        line.push_str(&format!("{}:1:1: ", flatten_to_one_line(path)));
     }
+
     line.push_str(diagnostic.severity_word());
     line.push_str(": ");
-    line.push_str(diagnostic.plain_message());
+    line.push_str(&flatten_to_one_line(diagnostic.plain_message()));
+
+    if let Some(label) = diagnostic.located_label() {
+        line.push_str(": ");
+        line.push_str(&flatten_to_one_line(label));
+    }
+
+    if let Some(help) = diagnostic.help_and_note() {
+        line.push_str(" · ");
+        line.push_str(&flatten_to_one_line(&help));
+    }
+
     if let Some(code) = diagnostic.code_str() {
         line.push_str(&format!(" [{}]", code));
     }
+    if diagnostic.fix().is_some() {
+        line.push_str(" [autofixable]");
+    }
+
     line
 }
 

--- a/tests/ui/errors/snapshots/module_graph_import_cycle.snap
+++ b/tests/ui/errors/snapshots/module_graph_import_cycle.snap
@@ -1,9 +1,5 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Import cycle detected
-  │
-  │ module_a -> module_b -> module_c
-  │ ────┬───                ────┬───
-  │     ╰───────────────────────╯
+  ✕ Import cycle detected: module_a -> module_b -> module_c -> module_a
   help: To break the cycle, remove one of the imports or extract common dependencies into a separate module · code: [resolve.import_cycle]

--- a/tests/ui/errors/snapshots/module_graph_import_self_loop.snap
+++ b/tests/ui/errors/snapshots/module_graph_import_self_loop.snap
@@ -1,9 +1,5 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Import cycle detected
-  │
-  │ module_a -> module_a
-  │ ────┬───    ────┬───
-  │     ╰───────────╯
+  ✕ Import cycle detected: module_a -> module_a
   help: Remove the self-import · code: [resolve.import_cycle]

--- a/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
+++ b/tests/ui/snapshots/unix_multi_label_emits_single_location.snap
@@ -1,4 +1,4 @@
 ---
 source: tests/ui/unix.rs
 ---
-src/main.lis:3:8: error: Duplicate binding [infer.duplicate_binding_in_pattern]
+src/main.lis:3:8: error: Duplicate binding: first use of `x` · Remove the duplicate binding [infer.duplicate_binding_in_pattern]

--- a/tests/ui/snapshots/unix_parse_error_shape.snap
+++ b/tests/ui/snapshots/unix_parse_error_shape.snap
@@ -1,4 +1,4 @@
 ---
 source: tests/ui/unix.rs
 ---
-src/main.lis:2:11: error: Unclosed block [parse.unclosed_block]
+src/main.lis:2:11: error: Unclosed block: opening brace here · Add a closing `}` [parse.unclosed_block]

--- a/tests/ui/unix.rs
+++ b/tests/ui/unix.rs
@@ -1,8 +1,8 @@
 use crate::_harness::formatting::{format_diagnostic_unix, format_parse_error_unix};
 use crate::_harness::infer::infer;
 
-use diagnostics::LisetteDiagnostic;
 use diagnostics::render::{self, Filter};
+use diagnostics::{Edit, Fix, LisetteDiagnostic};
 use syntax::ast::Span;
 use syntax::lex::Lexer;
 use syntax::parse::Parser;
@@ -65,7 +65,7 @@ fn unix_diagnostic_without_code_omits_bracket() {
 
     let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
 
-    assert_eq!(output, "src/main.lis:1:5: error: Custom message");
+    assert_eq!(output, "src/main.lis:1:5: error: Custom message: here");
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn unix_column_is_byte_offset_within_line() {
 
     let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
 
-    assert_eq!(output, "src/main.lis:1:7: error: Bad token");
+    assert_eq!(output, "src/main.lis:1:7: error: Bad token: here");
 }
 
 #[test]
@@ -107,4 +107,165 @@ fn test() {
         assert!(line.contains(": error: "));
     }
     assert_eq!(output.lines().count(), counts.errors);
+}
+
+#[test]
+fn unix_flattens_multi_line_help_onto_one_line() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::error("Broken")
+        .with_span_label(&span, "here")
+        .with_help("First line.\n\n  - second\n  - third");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output.lines().count(), 1);
+    assert_eq!(
+        output,
+        "src/main.lis:1:5: error: Broken: here · First line. - second - third"
+    );
+}
+
+#[test]
+fn unix_flattens_a_multi_line_message() {
+    let source = "let x = 1";
+    let diagnostic = LisetteDiagnostic::error("Import cycle detected\n\nalpha -> beta\n──┬──");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output.lines().count(), 1);
+    assert_eq!(output, "error: Import cycle detected alpha -> beta ──┬──");
+}
+
+#[test]
+fn unix_marks_a_diagnostic_that_carries_a_fix() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::warn("Removable")
+        .with_span_label(&span, "drop this")
+        .with_resolve_code("removable")
+        .with_fix(Fix::new("Remove it", Edit::deletion(span)));
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(
+        output,
+        "src/main.lis:1:5: warning: Removable: drop this [resolve.removable] [autofixable]"
+    );
+}
+
+#[test]
+fn unix_locates_a_whole_file_diagnostic_at_its_first_column() {
+    let diagnostic = LisetteDiagnostic::error("Test file `tests/thing_test.lis` is misnamed")
+        .with_resolve_code("wrong_test_file_suffix")
+        .with_file_location("tests/thing_test.lis");
+
+    let output = format_diagnostic_unix(&diagnostic, "", "src/main.lis");
+
+    assert_eq!(
+        output,
+        "tests/thing_test.lis:1:1: error: Test file `tests/thing_test.lis` is misnamed [resolve.wrong_test_file_suffix]"
+    );
+}
+
+#[test]
+fn unix_reports_only_the_start_of_a_span_that_crosses_lines() {
+    let source = "fn main() {\n  let x = 1;\n}\n";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 10,
+        byte_length: 15,
+    };
+    let diagnostic = LisetteDiagnostic::error("Spans lines").with_span_label(&span, "block");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output, "src/main.lis:1:11: error: Spans lines: block");
+}
+
+#[test]
+fn unix_renders_a_zero_length_span_at_its_position() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 0,
+    };
+    let diagnostic = LisetteDiagnostic::error("Points at a spot").with_span_label(&span, "here");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(output, "src/main.lis:1:5: error: Points at a spot: here");
+}
+
+#[test]
+fn unix_carries_the_note_alongside_the_help() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::error("Invalid or-pattern")
+        .with_span_label(&span, "here")
+        .with_resolve_code("or_pattern")
+        .with_help("Use a single binding")
+        .with_note("Or-patterns can only be used in `match`, `if let`, and `while let`.");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert_eq!(
+        output,
+        "src/main.lis:1:5: error: Invalid or-pattern: here · Use a single binding Or-patterns can only be used in `match`, `if let`, and `while let` [resolve.or_pattern]"
+    );
+}
+
+#[test]
+fn unix_flattens_a_bare_carriage_return() {
+    let source = "let x = 1";
+    let diagnostic = LisetteDiagnostic::error("Captured output:\roverwritten");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/main.lis");
+
+    assert!(!output.contains('\r'));
+    assert_eq!(output, "error: Captured output: overwritten");
+}
+
+#[test]
+fn unix_flattens_a_newline_inside_a_filename() {
+    let source = "let x = 1";
+    let span = Span {
+        file_id: 0,
+        byte_offset: 4,
+        byte_length: 1,
+    };
+    let diagnostic = LisetteDiagnostic::error("Broken").with_span_label(&span, "here");
+
+    let output = format_diagnostic_unix(&diagnostic, source, "src/inject\nevil.lis");
+
+    assert_eq!(output.lines().count(), 1);
+    assert_eq!(output, "src/inject evil.lis:1:5: error: Broken: here");
+}
+
+#[test]
+fn unix_flattens_a_newline_inside_a_file_location() {
+    let diagnostic = LisetteDiagnostic::error("Misnamed file")
+        .with_resolve_code("wrong_test_file_suffix")
+        .with_file_location("tests/inject\nevil.lis");
+
+    let output = format_diagnostic_unix(&diagnostic, "", "src/main.lis");
+
+    assert_eq!(output.lines().count(), 1);
+    assert_eq!(
+        output,
+        "tests/inject evil.lis:1:1: error: Misnamed file [resolve.wrong_test_file_suffix]"
+    );
 }


### PR DESCRIPTION
`lis check --output unix` now carries the label, help, and note text that until now were present only in the human-friendly output. A line in `unix` mode now has enough details to act on without opening the file:

```rs
fn add(a: int, b: int) -> int {
  return a + b
}

fn main() {
  let total = add(1, "two")
}
```

```
errors.lis:6:22: error: Type mismatch: expected `int`, found `string` · Change the type annotation to `string` or convert the value to `int` [infer.type_mismatch]
errors.lis:2:3: info: Unnecessary `return`: redundant in tail position · The final expression of a function is its return value. Drop `return` and keep the value [lint.unnecessary_return] [autofixable]
```

The `file:line:col:` prefix and the trailing `[code]` are unchanged, so existing parsers keep working. A new `[autofixable]` tag marks the diagnostics `lis check --fix` would rewrite.

This required making a few diagnostics more consistent with the rest:
- `resolve.import_cycle` used to embed box-drawing art in its msg, breaking the one-diagnostic-per-line pattern. This is now a single line naming the chain. 
- `resolve.wrong_test_file_suffix`, `resolve.non_test_file_under_tests` and `resolve.cannot_emit_test_file` carried no lcation and are now reported against the file they name. 
- `Unreachable modules` becomes one `resolve.unreachable_module` diagnostic per module, instead of consolidating all  module names into one message.
