### PR TITLE
refactor: take over diagnostic rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ name = "lisette-diagnostics"
 version = "0.11.0"
 dependencies = [
  "lisette-syntax",
- "miette",
  "owo-colors",
  "rustc-hash",
+ "unicode-width",
 ]
 
 [[package]]
@@ -285,7 +285,6 @@ dependencies = [
  "lisette-semantics",
  "lisette-stdlib",
  "lisette-syntax",
- "miette",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -339,18 +338,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "owo-colors",
- "textwrap",
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -574,22 +561,11 @@ dependencies = [
  "lisette-semantics",
  "lisette-stdlib",
  "lisette-syntax",
- "miette",
  "rayon",
  "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -655,22 +631,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ large_enum_variant = "forbid"
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-miette = { version = "7.6", default-features = false, features = ["fancy-no-syscall"] }
 owo-colors = "4.0"
 insta = "1.48.0"
 ecow = "0.2"

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -13,9 +13,9 @@ doctest = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
-miette.workspace = true
 owo-colors.workspace = true
 rustc-hash.workspace = true
+unicode-width = "0.2"
 
 [lints]
 workspace = true

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -1,10 +1,17 @@
-use miette::{Diagnostic, LabeledSpan, Severity};
 use owo_colors::OwoColorize;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::graphical::FrameLabel;
 use syntax::ParseError;
 use syntax::ast::Span;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Severity {
+    Error,
+    Warning,
+    Advice,
+}
 
 /// Source text with a precomputed line-offset index for O(log n) span lookups.
 #[derive(Clone, Debug)]
@@ -28,62 +35,23 @@ impl IndexedSource {
     }
 
     pub(crate) fn line_col(&self, offset: usize) -> (usize, usize) {
-        let line = match self.line_starts.binary_search(&offset) {
-            Ok(exact) => exact,
-            Err(idx) => idx.saturating_sub(1),
-        };
+        let line = self.line_index_of_offset(offset);
         (line + 1, offset - self.line_starts[line] + 1)
     }
-}
 
-impl miette::SourceCode for IndexedSource {
-    fn read_span<'a>(
-        &'a self,
-        span: &miette::SourceSpan,
-        context_lines_before: usize,
-        context_lines_after: usize,
-    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
-        let src = self.source.as_ref();
-        let offset = span.offset();
-        let len = span.len();
+    pub(crate) fn text(&self) -> &str {
+        &self.source
+    }
 
-        if offset + len > src.len() {
-            return Err(miette::MietteError::OutOfBounds);
+    pub(crate) fn line_starts(&self) -> &[usize] {
+        &self.line_starts
+    }
+
+    pub(crate) fn line_index_of_offset(&self, offset: usize) -> usize {
+        match self.line_starts.binary_search(&offset) {
+            Ok(exact) => exact,
+            Err(index) => index.saturating_sub(1),
         }
-
-        let span_line = match self.line_starts.binary_search(&offset) {
-            Ok(exact) => exact,
-            Err(idx) => idx.saturating_sub(1),
-        };
-
-        let start_line = span_line.saturating_sub(context_lines_before);
-        let start_offset = self.line_starts[start_line];
-        let start_column = if context_lines_before == 0 {
-            offset - self.line_starts[span_line]
-        } else {
-            0
-        };
-
-        let span_end = offset + len.saturating_sub(1);
-        let end_line = match self.line_starts.binary_search(&span_end) {
-            Ok(exact) => exact,
-            Err(idx) => idx.saturating_sub(1),
-        };
-
-        let last_line = (end_line + context_lines_after).min(self.line_starts.len() - 1);
-        let end_offset = if last_line + 1 < self.line_starts.len() {
-            self.line_starts[last_line + 1].min(src.len())
-        } else {
-            src.len()
-        };
-
-        Ok(Box::new(miette::MietteSpanContents::new(
-            &src.as_bytes()[start_offset..end_offset],
-            (start_offset, end_offset - start_offset).into(),
-            start_line,
-            start_column,
-            last_line + 1,
-        )))
     }
 }
 
@@ -110,22 +78,6 @@ struct Label {
     text: String,
     primary: bool,
 }
-
-impl Label {
-    fn to_miette(&self, text: String) -> LabeledSpan {
-        let source_span = miette::SourceSpan::new(
-            (self.span.byte_offset as usize).into(),
-            self.span.byte_length as usize,
-        );
-        if self.primary {
-            LabeledSpan::new_primary_with_span(Some(text), source_span)
-        } else {
-            LabeledSpan::new_with_span(Some(text), source_span)
-        }
-    }
-}
-
-pub use miette::Report;
 
 impl From<ParseError> for LisetteDiagnostic {
     fn from(err: ParseError) -> Self {
@@ -209,29 +161,7 @@ pub struct LisetteDiagnostic {
 
 impl fmt::Display for LisetteDiagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.fmt_message(f, false)
-    }
-}
-
-impl LisetteDiagnostic {
-    fn fmt_message(&self, f: &mut fmt::Formatter<'_>, use_color: bool) -> fmt::Result {
-        if use_color {
-            let styled_message = match self.severity {
-                Severity::Error => {
-                    format_with_backticks(&self.message, true, |s| format!("{}", s.red().bold()))
-                }
-                Severity::Warning => {
-                    format_with_backticks(&self.message, true, |s| format!("{}", s.yellow().bold()))
-                }
-                Severity::Advice => {
-                    format_with_backticks(&self.message, true, |s| format!("{}", s.blue().bold()))
-                }
-            };
-            write!(f, "{}", styled_message)?;
-        } else {
-            f.write_str(&self.message)?;
-        }
-        Ok(())
+        f.write_str(&self.message)
     }
 }
 
@@ -273,34 +203,6 @@ impl fmt::Display for HelpText<'_> {
         }
 
         Ok(())
-    }
-}
-
-impl Diagnostic for LisetteDiagnostic {
-    fn severity(&self) -> Option<Severity> {
-        Some(self.severity)
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        let diagnostic_code = self.code.as_deref();
-
-        if self.help.is_none() && self.note.is_none() && diagnostic_code.is_none() {
-            return None;
-        }
-        Some(Box::new(HelpText {
-            help: self.help.as_deref(),
-            note: self.note.as_deref(),
-            diagnostic_code,
-            use_color: false,
-        }))
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        Some(Box::new(self.formatted_labels(false).into_iter()))
-    }
-
-    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        None // rendered with the help text instead
     }
 }
 
