### PR TITLE
refactor: drop the source-cache fallback to a default file

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -286,7 +286,7 @@ pub(super) fn build_locked(
     let entry = EntryPoint::resolve(prep)?;
 
     let result = compile_project(prep, mode, &entry, &locator);
-    let counts = render_diagnostics(&result, &entry);
+    let counts = render_diagnostics(&result);
     if counts.errors > 0 {
         return Err(1);
     }
@@ -346,20 +346,6 @@ impl EntryPoint {
                 display_path: display,
             }),
             Self::Library => CompileInput::Library,
-        }
-    }
-
-    fn source(&self) -> &str {
-        match self {
-            Self::Binary { source, .. } => source,
-            Self::Library => "",
-        }
-    }
-
-    fn display(&self) -> &str {
-        match self {
-            Self::Binary { display, .. } => display,
-            Self::Library => "",
         }
     }
 }
@@ -449,22 +435,15 @@ fn compile_project(
     compile(entry.compile_input(), compile_config, &local_fs)
 }
 
-fn render_diagnostics(
-    result: &lisette::pipeline::CompileResult,
-    entry: &EntryPoint,
-) -> render::Counts {
+fn render_diagnostics(result: &lisette::pipeline::CompileResult) -> render::Counts {
     render::render_all(
         &result.diagnostics,
-        render::SourceCache::new(
-            |file_id| {
-                result
-                    .sources
-                    .get(&file_id)
-                    .map(|info| (info.source.clone(), info.filename.clone()))
-            },
-            entry.source(),
-            entry.display(),
-        ),
+        render::SourceCache::new(|file_id| {
+            result
+                .sources
+                .get(&file_id)
+                .map(|info| (info.source.clone(), info.filename.clone()))
+        }),
         result.user_file_count,
         &Filter::All,
     )

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -26,12 +26,6 @@ struct CheckOptions {
     action: CheckAction,
 }
 
-struct CompiledFile {
-    result: CompileResult,
-    source: String,
-    display_path: String,
-}
-
 struct ScannedSources {
     sources: Vec<PathBuf>,
     test_sources: Vec<PathBuf>,
@@ -182,7 +176,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
                 &go_module,
                 Some(scanned),
             );
-            report_check(&result, "", "", options, start)
+            report_check(&result, options, start)
         }
     };
     drop(target_lock);
