### PR TITLE
refactor: simplify passes crate data flow

### DIFF
--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -76,7 +76,7 @@ impl Analysis {
 pub fn analyze(input: AnalyzeInput) -> Analysis {
     let InferenceOutput {
         store,
-        mut facts,
+        facts,
         sink,
         has_pre_check_errors,
         compiled_modules,
@@ -85,23 +85,27 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         unreachable_modules,
         entry_parse,
     } = run_inference(input);
-    let run_lints = entry_parse.is_clean();
+    let lint_mode = if entry_parse.is_clean() {
+        passes::LintMode::Run
+    } else {
+        passes::LintMode::Skip
+    };
     let entry_parse_status = entry_parse.status();
     let entry_parse_errors = entry_parse.into_errors();
 
-    let mut unused = UnusedInfo::default();
-    if !has_pre_check_errors {
-        passes::run(&store, &mut facts, &sink, &mut unused, run_lints);
-    }
+    let unused = if has_pre_check_errors {
+        UnusedInfo::default()
+    } else {
+        passes::run(&store, &facts, &sink, lint_mode)
+    };
     let mut mutations = MutationInfo::default();
     for (&binding_id, b) in facts.bindings.iter() {
         if let Some(mutation) = b.mutation {
             mutations.record(binding_id, mutation);
         }
     }
-    let bindings = std::mem::take(&mut facts.bindings);
-    let usages = std::mem::take(&mut facts.usages);
-    drop(facts);
+    let bindings = facts.bindings;
+    let usages = facts.usages;
 
     // Canonicalize diagnostic order so the output is stable regardless of
     // phase ordering, FxHashMap iteration, or parallel inference scheduling.

--- a/crates/passes/src/lib.rs
+++ b/crates/passes/src/lib.rs
@@ -2,4 +2,4 @@ mod analyze;
 mod passes;
 
 pub use analyze::{Analysis, analyze};
-pub use passes::{Lint, run};
+pub use passes::{Lint, LintMode, run};

--- a/crates/passes/src/passes/checks/always_true_disjunction.rs
+++ b/crates/passes/src/passes/checks/always_true_disjunction.rs
@@ -2,7 +2,7 @@ use crate::passes::comparison::{
     Bound, expressions_equivalent, flip_comparison, in_scope_comparison, is_side_effect_free,
     is_skippable_boolean, signed_integer_literal, tighter,
 };
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use syntax::ast::{BinaryOperator, Expression, Span};
 
 pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
@@ -15,7 +15,7 @@ pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
         return;
     };
 
-    if ctx.claimed_spans.contains(root_span) {
+    if ctx.is_claimed(ClaimKind::AlwaysTrueDisjunction, root_span) {
         return;
     }
 
@@ -74,7 +74,7 @@ fn collect_disjuncts<'a>(
             ..
         } => {
             if span != root_span {
-                ctx.claimed_spans.insert(*span);
+                ctx.claim(ClaimKind::AlwaysTrueDisjunction, *span);
             }
             collect_disjuncts(left, root_span, disjuncts, ctx);
             collect_disjuncts(right, root_span, disjuncts, ctx);

--- a/crates/passes/src/passes/checks/const_naming.rs
+++ b/crates/passes/src/passes/checks/const_naming.rs
@@ -4,7 +4,7 @@ use crate::passes::lints::ast_walk::casing::{is_screaming_snake_case, to_screami
 use crate::passes::walk::NodeCtx;
 
 pub(crate) fn check(expression: &Expression, ctx: &NodeCtx) {
-    if ctx.is_d_lis {
+    if ctx.is_d_lis() {
         return;
     }
     let Expression::Const {

--- a/crates/passes/src/passes/checks/impossible_comparison.rs
+++ b/crates/passes/src/passes/checks/impossible_comparison.rs
@@ -2,7 +2,7 @@ use crate::passes::comparison::{
     Bound, expressions_equivalent, flip_comparison, in_scope_comparison, is_side_effect_free,
     is_skippable_boolean, signed_integer_literal, tighter,
 };
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use syntax::ast::{BinaryOperator, Expression, Span};
 
 pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
@@ -16,7 +16,7 @@ pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
     };
 
     // A nested `&&` is covered by the outermost chain that encloses it.
-    if ctx.claimed_spans.contains(root_span) {
+    if ctx.is_claimed(ClaimKind::ImpossibleComparison, root_span) {
         return;
     }
 
@@ -78,7 +78,7 @@ fn collect_conjuncts<'a>(
             ..
         } => {
             if span != root_span {
-                ctx.claimed_spans.insert(*span);
+                ctx.claim(ClaimKind::ImpossibleComparison, *span);
             }
             collect_conjuncts(left, root_span, conjuncts, ctx);
             collect_conjuncts(right, root_span, conjuncts, ctx);

--- a/crates/passes/src/passes/checks/map_key.rs
+++ b/crates/passes/src/passes/checks/map_key.rs
@@ -6,7 +6,7 @@ use syntax::ast::{Expression, Span};
 use syntax::program::{CallKind, Definition, NativeTypeKind};
 use syntax::types::{CompoundKind, Symbol, Type};
 
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 
 pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
     match expression {
@@ -18,7 +18,7 @@ pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
                     ..
                 } = value.unwrap_parens()
             {
-                ctx.claimed_spans.insert(*span);
+                ctx.claim(ClaimKind::MapKey, *span);
             }
         }
         Expression::Call {
@@ -27,7 +27,7 @@ pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
             span,
             ..
         } => {
-            if ctx.claimed_spans.contains(span) {
+            if ctx.is_claimed(ClaimKind::MapKey, span) {
                 return;
             }
             report_bad_map_key(ctx.store, ty, *span, ctx.sink, &mut HashSet::default());

--- a/crates/passes/src/passes/checks/min_max.rs
+++ b/crates/passes/src/passes/checks/min_max.rs
@@ -1,11 +1,11 @@
 use crate::passes::comparison::{MinMaxOp, prelude_min_max, signed_integer_literal};
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use syntax::ast::Expression;
 use syntax::types::SimpleKind;
 
 pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
     let span = expression.get_span();
-    if ctx.claimed_spans.contains(&span) {
+    if ctx.is_claimed(ClaimKind::MinMax, &span) {
         return;
     }
 
@@ -55,7 +55,7 @@ pub(crate) fn check(expression: &Expression, ctx: &mut NodeCtx) {
         return;
     }
 
-    ctx.claimed_spans.insert(nested.get_span());
+    ctx.claim(ClaimKind::MinMax, nested.get_span());
     ctx.sink
         .push(diagnostics::infer::min_max(&span, outer_constant));
 }

--- a/crates/passes/src/passes/checks/mod.rs
+++ b/crates/passes/src/passes/checks/mod.rs
@@ -42,12 +42,12 @@ use crate::passes::walk::NodeCtx;
 use semantics::facts::Facts;
 use semantics::store::Store;
 
-use super::{PARALLEL_THRESHOLD, source_file_work};
+use super::{LintMode, PARALLEL_THRESHOLD, source_file_work};
 
 pub(crate) fn run_all(
     store: &Store,
     facts: &Facts,
-    run_lints: bool,
+    lint_mode: LintMode,
 ) -> (Vec<LisetteDiagnostic>, Vec<LisetteDiagnostic>) {
     let sink = LocalSink::new();
     let pattern_lint_sink = LocalSink::new();
@@ -69,7 +69,10 @@ pub(crate) fn run_all(
             store,
             or_spans,
             &sink,
-            run_lints.then_some(&pattern_lint_sink),
+            match lint_mode {
+                LintMode::Skip => None,
+                LintMode::Run => Some(&pattern_lint_sink),
+            },
         );
         for (module, file) in &work {
             run_file_checks(module, file, store, facts, &mut pattern_ctx);
@@ -89,7 +92,10 @@ pub(crate) fn run_all(
                 store,
                 or_spans,
                 &local_sink,
-                run_lints.then_some(&local_pattern_lint_sink),
+                match lint_mode {
+                    LintMode::Skip => None,
+                    LintMode::Run => Some(&local_pattern_lint_sink),
+                },
             );
             run_file_checks(module, file, store, facts, &mut pattern_ctx);
             drop(pattern_ctx);
@@ -114,17 +120,7 @@ fn run_file_checks(
     pattern_ctx: &mut pattern_analysis::Context,
 ) {
     let sink = pattern_ctx.sink();
-    let mut ctx = NodeCtx {
-        store,
-        facts,
-        files: &module.files,
-        module_id: &module.id,
-        source: &file.source,
-        is_d_lis: file.is_d_lis(),
-        is_test: file.is_test(),
-        sink,
-        claimed_spans: Default::default(),
-    };
+    let mut ctx = NodeCtx::new(store, facts, module, file, sink);
     node_walk::run(&file.items, &mut ctx);
     interpolation_stringer::run(&file.items, store, sink);
 

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -6,7 +6,7 @@ use semantics::generics::bound_display_name;
 use semantics::store::Store;
 use syntax::types::{CompoundKind, TypeVarId};
 
-pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
+pub(crate) fn run(store: &Store, checks: &DeferredChecks, sink: &LocalSink) {
     let mut reported_vars: HashSet<(String, TypeVarId)> = HashSet::default();
     let mut collected = Vec::new();
     let mut report_vars = |ty: &syntax::types::Type, module_id: &str| {
@@ -14,13 +14,13 @@ pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
         ty.collect_unbound_variables(&mut collected);
         reported_vars.extend(collected.iter().map(|v| (module_id.to_string(), *v)));
     };
-    for check in checks.generic_calls {
+    for check in &checks.generic_calls {
         if check.ty.has_unbound_variables() {
             sink.push(diagnostics::infer::cannot_infer_type_argument(check.span));
             report_vars(&check.ty, &check.module_id);
         }
     }
-    for obligation in checks.generic_bounds {
+    for obligation in &checks.generic_bounds {
         if obligation.argument.has_unbound_variables() {
             let required_name = bound_display_name(store, &obligation.required);
             let diagnostic = match &obligation.origin {
@@ -45,7 +45,7 @@ pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
             report_vars(&obligation.argument, &obligation.module_id);
         }
     }
-    for check in checks.empty_collections {
+    for check in &checks.empty_collections {
         if check.ty.has_unbound_variables() {
             sink.push(diagnostics::infer::uninferred_binding(
                 &check.name,
@@ -55,7 +55,7 @@ pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
         }
     }
     let mut reported_literal_spans = HashSet::default();
-    for check in checks.empty_literals {
+    for check in &checks.empty_literals {
         if !check.ty.has_unbound_variables() {
             continue;
         }
@@ -71,7 +71,7 @@ pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
             sink.push(diagnostics::infer::empty_slice_no_element_type(check.span));
         }
     }
-    for check in checks.slice_makes {
+    for check in &checks.slice_makes {
         let slice_ty = store.peel_alias(&check.ty);
         let Some((CompoundKind::Slice, args)) = slice_ty.as_compound() else {
             continue;
@@ -90,7 +90,7 @@ pub(crate) fn run(store: &Store, checks: DeferredChecks, sink: &LocalSink) {
             ));
         }
     }
-    for check in checks.statement_tails {
+    for check in &checks.statement_tails {
         if !check.expected_ty.is_unit()
             && !check.expected_ty.is_variable()
             && !check.expected_ty.is_ignored()
@@ -134,7 +134,7 @@ mod tests {
             module_id: literal_module.to_string(),
         });
         let sink = LocalSink::new();
-        run(&Store::new(), checks, &sink);
+        run(&Store::new(), &checks, &sink);
         sink.into_diagnostics()
             .iter()
             .filter_map(|d| d.code_str().map(str::to_string))

--- a/crates/passes/src/passes/lints/ast_walk/checks/bind_instead_of_map.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/bind_instead_of_map.rs
@@ -44,8 +44,8 @@ pub fn check_bind_instead_of_map(expression: &Expression, ctx: &NodeCtx) {
     if !lambda_is_annotated(closure)
         && reads_as_method_call(receiver, args)
         && let (Some(receiver_text), Some(wrapped_text)) = (
-            span_text(ctx.source, receiver),
-            span_text(ctx.source, wrapped),
+            span_text(ctx.source(), receiver),
+            span_text(ctx.source(), wrapped),
         )
     {
         let replacement = format!(

--- a/crates/passes/src/passes/lints/ast_walk/checks/collapsible_else_if.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/collapsible_else_if.rs
@@ -37,9 +37,9 @@ pub fn check_collapsible_else_if(expression: &Expression, ctx: &NodeCtx) {
     let mut diagnostic = diagnostics::lint::collapsible_else_if(&inner_if_keyword_span);
     let alternative_span = alternative.get_span();
     if let Some(inner_text) = ctx
-        .source
+        .source()
         .get(inner_span.byte_offset as usize..inner_span.end() as usize)
-        && !replacement_drops_comment(ctx.source, alternative_span, inner_text)
+        && !replacement_drops_comment(ctx.source(), alternative_span, inner_text)
     {
         diagnostic = diagnostic.with_fix(Fix::new(
             "Collapse into `else if`",

--- a/crates/passes/src/passes/lints/ast_walk/checks/collapsible_if.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/collapsible_if.rs
@@ -46,12 +46,12 @@ pub fn check_collapsible_if(expression: &Expression, ctx: &NodeCtx) {
     let inner_if_keyword_span = Span::new(inner_span.file_id, inner_span.byte_offset, 2);
     let mut diagnostic = diagnostics::lint::collapsible_if(&inner_if_keyword_span);
     if let (Some(outer), Some(inner), Some(body)) = (
-        as_and_operand(ctx.source, condition),
-        as_and_operand(ctx.source, inner_condition),
-        span_text(ctx.source, inner_consequence),
+        as_and_operand(ctx.source(), condition),
+        as_and_operand(ctx.source(), inner_condition),
+        span_text(ctx.source(), inner_consequence),
     ) {
         let replacement = format!("if {outer} && {inner} {body}");
-        if !replacement_drops_comment(ctx.source, *span, &replacement) {
+        if !replacement_drops_comment(ctx.source(), *span, &replacement) {
             diagnostic = diagnostic.with_fix(Fix::new(
                 format!("Collapse into `if {outer} && {inner}`"),
                 Edit::replacement(*span, replacement),

--- a/crates/passes/src/passes/lints/ast_walk/checks/collapsible_match.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/collapsible_match.rs
@@ -1,4 +1,4 @@
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use diagnostics::{Edit, Fix};
 use syntax::ast::{Expression, MatchArm, Pattern, Span};
 
@@ -105,16 +105,22 @@ pub fn check_collapsible_match(expression: &Expression, ctx: &mut NodeCtx) {
 
     // Claim both nodes so `match_as_if_let` does not also advise on a node the
     // merge removes.
-    ctx.claimed_spans.insert(Span::new(
-        outer.span.file_id,
-        outer.span.byte_offset,
-        outer.keyword_len,
-    ));
-    ctx.claimed_spans.insert(Span::new(
-        inner.span.file_id,
-        inner.span.byte_offset,
-        inner.keyword_len,
-    ));
+    ctx.claim(
+        ClaimKind::CollapsibleMatch,
+        Span::new(
+            outer.span.file_id,
+            outer.span.byte_offset,
+            outer.keyword_len,
+        ),
+    );
+    ctx.claim(
+        ClaimKind::CollapsibleMatch,
+        Span::new(
+            inner.span.file_id,
+            inner.span.byte_offset,
+            inner.keyword_len,
+        ),
+    );
 
     let inner_keyword_span = Span::new(
         inner.span.file_id,
@@ -123,7 +129,7 @@ pub fn check_collapsible_match(expression: &Expression, ctx: &mut NodeCtx) {
     );
     let mut diagnostic = diagnostics::lint::collapsible_match(&inner_keyword_span);
     if matches!(expression, Expression::Match { .. })
-        && let Some(fix) = merge_fix(ctx.source, &outer, &inner)
+        && let Some(fix) = merge_fix(ctx.source(), &outer, &inner)
     {
         diagnostic = diagnostic.with_fix(fix);
     }

--- a/crates/passes/src/passes/lints/ast_walk/checks/discarded_unit_binding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/discarded_unit_binding.rs
@@ -35,7 +35,7 @@ pub fn check_discarded_unit_binding(expression: &Expression, ctx: &NodeCtx) {
         // `let _ = ()` has nothing to keep as a statement.
         Expression::Unit { .. } => (
             "Remove the discard",
-            Edit::deletion(statement_deletion(ctx.source, *span)),
+            Edit::deletion(statement_deletion(ctx.source(), *span)),
         ),
         _ => {
             let value_span = value.get_span();

--- a/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/double_comparison.rs
@@ -46,8 +46,8 @@ pub fn check_double_comparison(expression: &Expression, ctx: &NodeCtx) {
 
     let mut diagnostic = diagnostics::lint::double_comparison(span, combined);
     if let (Some(lhs), Some(rhs)) = (
-        span_text(ctx.source, left_lhs),
-        span_text(ctx.source, left_rhs),
+        span_text(ctx.source(), left_lhs),
+        span_text(ctx.source(), left_rhs),
     ) {
         let replacement = format!("{lhs} {combined} {rhs}");
         diagnostic = diagnostic.with_fix(Fix::new(

--- a/crates/passes/src/passes/lints/ast_walk/checks/double_negation.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/double_negation.rs
@@ -42,7 +42,7 @@ pub fn check_double_negation(expression: &Expression, ctx: &NodeCtx) {
     let is_bool = *operator == UnaryOperator::Not;
     let mut diagnostic = diagnostics::lint::double_negation(&operators_span, is_bool);
 
-    if let Some(text) = span_text(ctx.source, inner_operand) {
+    if let Some(text) = span_text(ctx.source(), inner_operand) {
         diagnostic = diagnostic.with_fix(Fix::new(
             "Remove double negation",
             Edit::replacement(*outer_span, text),

--- a/crates/passes/src/passes/lints/ast_walk/checks/duplicate_logical_operand.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/duplicate_logical_operand.rs
@@ -1,9 +1,7 @@
 use crate::passes::walk::NodeCtx;
-use rustc_hash::FxHashMap as HashMap;
-use syntax::ast::{BinaryOperator, Expression, Span};
-use syntax::program::File;
+use syntax::ast::{BinaryOperator, Expression};
 
-use super::helpers::{expressions_equivalent, is_side_effect_free};
+use super::helpers::{expressions_equivalent, is_side_effect_free, span_text};
 
 pub fn check_duplicate_logical_operand(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Binary {
@@ -34,7 +32,7 @@ pub fn check_duplicate_logical_operand(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let Some(operand_text) = source_text(left.get_span(), ctx.files) else {
+    let Some(operand_text) = span_text(ctx.source(), left) else {
         return;
     };
 
@@ -42,10 +40,4 @@ pub fn check_duplicate_logical_operand(expression: &Expression, ctx: &NodeCtx) {
         span,
         operand_text,
     ));
-}
-
-fn source_text(span: Span, files: &HashMap<u32, File>) -> Option<&str> {
-    let file = files.get(&span.file_id)?;
-    file.source
-        .get(span.byte_offset as usize..span.end() as usize)
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/enum_variant_names.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/enum_variant_names.rs
@@ -3,7 +3,7 @@ use crate::passes::walk::NodeCtx;
 use syntax::ast::Expression;
 
 pub fn check_enum_variant_names(expression: &Expression, ctx: &NodeCtx) {
-    if ctx.is_d_lis {
+    if ctx.is_d_lis() {
         return;
     }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/equatable_if_let.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/equatable_if_let.rs
@@ -53,9 +53,9 @@ pub fn check_equatable_if_let(expression: &Expression, ctx: &NodeCtx) {
 
     let pattern_span = pattern.get_span();
     let (Some(pattern_text), Some(subject_text)) = (
-        ctx.source
+        ctx.source()
             .get(pattern_span.byte_offset as usize..pattern_span.end() as usize),
-        span_text(ctx.source, scrutinee),
+        span_text(ctx.source(), scrutinee),
     ) else {
         return;
     };
@@ -69,7 +69,7 @@ pub fn check_equatable_if_let(expression: &Expression, ctx: &NodeCtx) {
     let replacement = format!("if {subject_text} == {pattern_text}");
     let mut diagnostic =
         diagnostics::lint::equatable_if_let(&if_keyword_span, pattern_text, subject_text);
-    if !replacement_drops_comment(ctx.source, condition_span, &replacement) {
+    if !replacement_drops_comment(ctx.source(), condition_span, &replacement) {
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),
             Edit::replacement(condition_span, replacement),

--- a/crates/passes/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/excess_parens_on_condition.rs
@@ -18,7 +18,7 @@ pub fn check_excess_parens_on_condition(expression: &Expression, ctx: &NodeCtx) 
     } = condition
     {
         let mut diagnostic = diagnostics::lint::unnecessary_parens(span, keyword);
-        if let Some(inner) = span_text(ctx.source, expression) {
+        if let Some(inner) = span_text(ctx.source(), expression) {
             diagnostic = diagnostic.with_fix(Fix::new(
                 "Remove redundant parentheses",
                 Edit::replacement(*span, inner),

--- a/crates/passes/src/passes/lints/ast_walk/checks/infallible_assertion.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/infallible_assertion.rs
@@ -6,7 +6,7 @@ use super::helpers::bool_literal;
 const TEST_CONTEXT_QUALIFIED_ID: &str = "**test_prelude.TestContext";
 
 pub fn check_infallible_assertion(expression: &Expression, ctx: &NodeCtx) {
-    if !ctx.is_test || !establishes_test_context(expression) {
+    if !ctx.is_test() || !establishes_test_context(expression) {
         return;
     }
     for child in expression.children() {

--- a/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/let_and_return.rs
@@ -51,7 +51,7 @@ pub fn check_let_and_return(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let mut diagnostic = diagnostics::lint::let_and_return(span);
-    if let Some(value_text) = span_text(ctx.source, bound_value) {
+    if let Some(value_text) = span_text(ctx.source(), bound_value) {
         let edit_span = span.merge(tail.get_span());
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{value_text}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_bytes_equal.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_bytes_equal.rs
@@ -32,9 +32,9 @@ pub fn check_manual_bytes_equal(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let (Some(namespace_text), Some(left_text), Some(right_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, left_arg),
-        span_text(ctx.source, right_arg),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), left_arg),
+        span_text(ctx.source(), right_arg),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_compound_assignment.rs
@@ -35,9 +35,10 @@ pub fn check_manual_compound_assignment(expression: &Expression, ctx: &NodeCtx) 
 
     let mut diagnostic = diagnostics::lint::manual_compound_assignment(span, symbol);
 
-    if let (Some(target_text), Some(rhs_text)) =
-        (span_text(ctx.source, target), span_text(ctx.source, right))
-    {
+    if let (Some(target_text), Some(rhs_text)) = (
+        span_text(ctx.source(), target),
+        span_text(ctx.source(), right),
+    ) {
         let replacement = format!("{target_text} {symbol} {rhs_text}");
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Use `{symbol}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_contains.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_contains.rs
@@ -63,8 +63,8 @@ pub fn check_manual_contains(expression: &Expression, ctx: &NodeCtx) {
     if !lambda_is_annotated(closure)
         && reads_as_method_call(receiver, args)
         && let (Some(receiver_text), Some(value_text)) = (
-            span_text(ctx.source, receiver),
-            span_text(ctx.source, value),
+            span_text(ctx.source(), receiver),
+            span_text(ctx.source(), value),
         )
     {
         let replacement = format!(

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_equal_fold.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_equal_fold.rs
@@ -34,9 +34,9 @@ pub fn check_manual_equal_fold(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(left_text), Some(right_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, left_arg),
-        span_text(ctx.source, right_arg),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), left_arg),
+        span_text(ctx.source(), right_arg),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_extend.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_extend.rs
@@ -181,7 +181,7 @@ fn local_binding(expression: &Expression) -> Option<Local<'_>> {
 fn report(span: Span, accumulator: &str, iterable: &str, ctx: &NodeCtx) {
     let replacement = format!("{accumulator} = {accumulator}.append({iterable}...)");
     let mut diagnostic = diagnostics::lint::manual_extend(&span, &replacement);
-    if !replacement_drops_comment(ctx.source, span, &replacement) {
+    if !replacement_drops_comment(ctx.source(), span, &replacement) {
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),
             Edit::replacement(span, replacement),

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
@@ -26,8 +26,8 @@ pub fn check_manual_find(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(receiver_text), Some(predicate_text)) = (
-        span_text(ctx.source, receiver),
-        span_text(ctx.source, predicate),
+        span_text(ctx.source(), receiver),
+        span_text(ctx.source(), predicate),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_option_zip.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_option_zip.rs
@@ -82,8 +82,8 @@ pub fn check_manual_option_zip(expression: &Expression, ctx: &NodeCtx) {
         && !lambda_is_annotated(inner_closure)
         && reads_as_method_call(outer_receiver, outer_args)
         && let (Some(receiver_text), Some(other_text)) = (
-            span_text(ctx.source, outer_receiver),
-            span_text(ctx.source, inner_receiver),
+            span_text(ctx.source(), outer_receiver),
+            span_text(ctx.source(), inner_receiver),
         )
     {
         let replacement = format!(

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_replace_all.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_replace_all.rs
@@ -40,10 +40,10 @@ pub fn check_manual_replace_all(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(s_text), Some(old_text), Some(new_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, s),
-        span_text(ctx.source, old),
-        span_text(ctx.source, new),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), s),
+        span_text(ctx.source(), old),
+        span_text(ctx.source(), new),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_time_since.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_time_since.rs
@@ -39,9 +39,10 @@ pub fn check_manual_time_since(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let (Some(namespace_text), Some(arg_text)) =
-        (span_text(ctx.source, namespace), span_text(ctx.source, arg))
-    else {
+    let (Some(namespace_text), Some(arg_text)) = (
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), arg),
+    ) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_time_until.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_time_until.rs
@@ -46,8 +46,8 @@ pub fn check_manual_time_until(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(receiver_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, receiver),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), receiver),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/map_identity.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/map_identity.rs
@@ -28,7 +28,7 @@ pub fn check_map_identity(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let mut diagnostic = diagnostics::lint::map_identity(span);
-    if let Some(text) = span_text(ctx.source, receiver) {
+    if let Some(text) = span_text(ctx.source(), receiver) {
         diagnostic = diagnostic.with_fix(Fix::new(
             "Remove identity map",
             Edit::replacement(*span, text),

--- a/crates/passes/src/passes/lints/ast_walk/checks/match_as_if_let.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/match_as_if_let.rs
@@ -1,4 +1,4 @@
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::{Type, unqualified_name};
 
@@ -21,7 +21,7 @@ pub fn check_match_as_if_let(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
-    if ctx.claimed_spans.contains(&match_keyword_span) {
+    if ctx.is_claimed(ClaimKind::CollapsibleMatch, &match_keyword_span) {
         return;
     }
 
@@ -45,7 +45,7 @@ pub fn check_match_as_if_let(expression: &Expression, ctx: &NodeCtx) {
 
     let pattern_span = meaningful.pattern.get_span();
     let Some(pattern_text) = ctx
-        .source
+        .source()
         .get(pattern_span.byte_offset as usize..pattern_span.end() as usize)
     else {
         return;

--- a/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/match_same_arms.rs
@@ -55,9 +55,9 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
         let earlier_span = earlier.pattern.get_span();
         let later_span = later.pattern.get_span();
         let (Some(earlier_text), Some(later_text)) = (
-            ctx.source
+            ctx.source()
                 .get(earlier_span.byte_offset as usize..earlier_span.end() as usize),
-            ctx.source
+            ctx.source()
                 .get(later_span.byte_offset as usize..later_span.end() as usize),
         ) else {
             continue;
@@ -65,7 +65,7 @@ pub fn check_match_same_arms(expression: &Expression, ctx: &NodeCtx) {
 
         let merged = format!("{earlier_text} | {later_text}");
         let arm_span = later_span.merge(later.expression.get_span());
-        let deletion = match_arm_deletion(ctx.source, arm_span);
+        let deletion = match_arm_deletion(ctx.source(), arm_span);
         ctx.sink.push(
             diagnostics::lint::match_same_arms(&later_span, earlier_text).with_fix(Fix::multi(
                 format!("Merge into `{merged}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/misrefactored_assign_op.rs
@@ -49,9 +49,10 @@ pub fn check_misrefactored_assign_op(expression: &Expression, ctx: &NodeCtx) {
     let Some(symbol) = compound.compound_assignment_symbol() else {
         return;
     };
-    let (Some(target_text), Some(other_text)) =
-        (span_text(ctx.source, target), span_text(ctx.source, other))
-    else {
+    let (Some(target_text), Some(other_text)) = (
+        span_text(ctx.source(), target),
+        span_text(ctx.source(), other),
+    ) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/naming.rs
@@ -12,7 +12,7 @@ pub fn check_expression_naming<'a>(
     role: FunctionRole<'a>,
 ) {
     let sink = ctx.sink;
-    let is_d_lis = ctx.is_d_lis;
+    let is_d_lis = ctx.is_d_lis();
     match expression {
         Expression::Struct {
             name,
@@ -140,7 +140,7 @@ pub fn check_expression_naming<'a>(
 }
 
 pub fn check_pattern_naming(pattern: &Pattern, ctx: &NodeCtx, role: PatternRole) {
-    if ctx.is_d_lis {
+    if ctx.is_d_lis() {
         return;
     }
     let (name, span) = match pattern {
@@ -188,7 +188,7 @@ fn go_method_name_exempt(
     if let Some(type_name) = impl_type
         && ctx
             .facts
-            .method_spelling_pinned_by_interface(ctx.module_id, name, type_name)
+            .method_spelling_pinned_by_interface(ctx.module_id(), name, type_name)
     {
         return true;
     }

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_bool_assign.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_bool_assign.rs
@@ -43,8 +43,8 @@ pub fn check_needless_bool_assign(expression: &Expression, ctx: &NodeCtx) {
 
     let condition = condition.unwrap_parens();
     let (Some(target), Some(condition_text)) = (
-        span_text(ctx.source, then_target),
-        span_text(ctx.source, condition),
+        span_text(ctx.source(), then_target),
+        span_text(ctx.source(), condition),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_continue.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_continue.rs
@@ -22,10 +22,10 @@ pub fn check_needless_continue(expression: &Expression, ctx: &NodeCtx) {
     let keyword = Span::new(span.file_id, span.byte_offset, "continue".len() as u32);
 
     let mut diagnostic = diagnostics::lint::needless_continue(&keyword);
-    if !same_line_comment_follows(ctx.source, keyword) {
+    if !same_line_comment_follows(ctx.source(), keyword) {
         diagnostic = diagnostic.with_fix(Fix::new(
             "Remove the redundant `continue`",
-            Edit::deletion(statement_deletion(ctx.source, keyword)),
+            Edit::deletion(statement_deletion(ctx.source(), keyword)),
         ));
     }
     ctx.sink.push(diagnostic);

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_match.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_match.rs
@@ -42,7 +42,7 @@ pub fn check_needless_match(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let Some(subject_text) = span_text(ctx.source, subject) else {
+    let Some(subject_text) = span_text(ctx.source(), subject) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_question_mark.rs
@@ -93,7 +93,7 @@ fn flag_needless(value: &Expression, ctx: &NodeCtx) {
 
     let span = value.get_span();
     let mut diagnostic = diagnostics::lint::needless_question_mark(&span, wrapper);
-    if let Some(inner_text) = span_text(ctx.source, inner) {
+    if let Some(inner_text) = span_text(ctx.source(), inner) {
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{inner_text}`"),
             Edit::replacement(span, inner_text),

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_splitn.rs
@@ -44,10 +44,10 @@ pub fn check_needless_splitn(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(s_text), Some(sep_text), Some(count_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, s),
-        span_text(ctx.source, sep),
-        span_text(ctx.source, count),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), s),
+        span_text(ctx.source(), sep),
+        span_text(ctx.source(), count),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/needless_update.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/needless_update.rs
@@ -41,12 +41,12 @@ pub fn check_needless_update(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let base_span = base.get_span();
-    let span = spread_span(ctx.source, base_span);
+    let span = spread_span(ctx.source(), base_span);
     let base_text = ctx
-        .source
+        .source()
         .get(base_span.byte_offset as usize..base_span.end() as usize)
         .unwrap_or("");
-    let deletion = list_item_deletion(ctx.source, span);
+    let deletion = list_item_deletion(ctx.source(), span);
     ctx.sink.push(
         diagnostics::lint::needless_update(&span, base_text).with_fix(Fix::new(
             "Remove the redundant `..` update",

--- a/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/neg_multiply.rs
@@ -19,7 +19,7 @@ pub fn check_neg_multiply(expression: &Expression, ctx: &NodeCtx) {
     // Skip the lowered `a *= -1` (operator `*=`), whose span is the assignment's,
     // so a `-a` suggestion would drop the assignment. A genuine `a * -1` has no `=`.
     let gap = (left.get_span().end() as usize)..(right.get_span().byte_offset as usize);
-    if ctx.source.get(gap).is_some_and(|text| text.contains('=')) {
+    if ctx.source().get(gap).is_some_and(|text| text.contains('=')) {
         return;
     }
 
@@ -54,7 +54,7 @@ pub fn check_neg_multiply(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let Some(text) = span_text(ctx.source, operand) else {
+    let Some(text) = span_text(ctx.source(), operand) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/negated_equality.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/negated_equality.rs
@@ -33,7 +33,10 @@ pub fn check_negated_equality(expression: &Expression, ctx: &NodeCtx) {
 
     let mut diagnostic = diagnostics::lint::negated_equality(span, is_equal);
 
-    if let (Some(lhs), Some(rhs)) = (span_text(ctx.source, left), span_text(ctx.source, right)) {
+    if let (Some(lhs), Some(rhs)) = (
+        span_text(ctx.source(), left),
+        span_text(ctx.source(), right),
+    ) {
         let replacement = format!("{lhs} {flipped} {rhs}");
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/or_fn_call.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/or_fn_call.rs
@@ -71,8 +71,11 @@ pub fn check_or_fn_call(expression: &Expression, ctx: &NodeCtx) {
     } else {
         "||"
     };
-    let arg_texts: Option<Vec<&str>> = args.iter().map(|arg| span_text(ctx.source, arg)).collect();
-    if let Some(receiver_text) = span_text(ctx.source, receiver)
+    let arg_texts: Option<Vec<&str>> = args
+        .iter()
+        .map(|arg| span_text(ctx.source(), arg))
+        .collect();
+    if let Some(receiver_text) = span_text(ctx.source(), receiver)
         && let Some(arg_texts) = arg_texts
         && let [first, rest @ ..] = arg_texts.as_slice()
     {

--- a/crates/passes/src/passes/lints/ast_walk/checks/out_of_domain.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/out_of_domain.rs
@@ -2,7 +2,7 @@ use syntax::ast::{Expression, Literal, Span, UnaryOperator};
 use syntax::program::CallKind;
 use syntax::types::{SimpleKind, Type};
 
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use semantics::store::{ClosedDomain, ClosedMember, DomainValue, Store};
 
 /// Flags an out-of-domain literal targeting a `#[go(closed_domain)]` named
@@ -18,7 +18,7 @@ use semantics::store::{ClosedDomain, ClosedMember, DomainValue, Store};
 /// The explicit `as` conversion (`7 as time.Weekday`) is the escape hatch and
 /// does not warn.
 ///
-/// `ctx.claimed_spans` collects the spans of magnitude literals owned by a parent
+/// Claims collect the spans of magnitude literals owned by a parent
 /// negation. The visitor walks parents before children, so the negation arm
 /// claims its magnitude before the literal arm reaches it; this stops `-1` from
 /// being judged on the magnitude `1` alone.
@@ -28,7 +28,7 @@ pub fn check_out_of_domain_value(expression: &Expression, ctx: &mut NodeCtx) {
             let Some(domain) = closed_domain_of(ty, ctx.store) else {
                 return;
             };
-            if ctx.claimed_spans.contains(span) {
+            if ctx.is_claimed(ClaimKind::OutOfDomain, span) {
                 return;
             }
             let Some(value) = DomainValue::from_literal(literal, domain.base()) else {
@@ -51,7 +51,7 @@ pub fn check_out_of_domain_value(expression: &Expression, ctx: &mut NodeCtx) {
             let Some((value, magnitude_span)) = negative_value(inner, domain.base()) else {
                 return;
             };
-            ctx.claimed_spans.insert(magnitude_span);
+            ctx.claim(ClaimKind::OutOfDomain, magnitude_span);
             if !is_member(&domain, &value) {
                 emit(*span, &domain, ctx);
             }

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure.rs
@@ -4,7 +4,7 @@ use syntax::program::{CallKind, DotAccessKind};
 use syntax::types::Type;
 
 use super::helpers::lambda_is_annotated;
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use semantics::facts::Facts;
 
 pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
@@ -21,7 +21,7 @@ pub fn check_redundant_closure(expression: &Expression, ctx: &NodeCtx) {
 
     // An immediately-invoked closure is owned by `redundant_closure_call`, which
     // claims this span when it removes the wrapper.
-    if ctx.claimed_spans.contains(span) {
+    if ctx.is_claimed(ClaimKind::RedundantClosure, span) {
         return;
     }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure_call.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_closure_call.rs
@@ -1,4 +1,4 @@
-use crate::passes::walk::NodeCtx;
+use crate::passes::walk::{ClaimKind, NodeCtx};
 use diagnostics::{Edit, Fix};
 use syntax::ast::Expression;
 
@@ -42,12 +42,12 @@ pub fn check_redundant_closure_call(expression: &Expression, ctx: &mut NodeCtx) 
     }
 
     // Claim the closure so `redundant_closure` does not also advise on it.
-    ctx.claimed_spans.insert(*lambda_span);
+    ctx.claim(ClaimKind::RedundantClosure, *lambda_span);
 
     let mut diagnostic = diagnostics::lint::redundant_closure_call(span);
     if return_annotation.is_unknown()
         && let Some(inner) = inlinable_value(body)
-        && let Some(text) = span_text(ctx.source, inner)
+        && let Some(text) = span_text(ctx.source(), inner)
     {
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{text}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_else.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_else.rs
@@ -40,7 +40,7 @@ pub fn check_redundant_else(expression: &Expression, ctx: &NodeCtx) {
 
         let consequence_span = consequence.get_span();
         let Some(else_offset) = else_keyword_offset(
-            ctx.source,
+            ctx.source(),
             consequence_span.end(),
             alternative.get_span().byte_offset,
         ) else {
@@ -50,7 +50,7 @@ pub fn check_redundant_else(expression: &Expression, ctx: &NodeCtx) {
         let else_span = Span::new(consequence_span.file_id, else_offset, 4);
         let mut diagnostic = diagnostics::lint::redundant_else(&else_span);
         if let Some(fix) = denest_fix(
-            ctx.source,
+            ctx.source(),
             if_span,
             consequence_span,
             alternative,

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_fstring_conversion.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_fstring_conversion.rs
@@ -26,7 +26,7 @@ pub fn check_redundant_fstring_conversion(expression: &Expression, ctx: &NodeCtx
         let Some((method, arg)) = redundant_conversion(call) else {
             continue;
         };
-        let Some(arg_text) = span_text(ctx.source, arg) else {
+        let Some(arg_text) = span_text(ctx.source(), arg) else {
             continue;
         };
         ctx.sink.push(

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_guards.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_guards.rs
@@ -62,7 +62,7 @@ fn check_arm(arm: &MatchArm, ctx: &NodeCtx) {
         return;
     }
 
-    let Some(literal_text) = span_text(ctx.source, literal) else {
+    let Some(literal_text) = span_text(ctx.source(), literal) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_operation.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_operation.rs
@@ -56,7 +56,7 @@ pub fn check_redundant_operation(expression: &Expression, ctx: &NodeCtx) {
         );
     } else {
         let mut diagnostic = diagnostics::lint::redundant_operation(span, None);
-        if let Some(text) = span_text(ctx.source, other_source) {
+        if let Some(text) = span_text(ctx.source(), other_source) {
             diagnostic = diagnostic.with_fix(Fix::new(
                 format!("Replace with `{text}`"),
                 Edit::replacement(*span, text),

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_pattern_matching.rs
@@ -59,7 +59,7 @@ pub fn check_redundant_pattern_matching(expression: &Expression, ctx: &NodeCtx) 
     let match_keyword_span = Span::new(span.file_id, span.byte_offset, 5);
     let mut diagnostic =
         diagnostics::lint::redundant_pattern_matching(&match_keyword_span, predicate);
-    if let Some(subject_text) = span_text(ctx.source, subject) {
+    if let Some(subject_text) = span_text(ctx.source(), subject) {
         let replacement = format!("{}.{predicate}()", as_tight_operand(subject_text, subject));
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_rebinding.rs
@@ -73,7 +73,7 @@ pub fn check_redundant_rebinding(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let deletion = statement_deletion(ctx.source, *span);
+    let deletion = statement_deletion(ctx.source(), *span);
     ctx.sink.push(
         diagnostics::lint::redundant_rebinding(span, identifier).with_fix(Fix::new(
             "Remove the redundant rebinding",

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_slice_bounds.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_slice_bounds.rs
@@ -55,12 +55,12 @@ pub fn check_redundant_slice_bounds(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let Some(receiver_text) = span_text(ctx.source, receiver) else {
+    let Some(receiver_text) = span_text(ctx.source(), receiver) else {
         return;
     };
 
     let replacement = if drop_start {
-        let Some(end_text) = end.as_deref().and_then(|end| span_text(ctx.source, end)) else {
+        let Some(end_text) = end.as_deref().and_then(|end| span_text(ctx.source(), end)) else {
             return;
         };
         let separator = if *inclusive { "..=" } else { ".." };
@@ -68,7 +68,7 @@ pub fn check_redundant_slice_bounds(expression: &Expression, ctx: &NodeCtx) {
     } else {
         let Some(start_text) = start
             .as_deref()
-            .and_then(|start| span_text(ctx.source, start))
+            .and_then(|start| span_text(ctx.source(), start))
         else {
             return;
         };

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_sprintf.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_sprintf.rs
@@ -55,8 +55,8 @@ pub fn check_redundant_sprintf(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(value_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, value),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), value),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_trim_guard.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_trim_guard.rs
@@ -83,9 +83,9 @@ fn fire_if_redundant(statement: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace), Some(replacement), Some(guarded)) = (
-        span_text(ctx.source, trim.namespace),
-        span_text(ctx.source, assignment),
-        span_text(ctx.source, statement),
+        span_text(ctx.source(), trim.namespace),
+        span_text(ctx.source(), assignment),
+        span_text(ctx.source(), statement),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/replace_count_zero.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/replace_count_zero.rs
@@ -39,10 +39,10 @@ pub fn check_replace_count_zero(expression: &Expression, ctx: &NodeCtx) {
     }
 
     let (Some(namespace_text), Some(s_text), Some(old_text), Some(new_text)) = (
-        span_text(ctx.source, namespace),
-        span_text(ctx.source, s),
-        span_text(ctx.source, old),
-        span_text(ctx.source, new),
+        span_text(ctx.source(), namespace),
+        span_text(ctx.source(), s),
+        span_text(ctx.source(), old),
+        span_text(ctx.source(), new),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
@@ -41,11 +41,11 @@ pub fn check_replaceable_with_autofill(expression: &Expression, ctx: &NodeCtx) {
     if !unspecified.is_empty() {
         return;
     }
-    if !rewrite_would_typecheck(ctx.store, ty, name, field_assignments, ctx.module_id) {
+    if !rewrite_would_typecheck(ctx.store, ty, name, field_assignments, ctx.module_id()) {
         return;
     }
 
-    let kept = render_kept_fields(ctx.source, field_assignments);
+    let kept = render_kept_fields(ctx.source(), field_assignments);
     let owner_span = Span::new(span.file_id, span.byte_offset, name.len() as u32);
     let replacement = if kept.is_empty() {
         format!("{name} {{ .. }}")
@@ -53,7 +53,7 @@ pub fn check_replaceable_with_autofill(expression: &Expression, ctx: &NodeCtx) {
         format!("{name} {{ {kept}, .. }}")
     };
     let mut diagnostic = diagnostics::lint::replaceable_with_autofill(&owner_span, &kept, name);
-    if !replacement_drops_comment(ctx.source, *span, &replacement) {
+    if !replacement_drops_comment(ctx.source(), *span, &replacement) {
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),
             Edit::replacement(*span, replacement),

--- a/crates/passes/src/passes/lints/ast_walk/checks/self_named_constructors.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/self_named_constructors.rs
@@ -5,7 +5,7 @@ use syntax::ast::{Annotation, Expression};
 use super::helpers::first_param_is_self;
 
 pub fn check_self_named_constructors(expression: &Expression, ctx: &NodeCtx) {
-    if ctx.is_d_lis {
+    if ctx.is_d_lis() {
         return;
     }
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/single_arm_select.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/single_arm_select.rs
@@ -19,7 +19,7 @@ pub fn check_single_arm_select(expression: &Expression, ctx: &NodeCtx) {
         return;
     };
 
-    let Some(receive_text) = span_text(ctx.source, receive_expression) else {
+    let Some(receive_text) = span_text(ctx.source(), receive_expression) else {
         return;
     };
 

--- a/crates/passes/src/passes/lints/ast_walk/checks/unconditional_recursion.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unconditional_recursion.rs
@@ -11,9 +11,9 @@ pub fn check_unconditional_recursion(expression: &Expression, ctx: &NodeCtx, rol
         return;
     };
     let target = match role {
-        FunctionRole::Free => Symbol::from_parts(ctx.module_id, name),
+        FunctionRole::Free => Symbol::from_parts(ctx.module_id(), name),
         FunctionRole::ImplMethod { type_name } => {
-            Symbol::from_parts(ctx.module_id, type_name).with_segment(name)
+            Symbol::from_parts(ctx.module_id(), type_name).with_segment(name)
         }
         FunctionRole::InterfaceMethod { .. } => return,
     };

--- a/crates/passes/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/uninterpolated_fstring.rs
@@ -23,7 +23,7 @@ pub fn check_uninterpolated_fstring(expression: &Expression, ctx: &NodeCtx) {
     let mut diagnostic = diagnostics::lint::uninterpolated_fstring(span);
 
     if let Some(source) = ctx
-        .source
+        .source()
         .get(span.byte_offset as usize..span.end() as usize)
         && let Some(without_prefix) = source.strip_prefix('f')
     {

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_bool.rs
@@ -39,9 +39,9 @@ pub fn check_unnecessary_bool(expression: &Expression, ctx: &NodeCtx) {
 
     let mut diagnostic = diagnostics::lint::unnecessary_bool(span, then_value);
     let replacement = if then_value {
-        span_text(ctx.source, condition).map(|text| as_tight_operand(text, condition))
+        span_text(ctx.source(), condition).map(|text| as_tight_operand(text, condition))
     } else {
-        negated_condition(ctx.source, condition, ctx)
+        negated_condition(ctx.source(), condition, ctx)
     };
     if let Some(replacement) = replacement {
         diagnostic = diagnostic.with_fix(Fix::new(

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_lazy_evaluations.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_lazy_evaluations.rs
@@ -65,11 +65,11 @@ pub fn check_unnecessary_lazy_evaluations(expression: &Expression, ctx: &NodeCtx
         diagnostics::lint::unnecessary_lazy_evaluations(&lazy_argument.get_span(), lazy, eager);
     let rest_texts: Option<Vec<&str>> = args[1..]
         .iter()
-        .map(|arg| span_text(ctx.source, arg))
+        .map(|arg| span_text(ctx.source(), arg))
         .collect();
     if let (Some(receiver_text), Some(constant_text), Some(rest_texts)) = (
-        span_text(ctx.source, receiver),
-        span_text(ctx.source, constant),
+        span_text(ctx.source(), receiver),
+        span_text(ctx.source(), constant),
         rest_texts,
     ) {
         let mut call_args = constant_text.to_string();

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
@@ -65,8 +65,8 @@ fn push_map_on_constructor(
     if !matches!(mapper.unwrap_parens(), Expression::Lambda { .. })
         && reads_as_method_call(receiver, std::slice::from_ref(mapper))
         && let (Some(mapper_text), Some(payload_text)) = (
-            span_text(ctx.source, mapper),
-            span_text(ctx.source, payload),
+            span_text(ctx.source(), mapper),
+            span_text(ctx.source(), payload),
         )
     {
         let replacement = format!(

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_min_or_max.rs
@@ -40,7 +40,7 @@ pub fn check_unnecessary_min_or_max(expression: &Expression, ctx: &NodeCtx) {
 
     let span = expression.get_span();
     let mut diagnostic = diagnostics::lint::unnecessary_min_or_max(&span, op);
-    if let Some(text) = span_text(ctx.source, survivor) {
+    if let Some(text) = span_text(ctx.source(), survivor) {
         let replacement = as_tight_operand(text, survivor);
         diagnostic = diagnostic.with_fix(Fix::new(
             format!("Replace with `{replacement}`"),

--- a/crates/passes/src/passes/lints/ast_walk/checks/while_let_loop.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/while_let_loop.rs
@@ -47,9 +47,9 @@ pub fn check_while_let_loop(expression: &Expression, ctx: &NodeCtx) {
 
     let pattern_span = first.pattern.get_span();
     let (Some(pattern_text), Some(subject_text)) = (
-        ctx.source
+        ctx.source()
             .get(pattern_span.byte_offset as usize..pattern_span.end() as usize),
-        span_text(ctx.source, subject),
+        span_text(ctx.source(), subject),
     ) else {
         return;
     };

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -272,17 +272,7 @@ fn run_module(
 ) {
     for (file_id, file) in module.source_file_entries() {
         let file_sink = LocalSink::new();
-        let mut ctx = NodeCtx {
-            store,
-            facts,
-            files: &module.files,
-            module_id: &module.id,
-            source: &file.source,
-            is_d_lis: file.is_d_lis(),
-            is_test: file.is_test(),
-            sink: &file_sink,
-            claimed_spans: Default::default(),
-        };
+        let mut ctx = NodeCtx::new(store, facts, module, file, &file_sink);
         walk_nodes(
             &file.items,
             &mut ctx,

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
@@ -64,16 +64,14 @@ pub(crate) fn run(
     facts: &Facts,
     pattern_lints: Vec<LisetteDiagnostic>,
     mut diagnostics: Vec<LisetteDiagnostic>,
-    unused: &mut UnusedInfo,
     sink: &LocalSink,
-) {
-    let sources = source_by_file(store);
-
+) -> UnusedInfo {
+    let mut unused = UnusedInfo::default();
     let erroring_functions = erroring_function_spans(facts, sink);
     collect_bindings(
+        store,
         facts,
-        unused,
-        &sources,
+        &mut unused,
         &erroring_functions,
         &mut diagnostics,
     );
@@ -82,24 +80,15 @@ pub(crate) fn run(
     diagnostics.extend(pattern_lints);
     collect_overused_references(facts, &mut diagnostics);
     collect_always_failing_try_blocks(facts, &mut diagnostics);
-    collect_expression_only_fstrings(facts, &sources, &mut diagnostics);
+    collect_expression_only_fstrings(store, facts, &mut diagnostics);
 
     diagnostics.sort_by(LisetteDiagnostic::sort_key);
     sink.extend(diagnostics);
+    unused
 }
 
-fn source_by_file(store: &Store) -> HashMap<u32, &str> {
-    let mut sources = HashMap::default();
-    for module in store.modules.values() {
-        for (file_id, file) in module.source_file_entries() {
-            sources.insert(*file_id, file.source.as_str());
-        }
-    }
-    sources
-}
-
-fn mut_keyword_deletion(sources: &HashMap<u32, &str>, name: Span) -> Option<Span> {
-    let source = sources.get(&name.file_id)?;
+fn mut_keyword_deletion(store: &Store, name: Span) -> Option<Span> {
+    let source = &store.get_file(name.file_id)?.source;
     let name_start = name.byte_offset as usize;
     let before = source.get(..name_start)?.trim_end();
     let mut_start = before.strip_suffix("mut")?.len();
@@ -117,8 +106,8 @@ fn mut_keyword_deletion(sources: &HashMap<u32, &str>, name: Span) -> Option<Span
     ))
 }
 
-fn fstring_inner<'a>(sources: &HashMap<u32, &'a str>, span: Span) -> Option<&'a str> {
-    let source = sources.get(&span.file_id)?;
+fn fstring_inner(store: &Store, span: Span) -> Option<&str> {
+    let source = &store.get_file(span.file_id)?.source;
     let text = source.get(span.byte_offset as usize..span.end() as usize)?;
     let inner = text.strip_prefix("f\"")?.strip_suffix('"')?.trim();
     Some(inner.strip_prefix('{')?.strip_suffix('}')?.trim())
@@ -152,9 +141,9 @@ fn within_any(function_spans: &[Span], span: Span) -> bool {
 }
 
 fn collect_bindings(
+    store: &Store,
     facts: &Facts,
     unused: &mut UnusedInfo,
-    sources: &HashMap<u32, &str>,
     erroring_functions: &[Span],
     out: &mut Vec<LisetteDiagnostic>,
 ) {
@@ -183,7 +172,7 @@ fn collect_bindings(
 
         if b.kind.is_mutable() && b.mutation.is_none() && !within_any(erroring_functions, b.span) {
             let mut diagnostic = diagnostics::lint::unused_mut(&b.span);
-            if let Some(deletion) = mut_keyword_deletion(sources, b.span) {
+            if let Some(deletion) = mut_keyword_deletion(store, b.span) {
                 diagnostic =
                     diagnostic.with_fix(Fix::new("Remove `mut`", Edit::deletion(deletion)));
             }
@@ -254,13 +243,13 @@ fn collect_always_failing_try_blocks(facts: &Facts, out: &mut Vec<LisetteDiagnos
 }
 
 fn collect_expression_only_fstrings(
+    store: &Store,
     facts: &Facts,
-    sources: &HashMap<u32, &str>,
     out: &mut Vec<LisetteDiagnostic>,
 ) {
     for fact in &facts.expression_only_fstrings {
         let mut diagnostic = diagnostics::lint::expression_only_fstring(&fact.span);
-        if let Some(inner) = fstring_inner(sources, fact.span) {
+        if let Some(inner) = fstring_inner(store, fact.span) {
             let replacement = if fact.needs_parens {
                 format!("({inner})")
             } else {

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -2,9 +2,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use semantics::checker::promotion::{self, MemberKind, Resolution};
 use semantics::store::Store;
-use syntax::ast::{
-    Annotation, Attribute, Expression, ImportAlias, Pattern, SelectArm, StructSpread,
-};
+use syntax::ast::{Annotation, Attribute, Expression, Pattern, SelectArm, Span, StructSpread};
 use syntax::program::File;
 use syntax::program::{DefinitionBody, DotAccessKind, EqualityIndex, Module};
 use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
@@ -12,8 +10,14 @@ use syntax::types::{CompoundKind, Symbol, Type, unqualified_name};
 use super::reference_graph::{EnumVariantId, ModuleItemId, ReferenceGraph, StructFieldId};
 
 pub struct AliasMap<'a> {
-    aliases: HashMap<String, ModuleItemId>,
+    aliases: HashMap<String, ImportSpans>,
+    file_id: u32,
     store: &'a Store,
+}
+
+struct ImportSpans {
+    name: Span,
+    statement: Span,
 }
 
 impl<'a> AliasMap<'a> {
@@ -21,15 +25,22 @@ impl<'a> AliasMap<'a> {
         let mut aliases = HashMap::default();
 
         for import in file.imports() {
-            if matches!(import.alias, Some(ImportAlias::Blank(_))) {
-                continue;
-            }
             if let Some(effective) = import.effective_alias(&store.go_package_names) {
-                aliases.insert(effective.clone(), ModuleItemId::import(file.id, &effective));
+                aliases.insert(
+                    effective,
+                    ImportSpans {
+                        name: import.name_span,
+                        statement: import.span,
+                    },
+                );
             }
         }
 
-        Self { aliases, store }
+        Self {
+            aliases,
+            file_id: file.id,
+            store,
+        }
     }
 
     fn resolve(&self, module: &Module, name: &str) -> Option<ModuleItemId> {
@@ -37,11 +48,19 @@ impl<'a> AliasMap<'a> {
         if module.definitions.contains_key(qualified_name.as_str()) {
             return Some(ModuleItemId::new(name));
         }
-        self.aliases.get(name).cloned()
+        self.aliases
+            .contains_key(name)
+            .then(|| ModuleItemId::import(self.file_id, name))
     }
 
     fn is_import_alias(&self, name: &str) -> bool {
         self.aliases.contains_key(name)
+    }
+
+    pub(super) fn imports(&self) -> impl Iterator<Item = (&str, Span, Span)> {
+        self.aliases
+            .iter()
+            .map(|(alias, spans)| (alias.as_str(), spans.name, spans.statement))
     }
 }
 

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -4,7 +4,7 @@ mod reference_graph;
 mod visibility_constraints;
 
 use rayon::prelude::*;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 use std::sync::Arc;
 
 use crate::passes::PARALLEL_THRESHOLD;
@@ -14,17 +14,17 @@ use diagnostics::LocalSink;
 use diagnostics::{Edit, Fix};
 use semantics::facts::Facts;
 use semantics::store::Store;
-use syntax::ast::{
-    Attribute, AttributeArg, Expression, ImportAlias, Span, StructFieldDefinition, Visibility,
-};
+use syntax::ast::{Attribute, AttributeArg, Expression, Span, StructFieldDefinition, Visibility};
 use syntax::program::EqualityIndex;
+use syntax::program::File;
 use syntax::program::Module;
 use syntax::program::UnusedInfo;
-use syntax::program::{File, FileImport};
 
 use extract::{AliasMap, is_upper, walk_expression};
 use redundant_import_alias::check_redundant_aliases;
-use reference_graph::{EnumVariantId, ItemKind, ModuleItemId, ReferenceGraph, StructFieldId};
+use reference_graph::{
+    EnumVariantId, ItemKind, MemberKind, ModuleItemId, ReferenceGraph, StructFieldId,
+};
 use syntax::attributes::SERIALIZATION_KEYS;
 use visibility_constraints::check_visibility_constraints;
 
@@ -113,18 +113,16 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
     let mut unused_definition_spans = Vec::new();
     let mut graph = ReferenceGraph::new();
 
-    let imports_per_alias = collect_items(
-        files,
-        &module.id,
-        &store.go_package_names,
-        equality_index,
-        &mut graph,
-    );
+    let files_with_aliases: Vec<_> = files
+        .values()
+        .filter(|file| !file.is_d_lis())
+        .map(|file| (file, AliasMap::build(file, store)))
+        .collect();
+    collect_items(&files_with_aliases, &module.id, equality_index, &mut graph);
 
-    for file in files.values().filter(|file| !file.is_d_lis()) {
-        let alias_map = AliasMap::build(file, store);
+    for (file, alias_map) in &files_with_aliases {
         for item in &file.items {
-            walk_expression(module, item, &mut graph, &alias_map, None);
+            walk_expression(module, item, &mut graph, alias_map, None);
         }
     }
 
@@ -141,49 +139,39 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
         }
     }
 
-    let mut unused_imports_per_alias: HashMap<String, usize> = HashMap::default();
-    for item_id in graph.get_unreachable() {
-        if let Some(info) = graph.get_item(item_id) {
-            if matches!(info.kind, ItemKind::Import { .. }) {
-                *unused_imports_per_alias
-                    .entry(item_id.name.to_string())
-                    .or_default() += 1;
-                unused_import_spans.insert(info.span);
-            }
-            if info.kind == ItemKind::Function {
-                unused_definition_spans.push(info.span);
-            }
-            let mut diagnostic = create_unused_diagnostic(info.kind, &info.span);
-            if let ItemKind::Import { statement_span } = info.kind
-                && let Some(file) = files.get(&statement_span.file_id)
-            {
-                let deletion = statement_deletion(&file.source, statement_span);
-                diagnostic = diagnostic.with_fix(Fix::new(
-                    "Remove the unused import",
-                    Edit::deletion(deletion),
-                ));
-            }
-            diagnostics.push(diagnostic);
+    let usage = graph.analyze();
+    for (_, info) in usage.unreachable_items() {
+        if matches!(info.kind, ItemKind::Import { .. }) {
+            unused_import_spans.insert(info.span);
         }
+        if info.kind == ItemKind::Function {
+            unused_definition_spans.push(info.span);
+        }
+        let mut diagnostic = create_unused_diagnostic(info.kind, &info.span);
+        if let ItemKind::Import { statement_span } = info.kind
+            && let Some(file) = files.get(&statement_span.file_id)
+        {
+            let deletion = statement_deletion(&file.source, statement_span);
+            diagnostic = diagnostic.with_fix(Fix::new(
+                "Remove the unused import",
+                Edit::deletion(deletion),
+            ));
+        }
+        diagnostics.push(diagnostic);
     }
 
     // Emit drops an import from every file of the module at once.
-    let unused_import_aliases: HashSet<String> = unused_imports_per_alias
-        .into_iter()
-        .filter(|(alias, unused)| imports_per_alias.get(alias) == Some(unused))
-        .map(|(alias, _)| alias)
-        .collect();
+    let unused_import_aliases = usage.unused_import_aliases();
 
     check_redundant_aliases(files, store, &unused_import_spans, &mut diagnostics);
 
     check_visibility_constraints(module, files, &mut diagnostics);
 
-    for span in graph.get_unused_struct_fields() {
-        diagnostics.push(diagnostics::lint::unused_field(span));
-    }
-
-    for span in graph.get_unused_enum_variants() {
-        diagnostics.push(diagnostics::lint::unused_variant(span));
+    for (kind, span) in graph.unused_members() {
+        diagnostics.push(match kind {
+            MemberKind::StructField => diagnostics::lint::unused_field(span),
+            MemberKind::EnumVariant => diagnostics::lint::unused_variant(span),
+        });
     }
 
     RefLintResult {
@@ -193,45 +181,23 @@ fn run_ref_lints(module: &Module, facts: &Facts, store: &Store) -> RefLintResult
     }
 }
 
-/// Returns how many files import each alias.
 fn collect_items(
-    files: &HashMap<u32, File>,
+    files: &[(&File, AliasMap<'_>)],
     module_id: &str,
-    go_package_names: &HashMap<String, String>,
     equality_index: &EqualityIndex,
     graph: &mut ReferenceGraph,
-) -> HashMap<String, usize> {
-    let mut imports_per_alias: HashMap<String, usize> = HashMap::default();
-
-    for file in files.values().filter(|file| !file.is_d_lis()) {
+) {
+    for (file, aliases) in files {
+        for (alias, name_span, statement_span) in aliases.imports() {
+            graph.add_import(
+                ModuleItemId::import(file.id, alias),
+                name_span,
+                statement_span,
+            );
+        }
         for item in &file.items {
             match item {
-                Expression::ModuleImport {
-                    name,
-                    alias,
-                    name_span,
-                    span,
-                } => {
-                    if matches!(alias, Some(ImportAlias::Blank(_))) {
-                        continue;
-                    }
-
-                    let file_import = FileImport {
-                        name: name.clone(),
-                        name_span: *name_span,
-                        alias: alias.clone(),
-                        span: *span,
-                    };
-
-                    if let Some(effective) = file_import.effective_alias(go_package_names) {
-                        *imports_per_alias.entry(effective.clone()).or_default() += 1;
-                        graph.add_import(
-                            ModuleItemId::import(file.id, &effective),
-                            *name_span,
-                            *span,
-                        );
-                    }
-                }
+                Expression::ModuleImport { .. } => {}
                 Expression::Function {
                     name,
                     name_span,
@@ -348,8 +314,6 @@ fn collect_items(
             }
         }
     }
-
-    imports_per_alias
 }
 
 fn function_is_entry(name: &str, visibility: Visibility, attributes: &[Attribute]) -> bool {

--- a/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
@@ -3,30 +3,31 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::Span;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ModuleItemId {
-    pub name: EcoString,
-    pub file_id: Option<u32>,
+pub enum ModuleItemId {
+    Definition(EcoString),
+    Import { file_id: u32, alias: EcoString },
 }
 
 impl ModuleItemId {
     pub fn new(name: &str) -> Self {
-        Self {
-            name: name.into(),
-            file_id: None,
-        }
+        Self::Definition(name.into())
     }
 
     pub fn import(file_id: u32, name: &str) -> Self {
-        Self {
-            name: name.into(),
-            file_id: Some(file_id),
+        Self::Import {
+            file_id,
+            alias: name.into(),
         }
     }
 
     pub fn equals_method(type_name: &str) -> Self {
-        Self {
-            name: format!("{type_name}#equals").into(),
-            file_id: None,
+        Self::Definition(format!("{type_name}#equals").into())
+    }
+
+    fn import_alias(&self) -> Option<&str> {
+        match self {
+            Self::Import { alias, .. } => Some(alias),
+            Self::Definition(_) => None,
         }
     }
 
@@ -72,10 +73,8 @@ impl EnumVariantId {
 #[derive(Debug, Default)]
 pub struct ReferenceGraph {
     edges: HashMap<ModuleItemId, HashSet<ModuleItemId>>,
-    entrypoints: HashSet<ModuleItemId>,
     items: HashMap<ModuleItemId, ItemInfo>,
-    unused_struct_fields: HashMap<StructFieldId, Span>,
-    unused_enum_variants: HashMap<EnumVariantId, Span>,
+    unused_members: HashMap<MemberId, Span>,
 }
 
 impl ReferenceGraph {
@@ -84,10 +83,14 @@ impl ReferenceGraph {
     }
 
     pub fn add_item(&mut self, id: ModuleItemId, span: Span, kind: ItemKind, is_entry_point: bool) {
-        self.items.insert(id.clone(), ItemInfo { span, kind });
-        if is_entry_point {
-            self.entrypoints.insert(id);
-        }
+        self.items.insert(
+            id,
+            ItemInfo {
+                span,
+                kind,
+                is_entry_point,
+            },
+        );
     }
 
     pub fn add_import(&mut self, id: ModuleItemId, span: Span, statement_span: Span) {
@@ -96,6 +99,7 @@ impl ReferenceGraph {
             ItemInfo {
                 span,
                 kind: ItemKind::Import { statement_span },
+                is_entry_point: false,
             },
         );
     }
@@ -105,12 +109,19 @@ impl ReferenceGraph {
     }
 
     pub fn mark_as_used(&mut self, id: ModuleItemId) {
-        self.entrypoints.insert(id);
+        if let Some(item) = self.items.get_mut(&id) {
+            item.is_entry_point = true;
+        }
     }
 
-    pub fn compute_reachable(&self) -> HashSet<ModuleItemId> {
+    pub fn analyze(&self) -> ReferenceUsage<'_> {
         let mut reachable = HashSet::default();
-        let mut worklist: Vec<ModuleItemId> = self.entrypoints.iter().cloned().collect();
+        let mut worklist: Vec<ModuleItemId> = self
+            .items
+            .iter()
+            .filter(|(_, item)| item.is_entry_point)
+            .map(|(id, _)| id.clone())
+            .collect();
 
         while let Some(item) = worklist.pop() {
             if reachable.contains(&item) {
@@ -127,44 +138,86 @@ impl ReferenceGraph {
             }
         }
 
-        reachable
-    }
-
-    pub fn get_unreachable(&self) -> Vec<&ModuleItemId> {
-        let reachable = self.compute_reachable();
-        self.items
-            .keys()
-            .filter(|id| !reachable.contains(*id))
-            .collect()
-    }
-
-    pub fn get_item(&self, id: &ModuleItemId) -> Option<&ItemInfo> {
-        self.items.get(id)
+        ReferenceUsage {
+            graph: self,
+            reachable,
+        }
     }
 
     pub fn add_struct_field(&mut self, id: StructFieldId, span: Span) {
-        self.unused_struct_fields.insert(id, span);
+        self.unused_members.insert(MemberId::StructField(id), span);
     }
 
     pub fn mark_struct_field_used(&mut self, id: StructFieldId) {
-        self.unused_struct_fields.remove(&id);
+        self.unused_members.remove(&MemberId::StructField(id));
     }
 
     pub fn add_enum_variant(&mut self, id: EnumVariantId, span: Span) {
-        self.unused_enum_variants.insert(id, span);
+        self.unused_members.insert(MemberId::EnumVariant(id), span);
     }
 
     pub fn mark_enum_variant_used(&mut self, id: EnumVariantId) {
-        self.unused_enum_variants.remove(&id);
+        self.unused_members.remove(&MemberId::EnumVariant(id));
     }
 
-    pub fn get_unused_struct_fields(&self) -> impl Iterator<Item = &Span> {
-        self.unused_struct_fields.values()
+    pub fn unused_members(&self) -> impl Iterator<Item = (MemberKind, &Span)> {
+        self.unused_members
+            .iter()
+            .map(|(id, span)| (id.kind(), span))
+    }
+}
+
+pub struct ReferenceUsage<'a> {
+    graph: &'a ReferenceGraph,
+    reachable: HashSet<ModuleItemId>,
+}
+
+impl<'a> ReferenceUsage<'a> {
+    pub fn unreachable_items(&self) -> impl Iterator<Item = (&ModuleItemId, &ItemInfo)> {
+        self.graph
+            .items
+            .iter()
+            .filter(|(id, _)| !self.reachable.contains(*id))
     }
 
-    pub fn get_unused_enum_variants(&self) -> impl Iterator<Item = &Span> {
-        self.unused_enum_variants.values()
+    pub fn unused_import_aliases(&self) -> HashSet<String> {
+        let mut aliases = HashMap::default();
+        for (id, item) in &self.graph.items {
+            if let Some(alias) = id.import_alias() {
+                debug_assert!(matches!(item.kind, ItemKind::Import { .. }));
+                aliases
+                    .entry(alias)
+                    .and_modify(|all_unused| *all_unused &= !self.reachable.contains(id))
+                    .or_insert_with(|| !self.reachable.contains(id));
+            }
+        }
+        aliases
+            .into_iter()
+            .filter(|(_, all_unused)| *all_unused)
+            .map(|(alias, _)| alias.to_string())
+            .collect()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum MemberId {
+    StructField(StructFieldId),
+    EnumVariant(EnumVariantId),
+}
+
+impl MemberId {
+    fn kind(&self) -> MemberKind {
+        match self {
+            Self::StructField(_) => MemberKind::StructField,
+            Self::EnumVariant(_) => MemberKind::EnumVariant,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberKind {
+    StructField,
+    EnumVariant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -179,6 +232,7 @@ pub enum ItemKind {
 pub struct ItemInfo {
     pub span: Span,
     pub kind: ItemKind,
+    is_entry_point: bool,
 }
 
 #[cfg(test)]
@@ -198,7 +252,19 @@ mod tests {
         graph.add_item(child.clone(), span(1), ItemKind::Function, false);
         graph.add_reference(&root, child);
 
-        assert!(graph.get_unreachable().is_empty());
+        assert!(graph.analyze().unreachable_items().next().is_none());
+    }
+
+    #[test]
+    fn import_alias_is_unused_only_when_unused_in_every_file() {
+        let mut graph = ReferenceGraph::new();
+        let used = ModuleItemId::import(0, "dep");
+        let unused = ModuleItemId::import(1, "dep");
+        graph.add_import(used.clone(), span(0), span(0));
+        graph.add_import(unused, span(1), span(1));
+        graph.mark_as_used(used);
+
+        assert!(graph.analyze().unused_import_aliases().is_empty());
     }
 
     #[test]
@@ -212,12 +278,6 @@ mod tests {
         graph.mark_struct_field_used(field);
         graph.mark_enum_variant_used(variant);
 
-        assert_eq!(
-            (
-                graph.get_unused_struct_fields().count(),
-                graph.get_unused_enum_variants().count(),
-            ),
-            (0, 0)
-        );
+        assert_eq!(graph.unused_members().count(), 0);
     }
 }

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -15,6 +15,12 @@ pub(crate) mod walk;
 
 pub use lints::Lint;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LintMode {
+    Skip,
+    Run,
+}
+
 pub(crate) const PARALLEL_THRESHOLD: usize = 4;
 
 pub(crate) fn source_file_work(store: &semantics::store::Store) -> Vec<(&Module, &File)> {
@@ -44,39 +50,36 @@ pub(crate) fn is_trivial_expression(expression: &Expression) -> bool {
     }
 }
 
-pub fn run(
-    store: &Store,
-    facts: &mut Facts,
-    sink: &LocalSink,
-    unused: &mut UnusedInfo,
-    run_lints: bool,
-) {
-    let facts_ref: &Facts = facts;
+pub fn run(store: &Store, facts: &Facts, sink: &LocalSink, lint_mode: LintMode) -> UnusedInfo {
     let ((checks_diagnostics, pattern_lints), lint_outputs) = rayon::join(
-        || checks::run_all(store, facts_ref, run_lints),
-        || {
-            run_lints.then(|| {
+        || checks::run_all(store, facts, lint_mode),
+        || match lint_mode {
+            LintMode::Skip => None,
+            LintMode::Run => {
                 let (produced_facts, (ast_walk_diagnostics, ref_graph_output)) = rayon::join(
                     || diagnostic_producers::run_all(store),
                     || {
                         rayon::join(
-                            || lints::ast_walk::run(store, facts_ref),
-                            || lints::ref_graph::run(store, facts_ref),
+                            || lints::ast_walk::run(store, facts),
+                            || lints::ref_graph::run(store, facts),
                         )
                     },
                 );
-                (produced_facts, ast_walk_diagnostics, ref_graph_output)
-            })
+                Some((produced_facts, ast_walk_diagnostics, ref_graph_output))
+            }
         },
     );
 
     sink.extend(checks_diagnostics);
-    deferred::run(store, facts.take_deferred_checks(), sink);
+    deferred::run(store, facts.deferred_checks(), sink);
     if let Some((produced_facts, ast_walk_diagnostics, ref_graph_output)) = lint_outputs {
-        lints::from_facts::run(store, facts, pattern_lints, produced_facts, unused, sink);
+        let mut unused = lints::from_facts::run(store, facts, pattern_lints, produced_facts, sink);
         let (ref_graph_diagnostics, ref_graph_unused) = ref_graph_output;
         sink.extend(ast_walk_diagnostics);
         sink.extend(ref_graph_diagnostics);
         unused.merge(ref_graph_unused);
+        unused
+    } else {
+        UnusedInfo::default()
     }
 }

--- a/crates/passes/src/passes/walk.rs
+++ b/crates/passes/src/passes/walk.rs
@@ -1,7 +1,7 @@
 use diagnostics::LocalSink;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Pattern, SelectArm, Span};
-use syntax::program::File;
+use syntax::program::{File, Module};
 
 use semantics::facts::Facts;
 use semantics::store::Store;
@@ -9,14 +9,64 @@ use semantics::store::Store;
 pub(crate) struct NodeCtx<'a> {
     pub store: &'a Store,
     pub facts: &'a Facts,
-    pub files: &'a HashMap<u32, File>,
-    pub module_id: &'a str,
-    pub source: &'a str,
-    pub is_d_lis: bool,
-    pub is_test: bool,
+    module: &'a Module,
+    file: &'a File,
     pub sink: &'a LocalSink,
-    /// Spans claimed by enclosing nodes to prevent duplicate diagnostics.
-    pub claimed_spans: HashSet<Span>,
+    claimed_spans: HashSet<(ClaimKind, Span)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ClaimKind {
+    AlwaysTrueDisjunction,
+    CollapsibleMatch,
+    ImpossibleComparison,
+    MapKey,
+    MinMax,
+    OutOfDomain,
+    RedundantClosure,
+}
+
+impl<'a> NodeCtx<'a> {
+    pub fn new(
+        store: &'a Store,
+        facts: &'a Facts,
+        module: &'a Module,
+        file: &'a File,
+        sink: &'a LocalSink,
+    ) -> Self {
+        Self {
+            store,
+            facts,
+            module,
+            file,
+            sink,
+            claimed_spans: HashSet::default(),
+        }
+    }
+
+    pub fn module_id(&self) -> &str {
+        &self.module.id
+    }
+
+    pub fn source(&self) -> &str {
+        &self.file.source
+    }
+
+    pub fn is_d_lis(&self) -> bool {
+        self.file.is_d_lis()
+    }
+
+    pub fn is_test(&self) -> bool {
+        self.file.is_test()
+    }
+
+    pub fn is_claimed(&self, kind: ClaimKind, span: &Span) -> bool {
+        self.claimed_spans.contains(&(kind, *span))
+    }
+
+    pub fn claim(&mut self, kind: ClaimKind, span: Span) {
+        self.claimed_spans.insert((kind, span));
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -234,5 +284,25 @@ fn visit_pattern<C, F: FnMut(&Pattern, PatternRole, &mut C)>(
         Pattern::AsBinding { pattern, .. } => {
             visit_pattern(pattern, role, ctx, visitor);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claims_only_suppress_their_own_diagnostic_family() {
+        let store = Store::new();
+        let facts = Facts::new(Default::default());
+        let module = Module::new("main");
+        let file = File::new_cached("main", "main.lis", "main.lis", "", 0);
+        let sink = LocalSink::new();
+        let mut ctx = NodeCtx::new(&store, &facts, &module, &file, &sink);
+        let span = Span::new(0, 0, 1);
+
+        ctx.claim(ClaimKind::MinMax, span);
+
+        assert!(!ctx.is_claimed(ClaimKind::MapKey, &span));
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -201,8 +201,8 @@ impl Facts {
         self.allocator.clone()
     }
 
-    pub fn take_deferred_checks(&mut self) -> DeferredChecks {
-        std::mem::take(&mut self.deferred)
+    pub fn deferred_checks(&self) -> &DeferredChecks {
+        &self.deferred
     }
 
     pub(crate) fn add_binding(

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -143,13 +143,11 @@ pub fn infer_module(module_name: &str, fs: MockFileSystem) -> InferResult {
             .collect();
 
         if !checker.failed() {
-            let mut unused = syntax::program::UnusedInfo::default();
             passes::run(
                 &store,
-                &mut checker.facts,
+                &checker.facts,
                 &checker.sink,
-                &mut unused,
-                false,
+                passes::LintMode::Skip,
             );
         }
 

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -5,7 +5,7 @@ use syntax::{
     ast::Expression,
     lex::Lexer,
     parse::Parser,
-    program::{File, FileImport, UnusedInfo, Visibility},
+    program::{File, FileImport, Visibility},
 };
 
 use super::new_test_store;
@@ -103,8 +103,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     store.store_file(typed_file);
     let inference_checkpoint = checker.sink.checkpoint();
 
-    let mut unused = UnusedInfo::default();
-    passes::run(&store, &mut checker.facts, &checker.sink, &mut unused, true);
+    passes::run(&store, &checker.facts, &checker.sink, passes::LintMode::Run);
 
     // Deferred inference errors surface during passes::run, mixed in with
     // the error-severity lint diagnostics the tests assert on.

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -198,13 +198,11 @@ impl CompiledTest {
                     items: typed_ast.clone(),
                     file_comment: None,
                 });
-                let mut harness_unused = UnusedInfo::default();
                 passes::run(
                     &store,
-                    &mut checker.facts,
+                    &checker.facts,
                     &checker.sink,
-                    &mut harness_unused,
-                    false,
+                    passes::LintMode::Skip,
                 );
             }
 


### PR DESCRIPTION
Simplifies data flow in the `passes` crate:

- `passes::run` borrows `Facts` immutably and returns `UnusedInfo` instead of filling out-parameters.
- `NodeCtx` moves behind a constructor and accessors, allowing spans to be claimed per lint.
- `ReferenceGraph` owns its unreachable-item analysis instead of leaking alias counting to callers.