### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Lisette is under active development. Any version before 1.0.0 may include breaking changes.
 
+## [0.11.1](https://github.com/ivov/lisette/compare/lisette-v0.11.0...lisette-v0.11.1) - 2026-08-02
+
+### Fixes
+
+- fix: allow autofill of Go structs with hidden fields by default [#1198](https://github.com/ivov/lisette/pull/1198) [`0ab5f68`](https://github.com/ivov/lisette/commit/0ab5f68607a27d304b14ba8504462577b629c320)
+
+### Internals
+
+- chore: version releases by commits, not internal crate APIs [#1196](https://github.com/ivov/lisette/pull/1196) [`4255d9d`](https://github.com/ivov/lisette/commit/4255d9d919e7dc370e1796e2ca51f3158a6de2f1)
+- refactor: shed `tokio` [#1195](https://github.com/ivov/lisette/pull/1195) [`8a0ad45`](https://github.com/ivov/lisette/commit/8a0ad453596f4bf3f93245b3292747cc977244a6)
+- refactor: simplify `passes` crate data flow [#1194](https://github.com/ivov/lisette/pull/1194) [`169e59c`](https://github.com/ivov/lisette/commit/169e59cbb9cfb93bdbe8f3e73e82b5091b9f1262)
+- chore: restore lowercase commit subject enforcement [#1190](https://github.com/ivov/lisette/pull/1190) [`178666a`](https://github.com/ivov/lisette/commit/178666ab1382446535d844a633b8ad34aab302ae)
+- chore: upgrade Rust toolchain to 1.97 [#1189](https://github.com/ivov/lisette/pull/1189) [`4b6dd29`](https://github.com/ivov/lisette/commit/4b6dd29b28ecccd74ca470dfd0fc478c4b42fb61)
+- refactor: take over diagnostic rendering [#1188](https://github.com/ivov/lisette/pull/1188) [`fbc5f3a`](https://github.com/ivov/lisette/commit/fbc5f3a13c080ed8386c1f58e2a880786dfbb5d2)
+
+
 ## [0.11.0](https://github.com/ivov/lisette/compare/lisette-v0.10.0...lisette-v0.11.0) - 2026-08-02
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lisette"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "lisette-deps",
  "lisette-diagnostics",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-deps"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "lisette-stdlib",
  "serde",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-diagnostics"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "lisette-syntax",
  "owo-colors",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-emit"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-format"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "lisette-syntax",
  "unicode-segmentation",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-lsp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "lisette-deps",
  "lisette-diagnostics",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-passes"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ecow",
  "lisette-diagnostics",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "lisette-semantics"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "ecow",
@@ -267,11 +267,11 @@ dependencies = [
 
 [[package]]
 name = "lisette-stdlib"
-version = "0.11.0"
+version = "0.11.1"
 
 [[package]]
 name = "lisette-syntax"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ecow",
  "rustc-hash",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "insta",
  "lisette-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,15 +20,15 @@ name = "lis"
 path = "src/main.rs"
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.11.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.11.0", path = "../passes" }
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "../diagnostics" }
-format = { package = "lisette-format", version = "=0.11.0", path = "../format" }
-emit = { package = "lisette-emit", version = "=0.11.0", path = "../emit" }
-stdlib = { package = "lisette-stdlib", version = "=0.11.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.11.0", path = "../deps" }
-lsp = { package = "lisette-lsp", version = "=0.11.0", path = "../lsp" }
+semantics = { package = "lisette-semantics", version = "=0.11.1", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.11.1", path = "../passes" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.11.1", path = "../diagnostics" }
+format = { package = "lisette-format", version = "=0.11.1", path = "../format" }
+emit = { package = "lisette-emit", version = "=0.11.1", path = "../emit" }
+stdlib = { package = "lisette-stdlib", version = "=0.11.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.11.1", path = "../deps" }
+lsp = { package = "lisette-lsp", version = "=0.11.1", path = "../lsp" }
 owo-colors.workspace = true
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/deps/Cargo.toml
+++ b/crates/deps/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-stdlib = { package = "lisette-stdlib", version = "=0.11.0", path = "../stdlib" }
+stdlib = { package = "lisette-stdlib", version = "=0.11.1", path = "../stdlib" }
 toml_edit = { version = "0.22", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
 owo-colors.workspace = true
 rustc-hash.workspace = true
 unicode-width = "0.2"

--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "../diagnostics" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.11.1", path = "../diagnostics" }
 ecow.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 test = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
 unicode-segmentation = "1.11"
 
 [lints]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
-semantics = { package = "lisette-semantics", version = "=0.11.0", path = "../semantics" }
-passes = { package = "lisette-passes", version = "=0.11.0", path = "../passes" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "../diagnostics" }
-deps = { package = "lisette-deps", version = "=0.11.0", path = "../deps" }
-format = { package = "lisette-format", version = "=0.11.0", path = "../format" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
+semantics = { package = "lisette-semantics", version = "=0.11.1", path = "../semantics" }
+passes = { package = "lisette-passes", version = "=0.11.1", path = "../passes" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.11.1", path = "../diagnostics" }
+deps = { package = "lisette-deps", version = "=0.11.1", path = "../deps" }
+format = { package = "lisette-format", version = "=0.11.1", path = "../format" }
 rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-semantics = { package = "lisette-semantics", version = "=0.11.0", path = "../semantics" }
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax" }
-diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "../diagnostics" }
+semantics = { package = "lisette-semantics", version = "=0.11.1", path = "../semantics" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax" }
+diagnostics = { package = "lisette-diagnostics", version = "=0.11.1", path = "../diagnostics" }
 ecow = "0.2"
 rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/semantics/Cargo.toml
+++ b/crates/semantics/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-syntax = { package = "lisette-syntax", version = "=0.11.0", path = "../syntax", features = ["serde"] }
-diagnostics = { package = "lisette-diagnostics", version = "=0.11.0", path = "../diagnostics" }
-stdlib = { package = "lisette-stdlib", version = "=0.11.0", path = "../stdlib" }
-deps = { package = "lisette-deps", version = "=0.11.0", path = "../deps" }
+syntax = { package = "lisette-syntax", version = "=0.11.1", path = "../syntax", features = ["serde"] }
+diagnostics = { package = "lisette-diagnostics", version = "=0.11.1", path = "../diagnostics" }
+stdlib = { package = "lisette-stdlib", version = "=0.11.1", path = "../stdlib" }
+deps = { package = "lisette-deps", version = "=0.11.1", path = "../deps" }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 ecow = "0.2"


### PR DESCRIPTION
## 0.11.1 (upcoming)

### Fixes

- fix: allow autofill of Go structs with hidden fields by default [#1198](https://github.com/ivov/lisette/pull/1198) [`0ab5f68`](https://github.com/ivov/lisette/commit/0ab5f68607a27d304b14ba8504462577b629c320)

### Internals

- chore: version releases by commits, not internal crate APIs [#1196](https://github.com/ivov/lisette/pull/1196) [`4255d9d`](https://github.com/ivov/lisette/commit/4255d9d919e7dc370e1796e2ca51f3158a6de2f1)
- refactor: shed `tokio` [#1195](https://github.com/ivov/lisette/pull/1195) [`8a0ad45`](https://github.com/ivov/lisette/commit/8a0ad453596f4bf3f93245b3292747cc977244a6)
- refactor: simplify `passes` crate data flow [#1194](https://github.com/ivov/lisette/pull/1194) [`169e59c`](https://github.com/ivov/lisette/commit/169e59cbb9cfb93bdbe8f3e73e82b5091b9f1262)
- chore: restore lowercase commit subject enforcement [#1190](https://github.com/ivov/lisette/pull/1190) [`178666a`](https://github.com/ivov/lisette/commit/178666ab1382446535d844a633b8ad34aab302ae)
- chore: upgrade Rust toolchain to 1.97 [#1189](https://github.com/ivov/lisette/pull/1189) [`4b6dd29`](https://github.com/ivov/lisette/commit/4b6dd29b28ecccd74ca470dfd0fc478c4b42fb61)
- refactor: take over diagnostic rendering [#1188](https://github.com/ivov/lisette/pull/1188) [`fbc5f3a`](https://github.com/ivov/lisette/commit/fbc5f3a13c080ed8386c1f58e2a880786dfbb5d2)