@@ -198,26 +192,14 @@ fn check_single_file(
     scanned: Option<ScannedSources>,
 ) -> i32 {
     let start = Instant::now();
-    let compiled = match compile_single_file(file_path, scope, locator, go_module, scanned) {
-        Ok(compiled) => compiled,
+    let result = match compile_single_file(file_path, scope, locator, go_module, scanned) {
+        Ok(result) => result,
         Err(ReadFailure) => return 1,
     };
-    report_check(
-        &compiled.result,
-        &compiled.source,
-        &compiled.display_path,
-        options,
-        start,
-    )
+    report_check(&result, options, start)
 }
 
-fn report_check(
-    result: &CompileResult,
-    source: &str,
-    filename: &str,
-    options: &CheckOptions,
-    start: Instant,
-) -> i32 {
+fn report_check(result: &CompileResult, options: &CheckOptions, start: Instant) -> i32 {
     let unix = matches!(options.format, OutputFormat::Unix);
     if options.fixes() {
         let mut summary = FixSummary::default();
@@ -235,7 +217,7 @@ fn report_check(
     let counts = if unix {
         let (output, counts) = render::render_unix(
             &result.diagnostics,
-            render::SourceCache::new(get_source, source, filename),
+            render::SourceCache::new(get_source),
             result.user_file_count,
             &options.filter,
         );
@@ -244,7 +226,7 @@ fn report_check(
     } else {
         render::render_all(
             &result.diagnostics,
-            render::SourceCache::new(get_source, source, filename),
+            render::SourceCache::new(get_source),
             result.user_file_count,
             &options.filter,
         )
@@ -270,7 +252,7 @@ fn compile_single_file(
     locator: TypedefLocator,
     go_module: &str,
     scanned: Option<ScannedSources>,
-) -> Result<CompiledFile, ReadFailure> {
+) -> Result<CompileResult, ReadFailure> {
     let source = match fs::read_to_string(file_path) {
         Ok(s) => s,
         Err(e) => {
@@ -292,7 +274,7 @@ fn compile_single_file(
         lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
     let working_dir = file_path.parent().unwrap_or_else(|| Path::new("."));
 
-    let result = compile_project_entry(
+    Ok(compile_project_entry(
         working_dir,
         CompileInput::Binary(CompileEntry {
             source: &source,
@@ -303,13 +285,7 @@ fn compile_single_file(
         locator,
         go_module,
         scanned,
-    );
-
-    Ok(CompiledFile {
-        result,
-        source,
-        display_path: entry_display,
-    })
+    ))
 }
 
 fn compile_project_entry(
@@ -400,38 +376,37 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
         };
 
         if options.fixes() {
-            apply_result_fixes(&compiled.result, &mut fix_summary);
+            apply_result_fixes(&compiled, &mut fix_summary);
             continue;
         }
 
         let get_source = |file_id: u32| {
             compiled
-                .result
                 .sources
                 .get(&file_id)
                 .map(|info| (info.source.clone(), info.filename.clone()))
         };
         let counts = if unix {
             let (output, counts) = render::render_unix(
-                &compiled.result.diagnostics,
-                render::SourceCache::new(get_source, &compiled.source, &compiled.display_path),
-                compiled.result.user_file_count,
+                &compiled.diagnostics,
+                render::SourceCache::new(get_source),
+                compiled.user_file_count,
                 &options.filter,
             );
             print!("{}", output);
             counts
         } else {
             render::render_all(
-                &compiled.result.diagnostics,
-                render::SourceCache::new(get_source, &compiled.source, &compiled.display_path),
-                compiled.result.user_file_count,
+                &compiled.diagnostics,
+                render::SourceCache::new(get_source),
+                compiled.user_file_count,
                 &options.filter,
             )
         };
         total_errors += counts.errors;
         total_warnings += counts.warnings;
         total_info += counts.info;
-        total_files += compiled.result.user_file_count;
+        total_files += compiled.user_file_count;
     }
 
     let elapsed = start.elapsed();

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -163,16 +163,12 @@ fn run_standalone(file: &str, args: Vec<String>, sourcemap: bool, go_flags: &[St
 
     let counts = render::render_all(
         &result.diagnostics,
-        render::SourceCache::new(
-            |file_id| {
-                result
-                    .sources
-                    .get(&file_id)
-                    .map(|info| (info.source.clone(), info.filename.clone()))
-            },
-            &source,
-            &entry_display,
-        ),
+        render::SourceCache::new(|file_id| {
+            result
+                .sources
+                .get(&file_id)
+                .map(|info| (info.source.clone(), info.filename.clone()))
+        }),
         result.user_file_count,
         &filter,
     );

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -174,20 +174,22 @@ fn nocolor_handler() -> GraphicalReportHandler {
     GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
 }
 
-fn render(
+fn graphical_report(
     handler: &GraphicalReportHandler,
     diagnostic: &LisetteDiagnostic,
-    source: &IndexedSource,
-    filename: &str,
+    source: Option<(&IndexedSource, &str)>,
     use_color: bool,
-) {
-    let report = diagnostic.clone().into_rendered(use_color);
-    let report = miette::Report::new(report)
-        .with_source_code(miette::NamedSource::new(filename, source.clone()));
+) -> Option<String> {
+    let report = miette::Report::new(diagnostic.clone().into_rendered(use_color));
+    let report = match source {
+        Some((source, filename)) => {
+            report.with_source_code(miette::NamedSource::new(filename, source.clone()))
+        }
+        None => report,
+    };
     let mut output = String::new();
-    if handler.render_report(&mut output, report.as_ref()).is_ok() {
-        eprintln!("{}", output);
-    }
+    handler.render_report(&mut output, report.as_ref()).ok()?;
+    Some(output)
 }
 
 pub fn render_to_string(
@@ -235,8 +237,10 @@ fn render_group<F: Fn(u32) -> Option<(String, String)>>(
         nocolor_handler()
     };
     for diagnostic in diagnostics {
-        let (src, name) = sources.get(diagnostic.file_id());
-        render(&handler, diagnostic, &src, &name, use_color);
+        let source = sources.get(diagnostic.file_id());
+        if let Some(output) = graphical_report(&handler, diagnostic, source, use_color) {
+            eprintln!("{}", output);
+        }
     }
 }
 
@@ -247,37 +251,27 @@ pub struct Counts {
     pub info: usize,
 }
 
-/// Resolves a `file_id` to its source, falling back to the entry file.
+/// Resolves the file a diagnostic's spans are measured against.
 pub struct SourceCache<F> {
     get_source: F,
-    default_source: IndexedSource,
-    default_filename: String,
-    cache: FxHashMap<u32, (IndexedSource, String)>,
+    cache: FxHashMap<u32, Option<(IndexedSource, String)>>,
 }
 
 impl<F: Fn(u32) -> Option<(String, String)>> SourceCache<F> {
-    pub fn new(get_source: F, default_source: &str, default_filename: &str) -> Self {
+    pub fn new(get_source: F) -> Self {
         Self {
             get_source,
-            default_source: IndexedSource::new(default_source),
-            default_filename: default_filename.to_string(),
             cache: FxHashMap::default(),
         }
     }
 
-    fn get(&mut self, file_id: Option<u32>) -> (IndexedSource, String) {
-        let Some(fid) = file_id else {
-            return (self.default_source.clone(), self.default_filename.clone());
-        };
-        let default_source = &self.default_source;
-        let default_filename = &self.default_filename;
+    fn get(&mut self, file_id: Option<u32>) -> Option<(&IndexedSource, &str)> {
+        let file_id = file_id?;
         let get_source = &self.get_source;
-        let entry = self.cache.entry(fid).or_insert_with(|| {
-            get_source(fid)
-                .map(|(src, name)| (IndexedSource::new(&src), name))
-                .unwrap_or_else(|| (default_source.clone(), default_filename.clone()))
+        let entry = self.cache.entry(file_id).or_insert_with(|| {
+            get_source(file_id).map(|(source, name)| (IndexedSource::new(&source), name))
         });
-        (entry.0.clone(), entry.1.clone())
+        entry.as_ref().map(|(source, name)| (source, name.as_str()))
     }
 }
 
@@ -390,9 +384,11 @@ fn flatten_to_one_line(text: &str) -> Cow<'_, str> {
 }
 
 /// Renders one diagnostic as `file:line:col: severity: message: label · help [code flags]`.
-pub fn unix_line(diagnostic: &LisetteDiagnostic, source: &IndexedSource, filename: &str) -> String {
+pub fn unix_line(diagnostic: &LisetteDiagnostic, source: Option<(&IndexedSource, &str)>) -> String {
     let mut line = String::new();
-    if let Some(offset) = diagnostic.location_offset() {
+    if let Some((source, filename)) = source
+        && let Some(offset) = diagnostic.location_offset()
+    {
         let (lineno, column) = source.line_col(offset);
         line.push_str(&format!(
             "{}:{}:{}: ",
@@ -445,8 +441,7 @@ pub fn render_unix(
         .chain(&groups.warnings)
         .chain(&groups.info)
     {
-        let (src, name) = sources.get(diagnostic.file_id());
-        output.push_str(&unix_line(diagnostic, &src, &name));
+        output.push_str(&unix_line(diagnostic, sources.get(diagnostic.file_id())));
         output.push('\n');
     }
 
@@ -457,9 +452,27 @@ pub fn render_unix(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use syntax::ast::Span;
+
+    const ENTRY_SOURCE: &str = "fn main() {\n  let x = 1;\n  let y = 2;\n}\n";
 
     fn show_all() -> Filter {
         Filter::All
+    }
+
+    fn entry_only(file_id: u32) -> Option<(String, String)> {
+        (file_id == 0).then(|| (ENTRY_SOURCE.to_string(), "src/main.lis".to_string()))
+    }
+
+    fn points_into(file_id: u32) -> LisetteDiagnostic {
+        LisetteDiagnostic::error("Points into another file")
+            .with_span_primary_label(&Span::new(file_id, 32, 6), "over here")
+    }
+
+    fn graphical_output(diagnostic: &LisetteDiagnostic) -> String {
+        let mut sources = SourceCache::new(entry_only);
+        let source = sources.get(diagnostic.file_id());
+        graphical_report(&nocolor_handler(), diagnostic, source, false).expect("rendering succeeds")
     }
 
     #[test]
@@ -497,14 +510,50 @@ mod tests {
     }
 
     #[test]
-    fn unix_counts_and_labels_info_separately() {
-        let diagnostics = vec![LisetteDiagnostic::info("advisory")];
-        let (output, counts) = render_unix(
-            &diagnostics,
-            SourceCache::new(|_| None, "", "f.lis"),
+    fn unix_omits_the_location_of_an_unresolved_file() {
+        let (output, _) = render_unix(
+            &[points_into(7)],
+            SourceCache::new(entry_only),
             1,
             &show_all(),
         );
+        assert_eq!(output, "error: Points into another file: over here\n");
+    }
+
+    #[test]
+    fn unix_locates_a_resolved_file() {
+        let (output, _) = render_unix(
+            &[points_into(0)],
+            SourceCache::new(entry_only),
+            1,
+            &show_all(),
+        );
+        assert_eq!(
+            output,
+            "src/main.lis:3:8: error: Points into another file: over here\n"
+        );
+    }
+
+    #[test]
+    fn graphical_omits_the_source_frame_of_an_unresolved_file() {
+        let output = graphical_output(&points_into(7));
+        assert!(output.contains("Points into another file"));
+        assert!(!output.contains("src/main.lis"));
+        assert!(!output.contains("let y = 2"));
+    }
+
+    #[test]
+    fn graphical_draws_the_source_frame_of_a_resolved_file() {
+        let output = graphical_output(&points_into(0));
+        assert!(output.contains("src/main.lis"));
+        assert!(output.contains("let y = 2"));
+    }
+
+    #[test]
+    fn unix_counts_and_labels_info_separately() {
+        let diagnostics = vec![LisetteDiagnostic::info("advisory")];
+        let (output, counts) =
+            render_unix(&diagnostics, SourceCache::new(|_| None), 1, &show_all());
         assert_eq!(counts.errors, 0);
         assert_eq!(counts.warnings, 0);
         assert_eq!(counts.info, 1);

--- a/tests/_harness/formatting.rs
+++ b/tests/_harness/formatting.rs
@@ -63,7 +63,7 @@ pub fn format_diagnostic_unix(
     source: &str,
     filename: &str,
 ) -> String {
-    diagnostics::render::unix_line(diagnostic, &IndexedSource::new(source), filename)
+    diagnostics::render::unix_line(diagnostic, Some((&IndexedSource::new(source), filename)))
 }
 
 pub fn format_parse_error_unix(error: &ParseError, source: &str, filename: &str) -> String {

--- a/tests/ui/unix.rs
+++ b/tests/ui/unix.rs
@@ -96,7 +96,9 @@ fn test() {
 
     let (output, counts) = render::render_unix(
         &result.errors,
-        render::SourceCache::new(|_| None, source, "src/main.lis"),
+        render::SourceCache::new(|file_id| {
+            (file_id == 0).then(|| (source.to_string(), "src/main.lis".to_string()))
+        }),
         1,
         &unfiltered(),
     );


### PR DESCRIPTION
The source cache was answering a file ID it could not resolve by referring to a hardcoded default, so a span pointing outside the compiled set could render a line/col of an unrelated file. Lis now reports the miss and both renderers omit the location in that case instead. This was latent but not an actual bug yet.