@@ -440,18 +342,39 @@ impl LisetteDiagnostic {
         self
     }
 
-    pub fn with_source_code(self, source: IndexedSource, filename: String) -> miette::Report {
-        miette::Report::new(self).with_source_code(miette::NamedSource::new(filename, source))
-    }
-
-    pub(crate) fn into_rendered(self, use_color: bool) -> RenderedDiagnostic {
-        RenderedDiagnostic {
-            diagnostic: self,
-            use_color,
+    pub(crate) fn styled_message(&self, use_color: bool) -> String {
+        if !use_color {
+            return self.message.clone();
+        }
+        match self.severity {
+            Severity::Error => {
+                format_with_backticks(&self.message, true, |s| format!("{}", s.red().bold()))
+            }
+            Severity::Warning => {
+                format_with_backticks(&self.message, true, |s| format!("{}", s.yellow().bold()))
+            }
+            Severity::Advice => {
+                format_with_backticks(&self.message, true, |s| format!("{}", s.blue().bold()))
+            }
         }
     }
 
-    fn formatted_labels(&self, use_color: bool) -> Vec<LabeledSpan> {
+    pub(crate) fn styled_help_text(&self, use_color: bool) -> Option<String> {
+        if self.help.is_none() && self.note.is_none() && self.code.is_none() {
+            return None;
+        }
+        Some(
+            HelpText {
+                help: self.help.as_deref(),
+                note: self.note.as_deref(),
+                diagnostic_code: self.code.as_deref(),
+                use_color,
+            }
+            .to_string(),
+        )
+    }
+
+    pub(crate) fn frame_labels(&self, use_color: bool) -> Vec<FrameLabel> {
         let file_id = self.file_id();
         self.labels
             .iter()
@@ -467,9 +390,24 @@ impl LisetteDiagnostic {
                 } else {
                     label.text.clone()
                 };
-                label.to_miette(formatted)
+                FrameLabel::new(
+                    label.span.byte_offset as usize,
+                    label.span.byte_length as usize,
+                    formatted,
+                    label.primary,
+                )
             })
             .collect()
+    }
+
+    /// Byte offset and length of the first label, which anchors the diagnostic.
+    pub fn first_label_span(&self) -> Option<(usize, usize)> {
+        self.labels.first().map(|label| {
+            (
+                label.span.byte_offset as usize,
+                label.span.byte_length as usize,
+            )
+        })
     }
 
     pub fn code_str(&self) -> Option<&str> {
@@ -558,48 +496,6 @@ impl LisetteDiagnostic {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct RenderedDiagnostic {
-    diagnostic: LisetteDiagnostic,
-    use_color: bool,
-}
-
-impl fmt::Display for RenderedDiagnostic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.diagnostic.fmt_message(f, self.use_color)
-    }
-}
-
-impl std::error::Error for RenderedDiagnostic {}
-
-impl Diagnostic for RenderedDiagnostic {
-    fn severity(&self) -> Option<Severity> {
-        Some(self.diagnostic.severity)
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        let diagnostic_code = self.diagnostic.code.as_deref();
-        if self.diagnostic.help.is_none()
-            && self.diagnostic.note.is_none()
-            && diagnostic_code.is_none()
-        {
-            return None;
-        }
-        Some(Box::new(HelpText {
-            help: self.diagnostic.help.as_deref(),
-            note: self.diagnostic.note.as_deref(),
-            diagnostic_code,
-            use_color: self.use_color,
-        }))
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        Some(Box::new(
-            self.diagnostic.formatted_labels(self.use_color).into_iter(),
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -630,6 +526,6 @@ mod tests {
 
         assert_eq!(diagnostic.file_id(), Some(3));
         assert_eq!(diagnostic.label_points(), vec![(3, 4), (7, 8)]);
-        assert_eq!(diagnostic.formatted_labels(false).len(), 1);
+        assert_eq!(diagnostic.frame_labels(false).len(), 1);
     }
 }

--- a/crates/diagnostics/src/graphical.rs
+++ b/crates/diagnostics/src/graphical.rs
@@ -1,0 +1,834 @@
+//! Renders a diagnostic as a message, labeled source frames, and help footer.
+//!
+//! Derived from the `GraphicalReportHandler` in miette 7.6.0
+//! (<https://github.com/zkat/miette>, copyright Kat Marchán and miette
+//! contributors, Apache-2.0).
+
+use std::fmt::{self, Write as _};
+
+use owo_colors::{OwoColorize, Style};
+
+use crate::diagnostic::IndexedSource;
+
+const HBAR: char = '─';
+const VBAR: char = '│';
+const VBAR_BREAK: char = '·';
+const UARROW: char = '▲';
+const RARROW: char = '▶';
+const LTOP: char = '╭';
+const LBOT: char = '╰';
+const LCROSS: char = '├';
+const RCROSS: char = '┤';
+const UNDERBAR: char = '┬';
+const UNDERLINE: char = '─';
+const TAB_WIDTH: usize = 4;
+
+pub(crate) struct FrameTheme {
+    pub icon: &'static str,
+    pub severity: Style,
+    pub highlight: Style,
+    pub line_number: Style,
+    pub location: Style,
+    pub help: Style,
+}
+
+#[derive(Clone)]
+pub(crate) struct FrameLabel {
+    offset: usize,
+    length: usize,
+    parts: Vec<String>,
+    primary: bool,
+}
+
+impl PartialEq for FrameLabel {
+    fn eq(&self, other: &Self) -> bool {
+        self.parts == other.parts && self.offset == other.offset && self.length == other.length
+    }
+}
+
+impl FrameLabel {
+    pub(crate) fn new(offset: usize, length: usize, text: String, primary: bool) -> Self {
+        Self {
+            offset,
+            length,
+            parts: text.split('\n').map(str::to_string).collect(),
+            primary,
+        }
+    }
+
+    fn end(&self) -> usize {
+        self.offset + self.length
+    }
+
+    /// Zero-length spans occupy one column when deciding line membership.
+    fn effective_end(&self) -> usize {
+        self.offset + self.length.max(1)
+    }
+
+    fn joined_text(&self) -> String {
+        self.parts.join("\n")
+    }
+
+    fn styled_parts(&self, style: Style) -> Vec<String> {
+        self.parts
+            .iter()
+            .map(|part| part.style(style).to_string())
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum LabelRenderMode {
+    SingleLine,
+    MultiLineFirst,
+    MultiLineRest,
+}
+
+/// Marker columns of the single-line labels under one source line.
+struct LabelRow<'a> {
+    line: &'a FrameLine<'a>,
+    columns: &'a [(&'a FrameLabel, usize)],
+}
+
+struct FrameLine<'a> {
+    line_number: usize,
+    offset: usize,
+    length: usize,
+    text: &'a str,
+}
+
+impl FrameLine<'_> {
+    fn end(&self) -> usize {
+        self.offset + self.length
+    }
+
+    fn span_line_only(&self, label: &FrameLabel) -> bool {
+        label.offset >= self.offset && label.end() <= self.end()
+    }
+
+    fn span_applies(&self, label: &FrameLabel) -> bool {
+        label.offset < self.end() && label.effective_end() > self.offset
+    }
+
+    fn span_applies_gutter(&self, label: &FrameLabel) -> bool {
+        self.span_applies(label)
+            && !(label.offset >= self.offset && label.effective_end() <= self.end())
+    }
+
+    fn span_flyby(&self, label: &FrameLabel) -> bool {
+        label.offset < self.offset && label.end() > self.end()
+    }
+
+    fn span_starts(&self, label: &FrameLabel) -> bool {
+        label.offset >= self.offset
+    }
+
+    fn span_ends(&self, label: &FrameLabel) -> bool {
+        label.end() >= self.offset && label.end() <= self.end()
+    }
+}
+
+/// The line window a span occupies once context lines are included.
+struct ContextWindow {
+    offset: usize,
+    length: usize,
+    start_line: usize,
+    last_line: usize,
+    end_offset: usize,
+}
+
+impl ContextWindow {
+    fn end(&self) -> usize {
+        self.offset + self.length
+    }
+}
+
+fn read_window(
+    source: &IndexedSource,
+    offset: usize,
+    length: usize,
+    context_lines: usize,
+) -> Result<ContextWindow, ()> {
+    let text = source.text();
+    if offset + length > text.len() {
+        return Err(());
+    }
+    let line_starts = source.line_starts();
+    let span_line = source.line_index_of_offset(offset);
+    let start_line = span_line.saturating_sub(context_lines);
+    let end_line = source.line_index_of_offset(offset + length.saturating_sub(1));
+    let last_line = (end_line + context_lines).min(line_starts.len() - 1);
+    let end_offset = if last_line + 1 < line_starts.len() {
+        line_starts[last_line + 1].min(text.len())
+    } else {
+        text.len()
+    };
+    Ok(ContextWindow {
+        offset,
+        length,
+        start_line,
+        last_line,
+        end_offset,
+    })
+}
+
+pub(crate) struct FrameReport<'a> {
+    pub message: &'a str,
+    pub labels: &'a [FrameLabel],
+    pub help: Option<&'a str>,
+}
+
+pub(crate) fn render_report(
+    output: &mut String,
+    report: &FrameReport<'_>,
+    source: Option<(&IndexedSource, &str)>,
+    theme: &FrameTheme,
+    context_lines: usize,
+) -> fmt::Result {
+    render_message(output, report.message, theme)?;
+    if let Some((source, filename)) = source {
+        render_snippets(
+            output,
+            source,
+            filename,
+            report.labels,
+            theme,
+            context_lines,
+        )?;
+    }
+    if let Some(help) = report.help {
+        render_help(output, help, theme)?;
+    }
+    Ok(())
+}
+
+/// Prefixes each line of a block without wrapping, dropping trailing
+/// whitespace from the indent on blank lines.
+fn indent_block(text: &str, initial_indent: &str, subsequent_indent: &str) -> String {
+    let mut result = String::with_capacity(2 * text.len());
+    let trimmed_indent = subsequent_indent.trim_end();
+    for (index, line) in text.split_terminator('\n').enumerate() {
+        if index > 0 {
+            result.push('\n');
+        }
+        if index == 0 {
+            if line.trim().is_empty() {
+                result.push_str(initial_indent.trim_end());
+            } else {
+                result.push_str(initial_indent);
+            }
+        } else if line.trim().is_empty() {
+            result.push_str(trimmed_indent);
+        } else {
+            result.push_str(subsequent_indent);
+        }
+        result.push_str(line);
+    }
+    if text.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+fn render_message(output: &mut String, message: &str, theme: &FrameTheme) -> fmt::Result {
+    let initial_indent = format!("  {} ", theme.icon.style(theme.severity));
+    let rest_indent = format!("  {} ", VBAR.style(theme.severity));
+    writeln!(
+        output,
+        "{}",
+        indent_block(message, &initial_indent, &rest_indent)
+    )
+}
+
+fn render_help(output: &mut String, help: &str, theme: &FrameTheme) -> fmt::Result {
+    let initial_indent = "  help: ".style(theme.help).to_string();
+    writeln!(
+        output,
+        "{}",
+        indent_block(help, &initial_indent, "        ")
+    )
+}
+
+fn render_snippets(
+    output: &mut String,
+    source: &IndexedSource,
+    filename: &str,
+    labels: &[FrameLabel],
+    theme: &FrameTheme,
+    context_lines: usize,
+) -> fmt::Result {
+    let mut sorted = labels.to_vec();
+    sorted.sort_unstable_by_key(|label| label.offset);
+
+    let mut contexts: Vec<ContextWindow> = Vec::with_capacity(sorted.len());
+    for right in &sorted {
+        let right_window = match read_window(source, right.offset, right.length, context_lines) {
+            Ok(window) => window,
+            Err(()) => {
+                writeln!(
+                    output,
+                    "  [{} `{}` (offset: {}, length: {}): OutOfBounds]",
+                    "Failed to read contents for label".style(theme.severity),
+                    right.joined_text().style(theme.location),
+                    right.offset.style(theme.location),
+                    right.length.style(theme.location),
+                )?;
+                return Ok(());
+            }
+        };
+
+        if let Some(left) = contexts.last()
+            && left.last_line + 1 >= right_window.start_line
+            && let Ok(merged) = read_window(
+                source,
+                left.offset,
+                left.end().max(right.end()) - left.offset,
+                context_lines,
+            )
+        {
+            contexts.pop();
+            contexts.push(merged);
+            continue;
+        }
+
+        contexts.push(right_window);
+    }
+
+    for window in &contexts {
+        ContextRenderer::new(source, &sorted, window, theme).render(output, filename)?;
+    }
+    Ok(())
+}
+
+struct ContextRenderer<'a> {
+    theme: &'a FrameTheme,
+    source: &'a IndexedSource,
+    window: &'a ContextWindow,
+    labels: &'a [FrameLabel],
+    lines: Vec<FrameLine<'a>>,
+    max_gutter: usize,
+    line_number_width: usize,
+}
+
+impl<'a> ContextRenderer<'a> {
+    fn new(
+        source: &'a IndexedSource,
+        labels: &'a [FrameLabel],
+        window: &'a ContextWindow,
+        theme: &'a FrameTheme,
+    ) -> Self {
+        let lines = context_lines_of(source, window);
+
+        let mut max_gutter = 0;
+        for line in &lines {
+            let mut applicable = 0;
+            for label in labels {
+                if !line.span_line_only(label) && line.span_applies_gutter(label) {
+                    applicable += 1;
+                }
+            }
+            max_gutter = max_gutter.max(applicable);
+        }
+
+        let line_number_width = lines
+            .last()
+            .map(|line| line.line_number)
+            .unwrap_or(0)
+            .to_string()
+            .len();
+
+        Self {
+            theme,
+            source,
+            window,
+            labels,
+            lines,
+            max_gutter,
+            line_number_width,
+        }
+    }
+
+    fn render(&self, output: &mut String, filename: &str) -> fmt::Result {
+        let contained = |label: &&FrameLabel| {
+            self.window.offset <= label.offset && label.end() <= self.window.end()
+        };
+        let primary_label = self
+            .labels
+            .iter()
+            .filter(contained)
+            .find(|label| label.primary)
+            .or_else(|| self.labels.iter().find(contained))
+            .expect("every context contains the label that created it");
+
+        write!(
+            output,
+            "{}{}{}",
+            " ".repeat(self.line_number_width + 2),
+            LTOP,
+            HBAR,
+        )?;
+
+        let (location_line, location_column) = self.source.line_col(primary_label.offset);
+        writeln!(
+            output,
+            "[{}]",
+            format_args!("{}:{}:{}", filename, location_line, location_column)
+                .style(self.theme.location)
+        )?;
+
+        for line in &self.lines {
+            self.write_line_number(output, line.line_number)?;
+            self.render_line_gutter(output, line)?;
+            self.render_line_text(output, line)?;
+
+            let (single_line, multi_line): (Vec<_>, Vec<_>) = self
+                .labels
+                .iter()
+                .filter(|label| line.span_applies(label))
+                .partition(|label| line.span_line_only(label));
+            if !single_line.is_empty() {
+                self.write_no_line_number(output)?;
+                self.render_highlight_gutter(output, line, LabelRenderMode::SingleLine)?;
+                self.render_single_line_highlights(output, line, &single_line)?;
+            }
+            for label in multi_line {
+                if line.span_ends(label) && !line.span_starts(label) {
+                    self.render_multi_line_end(output, line, label)?;
+                }
+            }
+        }
+        writeln!(
+            output,
+            "{}{}{}",
+            " ".repeat(self.line_number_width + 2),
+            LBOT,
+            HBAR.to_string().repeat(4),
+        )?;
+        Ok(())
+    }
+
+    fn write_line_number(&self, output: &mut String, line_number: usize) -> fmt::Result {
+        write!(
+            output,
+            " {:width$} {} ",
+            line_number.style(self.theme.line_number),
+            VBAR,
+            width = self.line_number_width,
+        )
+    }
+
+    fn write_no_line_number(&self, output: &mut String) -> fmt::Result {
+        write!(
+            output,
+            " {:width$} {} ",
+            "",
+            VBAR_BREAK,
+            width = self.line_number_width,
+        )
+    }
+
+    /// Visual width of each character, expanding tabs and skipping ANSI escapes.
+    fn visual_char_widths<'t>(&self, text: &'t str) -> impl Iterator<Item = usize> + 't {
+        let mut column = 0;
+        let mut escaped = false;
+        text.chars().map(move |character| {
+            let width = match (escaped, character) {
+                (false, '\t') => TAB_WIDTH - column % TAB_WIDTH,
+                (false, '\x1b') => {
+                    escaped = true;
+                    0
+                }
+                (false, character) => {
+                    unicode_width::UnicodeWidthChar::width(character).unwrap_or(0)
+                }
+                (true, 'm') => {
+                    escaped = false;
+                    0
+                }
+                (true, _) => 0,
+            };
+            column += width;
+            width
+        })
+    }
+
+    /// Visual column of a byte offset on a line. Offsets past the end of the
+    /// line land one column past the visible text.
+    fn visual_offset(&self, line: &FrameLine, offset: usize, start: bool) -> usize {
+        let line_range = line.offset..=(line.offset + line.length);
+        assert!(line_range.contains(&offset));
+
+        let mut text_index = offset - line.offset;
+        while text_index <= line.text.len() && !line.text.is_char_boundary(text_index) {
+            if start {
+                text_index -= 1;
+            } else {
+                text_index += 1;
+            }
+        }
+        let text = &line.text[..text_index.min(line.text.len())];
+        let text_width = self.visual_char_widths(text).sum();
+        if text_index > line.text.len() {
+            text_width + 1
+        } else {
+            text_width
+        }
+    }
+
+    /// Byte ranges of this line's text covered by labels, merged and
+    /// line-relative, so the snippet renders in the highlight color.
+    fn covered_ranges(&self, line: &FrameLine<'_>) -> Vec<(usize, usize)> {
+        let line_start = line.offset;
+        let line_end = line.offset + line.text.len();
+        let mut ranges: Vec<(usize, usize)> = self
+            .labels
+            .iter()
+            .filter(|label| label.length > 0)
+            .map(|label| (label.offset.max(line_start), label.end().min(line_end)))
+            .filter(|(start, end)| start < end)
+            .map(|(start, end)| (start - line_start, end - line_start))
+            .collect();
+        ranges.sort_unstable();
+        let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+        for (start, end) in ranges {
+            match merged.last_mut() {
+                Some((_, last_end)) if start <= *last_end => *last_end = (*last_end).max(end),
+                _ => merged.push((start, end)),
+            }
+        }
+        merged
+    }
+
+    fn render_line_text(&self, output: &mut String, line: &FrameLine<'_>) -> fmt::Result {
+        let style = self.theme.highlight;
+        let covered = self.covered_ranges(line);
+        let mut inside = false;
+        let widths = self.visual_char_widths(line.text);
+        for ((byte_index, character), width) in line.text.char_indices().zip(widths) {
+            let now_inside = covered
+                .iter()
+                .any(|&(start, end)| byte_index >= start && byte_index < end);
+            if now_inside != inside {
+                if now_inside {
+                    write!(output, "{}", style.prefix_formatter())?;
+                } else {
+                    write!(output, "{}", style.suffix_formatter())?;
+                }
+                inside = now_inside;
+            }
+            if character == '\t' {
+                for _ in 0..width {
+                    output.write_char(' ')?;
+                }
+            } else {
+                output.write_char(character)?;
+            }
+        }
+        if inside {
+            write!(output, "{}", style.suffix_formatter())?;
+        }
+        output.write_char('\n')?;
+        Ok(())
+    }
+
+    fn render_line_gutter(&self, output: &mut String, line: &FrameLine) -> fmt::Result {
+        if self.max_gutter == 0 {
+            return Ok(());
+        }
+        let style = self.theme.highlight;
+        let mut gutter = String::new();
+        let applicable = self
+            .labels
+            .iter()
+            .filter(|label| line.span_applies_gutter(label));
+        let mut arrow = false;
+        for (index, label) in applicable.enumerate() {
+            if line.span_starts(label) {
+                gutter.push_str(&LTOP.style(style).to_string());
+                gutter.push_str(
+                    &HBAR
+                        .to_string()
+                        .repeat(self.max_gutter.saturating_sub(index))
+                        .style(style)
+                        .to_string(),
+                );
+                gutter.push_str(&RARROW.style(style).to_string());
+                arrow = true;
+                break;
+            } else if line.span_ends(label) {
+                gutter.push_str(&LCROSS.style(style).to_string());
+                gutter.push_str(
+                    &HBAR
+                        .to_string()
+                        .repeat(self.max_gutter.saturating_sub(index))
+                        .style(style)
+                        .to_string(),
+                );
+                gutter.push_str(&RARROW.style(style).to_string());
+                arrow = true;
+                break;
+            } else if line.span_flyby(label) {
+                gutter.push_str(&VBAR.style(style).to_string());
+            } else {
+                gutter.push(' ');
+            }
+        }
+        write!(
+            output,
+            "{}{}",
+            gutter,
+            " ".repeat(
+                if arrow { 1 } else { 3 } + self.max_gutter.saturating_sub(gutter.chars().count())
+            ),
+        )?;
+        Ok(())
+    }
+
+    fn render_highlight_gutter(
+        &self,
+        output: &mut String,
+        line: &FrameLine,
+        render_mode: LabelRenderMode,
+    ) -> fmt::Result {
+        if self.max_gutter == 0 {
+            return Ok(());
+        }
+
+        let style = self.theme.highlight;
+        let mut gutter_columns = 0;
+        let mut gutter = String::new();
+        let applicable = self
+            .labels
+            .iter()
+            .filter(|label| line.span_applies_gutter(label));
+        for (index, label) in applicable.enumerate() {
+            if !line.span_line_only(label) && line.span_ends(label) {
+                if render_mode == LabelRenderMode::MultiLineRest {
+                    let horizontal_space = self.max_gutter.saturating_sub(index) + 2;
+                    for _ in 0..horizontal_space {
+                        gutter.push(' ');
+                    }
+                    gutter_columns += horizontal_space + 1;
+                } else {
+                    let repeats = self.max_gutter.saturating_sub(index) + 2;
+                    gutter.push_str(&LBOT.style(style).to_string());
+                    gutter.push_str(
+                        &HBAR
+                            .to_string()
+                            .repeat(
+                                repeats
+                                    - if render_mode == LabelRenderMode::MultiLineFirst {
+                                        1
+                                    } else {
+                                        0
+                                    },
+                            )
+                            .style(style)
+                            .to_string(),
+                    );
+                    gutter_columns += repeats + 1;
+                }
+                break;
+            } else {
+                gutter.push_str(&VBAR.style(style).to_string());
+                gutter_columns += 1;
+            }
+        }
+
+        let padding = (self.max_gutter + 3).saturating_sub(gutter_columns);
+        write!(output, "{}{:padding$}", gutter, "")?;
+        Ok(())
+    }
+
+    fn render_single_line_highlights(
+        &self,
+        output: &mut String,
+        line: &FrameLine,
+        single_line: &[&FrameLabel],
+    ) -> fmt::Result {
+        let style = self.theme.highlight;
+        let mut underlines = String::new();
+        let mut highest = 0;
+
+        let columns: Vec<(&FrameLabel, usize)> = single_line
+            .iter()
+            .map(|label| {
+                let byte_start = label.offset;
+                let byte_end = label.end();
+                let start = self.visual_offset(line, byte_start, true).max(highest);
+                let end = if label.length == 0 {
+                    start + 1
+                } else {
+                    self.visual_offset(line, byte_end, false).max(start + 1)
+                };
+
+                let marker_column = (start + end) / 2;
+                let dashes_left = marker_column - start;
+                let dashes_right = end - marker_column - 1;
+                underlines.push_str(
+                    &format!(
+                        "{:padding$}{}{}{}",
+                        "",
+                        UNDERLINE.to_string().repeat(dashes_left),
+                        if label.length == 0 { UARROW } else { UNDERBAR },
+                        UNDERLINE.to_string().repeat(dashes_right),
+                        padding = start.saturating_sub(highest),
+                    )
+                    .style(style)
+                    .to_string(),
+                );
+                highest = highest.max(end);
+
+                (*label, marker_column)
+            })
+            .collect();
+        writeln!(output, "{}", underlines)?;
+
+        let row = LabelRow {
+            line,
+            columns: &columns,
+        };
+        for label in single_line.iter().rev() {
+            let parts = label.styled_parts(style);
+            if parts.len() == 1 {
+                self.write_label_text(output, &row, label, &parts[0], LabelRenderMode::SingleLine)?;
+            } else {
+                let mut first = true;
+                for part in &parts {
+                    self.write_label_text(
+                        output,
+                        &row,
+                        label,
+                        part,
+                        if first {
+                            LabelRenderMode::MultiLineFirst
+                        } else {
+                            LabelRenderMode::MultiLineRest
+                        },
+                    )?;
+                    first = false;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn write_label_text(
+        &self,
+        output: &mut String,
+        row: &LabelRow<'_>,
+        label: &FrameLabel,
+        text: &str,
+        render_mode: LabelRenderMode,
+    ) -> fmt::Result {
+        let style = self.theme.highlight;
+        self.write_no_line_number(output)?;
+        self.render_highlight_gutter(output, row.line, LabelRenderMode::SingleLine)?;
+        let mut current_column = 1usize;
+        for (column_label, marker_column) in row.columns {
+            while current_column < *marker_column + 1 {
+                write!(output, " ")?;
+                current_column += 1;
+            }
+            if *column_label != label {
+                write!(output, "{}", VBAR.to_string().style(style))?;
+                current_column += 1;
+            } else {
+                let connector = match render_mode {
+                    LabelRenderMode::SingleLine => {
+                        format!("{}{} {}", LBOT, HBAR.to_string().repeat(2), text)
+                    }
+                    LabelRenderMode::MultiLineFirst => {
+                        format!("{}{}{} {}", LBOT, HBAR, RCROSS, text)
+                    }
+                    LabelRenderMode::MultiLineRest => {
+                        format!("  {} {}", VBAR, text)
+                    }
+                };
+                writeln!(output, "{}", connector.style(style))?;
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn render_multi_line_end(
+        &self,
+        output: &mut String,
+        line: &FrameLine,
+        label: &FrameLabel,
+    ) -> fmt::Result {
+        self.write_no_line_number(output)?;
+
+        let parts = label.styled_parts(self.theme.highlight);
+        let (first, rest) = parts
+            .split_first()
+            .expect("split on newline always yields at least one part");
+
+        if rest.is_empty() {
+            self.render_highlight_gutter(output, line, LabelRenderMode::SingleLine)?;
+            self.render_multi_line_end_single(output, first, LabelRenderMode::SingleLine)?;
+        } else {
+            self.render_highlight_gutter(output, line, LabelRenderMode::MultiLineFirst)?;
+            self.render_multi_line_end_single(output, first, LabelRenderMode::MultiLineFirst)?;
+            for part in rest {
+                self.write_no_line_number(output)?;
+                self.render_highlight_gutter(output, line, LabelRenderMode::MultiLineRest)?;
+                self.render_multi_line_end_single(output, part, LabelRenderMode::MultiLineRest)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn render_multi_line_end_single(
+        &self,
+        output: &mut String,
+        text: &str,
+        render_mode: LabelRenderMode,
+    ) -> fmt::Result {
+        let style = self.theme.highlight;
+        match render_mode {
+            LabelRenderMode::SingleLine => {
+                writeln!(output, "{} {}", HBAR.style(style), text)?;
+            }
+            LabelRenderMode::MultiLineFirst => {
+                writeln!(output, "{} {}", RCROSS.style(style), text)?;
+            }
+            LabelRenderMode::MultiLineRest => {
+                writeln!(output, "{} {}", VBAR.style(style), text)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Splits a context window into rendered lines. A line's length keeps its
+/// newline bytes, its text drops them, and a lone trailing CR stays visible.
+fn context_lines_of<'a>(source: &'a IndexedSource, window: &ContextWindow) -> Vec<FrameLine<'a>> {
+    let text = source.text();
+    let line_starts = source.line_starts();
+    let mut lines = Vec::with_capacity(window.last_line - window.start_line + 1);
+    for line_index in window.start_line..=window.last_line {
+        let line_offset = line_starts[line_index];
+        if line_offset >= window.end_offset {
+            break;
+        }
+        let line_end = if line_index + 1 < line_starts.len() {
+            line_starts[line_index + 1].min(window.end_offset)
+        } else {
+            window.end_offset
+        };
+        let raw = &text[line_offset..line_end];
+        let line_text = raw
+            .strip_suffix('\n')
+            .map(|stripped| stripped.strip_suffix('\r').unwrap_or(stripped))
+            .unwrap_or(raw);
+        lines.push(FrameLine {
+            line_number: line_index + 1,
+            offset: line_offset,
+            length: raw.len(),
+            text: line_text,
+        });
+    }
+    lines
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -1,5 +1,6 @@
 mod diagnostic;
 mod fix;
+mod graphical;
 mod sink;
 
 pub mod attribute;
@@ -11,7 +12,7 @@ pub mod module_graph;
 pub mod pattern;
 pub mod render;
 
-pub use diagnostic::{IndexedSource, LisetteDiagnostic, Report};
+pub use diagnostic::{IndexedSource, LisetteDiagnostic};
 pub use fix::{Edit, Fix, FixApplicationOutcome, apply_fixes};
 pub use sink::{DiagnosticCheckpoint, LocalSink};
 

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::time::Duration;
 
 use rustc_hash::FxHashMap;
 
 use crate::LisetteDiagnostic;
 use crate::diagnostic::IndexedSource;
-use miette::{GraphicalReportHandler, GraphicalTheme, ThemeCharacters, ThemeStyles};
+use crate::graphical::{self, FrameReport, FrameTheme};
 use owo_colors::{OwoColorize, Style};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -119,77 +120,71 @@ pub fn print_summary(
     }
 }
 
-fn color_handler(highlight: Style) -> GraphicalReportHandler {
-    let theme = GraphicalTheme {
-        characters: ThemeCharacters {
-            error: "✕".into(),
-            warning: "▲".into(),
-            advice: "●".into(),
-            ..ThemeCharacters::unicode()
-        },
-        styles: ThemeStyles {
-            error: Style::new().red(),
-            warning: Style::new().yellow(),
-            advice: Style::new().blue(),
-            link: Style::new(),
-            help: Style::new().dimmed(),
-            highlights: vec![highlight],
-            ..ThemeStyles::ansi()
-        },
+fn frame_theme(diagnostic: &LisetteDiagnostic, use_color: bool) -> FrameTheme {
+    let icon = if diagnostic.is_error() {
+        "✕"
+    } else if diagnostic.is_info() {
+        "●"
+    } else {
+        "▲"
     };
-    GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
+    if !use_color {
+        return FrameTheme {
+            icon,
+            severity: Style::new(),
+            highlight: Style::new(),
+            line_number: Style::new(),
+            location: Style::new(),
+            help: Style::new(),
+        };
+    }
+    let severity = if diagnostic.is_error() {
+        Style::new().red()
+    } else if diagnostic.is_info() {
+        Style::new().blue()
+    } else {
+        Style::new().yellow()
+    };
+    FrameTheme {
+        icon,
+        severity,
+        highlight: severity,
+        line_number: Style::new().dimmed(),
+        location: Style::new(),
+        help: Style::new().dimmed(),
+    }
 }
 
-fn accent_handler(accent: Style) -> GraphicalReportHandler {
-    let theme = GraphicalTheme {
-        characters: ThemeCharacters {
-            error: "✕".into(),
-            warning: "▲".into(),
-            advice: "●".into(),
-            ..ThemeCharacters::unicode()
-        },
-        styles: ThemeStyles {
-            error: Style::new().red(),
-            warning: Style::new().yellow(),
-            advice: accent,
-            link: Style::new(),
-            help: Style::new().dimmed(),
-            highlights: vec![accent],
-            ..ThemeStyles::ansi()
-        },
-    };
-    GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
-}
-
-fn nocolor_handler() -> GraphicalReportHandler {
-    let theme = GraphicalTheme {
-        characters: ThemeCharacters {
-            error: "✕".into(),
-            warning: "▲".into(),
-            advice: "●".into(),
-            ..ThemeCharacters::unicode()
-        },
-        styles: ThemeStyles::none(),
-    };
-    GraphicalReportHandler::new_themed(theme).with_wrap_lines(false)
-}
-
-fn graphical_report(
-    handler: &GraphicalReportHandler,
+fn write_graphical_report(
+    output: &mut String,
     diagnostic: &LisetteDiagnostic,
     source: Option<(&IndexedSource, &str)>,
     use_color: bool,
-) -> Option<String> {
-    let report = miette::Report::new(diagnostic.clone().into_rendered(use_color));
-    let report = match source {
-        Some((source, filename)) => {
-            report.with_source_code(miette::NamedSource::new(filename, source.clone()))
-        }
-        None => report,
-    };
+    context_lines: usize,
+) -> fmt::Result {
+    let labels = diagnostic.frame_labels(use_color);
+    let help = diagnostic.styled_help_text(use_color);
+    graphical::render_report(
+        output,
+        &FrameReport {
+            message: &diagnostic.styled_message(use_color),
+            labels: &labels,
+            help: help.as_deref(),
+        },
+        source,
+        &frame_theme(diagnostic, use_color),
+        context_lines,
+    )
+}
+
+fn graphical_report(
+    diagnostic: &LisetteDiagnostic,
+    source: Option<(&IndexedSource, &str)>,
+    use_color: bool,
+) -> String {
     let mut output = String::new();
-    handler.render_report(&mut output, report.as_ref()).ok()?;
-    Some(output)
+    let _ = write_graphical_report(&mut output, diagnostic, source, use_color, 1);
+    output
 }
 
 pub fn render_to_string(
@@ -199,48 +194,32 @@ pub fn render_to_string(
     use_color: bool,
     context_lines: usize,
 ) -> String {
-    let accent = if diagnostic.is_error() {
-        Style::new().red()
-    } else if diagnostic.is_info() {
-        Style::new().blue()
-    } else {
-        Style::new().yellow()
-    };
-    let handler = if use_color {
-        accent_handler(accent)
-    } else {
-        nocolor_handler()
-    }
-    .with_context_lines(context_lines);
-    let report = diagnostic.clone().into_rendered(use_color);
-    let report = miette::Report::new(report).with_source_code(miette::NamedSource::new(
-        filename,
-        IndexedSource::new(source),
-    ));
+    let source = IndexedSource::new(source);
     let mut output = String::new();
-    let _ = handler.render_report(&mut output, report.as_ref());
+    let _ = write_graphical_report(
+        &mut output,
+        diagnostic,
+        Some((&source, filename)),
+        use_color,
+        context_lines,
+    );
+    output
+}
+
+pub fn render_standalone(diagnostic: &LisetteDiagnostic) -> String {
+    let mut output = String::new();
+    let _ = write_graphical_report(&mut output, diagnostic, None, false, 1);
     output
 }
 
 fn render_group<F: Fn(u32) -> Option<(String, String)>>(
     diagnostics: &[&LisetteDiagnostic],
-    highlight: Style,
     use_color: bool,
     sources: &mut SourceCache<F>,
 ) {
-    if diagnostics.is_empty() {
-        return;
-    }
-    let handler = if use_color {
-        color_handler(highlight)
-    } else {
-        nocolor_handler()
-    };
     for diagnostic in diagnostics {
         let source = sources.get(diagnostic.file_id());
-        if let Some(output) = graphical_report(&handler, diagnostic, source, use_color) {
-            eprintln!("{}", output);
-        }
+        eprintln!("{}", graphical_report(diagnostic, source, use_color));
     }
 }
 
@@ -334,14 +313,9 @@ pub fn render_all(
 
     let use_color = std::env::var("NO_COLOR").is_err();
 
-    render_group(&groups.errors, Style::new().red(), use_color, &mut sources);
-    render_group(
-        &groups.warnings,
-        Style::new().yellow(),
-        use_color,
-        &mut sources,
-    );
-    render_group(&groups.info, Style::new().blue(), use_color, &mut sources);
+    render_group(&groups.errors, use_color, &mut sources);
+    render_group(&groups.warnings, use_color, &mut sources);
+    render_group(&groups.info, use_color, &mut sources);
 
     groups.counts(file_count)
 }
@@ -472,7 +446,7 @@ mod tests {
     fn graphical_output(diagnostic: &LisetteDiagnostic) -> String {
         let mut sources = SourceCache::new(entry_only);
         let source = sources.get(diagnostic.file_id());
-        graphical_report(&nocolor_handler(), diagnostic, source, false).expect("rendering succeeds")
+        graphical_report(diagnostic, source, false)
     }
 
     #[test]
@@ -507,6 +481,45 @@ mod tests {
         let filter = Filter::Warnings;
         let groups = partition_diagnostics(&diagnostics, &filter);
         assert!(groups.info.is_empty());
+    }
+
+    fn hundred_line_source() -> String {
+        let mut source = String::new();
+        for i in 1..=100 {
+            source.push_str(&format!("line number {}\n", i));
+        }
+        source
+    }
+
+    fn line_offset(source: &str, line: usize) -> u32 {
+        source
+            .lines()
+            .take(line - 1)
+            .map(|line| line.len() as u32 + 1)
+            .sum()
+    }
+
+    #[test]
+    fn distant_labels_render_separate_frames() {
+        let source = hundred_line_source();
+        let diagnostic = LisetteDiagnostic::warn("Two places")
+            .with_span_primary_label(&Span::new(0, line_offset(&source, 50), 4), "first")
+            .with_span_label(&Span::new(0, line_offset(&source, 80), 4), "second");
+        let output = render_to_string(&diagnostic, &source, "src/main.lis", false, 1);
+        assert_eq!(output.matches("╭─[").count(), 2);
+        assert!(!output.contains("line number 65"));
+    }
+
+    #[test]
+    fn touching_labels_share_one_frame() {
+        let source = hundred_line_source();
+        let diagnostic = LisetteDiagnostic::warn("Two neighbors")
+            .with_span_primary_label(&Span::new(0, line_offset(&source, 50), 4), "first")
+            .with_span_label(&Span::new(0, line_offset(&source, 52), 4), "second");
+        let output = render_to_string(&diagnostic, &source, "src/main.lis", false, 1);
+        assert_eq!(output.matches("╭─[").count(), 1);
+        assert!(output.contains("first"));
+        assert!(output.contains("second"));
     }
 
     #[test]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -19,7 +19,6 @@ diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "..
 deps = { package = "lisette-deps", version = "=0.11.0", path = "../deps" }
 format = { package = "lisette-format", version = "=0.11.0", path = "../format" }
 tokio = { version = "1", features = ["rt", "sync", "time", "io-util"] }
-miette.workspace = true
 rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::protocol::*;
-use miette::Diagnostic as MietteDiagnostic;
 use rustc_hash::FxHashMap;
 
 use deps::TypedefLocator;
@@ -253,9 +252,8 @@ impl SharedState {
 
 pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Diagnostic {
     let range = d
-        .labels()
-        .and_then(|labels| labels.into_iter().next())
-        .map(|label| index.offset_len_to_range(label.offset(), label.len()))
+        .first_label_span()
+        .map(|(offset, length)| index.offset_len_to_range(offset, length))
         .unwrap_or_default();
 
     Diagnostic {

--- a/playground/wasm/Cargo.lock
+++ b/playground/wasm/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lisette-deps"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -112,17 +112,17 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lisette-syntax",
- "miette",
  "owo-colors",
  "rustc-hash",
+ "unicode-width",
 ]
 
 [[package]]
 name = "lisette-emit"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "ecow",
@@ -168,11 +168,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -202,18 +202,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "owo-colors",
- "textwrap",
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "once_cell"
@@ -341,16 +329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "unicode-linebreak",
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,22 +364,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,7 +17,6 @@ deps = { package = "lisette-deps", path = "../crates/deps" }
 rustc-hash.workspace = true
 rayon.workspace = true
 insta.workspace = true
-miette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile = "3"

--- a/tests/_harness/formatting.rs
+++ b/tests/_harness/formatting.rs
@@ -1,36 +1,13 @@
 use diagnostics::{IndexedSource, LisetteDiagnostic};
-use miette::{GraphicalReportHandler, GraphicalTheme, ThemeCharacters, ThemeStyles};
 use passes::Analysis;
 use syntax::ParseError;
-
-fn snapshot_theme() -> GraphicalTheme {
-    GraphicalTheme {
-        characters: ThemeCharacters {
-            error: "✕".into(),
-            warning: "▲".into(),
-            advice: "●".into(),
-            ..ThemeCharacters::unicode()
-        },
-        styles: ThemeStyles::none(),
-    }
-}
 
 pub fn format_diagnostic_for_snapshot(
     diagnostic: &LisetteDiagnostic,
     source: &str,
     filename: &str,
 ) -> String {
-    let handler = GraphicalReportHandler::new()
-        .with_theme(snapshot_theme())
-        .with_wrap_lines(false);
-
-    let report = diagnostic
-        .clone()
-        .with_source_code(IndexedSource::new(source), filename.to_string());
-
-    let mut output = String::new();
-    handler.render_report(&mut output, report.as_ref()).unwrap();
-    output
+    diagnostics::render::render_to_string(diagnostic, source, filename, false, 1)
 }
 
 pub fn format_result_diagnostic_for_snapshot(
@@ -72,12 +49,5 @@ pub fn format_parse_error_unix(error: &ParseError, source: &str, filename: &str)
 }
 
 pub fn format_diagnostic_standalone(diagnostic: &LisetteDiagnostic) -> String {
-    let handler = GraphicalReportHandler::new()
-        .with_theme(snapshot_theme())
-        .with_wrap_lines(false);
-    let report = miette::Report::new(diagnostic.clone());
-
-    let mut output = String::new();
-    handler.render_report(&mut output, report.as_ref()).unwrap();
-    output
+    diagnostics::render::render_standalone(diagnostic)
 }


### PR DESCRIPTION
Move diagnostic rendering from miette to an in-crate renderer, so we own frame layout and remove `miette`, `textwrap`, `unicode-linebreak` and `unicode-width` 0.1 from the dep tree. Output unchanged, except for:

- Labeled snippets now render in the severity color.
- Two labels far apart deep in a file now render as two frames instead of one.
