### PR TITLE
ci: mark breaking release via PR label

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -37,6 +37,52 @@ jobs:
         with:
           tool: git-cliff@2.13.1
 
+      - name: Bump version if breaking label
+        if: ${{ steps.release-plz.outputs.pr != '' && steps.release-plz.outputs.pr != '{}' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          PR_JSON: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git tag --list 'lisette-v*' --sort=-v:refname | head -1)
+          WANT_MINOR=false
+          for sha in $(gh pr list --state merged --label breaking --limit 100 --json mergeCommit --jq '.[].mergeCommit.oid'); do
+            if git merge-base --is-ancestor "$LAST_TAG" "$sha" && git merge-base --is-ancestor "$sha" origin/main; then
+              WANT_MINOR=true
+            fi
+          done
+          if [ "$WANT_MINOR" = "false" ]; then
+            echo "No unreleased breaking-labeled PRs"
+            exit 0
+          fi
+
+          IFS=. read -r MAJOR MINOR _ <<< "${LAST_TAG#lisette-v}"
+          if [ "$MAJOR" -eq 0 ]; then
+            TARGET="0.$((MINOR + 1)).0"
+          else
+            TARGET="$((MAJOR + 1)).0.0"
+          fi
+          BRANCH=$(echo "$PR_JSON" | jq -er '.head_branch')
+          PR_NUM=$(echo "$PR_JSON" | jq -er '.number')
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          CURRENT=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+          if [ "$(printf '%s\n%s\n' "$TARGET" "$CURRENT" | sort -V | head -1)" = "$TARGET" ]; then
+            echo "Version already $CURRENT, at or above target $TARGET"
+            git checkout -
+            exit 0
+          fi
+
+          git grep -l "\"=${CURRENT}\"" -- '*.toml' | xargs sed -i "s/\"=${CURRENT}\"/\"=${TARGET}\"/g"
+          sed -i "s/^version = \"${CURRENT}\"/version = \"${TARGET}\"/" Cargo.toml
+          cargo update --workspace
+          git -c "user.name=github-actions[bot]" \
+              -c "user.email=41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -am "chore: bump to ${TARGET} for breaking-labeled changes"
+          git push origin "HEAD:${BRANCH}"
+          gh pr edit "$PR_NUM" --title "chore: release v${TARGET}"
+          git checkout -
+
       - name: Regenerate changelog with full-repo scope
         if: ${{ steps.release-plz.outputs.pr != '' && steps.release-plz.outputs.pr != '{}' }}
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -44,6 +44,7 @@ jobs:
         if: steps.release.outputs.releases_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ steps.release.outputs.releases }}
         run: |
           set -euo pipefail

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,6 +10,12 @@ body = '''
 ### {{ group | striptags | trim }}
 {% for commit in commits | sort(attribute="author.timestamp") | reverse %}
 {%- set subject = commit.raw_message | split(pat="\n") | first | trim -%}
+{%- if commit.remote.pr_labels is defined and commit.remote.pr_labels is containing("breaking") and subject is matching("^[a-z]+(\([^)]*\))?: ") -%}
+{%- set parts = subject | split(pat=": ") -%}
+{%- set breaking_type = parts | first -%}
+{%- set breaking_rest = parts | slice(start=1) | join(sep=": ") -%}
+{%- set subject = breaking_type ~ "!: " ~ breaking_rest -%}
+{%- endif -%}
 {%- set sha = commit.id | truncate(length=7, end="") -%}
 {%- if subject is matching("\(\[#\d+\]\([^)]*\)\)$") -%}
 {%- set head = subject | split(pat=" ([#") | slice(end=-1) | join(sep=" ([#") -%}
@@ -32,6 +38,7 @@ commit_preprocessors = [
 ]
 commit_parsers = [
   { message = "^chore: bump stdlib typedefs", skip = true },
+  { message = "^chore: bump to .* for breaking-labeled changes", skip = true },
   { message = "^chore: release", skip = true },
   { message = "^feat", group = "<!-- 0 -->Features" },
   { message = "^fix", group = "<!-- 1 -->Fixes" },
@@ -40,3 +47,7 @@ commit_parsers = [
 include_paths = ["**"]
 tag_pattern = "lisette-v[0-9]*"
 sort_commits = "newest"
+
+[remote.github]
+owner = "ivov"
+repo = "lisette"


### PR DESCRIPTION
In case I ever merge a PR with breaking changes without `!` on the title, as long as that PR has not been released yet, I can now apply a `breaking` label to the already merged PR, which will...

- bump the upcoming release PR accordingly (patch to minor pre-1.0, minor to major post-1.0)
- render `!` in the release PR body, release note and changelog (without rewriting history)
- add a breaking-changes banner to the release PR body and release note


