### PR TITLE
refactor: reword diagnostic labels that restate their titles

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -4,7 +4,7 @@ use syntax::ast::Span;
 pub fn unknown_go_hint(attribute_span: &Span, hint: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("Unknown go hint `{}`", hint))
         .with_attribute_code("unknown")
-        .with_span_label(attribute_span, "unknown")
+        .with_span_label(attribute_span, "not one of the hints `lis add` emits")
         .with_help(
             "The hint in this attribute is not recognized. Regenerate this typedef by re-running `lis add`",
         )
@@ -26,7 +26,7 @@ pub fn field_attribute_without_struct_attribute(
 pub fn duplicate_tag_key(span: &Span, key: &str, first_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Duplicate tag")
         .with_attribute_code("duplicate_tag")
-        .with_span_label(span, "duplicate")
+        .with_span_label(span, format!("`{}` is already set", key))
         .with_span_label(first_span, "first occurrence")
         .with_help(format!(
             "Remove one of the `{}` attributes - each tag key may appear only once per field",
@@ -37,7 +37,7 @@ pub fn duplicate_tag_key(span: &Span, key: &str, first_span: &Span) -> LisetteDi
 pub fn conflicting_case_transforms(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Conflicting case transforms")
         .with_attribute_code("conflicting_case_transforms")
-        .with_span_label(span, "conflicting")
+        .with_span_label(span, "only one case transform per tag")
         .with_help("Choose either `snake_case` or `camel_case`, not both")
 }
 
@@ -59,7 +59,7 @@ pub fn iterate_generic_enum(attribute_span: &Span) -> LisetteDiagnostic {
 pub fn iterate_not_an_enum(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[iterate]` not on enum")
         .with_attribute_code("iterate_not_an_enum")
-        .with_span_label(attribute_span, "not on an enum")
+        .with_span_label(attribute_span, "no variants to iterate here")
         .with_help("Only an enum can be marked `#[iterate]`")
 }
 
@@ -73,7 +73,7 @@ pub fn iterate_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
 pub fn display_not_a_struct_or_enum(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[display]` not on a struct or enum")
         .with_attribute_code("display_not_a_struct_or_enum")
-        .with_span_label(attribute_span, "not on a struct or enum")
+        .with_span_label(attribute_span, "no fields or variants to print here")
         .with_help("Only a struct or enum can be marked `#[display]`")
 }
 
@@ -110,7 +110,7 @@ pub fn display_specialized_to_string(attribute_span: &Span) -> LisetteDiagnostic
 pub fn equality_not_a_struct_or_enum(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[equality]` not on a struct or enum")
         .with_attribute_code("equality_not_a_struct_or_enum")
-        .with_span_label(attribute_span, "not on a struct or enum")
+        .with_span_label(attribute_span, "no fields or variants to compare here")
         .with_help("Only a struct or enum can be marked `#[equality]`")
 }
 

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -186,7 +186,7 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
     if looks_like_type_param {
         return LisetteDiagnostic::error("Undeclared type parameter")
             .with_resolve_code("type_not_found")
-            .with_span_label(&name_span, "undeclared")
+            .with_span_label(&name_span, "looks like a type parameter")
             .with_help(format!(
                 "Declare the type parameter, e.g. `impl<{t}>` or `fn foo<{t}>`",
                 t = simple_name
@@ -195,7 +195,7 @@ pub fn type_not_found(type_name: &str, annotation_span: Span) -> LisetteDiagnost
 
     let diagnostic = LisetteDiagnostic::error("Type not found")
         .with_resolve_code("type_not_found")
-        .with_span_label(&name_span, "type not found in scope");
+        .with_span_label(&name_span, "not declared or imported");
 
     match foreign_type_alias(simple_name) {
         Some(suggestion) => diagnostic.with_help(format!("Did you mean `{}`?", suggestion)),
@@ -266,7 +266,7 @@ pub fn undeclared_impl_type_param(
 
     LisetteDiagnostic::error("Undeclared type parameter")
         .with_resolve_code("type_not_found")
-        .with_span_label(&name_span, "undeclared")
+        .with_span_label(&name_span, "not declared by this `impl`")
         .with_help(format!(
             "Declare the type parameter: `impl<{t}> {r}<{t}>`",
             t = type_name,
@@ -353,7 +353,7 @@ pub fn name_not_found(
     if let Some(hint) = go_builtin_hint(variable_name) {
         return LisetteDiagnostic::error("Name not found")
             .with_resolve_code("name_not_found")
-            .with_span_label(&span, "name not found in scope")
+            .with_span_label(&span, "not a Lisette builtin")
             .with_help(hint);
     }
 
@@ -374,7 +374,7 @@ pub fn name_not_found(
     {
         return LisetteDiagnostic::error("Undeclared test handle")
             .with_resolve_code("undeclared_test_handle")
-            .with_span_label(&span, "undeclared")
+            .with_span_label(&span, format!("`{function}` declares no `t` parameter"))
             .with_help(format!(
                 "Declare a `t` parameter to receive the test handle: `fn {function}(t)`"
             ));
@@ -382,12 +382,12 @@ pub fn name_not_found(
 
     let mut diagnostic = LisetteDiagnostic::error("Name not found")
         .with_resolve_code("name_not_found")
-        .with_span_label(&span, "name not found in scope");
+        .with_span_label(&span, "not declared or imported");
 
     if let Some(suggestion) = suggestion {
         diagnostic = diagnostic.with_help(format!("Did you mean `{}`?", suggestion));
     } else {
-        diagnostic = diagnostic.with_help(format!("Define or import `{}`.", variable_name));
+        diagnostic = diagnostic.with_help(format!("Define or import `{}`", variable_name));
     }
 
     diagnostic
@@ -538,14 +538,17 @@ pub fn disallowed_mutation(
     } else if is_pattern_binding {
         LisetteDiagnostic::error("Immutable variable")
             .with_infer_code("immutable")
-            .with_span_label(&span, "cannot mutate an immutable variable")
+            .with_span_label(&span, "patterns cannot bind with `mut`")
             .with_help(format!(
-                "Pattern bindings are immutable; rebind with `let mut {variable_name} = {variable_name}` to mutate"
+                "Rebind with `let mut {variable_name} = {variable_name}`, then mutate that"
             ))
     } else {
         LisetteDiagnostic::error("Immutable variable")
             .with_infer_code("immutable")
-            .with_span_label(&span, "cannot mutate an immutable variable")
+            .with_span_label(
+                &span,
+                format!("`{variable_name}` was declared without `mut`"),
+            )
             .with_help(format!(
                 "Declare using `let mut {variable_name}` to make the variable mutable"
             ))
@@ -628,48 +631,76 @@ pub fn uppercase_binding(span: Span, name: &str) -> LisetteDiagnostic {
 pub fn enum_variant_constructor_not_found(
     span: Span,
     enum_info: Option<(&str, &[String])>,
-    variant_name: &str,
+    written_path: &str,
     bare_allowed: bool,
 ) -> LisetteDiagnostic {
-    let help = if let Some((enum_name, variants)) = enum_info {
+    let variant_name = written_path.rsplit('.').next().unwrap_or(written_path);
+    let qualifier = written_path
+        .rsplit_once('.')
+        .map(|(qualifier, _)| qualifier);
+
+    let (label, help) = if let Some((enum_name, variants)) = enum_info {
         if variants.iter().any(|v| v == variant_name) {
-            if bare_allowed {
-                format!("Use `{}` to match this variant", variant_name)
-            } else {
-                format!("Use `{}.{}` to match this variant", enum_name, variant_name)
-            }
-        } else if let Some(closest) = variants
-            .iter()
-            .filter_map(|v| {
-                let d = levenshtein_distance(variant_name, v);
-                (d <= 2).then_some((v, d))
-            })
-            .min_by_key(|(_, d)| *d)
-            .map(|(v, _)| v)
-        {
-            if bare_allowed {
-                format!("Did you mean `{}`?", closest)
-            } else {
-                format!("Did you mean `{}.{}`?", enum_name, closest)
+            // A written qualifier can be unbound or can be another enum that is in scope, so
+            // the fact covering both is the enum's own path.
+            let qualified = format!("{}.{}", enum_name, variant_name);
+            match (qualifier, bare_allowed) {
+                (Some(_), true) => (
+                    format!("the enum is `{}`", enum_name),
+                    format!("Use `{}`, or just `{}`", qualified, variant_name),
+                ),
+                (Some(_), false) => (
+                    format!("the enum is `{}`", enum_name),
+                    format!("Use `{}` to match this variant", qualified),
+                ),
+                (None, false) => (
+                    "bare variants work only in match arms".to_string(),
+                    format!("Use `{}` to match this variant", qualified),
+                ),
+                (None, true) => (
+                    format!("the enum is `{}`", enum_name),
+                    format!("Use `{}` to match this variant", variant_name),
+                ),
             }
         } else {
-            let variants_fmt = if bare_allowed {
-                format_list(variants, |v| format!("`{}`", v))
+            let label = format!("no variant `{}` on `{}`", variant_name, enum_name);
+            let help = if let Some(closest) = variants
+                .iter()
+                .filter_map(|v| {
+                    let d = levenshtein_distance(variant_name, v);
+                    (d <= 2).then_some((v, d))
+                })
+                .min_by_key(|(_, d)| *d)
+                .map(|(v, _)| v)
+            {
+                if bare_allowed {
+                    format!("Did you mean `{}`?", closest)
+                } else {
+                    format!("Did you mean `{}.{}`?", enum_name, closest)
+                }
             } else {
-                format_list(variants, |v| format!("`{}.{}`", enum_name, v))
+                let variants_fmt = if bare_allowed {
+                    format_list(variants, |v| format!("`{}`", v))
+                } else {
+                    format_list(variants, |v| format!("`{}.{}`", enum_name, v))
+                };
+                format!(
+                    "Available variants for `{}` are {}",
+                    enum_name, variants_fmt
+                )
             };
-            format!(
-                "Available variants for `{}` are {}",
-                enum_name, variants_fmt
-            )
+            (label, help)
         }
     } else {
-        "Check that the variant is defined in the enum and spelled correctly".to_string()
+        (
+            "not a variant of any enum in scope".to_string(),
+            "Check that the variant is defined in the enum and spelled correctly".to_string(),
+        )
     };
 
     LisetteDiagnostic::error("Variant not found")
         .with_resolve_code("variant_not_found")
-        .with_span_label(&span, "not found")
+        .with_span_label(&span, label)
         .with_help(help)
 }
 
@@ -849,7 +880,7 @@ pub fn struct_not_found(identifier: &str, span: Span) -> LisetteDiagnostic {
 
     LisetteDiagnostic::error("Struct not found")
         .with_resolve_code("struct_not_found")
-        .with_span_label(&name_span, "struct not found in scope")
+        .with_span_label(&name_span, "not declared or imported")
         .with_help("Define or import this struct")
 }
 
@@ -893,22 +924,32 @@ pub fn pattern_missing_fields(missing: &[String], span: Span) -> LisetteDiagnost
         ))
 }
 
-pub fn private_field_access(field_name: &str, struct_name: &str, span: Span) -> LisetteDiagnostic {
+pub fn private_field_access(
+    field_name: &str,
+    struct_name: &str,
+    owning_module: &str,
+    span: Span,
+) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Private field")
         .with_resolve_code("private_field_access")
-        .with_span_label(&span, "private")
+        .with_span_label(&span, format!("private to `{}`", owning_module))
         .with_help(format!(
-            "Cannot access private field `{}` of struct `{}`. Mark the field as `pub`.",
+            "Cannot access private field `{}` of struct `{}`. Mark the field as `pub`",
             field_name, struct_name
         ))
 }
 
-pub fn private_method_access(method_name: &str, type_name: &str, span: Span) -> LisetteDiagnostic {
+pub fn private_method_access(
+    method_name: &str,
+    type_name: &str,
+    owning_module: &str,
+    span: Span,
+) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Private method")
         .with_resolve_code("private_method_access")
-        .with_span_label(&span, "private")
+        .with_span_label(&span, format!("private to `{}`", owning_module))
         .with_help(format!(
-            "Cannot access private method `{}` of type `{}`. Mark the method as `pub`.",
+            "Cannot access private method `{}` of type `{}`. Mark the method as `pub`",
             method_name, type_name
         ))
 }
@@ -916,13 +957,17 @@ pub fn private_method_access(method_name: &str, type_name: &str, span: Span) -> 
 pub fn private_field_in_spread(
     field_name: &str,
     struct_name: &str,
+    owning_module: &str,
     span: Span,
 ) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Private field")
         .with_resolve_code("private_field_spread")
-        .with_span_label(&span, "private")
+        .with_span_label(
+            &span,
+            format!("`{}` is private to `{}`", field_name, owning_module),
+        )
         .with_help(format!(
-            "Cannot spread `{}` because field `{}` is private. Mark the field as `pub`.",
+            "Cannot spread `{}` because field `{}` is private. Mark the field as `pub`",
             struct_name, field_name
         ))
 }
@@ -935,7 +980,10 @@ pub fn private_field_in_autofill(
 ) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Private field")
         .with_resolve_code("private_field_autofill")
-        .with_span_label(&span, "private")
+        .with_span_label(
+            &span,
+            format!("`{}` is private to `{}`", field_name, owning_module),
+        )
         .with_help(format!(
             "`{}` of `{}` cannot be autofilled because `{}` is private to module `{}`. \
              Provide an explicit value, or have `{}` expose `{}` as `pub` or offer a \
@@ -1683,7 +1731,7 @@ pub fn try_return_type_mismatch(expected: &str, actual_ty: &Type, span: Span) ->
 pub fn try_block_empty(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Empty `try` block")
         .with_infer_code("try_block_empty")
-        .with_span_label(&span, "empty")
+        .with_span_label(&span, "no expressions to propagate from")
         .with_help("Ensure the `try` block contains at least one expression")
 }
 
@@ -1750,7 +1798,7 @@ pub fn continue_in_try_block(span: Span) -> LisetteDiagnostic {
 pub fn recover_block_empty(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Empty `recover` block")
         .with_infer_code("recover_block_empty")
-        .with_span_label(&span, "empty")
+        .with_span_label(&span, "no expressions that could panic")
         .with_help("Ensure the `recover` block contains at least one expression that may panic")
 }
 
@@ -2782,16 +2830,16 @@ pub fn repeated_if_condition(span: &Span) -> LisetteDiagnostic {
 pub fn unchanging_loop_condition(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Loop condition never changes")
         .with_infer_code("unchanging_loop_condition")
-        .with_span_label(span, "never changes")
+        .with_span_label(span, "the loop either never runs or never ends")
         .with_help(
-            "Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop?",
+            "Nothing in the loop body changes this condition. Did you forget to update a variable, or mean to `break` out of the loop?",
         )
 }
 
 pub fn index_out_of_bounds(span: &Span, index_text: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Index out of bounds")
         .with_infer_code("index_out_of_bounds")
-        .with_span_label(span, "out of bounds")
+        .with_span_label(span, format!("no element at `{index_text}`"))
         .with_help(format!("Indexing at `{index_text}` will panic at runtime"))
 }
 
@@ -3035,32 +3083,20 @@ pub fn cannot_negate_unsigned(target_ty: &str, span: Span) -> LisetteDiagnostic 
 
 fn go_builtin_hint(name: &str) -> Option<&'static str> {
     match name {
-        "len" => Some(
-            "Lisette has no `len` builtin. Use the `.length()` method instead, e.g. `items.length()`.",
-        ),
-        "cap" => Some(
-            "Lisette has no `cap` builtin. Use the `.capacity()` method instead, e.g. `items.capacity()`.",
-        ),
+        "len" => Some("Lisette has no `len` builtin. Use `items.length()`"),
+        "cap" => Some("Lisette has no `cap` builtin. Use `items.capacity()`"),
         "make" => Some(
-            "Lisette has no `make` builtin. Use `Slice.new<T>()`, `Map.new<K, V>()`, or `Channel.new<T>()`.",
+            "Lisette has no `make` builtin. Use `Slice.new<T>()`, `Map.new<K, V>()`, or `Channel.new<T>()`",
         ),
-        "append" => Some(
-            "Lisette has no `append` builtin. Use the `.append()` method instead, e.g. `items.append(1)`.",
-        ),
-        "close" => Some(
-            "Lisette has no `close` builtin. Use the `.close()` method instead, e.g. `ch.close()`.",
-        ),
-        "copy" => Some(
-            "Lisette has no `copy` builtin. Use the `.copy_from()` method instead, e.g. `dst.copy_from(src)`.",
-        ),
-        "delete" => Some(
-            "Lisette has no `delete` builtin. Use the `.delete()` method instead, e.g. `map.delete(key)`.",
-        ),
-        "new" => Some(
-            "Lisette has no `new` builtin. Use constructor methods instead, e.g. `MyStruct { field: value }` or `MyType.new()`.",
-        ),
+        "append" => Some("Lisette has no `append` builtin. Use `items.append(1)`"),
+        "close" => Some("Lisette has no `close` builtin. Use `ch.close()`"),
+        "copy" => Some("Lisette has no `copy` builtin. Use `dst.copy_from(src)`"),
+        "delete" => Some("Lisette has no `delete` builtin. Use `map.delete(key)`"),
+        "new" => {
+            Some("Lisette has no `new` builtin. Use `MyStruct { field: value }` or `MyType.new()`")
+        }
         "print" | "println" | "printf" => Some(
-            "Lisette has no `print` builtin. Use `fmt.Println`, `fmt.Printf`, etc. after `import \"go:fmt\"`.",
+            "Lisette has no `print` builtin. Use `fmt.Println`, `fmt.Printf`, etc. after `import \"go:fmt\"`",
         ),
         _ => None,
     }
@@ -3381,7 +3417,7 @@ pub fn impl_bound_strengthens_type(type_name: &str, span: Span) -> LisetteDiagno
 pub fn impl_on_type_alias(_type_name: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot implement methods on type alias")
         .with_infer_code("impl_on_type_alias")
-        .with_span_label(&span, "type alias")
+        .with_span_label(&span, "not a distinct type")
         .with_help(
             "A type alias cannot carry its own methods. Either add methods to the underlying \
              type directly or define a tuple struct instead",

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -361,7 +361,7 @@ pub fn unsigned_comparison(span: &Span, always_true: bool) -> LisetteDiagnostic 
 
     LisetteDiagnostic::warn(format!("Comparison is always {result}"))
         .with_lint_code("unsigned_comparison")
-        .with_span_label(span, format!("always {result}"))
+        .with_span_label(span, "an unsigned integer is never negative")
         .with_help(
             "An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value?",
         )
@@ -372,7 +372,7 @@ pub fn type_limit_comparison(span: &Span, always_true: bool) -> LisetteDiagnosti
 
     LisetteDiagnostic::warn(format!("Comparison is always {result}"))
         .with_lint_code("type_limit_comparison")
-        .with_span_label(span, format!("always `{result}`"))
+        .with_span_label(span, "compares against the limit of the value's type")
         .with_help(format!(
             "This compares against the limit of the value's type, so this comparison is always `{result}`. Did you mean to compare against a different value?"
         ))
@@ -381,9 +381,9 @@ pub fn type_limit_comparison(span: &Span, always_true: bool) -> LisetteDiagnosti
 pub fn redundant_comparison(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Redundant comparison")
         .with_lint_code("redundant_comparison")
-        .with_span_label(span, "redundant")
+        .with_span_label(span, "already implied by the other comparison")
         .with_help(
-            "This comparison is already implied by the other, so the expression is equivalent to the other side alone",
+            "Drop this comparison, since the expression is equivalent to the other side alone",
         )
 }
 
@@ -459,7 +459,7 @@ pub fn non_negative_comparison(span: &Span, always_true: bool) -> LisetteDiagnos
 
     LisetteDiagnostic::warn(format!("Comparison is always {result}"))
         .with_lint_code("non_negative_comparison")
-        .with_span_label(span, format!("always {result}"))
+        .with_span_label(span, "a length is never negative")
         .with_help(
             "A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value?",
         )
@@ -476,7 +476,7 @@ pub fn goos_goarch_comparison(
 
     LisetteDiagnostic::warn(format!("Comparison is always {result}"))
         .with_lint_code("goos_goarch_comparison")
-        .with_span_label(span, format!("always {result}"))
+        .with_span_label(span, format!("`runtime.{const_name}` never holds this value"))
         .with_help(format!(
             "`runtime.{const_name}` only ever holds a known {kind}, and this is not one. Did you mean a valid value such as {examples}?"
         ))
@@ -486,11 +486,11 @@ pub fn redundant_operation(span: &Span, always: Option<&str>) -> LisetteDiagnost
     match always {
         Some(value) => LisetteDiagnostic::info(format!("Operation always evaluates to `{value}`"))
             .with_lint_code("redundant_operation")
-            .with_span_label(span, format!("always `{value}`"))
+            .with_span_label(span, "the other operand cannot change the result")
             .with_help(format!("Simplify this operation to `{value}`")),
         None => LisetteDiagnostic::info("Operation has no effect")
             .with_lint_code("redundant_operation")
-            .with_span_label(span, "has no effect")
+            .with_span_label(span, "one operand leaves the other unchanged")
             .with_help("Simplify this operation to its other operand"),
     }
 }
@@ -507,7 +507,7 @@ pub fn unnecessary_min_or_max(span: &Span, op: &str) -> LisetteDiagnostic {
 pub fn integer_division_to_zero(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Integer division is always `0`")
         .with_lint_code("integer_division_to_zero")
-        .with_span_label(span, "always `0`")
+        .with_span_label(span, "the numerator is smaller in magnitude")
         .with_help(
             "Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division?",
         )
@@ -516,7 +516,7 @@ pub fn integer_division_to_zero(span: &Span) -> LisetteDiagnostic {
 pub fn verbose_failure_propagation(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Verbose failure propagation")
         .with_lint_code("verbose_failure_propagation")
-        .with_span_label(span, "verbose")
+        .with_span_label(span, "re-returns the failure by hand")
         .with_help("Use `?` to propagate the failure concisely")
 }
 
@@ -786,7 +786,7 @@ pub fn match_same_arms(span: &Span, earlier: &str) -> LisetteDiagnostic {
 pub fn redundant_guards(span: &Span, binding: &str, literal: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Redundant guard")
         .with_lint_code("redundant_guards")
-        .with_span_label(span, "redundant guard")
+        .with_span_label(span, "the pattern can test this directly")
         .with_help(format!(
             "Replace `{binding}` with `{literal}` in the pattern and drop the guard"
         ))
@@ -1083,7 +1083,7 @@ pub fn uninterpolated_fstring(span: &Span) -> LisetteDiagnostic {
 pub fn nested_fstring(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Nested f-string")
         .with_lint_code("nested_fstring")
-        .with_span_label(span, "nested f-string")
+        .with_span_label(span, "already inside an f-string")
         .with_help(
             "Move the inner f-string's text and interpolations into the surrounding f-string",
         )
@@ -1259,7 +1259,7 @@ pub fn private_type_in_public_api(
     ));
 
     if let Some(s) = span {
-        diagnostic = diagnostic.with_span_label(s, "private");
+        diagnostic = diagnostic.with_span_label(s, format!("exposed by `{}`", public_definition));
     }
 
     diagnostic
@@ -1561,7 +1561,7 @@ pub fn waitgroup_add_in_task(span: &Span) -> LisetteDiagnostic {
 pub fn deprecated_api(span: &Span, message: &str) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Use of deprecated API")
         .with_lint_code("deprecated")
-        .with_span_label(span, "deprecated")
+        .with_span_label(span, "not intended for new code")
         .with_help(message)
 }
 

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -33,7 +33,7 @@ pub fn module_not_found(
 
     LisetteDiagnostic::error("Module not found")
         .with_resolve_code("module_not_found")
-        .with_span_label(&span, "not found")
+        .with_span_label(&span, "not a module in this project")
         .with_help(help)
 }
 

--- a/crates/diagnostics/src/pattern.rs
+++ b/crates/diagnostics/src/pattern.rs
@@ -29,7 +29,7 @@ fn join_and(items: &[String]) -> String {
 pub fn irrefutable_while_let(pattern_span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Pattern always matches")
         .with_infer_code("irrefutable_while_let")
-        .with_span_label(&pattern_span, "always matches")
+        .with_span_label(&pattern_span, "matches every value, so the loop never ends")
         .with_help("Use `loop` with `let` binding instead")
 }
 

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -314,6 +314,7 @@ impl InferCtx<'_> {
             self.sink.push(diagnostics::infer::private_field_access(
                 args.member_name,
                 qualified_name,
+                struct_module,
                 *args.span,
             ));
         }
@@ -374,6 +375,7 @@ impl InferCtx<'_> {
             self.sink.push(diagnostics::infer::private_field_access(
                 args.member_name,
                 qualified_name.as_str(),
+                declaring_module,
                 *args.span,
             ));
         }

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -197,6 +197,9 @@ impl InferCtx<'_> {
                 self.sink.push(diagnostics::infer::private_method_access(
                     args.member_name,
                     declaring,
+                    store
+                        .module_for_qualified_name(declaring)
+                        .unwrap_or(declaring),
                     *args.span,
                 ));
             }
@@ -512,6 +515,7 @@ impl InferCtx<'_> {
             self.sink.push(diagnostics::infer::private_method_access(
                 args.member_name,
                 type_simple_name,
+                store.module_for_qualified_name(&id).unwrap_or(&id),
                 *args.span,
             ));
         }

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -543,7 +543,7 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::enum_variant_constructor_not_found(
                     span,
                     enum_info.as_ref().map(|(n, v)| (n.as_str(), v.as_slice())),
-                    unqualified_name(identifier),
+                    identifier,
                     kind.is_match_arm(),
                 ));
         }
@@ -709,6 +709,7 @@ impl InferCtx<'_> {
                             self.sink.push(diagnostics::infer::private_field_access(
                                 &field.name,
                                 &qualified_name,
+                                struct_module,
                                 field.value.get_span(),
                             ));
                         }

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -352,6 +352,7 @@ impl InferCtx<'_> {
                     checker.sink.push(diagnostics::infer::private_field_access(
                         &assignment.name,
                         &struct_name,
+                        struct_module,
                         assignment.name_span,
                     ));
                 }
@@ -396,6 +397,7 @@ impl InferCtx<'_> {
                         _ => diagnostics::infer::private_field_in_spread(
                             &field.name,
                             &struct_name,
+                            owning_module,
                             spread_span,
                         ),
                     };

--- a/crates/syntax/src/lex/errors.rs
+++ b/crates/syntax/src/lex/errors.rs
@@ -250,9 +250,13 @@ impl<'source> Lexer<'source> {
 
     pub(super) fn error_empty_rune_literal(&mut self, offset: usize) {
         let span = self.span(offset as u32, 2);
-        let error = ParseError::new("Empty rune literal", span, "empty rune")
-            .with_lex_code("empty_rune")
-            .with_help("Add a rune between the single quotes");
+        let error = ParseError::new(
+            "Empty rune literal",
+            span,
+            "must hold exactly one character",
+        )
+        .with_lex_code("empty_rune")
+        .with_help("Add a rune between the single quotes");
         self.errors.push(error);
     }
 
@@ -355,7 +359,7 @@ impl<'source> Lexer<'source> {
         let help = "Remove this character";
 
         let span = self.span(offset as u32, ch.len_utf8() as u32);
-        let error = ParseError::new("Unexpected character", span, "unexpected character")
+        let error = ParseError::new("Unexpected character", span, "not part of any token")
             .with_lex_code("unexpected_char")
             .with_help(help);
         self.errors.push(error);

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1642,7 +1642,7 @@ impl<'source> Parser<'source> {
                 .with_parse_code("expected_let")
                 .with_help("Use `let` to declare a variable: `let x = 0`")
         } else {
-            ParseError::new("Reserved keyword", span, "reserved keyword")
+            ParseError::new("Reserved keyword", span, "cannot be used as an identifier")
                 .with_parse_code("keyword_as_identifier")
                 .with_help(format!("Rename `{}`", keyword))
         };

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -1066,7 +1066,7 @@ impl<'source> Parser<'source> {
         let error = ParseError::new(
             "Attribute not supported on target",
             span,
-            "not supported on target",
+            "nothing here can carry an attribute",
         )
         .with_parse_code("misplaced_attribute")
         .with_help("Remove the attribute, or move it onto an enum, struct, or function");

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -97,9 +97,10 @@ impl<'source> Parser<'source> {
                 }
                 _ => format!("Rename binding `{}`", keyword),
             };
-            let error = ParseError::new("Reserved keyword", span, "reserved keyword")
-                .with_parse_code("keyword_as_binding")
-                .with_help(help);
+            let error =
+                ParseError::new("Reserved keyword", span, "cannot be used as a binding name")
+                    .with_parse_code("keyword_as_binding")
+                    .with_help(help);
             self.errors.push(error);
             self.next();
             return Pattern::Identifier {

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -289,7 +289,7 @@ impl<'source> Parser<'source> {
                         (last_span.byte_offset + last_span.byte_length)
                             .saturating_sub(first_span.byte_offset),
                     );
-                    let error = ParseError::new(title, span, "misplaced")
+                    let error = ParseError::new(title, span, format!("belongs on `{}`", method))
                         .with_parse_code("syntax_error")
                         .with_help(help);
                     self.errors.push(error);

--- a/tests/ui/errors/snapshots/attribute_removed_go_hint.snap
+++ b/tests/ui/errors/snapshots/attribute_removed_go_hint.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[go(array_return)]
    · ─────────┬─────────
-   ·          ╰── unknown
+   ·          ╰── not one of the hints `lis add` emits
  3 │ pub fn Sum(data: Slice<byte>) -> Slice<byte>
    ╰────
   help: The hint in this attribute is not recognized. Regenerate this typedef by re-running `lis add` · code: [attribute.unknown]

--- a/tests/ui/errors/snapshots/attribute_unknown_go_hint.snap
+++ b/tests/ui/errors/snapshots/attribute_unknown_go_hint.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[go(comma_okay)]
    · ────────┬────────
-   ·         ╰── unknown
+   ·         ╰── not one of the hints `lis add` emits
  3 │ pub fn Get() -> Option<int>
    ╰────
   help: The hint in this attribute is not recognized. Regenerate this typedef by re-running `lis add` · code: [attribute.unknown]

--- a/tests/ui/errors/snapshots/attribute_unknown_go_hint_on_method.snap
+++ b/tests/ui/errors/snapshots/attribute_unknown_go_hint_on_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │ impl Widget {
  7 │   #[go(array_return)]
    ·   ─────────┬─────────
-   ·            ╰── unknown
+   ·            ╰── not one of the hints `lis add` emits
  8 │   fn Bytes(self) -> Slice<byte>
    ╰────
   help: The hint in this attribute is not recognized. Regenerate this typedef by re-running `lis add` · code: [attribute.unknown]

--- a/tests/ui/errors/snapshots/attribute_unknown_go_hint_on_type_alias.snap
+++ b/tests/ui/errors/snapshots/attribute_unknown_go_hint_on_type_alias.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[go(array_return)]
    · ─────────┬─────────
-   ·          ╰── unknown
+   ·          ╰── not one of the hints `lis add` emits
  3 │ pub type Handle
    ╰────
   help: The hint in this attribute is not recognized. Regenerate this typedef by re-running `lis add` · code: [attribute.unknown]

--- a/tests/ui/errors/snapshots/display_on_function.snap
+++ b/tests/ui/errors/snapshots/display_on_function.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[display]
    · ─────┬────
-   ·      ╰── not on a struct or enum
+   ·      ╰── no fields or variants to print here
  3 │ fn run() -> int {
    ╰────
   help: Only a struct or enum can be marked `#[display]` · code: [attribute.display_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/display_on_impl_method.snap
+++ b/tests/ui/errors/snapshots/display_on_impl_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ impl Widget {
  5 │   #[display]
    ·   ─────┬────
-   ·        ╰── not on a struct or enum
+   ·        ╰── no fields or variants to print here
  6 │   fn build() -> int {
    ╰────
   help: Only a struct or enum can be marked `#[display]` · code: [attribute.display_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/display_on_interface_method.snap
+++ b/tests/ui/errors/snapshots/display_on_interface_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ interface Service {
  3 │   #[display]
    ·   ─────┬────
-   ·        ╰── not on a struct or enum
+   ·        ╰── no fields or variants to print here
  4 │   fn run() -> int
    ╰────
   help: Only a struct or enum can be marked `#[display]` · code: [attribute.display_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/display_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/display_on_struct_field.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ struct Config {
  3 │   #[display]
    ·   ─────┬────
-   ·        ╰── not on a struct or enum
+   ·        ╰── no fields or variants to print here
  4 │   value: int,
    ╰────
   help: Only a struct or enum can be marked `#[display]` · code: [attribute.display_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_on_function.snap
+++ b/tests/ui/errors/snapshots/equality_on_function.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[equality]
    · ─────┬─────
-   ·      ╰── not on a struct or enum
+   ·      ╰── no fields or variants to compare here
  3 │ fn run() -> int {
    ╰────
   help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/equality_on_struct_field.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ struct Config {
  3 │   #[equality]
    ·   ─────┬─────
-   ·        ╰── not on a struct or enum
+   ·        ╰── no fields or variants to compare here
  4 │   value: int,
    ╰────
   help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/equality_on_type_alias.snap
+++ b/tests/ui/errors/snapshots/equality_on_type_alias.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[equality]
    · ─────┬─────
-   ·      ╰── not on a struct or enum
+   ·      ╰── no fields or variants to compare here
  3 │ type Foo = int
    ╰────
   help: Only a struct or enum can be marked `#[equality]` · code: [attribute.equality_not_a_struct_or_enum]

--- a/tests/ui/errors/snapshots/infer_const_of_struct_type_as_interface_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_const_of_struct_type_as_interface_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
   9 │   match s {
  10 │     ZERO => 0,
     ·     ──┬─
-    ·       ╰── not found
+    ·       ╰── not a variant of any enum in scope
  11 │     _ => 1,
     ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_name_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_enum_name_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match c {
  6 │     Color => 0,
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── no variant `Color` on `Color`
  7 │   }
    ╰────
   help: Available variants for `Color` are `Red` and `Blue` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_name_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_enum_name_as_pattern_on_interface_scrutinee.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  7 │   match e {
  8 │     Color => 0,
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  9 │     _ => 1,
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_misqualified_in_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_misqualified_in_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │   match s {
  7 │     Shape.Circle(r) => {}
    ·     ───────┬───────
-   ·            ╰── not found
+   ·            ╰── the enum is `shapes.Shape`
  8 │   }
    ╰────
-  help: Use `Circle` to match this variant · code: [resolve.variant_not_found]
+  help: Use `shapes.Shape.Circle`, or just `Circle` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let x = Maybe(42);
    ·           ──┬──
-   ·             ╰── name not found in scope
+   ·             ╰── not declared or imported
  4 │ }
    ╰────
   help: Define or import `Maybe` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │   match s {
  7 │     Nope => {}
    ·     ──┬─
-   ·       ╰── not found
+   ·       ╰── no variant `Nope` on `Status`
  8 │   }
    ╰────
   help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_close_match.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found_in_pattern_close_match.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │   match s {
  7 │     Circl(r) => {}
    ·     ────┬───
-   ·         ╰── not found
+   ·         ╰── no variant `Circl` on `shapes.Shape`
  8 │   }
    ╰────
   help: Did you mean `Circle`? · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_not_found_outside_match_suggests_qualified_only.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_not_found_outside_match_suggests_qualified_only.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn test(c: Color) -> int {
  5 │   let Color.Gren = c else { return 0 }
    ·       ─────┬────
-   ·            ╰── not found
+   ·            ╰── no variant `Gren` on `Color`
  6 │   1
    ╰────
   help: Did you mean `Color.Green`? · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_typo_through_alias_suggests_variants.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_typo_through_alias_suggests_variants.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
   8 │     Green => 2,
   9 │     Bluu => 3,
     ·     ──┬─
-    ·       ╰── not found
+    ·       ╰── no variant `Bluu` on `Palette`
  10 │   }
     ╰────
   help: Did you mean `Blue`? · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_enum_variant_typo_through_cross_module_alias_suggests_reachable_qualifier.snap
+++ b/tests/ui/errors/snapshots/infer_enum_variant_typo_through_cross_module_alias_suggests_reachable_qualifier.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn handle(e: api.UIEvent) -> int {
  5 │   let api.UIEvent.Hovr = e else { return 0 }
    ·       ────────┬───────
-   ·               ╰── not found
+   ·               ╰── no variant `Hovr` on `api.UIEvent`
  6 │   1
    ╰────
   help: Did you mean `api.UIEvent.Hover`? · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
   9 │   match s {
  10 │     Pretend => 0,
     ·     ───┬───
-    ·        ╰── not found
+    ·        ╰── no variant `Pretend` on `Status`
  11 │     _ => 1,
     ╰────
   help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_returning_enum_as_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_returning_enum_as_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
   9 │   match s {
  10 │     Make(x) => x,
     ·     ───┬───
-    ·        ╰── not found
+    ·        ╰── no variant `Make` on `Status`
  11 │     _ => 1,
     ╰────
   help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_function_type_alias_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match f {
  6 │     Callback => 0,
    ·     ────┬───
-   ·         ╰── not found
+   ·         ╰── not a variant of any enum in scope
  7 │     _ => 1,
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_function_type_alias_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_function_type_alias_as_pattern_on_interface_scrutinee.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  7 │   match e {
  8 │     Callback => 0,
    ·     ────┬───
-   ·         ╰── not found
+   ·         ╰── not a variant of any enum in scope
  9 │     _ => 1,
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_append.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_append.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(items: Slice<int>) -> Slice<int> {
  3 │   append(items, 1)
    ·   ───┬──
-   ·      ╰── name not found in scope
+   ·      ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `append` builtin. Use the `.append()` method instead, e.g. `items.append(1)` · code: [resolve.name_not_found]
+  help: Lisette has no `append` builtin. Use `items.append(1)` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_cap.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_cap.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(items: Slice<int>) -> int {
  3 │   cap(items)
    ·   ─┬─
-   ·    ╰── name not found in scope
+   ·    ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `cap` builtin. Use the `.capacity()` method instead, e.g. `items.capacity()` · code: [resolve.name_not_found]
+  help: Lisette has no `cap` builtin. Use `items.capacity()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_close.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_close.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(ch: Channel<int>) {
  3 │   close(ch);
    ·   ──┬──
-   ·     ╰── name not found in scope
+   ·     ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `close` builtin. Use the `.close()` method instead, e.g. `ch.close()` · code: [resolve.name_not_found]
+  help: Lisette has no `close` builtin. Use `ch.close()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_copy.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_copy.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(dst: Slice<int>, src: Slice<int>) {
  3 │   copy(dst, src);
    ·   ──┬─
-   ·     ╰── name not found in scope
+   ·     ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `copy` builtin. Use the `.copy_from()` method instead, e.g. `dst.copy_from(src)` · code: [resolve.name_not_found]
+  help: Lisette has no `copy` builtin. Use `dst.copy_from(src)` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_delete.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_delete.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(m: Map<string, int>) {
  3 │   delete(m, "key");
    ·   ───┬──
-   ·      ╰── name not found in scope
+   ·      ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `delete` builtin. Use the `.delete()` method instead, e.g. `map.delete(key)` · code: [resolve.name_not_found]
+  help: Lisette has no `delete` builtin. Use `map.delete(key)` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_len.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_len.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(items: Slice<int>) -> int {
  3 │   len(items)
    ·   ─┬─
-   ·    ╰── name not found in scope
+   ·    ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `len` builtin. Use the `.length()` method instead, e.g. `items.length()` · code: [resolve.name_not_found]
+  help: Lisette has no `len` builtin. Use `items.length()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_make.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_make.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let ch = make(10);
    ·            ──┬─
-   ·              ╰── name not found in scope
+   ·              ╰── not a Lisette builtin
  4 │ }
    ╰────
   help: Lisette has no `make` builtin. Use `Slice.new<T>()`, `Map.new<K, V>()`, or `Channel.new<T>()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_new.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_new.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let p = new(int);
    ·           ─┬─
-   ·            ╰── name not found in scope
+   ·            ╰── not a Lisette builtin
  4 │ }
    ╰────
-  help: Lisette has no `new` builtin. Use constructor methods instead, e.g. `MyStruct { field: value }` or `MyType.new()` · code: [resolve.name_not_found]
+  help: Lisette has no `new` builtin. Use `MyStruct { field: value }` or `MyType.new()` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_print.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_print.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(name: string) {
  3 │   print(name)
    ·   ──┬──
-   ·     ╰── name not found in scope
+   ·     ╰── not a Lisette builtin
  4 │ }
    ╰────
   help: Lisette has no `print` builtin. Use `fmt.Println`, `fmt.Printf`, etc. after `import "go:fmt"` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_go_builtin_println.snap
+++ b/tests/ui/errors/snapshots/infer_go_builtin_println.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(name: string) {
  3 │   println(name)
    ·   ───┬───
-   ·      ╰── name not found in scope
+   ·      ╰── not a Lisette builtin
  4 │ }
    ╰────
   help: Lisette has no `print` builtin. Use `fmt.Println`, `fmt.Printf`, etc. after `import "go:fmt"` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_impl_on_type_alias.snap
+++ b/tests/ui/errors/snapshots/infer_impl_on_type_alias.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │ 
  4 │ impl UserId {
    ·      ───┬──
-   ·         ╰── type alias
+   ·         ╰── not a distinct type
  5 │   fn bump(self) -> int {
    ╰────
   help: A type alias cannot carry its own methods. Either add methods to the underlying type directly or define a tuple struct instead · code: [infer.impl_on_type_alias]

--- a/tests/ui/errors/snapshots/infer_irrefutable_while_let.snap
+++ b/tests/ui/errors/snapshots/infer_irrefutable_while_let.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │   let mut x = 0;
  4 │   while let y = x {
    ·             ┬
-   ·             ╰── always matches
+   ·             ╰── matches every value, so the loop never ends
  5 │     x = x + 1;
    ╰────
   help: Use `loop` with `let` binding instead · code: [infer.irrefutable_while_let]

--- a/tests/ui/errors/snapshots/infer_irrefutable_while_let_or_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_irrefutable_while_let_or_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test(opt: Option<int>) {
  3 │   while let Some(_) | None = opt {
    ·             ───────┬──────
-   ·                    ╰── always matches
+   ·                    ╰── matches every value, so the loop never ends
  4 │     break;
    ╰────
   help: Use `loop` with `let` binding instead · code: [infer.irrefutable_while_let]

--- a/tests/ui/errors/snapshots/infer_mutate_match_arm_binding.snap
+++ b/tests/ui/errors/snapshots/infer_mutate_match_arm_binding.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  11 │   if let Some(Counter { n, .. } as c) = opt {
  12 │     c.bump();
     ·     ───┬──
-    ·        ╰── cannot mutate an immutable variable
+    ·        ╰── patterns cannot bind with `mut`
  13 │     let _ = n;
     ╰────
-  help: Pattern bindings are immutable; rebind with `let mut c = c` to mutate · code: [infer.immutable]
+  help: Rebind with `let mut c = c`, then mutate that · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_never_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_alias_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  7 │   match s {
  8 │     Impossible => {}
    ·     ─────┬────
-   ·          ╰── not found
+   ·          ╰── no variant `Impossible` on `Status`
  9 │   }
    ╰────
   help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_if_let_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_if_let_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn test(s: Status) {
  5 │   if let Never = s {}
    ·          ──┬──
-   ·            ╰── not found
+   ·            ╰── no variant `Never` on `Status`
  6 │ }
    ╰────
   help: Available variants for `Status` are `Status.Active` and `Status.Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match s {
  6 │     Never => {}
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── no variant `Never` on `Status`
  7 │   }
    ╰────
   help: Available variants for `Status` are `Active` and `Inactive` · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_interface_scrutinee.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match e {
  6 │     Never => {}
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  7 │   }
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_never_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_never_type_as_pattern_on_never_scrutinee.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  7 │   match diverge() {
  8 │     Never => {}
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  9 │   }
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_private_field_access.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_access.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn main() -> int {
  5 │   let p = shapes.Point { x: 1, y: 2 };
    ·                          ┬
-   ·                          ╰── private
+   ·                          ╰── private to `shapes`
  6 │   p.x
    ╰────
   help: Cannot access private field `x` of struct `shapes.Point`. Mark the field as `pub` · code: [resolve.private_field_access]

--- a/tests/ui/errors/snapshots/infer_private_field_in_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_in_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │   match p {
  7 │     shapes.Point { x, y } => x + y,
    ·                    ┬
-   ·                    ╰── private
+   ·                    ╰── private to `shapes`
  8 │   }
    ╰────
   help: Cannot access private field `x` of struct `shapes.Point`. Mark the field as `pub` · code: [resolve.private_field_access]

--- a/tests/ui/errors/snapshots/infer_private_field_in_struct_autofill_direct.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_in_struct_autofill_direct.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn main() {
  5 │   let q = shapes.Point { y: 10, .. };
    ·                                 ─┬
-   ·                                  ╰── private
+   ·                                  ╰── `x` is private to `shapes`
  6 │ }
    ╰────
   help: `x` of `shapes.Point` cannot be autofilled because `x` is private to module `shapes`. Provide an explicit value, or have `shapes` expose `x` as `pub` or offer a constructor · code: [resolve.private_field_autofill]

--- a/tests/ui/errors/snapshots/infer_private_field_in_struct_literal.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_in_struct_literal.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn main() {
  5 │   let p = shapes.Point { x: 1, y: 2 };
    ·                          ┬
-   ·                          ╰── private
+   ·                          ╰── private to `shapes`
  6 │ }
    ╰────
   help: Cannot access private field `x` of struct `shapes.Point`. Mark the field as `pub` · code: [resolve.private_field_access]

--- a/tests/ui/errors/snapshots/infer_private_field_in_struct_literal_aliased_import.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_in_struct_literal_aliased_import.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ fn main() {
  5 │   let p = s.Point { x: 1, y: 2 };
    ·                     ┬
-   ·                     ╰── private
+   ·                     ╰── private to `shapes`
  6 │ }
    ╰────
   help: Cannot access private field `x` of struct `s.Point`. Mark the field as `pub` · code: [resolve.private_field_access]

--- a/tests/ui/errors/snapshots/infer_private_field_in_struct_spread.snap
+++ b/tests/ui/errors/snapshots/infer_private_field_in_struct_spread.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   let p = shapes.make_point();
  6 │   let q = shapes.Point { y: 10, ..p };
    ·                                   ┬
-   ·                                   ╰── private
+   ·                                   ╰── `x` is private to `shapes`
  7 │ }
    ╰────
   help: Cannot spread `shapes.Point` because field `x` is private. Mark the field as `pub` · code: [resolve.private_field_spread]

--- a/tests/ui/errors/snapshots/infer_recover_block_empty.snap
+++ b/tests/ui/errors/snapshots/infer_recover_block_empty.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   recover {}
    ·   ───┬───
-   ·      ╰── empty
+   ·      ╰── no expressions that could panic
  4 │ }
    ╰────
   help: Ensure the `recover` block contains at least one expression that may panic · code: [infer.recover_block_empty]

--- a/tests/ui/errors/snapshots/infer_struct_name_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_struct_name_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match p {
  6 │     Point => 0,
    ·     ──┬──
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  7 │   }
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_struct_not_found.snap
+++ b/tests/ui/errors/snapshots/infer_struct_not_found.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let p = UnknownStruct { x: 1, y: 2 };
    ·           ──────┬──────
-   ·                 ╰── struct not found in scope
+   ·                 ╰── not declared or imported
  4 │ }
    ╰────
   help: Define or import this struct · code: [resolve.struct_not_found]

--- a/tests/ui/errors/snapshots/infer_try_block_empty.snap
+++ b/tests/ui/errors/snapshots/infer_try_block_empty.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let result = try {};
    ·                ─┬─
-   ·                 ╰── empty
+   ·                 ╰── no expressions to propagate from
  4 │ }
    ╰────
   help: Ensure the `try` block contains at least one expression · code: [infer.try_block_empty]

--- a/tests/ui/errors/snapshots/infer_type_alias_as_match_pattern.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_as_match_pattern.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │   match xs {
  6 │     Ints => 0,
    ·     ──┬─
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  7 │   }
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_type_alias_as_pattern_on_interface_scrutinee.snap
+++ b/tests/ui/errors/snapshots/infer_type_alias_as_pattern_on_interface_scrutinee.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  7 │   match e {
  8 │     Ints => 0,
    ·     ──┬─
-   ·       ╰── not found
+   ·       ╰── not a variant of any enum in scope
  9 │     _ => 1,
    ╰────
   help: Check that the variant is defined in the enum and spelled correctly · code: [resolve.variant_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let x: UnknownType = 42;
    ·          ─────┬─────
-   ·               ╰── type not found in scope
+   ·               ╰── not declared or imported
  4 │ }
    ╰────
   help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_enum_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_enum_bound.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ enum Foo<T: Undefined> {
    ·             ────┬────
-   ·                 ╰── type not found in scope
+   ·                 ╰── not declared or imported
  3 │   Bar(T)
    ╰────
   help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_float_suggests_float64.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_float_suggests_float64.snap
@@ -6,6 +6,6 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ struct Circle { radius: float }
    ·                         ──┬──
-   ·                           ╰── type not found in scope
+   ·                           ╰── not declared or imported
    ╰────
   help: Did you mean `float64`? · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_interface_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_interface_bound.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ interface Foo<T: Undefined> {
    ·                  ────┬────
-   ·                      ╰── type not found in scope
+   ·                      ╰── not declared or imported
  3 │   fn get() -> T
    ╰────
   help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_struct_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_struct_bound.snap
@@ -6,6 +6,6 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ struct Foo<T: Undefined> {}
    ·               ────┬────
-   ·                   ╰── type not found in scope
+   ·                   ╰── not declared or imported
    ╰────
   help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_type_alias_bound.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_type_alias_bound.snap
@@ -6,6 +6,6 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ type Foo<T: Undefined> = T
    ·             ────┬────
-   ·                 ╰── type not found in scope
+   ·                 ╰── not declared or imported
    ╰────
   help: Define or import this type · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_not_found_vec_suggests_slice.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_vec_suggests_slice.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ fn test(items: Vec<int>) -> int {
    ·                ─┬─
-   ·                 ╰── type not found in scope
+   ·                 ╰── not declared or imported
  3 │   0
    ╰────
   help: Did you mean `Slice`? · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_type_param_not_declared.snap
+++ b/tests/ui/errors/snapshots/infer_type_param_not_declared.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │ 
  6 │ impl Container<T> {
    ·                ┬
-   ·                ╰── undeclared
+   ·                ╰── not declared by this `impl`
  7 │   fn get(self) -> T {}
    ╰────
   help: Declare the type parameter: `impl<T> Container<T>` · code: [resolve.type_not_found]

--- a/tests/ui/errors/snapshots/infer_undeclared_test_handle_hints_at_parameter.snap
+++ b/tests/ui/errors/snapshots/infer_undeclared_test_handle_hints_at_parameter.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn forgot_the_handle() {
  3 │   t.skip("not ready")
    ·   ┬
-   ·   ╰── undeclared
+   ·   ╰── `forgot_the_handle` declares no `t` parameter
  4 │ }
    ╰────
   help: Declare a `t` parameter to receive the test handle: `fn forgot_the_handle(t)` · code: [resolve.undeclared_test_handle]

--- a/tests/ui/errors/snapshots/infer_variable_not_found_no_suggestion.snap
+++ b/tests/ui/errors/snapshots/infer_variable_not_found_no_suggestion.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn test() {
  3 │   let x = unknown_variable;
    ·           ────────┬───────
-   ·                   ╰── name not found in scope
+   ·                   ╰── not declared or imported
  4 │ }
    ╰────
   help: Define or import `unknown_variable` · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_variable_not_found_with_suggestion.snap
+++ b/tests/ui/errors/snapshots/infer_variable_not_found_with_suggestion.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │   let counter = 42;
  4 │   countr
    ·   ───┬──
-   ·      ╰── name not found in scope
+   ·      ╰── not declared or imported
  5 │ }
    ╰────
   help: Did you mean `counter`? · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_variable_not_mutable.snap
+++ b/tests/ui/errors/snapshots/infer_variable_not_mutable.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │   let x = 10;
  4 │   x = 20;
    ·   ───┬──
-   ·      ╰── cannot mutate an immutable variable
+   ·      ╰── `x` was declared without `mut`
  5 │ }
    ╰────
   help: Declare using `let mut x` to make the variable mutable · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/iterate_on_impl_method.snap
+++ b/tests/ui/errors/snapshots/iterate_on_impl_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ impl Widget {
  5 │   #[iterate]
    ·   ─────┬────
-   ·        ╰── not on an enum
+   ·        ╰── no variants to iterate here
  6 │   fn build() -> int {
    ╰────
   help: Only an enum can be marked `#[iterate]` · code: [attribute.iterate_not_an_enum]

--- a/tests/ui/errors/snapshots/iterate_on_interface_method.snap
+++ b/tests/ui/errors/snapshots/iterate_on_interface_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ interface Service {
  3 │   #[iterate]
    ·   ─────┬────
-   ·        ╰── not on an enum
+   ·        ╰── no variants to iterate here
  4 │   fn run() -> int
    ╰────
   help: Only an enum can be marked `#[iterate]` · code: [attribute.iterate_not_an_enum]

--- a/tests/ui/errors/snapshots/iterate_on_struct.snap
+++ b/tests/ui/errors/snapshots/iterate_on_struct.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[iterate]
    · ─────┬────
-   ·      ╰── not on an enum
+   ·      ╰── no variants to iterate here
  3 │ struct Point { x: int, y: int }
    ╰────
   help: Only an enum can be marked `#[iterate]` · code: [attribute.iterate_not_an_enum]

--- a/tests/ui/errors/snapshots/iterate_on_struct_field.snap
+++ b/tests/ui/errors/snapshots/iterate_on_struct_field.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ struct Config {
  3 │   #[iterate]
    ·   ─────┬────
-   ·        ╰── not on an enum
+   ·        ╰── no variants to iterate here
  4 │   value: int,
    ╰────
   help: Only an enum can be marked `#[iterate]` · code: [attribute.iterate_not_an_enum]

--- a/tests/ui/errors/snapshots/lex_empty_char.snap
+++ b/tests/ui/errors/snapshots/lex_empty_char.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:9]
  1 │ let x = ''
    ·         ─┬
-   ·          ╰── empty rune
+   ·          ╰── must hold exactly one character
    ╰────
   help: Add a rune between the single quotes · code: [lex.empty_rune]

--- a/tests/ui/errors/snapshots/lex_unexpected_character.snap
+++ b/tests/ui/errors/snapshots/lex_unexpected_character.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:12]
  1 │ let x = 42 ~ invalid
    ·            ┬
-   ·            ╰── unexpected character
+   ·            ╰── not part of any token
    ╰────
   help: Remove this character · code: [lex.unexpected_char]

--- a/tests/ui/errors/snapshots/module_graph_go_stdlib_hint.snap
+++ b/tests/ui/errors/snapshots/module_graph_go_stdlib_hint.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[main.lis:1:8]
  1 │ import "time"
    ·        ───┬──
-   ·           ╰── not found
+   ·           ╰── not a module in this project
    ╰────
   help: No `time` module found in your local project. Did you mean `import "go:time"` from Go's stdlib? · code: [resolve.module_not_found]

--- a/tests/ui/errors/snapshots/module_graph_module_not_found.snap
+++ b/tests/ui/errors/snapshots/module_graph_module_not_found.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[main.lis:1:8]
  1 │ import "nonexistent"
    ·        ──────┬──────
-   ·              ╰── not found
+   ·              ╰── not a module in this project
    ╰────
   help: Check the module path and ensure the file exists · code: [resolve.module_not_found]

--- a/tests/ui/errors/snapshots/module_graph_nested_import_error_attribution.snap
+++ b/tests/ui/errors/snapshots/module_graph_nested_import_error_attribution.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[mod.lis:1:8]
  1 │ import "inner"
    ·        ───┬───
-   ·           ╰── not found
+   ·           ╰── not a module in this project
    ╰────
   help: Check the module path and ensure the file exists · code: [resolve.module_not_found]

--- a/tests/ui/errors/snapshots/module_graph_src_prefix_hint.snap
+++ b/tests/ui/errors/snapshots/module_graph_src_prefix_hint.snap
@@ -5,6 +5,6 @@ source: tests/ui/errors/mod.rs
    ╭─[main.lis:1:8]
  1 │ import "src/math"
    ·        ─────┬────
-   ·             ╰── not found
+   ·             ╰── not a module in this project
    ╰────
   help: Did you mean `import "math"`? The `src/` prefix is not needed — imports are relative to the source directory · code: [resolve.module_not_found]

--- a/tests/ui/errors/snapshots/parse_attribute_inside_function_body.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_inside_function_body.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ 
  5 │   #[iterate]
    ·   ─────┬────
-   ·        ╰── not supported on target
+   ·        ╰── nothing here can carry an attribute
  6 │   let result = match command {
    ╰────
   help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]

--- a/tests/ui/errors/snapshots/parse_attribute_on_interface_parent.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_on_interface_parent.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  6 │ interface Child {
  7 │   #[iterate]
    ·   ─────┬────
-   ·        ╰── not supported on target
+   ·        ╰── nothing here can carry an attribute
  8 │   embed Parent
    ╰────
   help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]

--- a/tests/ui/errors/snapshots/parse_attribute_on_unsupported_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_attribute_on_unsupported_declaration.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ #[iterate]
    · ─────┬────
-   ·      ╰── not supported on target
+   ·      ╰── nothing here can carry an attribute
  3 │ interface Service {
    ╰────
   help: Remove the attribute, or move it onto an enum, struct, or function · code: [parse.misplaced_attribute]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding.snap
@@ -6,6 +6,6 @@ source: tests/ui/errors/mod.rs
  1 │ 
  2 │ fn walk_dir(root: string, fn: string) {}
    ·                           ─┬
-   ·                            ╰── reserved keyword
+   ·                            ╰── cannot be used as a binding name
    ╰────
   help: Rename binding `fn` · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_defer.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_defer.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let defer = 1
    ·       ──┬──
-   ·         ╰── reserved keyword
+   ·         ╰── cannot be used as a binding name
  4 │ }
    ╰────
   help: Rename this binding. `defer` is a keyword reserved for scheduling cleanup · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_in_for_loop.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_in_for_loop.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  3 │   let items = [1, 2, 3];
  4 │   for type in items {
    ·       ──┬─
-   ·         ╰── reserved keyword
+   ·         ╰── cannot be used as a binding name
  5 │     items
    ╰────
   help: Rename this binding. `type` is a keyword reserved for declaring named types · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_in_match.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_in_match.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │   match x {
  5 │     Some(type) => 0,
    ·          ──┬─
-   ·            ╰── reserved keyword
+   ·            ╰── cannot be used as a binding name
  6 │     None => 0,
    ╰────
   help: Rename this binding. `type` is a keyword reserved for declaring named types · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_match_kw.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_match_kw.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let match = 1
    ·       ──┬──
-   ·         ╰── reserved keyword
+   ·         ╰── cannot be used as a binding name
  4 │ }
    ╰────
   help: Rename this binding. `match` is a keyword reserved for pattern matching · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_recover.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_recover.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let recover = 1
    ·       ───┬───
-   ·          ╰── reserved keyword
+   ·          ╰── cannot be used as a binding name
  4 │ }
    ╰────
   help: Rename this binding. `recover` is a keyword reserved for catching panics · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_select.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_select.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let select = "SELECT * FROM users"
    ·       ───┬──
-   ·          ╰── reserved keyword
+   ·          ╰── cannot be used as a binding name
  4 │ }
    ╰────
   help: Rename this binding. `select` is a keyword reserved for waiting on multiple channel operations · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_keyword_as_binding_task.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_as_binding_task.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let task = || {}
    ·       ──┬─
-   ·         ╰── reserved keyword
+   ·         ╰── cannot be used as a binding name
  4 │ }
    ╰────
   help: Rename this binding. `task` is a keyword reserved for spawning concurrent work · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_misplaced_type_args_on_type_not_method.snap
+++ b/tests/ui/errors/snapshots/parse_misplaced_type_args_on_type_not_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ fn main() {
  3 │   let x = Slice<int>.new()
    ·                 ─┬─
-   ·                  ╰── misplaced
+   ·                  ╰── belongs on `new`
  4 │ }
    ╰────
   help: Set the type argument on the method: `Slice.new<int>()` · code: [parse.syntax_error]

--- a/tests/ui/lint/snapshots/conflicting_case_transforms.snap
+++ b/tests/ui/lint/snapshots/conflicting_case_transforms.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  1 │ 
  2 │ #[json(snake_case, camel_case)]
    · ───────────────┬───────────────
-   ·                ╰── conflicting
+   ·                ╰── only one case transform per tag
  3 │ pub struct User {
    ╰────
   help: Choose either `snake_case` or `camel_case`, not both · code: [attribute.conflicting_case_transforms]

--- a/tests/ui/lint/snapshots/deprecated_function.snap
+++ b/tests/ui/lint/snapshots/deprecated_function.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  7 │ fn main() {
  8 │   let _ = legacy()
    ·           ───┬──
-   ·              ╰── deprecated
+   ·              ╰── not intended for new code
  9 │ }
    ╰────
   help: Use the new API instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_function_value.snap
+++ b/tests/ui/lint/snapshots/deprecated_function_value.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  7 │ fn main() {
  8 │   let f = legacy
    ·           ───┬──
-   ·              ╰── deprecated
+   ·              ╰── not intended for new code
  9 │   let _ = f()
    ╰────
   help: Use the new API instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_go_stdlib_function.snap
+++ b/tests/ui/lint/snapshots/deprecated_go_stdlib_function.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  4 │ fn main() {
  5 │   let _ = strings.Title("hello world")
    ·           ──────┬──────
-   ·                 ╰── deprecated
+   ·                 ╰── not intended for new code
  6 │ }
    ╰────
   help: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_interface_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_interface_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  15 │ fn read(s: Store) -> int {
  16 │   s.old_get()
     ·   ────┬────
-    ·       ╰── deprecated
+    ·       ╰── not intended for new code
  17 │ }
     ╰────
   help: Use `fetch` instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  12 │   let c = Cache {}
  13 │   let _ = c.warm()
     ·           ───┬──
-    ·              ╰── deprecated
+    ·              ╰── not intended for new code
  14 │ }
     ╰────
   help: Use the new method instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/deprecated_promoted_method.snap
+++ b/tests/ui/lint/snapshots/deprecated_promoted_method.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  19 │   let s = Server { Logger: Logger { prefix: "[api]" }, port: 8080 }
  20 │   let _ = s.old_log()
     ·           ────┬────
-    ·               ╰── deprecated
+    ·               ╰── not intended for new code
  21 │ }
     ╰────
   help: Use the new method instead · code: [lint.deprecated]

--- a/tests/ui/lint/snapshots/duplicate_tag_key.snap
+++ b/tests/ui/lint/snapshots/duplicate_tag_key.snap
@@ -9,7 +9,7 @@ source: tests/ui/lint/mod.rs
    ·            ╰── first occurrence
  5 │   #[json(skip)]
    ·   ──────┬──────
-   ·         ╰── duplicate
+   ·         ╰── `json` is already set
  6 │   name: string,
    ╰────
   help: Remove one of the `json` attributes - each tag key may appear only once per field · code: [attribute.duplicate_tag]

--- a/tests/ui/lint/snapshots/goarch_comparison_invalid_equal.snap
+++ b/tests/ui/lint/snapshots/goarch_comparison_invalid_equal.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │ fn main() {
  4 │   let _ = runtime.GOARCH == "x86"
    ·           ───────────┬───────────
-   ·                      ╰── always false
+   ·                      ╰── `runtime.GOARCH` never holds this value
  5 │ }
    ╰────
   help: `runtime.GOARCH` only ever holds a known architecture, and this is not one. Did you mean a valid value such as `amd64`, `arm64`, or `386`? · code: [lint.goos_goarch_comparison]

--- a/tests/ui/lint/snapshots/goos_comparison_alias_import.snap
+++ b/tests/ui/lint/snapshots/goos_comparison_alias_import.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │ fn main() {
  4 │   let _ = r.GOOS == "win"
    ·           ───────┬───────
-   ·                  ╰── always false
+   ·                  ╰── `runtime.GOOS` never holds this value
  5 │ }
    ╰────
   help: `runtime.GOOS` only ever holds a known operating system, and this is not one. Did you mean a valid value such as `linux`, `darwin`, or `windows`? · code: [lint.goos_goarch_comparison]

--- a/tests/ui/lint/snapshots/goos_comparison_invalid_equal.snap
+++ b/tests/ui/lint/snapshots/goos_comparison_invalid_equal.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │ fn main() {
  4 │   let _ = runtime.GOOS == "windows10"
    ·           ─────────────┬─────────────
-   ·                        ╰── always false
+   ·                        ╰── `runtime.GOOS` never holds this value
  5 │ }
    ╰────
   help: `runtime.GOOS` only ever holds a known operating system, and this is not one. Did you mean a valid value such as `linux`, `darwin`, or `windows`? · code: [lint.goos_goarch_comparison]

--- a/tests/ui/lint/snapshots/goos_comparison_invalid_not_equal.snap
+++ b/tests/ui/lint/snapshots/goos_comparison_invalid_not_equal.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │ fn main() {
  4 │   let _ = runtime.GOOS != "frobnix"
    ·           ────────────┬────────────
-   ·                       ╰── always true
+   ·                       ╰── `runtime.GOOS` never holds this value
  5 │ }
    ╰────
   help: `runtime.GOOS` only ever holds a known operating system, and this is not one. Did you mean a valid value such as `linux`, `darwin`, or `windows`? · code: [lint.goos_goarch_comparison]

--- a/tests/ui/lint/snapshots/goos_comparison_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/goos_comparison_literal_on_left.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │ fn main() {
  4 │   let _ = "windows10" == runtime.GOOS
    ·           ─────────────┬─────────────
-   ·                        ╰── always false
+   ·                        ╰── `runtime.GOOS` never holds this value
  5 │ }
    ╰────
   help: `runtime.GOOS` only ever holds a known operating system, and this is not one. Did you mean a valid value such as `linux`, `darwin`, or `windows`? · code: [lint.goos_goarch_comparison]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_empty_slice.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_empty_slice.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _: int = [][0]
    ·                  ─┬─
-   ·                   ╰── out of bounds
+   ·                   ╰── no element at `0`
  4 │ }
    ╰────
   help: Indexing at `0` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_equal_to_length.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_equal_to_length.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = [10, 20, 30][3]
    ·                       ─┬─
-   ·                        ╰── out of bounds
+   ·                        ╰── no element at `3`
  4 │ }
    ╰────
   help: Indexing at `3` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_fixed_array.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_fixed_array.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn at(xs: Array<int, 3>) -> int {
  3 │   xs[3]
    ·     ─┬─
-   ·      ╰── out of bounds
+   ·      ╰── no element at `3`
  4 │ }
    ╰────
   help: Indexing at `3` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_length_call.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_length_call.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [10, 20]
  4 │   let _ = xs[xs.length()]
    ·             ──────┬──────
-   ·                   ╰── out of bounds
+   ·                   ╰── no element at `xs.length()`
  5 │ }
    ╰────
   help: Indexing at `xs.length()` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_past_length.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_past_length.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = [1, 2, 3][5]
    ·                    ─┬─
-   ·                     ╰── out of bounds
+   ·                     ╰── no element at `5`
  4 │ }
    ╰────
   help: Indexing at `5` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/index_out_of_bounds_single_element.snap
+++ b/tests/ui/lint/snapshots/index_out_of_bounds_single_element.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = [42][1]
    ·               ─┬─
-   ·                ╰── out of bounds
+   ·                ╰── no element at `1`
  4 │ }
    ╰────
   help: Indexing at `1` will panic at runtime · code: [infer.index_out_of_bounds]

--- a/tests/ui/lint/snapshots/integer_division_to_zero_basic.snap
+++ b/tests/ui/lint/snapshots/integer_division_to_zero_basic.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = 1 / 2
    ·           ──┬──
-   ·             ╰── always `0`
+   ·             ╰── the numerator is smaller in magnitude
  4 │ }
    ╰────
   help: Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division? · code: [lint.integer_division_to_zero]

--- a/tests/ui/lint/snapshots/integer_division_to_zero_larger_denominator.snap
+++ b/tests/ui/lint/snapshots/integer_division_to_zero_larger_denominator.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = 5 / 10
    ·           ───┬──
-   ·              ╰── always `0`
+   ·              ╰── the numerator is smaller in magnitude
  4 │ }
    ╰────
   help: Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division? · code: [lint.integer_division_to_zero]

--- a/tests/ui/lint/snapshots/integer_division_to_zero_negative_denominator.snap
+++ b/tests/ui/lint/snapshots/integer_division_to_zero_negative_denominator.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = 1 / -2
    ·           ───┬──
-   ·              ╰── always `0`
+   ·              ╰── the numerator is smaller in magnitude
  4 │ }
    ╰────
   help: Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division? · code: [lint.integer_division_to_zero]

--- a/tests/ui/lint/snapshots/integer_division_to_zero_negative_numerator.snap
+++ b/tests/ui/lint/snapshots/integer_division_to_zero_negative_numerator.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = -1 / 2
    ·           ───┬──
-   ·              ╰── always `0`
+   ·              ╰── the numerator is smaller in magnitude
  4 │ }
    ╰────
   help: Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division? · code: [lint.integer_division_to_zero]

--- a/tests/ui/lint/snapshots/integer_division_to_zero_parenthesized.snap
+++ b/tests/ui/lint/snapshots/integer_division_to_zero_parenthesized.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn main() {
  3 │   let _ = (1) / (2)
    ·           ────┬────
-   ·               ╰── always `0`
+   ·               ╰── the numerator is smaller in magnitude
  4 │ }
    ╰────
   help: Dividing these integer literals truncates to `0` because the numerator is smaller in magnitude than the denominator. Did you mean floating-point division? · code: [lint.integer_division_to_zero]

--- a/tests/ui/lint/snapshots/internal_type_leak.snap
+++ b/tests/ui/lint/snapshots/internal_type_leak.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │ 
  6 │ pub fn leaky_function() -> PrivateData {
    ·                            ─────┬─────
-   ·                                 ╰── private
+   ·                                 ╰── exposed by `leaky_function`
  7 │   PrivateData { _value: 42 }
    ╰────
   help: `PrivateData` is private but exposed by `leaky_function`, which is public. Add `pub` to the private type or remove it from the public API · code: [lint.internal_type_leak]

--- a/tests/ui/lint/snapshots/internal_type_leak_in_higher_order_function.snap
+++ b/tests/ui/lint/snapshots/internal_type_leak_in_higher_order_function.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │ 
  6 │ pub fn make_handler(seed: int) -> fn() -> PrivateOutput {
    ·                                           ──────┬──────
-   ·                                                 ╰── private
+   ·                                                 ╰── exposed by `make_handler`
  7 │   || PrivateOutput { _result: seed }
    ╰────
   help: `PrivateOutput` is private but exposed by `make_handler`, which is public. Add `pub` to the private type or remove it from the public API · code: [lint.internal_type_leak]

--- a/tests/ui/lint/snapshots/internal_type_leak_in_tuple_return.snap
+++ b/tests/ui/lint/snapshots/internal_type_leak_in_tuple_return.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
   9 │ 
  10 │ pub fn get_pair() -> (PrivateA, PrivateB) {
     ·                       ────┬───
-    ·                           ╰── private
+    ·                           ╰── exposed by `get_pair`
  11 │   (PrivateA { _a: 1 }, PrivateB { _b: 2 })
     ╰────
   help: `PrivateA` is private but exposed by `get_pair`, which is public. Add `pub` to the private type or remove it from the public API · code: [lint.internal_type_leak]

--- a/tests/ui/lint/snapshots/nested_fstring.snap
+++ b/tests/ui/lint/snapshots/nested_fstring.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  6 │   let b = 2
  7 │   fmt.Print(f"result: {f"{a} of {b}"}")
    ·                        ──────┬──────
-   ·                              ╰── nested f-string
+   ·                              ╰── already inside an f-string
  8 │ }
    ╰────
   help: Move the inner f-string's text and interpolations into the surrounding f-string · code: [lint.nested_fstring]

--- a/tests/ui/lint/snapshots/nested_fstring_solo_int_inner.snap
+++ b/tests/ui/lint/snapshots/nested_fstring_solo_int_inner.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let n = 1
  6 │   fmt.Print(f"n = {f"{n}"} done")
    ·                    ───┬──
-   ·                       ╰── nested f-string
+   ·                       ╰── already inside an f-string
  7 │ }
    ╰────
   help: Move the inner f-string's text and interpolations into the surrounding f-string · code: [lint.nested_fstring]

--- a/tests/ui/lint/snapshots/non_negative_comparison_alias_identifier_form.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_alias_identifier_form.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let s: MyString = "hi"
  6 │   let _ = MyString.length(s) < 0
    ·           ───────────┬──────────
-   ·                      ╰── always false
+   ·                      ╰── a length is never negative
  7 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_greater_or_equal_zero.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_greater_or_equal_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = xs.length() >= 0
    ·           ────────┬───────
-   ·                   ╰── always true
+   ·                   ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_less_than_zero.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_less_than_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = xs.length() < 0
    ·           ───────┬───────
-   ·                  ╰── always false
+   ·                  ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_native_identifier_form.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_native_identifier_form.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = Slice.length(xs) < 0
    ·           ──────────┬─────────
-   ·                     ╰── always false
+   ·                     ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_pipeline_form.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_pipeline_form.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = (xs |> Slice.length) >= 0
    ·           ────────────┬────────────
-   ·                       ╰── always true
+   ·                       ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_ref_receiver.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_ref_receiver.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  4 │   let r = &xs
  5 │   let _ = r.length() < 0
    ·           ───────┬──────
-   ·                  ╰── always false
+   ·                  ╰── a length is never negative
  6 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_string_receiver.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_string_receiver.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let s = "hello"
  4 │   let _ = s.length() < 0
    ·           ───────┬──────
-   ·                  ╰── always false
+   ·                  ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_with_parens.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_with_parens.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = (xs.length()) >= (0)
    ·           ──────────┬─────────
-   ·                     ╰── always true
+   ·                     ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_zero_greater.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_zero_greater.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = 0 > xs.length()
    ·           ───────┬───────
-   ·                  ╰── always false
+   ·                  ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/non_negative_comparison_zero_less_or_equal.snap
+++ b/tests/ui/lint/snapshots/non_negative_comparison_zero_less_or_equal.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let xs = [1, 2, 3]
  4 │   let _ = 0 <= xs.length()
    ·           ────────┬───────
-   ·                   ╰── always true
+   ·                   ╰── a length is never negative
  5 │ }
    ╰────
   help: A length is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.non_negative_comparison]

--- a/tests/ui/lint/snapshots/raw_tag_plus_alias_same_key_duplicate.snap
+++ b/tests/ui/lint/snapshots/raw_tag_plus_alias_same_key_duplicate.snap
@@ -9,7 +9,7 @@ source: tests/ui/lint/mod.rs
    ·                 ╰── first occurrence
  5 │   #[tag("validate", "email")]
    ·   ─────────────┬─────────────
-   ·                ╰── duplicate
+   ·                ╰── `validate` is already set
  6 │   name: string,
    ╰────
   help: Remove one of the `validate` attributes - each tag key may appear only once per field · code: [attribute.duplicate_tag]

--- a/tests/ui/lint/snapshots/redundant_comparison_conjunction_wider.snap
+++ b/tests/ui/lint/snapshots/redundant_comparison_conjunction_wider.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5;
  4 │   let _ = x < 5 && x < 10
    ·                    ───┬──
-   ·                       ╰── redundant
+   ·                       ╰── already implied by the other comparison
  5 │ }
    ╰────
-  help: This comparison is already implied by the other, so the expression is equivalent to the other side alone · code: [lint.redundant_comparison]
+  help: Drop this comparison, since the expression is equivalent to the other side alone · code: [lint.redundant_comparison]

--- a/tests/ui/lint/snapshots/redundant_comparison_disjunction_narrower.snap
+++ b/tests/ui/lint/snapshots/redundant_comparison_disjunction_narrower.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5;
  4 │   let _ = x < 5 || x < 10
    ·           ──┬──
-   ·             ╰── redundant
+   ·             ╰── already implied by the other comparison
  5 │ }
    ╰────
-  help: This comparison is already implied by the other, so the expression is equivalent to the other side alone · code: [lint.redundant_comparison]
+  help: Drop this comparison, since the expression is equivalent to the other side alone · code: [lint.redundant_comparison]

--- a/tests/ui/lint/snapshots/redundant_comparison_float_operand_integer_literals.snap
+++ b/tests/ui/lint/snapshots/redundant_comparison_float_operand_integer_literals.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let f: float64 = 1.0
  4 │   let _ = f < 5 || f < 10
    ·           ──┬──
-   ·             ╰── redundant
+   ·             ╰── already implied by the other comparison
  5 │ }
    ╰────
-  help: This comparison is already implied by the other, so the expression is equivalent to the other side alone · code: [lint.redundant_comparison]
+  help: Drop this comparison, since the expression is equivalent to the other side alone · code: [lint.redundant_comparison]

--- a/tests/ui/lint/snapshots/redundant_comparison_greater_than.snap
+++ b/tests/ui/lint/snapshots/redundant_comparison_greater_than.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5;
  4 │   let _ = x > 5 || x > 3
    ·           ──┬──
-   ·             ╰── redundant
+   ·             ╰── already implied by the other comparison
  5 │ }
    ╰────
-  help: This comparison is already implied by the other, so the expression is equivalent to the other side alone · code: [lint.redundant_comparison]
+  help: Drop this comparison, since the expression is equivalent to the other side alone · code: [lint.redundant_comparison]

--- a/tests/ui/lint/snapshots/redundant_guards_int.snap
+++ b/tests/ui/lint/snapshots/redundant_guards_int.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   match o {
  4 │     Some(x) if x == 5 => 1,
    ·                ───┬──
-   ·                   ╰── redundant guard
+   ·                   ╰── the pattern can test this directly
  5 │     _ => 0,
    ╰────
   help: Replace `x` with `5` in the pattern and drop the guard · code: [lint.redundant_guards]

--- a/tests/ui/lint/snapshots/redundant_guards_reversed_operands.snap
+++ b/tests/ui/lint/snapshots/redundant_guards_reversed_operands.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   match o {
  4 │     Some(x) if 5 == x => 1,
    ·                ───┬──
-   ·                   ╰── redundant guard
+   ·                   ╰── the pattern can test this directly
  5 │     _ => 0,
    ╰────
   help: Replace `x` with `5` in the pattern and drop the guard · code: [lint.redundant_guards]

--- a/tests/ui/lint/snapshots/redundant_guards_string.snap
+++ b/tests/ui/lint/snapshots/redundant_guards_string.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   match o {
  4 │     Some(x) if x == "hi" => 1,
    ·                ────┬────
-   ·                    ╰── redundant guard
+   ·                    ╰── the pattern can test this directly
  5 │     _ => 0,
    ╰────
   help: Replace `x` with `"hi"` in the pattern and drop the guard · code: [lint.redundant_guards]

--- a/tests/ui/lint/snapshots/redundant_guards_top_level_binding.snap
+++ b/tests/ui/lint/snapshots/redundant_guards_top_level_binding.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   match n {
  4 │     x if x == 5 => 1,
    ·          ───┬──
-   ·             ╰── redundant guard
+   ·             ╰── the pattern can test this directly
  5 │     _ => 0,
    ╰────
   help: Replace `x` with `5` in the pattern and drop the guard · code: [lint.redundant_guards]

--- a/tests/ui/lint/snapshots/redundant_operation_add_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_add_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x + 0
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_and_false.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_and_false.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b = true
  4 │   let _ = b && false
    ·           ─────┬────
-   ·                ╰── always `false`
+   ·                ╰── the other operand cannot change the result
  5 │ }
    ╰────
   help: Simplify this operation to `false` · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_and_true.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_and_true.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b = true
  4 │   let _ = b && true
    ·           ────┬────
-   ·               ╰── has no effect
+   ·               ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_bitwise_and_not_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_bitwise_and_not_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x &^ 0
    ·           ───┬──
-   ·              ╰── has no effect
+   ·              ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_bitwise_and_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_bitwise_and_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x & 0
    ·           ──┬──
-   ·             ╰── always `0`
+   ·             ╰── the other operand cannot change the result
  5 │ }
    ╰────
   help: Simplify this operation to `0` · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_bitwise_or_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_bitwise_or_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x | 0
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_div_one.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_div_one.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x / 1
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_identity_keeps_call.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_identity_keeps_call.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let x = 5
  6 │   let _ = ident(x) + 0
    ·           ──────┬─────
-   ·                 ╰── has no effect
+   ·                 ╰── one operand leaves the other unchanged
  7 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_modulo_one.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_modulo_one.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x % 1
    ·           ──┬──
-   ·             ╰── always `0`
+   ·             ╰── the other operand cannot change the result
  5 │ }
    ╰────
   help: Simplify this operation to `0` · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_mul_one.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_mul_one.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x * 1
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_mul_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_mul_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x * 0
    ·           ──┬──
-   ·             ╰── always `0`
+   ·             ╰── the other operand cannot change the result
  5 │ }
    ╰────
   help: Simplify this operation to `0` · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_or_false.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_or_false.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b = true
  4 │   let _ = b || false
    ·           ─────┬────
-   ·                ╰── has no effect
+   ·                ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_or_true.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_or_true.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b = true
  4 │   let _ = b || true
    ·           ────┬────
-   ·               ╰── always `true`
+   ·               ╰── the other operand cannot change the result
  5 │ }
    ╰────
   help: Simplify this operation to `true` · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_shift_left_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_shift_left_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x << 0
    ·           ───┬──
-   ·              ╰── has no effect
+   ·              ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_shift_right_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_shift_right_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x >> 0
    ·           ───┬──
-   ·              ╰── has no effect
+   ·              ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_sub_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_sub_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = x - 0
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_unsigned_add_zero.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_unsigned_add_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let u: uint = 5
  4 │   let _ = u + 0
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/redundant_operation_zero_add.snap
+++ b/tests/ui/lint/snapshots/redundant_operation_zero_add.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let x = 5
  4 │   let _ = 0 + x
    ·           ──┬──
-   ·             ╰── has no effect
+   ·             ╰── one operand leaves the other unchanged
  5 │ }
    ╰────
   help: Simplify this operation to its other operand · code: [lint.redundant_operation]

--- a/tests/ui/lint/snapshots/type_limit_comparison_alias.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_alias.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let b: Big = 5
  6 │   let _ = b > 65535
    ·           ────┬────
-   ·               ╰── always `false`
+   ·               ╰── compares against the limit of the value's type
  7 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_byte_max.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_byte_max.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b: byte = 5
  4 │   let _ = b > 255
    ·           ───┬───
-   ·              ╰── always `false`
+   ·              ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_int32_gt_max.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_int32_gt_max.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b: int32 = 5
  4 │   let _ = b > 2147483647
    ·           ───────┬──────
-   ·                  ╰── always `false`
+   ·                  ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_int8_ge_min.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_int8_ge_min.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let c: int8 = 5
  4 │   let _ = c >= -128
    ·           ────┬────
-   ·               ╰── always `true`
+   ·               ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `true`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_int8_lt_min.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_int8_lt_min.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let c: int8 = 5
  4 │   let _ = c < -128
    ·           ────┬───
-   ·               ╰── always `false`
+   ·               ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_literal_on_left.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_literal_on_left.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let a: uint8 = 5
  4 │   let _ = 255 < a
    ·           ───┬───
-   ·              ╰── always `false`
+   ·              ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_named_newtype.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_named_newtype.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let s = Small(5)
  6 │   let _ = s <= 255
    ·           ────┬───
-   ·               ╰── always `true`
+   ·               ╰── compares against the limit of the value's type
  7 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `true`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_uint8_gt_max.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_uint8_gt_max.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let a: uint8 = 5
  4 │   let _ = a > 255
    ·           ───┬───
-   ·              ╰── always `false`
+   ·              ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `false`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/type_limit_comparison_uint8_le_max.snap
+++ b/tests/ui/lint/snapshots/type_limit_comparison_uint8_le_max.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let a: uint8 = 5
  4 │   let _ = a <= 255
    ·           ────┬───
-   ·               ╰── always `true`
+   ·               ╰── compares against the limit of the value's type
  5 │ }
    ╰────
   help: This compares against the limit of the value's type, so this comparison is always `true`. Did you mean to compare against a different value? · code: [lint.type_limit_comparison]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_comparison.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_comparison.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n = 5;
  4 │   while n < 10 {
    ·         ───┬──
-   ·            ╰── never changes
+   ·            ╰── the loop either never runs or never ends
  5 │     let _ = n
    ╰────
-  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]
+  help: Nothing in the loop body changes this condition. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_negated_flag.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_negated_flag.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let done = false;
  4 │   while !done {
    ·         ──┬──
-   ·           ╰── never changes
+   ·           ╰── the loop either never runs or never ends
  5 │     let _ = done
    ╰────
-  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]
+  help: Nothing in the loop body changes this condition. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_task_return.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_task_return.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n = 5;
  4 │   while n < 10 {
    ·         ───┬──
-   ·            ╰── never changes
+   ·            ╰── the loop either never runs or never ends
  5 │     task { return }
    ╰────
-  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]
+  help: Nothing in the loop body changes this condition. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unchanging_loop_condition_try_scoped_propagate.snap
+++ b/tests/ui/lint/snapshots/unchanging_loop_condition_try_scoped_propagate.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let n = 5;
  6 │   while n < 10 {
    ·         ───┬──
-   ·            ╰── never changes
+   ·            ╰── the loop either never runs or never ends
  7 │     let _ = try { may_fail()? }
    ╰────
-  help: Nothing in the loop body changes this condition, so the loop either never runs or never terminates. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]
+  help: Nothing in the loop body changes this condition. Did you forget to update a variable, or mean to `break` out of the loop? · code: [infer.unchanging_loop_condition]

--- a/tests/ui/lint/snapshots/unsigned_comparison_byte.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_byte.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let b: byte = 5;
  4 │   let _ = b < 0
    ·           ──┬──
-   ·             ╰── always false
+   ·             ╰── an unsigned integer is never negative
  5 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_greater_than_or_equal_zero.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_greater_than_or_equal_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n: uint = 5;
  4 │   let _ = n >= 0
    ·           ───┬──
-   ·              ╰── always true
+   ·              ╰── an unsigned integer is never negative
  5 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_less_than_zero.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_less_than_zero.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n: uint = 5;
  4 │   let _ = n < 0
    ·           ──┬──
-   ·             ╰── always false
+   ·             ╰── an unsigned integer is never negative
  5 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_named_newtype.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_named_newtype.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  5 │   let c = Counter(5)
  6 │   let _ = c < 0
    ·           ──┬──
-   ·             ╰── always false
+   ·             ╰── an unsigned integer is never negative
  7 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_with_parens.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_with_parens.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n: uint = 5;
  4 │   let _ = (n) >= (0)
    ·           ─────┬────
-   ·                ╰── always true
+   ·                ╰── an unsigned integer is never negative
  5 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/unsigned_comparison_zero_on_left.snap
+++ b/tests/ui/lint/snapshots/unsigned_comparison_zero_on_left.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  3 │   let n: uint = 5;
  4 │   let _ = 0 > n
    ·           ──┬──
-   ·             ╰── always false
+   ·             ╰── an unsigned integer is never negative
  5 │ }
    ╰────
   help: An unsigned integer is never negative, so this comparison always has the same result. Did you mean to compare against a different value? · code: [lint.unsigned_comparison]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_if_let_option.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_if_let_option.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn first(x: Option<int>) -> Option<int> {
  3 │   let v = if let Some(v) = x {
    ·           ─┬
-   ·            ╰── verbose
+   ·            ╰── re-returns the failure by hand
  4 │     v
    ╰────
   help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn first(x: Option<int>) -> Option<int> {
  3 │   let v = match x {
    ·           ──┬──
-   ·             ╰── verbose
+   ·             ╰── re-returns the failure by hand
  4 │     Some(v) => v,
    ╰────
   help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_reversed_arms.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_reversed_arms.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn first(x: Option<int>) -> Option<int> {
  3 │   let v = match x {
    ·           ──┬──
-   ·             ╰── verbose
+   ·             ╰── re-returns the failure by hand
  4 │     None => return None,
    ╰────
   help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_wildcard_arm.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_option_match_wildcard_arm.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn first(x: Option<int>) -> Option<int> {
  3 │   let v = match x {
    ·           ──┬──
-   ·             ╰── verbose
+   ·             ╰── re-returns the failure by hand
  4 │     Some(v) => v,
    ╰────
   help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]

--- a/tests/ui/lint/snapshots/verbose_failure_propagation_result_match.snap
+++ b/tests/ui/lint/snapshots/verbose_failure_propagation_result_match.snap
@@ -6,7 +6,7 @@ source: tests/ui/lint/mod.rs
  2 │ fn first(x: Result<int, string>) -> Result<int, string> {
  3 │   let v = match x {
    ·           ──┬──
-   ·             ╰── verbose
+   ·             ╰── re-returns the failure by hand
  4 │     Ok(v) => v,
    ╰────
   help: Use `?` to propagate the failure concisely · code: [lint.verbose_failure_propagation]


### PR DESCRIPTION
48 diagnostic labels only restated their title, so the label now carries extra details. This was not obvious while the label appeared only in human-friendly diagnostics, but `lis check --output unix` puts the two on the same line, where the repetition/redundancy is clear.

```
✕ Private field                        ✕ Private field
  ╰── private                            ╰── private to `shapes`

✕ Variant not found                    ✕ Variant not found
  ╰── not found                          ╰── the enum is `shapes.Shape`
```

Follow-up to #1181
