### PR TITLE
perf: scan imports instead of parsing cache-hit modules

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,9 +8,19 @@ permissions:
   issues: write
 
 jobs:
-  fuzz-parse:
+  fuzz:
     if: github.repository == 'ivov/lisette'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: parse
+            recipe: fuzz-parse
+          - target: infer
+            recipe: fuzz-infer
+          - target: scan_imports
+            recipe: fuzz-scan-imports
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
@@ -31,32 +41,34 @@ jobs:
         if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --version 0.13.1 --locked
 
-      - name: Restore fuzz-parse corpus
+      - name: Restore corpus
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
         with:
-          path: fuzz/corpus/parse
-          key: fuzz-corpus-parse
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
 
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # ratchet:extractions/setup-just@v3
 
-      - name: Minimize fuzz-parse corpus
-        run: cargo +nightly fuzz cmin parse -- -rss_limit_mb=2048
+      - name: Minimize corpus
+        run: cargo +nightly fuzz cmin ${{ matrix.target }} -- -rss_limit_mb=2048
 
-      - name: Fuzz parse
-        run: just fuzz-parse
+      - name: Fuzz ${{ matrix.target }}
+        run: just ${{ matrix.recipe }}
 
-      - name: Save fuzz-parse corpus
+      - name: Save corpus
         if: always()
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/save@v5
         with:
-          path: fuzz/corpus/parse
-          key: fuzz-corpus-parse-${{ github.run_id }}
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
 
       - name: Upload crash artifacts
         if: failure() && hashFiles('fuzz/artifacts/**') != ''
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6
         with:
-          name: fuzz-crash-parse
+          name: fuzz-crash-${{ matrix.target }}
           path: fuzz/artifacts/
 
       - name: Create issue on crash
@@ -64,11 +76,11 @@ jobs:
         run: |
           gh issue create \
             --repo ivov/lisette \
