### PR TITLE
refactor: consolidate type-argument scanning

### DIFF
--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -54,7 +54,7 @@ impl<'source> Parser<'source> {
                         span: error_span,
                     };
                 }
-                let span = self.span_from_tokens(start);
+                let span = self.span_from_offset(start.byte_offset);
                 self.track_error("unexpected `[` in type", "Use `Slice<T>` for slice types.");
                 Annotation::Constructor {
                     name: "".into(),
@@ -109,7 +109,7 @@ impl<'source> Parser<'source> {
             return Annotation::Constructor {
                 name,
                 params: type_params,
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -120,7 +120,7 @@ impl<'source> Parser<'source> {
         Annotation::Constructor {
             name,
             params: vec![],
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -179,7 +179,7 @@ impl<'source> Parser<'source> {
         Annotation::Constructor {
             name,
             params: type_params,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -208,7 +208,7 @@ impl<'source> Parser<'source> {
             self.next();
         }
         self.track_error_at(
-            self.span_from_tokens(start),
+            self.span_from_offset(start.byte_offset),
             "Array size must be an integer literal",
             "Array sizes are whole numbers, e.g. `Array<string, 3>`",
         );
@@ -238,7 +238,7 @@ impl<'source> Parser<'source> {
         Annotation::Function {
             params,
             return_type: return_type.into(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -257,7 +257,7 @@ impl<'source> Parser<'source> {
 
         self.ensure(RightParen);
 
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
 
         if annotations.is_empty() {
             return Annotation::unit();
@@ -303,7 +303,7 @@ impl<'source> Parser<'source> {
         let start = self.current_token();
         let name = self.read_identifier();
         let bounds = self.parse_generic_bounds();
-        Generic::new(name, bounds, self.span_from_tokens(start))
+        Generic::new(name, bounds, self.span_from_offset(start.byte_offset))
     }
 
     fn parse_generic_bounds(&mut self) -> Vec<Annotation> {
@@ -367,7 +367,7 @@ impl<'source> Parser<'source> {
         if self.is(LeftAngleBracket) {
             let generics_start = self.current_token();
             let generics = self.parse_generics(); // consume and discard
-            let generics_span = self.span_from_tokens(generics_start);
+            let generics_span = self.span_from_offset(generics_start.byte_offset);
             self.error_interface_method_with_type_parameters(generics_span, generics.len());
         }
 
@@ -383,7 +383,7 @@ impl<'source> Parser<'source> {
             visibility: Visibility::Private,
             body: FunctionBody::Declaration,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -405,7 +405,7 @@ impl<'source> Parser<'source> {
             self.parse_annotation()
         } else {
             Annotation::Opaque {
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             }
         };
 
@@ -418,7 +418,7 @@ impl<'source> Parser<'source> {
             annotation,
             ty: Type::uninferred(),
             visibility: Visibility::Private,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 }

--- a/crates/syntax/src/parse/control_flow.rs
+++ b/crates/syntax/src/parse/control_flow.rs
@@ -40,7 +40,7 @@ impl<'source> Parser<'source> {
             ty: Type::uninferred(),
             subject: subject.into(),
             arms,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -103,7 +103,7 @@ impl<'source> Parser<'source> {
                 condition: condition.into(),
                 consequence: consequence.into(),
                 alternative,
-                span: parser.span_from_tokens(start),
+                span: parser.span_from_offset(start.byte_offset),
             }
         }) {
             return result;
@@ -147,7 +147,7 @@ impl<'source> Parser<'source> {
             consequence: consequence.into(),
             alternative,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -159,7 +159,7 @@ impl<'source> Parser<'source> {
         let expression = match self.current_token().kind {
             Semicolon | RightCurlyBrace => Expression::Unit {
                 ty: Type::uninferred(),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             },
             _ => self.parse_expression(),
         };
@@ -173,7 +173,7 @@ impl<'source> Parser<'source> {
         Expression::Return {
             expression: expression.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -237,7 +237,7 @@ impl<'source> Parser<'source> {
         Expression::Assert {
             expression: expression.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -257,7 +257,7 @@ impl<'source> Parser<'source> {
             binding: Box::new(binding),
             iterable: iterable.into(),
             body: body.into(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -276,7 +276,7 @@ impl<'source> Parser<'source> {
         Expression::While {
             condition: condition.into(),
             body: body.into(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -292,7 +292,7 @@ impl<'source> Parser<'source> {
             pattern,
             scrutinee: scrutinee.into(),
             body: body.into(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -305,7 +305,7 @@ impl<'source> Parser<'source> {
         Expression::Loop {
             body: body.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -321,7 +321,7 @@ impl<'source> Parser<'source> {
 
         Expression::Break {
             value,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -331,7 +331,7 @@ impl<'source> Parser<'source> {
         self.next();
 
         Expression::Continue {
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 }

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -91,7 +91,7 @@ impl<'source> Parser<'source> {
         Some(Attribute {
             name: name.to_string(),
             args,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         })
     }
 
@@ -248,7 +248,7 @@ impl<'source> Parser<'source> {
             generics,
             variants,
             visibility: Visibility::Private,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -452,7 +452,7 @@ impl<'source> Parser<'source> {
             generics,
             fields: StructFields::Record(fields),
             visibility: Visibility::Private,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -469,7 +469,7 @@ impl<'source> Parser<'source> {
 
             let field_start = self.current_token();
             let annotation = self.parse_annotation();
-            let field_span = self.span_from_tokens(field_start);
+            let field_span = self.span_from_offset(field_start.byte_offset);
 
             fields.push(StructFieldDefinition {
                 doc: None,
@@ -503,7 +503,7 @@ impl<'source> Parser<'source> {
             generics,
             fields: StructFields::Tuple(fields),
             visibility: Visibility::Private,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -571,7 +571,7 @@ impl<'source> Parser<'source> {
         self.ensure(Identifier);
 
         let annotation = self.parse_annotation();
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
 
         let Some(name) = Self::embedded_field_name(&annotation) else {
             self.track_error_at(
@@ -651,7 +651,7 @@ impl<'source> Parser<'source> {
             expression,
             visibility: Visibility::Private,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -682,7 +682,7 @@ impl<'source> Parser<'source> {
             annotation,
             visibility: Visibility::Private,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -692,7 +692,7 @@ impl<'source> Parser<'source> {
 
         Expression::Unit {
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -768,7 +768,7 @@ impl<'source> Parser<'source> {
             receiver_name,
             generics,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -864,7 +864,7 @@ impl<'source> Parser<'source> {
             parents,
             method_signatures,
             visibility: Visibility::Private,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -880,7 +880,7 @@ impl<'source> Parser<'source> {
 
         let parent_start = self.current_token();
         let annotation = self.parse_annotation();
-        let parent_span = self.span_from_tokens(parent_start);
+        let parent_span = self.span_from_offset(parent_start.byte_offset);
 
         if let Annotation::Constructor { name, .. } = &annotation {
             if let Some((_, first_span)) = seen_parents.iter().find(|(n, _)| n == name.as_str()) {

--- a/crates/syntax/src/parse/directives.rs
+++ b/crates/syntax/src/parse/directives.rs
@@ -18,7 +18,7 @@ impl<'source> Parser<'source> {
                 }
                 Expression::Unit {
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
         }

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -140,7 +140,7 @@ impl<'source> Parser<'source> {
             end,
             inclusive,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(span_start),
+            span: self.span_from_offset(span_start.byte_offset),
         }
     }
 
@@ -244,7 +244,7 @@ impl<'source> Parser<'source> {
         Expression::Literal {
             literal,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -256,7 +256,7 @@ impl<'source> Parser<'source> {
         Expression::Literal {
             literal: Literal::Slice(expressions),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -279,7 +279,7 @@ impl<'source> Parser<'source> {
         Expression::Identifier {
             value: text.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
             resolution: IdentifierResolution::Unresolved,
         }
     }
@@ -343,7 +343,7 @@ impl<'source> Parser<'source> {
                 Expression::Identifier {
                     value: field_name.clone(),
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(field_name_token),
+                    span: self.span_from_offset(field_name_token.byte_offset),
                     resolution: IdentifierResolution::Unresolved,
                 }
             };
@@ -394,7 +394,7 @@ impl<'source> Parser<'source> {
                 end: upper,
                 inclusive: false,
                 ty: Type::uninferred(),
-                span: self.span_from_tokens(index_start),
+                span: self.span_from_offset(index_start.byte_offset),
             }
         } else {
             *lower.expect("non-colon index must have a lower expression")
@@ -406,7 +406,7 @@ impl<'source> Parser<'source> {
             ty: Type::uninferred(),
             expression: expression.into(),
             index: index.into(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
             from_colon_syntax,
         }
     }
@@ -434,6 +434,42 @@ impl<'source> Parser<'source> {
             spread: spread.map(Box::new),
             type_arguments: CallTypeArguments::unresolved(raw_type_args),
             span: self.span_from_offset(start_offset),
+            call_kind: CallKind::Unresolved,
+        }
+    }
+
+    pub(crate) fn recover_call_missing_parens(
+        &mut self,
+        expression: Expression,
+        raw_type_args: Vec<Annotation>,
+    ) -> Expression {
+        let start_offset = expression.get_span().byte_offset;
+        let span = self.span_from_offset(start_offset);
+        let called = self.source
+            [span.byte_offset as usize..(span.byte_offset + span.byte_length) as usize]
+            .trim_end();
+
+        if !self.too_many_errors() {
+            let label = if raw_type_args.len() == 1 {
+                "expected `()` after type argument"
+            } else {
+                "expected `()` after type arguments"
+            };
+
+            self.errors.push(
+                ParseError::new("Missing call parens", span, label)
+                    .with_parse_code("call_missing_parens")
+                    .with_help(format!("Add parens to call it: `{called}()`")),
+            );
+        }
+
+        Expression::Call {
+            ty: Type::uninferred(),
+            expression: expression.into(),
+            args: vec![],
+            spread: None,
+            type_arguments: CallTypeArguments::unresolved(raw_type_args),
+            span,
             call_kind: CallKind::Unresolved,
         }
     }
@@ -619,7 +655,7 @@ impl<'source> Parser<'source> {
         } else {
             Expression::Unit {
                 ty: Type::uninferred(),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             }
         };
 
@@ -628,7 +664,7 @@ impl<'source> Parser<'source> {
             return_annotation,
             body: body.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -715,7 +751,7 @@ impl<'source> Parser<'source> {
 
         let (expressions, has_trailing_comma) =
             self.collect_delimited_expressions(LeftParen, RightParen);
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
 
         match expressions.len() {
             0 => Expression::Unit {
@@ -790,7 +826,7 @@ impl<'source> Parser<'source> {
             return_annotation,
             body: body.into(),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -806,7 +842,7 @@ impl<'source> Parser<'source> {
             return Expression::Block {
                 ty: Type::uninferred(),
                 items: vec![],
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -918,7 +954,7 @@ impl<'source> Parser<'source> {
             visibility: Visibility::Private,
             body,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -933,7 +969,7 @@ impl<'source> Parser<'source> {
                 ty: Type::uninferred(),
                 operator: UnaryOperator::Deref,
                 expression: expression.into(),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -1068,7 +1104,7 @@ impl<'source> Parser<'source> {
             && let Some(Annotation::Constructor { span, .. }) = binding.annotation.as_ref()
         {
             self.error_missing_initializer(*span);
-            let stub_span = self.span_from_tokens(start);
+            let stub_span = self.span_from_offset(start.byte_offset);
             return Expression::Let {
                 binding: Box::new(binding),
                 value: Box::new(Expression::Block {
@@ -1118,7 +1154,7 @@ impl<'source> Parser<'source> {
             value: expression.into(),
             mode,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1183,7 +1219,7 @@ impl<'source> Parser<'source> {
             self.resync_on_error();
             return Expression::Unit {
                 ty: Type::uninferred(),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -1207,7 +1243,7 @@ impl<'source> Parser<'source> {
             self.next();
             self.next();
             self.error_import_alias_after_path(
-                self.span_from_tokens(as_token),
+                self.span_from_offset(as_token.byte_offset),
                 alias_identifier.text,
                 unquoted,
             );
@@ -1220,7 +1256,7 @@ impl<'source> Parser<'source> {
             name,
             name_span,
             alias,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1260,7 +1296,7 @@ impl<'source> Parser<'source> {
                 target: lhs.into(),
                 value: rhs.into(),
                 compound_operator: Some(operator),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -1294,7 +1330,7 @@ impl<'source> Parser<'source> {
             target: lhs.into(),
             value: self.parse_expression().into(),
             compound_operator: None,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1368,7 +1404,7 @@ impl<'source> Parser<'source> {
         Expression::Literal {
             literal: Literal::FormatString(parts),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1398,7 +1434,7 @@ impl<'source> Parser<'source> {
         Expression::Task {
             expression: Box::new(expression),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1428,7 +1464,7 @@ impl<'source> Parser<'source> {
         Expression::Defer {
             expression: Box::new(expression),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -1439,7 +1475,7 @@ impl<'source> Parser<'source> {
         self.ensure(Try);
 
         if !self.is(LeftCurlyBrace) {
-            let span = self.span_from_tokens(start);
+            let span = self.span_from_offset(start.byte_offset);
             let error = ParseError::new("Invalid `try`", span, "requires a block")
                 .with_parse_code("syntax_error")
                 .with_help("Use `try { expression }` instead of `try expression`");
@@ -1449,7 +1485,7 @@ impl<'source> Parser<'source> {
                 items: vec![expression],
                 ty: Type::uninferred(),
                 try_keyword_span,
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -1472,7 +1508,7 @@ impl<'source> Parser<'source> {
         self.ensure(Recover);
 
         if !self.is(LeftCurlyBrace) {
-            let span = self.span_from_tokens(start);
+            let span = self.span_from_offset(start.byte_offset);
             let error = ParseError::new("Invalid `recover`", span, "requires a block")
                 .with_parse_code("syntax_error")
                 .with_help("Use `recover { expression }` instead of `recover expression`");
@@ -1482,7 +1518,7 @@ impl<'source> Parser<'source> {
                 items: vec![expression],
                 ty: Type::uninferred(),
                 recover_keyword_span,
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -1522,7 +1558,7 @@ impl<'source> Parser<'source> {
         Expression::Select {
             arms,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -19,6 +19,11 @@ pub(crate) enum ParamMode {
     TestFunction,
 }
 
+struct TypeArgsScan {
+    end: usize,
+    crossed_newline: bool,
+}
+
 mod annotations;
 mod control_flow;
 mod definitions;
@@ -229,7 +234,7 @@ impl<'source> Parser<'source> {
                 self.skip_comments();
                 ast::Expression::Unit {
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
             _ => self.unexpected_token("top_item"),
@@ -489,46 +494,38 @@ impl<'source> Parser<'source> {
         ast::Span::new(self.file_id, token.byte_offset, token.byte_length)
     }
 
-    fn span_from_tokens(&self, start_token: Token<'source>) -> ast::Span {
-        let previous = self.stream.previous();
-        let end_byte_offset = previous.byte_offset + previous.byte_length;
-        let byte_length = end_byte_offset.saturating_sub(start_token.byte_offset);
-
-        ast::Span::new(self.file_id, start_token.byte_offset, byte_length)
-    }
-
     fn span_from_offset(&self, start_byte_offset: u32) -> ast::Span {
-        let previous = self.stream.previous();
+        let previous = self.stream.previous_code();
         let end_byte_offset = previous.byte_offset + previous.byte_length;
         let byte_length = end_byte_offset.saturating_sub(start_byte_offset);
 
         ast::Span::new(self.file_id, start_byte_offset, byte_length)
     }
 
-    fn is_type_args_call(&self) -> bool {
+    fn scan_type_args(&self) -> Option<TypeArgsScan> {
         let mut position = 1; // 0 is <
         let mut depth = 1;
+        let mut crossed_newline = false;
 
         loop {
             if position > MAX_LOOKAHEAD {
-                return false;
+                return None;
             }
+            crossed_newline |= self.newline_before_peek(position);
             match self.stream.peek_ahead(position).kind {
                 LeftAngleBracket => depth += 1,
                 RightAngleBracket if depth == 1 => {
-                    let next = self.stream.peek_ahead(position + 1).kind;
-                    return next == LeftParen
-                        || (next == Dot
-                            && self.stream.peek_ahead(position + 2).kind == Identifier
-                            && self.stream.peek_ahead(position + 3).kind == LeftParen);
+                    return Some(TypeArgsScan {
+                        end: position + 1,
+                        crossed_newline,
+                    });
                 }
                 RightAngleBracket => depth -= 1,
                 ShiftRight if depth <= 2 => {
-                    let next = self.stream.peek_ahead(position + 1).kind;
-                    return next == LeftParen
-                        || (next == Dot
-                            && self.stream.peek_ahead(position + 2).kind == Identifier
-                            && self.stream.peek_ahead(position + 3).kind == LeftParen);
+                    return Some(TypeArgsScan {
+                        end: position + 1,
+                        crossed_newline,
+                    });
                 }
                 ShiftRight => depth -= 2,
                 LeftParen => {
@@ -536,12 +533,13 @@ impl<'source> Parser<'source> {
                     position += 1;
                     while paren_depth > 0 {
                         if position > MAX_LOOKAHEAD {
-                            return false;
+                            return None;
                         }
+                        crossed_newline |= self.newline_before_peek(position);
                         match self.stream.peek_ahead(position).kind {
                             LeftParen => paren_depth += 1,
                             RightParen => paren_depth -= 1,
-                            EOF => return false,
+                            EOF => return None,
                             _ => {}
                         }
                         position += 1;
@@ -550,11 +548,50 @@ impl<'source> Parser<'source> {
                 }
                 EOF | Plus | Minus | Star | Slash | Percent | EqualDouble | NotEqual
                 | AmpersandDouble | PipeDouble | Semicolon | LeftCurlyBrace | RightCurlyBrace
-                | LeftSquareBracket | RightSquareBracket => return false,
+                | LeftSquareBracket | RightSquareBracket => return None,
                 _ => {}
             }
             position += 1;
         }
+    }
+
+    fn opens_type_args(&self) -> bool {
+        let Some(scan) = self.scan_type_args() else {
+            return false;
+        };
+
+        let next = self.stream.peek_ahead(scan.end).kind;
+
+        let call = next == LeftParen
+            || (next == Dot
+                && self.stream.peek_ahead(scan.end + 1).kind == Identifier
+                && self.stream.peek_ahead(scan.end + 2).kind == LeftParen);
+
+        call || (!scan.crossed_newline && self.ends_expression_at(scan.end))
+    }
+
+    fn ends_expression_at(&self, position: usize) -> bool {
+        let mut position = position;
+        while matches!(
+            self.stream.peek_ahead(position).kind,
+            Comment | DocComment | FileComment
+        ) {
+            position += 1;
+        }
+
+        self.newline_before_peek(position)
+            || matches!(
+                self.stream.peek_ahead(position).kind,
+                EOF | Semicolon | RightCurlyBrace | RightParen | RightSquareBracket | Comma
+            )
+    }
+
+    fn newline_before_peek(&self, position: usize) -> bool {
+        let previous = self.stream.peek_ahead(position.saturating_sub(1));
+        let from = (previous.byte_offset + previous.byte_length) as usize;
+        let to = self.stream.peek_ahead(position).byte_offset as usize;
+
+        from <= to && to <= self.source.len() && self.source[from..to].contains('\n')
     }
 
     fn has_block_after_struct(&self) -> bool {
@@ -868,7 +905,7 @@ impl<'source> Parser<'source> {
             )
         } else {
             self.error_unclosed_block(&error_anchor);
-            self.span_from_tokens(start)
+            self.span_from_offset(start.byte_offset)
         }
     }
 
@@ -1284,6 +1321,16 @@ impl<'source> TokenStream<'source> {
 
     fn previous(&self) -> Token<'source> {
         self.tokens[self.position.saturating_sub(1)]
+    }
+
+    fn previous_code(&self) -> Token<'source> {
+        let mut index = self.position.saturating_sub(1);
+
+        while index > 0 && matches!(self.tokens[index].kind, Comment | DocComment | FileComment) {
+            index -= 1;
+        }
+
+        self.tokens[index]
     }
 
     fn consume(&mut self) -> Token<'source> {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -26,7 +26,7 @@ impl<'source> Parser<'source> {
 
         Pattern::Or {
             patterns,
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -51,7 +51,7 @@ impl<'source> Parser<'source> {
                         pattern: Box::new(result),
                         name,
                         name_span,
-                        span: parser.span_from_tokens(start),
+                        span: parser.span_from_offset(start.byte_offset),
                     };
                 }
             }
@@ -124,7 +124,7 @@ impl<'source> Parser<'source> {
                 );
                 self.next();
                 Pattern::WildCard {
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
 
@@ -139,7 +139,7 @@ impl<'source> Parser<'source> {
             _ => {
                 self.unexpected_token("pattern");
                 Pattern::WildCard {
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
         }
@@ -159,7 +159,7 @@ impl<'source> Parser<'source> {
                 else {
                     return int_pattern;
                 };
-                let span = self.span_from_tokens(start);
+                let span = self.span_from_offset(start.byte_offset);
                 if value > i64::MIN.unsigned_abs() {
                     self.track_error_at(
                         span,
@@ -182,7 +182,7 @@ impl<'source> Parser<'source> {
                 }
             }
             Float => {
-                let span = self.span_from_tokens(start);
+                let span = self.span_from_offset(start.byte_offset);
                 self.track_error_at(
                     span,
                     "not allowed",
@@ -190,7 +190,7 @@ impl<'source> Parser<'source> {
                 );
                 self.next();
                 Pattern::WildCard {
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
             _ => {
@@ -199,7 +199,7 @@ impl<'source> Parser<'source> {
                     "Negative patterns require a number, e.g., `-5`",
                 );
                 Pattern::WildCard {
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
         }
@@ -244,7 +244,7 @@ impl<'source> Parser<'source> {
         Pattern::Literal {
             literal,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -253,7 +253,7 @@ impl<'source> Parser<'source> {
         let float_text = start.text.to_string();
         self.next();
 
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
         self.error_float_pattern_not_allowed(span, &float_text);
 
         Pattern::WildCard { span }
@@ -267,7 +267,7 @@ impl<'source> Parser<'source> {
         Pattern::Literal {
             literal: Literal::Boolean(b),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -297,7 +297,7 @@ impl<'source> Parser<'source> {
         Pattern::Literal {
             literal: Literal::String { value, raw },
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -314,7 +314,7 @@ impl<'source> Parser<'source> {
         Pattern::Literal {
             literal: Literal::Char(char_str),
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -325,7 +325,7 @@ impl<'source> Parser<'source> {
         if self.advance_if(RightParen) {
             return Pattern::Unit {
                 ty: Type::uninferred(),
-                span: self.span_from_tokens(start),
+                span: self.span_from_offset(start.byte_offset),
             };
         }
 
@@ -352,7 +352,7 @@ impl<'source> Parser<'source> {
 
         self.ensure(RightParen);
 
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
 
         if elements.len() > MAX_TUPLE_ARITY {
             self.error_tuple_arity(elements.len(), span);
@@ -385,7 +385,7 @@ impl<'source> Parser<'source> {
             if rest.is_present() {
                 let suffix_start = self.current_token();
                 self.parse_pattern();
-                let suffix_span = self.span_from_tokens(suffix_start);
+                let suffix_span = self.span_from_offset(suffix_start.byte_offset);
                 let error = ParseError::new("Invalid pattern", suffix_span, "not supported")
                     .with_parse_code("suffix_slice_pattern")
                     .with_help("Use `[first, ..rest]` instead of `[..rest, last]`.")
@@ -400,7 +400,7 @@ impl<'source> Parser<'source> {
         }
 
         self.ensure(RightSquareBracket);
-        let span = self.span_from_tokens(start);
+        let span = self.span_from_offset(start.byte_offset);
 
         Pattern::Slice {
             prefix: elements,
@@ -451,7 +451,7 @@ impl<'source> Parser<'source> {
             LeftCurlyBrace => self.parse_struct_pattern(full_name, start),
             LeftParen => self.parse_enum_variant_pattern(full_name, start),
             _ => {
-                let span = self.span_from_tokens(start);
+                let span = self.span_from_offset(start.byte_offset);
                 if full_name == "_" {
                     Pattern::WildCard { span }
                 } else if full_name.contains('.') || self.is_uppercase(&full_name) {
@@ -519,7 +519,7 @@ impl<'source> Parser<'source> {
 
             let field_start = self.current_token();
             let field_name = self.read_identifier();
-            let field_name_span = self.span_from_tokens(field_start);
+            let field_name_span = self.span_from_offset(field_start.byte_offset);
 
             if let Some((_, first_span)) = seen_fields.iter().find(|(n, _)| n == &field_name) {
                 self.error_duplicate_field_in_pattern(&field_name, *first_span, field_name_span);
@@ -556,7 +556,7 @@ impl<'source> Parser<'source> {
             rest,
             resolution: RecordPatternResolution::Unresolved,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -588,7 +588,7 @@ impl<'source> Parser<'source> {
             rest,
             resolution: ConstructorPatternResolution::Unresolved,
             ty: Type::uninferred(),
-            span: self.span_from_tokens(start),
+            span: self.span_from_offset(start.byte_offset),
         }
     }
 
@@ -632,7 +632,7 @@ impl<'source> Parser<'source> {
             let name = start.text.to_string();
             self.next();
 
-            let span = self.span_from_tokens(start);
+            let span = self.span_from_offset(start.byte_offset);
             self.error_uppercase_binding(span);
 
             return Binding {
@@ -737,7 +737,9 @@ impl<'source> Parser<'source> {
                     span: self.span_from_token(name_token),
                 });
             }
-            return Some(RestPattern::Discard(self.span_from_tokens(rest_start)));
+            return Some(RestPattern::Discard(
+                self.span_from_offset(rest_start.byte_offset),
+            ));
         }
 
         if self.is(Identifier) {

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -80,7 +80,7 @@ impl<'source> Parser<'source> {
                     expression: lhs.into(),
                     target_type,
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 };
                 continue;
             }
@@ -105,7 +105,7 @@ impl<'source> Parser<'source> {
                     left: lhs.into(),
                     right: rhs.into(),
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 };
                 continue;
             }
@@ -143,7 +143,7 @@ impl<'source> Parser<'source> {
 
     fn binary_operator_precedence(&self, kind: TokenKind) -> Option<u8> {
         match kind {
-            LeftAngleBracket if self.is_type_args_call() => None,
+            LeftAngleBracket if self.opens_type_args() => None,
             Pipeline => Some(1),
             PipeDouble if self.stream.peek_ahead(1).kind == Arrow => None,
             PipeDouble => Some(3),
@@ -165,7 +165,7 @@ impl<'source> Parser<'source> {
                 }
                 _ => false,
             },
-            LeftAngleBracket => self.is_type_args_call(),
+            LeftAngleBracket => self.opens_type_args(),
             Colon if self.stream.peek_ahead(1).kind == Colon => true,
             _ => false,
         }
@@ -201,7 +201,7 @@ impl<'source> Parser<'source> {
                     operator,
                     expression: self.pratt_parse(prec, context).into(),
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
 
@@ -225,7 +225,7 @@ impl<'source> Parser<'source> {
                 ast::Expression::Reference {
                     expression: self.pratt_parse(prec, context).into(),
                     ty: Type::uninferred(),
-                    span: self.span_from_tokens(start),
+                    span: self.span_from_offset(start.byte_offset),
                 }
             }
 
@@ -298,6 +298,10 @@ impl<'source> Parser<'source> {
                     return self.parse_function_call(dot_access, type_args);
                 }
 
+                if !self.is(LeftParen) {
+                    return self.recover_call_missing_parens(lhs, type_args);
+                }
+
                 self.parse_function_call(lhs, type_args)
             }
 
@@ -312,6 +316,14 @@ impl<'source> Parser<'source> {
                 let after = self.stream.peek_ahead(2);
 
                 if after.kind == LeftAngleBracket {
+                    self.next(); // consume first `:`
+                    self.next(); // consume second `:`
+                    let type_args = self.parse_type_args();
+
+                    if self.at_turbofish_method() {
+                        return self.recover_turbofish_method(lhs, type_args, &lhs_name, span);
+                    }
+
                     let help = if !lhs_name.is_empty() {
                         format!(
                             "Lisette does not use turbofish syntax. Use `{}<T>(...)` instead",
@@ -322,9 +334,6 @@ impl<'source> Parser<'source> {
                             .to_string()
                     };
                     self.track_error_at(span, "invalid syntax", help);
-                    self.next(); // consume first `:`
-                    self.next(); // consume second `:`
-                    let type_args = self.parse_type_args();
                     self.parse_function_call(lhs, type_args)
                 } else {
                     let help = if !lhs_name.is_empty() && after.kind == Identifier {
@@ -336,18 +345,7 @@ impl<'source> Parser<'source> {
                         "Use `.` instead of `::` for enum variant access".to_string()
                     };
                     self.track_error_at(span, "invalid syntax", help);
-                    self.next(); // consume first `:`
-                    self.next(); // consume second `:`
-                    let field_start = self.current_token();
-                    let field: EcoString = self.current_token().text.into();
-                    self.ensure(Identifier);
-                    ast::Expression::DotAccess {
-                        ty: Type::uninferred(),
-                        expression: lhs.into(),
-                        member: field,
-                        span: self.span_from_tokens(field_start),
-                        resolution: DotAccessResolution::Unresolved,
-                    }
+                    self.recover_double_colon_access(lhs)
                 }
             }
 
@@ -360,6 +358,53 @@ impl<'source> Parser<'source> {
                 self.resync_on_error();
                 lhs
             }
+        }
+    }
+
+    fn at_turbofish_method(&self) -> bool {
+        self.is(Colon)
+            && self.stream.peek_ahead(1).kind == Colon
+            && self.stream.peek_ahead(2).kind == Identifier
+    }
+
+    fn recover_turbofish_method(
+        &mut self,
+        lhs: ast::Expression,
+        type_args: Vec<ast::Annotation>,
+        lhs_name: &str,
+        span: ast::Span,
+    ) -> ast::Expression {
+        let method = self.stream.peek_ahead(2).text;
+        let args = type_args
+            .iter()
+            .map(format_annotation)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let help = format!(
+            "Lisette does not use turbofish syntax. Use `{}.{}<{}>()` instead",
+            lhs_name, method, args
+        );
+        self.track_error_at(span, "invalid syntax", help);
+
+        let dot_access = self.recover_double_colon_access(lhs);
+
+        self.parse_function_call(dot_access, type_args)
+    }
+
+    fn recover_double_colon_access(&mut self, lhs: ast::Expression) -> ast::Expression {
+        self.next(); // consume first `:`
+        self.next(); // consume second `:`
+
+        let field_start = self.current_token();
+        let field: EcoString = self.current_token().text.into();
+        self.ensure(Identifier);
+
+        ast::Expression::DotAccess {
+            ty: Type::uninferred(),
+            expression: lhs.into(),
+            member: field,
+            span: self.span_from_offset(field_start.byte_offset),
+            resolution: DotAccessResolution::Unresolved,
         }
     }
 

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -2954,6 +2954,25 @@ fn test() { Map.new<string, fn(int, int) -> int>(); }
 }
 
 #[test]
+fn comparison_args_are_not_type_args() {
+    let input = r#"
+fn test() { take(a < b, c > d); }
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn comparison_ending_statement_is_not_type_args() {
+    let input = r#"
+fn test() {
+  let ok = a < b
+  side()
+}
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
 fn slice_pattern_empty() {
     let input = r#"
 fn test(items: Slice<int>) {

--- a/tests/spec/parse/snapshots/comparison_args_are_not_type_args.snap
+++ b/tests/spec/parse/snapshots/comparison_args_are_not_type_args.snap
@@ -1,0 +1,144 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  fn test() { take(a < b, c > d); }
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [],
+        return_annotation: Unknown,
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Definition(
+            Block {
+                items: [
+                    Call {
+                        expression: Identifier {
+                            value: "take",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 13,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [
+                            Binary {
+                                operator: LessThan,
+                                left: Identifier {
+                                    value: "a",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 18,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "b",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 22,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 18,
+                                    byte_length: 5,
+                                },
+                            },
+                            Binary {
+                                operator: GreaterThan,
+                                left: Identifier {
+                                    value: "c",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 25,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                right: Identifier {
+                                    value: "d",
+                                    ty: Var {
+                                        id: uninferred,
+                                    },
+                                    span: Span {
+                                        file_id: 0,
+                                        byte_offset: 29,
+                                        byte_length: 1,
+                                    },
+                                    resolution: Unresolved,
+                                },
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 25,
+                                    byte_length: 5,
+                                },
+                            },
+                        ],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 13,
+                            byte_length: 18,
+                        },
+                        call_kind: Unresolved,
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 23,
+                },
+            },
+        ),
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 33,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/comparison_ending_statement_is_not_type_args.snap
+++ b/tests/spec/parse/snapshots/comparison_ending_statement_is_not_type_args.snap
@@ -1,0 +1,136 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  fn test() {
+    let ok = a < b
+    side()
+  }
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "test",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [],
+        return_annotation: Unknown,
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Definition(
+            Block {
+                items: [
+                    Let {
+                        binding: Binding {
+                            pattern: Identifier {
+                                identifier: "ok",
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 19,
+                                    byte_length: 2,
+                                },
+                            },
+                            annotation: None,
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                        value: Binary {
+                            operator: LessThan,
+                            left: Identifier {
+                                value: "a",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            right: Identifier {
+                                value: "b",
+                                ty: Var {
+                                    id: uninferred,
+                                },
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 28,
+                                    byte_length: 1,
+                                },
+                                resolution: Unresolved,
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 24,
+                                byte_length: 5,
+                            },
+                        },
+                        mode: Plain,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 15,
+                            byte_length: 14,
+                        },
+                    },
+                    Call {
+                        expression: Identifier {
+                            value: "side",
+                            ty: Var {
+                                id: uninferred,
+                            },
+                            span: Span {
+                                file_id: 0,
+                                byte_offset: 32,
+                                byte_length: 4,
+                            },
+                            resolution: Unresolved,
+                        },
+                        args: [],
+                        spread: None,
+                        type_arguments: None,
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 32,
+                            byte_length: 6,
+                        },
+                        call_kind: Unresolved,
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 11,
+                    byte_length: 29,
+                },
+            },
+        ),
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 39,
+        },
+    },
+]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -101,6 +101,67 @@ fn test() {
 }
 
 #[test]
+fn parse_call_missing_parens_array_new() {
+    let input = r#"
+fn test() {
+  let buffer = Array.new<byte, 0x80>
+  buffer.length()
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_call_missing_parens_single_type_arg() {
+    let input = r#"
+fn test() {
+  let xs = Slice.new<int>
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_call_missing_parens_nested_type_arg() {
+    let input = r#"
+fn test() {
+  let m = Map.new<string, Slice<int>>
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_call_missing_parens_fn_type_arg() {
+    let input = r#"
+fn test() {
+  let m = Map.new<string, fn(int, int) -> int>
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_call_missing_parens_tuple_type_arg() {
+    let input = r#"
+fn test() {
+  let m = Map.new<string, (int, int)>
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_call_missing_parens_trailing_comment() {
+    let input = r#"
+fn test() {
+  let xs = Slice.new<int> // make a slice
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
 fn parse_go_make_unbuffered_channel() {
     let input = r#"
 fn test() {
@@ -3168,6 +3229,16 @@ fn infer_type_mismatch_int_string() {
     let input = r#"
 fn test() {
   let x: int = "hello";
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_mismatch_span_stops_before_trailing_comment() {
+    let input = r#"
+fn test() {
+  let xs: string = Slice.new<int>() // trailing note
 }
 "#;
     assert_infer_error_snapshot!(input);
@@ -8258,6 +8329,16 @@ fn identity<T>(x: T) -> T { x }
 
 fn test() {
   let x = identity::<int>(5);
+}
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_rust_turbofish_with_method() {
+    let input = r#"
+fn test() {
+  let xs = Slice::<int>::new()
 }
 "#;
     assert_parse_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_type_mismatch_span_stops_before_trailing_comment.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_span_stops_before_trailing_comment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:3:20]
+ 2 │ fn test() {
+ 3 │   let xs: string = Slice.new<int>() // trailing note
+   ·                    ────────┬───────
+   ·                            ╰── expected `string`, found `Slice<int>`
+ 4 │ }
+   ╰────
+  help: Change the type annotation to `Slice<int>` or convert the value to `string` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_array_new.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_array_new.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:16]
+ 2 │ fn test() {
+ 3 │   let buffer = Array.new<byte, 0x80>
+   ·                ──────────┬──────────
+   ·                          ╰── expected `()` after type arguments
+ 4 │   buffer.length()
+   ╰────
+  help: Add parens to call it: `Array.new<byte, 0x80>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_fn_type_arg.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_fn_type_arg.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let m = Map.new<string, fn(int, int) -> int>
+   ·           ──────────────────┬─────────────────
+   ·                             ╰── expected `()` after type arguments
+ 4 │ }
+   ╰────
+  help: Add parens to call it: `Map.new<string, fn(int, int) -> int>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_nested_type_arg.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_nested_type_arg.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let m = Map.new<string, Slice<int>>
+   ·           ─────────────┬─────────────
+   ·                        ╰── expected `()` after type arguments
+ 4 │ }
+   ╰────
+  help: Add parens to call it: `Map.new<string, Slice<int>>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_single_type_arg.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_single_type_arg.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let xs = Slice.new<int>
+   ·            ───────┬──────
+   ·                   ╰── expected `()` after type argument
+ 4 │ }
+   ╰────
+  help: Add parens to call it: `Slice.new<int>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_trailing_comment.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_trailing_comment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:12]
+ 2 │ fn test() {
+ 3 │   let xs = Slice.new<int> // make a slice
+   ·            ───────┬──────
+   ·                   ╰── expected `()` after type argument
+ 4 │ }
+   ╰────
+  help: Add parens to call it: `Slice.new<int>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_call_missing_parens_tuple_type_arg.snap
+++ b/tests/ui/errors/snapshots/parse_call_missing_parens_tuple_type_arg.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing call parens
+   ╭─[test.lis:3:11]
+ 2 │ fn test() {
+ 3 │   let m = Map.new<string, (int, int)>
+   ·           ─────────────┬─────────────
+   ·                        ╰── expected `()` after type arguments
+ 4 │ }
+   ╰────
+  help: Add parens to call it: `Map.new<string, (int, int)>()` · code: [parse.call_missing_parens]

--- a/tests/ui/errors/snapshots/parse_rust_turbofish_with_method.snap
+++ b/tests/ui/errors/snapshots/parse_rust_turbofish_with_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:17]
+ 2 │ fn test() {
+ 3 │   let xs = Slice::<int>::new()
+   ·                 ─┬
+   ·                  ╰── invalid syntax
+ 4 │ }
+   ╰────
+  help: Lisette does not use turbofish syntax. Use `Slice.new<int>()` instead · code: [parse.syntax_error]


### PR DESCRIPTION
Calls written without `()` after type arguments now name the corrected call instead of failing with a generic syntax error anchored on the comma. Diagnostic also spans no longer run through a trailing comment, and `Slice::<int>::new()` now reports one error rather than three.
