### PR TITLE
fix: anchor import cycle diagnostic on its imports

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -374,11 +374,20 @@ impl LisetteDiagnostic {
         )
     }
 
-    pub(crate) fn frame_labels(&self, use_color: bool) -> Vec<FrameLabel> {
-        let file_id = self.file_id();
+    pub(crate) fn label_file_ids(&self) -> Vec<u32> {
+        let mut file_ids: Vec<u32> = Vec::new();
+        for label in &self.labels {
+            if !file_ids.contains(&label.span.file_id) {
+                file_ids.push(label.span.file_id);
+            }
+        }
+        file_ids
+    }
+
+    pub(crate) fn frame_labels(&self, file_id: u32, use_color: bool) -> Vec<FrameLabel> {
         self.labels
             .iter()
-            .filter(|label| Some(label.span.file_id) == file_id)
+            .filter(|label| label.span.file_id == file_id)
             .map(|label| {
                 let formatted = if use_color {
                     let style = |s: &str| match self.severity {
@@ -526,6 +535,8 @@ mod tests {
 
         assert_eq!(diagnostic.file_id(), Some(3));
         assert_eq!(diagnostic.label_points(), vec![(3, 4), (7, 8)]);
-        assert_eq!(diagnostic.frame_labels(false).len(), 1);
+        assert_eq!(diagnostic.label_file_ids(), vec![3, 7]);
+        assert_eq!(diagnostic.frame_labels(3, false).len(), 1);
+        assert_eq!(diagnostic.frame_labels(7, false).len(), 1);
     }
 }

--- a/crates/diagnostics/src/graphical.rs
+++ b/crates/diagnostics/src/graphical.rs
@@ -172,26 +172,31 @@ fn read_window(
     })
 }
 
+pub(crate) struct FrameSource {
+    pub source: IndexedSource,
+    pub filename: String,
+    pub labels: Vec<FrameLabel>,
+}
+
 pub(crate) struct FrameReport<'a> {
     pub message: &'a str,
-    pub labels: &'a [FrameLabel],
+    pub sources: &'a [FrameSource],
     pub help: Option<&'a str>,
 }
 
 pub(crate) fn render_report(
     output: &mut String,
     report: &FrameReport<'_>,
-    source: Option<(&IndexedSource, &str)>,
     theme: &FrameTheme,
     context_lines: usize,
 ) -> fmt::Result {
     render_message(output, report.message, theme)?;
-    if let Some((source, filename)) = source {
+    for frame in report.sources {
         render_snippets(
             output,
-            source,
-            filename,
-            report.labels,
+            &frame.source,
+            &frame.filename,
+            &frame.labels,
             theme,
             context_lines,
         )?;

--- a/crates/diagnostics/src/module_graph.rs
+++ b/crates/diagnostics/src/module_graph.rs
@@ -305,8 +305,13 @@ pub fn unreachable_module(module_id: &str) -> LisetteDiagnostic {
         .with_help("This module is never imported. Use or remove it.")
 }
 
-pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
-    let is_self_import = path.len() == 2;
+pub struct CycleHop<'a> {
+    pub module: &'a str,
+    pub span: Span,
+}
+
+pub fn import_cycle(hops: &[CycleHop<'_>]) -> LisetteDiagnostic {
+    let is_self_import = hops.len() == 1;
 
     let help = if is_self_import {
         "Remove the self-import"
@@ -314,9 +319,35 @@ pub fn import_cycle(path: &[String]) -> LisetteDiagnostic {
         "To break the cycle, remove one of the imports or extract common dependencies into a separate module"
     };
 
-    LisetteDiagnostic::error(format!("Import cycle detected: {}", path.join(" -> ")))
-        .with_resolve_code("import_cycle")
-        .with_help(help)
+    let chain: Vec<&str> = hops
+        .iter()
+        .map(|hop| hop.module)
+        .chain(hops.first().map(|hop| hop.module))
+        .collect();
+
+    let mut diagnostic =
+        LisetteDiagnostic::error(format!("Import cycle detected: {}", chain.join(" -> ")))
+            .with_resolve_code("import_cycle")
+            .with_help(help);
+
+    for (index, hop) in hops.iter().enumerate() {
+        let label = if is_self_import {
+            format!("`{}` imports itself", hop.module)
+        } else {
+            format!(
+                "`{}` imports `{}`",
+                hop.module,
+                hops[(index + 1) % hops.len()].module
+            )
+        };
+        diagnostic = if index == 0 {
+            diagnostic.with_span_primary_label(&hop.span, label)
+        } else {
+            diagnostic.with_span_label(&hop.span, label)
+        };
+    }
+
+    diagnostic
 }
 
 #[cfg(test)]
@@ -331,11 +362,16 @@ mod tests {
         assert_eq!(diagnostic.code_str(), Some("resolve.unreachable_module"));
     }
 
+    fn hop(module: &str, file_id: u32) -> CycleHop<'_> {
+        CycleHop {
+            module,
+            span: Span::new(file_id, 7, 6),
+        }
+    }
+
     #[test]
     fn import_cycle_names_the_whole_chain_on_one_line() {
-        let cycle = ["alpha".to_string(), "beta".to_string(), "alpha".to_string()];
-
-        let diagnostic = import_cycle(&cycle);
+        let diagnostic = import_cycle(&[hop("alpha", 1), hop("beta", 2)]);
 
         assert_eq!(
             diagnostic.plain_message(),
@@ -345,15 +381,23 @@ mod tests {
     }
 
     #[test]
-    fn import_cycle_calls_out_a_self_import() {
-        let cycle = ["alpha".to_string(), "alpha".to_string()];
+    fn import_cycle_labels_the_import_of_every_hop() {
+        let diagnostic = import_cycle(&[hop("alpha", 1), hop("beta", 2)]);
 
-        let diagnostic = import_cycle(&cycle);
+        assert_eq!(diagnostic.label_file_ids(), vec![1, 2]);
+        assert_eq!(diagnostic.plain_label(), Some("`alpha` imports `beta`"));
+        assert_eq!(diagnostic.file_id(), Some(1));
+    }
+
+    #[test]
+    fn import_cycle_calls_out_a_self_import() {
+        let diagnostic = import_cycle(&[hop("alpha", 1)]);
 
         assert_eq!(
             diagnostic.plain_message(),
             "Import cycle detected: alpha -> alpha"
         );
         assert_eq!(diagnostic.plain_help(), Some("Remove the self-import"));
+        assert_eq!(diagnostic.plain_label(), Some("`alpha` imports itself"));
     }
 }

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -1,12 +1,11 @@
 use std::borrow::Cow;
-use std::fmt;
 use std::time::Duration;
 
 use rustc_hash::FxHashMap;
 
 use crate::LisetteDiagnostic;
 use crate::diagnostic::IndexedSource;
-use crate::graphical::{self, FrameReport, FrameTheme};
+use crate::graphical::{self, FrameReport, FrameSource, FrameTheme};
 use owo_colors::{OwoColorize, Style};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -155,35 +154,38 @@ fn frame_theme(diagnostic: &LisetteDiagnostic, use_color: bool) -> FrameTheme {
     }
 }
 
-fn write_graphical_report(
-    output: &mut String,
+/// Draws a frame for every file the labels point into.
+pub fn render_with_sources<F: Fn(u32) -> Option<(String, String)>>(
     diagnostic: &LisetteDiagnostic,
-    source: Option<(&IndexedSource, &str)>,
+    sources: &mut SourceCache<F>,
     use_color: bool,
     context_lines: usize,
-) -> fmt::Result {
-    let labels = diagnostic.frame_labels(use_color);
+) -> String {
+    let frames: Vec<FrameSource> = diagnostic
+        .label_file_ids()
+        .into_iter()
+        .filter_map(|file_id| {
+            let (source, filename) = sources.get(Some(file_id))?;
+            Some(FrameSource {
+                source,
+                filename,
+                labels: diagnostic.frame_labels(file_id, use_color),
+            })
+        })
+        .collect();
+
     let help = diagnostic.styled_help_text(use_color);
-    graphical::render_report(
-        output,
+    let mut output = String::new();
+    let _ = graphical::render_report(
+        &mut output,
         &FrameReport {
             message: &diagnostic.styled_message(use_color),
-            labels: &labels,
+            sources: &frames,
             help: help.as_deref(),
         },
-        source,
         &frame_theme(diagnostic, use_color),
         context_lines,
-    )
-}
-
-fn graphical_report(
-    diagnostic: &LisetteDiagnostic,
-    source: Option<(&IndexedSource, &str)>,
-    use_color: bool,
-) -> String {
-    let mut output = String::new();
-    let _ = write_graphical_report(&mut output, diagnostic, source, use_color, 1);
+    );
     output
 }
 
@@ -194,22 +196,11 @@ pub fn render_to_string(
     use_color: bool,
     context_lines: usize,
 ) -> String {
-    let source = IndexedSource::new(source);
-    let mut output = String::new();
-    let _ = write_graphical_report(
-        &mut output,
-        diagnostic,
-        Some((&source, filename)),
-        use_color,
-        context_lines,
-    );
-    output
-}
-
-pub fn render_standalone(diagnostic: &LisetteDiagnostic) -> String {
-    let mut output = String::new();
-    let _ = write_graphical_report(&mut output, diagnostic, None, false, 1);
-    output
+    let anchor = diagnostic.file_id();
+    let mut sources = SourceCache::new(|file_id| {
+        (Some(file_id) == anchor).then(|| (source.to_string(), filename.to_string()))
+    });
+    render_with_sources(diagnostic, &mut sources, use_color, context_lines)
 }
 
 fn render_group<F: Fn(u32) -> Option<(String, String)>>(
@@ -218,8 +209,7 @@ fn render_group<F: Fn(u32) -> Option<(String, String)>>(
     sources: &mut SourceCache<F>,
 ) {
     for diagnostic in diagnostics {
-        let source = sources.get(diagnostic.file_id());
-        eprintln!("{}", graphical_report(diagnostic, source, use_color));
+        eprintln!("{}", render_with_sources(diagnostic, sources, use_color, 1));
     }
 }
 
@@ -244,13 +234,13 @@ impl<F: Fn(u32) -> Option<(String, String)>> SourceCache<F> {
         }
     }
 
-    fn get(&mut self, file_id: Option<u32>) -> Option<(&IndexedSource, &str)> {
+    fn get(&mut self, file_id: Option<u32>) -> Option<(IndexedSource, String)> {
         let file_id = file_id?;
         let get_source = &self.get_source;
         let entry = self.cache.entry(file_id).or_insert_with(|| {
             get_source(file_id).map(|(source, name)| (IndexedSource::new(&source), name))
         });
-        entry.as_ref().map(|(source, name)| (source, name.as_str()))
+        entry.clone()
     }
 }
 
@@ -415,7 +405,9 @@ pub fn render_unix(
         .chain(&groups.warnings)
         .chain(&groups.info)
     {
-        output.push_str(&unix_line(diagnostic, sources.get(diagnostic.file_id())));
+        let source = sources.get(diagnostic.file_id());
+        let source = source.as_ref().map(|(text, name)| (text, name.as_str()));
+        output.push_str(&unix_line(diagnostic, source));
         output.push('\n');
     }
 
@@ -445,8 +437,7 @@ mod tests {
 
     fn graphical_output(diagnostic: &LisetteDiagnostic) -> String {
         let mut sources = SourceCache::new(entry_only);
-        let source = sources.get(diagnostic.file_id());
-        graphical_report(diagnostic, source, false)
+        render_with_sources(diagnostic, &mut sources, false, 1)
     }
 
     #[test]

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -380,7 +380,14 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     );
 
     for cycle in &graph_result.cycles {
-        sink.push(diagnostics::module_graph::import_cycle(cycle));
+        let hops: Vec<diagnostics::module_graph::CycleHop<'_>> = cycle
+            .iter()
+            .map(|hop| diagnostics::module_graph::CycleHop {
+                module: &hop.module,
+                span: hop.span,
+            })
+            .collect();
+        sink.push(diagnostics::module_graph::import_cycle(&hops));
     }
     let unreachable_modules = find_unreachable_modules(&discovered, &graph_result);
 

--- a/crates/semantics/src/analysis/modules.rs
+++ b/crates/semantics/src/analysis/modules.rs
@@ -1,6 +1,7 @@
 use super::*;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap as HashMap;
+use syntax::program::UninferredExports;
 
 struct CacheCandidate {
     compiled: CompiledModule,
@@ -241,6 +242,8 @@ pub(super) fn infer_all_modules(
     unparsed.extend(cache_load.missed);
 
     let has_parse_errors = parse_and_store_modules(&mut checker, store, unparsed, &mut to_infer);
+    let uninferred = std::mem::take(&mut input.graph_result.files);
+    store_uninferred_modules(&mut checker, store, uninferred);
 
     for pending in &to_infer {
         checker.predeclare_module_types(store, pending.module_id());
@@ -324,6 +327,38 @@ fn parse_and_store_modules(
         to_infer.push(module.pending);
     }
     has_parse_errors
+}
+
+fn store_uninferred_modules(
+    checker: &mut TaskState,
+    store: &mut Store,
+    modules: HashMap<String, Vec<ScannedFile>>,
+) {
+    for (module_id, scanned) in modules {
+        if scanned.is_empty() {
+            continue;
+        }
+        let mut files = Vec::with_capacity(scanned.len());
+        let mut parsed = true;
+        for scanned_file in scanned {
+            let (file, errors) = scanned_file.parse();
+            parsed &= errors.is_empty();
+            checker.sink.extend_parse_errors(errors);
+            files.push(file);
+        }
+        let exports = if parsed {
+            UninferredExports::Known(
+                files
+                    .iter()
+                    .filter(|file| !file.is_test())
+                    .flat_map(File::public_declarations)
+                    .collect(),
+            )
+        } else {
+            UninferredExports::Unreadable
+        };
+        store.store_uninferred_module(&module_id, files, exports);
+    }
 }
 
 /// Registers one `go:` module, reusing the stdlib cache when it covers the package.

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -438,12 +438,16 @@ impl InferCtx<'_> {
                 definition.visibility.is_public() && !store.is_test_definition(definition)
             })
         else {
-            self.sink
-                .push(diagnostics::infer::function_or_value_not_found_in_module(
-                    args.member_name,
-                    display_module,
-                    *args.span,
-                ));
+            if store.uninferred_module_may_export(&module_id, args.member_name) {
+                self.unify(args.expected_ty, &Type::Error, args.span);
+            } else {
+                self.sink
+                    .push(diagnostics::infer::function_or_value_not_found_in_module(
+                        args.member_name,
+                        display_module,
+                        *args.span,
+                    ));
+            }
             return Some(args.build_dot_access(
                 Type::Error,
                 DotAccessResolution::ModuleMember { definition: None },

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -358,8 +358,7 @@ impl InferCtx<'_> {
             return result;
         }
 
-        let is_bare_name =
-            fields.is_empty() && !identifier.contains('.') && !kind.is_pattern_position();
+        let is_bare_name = is_bare_constructor_name(&identifier, &fields, kind);
 
         let constructor_ty = if kind.is_match_arm()
             && let Some(ty) = self.resolve_bare_variant_type(&identifier, &expected_ty)
@@ -377,7 +376,7 @@ impl InferCtx<'_> {
                     &expected_ty,
                     span,
                     kind,
-                    is_bare_name,
+                    &fields,
                 );
             };
             ty
@@ -389,7 +388,7 @@ impl InferCtx<'_> {
                 &expected_ty,
                 span,
                 kind,
-                is_bare_name,
+                &fields,
             );
         };
 
@@ -532,9 +531,16 @@ impl InferCtx<'_> {
         expected_ty: &Type,
         span: Span,
         kind: BindingKind,
-        is_bare_name: bool,
+        fields: &[Pattern],
     ) -> Pattern {
-        if is_bare_name {
+        if self.may_name_uninferred_export(self.store, identifier) {
+            for field in fields {
+                self.infer_pattern_inner(field.clone(), Type::Error, kind, false);
+            }
+            return Pattern::WildCard { span };
+        }
+
+        if is_bare_constructor_name(identifier, fields, kind) {
             self.sink
                 .push(diagnostics::infer::uppercase_binding(span, identifier));
         } else {
@@ -624,6 +630,29 @@ impl InferCtx<'_> {
         })
     }
 
+    fn unresolved_struct_pattern(
+        &mut self,
+        identifier: &str,
+        fields: &[StructFieldPattern],
+        span: Span,
+        kind: BindingKind,
+    ) -> Pattern {
+        if !self.may_name_uninferred_export(self.store, identifier) {
+            self.sink
+                .push(diagnostics::infer::struct_not_found(identifier, span));
+            return Pattern::WildCard { span };
+        }
+
+        for field in fields {
+            let is_shorthand = matches!(
+                &field.value,
+                Pattern::Identifier { identifier, .. } if identifier == &field.name
+            );
+            self.infer_pattern_inner(field.value.clone(), Type::Error, kind, is_shorthand);
+        }
+        Pattern::WildCard { span }
+    }
+
     fn infer_struct_pattern(
         &mut self,
         pattern: Pattern,
@@ -655,11 +684,7 @@ impl InferCtx<'_> {
         let Some(qualified_name) = self.lookup_qualified_name(store, identifier) else {
             return self
                 .try_infer_enum_struct_variant(&pattern, &expected_ty, kind)
-                .unwrap_or_else(|| {
-                    self.sink
-                        .push(diagnostics::infer::struct_not_found(identifier, span));
-                    Pattern::WildCard { span }
-                });
+                .unwrap_or_else(|| self.unresolved_struct_pattern(identifier, fields, span, kind));
         };
         let Some(Definition {
             ty: struct_forall_ty,
@@ -673,11 +698,7 @@ impl InferCtx<'_> {
         else {
             return self
                 .try_infer_enum_struct_variant(&pattern, &expected_ty, kind)
-                .unwrap_or_else(|| {
-                    self.sink
-                        .push(diagnostics::infer::struct_not_found(identifier, span));
-                    Pattern::WildCard { span }
-                });
+                .unwrap_or_else(|| self.unresolved_struct_pattern(identifier, fields, span, kind));
         };
 
         let struct_forall_ty = struct_forall_ty.clone();
@@ -1104,6 +1125,10 @@ impl InferCtx<'_> {
             span: *span,
         })
     }
+}
+
+fn is_bare_constructor_name(identifier: &str, fields: &[Pattern], kind: BindingKind) -> bool {
+    fields.is_empty() && !identifier.contains('.') && !kind.is_pattern_position()
 }
 
 fn format_literal(lit: &Literal) -> String {

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -115,10 +115,12 @@ impl InferCtx<'_> {
             return self.infer_struct_call_for_enum_variant(literal, resolved, expected_ty);
         }
 
-        self.sink.push(diagnostics::infer::struct_not_found(
-            &literal.name,
-            literal.span,
-        ));
+        if !self.may_name_uninferred_export(store, &literal.name) {
+            self.sink.push(diagnostics::infer::struct_not_found(
+                &literal.name,
+                literal.span,
+            ));
+        }
         self.unify(expected_ty, &Type::Error, &literal.span);
         literal.with_type(Type::Error)
     }

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -281,7 +281,7 @@ impl TaskState {
                     annotation_span,
                     receiver.as_deref(),
                 ));
-            } else {
+            } else if !self.may_name_uninferred_export(store, type_name) {
                 self.sink.push(diagnostics::infer::type_not_found(
                     type_name,
                     annotation_span,

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -64,6 +64,15 @@ impl ImportState {
 }
 
 impl TaskState {
+    pub(super) fn may_name_uninferred_export(&self, store: &Store, name: &str) -> bool {
+        let Some((prefix, member)) = name.split_once('.') else {
+            return false;
+        };
+        self.imports
+            .module_id(prefix)
+            .is_some_and(|module_id| store.uninferred_module_may_export(module_id, member))
+    }
+
     /// Resolve a simple name (e.g., "Sunday") to a public definition in an imported module.
     /// First tries direct match (`module_id.name`), then falls back to searching
     /// for nested definitions (e.g., `module_id.Weekday.Sunday`) preferring top-level

--- a/crates/semantics/src/module_graph/kahn.rs
+++ b/crates/semantics/src/module_graph/kahn.rs
@@ -1,8 +1,18 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use syntax::ast::Span;
+
 use super::{DependencyGraph, ModuleId};
 
-pub fn topological_sort(edges: &DependencyGraph) -> (Vec<ModuleId>, Vec<Vec<ModuleId>>) {
+#[derive(Debug, Clone)]
+pub struct CycleHop {
+    pub module: ModuleId,
+    pub span: Span,
+}
+
+pub type Cycle = Vec<CycleHop>;
+
+pub fn topological_sort(edges: &DependencyGraph) -> (Vec<ModuleId>, Vec<Cycle>) {
     let mut in_degree: HashMap<ModuleId, usize> = HashMap::default();
     let mut order = Vec::new();
 
@@ -46,7 +56,7 @@ pub fn topological_sort(edges: &DependencyGraph) -> (Vec<ModuleId>, Vec<Vec<Modu
     (order, cycles)
 }
 
-fn find_cycles(edges: &DependencyGraph, processed: &[ModuleId]) -> Vec<Vec<ModuleId>> {
+fn find_cycles(edges: &DependencyGraph, processed: &[ModuleId]) -> Vec<Cycle> {
     let processed_set: HashSet<_> = processed.iter().collect();
     let unprocessed: Vec<_> = edges
         .modules()
@@ -61,26 +71,46 @@ fn find_cycles(edges: &DependencyGraph, processed: &[ModuleId]) -> Vec<Vec<Modul
             continue;
         }
 
-        let mut stack = vec![(start, vec![start.clone()])];
+        let mut stack: Vec<(&ModuleId, Cycle)> = vec![(start, Vec::new())];
 
         while let Some((node, path)) = stack.pop() {
             if !visited.insert(node.clone()) {
                 continue;
             }
 
-            for import in edges.dependencies(node) {
-                if let Some(position) = path.iter().position(|p| p == import) {
-                    let mut cycle_path: Vec<_> = path[position..].to_vec();
-                    cycle_path.push(import.clone());
-                    cycles.push(cycle_path);
+            for (import, span) in edges.imports(node) {
+                let hop = CycleHop {
+                    module: node.clone(),
+                    span,
+                };
+                let closes_on = path
+                    .iter()
+                    .chain([&hop])
+                    .position(|walked| &walked.module == import);
+                if let Some(position) = closes_on {
+                    let mut cycle: Cycle = path[position..].to_vec();
+                    cycle.push(hop);
+                    rotate_to_first_module(&mut cycle);
+                    cycles.push(cycle);
                 } else if !visited.contains(import) {
-                    let mut new_path = path.clone();
-                    new_path.push(import.clone());
-                    stack.push((import, new_path));
+                    let mut extended = path.clone();
+                    extended.push(hop);
+                    stack.push((import, extended));
                 }
             }
         }
     }
 
     cycles
+}
+
+/// So the reported chain does not depend on where the walk started.
+fn rotate_to_first_module(cycle: &mut Cycle) {
+    if let Some((position, _)) = cycle
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| left.module.cmp(&right.module))
+    {
+        cycle.rotate_left(position);
+    }
 }

--- a/crates/semantics/src/module_graph/mod.rs
+++ b/crates/semantics/src/module_graph/mod.rs
@@ -58,6 +58,14 @@ impl ImportUse {
 struct Dependency {
     kind: DependencyKind,
     usage: ImportUse,
+    span: Span,
+}
+
+impl Dependency {
+    fn merge(&mut self, other: Self) {
+        self.kind = self.kind.merge(other.kind);
+        self.usage = self.usage.merge(other.usage);
+    }
 }
 
 /// One canonical classification for every direct module dependency.
@@ -96,6 +104,17 @@ impl DependencyGraph {
             .get(module_id)
             .into_iter()
             .flat_map(HashMap::keys)
+    }
+
+    pub(crate) fn imports(&self, module_id: &str) -> impl Iterator<Item = (&ModuleId, Span)> {
+        self.edges
+            .get(module_id)
+            .into_iter()
+            .flat_map(|dependencies| {
+                dependencies
+                    .iter()
+                    .map(|(module_id, dependency)| (module_id, dependency.span))
+            })
     }
 
     pub(crate) fn production_dependencies(
@@ -145,6 +164,7 @@ impl From<HashMap<ModuleId, HashSet<ModuleId>>> for DependencyGraph {
                                 Dependency {
                                     kind: DependencyKind::Production,
                                     usage: ImportUse::Referenced,
+                                    span: Span::dummy(),
                                 },
                             )
                         })
@@ -195,7 +215,7 @@ impl ScannedFile {
 #[derive(Debug)]
 pub struct ModuleGraphResult {
     pub order: Vec<ModuleId>,
-    pub cycles: Vec<Vec<ModuleId>>,
+    pub cycles: Vec<kahn::Cycle>,
     pub files: HashMap<ModuleId, Vec<ScannedFile>>,
     pub dependencies: DependencyGraph,
     /// Reachable from the primary roots, snapshotted before `additional` runs.
@@ -365,20 +385,16 @@ impl<'a> GraphBuilder<'a> {
 
                 self.files.insert(module_id.clone(), module_files);
 
-                for (import, resolved) in &imports {
+                for (import, dependency) in &imports {
                     if !self.visited.contains(import) {
                         to_visit.push(import.clone());
                     }
                     self.import_spans
                         .entry(import.clone())
-                        .or_insert(resolved.span);
+                        .or_insert(dependency.span);
                 }
 
-                let dependencies = imports
-                    .into_iter()
-                    .map(|(module_id, resolved)| (module_id, resolved.dependency))
-                    .collect();
-                self.dependencies.insert(module_id.clone(), dependencies);
+                self.dependencies.insert(module_id.clone(), imports);
             }
         }
     }
@@ -550,19 +566,6 @@ fn scan_one(job: ScanJob) -> ScannedFile {
 }
 
 #[derive(Clone, Copy)]
-struct ResolvedImport {
-    span: Span,
-    dependency: Dependency,
-}
-
-impl ResolvedImport {
-    fn merge(&mut self, dependency: Dependency) {
-        self.dependency.kind = self.dependency.kind.merge(dependency.kind);
-        self.dependency.usage = self.dependency.usage.merge(dependency.usage);
-    }
-}
-
-#[derive(Clone, Copy)]
 struct ImportContext<'a> {
     sink: &'a LocalSink,
     scope: &'a AnalysisScope,
@@ -575,7 +578,7 @@ struct ImportContext<'a> {
 fn process_file_imports(
     file_imports: Vec<ClassifiedImport>,
     ctx: ImportContext<'_>,
-) -> HashMap<ModuleId, ResolvedImport> {
+) -> HashMap<ModuleId, Dependency> {
     let ImportContext {
         sink,
         scope,
@@ -585,7 +588,7 @@ fn process_file_imports(
         locator,
     } = ctx;
     let mut imports = HashMap::default();
-    let mut pending_go_imports: HashMap<&str, ResolvedImport> = HashMap::default();
+    let mut pending_go_imports: HashMap<&str, Dependency> = HashMap::default();
     for classified in &file_imports {
         let file_import = &classified.import;
         if !file_import.name.starts_with("go:") {
@@ -596,21 +599,15 @@ fn process_file_imports(
         } else {
             ImportUse::Referenced
         };
+        let dependency = Dependency {
+            kind: classified.kind,
+            usage,
+            span: file_import.name_span,
+        };
         pending_go_imports
             .entry(&file_import.name)
-            .and_modify(|pending| {
-                pending.merge(Dependency {
-                    kind: classified.kind,
-                    usage,
-                });
-            })
-            .or_insert(ResolvedImport {
-                span: file_import.name_span,
-                dependency: Dependency {
-                    kind: classified.kind,
-                    usage,
-                },
-            });
+            .and_modify(|pending| pending.merge(dependency))
+            .or_insert(dependency);
     }
 
     for classified in &file_imports {
@@ -660,14 +657,12 @@ fn process_file_imports(
                         let dependency = Dependency {
                             kind: classified.kind,
                             usage: ImportUse::Referenced,
+                            span: file_import.name_span,
                         };
                         imports
                             .entry(entry.to_string())
-                            .and_modify(|resolved: &mut ResolvedImport| resolved.merge(dependency))
-                            .or_insert(ResolvedImport {
-                                span: file_import.name_span,
-                                dependency,
-                            });
+                            .and_modify(|existing: &mut Dependency| existing.merge(dependency))
+                            .or_insert(dependency);
                     }
                     None if project_kind == ProjectKind::Binary => {
                         sink.push(diagnostics::module_graph::cannot_import_root_in_binary(
@@ -688,7 +683,7 @@ fn process_file_imports(
             let Some(pending) = pending_go_imports.remove(file_import.name.as_str()) else {
                 continue;
             };
-            let ok = match pending.dependency.usage {
+            let ok = match pending.usage {
                 ImportUse::Referenced => {
                     let result = locator.find_typedef_content(go_pkg);
                     emit_for_locator_result(
@@ -721,13 +716,7 @@ fn process_file_imports(
                 }
             };
             if ok {
-                imports.insert(
-                    file_import.name.to_string(),
-                    ResolvedImport {
-                        span: pending.span,
-                        dependency: pending.dependency,
-                    },
-                );
+                imports.insert(file_import.name.to_string(), pending);
             }
             continue;
         }
@@ -763,14 +752,12 @@ fn process_file_imports(
         let dependency = Dependency {
             kind: classified.kind,
             usage: ImportUse::Referenced,
+            span: file_import.name_span,
         };
         imports
             .entry(file_import.name.to_string())
-            .and_modify(|resolved: &mut ResolvedImport| resolved.merge(dependency))
-            .or_insert(ResolvedImport {
-                span: file_import.name_span,
-                dependency,
-            });
+            .and_modify(|existing: &mut Dependency| existing.merge(dependency))
+            .or_insert(dependency);
     }
 
     imports
@@ -818,7 +805,7 @@ mod tests {
         assert!(!sink.has_errors());
         resolved
             .get("go:fmt")
-            .is_some_and(|resolved| resolved.dependency.usage == ImportUse::LinkOnly)
+            .is_some_and(|dependency| dependency.usage == ImportUse::LinkOnly)
     }
 
     #[test]
@@ -928,6 +915,7 @@ mod tests {
         let dependency = |usage| Dependency {
             kind: DependencyKind::Production,
             usage,
+            span: Span::dummy(),
         };
         let mut graph = DependencyGraph::default();
         graph.insert(

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -5,7 +5,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::{EnumVariant, Expression, StructFieldDefinition};
 use syntax::program::{
-    Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module, TestIndex,
+    Definition, DefinitionBody, EqualityIndex, File, Interface, MethodSignatures, Module,
+    TestIndex, UninferredExports,
 };
 use syntax::types::{SimpleKind, SubstitutionMap, Symbol, Type, substitute};
 
@@ -110,6 +111,18 @@ impl Store {
         }
     }
 
+    pub(crate) fn store_uninferred_module(
+        &mut self,
+        module_id: &str,
+        files: Vec<File>,
+        exports: UninferredExports,
+    ) {
+        self.store_module(module_id, files);
+        if let Some(module) = self.get_module_mut(module_id) {
+            module.uninferred_exports = Some(exports);
+        }
+    }
+
     /// Stores a file in its owning module.
     pub fn store_file(&mut self, file: File) {
         let module_id = file.module_id.clone();
@@ -143,6 +156,13 @@ impl Store {
 
     pub(crate) fn has(&self, module_id: &str) -> bool {
         self.modules.contains_key(module_id)
+    }
+
+    pub(crate) fn uninferred_module_may_export(&self, module_id: &str, member: &str) -> bool {
+        self.modules
+            .get(module_id)
+            .and_then(|module| module.uninferred_exports.as_ref())
+            .is_some_and(|exports| exports.may_contain(member))
     }
 
     pub fn add_module(&mut self, module_id: &str) {

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::path::PathBuf;
 
-use ecow::EcoString;
+use ecow::{EcoString, eco_format};
 
 use crate::ast::{Expression, ImportAlias, Span};
 
@@ -128,6 +128,55 @@ impl File {
                 _ => None,
             })
             .collect()
+    }
+
+    pub fn public_declarations(&self) -> Vec<EcoString> {
+        let exports_all = self.is_d_lis();
+        let mut names = Vec::new();
+        for item in &self.items {
+            let (name, visibility) = match item {
+                Expression::Function {
+                    name, visibility, ..
+                }
+                | Expression::Struct {
+                    name, visibility, ..
+                }
+                | Expression::TypeAlias {
+                    name, visibility, ..
+                }
+                | Expression::Interface {
+                    name, visibility, ..
+                }
+                | Expression::VariableDeclaration {
+                    name, visibility, ..
+                } => (name, visibility),
+                Expression::Const {
+                    identifier,
+                    visibility,
+                    ..
+                } => (identifier, visibility),
+                Expression::Enum {
+                    name,
+                    variants,
+                    visibility,
+                    ..
+                } => {
+                    if exports_all || visibility.is_public() {
+                        names.extend(
+                            variants
+                                .iter()
+                                .map(|variant| eco_format!("{}.{}", name, variant.name)),
+                        );
+                    }
+                    (name, visibility)
+                }
+                _ => continue,
+            };
+            if exports_all || visibility.is_public() {
+                names.push(name.clone());
+            }
+        }
+        names
     }
 
     /// Redirects `import "{from}"` to `to`, keeping the source spelling as the qualifier.

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -12,7 +12,7 @@ pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,
 };
 pub use file::{File, FileImport, go_import_default_name, is_test_file, unaliased_binding_name};
-pub use module::{Module, ModuleId};
+pub use module::{Module, ModuleId, UninferredExports};
 pub use resolution::{
     CallKind, ChannelOperation, DotAccessKind, DotAccessResolution, NativeTypeKind,
     ReceiverCoercion, channel_operation, resolved_definition,

--- a/crates/syntax/src/program/module.rs
+++ b/crates/syntax/src/program/module.rs
@@ -1,4 +1,5 @@
-use rustc_hash::FxHashMap as HashMap;
+use ecow::EcoString;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::definition::{Definition, Visibility};
 use super::file::File;
@@ -13,6 +14,26 @@ pub struct Module {
     pub files: HashMap<u32, File>,
     /// qualified name -> definition
     pub definitions: HashMap<Symbol, Definition>,
+    /// Set when an import cycle keeps the module out of inference: nothing
+    /// registers its files, so its exports are read from syntax.
+    pub uninferred_exports: Option<UninferredExports>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UninferredExports {
+    /// Read from the syntax of the module's files.
+    Known(HashSet<EcoString>),
+    /// A file did not parse, so its declarations cannot be read.
+    Unreadable,
+}
+
+impl UninferredExports {
+    pub fn may_contain(&self, member: &str) -> bool {
+        match self {
+            Self::Known(names) => names.contains(member),
+            Self::Unreadable => true,
+        }
+    }
 }
 
 impl Module {
@@ -21,6 +42,7 @@ impl Module {
             id: id.to_string(),
             files: Default::default(),
             definitions: Default::default(),
+            uninferred_exports: None,
         }
     }
 

--- a/tests/_harness/formatting.rs
+++ b/tests/_harness/formatting.rs
@@ -25,6 +25,21 @@ pub fn format_result_diagnostic_for_snapshot(
     format_diagnostic_for_snapshot(diagnostic, &file.source, &file.name)
 }
 
+/// Renders a diagnostic against every file it labels, the way the CLI does.
+pub fn format_project_diagnostic_for_snapshot(
+    result: &Analysis,
+    diagnostic: &LisetteDiagnostic,
+) -> String {
+    let mut sources = diagnostics::render::SourceCache::new(|file_id: u32| {
+        result
+            .emit_input
+            .files
+            .get(&file_id)
+            .map(|file| (file.source.clone(), file.name.clone()))
+    });
+    diagnostics::render::render_with_sources(diagnostic, &mut sources, false, 1)
+}
+
 /// Escapes carriage returns, which insta's YAML literal blocks cannot round-trip.
 pub fn snapshot_description(input: &str) -> String {
     input.replace('\r', "\\r")
@@ -46,8 +61,4 @@ pub fn format_diagnostic_unix(
 pub fn format_parse_error_unix(error: &ParseError, source: &str, filename: &str) -> String {
     let diagnostic: LisetteDiagnostic = error.clone().into();
     format_diagnostic_unix(&diagnostic, source, filename)
-}
-
-pub fn format_diagnostic_standalone(diagnostic: &LisetteDiagnostic) -> String {
-    diagnostics::render::render_standalone(diagnostic)
 }

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -236,6 +236,294 @@ fn graph_cycle_detection() {
 }
 
 #[test]
+fn graph_cycle_carries_the_span_of_every_hop() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("a", "a.lis", "import \"b\"\n");
+    fs.add_file("b", "b.lis", "import \"a\"\n");
+
+    let mut store = Store::new();
+
+    let sink = LocalSink::new();
+    let result = build_module_graph(
+        &mut store,
+        roots("a"),
+        graph_options(&fs, &sink, &default_resolver(), &PROJECT_SCOPE),
+    );
+
+    let cycle = result.cycles.first().expect("the cycle must be detected");
+    let modules: Vec<&str> = cycle.iter().map(|hop| hop.module.as_str()).collect();
+    assert_eq!(
+        modules,
+        vec!["a", "b"],
+        "a cycle starts at its first module"
+    );
+    for hop in cycle {
+        assert_eq!(
+            hop.span.byte_offset, 7,
+            "each hop points at the name of its own `import`"
+        );
+    }
+    assert_ne!(
+        cycle[0].span.file_id, cycle[1].span.file_id,
+        "each hop belongs to the file that declares its import"
+    );
+}
+
+/// Every way an importer can name something in a module the cycle dropped.
+fn analyze_importer_of_cycle(entry_source: &str) -> passes::Analysis {
+    use passes::analyze;
+    use semantics::loader::MemoryLoader;
+    use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile};
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fs = MemoryLoader::new();
+    fs.add_file(
+        "alpha",
+        "alpha.lis",
+        "import \"beta\"\n\
+         pub struct Node { pub id: int }\n\
+         pub enum Color { Red, Green }\n\
+         pub enum Shape { Circle(int), Square(int) }\n\
+         pub const LIMIT: int = 10\n\
+         pub fn describe(n: Node) -> string { beta.render(n.id) }\n\
+         pub fn mk() -> Node { Node { id: 1 } }\n",
+    );
+    fs.add_file(
+        "beta",
+        "beta.lis",
+        "import \"alpha\"\npub fn render(_id: int) -> string { \"node\" }\n",
+    );
+
+    analyze(AnalyzeInput {
+        load_siblings: false,
+        scope: AnalysisScope::Project(tmp.path().to_path_buf()),
+        loader: &fs,
+        entry: Some(EntryFile::new(
+            entry_source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
+        compile_phase: CompilePhase::Check,
+        project_kind: semantics::ProjectKind::Binary,
+        locator: &deps::TypedefLocator::default(),
+        go_module: "",
+        disable_cache: true,
+    })
+}
+
+fn error_codes(analysis: &passes::Analysis) -> Vec<&str> {
+    analysis
+        .errors()
+        .iter()
+        .filter_map(|error| error.code_str())
+        .collect()
+}
+
+#[test]
+fn cycle_suppresses_the_name_errors_it_causes_in_importers() {
+    let output = analyze_importer_of_cycle(
+        "import \"alpha\"\n\
+         \n\
+         fn main() {\n\
+         \x20 let a = alpha.Node { id: 1 }\n\
+         \x20 let b: alpha.Node = alpha.mk()\n\
+         \x20 let c = alpha.describe(a)\n\
+         \x20 let d = alpha.LIMIT\n\
+         \x20 let e = alpha.Color.Red\n\
+         \x20 let f: Slice<alpha.Node> = []\n\
+         \x20 let g = alpha.Node { ..a }\n\
+         \x20 match alpha.mk() {\n\
+         \x20   alpha.Node { id } => { let _ = id },\n\
+         \x20 }\n\
+         \x20 match e {\n\
+         \x20   alpha.Color.Red => {},\n\
+         \x20   alpha.Color.Green => {},\n\
+         \x20 }\n\
+         \x20 match alpha.Shape.Circle(1) {\n\
+         \x20   alpha.Shape.Circle(r) => { let _ = r },\n\
+         \x20   alpha.Shape.Square(s) => { let _ = s },\n\
+         \x20 }\n\
+         }\n",
+    );
+
+    assert_eq!(
+        error_codes(&output),
+        vec!["resolve.import_cycle"],
+        "every one of those names is declared and `pub` in `alpha`, and unresolvable \
+         only because the cycle dropped it"
+    );
+}
+
+/// A name the dropped module never declared is the caller's own mistake.
+#[test]
+fn cycle_still_reports_names_the_dropped_module_never_declared() {
+    let output = analyze_importer_of_cycle(
+        "import \"alpha\"\n\
+         \n\
+         fn main() {\n\
+         \x20 let _ = alpha.missing()\n\
+         \x20 let _ = alpha.LIMITT\n\
+         \x20 let _ = alpha.Nope { x: 1 }\n\
+         \x20 let _: alpha.NoType = 1\n\
+         \x20 match alpha.Shape.Circle(1) {\n\
+         \x20   alpha.Shape.Triangle(r) => { let _ = r },\n\
+         \x20   _ => {},\n\
+         \x20 }\n\
+         }\n",
+    );
+
+    let mut codes = error_codes(&output);
+    codes.sort_unstable();
+    codes.dedup();
+    assert_eq!(
+        codes,
+        vec![
+            "resolve.import_cycle",
+            "resolve.name_not_found",
+            "resolve.not_found_in_module",
+            "resolve.struct_not_found",
+            "resolve.type_not_found",
+            "resolve.variant_not_found",
+        ],
+    );
+}
+
+/// A typedef exports every declaration, `pub` or not.
+#[test]
+fn cycle_reads_the_exports_of_a_declaration_only_module() {
+    use passes::analyze;
+    use semantics::loader::MemoryLoader;
+    use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile};
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fs = MemoryLoader::new();
+    fs.add_file(
+        "decl",
+        "decl.d.lis",
+        "import \"beta\"\n\
+         pub var Counter: int\n\
+         var Hidden: int\n\
+         pub fn helper() -> int\n\
+         enum Mode { Fast, Slow }\n",
+    );
+    fs.add_file(
+        "beta",
+        "beta.lis",
+        "import \"decl\"\npub fn g() -> int { decl.helper() }\n",
+    );
+
+    let source = "import \"decl\"\n\
+                  \n\
+                  fn main() {\n\
+                  \x20 let _ = decl.Counter\n\
+                  \x20 let _ = decl.Hidden\n\
+                  \x20 let _ = decl.helper()\n\
+                  \x20 let _ = decl.Mode.Fast\n\
+                  }\n";
+    let output = analyze(AnalyzeInput {
+        load_siblings: false,
+        scope: AnalysisScope::Project(tmp.path().to_path_buf()),
+        loader: &fs,
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
+        compile_phase: CompilePhase::Check,
+        project_kind: semantics::ProjectKind::Binary,
+        locator: &deps::TypedefLocator::default(),
+        go_module: "",
+        disable_cache: true,
+    });
+
+    assert_eq!(error_codes(&output), vec!["resolve.import_cycle"]);
+}
+
+/// Suppression follows the reference, not the file.
+#[test]
+fn cycle_keeps_the_unrelated_errors_of_an_importer() {
+    let output = analyze_importer_of_cycle(
+        "import \"alpha\"\n\
+         import \"alpha\"\n\
+         \n\
+         fn main() {\n\
+         \x20 let _ = alpha.mk()\n\
+         \x20 let _ = undefined_local\n\
+         \x20 let _: Undeclared = 1\n\
+         \x20 let _ = Nonexistent { x: 1 }\n\
+         }\n",
+    );
+
+    let mut codes = error_codes(&output);
+    codes.sort_unstable();
+    codes.dedup();
+    assert_eq!(
+        codes,
+        vec![
+            "resolve.duplicate_import",
+            "resolve.import_cycle",
+            "resolve.name_not_found",
+            "resolve.struct_not_found",
+            "resolve.type_not_found",
+        ],
+    );
+}
+
+/// An unregistered `go:` module would reach the shared stdlib cache empty.
+#[test]
+fn cycle_keeps_unregistered_go_modules_out_of_the_store() {
+    use passes::analyze;
+    use semantics::loader::MemoryLoader;
+    use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile};
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut fs = MemoryLoader::new();
+    fs.add_file(
+        "alpha",
+        "alpha.lis",
+        "import \"beta\"\nimport \"go:fmt\"\npub fn f() -> string { fmt.Sprintf(\"%d\", beta.g()) }\n",
+    );
+    fs.add_file(
+        "beta",
+        "beta.lis",
+        "import \"alpha\"\npub fn g() -> int { 2 }\n",
+    );
+
+    let source = "import \"alpha\"\n\nfn main() {\n  let _ = alpha.f()\n}\n";
+    let output = analyze(AnalyzeInput {
+        load_siblings: false,
+        scope: AnalysisScope::Project(tmp.path().to_path_buf()),
+        loader: &fs,
+        entry: Some(EntryFile::new(
+            source.to_string(),
+            "main.lis".to_string(),
+            "main.lis".to_string(),
+        )),
+        compile_phase: CompilePhase::Check,
+        project_kind: semantics::ProjectKind::Binary,
+        locator: &deps::TypedefLocator::default(),
+        go_module: "",
+        disable_cache: true,
+    });
+
+    assert!(
+        output.emit_input.go_module_ids.is_empty(),
+        "`go:fmt` is imported only by a module the cycle dropped, so it is never \
+         registered and must not reach the store: {:?}",
+        output.emit_input.go_module_ids,
+    );
+    assert!(
+        output
+            .errors()
+            .iter()
+            .any(|error| error.code_str() == Some("resolve.import_cycle")),
+    );
+}
+
+#[test]
 fn additional_roots_widen_graph_but_not_reachable_set() {
     let mut fs = MockFileSystem::new();
     fs.add_file("main", "main.lis", r#"import "lib""#);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1,13 +1,14 @@
 use crate::_harness::build::compile_check;
 use crate::_harness::filesystem::MockFileSystem;
-use crate::_harness::formatting::{format_diagnostic_for_snapshot, format_diagnostic_standalone};
+use crate::_harness::formatting::{
+    format_diagnostic_for_snapshot, format_project_diagnostic_for_snapshot,
+};
 use crate::_harness::infer::{infer, infer_module};
 use crate::{
     assert_infer_error_snapshot, assert_lex_error_snapshot,
     assert_multimodule_infer_error_snapshot, assert_parse_error_snapshot,
 };
 
-use diagnostics::module_graph::import_cycle;
 use semantics::store::ENTRY_MODULE_ID;
 
 #[test]
@@ -4611,17 +4612,42 @@ fn test() {
     });
 }
 
+fn cycle_diagnostic_snapshot(fs: MockFileSystem) -> String {
+    let result = compile_check(fs);
+    let cycle = result
+        .errors()
+        .iter()
+        .find(|error| error.code_str() == Some("resolve.import_cycle"))
+        .expect("the cycle must be reported");
+
+    format_project_diagnostic_for_snapshot(&result, cycle)
+}
+
 #[test]
 fn module_graph_import_cycle() {
-    let cycle = vec![
-        "module_a".to_string(),
-        "module_b".to_string(),
-        "module_c".to_string(),
-        "module_a".to_string(),
-    ];
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"module_a\"\n\nfn main() {}\n",
+    );
+    fs.add_file(
+        "module_a",
+        "module_a.lis",
+        "import \"module_b\"\n\npub fn a() -> int { module_b.b() }\n",
+    );
+    fs.add_file(
+        "module_b",
+        "module_b.lis",
+        "import \"module_c\"\n\npub fn b() -> int { module_c.c() }\n",
+    );
+    fs.add_file(
+        "module_c",
+        "module_c.lis",
+        "import \"module_a\"\n\npub fn c() -> int { module_a.a() }\n",
+    );
 
-    let diagnostic = import_cycle(&cycle);
-    let output = format_diagnostic_standalone(&diagnostic);
+    let output = cycle_diagnostic_snapshot(fs);
 
     insta::with_settings!({
         prepend_module_to_snapshot => false,
@@ -4633,10 +4659,19 @@ fn module_graph_import_cycle() {
 
 #[test]
 fn module_graph_import_self_loop() {
-    let cycle = vec!["module_a".to_string(), "module_a".to_string()];
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_MODULE_ID,
+        "main.lis",
+        "import \"module_a\"\n\nfn main() {}\n",
+    );
+    fs.add_file(
+        "module_a",
+        "module_a.lis",
+        "import \"module_a\"\n\npub fn a() -> int { 1 }\n",
+    );
 
-    let diagnostic = import_cycle(&cycle);
-    let output = format_diagnostic_standalone(&diagnostic);
+    let output = cycle_diagnostic_snapshot(fs);
 
     insta::with_settings!({
         prepend_module_to_snapshot => false,

--- a/tests/ui/errors/snapshots/module_graph_import_cycle.snap
+++ b/tests/ui/errors/snapshots/module_graph_import_cycle.snap
@@ -2,4 +2,22 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Import cycle detected: module_a -> module_b -> module_c -> module_a
+   ╭─[module_a.lis:1:8]
+ 1 │ import "module_b"
+   ·        ─────┬────
+   ·             ╰── `module_a` imports `module_b`
+ 2 │ 
+   ╰────
+   ╭─[module_b.lis:1:8]
+ 1 │ import "module_c"
+   ·        ─────┬────
+   ·             ╰── `module_b` imports `module_c`
+ 2 │ 
+   ╰────
+   ╭─[module_c.lis:1:8]
+ 1 │ import "module_a"
+   ·        ─────┬────
+   ·             ╰── `module_c` imports `module_a`
+ 2 │ 
+   ╰────
   help: To break the cycle, remove one of the imports or extract common dependencies into a separate module · code: [resolve.import_cycle]

--- a/tests/ui/errors/snapshots/module_graph_import_self_loop.snap
+++ b/tests/ui/errors/snapshots/module_graph_import_self_loop.snap
@@ -2,4 +2,10 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Import cycle detected: module_a -> module_a
+   ╭─[module_a.lis:1:8]
+ 1 │ import "module_a"
+   ·        ─────┬────
+   ·             ╰── `module_a` imports itself
+ 2 │ 
+   ╰────
   help: Remove the self-import · code: [resolve.import_cycle]


### PR DESCRIPTION
An import cycle now points at the imports that form it in every file involved, instead of printing a bare line with no location. The names those modules export are no longer misreported as missing, so the only error is the cycle itself.

```
  ✕ Import cycle detected: alpha -> beta -> alpha
   ╭─[src/alpha/a.lis:1:8]
 1 │ import "beta"
   ·        ───┬──
   ·           ╰── `alpha` imports `beta`
 2 │ pub struct Node { pub id: int }
   ╰────
   ╭─[src/beta/b.lis:1:8]
 1 │ import "alpha"
   ·        ───┬───
   ·           ╰── `beta` imports `alpha`
 2 │ pub fn render(_id: int) -> string { "node" }
   ╰────
  help: To break the cycle, remove one of the imports or extract common dependencies into a separate module · code: [resolve.import_cycle]
```