-            --title "fuzz-parse crash (run ${{ github.run_id }})" \
-            --body "The \`fuzz-parse\` target crashed in a scheduled fuzz run.
+            --title "fuzz-${{ matrix.target }} crash (run ${{ github.run_id }})" \
+            --body "The \`${{ matrix.target }}\` target crashed in a scheduled fuzz run.
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          **Artifact:** \`fuzz-crash-parse\` (attached to the run)"
+          **Artifact:** \`fuzz-crash-${{ matrix.target }}\` (attached to the run)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,84 +89,8 @@ jobs:
         run: |
           gh issue create \
             --repo ivov/lisette \
-            --title "fuzz-parse job failed (run ${{ github.run_id }})" \
-            --body "The \`fuzz-parse\` job failed in a scheduled fuzz run. The usual cause is the target no longer building against current \`crates/\`.
-
-          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  fuzz-infer:
-    if: github.repository == 'ivov/lisette'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # ratchet:dtolnay/rust-toolchain@nightly
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # ratchet:Swatinem/rust-cache@v2
-        with:
-          workspaces: fuzz -> target
-
-      - name: Cache cargo-fuzz binary
-        id: cache-cargo-fuzz
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-0.13.1
-
-      - name: Install cargo-fuzz
-        if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --version 0.13.1 --locked
-
-      - name: Restore fuzz-infer corpus
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
-        with:
-          path: fuzz/corpus/infer
-          key: fuzz-corpus-infer
-
-      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # ratchet:extractions/setup-just@v3
-
-      - name: Minimize fuzz-infer corpus
-        run: cargo +nightly fuzz cmin infer -- -rss_limit_mb=2048
-
-      - name: Fuzz infer
-        run: just fuzz-infer
-
-      - name: Save fuzz-infer corpus
-        if: always()
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/save@v5
-        with:
-          path: fuzz/corpus/infer
-          key: fuzz-corpus-infer-${{ github.run_id }}
-
-      - name: Upload crash artifacts
-        if: failure() && hashFiles('fuzz/artifacts/**') != ''
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # ratchet:actions/upload-artifact@v6
-        with:
-          name: fuzz-crash-infer
-          path: fuzz/artifacts/
-
-      - name: Create issue on crash
-        if: failure() && hashFiles('fuzz/artifacts/**') != ''
-        run: |
-          gh issue create \
-            --repo ivov/lisette \
-            --title "fuzz-infer crash (run ${{ github.run_id }})" \
-            --body "The \`fuzz-infer\` target crashed in a scheduled fuzz run.
-
-          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          **Artifact:** \`fuzz-crash-infer\` (attached to the run)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create issue on job failure
-        if: failure() && hashFiles('fuzz/artifacts/**') == ''
-        run: |
-          gh issue create \
-            --repo ivov/lisette \
-            --title "fuzz-infer job failed (run ${{ github.run_id }})" \
-            --body "The \`fuzz-infer\` job failed in a scheduled fuzz run. The usual cause is the target no longer building against current \`crates/\`.
+            --title "fuzz-${{ matrix.target }} job failed (run ${{ github.run_id }})" \
+            --body "The \`${{ matrix.target }}\` job failed in a scheduled fuzz run. The usual cause is the target no longer building against current \`crates/\`.
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -417,6 +417,84 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_dependency_edit_invalidates_its_dependents_on_a_warm_build() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        stdfs::create_dir_all(root.join("src").join("top")).unwrap();
+        stdfs::create_dir_all(root.join("src").join("dep")).unwrap();
+        stdfs::write(
+            root.join("lisette.toml"),
+            "[project]\nname = \"github.com/test/edges\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("main.lis"),
+            "import \"top\"\n\nfn main() {\n  let _ = top.value()\n}\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("top").join("top.lis"),
+            "import \"dep\"\n\npub fn value() -> int {\n  dep.number()\n}\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("dep").join("dep.lis"),
+            "pub fn number() -> int { 1 }\n",
+        )
+        .unwrap();
+
+        let cold = check_diagnostics(root);
+        assert!(cold.is_empty(), "fixture must be clean; got: {cold:?}");
+        assert!(
+            root.join("target/.lisette/cache/top.cache").exists(),
+            "top must be cached for this test to be meaningful"
+        );
+
+        stdfs::write(
+            root.join("src").join("dep").join("dep.lis"),
+            "pub fn number() -> string { \"one\" }\n",
+        )
+        .unwrap();
+
+        let warm = check_diagnostics(root);
+        assert!(
+            warm.iter().any(|(is_error, _)| *is_error),
+            "editing `dep` must invalidate `top`, whose edge comes from the scanner; got: {warm:?}"
+        );
+    }
+
+    #[test]
+    fn a_module_whose_body_fails_to_parse_still_reports_its_syntax_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        stdfs::create_dir_all(root.join("src").join("broken")).unwrap();
+        stdfs::write(
+            root.join("lisette.toml"),
+            "[project]\nname = \"github.com/test/broken\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("main.lis"),
+            "import \"broken\"\n\nfn main() {\n  let _ = broken.value()\n}\n",
+        )
+        .unwrap();
+        stdfs::write(
+            root.join("src").join("broken").join("broken.lis"),
+            "import \"go:fmt\"\n\npub fn value() -> int {\n",
+        )
+        .unwrap();
+
+        let diagnostics = check_diagnostics(root);
+
+        assert!(
+            diagnostics.iter().any(
+                |(is_error, code)| *is_error && code.as_deref() == Some("parse.unclosed_block")
+            ),
+            "a readable prologue must not hide a broken body; got: {diagnostics:?}"
+        );
+    }
+
     fn analyze_cache_state(
         project_dir: &std::path::Path,
     ) -> (Vec<String>, Vec<(bool, Option<String>)>) {

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -23,15 +23,16 @@ use crate::cache::{
     CompiledModule, ModuleInterface, build_cached_module, compute_emit_artifact_hash,
     compute_module_hash, get_dependency_module_hashes,
     go_stdlib::{self, load_cached_go_module},
-    hash_module_source_pair, hash_module_source_pair_refs, is_cache_disabled,
-    prelude as prelude_cache, try_load_cache,
+    hash_module_source_pair, is_cache_disabled, prelude as prelude_cache, try_load_cache,
 };
 use crate::checker::infer::{FileInferenceInput, InferCtx};
 use crate::checker::{TaskOutput, TaskState};
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use crate::facts::Facts;
 use crate::loader::{DiscoveredModules, Loader};
-use crate::module_graph::{DependencyGraph, ModuleGraphOptions, Roots, build_module_graph};
+use crate::module_graph::{
+    DependencyGraph, ModuleGraphOptions, Roots, ScannedFile, build_module_graph,
+};
 use crate::prelude::{parse_and_register_prelude, parse_and_register_test_prelude};
 use crate::store::{ENTRY_FILE_ID, ENTRY_MODULE_ID, Store};
 
@@ -370,7 +371,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     }
     let unreachable_modules = find_unreachable_modules(&discovered, &graph_result);
 
-    let has_pre_check_errors = sink.has_errors();
+    let has_graph_errors = sink.has_errors();
 
     let cache_disabled = input.disable_cache || is_cache_disabled();
     let cache = load_prelude(
@@ -400,7 +401,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         store,
         facts: module_output.facts,
         sink: module_output.sink,
-        has_pre_check_errors,
+        has_pre_check_errors: has_graph_errors || module_output.has_parse_errors,
         compiled_modules: module_output.compiled_modules,
         cached_modules: module_output.cached_modules,
         cache_root,

--- a/crates/semantics/src/analysis/modules.rs
+++ b/crates/semantics/src/analysis/modules.rs
@@ -4,8 +4,52 @@ use rustc_hash::FxHashMap as HashMap;
 
 struct CacheCandidate {
     compiled: CompiledModule,
-    files: Vec<File>,
+    files: Vec<ScannedFile>,
+    rewrite_root_import: bool,
     topo_rank: usize,
+}
+
+struct UnparsedModule {
+    module_id: String,
+    files: Vec<ScannedFile>,
+    rewrite_root_import: bool,
+    pending: PendingModule,
+}
+
+struct ParsedModule {
+    module_id: String,
+    files: Vec<File>,
+    errors: Vec<ParseError>,
+    pending: PendingModule,
+}
+
+impl UnparsedModule {
+    fn parse(self) -> ParsedModule {
+        let Self {
+            module_id,
+            files: scanned,
+            rewrite_root_import,
+            pending,
+        } = self;
+
+        let mut files = Vec::with_capacity(scanned.len());
+        let mut errors = Vec::new();
+        for scanned_file in scanned {
+            let (mut file, file_errors) = scanned_file.parse();
+            if rewrite_root_import {
+                file.rewrite_import(crate::loader::ROOT_IMPORT, ENTRY_MODULE_ID);
+            }
+            files.push(file);
+            errors.extend(file_errors);
+        }
+
+        ParsedModule {
+            module_id,
+            files,
+            errors,
+            pending,
+        }
+    }
 }
 
 enum PendingModule {
@@ -60,6 +104,7 @@ pub(super) struct ModuleInferenceOutput {
     pub(super) cached_modules: HashSet<String>,
     pub(super) compiled_modules: Vec<CompiledModule>,
     pub(super) sink: LocalSink,
+    pub(super) has_parse_errors: bool,
 }
 
 /// Classifies every topo-ordered module as a `go:` import, a cache candidate,
@@ -78,6 +123,7 @@ pub(super) fn infer_all_modules(
 
     let mut to_infer: Vec<PendingModule> = Vec::new();
     let mut candidates: Vec<CacheCandidate> = Vec::new();
+    let mut unparsed: Vec<UnparsedModule> = Vec::new();
 
     let mut source_hashes: HashMap<String, (u64, u64)> =
         if input.graph_result.files.len() < PARALLEL_THRESHOLD {
@@ -85,14 +131,14 @@ pub(super) fn infer_all_modules(
                 .graph_result
                 .files
                 .iter()
-                .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                .map(|(id, files)| (id.clone(), hash_module_source_pair(scanned_sources(files))))
                 .collect()
         } else {
             input
                 .graph_result
                 .files
                 .par_iter()
-                .map(|(id, files)| (id.clone(), hash_module_source_pair(files)))
+                .map(|(id, files)| (id.clone(), hash_module_source_pair(scanned_sources(files))))
                 .collect()
         };
 
@@ -101,9 +147,12 @@ pub(super) fn infer_all_modules(
         .map(|module| module.files.values().collect())
         .unwrap_or_default();
     if !entry_files.is_empty() {
+        let sources = entry_files
+            .iter()
+            .map(|file| (file.name.as_str(), file.source.as_str()));
         source_hashes.insert(
             ENTRY_MODULE_ID.to_string(),
-            hash_module_source_pair_refs(&entry_files),
+            hash_module_source_pair(sources),
         );
     }
 
@@ -123,24 +172,19 @@ pub(super) fn infer_all_modules(
             continue;
         }
 
-        let mut files = input
+        let files = input
             .graph_result
             .files
             .remove(&module_id)
             .unwrap_or_default();
-        if input.scope.has_project_root()
+        let rewrite_root_import = input.scope.has_project_root()
             && input.project_kind == ProjectKind::Library
-            && crate::loader::is_external_test_module(&module_id)
-        {
-            for file in &mut files {
-                file.rewrite_import(crate::loader::ROOT_IMPORT, ENTRY_MODULE_ID);
-            }
-        }
+            && crate::loader::is_external_test_module(&module_id);
         // Production-only hash drives dependents/emit; all-files hash drives own validity.
         let (production_hash, full_hash) = source_hashes
             .get(&module_id)
             .copied()
-            .unwrap_or_else(|| hash_module_source_pair(&files));
+            .unwrap_or_else(|| hash_module_source_pair(scanned_sources(&files)));
 
         let dep_hashes =
             get_dependency_module_hashes(dependencies.dependencies(&module_id), &module_hashes);
@@ -164,15 +208,20 @@ pub(super) fn infer_all_modules(
             (Some(_), Some(compiled)) => candidates.push(CacheCandidate {
                 compiled,
                 files,
+                rewrite_root_import,
                 topo_rank,
             }),
             (None, compiled) | (Some(_), compiled @ None) => {
-                store.store_module(&module_id, files);
                 let pending = match compiled {
                     Some(module) => PendingModule::Compiled { module, topo_rank },
                     None => PendingModule::Entry { topo_rank },
                 };
-                to_infer.push(pending);
+                unparsed.push(UnparsedModule {
+                    module_id,
+                    files,
+                    rewrite_root_import,
+                    pending,
+                });
             }
         }
     }
@@ -189,7 +238,9 @@ pub(super) fn infer_all_modules(
         }
     };
     cached_modules.extend(cache_load.cached);
-    to_infer.extend(cache_load.to_infer);
+    unparsed.extend(cache_load.missed);
+
+    let has_parse_errors = parse_and_store_modules(&mut checker, store, unparsed, &mut to_infer);
 
     for pending in &to_infer {
         checker.predeclare_module_types(store, pending.module_id());
@@ -238,7 +289,41 @@ pub(super) fn infer_all_modules(
         cached_modules,
         compiled_modules,
         sink: checker.sink,
+        has_parse_errors,
     }
+}
+
+fn scanned_sources(files: &[ScannedFile]) -> impl Iterator<Item = (&str, &str)> + Clone {
+    files
+        .iter()
+        .map(|file| (file.name.as_str(), file.source.as_str()))
+}
+
+/// Parses everything the cache did not serve, in one batch.
+fn parse_and_store_modules(
+    checker: &mut TaskState,
+    store: &mut Store,
+    unparsed: Vec<UnparsedModule>,
+    to_infer: &mut Vec<PendingModule>,
+) -> bool {
+    let file_count: usize = unparsed.iter().map(|module| module.files.len()).sum();
+    let parsed: Vec<ParsedModule> = if file_count < PARALLEL_THRESHOLD {
+        unparsed.into_iter().map(UnparsedModule::parse).collect()
+    } else {
+        unparsed
+            .into_par_iter()
+            .map(UnparsedModule::parse)
+            .collect()
+    };
+
+    let mut has_parse_errors = false;
+    for module in parsed {
+        has_parse_errors |= !module.errors.is_empty();
+        checker.sink.extend_parse_errors(module.errors);
+        store.store_module(&module.module_id, module.files);
+        to_infer.push(module.pending);
+    }
+    has_parse_errors
 }
 
 /// Registers one `go:` module, reusing the stdlib cache when it covers the package.
@@ -290,10 +375,10 @@ fn register_go_module(
 #[derive(Default)]
 struct CacheLoad {
     cached: HashSet<String>,
-    to_infer: Vec<PendingModule>,
+    missed: Vec<UnparsedModule>,
 }
 
-/// Merges cache hits into the store and returns the misses to register.
+/// Merges cache hits into the store and returns the misses, still unparsed.
 fn load_cache_candidates(
     checker: &mut TaskState,
     store: &mut Store,
@@ -321,11 +406,14 @@ fn load_cache_candidates(
     let mut build_jobs: Vec<CacheBuildJob> = Vec::new();
     for (candidate, interface) in candidates.into_iter().zip(loaded) {
         let Some(interface) = interface else {
-            let module_id = candidate.compiled.module_id.clone();
-            store.store_module(&module_id, candidate.files);
-            result.to_infer.push(PendingModule::Compiled {
-                module: candidate.compiled,
-                topo_rank: candidate.topo_rank,
+            result.missed.push(UnparsedModule {
+                module_id: candidate.compiled.module_id.clone(),
+                files: candidate.files,
+                rewrite_root_import: candidate.rewrite_root_import,
+                pending: PendingModule::Compiled {
+                    module: candidate.compiled,
+                    topo_rank: candidate.topo_rank,
+                },
             });
             continue;
         };

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use syntax::program::{File, Module};
+use syntax::program::{File, Module, is_test_file};
 
 use crate::loader::is_external_test_module;
 use crate::store::{ENTRY_MODULE_ID, Store};
@@ -126,11 +126,15 @@ pub fn compute_emit_artifact_hash(production_hash: u64, go_module: &str) -> u64 
     hasher.finish()
 }
 
-/// Hashes a module's sources: the production-only hash drives dependents and
-/// the emit artifact, the all-files hash drives the module's own validity.
-pub(crate) fn hash_module_source_pair(files: &[File]) -> (u64, u64) {
-    let production_hash = hash_module_sources(files.iter().filter(|f| !f.is_test()));
-    let full_hash = if files.iter().any(|f| f.is_test()) {
+/// Hashes a module's sources, given each file's name and source: the
+/// production-only hash drives dependents and the emit artifact, the all-files
+/// hash drives the module's own validity.
+pub(crate) fn hash_module_source_pair<'a>(
+    files: impl Iterator<Item = (&'a str, &'a str)> + Clone,
+) -> (u64, u64) {
+    let production_hash =
+        hash_module_sources(files.clone().filter(|(name, _)| !is_test_file(name)));
+    let full_hash = if files.clone().any(|(name, _)| is_test_file(name)) {
         hash_module_sources(files)
     } else {
         production_hash
@@ -138,25 +142,15 @@ pub(crate) fn hash_module_source_pair(files: &[File]) -> (u64, u64) {
     (production_hash, full_hash)
 }
 
-pub(crate) fn hash_module_source_pair_refs(files: &[&File]) -> (u64, u64) {
-    let production_hash = hash_module_sources(files.iter().copied().filter(|f| !f.is_test()));
-    let full_hash = if files.iter().any(|f| f.is_test()) {
-        hash_module_sources(files.iter().copied())
-    } else {
-        production_hash
-    };
-    (production_hash, full_hash)
-}
-
-fn hash_module_sources<'a>(files: impl IntoIterator<Item = &'a File>) -> u64 {
+fn hash_module_sources<'a>(files: impl Iterator<Item = (&'a str, &'a str)>) -> u64 {
     let mut hasher = FnvHasher::new();
 
-    let mut sorted: Vec<&File> = files.into_iter().collect();
-    sorted.sort_by_key(|f| &f.name);
+    let mut sorted: Vec<(&str, &str)> = files.collect();
+    sorted.sort_by_key(|(name, _)| *name);
 
-    for file in sorted {
-        file.name.hash(&mut hasher);
-        file.source.hash(&mut hasher);
+    for (name, source) in sorted {
+        name.hash(&mut hasher);
+        source.hash(&mut hasher);
     }
 
     hasher.finish()
@@ -470,42 +464,31 @@ mod tests {
 
     #[test]
     fn test_hash_module_sources_deterministic() {
-        let file1 = File::new_cached("mod", "a.lis", "a.lis", "fn foo() {}", 1);
-        let file2 = File::new_cached("mod", "b.lis", "b.lis", "fn bar() {}", 2);
+        let first = ("a.lis", "fn foo() {}");
+        let second = ("b.lis", "fn bar() {}");
 
-        let hash1 = hash_module_sources(&[file1.clone(), file2.clone()]);
-        let hash2 = hash_module_sources(&[file2.clone(), file1.clone()]);
-
-        assert_eq!(hash1, hash2);
+        assert_eq!(
+            hash_module_sources([first, second].into_iter()),
+            hash_module_sources([second, first].into_iter())
+        );
     }
 
     #[test]
     fn test_hash_module_sources_content_sensitive() {
-        let file1 = File::new_cached("mod", "a.lis", "a.lis", "fn foo() {}", 1);
-        let file2 = File::new_cached("mod", "a.lis", "a.lis", "fn bar() {}", 1);
-
-        let hash1 = hash_module_sources(&[file1]);
-        let hash2 = hash_module_sources(&[file2]);
-
-        assert_ne!(hash1, hash2);
+        assert_ne!(
+            hash_module_sources([("a.lis", "fn foo() {}")].into_iter()),
+            hash_module_sources([("a.lis", "fn bar() {}")].into_iter())
+        );
     }
 
     #[test]
     fn production_hash_ignores_test_edits_but_full_hash_does_not() {
-        let prod = File::new_cached("math", "core.lis", "core.lis", "pub fn add() {}", 1);
-        let test_a = File::new_cached("math", "core.test.lis", "core.test.lis", "fn t() {}", 2);
-        let test_b = File::new_cached(
-            "math",
-            "core.test.lis",
-            "core.test.lis",
-            "fn t() { add() }",
-            2,
-        );
+        let production = ("core.lis", "pub fn add() {}");
+        let test_a = ("core.test.lis", "fn t() {}");
+        let test_b = ("core.test.lis", "fn t() { add() }");
 
-        let production_a =
-            hash_module_sources([&prod, &test_a].into_iter().filter(|f| !f.is_test()));
-        let production_b =
-            hash_module_sources([&prod, &test_b].into_iter().filter(|f| !f.is_test()));
+        let (production_a, full_a) = hash_module_source_pair([production, test_a].into_iter());
+        let (production_b, full_b) = hash_module_source_pair([production, test_b].into_iter());
         assert_eq!(
             production_a, production_b,
             "editing a test file must not change the production hash"
@@ -518,8 +501,6 @@ mod tests {
             "the hash propagated to dependents must be invariant to test edits"
         );
 
-        let full_a = hash_module_sources([&prod, &test_a]);
-        let full_b = hash_module_sources([&prod, &test_b]);
         assert_ne!(
             full_a, full_b,
             "editing a test file must change the module's own full hash"
@@ -862,11 +843,11 @@ mod tests {
             "pub fn x() -> int { 1 }",
             1,
         );
+        let sources = |file: &File| {
+            hash_module_sources([(file.name.as_str(), file.source.as_str())].into_iter())
+        };
 
-        assert_eq!(
-            hash_module_sources(&[cli_file]),
-            hash_module_sources(&[lsp_file]),
-        );
+        assert_eq!(sources(&cli_file), sources(&lsp_file));
     }
 
     #[test]

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -156,11 +156,47 @@ impl From<HashMap<ModuleId, HashSet<ModuleId>>> for DependencyGraph {
     }
 }
 
+/// A module file read and scanned for imports, but not yet parsed.
+#[derive(Debug)]
+pub struct ScannedFile {
+    pub module_id: ModuleId,
+    pub file_id: u32,
+    pub name: String,
+    pub display_path: String,
+    pub source: String,
+    pub imports: Vec<syntax::program::FileImport>,
+}
+
+impl ScannedFile {
+    pub fn is_d_lis(&self) -> bool {
+        self.name.ends_with(".d.lis")
+    }
+
+    pub fn is_test(&self) -> bool {
+        syntax::program::is_test_file(&self.name)
+    }
+
+    pub fn parse(self) -> (File, Vec<syntax::ParseError>) {
+        let result = syntax::build_ast(&self.source, self.file_id);
+        let file = File {
+            id: self.file_id,
+            module_id: self.module_id,
+            name: self.name,
+            display_path: self.display_path,
+            source_path: None,
+            source: self.source,
+            items: result.ast,
+            file_comment: result.file_comment,
+        };
+        (file, result.errors)
+    }
+}
+
 #[derive(Debug)]
 pub struct ModuleGraphResult {
     pub order: Vec<ModuleId>,
     pub cycles: Vec<Vec<ModuleId>>,
-    pub files: HashMap<ModuleId, Vec<File>>,
+    pub files: HashMap<ModuleId, Vec<ScannedFile>>,
     pub dependencies: DependencyGraph,
     /// Reachable from the primary roots, snapshotted before `additional` runs.
     pub primary_reachable: HashSet<ModuleId>,
@@ -228,7 +264,7 @@ struct GraphBuilder<'a> {
     project_kind: ProjectKind,
     dependencies: DependencyGraph,
     visited: HashSet<ModuleId>,
-    files: HashMap<ModuleId, Vec<File>>,
+    files: HashMap<ModuleId, Vec<ScannedFile>>,
     import_spans: HashMap<ModuleId, Span>,
 }
 
@@ -248,7 +284,7 @@ impl<'a> GraphBuilder<'a> {
 
             batch.sort();
 
-            let mut parsed = batch_parse_modules(
+            let mut scanned = batch_scan_modules(
                 &batch,
                 self.store,
                 self.loader,
@@ -258,9 +294,9 @@ impl<'a> GraphBuilder<'a> {
             );
 
             for module_id in &batch {
-                let module_files = parsed.remove(module_id).unwrap_or_default();
+                let module_files = scanned.remove(module_id).unwrap_or_default();
                 let file_imports = if !module_files.is_empty() {
-                    classify_file_imports(&module_files)
+                    classify_scanned_imports(&module_files)
                 } else if let Some(module) = self.store.get_module(module_id) {
                     classify_file_imports(module.files.values())
                 } else {
@@ -364,15 +400,19 @@ struct ClassifiedImport {
     kind: DependencyKind,
 }
 
+fn dependency_kind(is_test: bool) -> DependencyKind {
+    if is_test {
+        DependencyKind::TestOnly
+    } else {
+        DependencyKind::Production
+    }
+}
+
 fn classify_file_imports<'a>(files: impl IntoIterator<Item = &'a File>) -> Vec<ClassifiedImport> {
     files
         .into_iter()
         .flat_map(|file| {
-            let kind = if file.is_test() {
-                DependencyKind::TestOnly
-            } else {
-                DependencyKind::Production
-            };
+            let kind = dependency_kind(file.is_test());
             file.imports()
                 .into_iter()
                 .map(move |import| ClassifiedImport { import, kind })
@@ -380,7 +420,20 @@ fn classify_file_imports<'a>(files: impl IntoIterator<Item = &'a File>) -> Vec<C
         .collect()
 }
 
-struct ParseJob {
+fn classify_scanned_imports(files: &[ScannedFile]) -> Vec<ClassifiedImport> {
+    files
+        .iter()
+        .flat_map(|file| {
+            let kind = dependency_kind(file.is_test());
+            file.imports.iter().map(move |import| ClassifiedImport {
+                import: import.clone(),
+                kind,
+            })
+        })
+        .collect()
+}
+
+struct ScanJob {
     module_id: ModuleId,
     file_id: u32,
     filename: String,
@@ -388,34 +441,38 @@ struct ParseJob {
     source: String,
 }
 
-fn batch_parse_modules(
+/// Reads and scans every file of the given modules. The parse waits for the cache.
+fn batch_scan_modules(
     modules: &[ModuleId],
     store: &Store,
     loader: Option<&dyn Loader>,
     sink: &LocalSink,
     include_tests: bool,
     has_project_root: bool,
-) -> HashMap<ModuleId, Vec<File>> {
+) -> HashMap<ModuleId, Vec<ScannedFile>> {
     let Some(fs) = loader else {
         return HashMap::default();
     };
 
     const PARALLEL_THRESHOLD: usize = 4;
 
-    let to_scan: Vec<&ModuleId> = modules.iter().filter(|m| !store.has(m)).collect();
-    let scanned: Vec<(&ModuleId, Vec<(String, semantics_loader::FileContent)>)> =
-        if to_scan.len() < PARALLEL_THRESHOLD {
-            to_scan.into_iter().map(|m| (m, scan_one(fs, m))).collect()
+    let to_read: Vec<&ModuleId> = modules.iter().filter(|m| !store.has(m)).collect();
+    let folders: Vec<(&ModuleId, Vec<(String, semantics_loader::FileContent)>)> =
+        if to_read.len() < PARALLEL_THRESHOLD {
+            to_read
+                .into_iter()
+                .map(|m| (m, read_folder(fs, m)))
+                .collect()
         } else {
             use rayon::prelude::*;
-            to_scan
+            to_read
                 .into_par_iter()
-                .map(|m| (m, scan_one(fs, m)))
+                .map(|m| (m, read_folder(fs, m)))
                 .collect()
         };
 
-    let mut jobs: Vec<ParseJob> = Vec::new();
-    for (module_id, entries) in scanned {
+    let mut jobs: Vec<ScanJob> = Vec::new();
+    for (module_id, entries) in folders {
         let is_external_test =
             has_project_root && semantics_loader::is_external_test_module(module_id);
         for (filename, content) in entries {
@@ -445,7 +502,7 @@ fn batch_parse_modules(
                 continue;
             }
             let file_id = store.new_file_id();
-            jobs.push(ParseJob {
+            jobs.push(ScanJob {
                 module_id: module_id.clone(),
                 file_id,
                 filename,
@@ -455,16 +512,15 @@ fn batch_parse_modules(
         }
     }
 
-    let parsed: Vec<(File, Vec<syntax::ParseError>)> = if jobs.len() < PARALLEL_THRESHOLD {
-        jobs.into_iter().map(parse_one).collect()
+    let scanned: Vec<ScannedFile> = if jobs.len() < PARALLEL_THRESHOLD {
+        jobs.into_iter().map(scan_one).collect()
     } else {
         use rayon::prelude::*;
-        jobs.into_par_iter().map(parse_one).collect()
+        jobs.into_par_iter().map(scan_one).collect()
     };
 
-    let mut grouped: HashMap<ModuleId, Vec<File>> = HashMap::default();
-    for (file, errors) in parsed {
-        sink.extend_parse_errors(errors);
+    let mut grouped: HashMap<ModuleId, Vec<ScannedFile>> = HashMap::default();
+    for file in scanned {
         grouped
             .entry(file.module_id.clone())
             .or_default()
@@ -473,26 +529,22 @@ fn batch_parse_modules(
     grouped
 }
 
-fn scan_one(fs: &dyn Loader, module_id: &str) -> Vec<(String, semantics_loader::FileContent)> {
+fn read_folder(fs: &dyn Loader, module_id: &str) -> Vec<(String, semantics_loader::FileContent)> {
     let mut entries: Vec<(String, semantics_loader::FileContent)> =
         fs.scan_folder(module_id).into_iter().collect();
     entries.sort_by(|a, b| a.0.cmp(&b.0));
     entries
 }
 
-fn parse_one(job: ParseJob) -> (File, Vec<syntax::ParseError>) {
-    let result = syntax::build_ast(&job.source, job.file_id);
-    let file = File {
-        id: job.file_id,
+fn scan_one(job: ScanJob) -> ScannedFile {
+    ScannedFile {
+        imports: syntax::imports::scan_imports(&job.source, job.file_id),
         module_id: job.module_id,
+        file_id: job.file_id,
         name: job.filename,
         display_path: job.display_path,
-        source_path: None,
         source: job.source,
-        items: result.ast,
-        file_comment: result.file_comment,
-    };
-    (file, result.errors)
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/syntax/src/imports.rs
+++ b/crates/syntax/src/imports.rs
@@ -1,0 +1,310 @@
+//! Reads a file's imports from its prologue, without lexing or parsing.
+
+use ecow::EcoString;
+
+use crate::ast::{ImportAlias, Span};
+use crate::program::FileImport;
+
+pub fn scan_imports(source: &str, file_id: u32) -> Vec<FileImport> {
+    if source.len() > crate::MAX_SOURCE_BYTES {
+        return Vec::new();
+    }
+
+    let mut scanner = Scanner {
+        source,
+        offset: 0,
+        file_id,
+    };
+    let mut imports = Vec::new();
+    while let Some(import) = scanner.next_import() {
+        imports.push(import);
+    }
+    imports
+}
+
+struct Scanner<'source> {
+    source: &'source str,
+    offset: usize,
+    file_id: u32,
+}
+
+impl<'source> Scanner<'source> {
+    fn byte(&self) -> Option<u8> {
+        self.source.as_bytes().get(self.offset).copied()
+    }
+
+    fn rest(&self) -> &'source str {
+        &self.source[self.offset..]
+    }
+
+    fn byte_at(&self, ahead: usize) -> Option<u8> {
+        self.source.as_bytes().get(self.offset + ahead).copied()
+    }
+
+    fn skip_line(&mut self) {
+        while !matches!(self.byte(), None | Some(b'\n')) {
+            self.offset += 1;
+        }
+    }
+
+    fn skip_trivia(&mut self) {
+        loop {
+            match self.byte() {
+                Some(byte) if byte.is_ascii_whitespace() => self.offset += 1,
+                Some(b';') => self.offset += 1,
+                Some(b'/') if self.byte_at(1) == Some(b'/') => self.skip_line(),
+                _ => return,
+            }
+        }
+    }
+
+    /// `Parser::next` skips plain `//` comments but stops at a doc or file comment.
+    fn skip_whitespace_and_comments(&mut self) {
+        loop {
+            match self.byte() {
+                Some(byte) if byte.is_ascii_whitespace() => self.offset += 1,
+                Some(b'/')
+                    if self.byte_at(1) == Some(b'/')
+                        && !matches!(self.byte_at(2), Some(b'/' | b'!')) =>
+                {
+                    self.skip_line()
+                }
+                _ => return,
+            }
+        }
+    }
+
+    fn skip_horizontal_whitespace(&mut self) {
+        while matches!(self.byte(), Some(b' ' | b'\t')) {
+            self.offset += 1;
+        }
+    }
+
+    fn eat_keyword(&mut self, keyword: &str) -> bool {
+        let Some(after) = self.rest().strip_prefix(keyword) else {
+            return false;
+        };
+        if after.chars().next().is_some_and(is_identifier_character) {
+            return false;
+        }
+        self.offset += keyword.len();
+        true
+    }
+
+    fn next_import(&mut self) -> Option<FileImport> {
+        self.skip_trivia();
+
+        let start = self.offset;
+        if !self.eat_keyword("import") {
+            return None;
+        }
+        self.skip_whitespace_and_comments();
+
+        let alias = if self.byte()? == b'"' {
+            None
+        } else {
+            let (text, span) = self.scan_identifier()?;
+            self.skip_horizontal_whitespace();
+            Some(match text {
+                "_" => ImportAlias::Blank(span),
+                _ => ImportAlias::Named(text.into(), span),
+            })
+        };
+
+        let path_start = self.offset;
+        let name = self.scan_path()?;
+
+        Some(FileImport {
+            name,
+            name_span: self.span_from(path_start),
+            alias,
+            span: self.span_from(start),
+        })
+    }
+
+    fn scan_identifier(&mut self) -> Option<(&'source str, Span)> {
+        let start = self.offset;
+        if !self
+            .rest()
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_alphabetic() || first == '_')
+        {
+            return None;
+        }
+        for character in self.rest().chars() {
+            if !is_identifier_character(character) {
+                break;
+            }
+            self.offset += character.len_utf8();
+        }
+
+        let text = &self.source[start..self.offset];
+        // `r"` and `f"` open a literal, not an identifier.
+        if matches!(text, "r" | "f" | "rf" | "fr") && self.byte() == Some(b'"') {
+            return None;
+        }
+        Some((text, self.span_from(start)))
+    }
+
+    /// The bytes between the quotes, left escaped, as the parser takes them.
+    fn scan_path(&mut self) -> Option<EcoString> {
+        if self.byte()? != b'"' {
+            return None;
+        }
+        self.offset += 1;
+
+        let content_start = self.offset;
+        loop {
+            match self.byte()? {
+                b'\\' => {
+                    self.offset += 1;
+                    let escaped = self.rest().chars().next().map_or(0, char::len_utf8);
+                    self.offset += escaped;
+                }
+                b'"' => {
+                    let content = &self.source[content_start..self.offset];
+                    self.offset += 1;
+                    return Some(content.into());
+                }
+                _ => self.offset += 1,
+            }
+        }
+    }
+
+    fn span_from(&self, start: usize) -> Span {
+        Span::new(self.file_id, start as u32, (self.offset - start) as u32)
+    }
+}
+
+fn is_identifier_character(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_ast;
+    use crate::program::File;
+
+    fn scanned(source: &str) -> Vec<FileImport> {
+        scan_imports(source, 7)
+    }
+
+    fn parsed(source: &str) -> Vec<FileImport> {
+        let result = build_ast(source, 7);
+        File {
+            id: 7,
+            module_id: "m".into(),
+            name: "m.lis".into(),
+            display_path: "m.lis".into(),
+            source_path: None,
+            source: source.to_string(),
+            items: result.ast,
+            file_comment: result.file_comment,
+        }
+        .imports()
+    }
+
+    #[track_caller]
+    fn assert_matches_parser(source: &str) {
+        assert_eq!(
+            scanned(source),
+            parsed(source),
+            "scanner and parser disagree on: {source:?}"
+        );
+    }
+
+    #[test]
+    fn every_import_form_matches_the_parser() {
+        for source in [
+            "",
+            "\n\n",
+            "import \"go:fmt\"",
+            "import \"go:fmt\"\nimport \"math\"\nfn f() {}",
+            "import _ \"go:fmt\"\nfn f() {}",
+            "import alias \"go:fmt\"\nfn f() {}",
+            "import alias\"go:fmt\"\nfn f() {}",
+            "import_alias \"go:fmt\"",
+            "//! header\n//! more\n\nimport \"go:fmt\"\nfn f() {}",
+            "// note\nimport \"go:fmt\"\n// between\nimport \"go:os\"\n\n/// docs\nfn f() {}",
+            "import \"go:fmt\"; import \"go:os\"\nfn f() {}",
+            "import\n\"go:fmt\"\nfn f() {}",
+            "import // note\n\"go:fmt\"\nfn f() {}",
+            "import // note\nalias \"go:fmt\"\nfn f() {}",
+            "import /// doc\n\"go:fmt\"\nfn f() {}",
+            "import //! file\n\"go:fmt\"\nfn f() {}",
+            "import ; \"go:fmt\"\nfn f() {}",
+            "import alias // note\n\"go:fmt\"\nfn f() {}",
+            "pub import \"go:fmt\"\nfn f() {}",
+            "fn f() {}\n",
+            "#[test]\nfn f() {}\n",
+            "struct S {}\nimport \"go:fmt\"",
+            "import \"esc\\\"aped\"\nfn f() {}",
+        ] {
+            assert_matches_parser(source);
+        }
+    }
+
+    /// A parse error discards the whole AST, so the parser reports no imports.
+    #[test]
+    fn a_broken_body_does_not_hide_the_prologue() {
+        let source = "import \"go:fmt\"\nfn f() {\n  import \"go:os\"\n}";
+
+        assert_eq!(
+            scanned(source)
+                .iter()
+                .map(|import| import.name.to_string())
+                .collect::<Vec<_>>(),
+            ["go:fmt"]
+        );
+        assert!(parsed(source).is_empty());
+    }
+
+    #[test]
+    fn malformed_imports_produce_none() {
+        for source in [
+            "import",
+            "import alias",
+            "import alias\n\"go:fmt\"",
+            "import \"unterminated",
+            "import r\"go:fmt\"",
+            "import f\"go:fmt\"",
+            "import 42",
+            "import /// doc\n\"go:fmt\"",
+        ] {
+            assert_matches_parser(source);
+            assert!(
+                scanned(source).is_empty(),
+                "expected no import for: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn spans_cover_the_keyword_and_the_quoted_path() {
+        let source = "import alias \"go:fmt\"";
+        let import = scanned(source).pop().unwrap();
+        let text = |span: Span| &source[span.byte_offset as usize..span.end() as usize];
+
+        assert_eq!(text(import.span), source);
+        assert_eq!(text(import.name_span), "\"go:fmt\"");
+        assert_eq!(import.name, "go:fmt");
+    }
+
+    #[test]
+    fn a_multibyte_escape_keeps_the_scan_on_a_character_boundary() {
+        let scanned = scanned("import \"\\é\"\nfn f() {}");
+
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].name, "\\é");
+    }
+
+    #[test]
+    fn oversized_sources_scan_as_empty() {
+        let mut source = String::from("import \"go:fmt\"\n");
+        source.push_str(&"\n".repeat(crate::MAX_SOURCE_BYTES));
+
+        assert!(scan_imports(&source, 0).is_empty());
+    }
+}

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -3,6 +3,7 @@ pub mod attributes;
 pub mod containment;
 mod display;
 pub mod go_names;
