### PR TITLE
fix: stop exempting `defer` and `task` from discard lints

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -3,8 +3,13 @@
     "lints": {
       "allow_unused_result": {
         "bytes": ["Buffer.WriteByte", "Buffer.WriteRune", "Buffer.WriteString"],
+        "crypto/tls": ["Conn.CloseWrite"],
+        "database/sql": ["Tx.Rollback"],
+        "database/sql/driver": ["Tx.Rollback"],
         "fmt": ["Print", "Printf", "Println", "Fprint", "Fprintf", "Fprintln"],
-        "strings": ["Builder.WriteByte", "Builder.WriteRune", "Builder.WriteString"]
+        "net": ["TCPConn.CloseRead", "TCPConn.CloseWrite", "UnixConn.CloseRead", "UnixConn.CloseWrite"],
+        "strings": ["Builder.WriteByte", "Builder.WriteRune", "Builder.WriteString"],
+        "syscall": ["Close"]
       },
       "deny_unused_value": {
         "go/types": ["TypeParam.Underlying"],

--- a/bindgen/internal/emit/emitter.go
+++ b/bindgen/internal/emit/emitter.go
@@ -420,11 +420,8 @@ func allowDiscardLint(returnType string) string {
 	return "unused_result"
 }
 
-// shouldAllowUnusedResult returns true if the function/method should be annotated
-// with a discard-suppression attribute. Checks config first, then applies
-// signature-based heuristics for common Go interface methods:
-//   - Close() error
-//   - Flush() error
+// shouldAllowUnusedResult reports whether a function or method should carry a
+// discard-suppression attribute, taking config over the signature heuristic.
 func (e *Emitter) shouldAllowUnusedResult(qualifiedName, methodName string, result convert.ConvertResult) bool {
 	if e.cfg.ShouldAllowUnusedResult(e.pkgPath, qualifiedName) {
 		return true
@@ -435,9 +432,25 @@ func (e *Emitter) shouldAllowUnusedResult(qualifiedName, methodName string, resu
 		name = result.Name
 	}
 
+	return isConventionalDiscard(name, len(result.Params), result.ReturnType)
+}
+
+// shouldAllowUnusedResultOnMethod is the same for an interface method, which
+// has no receiver to qualify itself with.
+func (e *Emitter) shouldAllowUnusedResultOnMethod(interfaceName string, m convert.InterfaceMethod) bool {
+	if e.cfg.ShouldAllowUnusedResult(e.pkgPath, interfaceName+"."+m.Name) {
+		return true
+	}
+
+	return isConventionalDiscard(m.Name, len(m.Params), m.ReturnType)
+}
+
+// isConventionalDiscard reports whether Go leaves this cleanup method's error
+// unchecked by convention.
+func isConventionalDiscard(name string, paramCount int, returnType string) bool {
 	switch name {
 	case "Close", "Flush":
-		return len(result.Params) == 0 && result.ReturnType == "Result<(), error>"
+		return paramCount == 0 && returnType == "Result<(), error>"
 	}
 
 	return false
@@ -529,6 +542,9 @@ func (e *Emitter) emitInterface(result convert.ConvertResult) {
 			}
 			if m.BuilderMethod {
 				signature.WriteString("  #[allow(unused_value)]\n")
+			}
+			if e.shouldAllowUnusedResultOnMethod(result.Name, m) {
+				fmt.Fprintf(&signature, "  #[allow(%s)]\n", allowDiscardLint(m.ReturnType))
 			}
 			signature.WriteString(formatSignature("  fn ", m.Name, "",
 				formatParams(m.Params), m.HasReturn(), m.ReturnType))

--- a/bindgen/tests/testdata/snapshots/structs.d.lis
+++ b/bindgen/tests/testdata/snapshots/structs.d.lis
@@ -90,6 +90,7 @@ pub struct Project {
 
 /// Interface embedding
 pub interface ReadWriteCloser {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
   fn Write(p: Slice<byte>) -> Partial<int, error>

--- a/crates/passes/src/passes/diagnostic_producers/unused_expressions.rs
+++ b/crates/passes/src/passes/diagnostic_producers/unused_expressions.rs
@@ -1,5 +1,5 @@
 use diagnostics::{LisetteDiagnostic, UnusedExpressionKind};
-use syntax::ast::{Annotation, Expression, SelectArm, Span, UnaryOperator};
+use syntax::ast::{Annotation, Expression, MatchArm, SelectArm, Span, UnaryOperator};
 use syntax::program::{CallKind, NativeTypeKind};
 use syntax::types::{Symbol, Type};
 
@@ -18,13 +18,26 @@ pub(crate) fn run(
     facts: &mut Vec<LisetteDiagnostic>,
 ) {
     for item in typed_ast {
-        visit_expression(item, None, module_id, store, facts);
+        visit_expression(item, TailUse::Kept, module_id, store, facts);
     }
+}
+
+/// Who reports a block's tail value.
+#[derive(Clone, Copy)]
+enum TailUse<'a> {
+    /// Measured against a declared return type.
+    Declared(&'a TailContext<'a>),
+    /// Flows out, so reported only if the block's own type drops it.
+    Kept,
+    /// Dropped whatever its type, and unreported so far.
+    Dropped,
+    /// Already reported by an enclosing discarded walk.
+    Walked,
 }
 
 fn visit_expression(
     expression: &Expression,
-    tail_ctx: Option<&TailContext<'_>>,
+    tail_use: TailUse<'_>,
     module_id: &str,
     store: &Store,
     facts: &mut Vec<LisetteDiagnostic>,
@@ -33,8 +46,8 @@ fn visit_expression(
         Expression::Block { items, ty, .. }
         | Expression::TryBlock { items, ty, .. }
         | Expression::RecoverBlock { items, ty, .. } => {
-            let tail_is_discarded = tail_ctx.is_some() || discards_value(ty);
-            visit_block_items(items, tail_is_discarded, tail_ctx, module_id, store, facts);
+            visit_block_items(items, ty, tail_use, module_id, store, facts);
+            return;
         }
         Expression::Function {
             body,
@@ -46,7 +59,7 @@ fn visit_expression(
                 return;
             };
             let ctx = tail_context_for_function(body, return_type, return_annotation);
-            visit_expression(body, ctx.as_ref(), module_id, store, facts);
+            visit_expression(body, declared_or_kept(&ctx), module_id, store, facts);
             return;
         }
         Expression::Lambda {
@@ -59,17 +72,19 @@ fn visit_expression(
             let body_ty = body.get_type();
             let ctx = tail_context_for_lambda(ty, *span, return_annotation, &body_ty);
 
-            if ctx.is_some() && !matches!(body.as_ref(), Expression::Block { .. }) {
-                descend_discarded(
-                    body,
-                    &DiscardMode::Tail(ctx.as_ref().into()),
-                    module_id,
-                    store,
-                    facts,
-                );
-            }
+            let body_use = match &ctx {
+                // A block reports its own tail, so descending here would duplicate.
+                Some(ctx) if matches!(body.as_ref(), Expression::Block { .. }) => {
+                    TailUse::Declared(ctx)
+                }
+                Some(ctx) => {
+                    descend_discarded(body, &DiscardMode::Tail(ctx), module_id, store, facts);
+                    TailUse::Walked
+                }
+                None => TailUse::Kept,
+            };
 
-            visit_expression(body, ctx.as_ref(), module_id, store, facts);
+            visit_expression(body, body_use, module_id, store, facts);
             return;
         }
         Expression::For {
@@ -87,19 +102,147 @@ fn visit_expression(
             body,
             ..
         } => {
-            visit_expression(pre_child, None, module_id, store, facts);
-            visit_loop_body(body, module_id, store, facts);
+            visit_expression(pre_child, TailUse::Kept, module_id, store, facts);
+            visit_loop_body(body, tail_use, module_id, store, facts);
             return;
         }
         Expression::Loop { body, .. } => {
-            visit_loop_body(body, module_id, store, facts);
+            visit_loop_body(body, tail_use, module_id, store, facts);
+            return;
+        }
+        // Walked by `visit_break_values` instead, under the loop's use.
+        Expression::Break { .. } => return,
+        Expression::Defer {
+            expression: wrapped,
+            ..
+        }
+        | Expression::Task {
+            expression: wrapped,
+            ..
+        } => {
+            visit_discarded_expression(wrapped, module_id, store, facts);
+            return;
+        }
+        // `descend_discarded` unwraps parens, so a walked spine passes through.
+        Expression::Paren {
+            expression: inner, ..
+        } => {
+            visit_expression(inner, tail_use, module_id, store, facts);
+            return;
+        }
+        // Branches carry the value and are what `descend_discarded` walks.
+        // Subjects, conditions and guards are inputs nothing has walked.
+        Expression::If {
+            condition,
+            consequence,
+            alternative,
+            ty,
+            ..
+        } => {
+            visit_expression(condition, TailUse::Kept, module_id, store, facts);
+            let branch_use = branch_use(tail_use, ty);
+            visit_expression(consequence, branch_use, module_id, store, facts);
+            if let Some(alternative) = alternative {
+                visit_expression(alternative, branch_use, module_id, store, facts);
+            }
+            return;
+        }
+        Expression::IfLet {
+            scrutinee,
+            consequence,
+            alternative,
+            ty,
+            ..
+        } => {
+            visit_expression(scrutinee, TailUse::Kept, module_id, store, facts);
+            let branch_use = branch_use(tail_use, ty);
+            visit_expression(consequence, branch_use, module_id, store, facts);
+            if let Some(alternative) = alternative.expression() {
+                visit_expression(alternative, branch_use, module_id, store, facts);
+            }
+            return;
+        }
+        Expression::Match { subject, arms, .. } => {
+            visit_expression(subject, TailUse::Kept, module_id, store, facts);
+            visit_match_arms(arms, tail_use, module_id, store, facts);
+            return;
+        }
+        Expression::Select { arms, .. } => {
+            for arm in arms {
+                match arm {
+                    SelectArm::Receive {
+                        receive_expression,
+                        body,
+                        ..
+                    }
+                    | SelectArm::Send {
+                        send_expression: receive_expression,
+                        body,
+                    } => {
+                        visit_expression(
+                            receive_expression,
+                            TailUse::Kept,
+                            module_id,
+                            store,
+                            facts,
+                        );
+                        visit_expression(body, tail_use, module_id, store, facts);
+                    }
+                    SelectArm::MatchReceive {
+                        receive_expression,
+                        arms,
+                    } => {
+                        visit_expression(
+                            receive_expression,
+                            TailUse::Kept,
+                            module_id,
+                            store,
+                            facts,
+                        );
+                        visit_match_arms(arms, tail_use, module_id, store, facts);
+                    }
+                    SelectArm::WildCard { body } => {
+                        visit_expression(body, tail_use, module_id, store, facts);
+                    }
+                }
+            }
             return;
         }
         _ => {}
     }
 
     for child in expression.children() {
-        visit_expression(child, None, module_id, store, facts);
+        visit_expression(child, TailUse::Kept, module_id, store, facts);
+    }
+}
+
+fn visit_match_arms(
+    arms: &[MatchArm],
+    tail_use: TailUse<'_>,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Vec<LisetteDiagnostic>,
+) {
+    for arm in arms {
+        if let Some(guard) = &arm.guard {
+            visit_expression(guard, TailUse::Kept, module_id, store, facts);
+        }
+        visit_expression(&arm.expression, tail_use, module_id, store, facts);
+    }
+}
+
+/// An `if` with no `else` yields unit while its branch still carries a value.
+fn branch_use<'a>(tail_use: TailUse<'a>, conditional_ty: &Type) -> TailUse<'a> {
+    match tail_use {
+        TailUse::Kept if discards_value(conditional_ty) => TailUse::Dropped,
+        other => other,
+    }
+}
+
+fn declared_or_kept<'a>(ctx: &'a Option<TailContext<'a>>) -> TailUse<'a> {
+    match ctx {
+        Some(ctx) => TailUse::Declared(ctx),
+        None => TailUse::Kept,
     }
 }
 
@@ -144,25 +287,93 @@ fn tail_context_for_lambda<'a>(
 
 fn visit_loop_body(
     body: &Expression,
+    loop_use: TailUse<'_>,
     module_id: &str,
     store: &Store,
     facts: &mut Vec<LisetteDiagnostic>,
 ) {
-    let items = match body {
+    visit_break_values(body, loop_use, module_id, store, facts);
+
+    match body {
         Expression::Block { items, .. }
         | Expression::TryBlock { items, .. }
-        | Expression::RecoverBlock { items, .. } => items,
-        _ => {
-            visit_expression(body, None, module_id, store, facts);
-            return;
+        | Expression::RecoverBlock { items, .. } => {
+            visit_discarded_items(items, module_id, store, facts);
         }
-    };
+        _ => visit_expression(body, TailUse::Kept, module_id, store, facts),
+    }
+}
 
-    for item in items {
-        if !is_statement_only(item) {
-            descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
+/// A `break` value belongs to the loop, not the body spine that leads to it.
+fn visit_break_values(
+    expression: &Expression,
+    loop_use: TailUse<'_>,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Vec<LisetteDiagnostic>,
+) {
+    match expression {
+        Expression::Break {
+            value: Some(value), ..
+        } => {
+            visit_expression(value, loop_use, module_id, store, facts);
         }
-        visit_expression(item, None, module_id, store, facts);
+        Expression::Loop { .. }
+        | Expression::While { .. }
+        | Expression::WhileLet { .. }
+        | Expression::For { .. }
+        | Expression::Function { .. }
+        | Expression::Lambda { .. }
+        | Expression::Task { .. }
+        | Expression::Defer { .. } => {}
+        _ => {
+            for child in expression.children() {
+                visit_break_values(child, loop_use, module_id, store, facts);
+            }
+        }
+    }
+}
+
+/// Unlike a loop body, a bare wrapped expression is itself a discarded value.
+fn visit_discarded_expression(
+    expression: &Expression,
+    module_id: &str,
+    store: &Store,
+    facts: &mut Vec<LisetteDiagnostic>,
+) {
+    match expression {
+        Expression::Block { items, .. }
+        | Expression::TryBlock { items, .. }
+        | Expression::RecoverBlock { items, .. } => {
+            visit_discarded_items(items, module_id, store, facts);
+        }
+        _ => {
+            descend_discarded(expression, &DiscardMode::NonTail, module_id, store, facts);
+            visit_expression(expression, TailUse::Walked, module_id, store, facts);
+        }
+    }
+}
+
+fn visit_discarded_items(
+    items: &[Expression],
+    module_id: &str,
+    store: &Store,
+    facts: &mut Vec<LisetteDiagnostic>,
+) {
+    for item in items {
+        let walked = if is_statement_only(item) {
+            false
+        } else {
+            descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
+            true
+        };
+
+        let item_use = if walked {
+            TailUse::Walked
+        } else {
+            TailUse::Kept
+        };
+        visit_expression(item, item_use, module_id, store, facts);
     }
 }
 
@@ -173,51 +384,50 @@ fn signature_marker_span(span: Span) -> Span {
 
 fn visit_block_items(
     items: &[Expression],
-    tail_is_discarded: bool,
-    tail_ctx: Option<&TailContext<'_>>,
+    block_ty: &Type,
+    tail_use: TailUse<'_>,
     module_id: &str,
     store: &Store,
     facts: &mut Vec<LisetteDiagnostic>,
 ) {
     let len = items.len();
     for (i, item) in items.iter().enumerate() {
-        let is_last = i == len - 1;
-        let is_statement_only = is_statement_only(item);
-
-        if !is_statement_only && !is_last {
+        let walked = if is_statement_only(item) {
+            false
+        } else if i != len - 1 {
             descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
-        }
+            true
+        } else {
+            match tail_use {
+                TailUse::Declared(ctx) => {
+                    descend_discarded(item, &DiscardMode::Tail(ctx), module_id, store, facts);
+                    true
+                }
+                TailUse::Dropped => {
+                    descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
+                    true
+                }
+                TailUse::Kept if discards_value(block_ty) => {
+                    descend_discarded(item, &DiscardMode::NonTail, module_id, store, facts);
+                    true
+                }
+                TailUse::Kept => false,
+                TailUse::Walked => true,
+            }
+        };
 
-        if is_last && !is_statement_only && tail_is_discarded {
-            descend_discarded(
-                item,
-                &DiscardMode::Tail(tail_ctx.into()),
-                module_id,
-                store,
-                facts,
-            );
-        }
+        let item_use = if walked {
+            TailUse::Walked
+        } else {
+            TailUse::Kept
+        };
+        visit_expression(item, item_use, module_id, store, facts);
     }
 }
 
 enum DiscardMode<'a> {
-    Tail(TailExpectation<'a>),
+    Tail(&'a TailContext<'a>),
     NonTail,
-}
-
-#[derive(Clone, Copy)]
-enum TailExpectation<'a> {
-    Declared(&'a TailContext<'a>),
-    Inferred,
-}
-
-impl<'a> From<Option<&'a TailContext<'a>>> for TailExpectation<'a> {
-    fn from(context: Option<&'a TailContext<'a>>) -> Self {
-        match context {
-            Some(context) => Self::Declared(context),
-            None => Self::Inferred,
-        }
-    }
 }
 
 fn descend_discarded(
@@ -296,7 +506,7 @@ fn descend_discarded(
         | Expression::For { .. } => {}
         unwrapped => match mode {
             DiscardMode::Tail(tail_ctx) => {
-                check_discarded_tail(expression, *tail_ctx, module_id, store, facts)
+                check_discarded_tail(expression, tail_ctx, module_id, store, facts)
             }
             DiscardMode::NonTail => emit_unused_at_leaf(unwrapped, module_id, store, facts),
         },
@@ -381,7 +591,7 @@ fn lvalue_slice_growth_kind(expression: &Expression) -> Option<UnusedExpressionK
 
 fn check_discarded_tail(
     item: &Expression,
-    expectation: TailExpectation<'_>,
+    expected: &TailContext<'_>,
     module_id: &str,
     store: &Store,
     facts: &mut Vec<LisetteDiagnostic>,
@@ -412,16 +622,11 @@ fn check_discarded_tail(
         return;
     }
 
-    let (expected_span, expected_ty) = match expectation {
-        TailExpectation::Declared(ctx) => (ctx.expected_span, ctx.expected_ty.to_string()),
-        TailExpectation::Inferred => (item.get_span(), reported_ty.to_string()),
-    };
-
     facts.push(diagnostics::infer::mismatched_tail_value(
         &item.get_span(),
         &reported_ty.to_string(),
-        &expected_span,
-        &expected_ty,
+        &expected.expected_span,
+        &expected.expected_ty.to_string(),
     ));
 }
 

--- a/crates/stdlib/typedefs/crypto/tls.d.lis
+++ b/crates/stdlib/typedefs/crypto/tls.d.lis
@@ -747,6 +747,7 @@ impl Conn {
   /// CloseWrite shuts down the writing side of the connection. It should only be
   /// called once the handshake has completed and does not call CloseWrite on the
   /// underlying connection. Most callers should just use [Conn.Close].
+  #[allow(unused_result)]
   fn CloseWrite(self: Ref<Conn>) -> Result<(), error>
 
   /// ConnectionState returns basic TLS details about the connection.

--- a/crates/stdlib/typedefs/database/sql.d.lis
+++ b/crates/stdlib/typedefs/database/sql.d.lis
@@ -913,6 +913,7 @@ impl Tx {
   ) -> Ref<Row>
 
   /// Rollback aborts the transaction.
+  #[allow(unused_result)]
   fn Rollback(self: Ref<Tx>) -> Result<(), error>
 
   /// Stmt returns a transaction-specific prepared statement from

--- a/crates/stdlib/typedefs/database/sql/driver.d.lis
+++ b/crates/stdlib/typedefs/database/sql/driver.d.lis
@@ -28,6 +28,7 @@ pub interface ColumnConverter {
 /// Conn is assumed to be stateful.
 pub interface Conn {
   fn Begin() -> Result<Tx, error>
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Prepare(query: string) -> Result<Stmt, error>
 }
@@ -196,6 +197,7 @@ pub interface Result {
 
 /// Rows is an iterator over an executed query's results.
 pub interface Rows {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Columns() -> Slice<string>
   fn Next(mut dest: Slice<Value>) -> Result<(), error>
@@ -211,6 +213,7 @@ pub struct RowsAffected(int64)
 /// "DECIMAL", "SMALLINT", "INT", "BIGINT", "BOOL", "[]BIGINT", "JSONB", "XML",
 /// "TIMESTAMP".
 pub interface RowsColumnTypeDatabaseTypeName {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ColumnTypeDatabaseTypeName(index: int) -> string
   fn Columns() -> Slice<string>
@@ -230,6 +233,7 @@ pub interface RowsColumnTypeDatabaseTypeName {
 /// 	int           (0, false)
 /// 	bytea(30)     (30, true)
 pub interface RowsColumnTypeLength {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ColumnTypeLength(index: int) -> Option<int64>
   fn Columns() -> Slice<string>
@@ -241,6 +245,7 @@ pub interface RowsColumnTypeLength {
 /// to be not nullable.
 /// If the column nullability is unknown, ok should be false.
 pub interface RowsColumnTypeNullable {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ColumnTypeNullable(index: int) -> Option<bool>
   fn Columns() -> Slice<string>
@@ -255,6 +260,7 @@ pub interface RowsColumnTypeNullable {
 /// 	int               (0, 0, false)
 /// 	decimal           (math.MaxInt64, math.MaxInt64, true)
 pub interface RowsColumnTypePrecisionScale {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ColumnTypePrecisionScale(index: int) -> Option<(int64, int64)>
   fn Columns() -> Slice<string>
@@ -265,6 +271,7 @@ pub interface RowsColumnTypePrecisionScale {
 /// the value type that can be used to scan types into. For example, the database
 /// column type "bigint" this should return "[reflect.TypeOf](int64(0))".
 pub interface RowsColumnTypeScanType {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ColumnTypeScanType(index: int) -> Option<reflect.Type>
   fn Columns() -> Slice<string>
@@ -274,6 +281,7 @@ pub interface RowsColumnTypeScanType {
 /// RowsNextResultSet extends the [Rows] interface by providing a way to signal
 /// the driver to advance to the next result set.
 pub interface RowsNextResultSet {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Columns() -> Slice<string>
   fn HasNextResultSet() -> bool
@@ -290,6 +298,7 @@ pub interface SessionResetter {
 /// Stmt is a prepared statement. It is bound to a [Conn] and not
 /// used by multiple goroutines concurrently.
 pub interface Stmt {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Exec(args: Slice<Value>) -> Result<Result, error>
   fn NumInput() -> int
@@ -309,6 +318,7 @@ pub interface StmtQueryContext {
 /// Tx is a transaction.
 pub interface Tx {
   fn Commit() -> Result<(), error>
+  #[allow(unused_result)]
   fn Rollback() -> Result<(), error>
 }
 

--- a/crates/stdlib/typedefs/io.d.lis
+++ b/crates/stdlib/typedefs/io.d.lis
@@ -157,6 +157,7 @@ pub interface ByteWriter {
 /// The behavior of Close after the first call is undefined.
 /// Specific implementations may document their own behavior.
 pub interface Closer {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
 }
 
@@ -182,6 +183,7 @@ pub type PipeWriter
 
 /// ReadCloser is the interface that groups the basic Read and Close methods.
 pub interface ReadCloser {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
 }
@@ -189,6 +191,7 @@ pub interface ReadCloser {
 /// ReadSeekCloser is the interface that groups the basic Read, Seek and Close
 /// methods.
 pub interface ReadSeekCloser {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
   fn Seek(offset: int64, whence: int) -> Result<int64, error>
@@ -202,6 +205,7 @@ pub interface ReadSeeker {
 
 /// ReadWriteCloser is the interface that groups the basic Read, Write and Close methods.
 pub interface ReadWriteCloser {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
   fn Write(p: Slice<byte>) -> Partial<int, error>
@@ -348,6 +352,7 @@ pub interface StringWriter {
 
 /// WriteCloser is the interface that groups the basic Write and Close methods.
 pub interface WriteCloser {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Write(p: Slice<byte>) -> Partial<int, error>
 }

--- a/crates/stdlib/typedefs/io/fs.d.lis
+++ b/crates/stdlib/typedefs/io/fs.d.lis
@@ -147,6 +147,7 @@ pub interface FS {
 /// Directory files should also implement [ReadDirFile].
 /// A file may implement [io.ReaderAt] or [io.Seeker] as optimizations.
 pub interface File {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut b: Slice<byte>) -> Partial<int, error>
   fn Stat() -> Result<FileInfo, error>
@@ -195,6 +196,7 @@ pub interface ReadDirFS {
 /// (It is permissible for any file to implement this interface,
 /// but if so ReadDir should return an error for non-directories.)
 pub interface ReadDirFile {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut b: Slice<byte>) -> Partial<int, error>
   fn ReadDir(n: int) -> Result<Slice<DirEntry>, error>

--- a/crates/stdlib/typedefs/mime/multipart.d.lis
+++ b/crates/stdlib/typedefs/mime/multipart.d.lis
@@ -26,6 +26,7 @@ pub fn NewWriter(w: io.Writer) -> Ref<Writer>
 /// Its contents may be either stored in memory or on disk.
 /// If stored on disk, the File's underlying concrete type will be an *os.File.
 pub interface File {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
   fn ReadAt(mut p: Slice<byte>, off: int64) -> Partial<int, error>

--- a/crates/stdlib/typedefs/net.d.lis
+++ b/crates/stdlib/typedefs/net.d.lis
@@ -521,6 +521,7 @@ pub struct Buffers(Slice<Slice<byte>>)
 /// 
 /// Multiple goroutines may invoke methods on a Conn simultaneously.
 pub interface Conn {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn LocalAddr() -> Option<Addr>
   fn Read(mut b: Slice<byte>) -> Partial<int, error>
@@ -669,6 +670,7 @@ pub struct ListenConfig {
 pub interface Listener {
   fn Accept() -> Result<Conn, error>
   fn Addr() -> Option<Addr>
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
 }
 
@@ -698,6 +700,7 @@ pub struct OpError {
 /// 
 /// Multiple goroutines may invoke methods on a PacketConn simultaneously.
 pub interface PacketConn {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn LocalAddr() -> Option<Addr>
   fn ReadFrom(mut p: Slice<byte>) -> Result<(int, Addr), error>
@@ -1317,10 +1320,12 @@ impl TCPAddr {
 impl TCPConn {
   /// CloseRead shuts down the reading side of the TCP connection.
   /// Most callers should just use Close.
+  #[allow(unused_result)]
   fn CloseRead(self: Ref<TCPConn>) -> Result<(), error>
 
   /// CloseWrite shuts down the writing side of the TCP connection.
   /// Most callers should just use Close.
+  #[allow(unused_result)]
   fn CloseWrite(self: Ref<TCPConn>) -> Result<(), error>
 
   /// MultipathTCP reports whether the ongoing connection is using MPTCP.
@@ -1520,10 +1525,12 @@ impl UnixAddr {
 impl UnixConn {
   /// CloseRead shuts down the reading side of the Unix domain connection.
   /// Most callers should just use [UnixConn.Close].
+  #[allow(unused_result)]
   fn CloseRead(self: Ref<UnixConn>) -> Result<(), error>
 
   /// CloseWrite shuts down the writing side of the Unix domain connection.
   /// Most callers should just use [UnixConn.Close].
+  #[allow(unused_result)]
   fn CloseWrite(self: Ref<UnixConn>) -> Result<(), error>
 
   /// ReadFrom implements the [PacketConn].ReadFrom method.

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -692,6 +692,7 @@ pub struct Dir(string)
 /// 
 /// The methods should behave the same as those on an [*os.File].
 pub interface File {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn Read(mut p: Slice<byte>) -> Partial<int, error>
   fn Readdir(count: int) -> Result<Slice<fs.FileInfo>, error>

--- a/crates/stdlib/typedefs/net/rpc.d.lis
+++ b/crates/stdlib/typedefs/net/rpc.d.lis
@@ -94,6 +94,7 @@ pub type Client
 /// discarded.
 /// See [NewClient]'s comment for information about concurrent access.
 pub interface ClientCodec {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ReadResponseBody(any: Unknown) -> Result<(), error>
   fn ReadResponseHeader(response: Ref<Response>) -> Result<(), error>
@@ -131,6 +132,7 @@ pub type Server
 /// argument to force the body of the request to be read and discarded.
 /// See [NewClient]'s comment for information about concurrent access.
 pub interface ServerCodec {
+  #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ReadRequestBody(any: Unknown) -> Result<(), error>
   fn ReadRequestHeader(request: Ref<Request>) -> Result<(), error>

--- a/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
@@ -499,6 +499,7 @@ pub fn Chroot(path: string) -> Result<(), error>
 
 pub fn Clearenv()
 
+#[allow(unused_result)]
 pub fn Close(fd: int) -> Result<(), error>
 
 pub fn CloseOnExec(fd: int)

--- a/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
@@ -502,6 +502,7 @@ pub fn Chroot(path: string) -> Result<(), error>
 
 pub fn Clearenv()
 
+#[allow(unused_result)]
 pub fn Close(fd: int) -> Result<(), error>
 
 pub fn CloseOnExec(fd: int)

--- a/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
@@ -596,6 +596,7 @@ pub fn Chroot(path: string) -> Result<(), error>
 
 pub fn Clearenv()
 
+#[allow(unused_result)]
 pub fn Close(fd: int) -> Result<(), error>
 
 pub fn CloseOnExec(fd: int)

--- a/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
@@ -599,6 +599,7 @@ pub fn Chroot(path: string) -> Result<(), error>
 
 pub fn Clearenv()
 
+#[allow(unused_result)]
 pub fn Close(fd: int) -> Result<(), error>
 
 pub fn CloseOnExec(fd: int)

--- a/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_windows_amd64.d.lis
@@ -442,6 +442,7 @@ pub fn Chown(path: string, uid: int, gid: int) -> Result<(), error>
 
 pub fn Clearenv()
 
+#[allow(unused_result)]
 pub fn Close(fd: Handle) -> Result<(), error>
 
 pub fn CloseHandle(handle: Handle) -> Result<(), error>

--- a/tests/_harness/macros.rs
+++ b/tests/_harness/macros.rs
@@ -238,6 +238,22 @@ macro_rules! assert_no_lint_warnings {
 }
 
 #[macro_export]
+macro_rules! assert_diagnostic_count {
+    ($source:expr, $expected:expr) => {
+        let diagnostics = $crate::_harness::lint::lint($source);
+        if diagnostics.len() != $expected {
+            let rendered: Vec<String> = diagnostics.iter().map(|d| format!("{:?}", d)).collect();
+            panic!(
+                "Expected {} diagnostics but got {}:\n{}",
+                $expected,
+                diagnostics.len(),
+                rendered.join("\n")
+            );
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! assert_build_snapshot {
     ($fs:expr, $go_module:expr) => {
         let output = $crate::_harness::build::compile_project($fs, $go_module);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -4,7 +4,7 @@ use crate::_harness::build::compile_check;
 use crate::_harness::filesystem::MockFileSystem;
 use crate::_harness::formatting::format_result_diagnostic_for_snapshot;
 use crate::_harness::lint::lint;
-use crate::{assert_lint_snapshot, assert_no_lint_warnings};
+use crate::{assert_diagnostic_count, assert_lint_snapshot, assert_no_lint_warnings};
 use semantics::store::ENTRY_MODULE_ID;
 
 #[test]
@@ -648,6 +648,565 @@ fn unsafe_call() -> Result<int, string> {
 fn main() {
   safe_call();
   unsafe_call();
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn unused_result_under_defer() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer commit()
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn unused_value_under_defer() {
+    assert_lint_snapshot!(
+        r#"
+fn count() -> int {
+  42
+}
+
+fn main() {
+  defer count()
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn unused_result_under_defer_block_tail() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer {
+    commit()
+  }
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn unused_result_under_defer_conditional_tail() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer {
+    if true {
+      commit()
+    }
+  }
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn defer_conditional_tail_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer {
+    if true {
+      commit()
+    }
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn unused_result_under_task() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  task commit()
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn task_conditional_tail_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  task {
+    if true {
+      commit()
+    }
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn defer_deeply_nested_conditional_tail_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer {
+    if true {
+      let _ = 1
+      if true {
+        commit()
+      }
+    }
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn nested_conditional_in_statement_position_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn value() -> int {
+  if true {
+    let _ = 1
+    if true {
+      commit()
+    }
+  }
+  5
+}
+
+fn main() {
+  let _ = value()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn nested_conditional_in_loop_body_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  for _i in 0..3 {
+    if true {
+      let _ = 1
+      if true {
+        commit()
+      }
+    }
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn unused_result_in_unit_block_initializer() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = {
+    if true {
+      commit()
+    }
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unit_block_initializer_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = {
+    if true {
+      commit()
+    }
+  }
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn unused_result_in_match_subject_block() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  match {
+    if true {
+      commit()
+    }
+  } {
+    _ => (),
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn match_subject_block_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  match {
+    if true {
+      commit()
+    }
+  } {
+    _ => (),
+  }
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn paren_block_statement_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  ({
+    if true {
+      commit()
+    }
+  })
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn paren_block_in_loop_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  for _i in 0..3 {
+    ({
+      if true {
+        commit()
+      }
+    })
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn paren_block_tail_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  ({
+    if true {
+      commit()
+    }
+  })
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn discarded_loop_break_block_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  loop {
+    if true {
+      break {
+        if true {
+          commit()
+        }
+      }
+    }
+  }
+  ()
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn kept_loop_break_block_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = loop {
+    if true {
+      break {
+        if true {
+          commit()
+        }
+      }
+    }
+  }
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn kept_loop_break_value_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let x = loop {
+    if true {
+      break commit()
+    }
+  }
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
+fn unused_result_in_unit_if_initializer() {
+    assert_lint_snapshot!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = if true {
+    commit()
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unit_if_initializer_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = if true {
+    commit()
+  }
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn unit_if_let_initializer_reports_once() {
+    assert_diagnostic_count!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let _x = if let Some(_v) = Some(1) {
+    commit()
+  }
+}
+"#,
+        1
+    );
+}
+
+#[test]
+fn if_else_initializer_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let x = if true {
+    commit()
+  } else {
+    Ok(0)
+  }
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
+fn kept_block_initializer_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  let x = {
+    commit()
+  }
+  let _ = x
+}
+"#
+    );
+}
+
+#[test]
+fn allow_unused_result_suppresses_lint_under_defer() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(unused_result)]
+fn cleanup() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer cleanup()
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn discarded_result_under_defer_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn commit() -> Result<int, string> {
+  Ok(42)
+}
+
+fn main() {
+  defer {
+    let _ = commit()
+  }
+  ()
+}
+"#
+    );
+}
+
+#[test]
+fn unit_call_under_defer_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn cleanup() {
+  ()
+}
+
+fn main() {
+  defer cleanup()
   ()
 }
 "#
@@ -24390,12 +24949,12 @@ fn main() {
 fn unconditional_recursion_after_defer() {
     assert_lint_snapshot!(
         r#"
-fn cleanup(n: int) -> int {
-  n + 1
+fn cleanup() {
+  ()
 }
 
 fn descend(n: int) -> int {
-  defer cleanup(n)
+  defer cleanup()
   descend(n - 1)
 }
 
@@ -24410,12 +24969,12 @@ fn main() {
 fn unconditional_recursion_after_task() {
     assert_lint_snapshot!(
         r#"
-fn cleanup(n: int) -> int {
-  n + 1
+fn cleanup() {
+  ()
 }
 
 fn descend(n: int) -> int {
-  task cleanup(n)
+  task cleanup()
   descend(n - 1)
 }
 
@@ -24881,8 +25440,8 @@ fn main() {
 fn unconditional_recursion_self_call_in_task_argument() {
     assert_lint_snapshot!(
         r#"
-fn consume(n: int) -> int {
-  n
+fn consume(n: int) {
+  let _ = n
 }
 
 fn spawn_wrap(n: int) -> int {
@@ -24901,13 +25460,13 @@ fn main() {
 fn unconditional_recursion_deferred_self_call_no_warning() {
     assert_no_lint_warnings!(
         r#"
-fn descend(n: int) -> int {
+fn descend(n: int) {
   defer descend(n)
-  0
+  ()
 }
 
 fn main() {
-  let _ = descend(3)
+  descend(3)
 }
 "#
     );
@@ -24917,7 +25476,7 @@ fn main() {
 fn unconditional_recursion_deferred_self_call_then_infinite_loop_no_warning() {
     assert_no_lint_warnings!(
         r#"
-fn descend(n: int) -> int {
+fn descend(n: int) {
   defer descend(n)
   loop {
     let _ = n
@@ -24925,7 +25484,7 @@ fn descend(n: int) -> int {
 }
 
 fn main() {
-  let _ = descend(3)
+  descend(3)
 }
 "#
     );

--- a/tests/ui/lint/snapshots/unconditional_recursion_after_defer.snap
+++ b/tests/ui/lint/snapshots/unconditional_recursion_after_defer.snap
@@ -3,7 +3,7 @@ source: tests/ui/lint/mod.rs
 ---
   ▲ Unconditional recursion
    ╭─[test.lis:8:3]
- 7 │   defer cleanup(n)
+ 7 │   defer cleanup()
  8 │   descend(n - 1)
    ·   ───────┬──────
    ·          ╰── recurses on every path

--- a/tests/ui/lint/snapshots/unconditional_recursion_after_task.snap
+++ b/tests/ui/lint/snapshots/unconditional_recursion_after_task.snap
@@ -3,7 +3,7 @@ source: tests/ui/lint/mod.rs
 ---
   ▲ Unconditional recursion
    ╭─[test.lis:8:3]
- 7 │   task cleanup(n)
+ 7 │   task cleanup()
  8 │   descend(n - 1)
    ·   ───────┬──────
    ·          ╰── recurses on every path

--- a/tests/ui/lint/snapshots/unused_result_in_match_subject_block.snap
+++ b/tests/ui/lint/snapshots/unused_result_in_match_subject_block.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+    ╭─[test.lis:9:7]
+  8 │     if true {
+  9 │       commit()
+    ·       ────┬───
+    ·           ╰── failure will go unnoticed
+ 10 │     }
+    ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_in_unit_block_initializer.snap
+++ b/tests/ui/lint/snapshots/unused_result_in_unit_block_initializer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+    ╭─[test.lis:9:7]
+  8 │     if true {
+  9 │       commit()
+    ·       ────┬───
+    ·           ╰── failure will go unnoticed
+ 10 │     }
+    ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_in_unit_if_initializer.snap
+++ b/tests/ui/lint/snapshots/unused_result_in_unit_if_initializer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+   ╭─[test.lis:8:5]
+ 7 │   let _x = if true {
+ 8 │     commit()
+   ·     ────┬───
+   ·         ╰── failure will go unnoticed
+ 9 │   }
+   ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_under_defer.snap
+++ b/tests/ui/lint/snapshots/unused_result_under_defer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+   ╭─[test.lis:7:9]
+ 6 │ fn main() {
+ 7 │   defer commit()
+   ·         ────┬───
+   ·             ╰── failure will go unnoticed
+ 8 │   ()
+   ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_under_defer_block_tail.snap
+++ b/tests/ui/lint/snapshots/unused_result_under_defer_block_tail.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+   ╭─[test.lis:8:5]
+ 7 │   defer {
+ 8 │     commit()
+   ·     ────┬───
+   ·         ╰── failure will go unnoticed
+ 9 │   }
+   ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_under_defer_conditional_tail.snap
+++ b/tests/ui/lint/snapshots/unused_result_under_defer_conditional_tail.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+    ╭─[test.lis:9:7]
+  8 │     if true {
+  9 │       commit()
+    ·       ────┬───
+    ·           ╰── failure will go unnoticed
+ 10 │     }
+    ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_result_under_task.snap
+++ b/tests/ui/lint/snapshots/unused_result_under_task.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ `Result` is silently discarded
+   ╭─[test.lis:7:8]
+ 6 │ fn main() {
+ 7 │   task commit()
+   ·        ────┬───
+   ·            ╰── failure will go unnoticed
+ 8 │   ()
+   ╰────
+  help: Handle this `Result` with `?` or `match`, or explicitly discard it with `let _ = ...` · code: [lint.unused_result]

--- a/tests/ui/lint/snapshots/unused_value_under_defer.snap
+++ b/tests/ui/lint/snapshots/unused_value_under_defer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused expression value
+   ╭─[test.lis:7:9]
+ 6 │ fn main() {
+ 7 │   defer count()
+   ·         ───┬───
+   ·            ╰── this value is discarded
+ 8 │   ()
+   ╰────
+  help: Use the value, or ignore with `let _ = ...` · code: [lint.unused_value]


### PR DESCRIPTION
`defer` and `task` no longer hide a discarded `Result`.

```rs
pub fn save(tx: Ref<sql.Tx>) -> Result<(), error> {
  defer tx.Rollback() // does not warn, exempted via override
  defer tx.Commit() // warns
  Ok(())
}
```

Cleanup whose error Go typically leaves unchecked stays silent: `Close` and `Flush` across the stdlib (including through interfaces e.g. `io.Closer` and `net.Conn`), `Tx.Rollback`, `syscall.Close`, `CloseRead`, `CloseWrite`, etc. Cases like `Commit`, `Sync`, `Wait` and `Shutdown` warn as expected.