+pub mod imports;
 pub mod lex;
 pub mod parse;
 pub mod program;

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -170,13 +170,21 @@ impl<'source> Parser<'source> {
             self.next();
         }
 
-        if is_public && self.is(Impl) {
-            let token = pub_token.unwrap();
+        if let Some(token) = pub_token {
             let span = ast::Span::new(self.file_id, token.byte_offset, token.byte_length);
-            let error = ParseError::new("Misplaced `pub`", span, "not allowed here")
-                .with_parse_code("syntax_error")
-                .with_help("Place `pub` on individual methods inside the `impl` block instead");
-            self.errors.push(error);
+            match self.current_token().kind {
+                Impl => self.error_misplaced_pub(
+                    span,
+                    "syntax_error",
+                    "Place `pub` on individual methods inside the `impl` block instead",
+                ),
+                Import => self.error_misplaced_pub(
+                    span,
+                    "pub_import",
+                    "An import is always private to the file that declares it. Remove `pub`",
+                ),
+                _ => {}
+            }
         }
 
         let is_documentable = matches!(
@@ -1062,6 +1070,14 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
+    fn error_misplaced_pub(&mut self, span: Span, code: &str, help: &str) {
+        let error = ParseError::new("Misplaced `pub`", span, "not allowed here")
+            .with_parse_code(code)
+            .with_help(help);
+
+        self.errors.push(error);
+    }
+
     fn error_misplaced_attribute(&mut self, span: Span) {
         let error = ParseError::new(
             "Attribute not supported on target",
@@ -1323,6 +1339,37 @@ mod import_order_tests {
             "// note\nimport \"go:fmt\"\n\n/// docs\nfn f() {}",
             "import \"go:fmt\"\n\n#[test]\nfn f(t: T) {}",
             "import \"go:fmt\"",
+        ] {
+            assert!(codes(source).is_empty(), "for source: {source:?}");
+        }
+    }
+
+    #[test]
+    fn a_public_import_is_rejected() {
+        for source in [
+            "pub import \"go:fmt\"",
+            "pub import _ \"go:fmt\"",
+            "pub import alias \"go:fmt\"",
+            "pub // note\nimport \"go:fmt\"",
+            "import \"go:os\"\npub import \"go:fmt\"\nfn f() {}",
+        ] {
+            assert_eq!(
+                codes(source),
+                ["parse.pub_import"],
+                "for source: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn visibility_on_definitions_is_untouched() {
+        for source in [
+            "pub fn f() {}",
+            "pub struct S {}",
+            "pub enum E { A }",
+            "pub const N: int = 1",
+            "pub type T = int",
+            "pub interface I {}",
         ] {
             assert!(codes(source).is_empty(), "for source: {source:?}");
         }

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -45,6 +45,10 @@ impl FileImport {
     }
 }
 
+pub fn is_test_file(name: &str) -> bool {
+    name.ends_with(".test.lis")
+}
+
 pub fn unaliased_binding_name<'a, S: BuildHasher>(
     path: &'a str,
     go_package_names: &'a HashMap<String, String, S>,
@@ -103,7 +107,7 @@ impl File {
 
     /// A test file (`*.test.lis`).
     pub fn is_test(&self) -> bool {
-        self.name.ends_with(".test.lis")
+        is_test_file(&self.name)
     }
 
     pub fn imports(&self) -> Vec<FileImport> {

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -11,7 +11,7 @@ pub use definition::{
 pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,
 };
-pub use file::{File, FileImport, go_import_default_name, unaliased_binding_name};
+pub use file::{File, FileImport, go_import_default_name, is_test_file, unaliased_binding_name};
 pub use module::{Module, ModuleId};
 pub use resolution::{
     CallKind, ChannelOperation, DotAccessKind, DotAccessResolution, NativeTypeKind,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,3 +30,10 @@ path = "fuzz_targets/infer.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "scan_imports"
+path = "fuzz_targets/scan_imports.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/scan_imports.rs
+++ b/fuzz/fuzz_targets/scan_imports.rs
@@ -1,0 +1,43 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use lisette_syntax::ast::Expression;
+use lisette_syntax::imports::scan_imports;
+use lisette_syntax::program::FileImport;
+
+/// The graph reads imports with the scanner, which must agree with the parser.
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // Scanned first for panic coverage on the inputs the parser rejects, which
+    // discard their AST and so have nothing to compare against.
+    let scanned = scan_imports(source, 0);
+
+    let result = lisette_syntax::build_ast(source, 0);
+    if result.failed() {
+        return;
+    }
+
+    let parsed: Vec<FileImport> = result
+        .ast
+        .iter()
+        .filter_map(|item| match item {
+            Expression::ModuleImport {
+                name,
+                name_span,
+                alias,
+                span,
+            } => Some(FileImport {
+                name: name.clone(),
+                name_span: *name_span,
+                alias: alias.clone(),
+                span: *span,
+            }),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(scanned, parsed, "scanner and parser disagree on: {source:?}");
+});

--- a/justfile
+++ b/justfile
@@ -106,6 +106,9 @@ fuzz-parse duration="300":
 fuzz-infer duration="300":
     cargo +nightly fuzz run --sanitizer address infer fuzz/corpus/infer fuzz/seed_corpus -- -max_total_time={{duration}} -rss_limit_mb=2048 -dict=fuzz/lisette.dict
 
+fuzz-scan-imports duration="300":
+    cargo +nightly fuzz run --sanitizer address scan_imports fuzz/corpus/scan_imports fuzz/seed_corpus -- -max_total_time={{duration}} -rss_limit_mb=2048 -dict=fuzz/lisette.dict
+
 _supported-targets := "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64"
 
 generate-stdlib-typedefs version targets=_supported-targets:

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -78,6 +78,22 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
         },
     );
 
+    let mut parsed: HashMap<String, Vec<syntax::program::File>> = graph_result
+        .files
+        .drain()
+        .map(|(module_id, files)| {
+            let files = files
+                .into_iter()
+                .map(|file| {
+                    let (file, errors) = file.parse();
+                    sink.extend_parse_errors(errors);
+                    file
+                })
+                .collect();
+            (module_id, files)
+        })
+        .collect();
+
     if sink.has_errors() {
         return InferResult {
             ast: vec![],
@@ -102,7 +118,7 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
                 continue;
             }
 
-            let files = graph_result.files.remove(&module_id).unwrap_or_default();
+            let files = parsed.remove(&module_id).unwrap_or_default();
 
             store.store_module(&module_id, files);
             checker.register_module(&mut store, &module_id);

--- a/tests/spec/imports.rs
+++ b/tests/spec/imports.rs
@@ -1,0 +1,85 @@
+//! The graph reads imports with the scanner, which must agree with the parser.
+
+use std::path::{Path, PathBuf};
+
+use syntax::build_ast;
+use syntax::imports::scan_imports;
+use syntax::program::{File, FileImport};
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("tests/ has a parent")
+        .to_path_buf()
+}
+
+fn collect_lisette_files(directory: &Path, found: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name != "target" && name != "node_modules" && !name.starts_with('.') {
+                collect_lisette_files(&path, found);
+            }
+        } else if name.ends_with(".lis") {
+            found.push(path);
+        }
+    }
+}
+
+fn parsed_imports(source: &str) -> Option<Vec<FileImport>> {
+    let result = build_ast(source, 0);
+    if !result.errors.is_empty() {
+        return None;
+    }
+    Some(
+        File {
+            id: 0,
+            module_id: "corpus".to_string(),
+            name: "corpus.lis".to_string(),
+            display_path: "corpus.lis".to_string(),
+            source_path: None,
+            source: source.to_string(),
+            items: result.ast,
+            file_comment: result.file_comment,
+        }
+        .imports(),
+    )
+}
+
+#[test]
+fn the_scanner_matches_the_parser_over_the_repository_corpus() {
+    let root = repository_root();
+    let mut files = Vec::new();
+    collect_lisette_files(&root, &mut files);
+    files.sort();
+
+    let mut compared = 0;
+    let mut with_imports = 0;
+    for path in &files {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Some(parsed) = parsed_imports(&source) else {
+            continue;
+        };
+        compared += 1;
+        with_imports += usize::from(!parsed.is_empty());
+
+        assert_eq!(
+            scan_imports(&source, 0),
+            parsed,
+            "scanner and parser disagree on {}",
+            path.display()
+        );
+    }
+
+    assert!(
+        compared > 300 && with_imports > 100,
+        "the corpus walk found too little to be meaningful: {compared} files, {with_imports} with imports"
+    );
+}

--- a/tests/spec/mod.rs
+++ b/tests/spec/mod.rs
@@ -2,6 +2,7 @@ mod build;
 mod emit;
 mod format;
 mod graph;
+mod imports;
 pub mod infer;
 mod lex;
 mod parse;

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1066,6 +1066,16 @@ fn parse_import_after_item_with_line_comment() {
 }
 
 #[test]
+fn parse_public_import() {
+    let input = r#"
+pub import "go:fmt"
+
+fn main() {}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_misplaced_file_comment_after_import() {
     let input = r#"
 import "some_module"

--- a/tests/ui/errors/snapshots/parse_public_import.snap
+++ b/tests/ui/errors/snapshots/parse_public_import.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Misplaced `pub`
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ pub import "go:fmt"
+   · ─┬─
+   ·  ╰── not allowed here
+ 3 │ 
+   ╰────
+  help: An import is always private to the file that declares it. Remove `pub` · code: [parse.pub_import]


### PR DESCRIPTION
Lis used to fully parse every reachable file just to find its imports, then throw that parse away for the modules it served from cache. Now it reads only the import "prologue" and parses only the modules the cache cannot serve.

This change makes warm builds 12 to 26% faster, as measured on synthetic projects of `n` 100-line modules:

| modules | warm no-op | after a one-module edit |
| --- | --- | --- |
| 50 | 9.0 ms → 7.7 ms (-14%) | 10.2 ms → 9.0 ms (-12%) |
| 500 | 63.1 ms → 47.7 ms (-24%) | 61.8 ms → 47.9 ms (-23%) |
| 2000 | 441 ms → 372 ms (-16%) | 449 ms → 374 ms (-17%) |

The percentage dips at 2000 because the per-module saving stays flat while the baseline grows faster than the module count, 7x the time for 4x the modules, and that extra growth is filesystem metadata this change does not touch.

Cold builds are unchanged, as every mdule is a cache miss and still gets parsed. The win scales with the number of cache hits, so the edit-then-recheck loop gains the most.

Builds on #1178
