### PR TITLE
feat: `lis build` and `lis emit` for scripts

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -34,10 +34,12 @@ pub enum Command {
         path: Option<String>,
         sourcemap: bool,
         go_flags: Vec<String>,
+        output: Option<String>,
     },
     Emit {
         path: Option<String>,
         sourcemap: bool,
+        output: Option<String>,
     },
     Run {
         target: Option<String>,
@@ -103,24 +105,61 @@ pub enum ParseError {
     },
 }
 
-fn parse_path_and_sourcemap(
-    arguments: impl Iterator<Item = String>,
-) -> Result<(Option<String>, bool), ParseError> {
+fn parse_emit(mut arguments: impl Iterator<Item = String>) -> Result<Command, ParseError> {
     let mut path = None;
     let mut sourcemap = false;
-    for arg in arguments {
-        match arg.as_str() {
-            "--sourcemap" => sourcemap = true,
-            s if s.starts_with('-') => return Err(ParseError::UnknownFlag(s.to_string())),
-            s => set_target(
-                &mut path,
-                s.to_string(),
-                "emit",
-                "Run `lis emit` once per path",
-            )?,
+    let mut output = None;
+
+    while let Some(arg) = arguments.next() {
+        if arg == "--sourcemap" {
+            sourcemap = true;
+        } else if let Some(value) = output_value(&arg, &mut arguments, "emit")? {
+            output = Some(value);
+        } else if arg.starts_with('-') {
+            return Err(ParseError::UnknownFlag(arg));
+        } else {
+            set_target(&mut path, arg, "emit", "Run `lis emit` once per path")?;
         }
     }
-    Ok((path, sourcemap))
+
+    Ok(Command::Emit {
+        path,
+        sourcemap,
+        output,
+    })
+}
+
+/// An option-looking value almost always means the path was left off, so a
+/// real one is spelled `./-name`.
+fn output_value(
+    arg: &str,
+    arguments: &mut impl Iterator<Item = String>,
+    command: &'static str,
+) -> Result<Option<String>, ParseError> {
+    let Some(value) = flag_value(arg, &["-o", "--output"], arguments, command, "-o <path>")? else {
+        return Ok(None);
+    };
+
+    if value.is_empty() {
+        return Err(ParseError::MissingArgument {
+            command,
+            argument: "-o <path>",
+        });
+    }
+
+    if value.starts_with('-') {
+        return Err(ParseError::UnexpectedArgument {
+            message: format!("unexpected value `{}` for `-o`", value),
+            reason: "`-o` takes a path, and a value starting with `-` reads as another flag"
+                .to_string(),
+            hint: format!(
+                "Give the path, or write `./{}` if that really is the filename",
+                value
+            ),
+        });
+    }
+
+    Ok(Some(value))
 }
 
 fn set_target(
@@ -264,10 +303,7 @@ impl Command {
         match command.as_str() {
             "new" => parse_new(arguments),
             "build" | "b" => parse_build(arguments),
-            "emit" | "e" => {
-                let (path, sourcemap) = parse_path_and_sourcemap(arguments)?;
-                Ok(Command::Emit { path, sourcemap })
-            }
+            "emit" | "e" => parse_emit(arguments),
             "run" | "r" => parse_run(arguments),
             "format" | "f" => parse_format(arguments),
             "check" | "c" => parse_check(arguments),
@@ -313,6 +349,7 @@ fn parse_build(mut arguments: impl Iterator<Item = String>) -> Result<Command, P
     let mut path = None;
     let mut sourcemap = false;
     let mut go_flags = Vec::new();
+    let mut output = None;
 
     while let Some(arg) = arguments.next() {
         if arg == "--sourcemap" {
@@ -325,6 +362,8 @@ fn parse_build(mut arguments: impl Iterator<Item = String>) -> Result<Command, P
             "--go-flags <flags>",
         )? {
             extend_go_flags(&mut go_flags, &value)?;
+        } else if let Some(value) = output_value(&arg, &mut arguments, "build")? {
+            output = Some(value);
         } else if arg.starts_with('-') {
             return Err(ParseError::UnknownFlag(arg));
         } else {
@@ -336,6 +375,7 @@ fn parse_build(mut arguments: impl Iterator<Item = String>) -> Result<Command, P
         path,
         sourcemap,
         go_flags,
+        output,
     })
 }
 
@@ -1205,7 +1245,9 @@ mod tests {
 
     #[test]
     fn emit_parses_path_and_sourcemap() {
-        let Ok(Command::Emit { path, sourcemap }) = parse(&["lis", "emit", "src", "--sourcemap"])
+        let Ok(Command::Emit {
+            path, sourcemap, ..
+        }) = parse(&["lis", "emit", "src", "--sourcemap"])
         else {
             panic!("expected Emit command");
         };
@@ -1219,6 +1261,87 @@ mod tests {
             parse(&["lis", "emit", "--bogus"]),
             Err(ParseError::UnknownFlag(_))
         ));
+    }
+
+    #[test]
+    fn emit_parses_both_output_spellings() {
+        for argument in [
+            vec!["lis", "emit", "tool.lis", "-o", "out.go"],
+            vec!["lis", "emit", "tool.lis", "--output", "out.go"],
+            vec!["lis", "emit", "tool.lis", "--output=out.go"],
+        ] {
+            let Ok(Command::Emit { path, output, .. }) = parse(&argument) else {
+                panic!("expected Emit command for {argument:?}");
+            };
+            assert_eq!(path.as_deref(), Some("tool.lis"));
+            assert_eq!(output.as_deref(), Some("out.go"), "for {argument:?}");
+        }
+    }
+
+    #[test]
+    fn build_parses_output_beside_go_flags() {
+        let Ok(Command::Build {
+            path,
+            go_flags,
+            output,
+            ..
+        }) = parse(&[
+            "lis",
+            "build",
+            "tool.lis",
+            "-o",
+            "dist/tool",
+            "--go-flags",
+            "-trimpath",
+        ])
+        else {
+            panic!("expected Build command");
+        };
+        assert_eq!(path.as_deref(), Some("tool.lis"));
+        assert_eq!(output.as_deref(), Some("dist/tool"));
+        assert_eq!(go_flags, vec!["-trimpath"]);
+    }
+
+    #[test]
+    fn output_flag_without_a_path_is_a_missing_argument() {
+        for argument in [vec!["lis", "emit", "-o"], vec!["lis", "build", "-o"]] {
+            assert!(
+                matches!(
+                    parse(&argument),
+                    Err(ParseError::MissingArgument {
+                        argument: "-o <path>",
+                        ..
+                    })
+                ),
+                "expected a missing-argument error for {argument:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn output_flag_rejects_a_value_that_looks_like_an_option() {
+        for argument in [
+            vec!["lis", "build", "-o", "--sourcemap"],
+            vec!["lis", "build", "-o", "--go-flags"],
+            vec!["lis", "emit", "-o", "--output"],
+            vec!["lis", "emit", "-o", "--bogus"],
+            vec!["lis", "emit", "--output=-o"],
+        ] {
+            assert!(
+                matches!(parse(&argument), Err(ParseError::UnexpectedArgument { .. })),
+                "expected a rejection for {argument:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn output_flag_accepts_a_dash_path_spelled_relatively() {
+        let Ok(Command::Emit { output, .. }) =
+            parse(&["lis", "emit", "f.lis", "-o", "./-weird.go"])
+        else {
+            panic!("expected Emit command");
+        };
+        assert_eq!(output.as_deref(), Some("./-weird.go"));
     }
 
     #[test]

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -21,17 +21,62 @@ use semantics::loader::{
 };
 use semantics::store::ENTRY_MODULE_ID;
 
-pub fn emit(path: Option<String>, sourcemap: bool) -> i32 {
-    with_locked_project(path, |prep| {
-        match build_locked(prep, BuildPurpose::Emit { sourcemap }) {
-            Ok(_) => 0,
-            Err(code) => code,
+pub fn emit(path: Option<String>, sourcemap: bool, output: Option<String>) -> i32 {
+    let target = path.unwrap_or_else(|| ".".to_string());
+    let target_path = Path::new(&target);
+
+    match resolve_target(target_path, "Failed to emit") {
+        Err(code) => code,
+        Ok(BuildTarget::Script { inside_project }) => {
+            super::script::emit(target_path, sourcemap, output.as_deref(), inside_project)
         }
-    })
+        Ok(BuildTarget::Project(root)) => {
+            if reject_project_output(output.as_deref(), "writes Go to `target/`").is_err() {
+                return 1;
+            }
+            with_locked_project(&root, |prep| {
+                match build_locked(prep, BuildPurpose::Emit { sourcemap }) {
+                    Ok(_) => 0,
+                    Err(code) => code,
+                }
+            })
+        }
+    }
 }
 
-pub fn build(path: Option<String>, sourcemap: bool, go_flags: Vec<String>) -> i32 {
-    with_locked_project(path, |prep| {
+pub fn build(
+    path: Option<String>,
+    sourcemap: bool,
+    go_flags: Vec<String>,
+    output: Option<String>,
+) -> i32 {
+    let target = path.unwrap_or_else(|| ".".to_string());
+    let target_path = Path::new(&target);
+
+    let root = match resolve_target(target_path, "Failed to build") {
+        Err(code) => return code,
+        Ok(BuildTarget::Script { inside_project }) => {
+            return super::script::build(
+                target_path,
+                sourcemap,
+                &go_flags,
+                output.as_deref(),
+                inside_project,
+            );
+        }
+        Ok(BuildTarget::Project(root)) => root,
+    };
+
+    if reject_project_output(
+        output.as_deref(),
+        "links into `target/bin/`. Use `--go-flags \"-o <path>\"` to choose the location",
+    )
+    .is_err()
+    {
+        return 1;
+    }
+
+    with_locked_project(&root, |prep| {
         if prep.kind == ProjectKind::Library {
             if go_flags.iter().any(|f| go_cli::is_go_output_flag(f)) {
                 cli_error!(
@@ -106,22 +151,60 @@ fn build_library(project: &LockedProject, go_flags: &[String], target: stdlib::T
     0
 }
 
-pub(super) fn with_locked_project(
-    path: Option<String>,
-    f: impl FnOnce(&LockedProject) -> i32,
-) -> i32 {
-    let target = path.unwrap_or_else(|| ".".to_string());
-    let target_path = Path::new(&target);
+enum BuildTarget {
+    Script { inside_project: bool },
+    Project(PathBuf),
+}
 
-    let owning_project = target_path
-        .is_file()
-        .then(|| match super::project::resolve_file_target(target_path) {
-            FileTarget::ProjectEntry { root } | FileTarget::ProjectModule { root } => Some(root),
-            FileTarget::Script { .. } => None,
-        })
-        .flatten();
+/// A file is a script, a directory is a project, anything else an error.
+fn resolve_target(target: &Path, heading: &str) -> Result<BuildTarget, i32> {
+    if !target.exists() {
+        cli_error!(
+            heading,
+            format!("Path `{}` does not exist", target.display()),
+            "Check the path and try again"
+        );
+        return Err(1);
+    }
 
-    let project = match LockedProject::acquire(owning_project.as_deref().unwrap_or(target_path)) {
+    if !target.is_file() {
+        return Ok(BuildTarget::Project(target.to_path_buf()));
+    }
+
+    match super::project::resolve_file_target(target) {
+        FileTarget::ProjectEntry { root } | FileTarget::ProjectModule { root } => {
+            Ok(BuildTarget::Project(root))
+        }
+        FileTarget::Script { inside_project } => Ok(BuildTarget::Script { inside_project }),
+    }
+}
+
+/// `-o` names one artifact, which a project build does not produce.
+fn reject_project_output(output: Option<&str>, instead: &str) -> Result<(), i32> {
+    if output.is_none() {
+        return Ok(());
+    }
+
+    cli_error!(
+        "Unsupported flag",
+        format!("`-o` has no meaning for a project, which {}", instead),
+        "Remove `-o`, or pass a single file to compile it as a script"
+    );
+    Err(1)
+}
+
+pub(super) fn project_root_for(target: &Path) -> PathBuf {
+    if !target.is_file() {
+        return target.to_path_buf();
+    }
+    match super::project::resolve_file_target(target) {
+        FileTarget::ProjectEntry { root } | FileTarget::ProjectModule { root } => root,
+        FileTarget::Script { .. } => target.to_path_buf(),
+    }
+}
+
+pub(super) fn with_locked_project(path: &Path, f: impl FnOnce(&LockedProject) -> i32) -> i32 {
+    let project = match LockedProject::acquire(path) {
         Ok(project) => project,
         Err(code) => return code,
     };

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -15,10 +15,10 @@ Commands:
     `new`          Create a new project
     `run`, `r`       Compile and run a project
     `build`, `b`     Compile a project to a binary
-    `emit`, `e`      Emit Go code into `target/` dir
+    `emit`, `e`      Emit Go code into target/ dir
     `check`, `c`     Lint and typecheck a project
     `format`, `f`    Format a project
-    `test`, `t`      Run a project's tests {(in development):d}
+    `test`, `t`      Run a project's tests
     `add`          Add a third-party Go dependency
     `sync`         Tidy up project manifest
 
@@ -71,45 +71,53 @@ Arguments:
         "build" | "b" => print_help(
             "`lis build` {[path]} {[--flags]:b}
 
-Compile a Lisette project to a binary at the `target/.lisette/bin/` dir.
+Compile a project to a binary at the `target/.lisette/bin/` dir.
 For a library, generate an importable Go package at the `target/` dir.
+For a script, compile it to a binary at the current dir.
 
 Arguments:
-    {path:g} {(optional):d}                     Path to project dir (default: current dir)
+    {path:g} {(optional):d}                     Path to project dir or file (default: current dir)
 
 Flags:
     {--sourcemap:b}                         Include `//line` in Go code for stack traces
     {--go-flags:b} {\"<flags>\":g}                Pass flags through to `go build`
+    {-o:b}{,:d} {--output:b} {<path>:g}                 Write the binary for a script at this path
 
 Examples:
     `lis build`                           Build project in current dir
     `lis build` {~/projects/demo:g}           Build project in specific dir
+    `lis build` {greet.lis:g}                 Build a script to `./greet`
+    `lis build` {greet.lis:g} {-o:b} {bin/greet:g}    Build a script to a chosen path
     `lis build` {--go-flags:b} {\"-trimpath\":g}    Strip file paths from the binary",
         ),
 
         "emit" | "e" => print_help(
             "`lis emit` {[path]} {[--flags]:b}
 
-Generate Go code from a Lisette project into the `target/` dir.
+Generate Go code from a Lisette project at the `target/` dir.
+For a script, generate its Go file at the current dir.
 
 Arguments:
-    {path:g} {(optional):d}             Path to project dir (default: current dir)
+    {path:g} {(optional):d}             Path to project dir or file (default: current dir)
 
 Flags:
     {--sourcemap:b}                 Include `//line` in Go code for stack traces
+    {-o:b}{,:d} {--output:b} {<path>:g}         Write the Go file for a script at this path
 
 Examples:
     `lis emit`                    Emit Go for project in current dir
-    `lis emit` {~/projects/demo:g}    Emit Go for project in specific dir",
+    `lis emit` {~/projects/demo:g}    Emit Go for project in specific dir
+    `lis emit` {greet.lis:g}          Emit a script to `./greet.go`",
         ),
 
         "run" | "r" => print_help(
             "`lis run` {[target]} {[--flags]:b}
 
 Compile a Lisette project to a binary at `target/bin/` and run the binary.
+For a script, compile it to a binary at `/tmp/lis-script-<hash>/` and run it.
 
 Arguments:
-    {target:g} {(optional):d}                        Project dir (default: current dir)
+    {target:g} {(optional):d}                        Project dir or file (default: current dir)
 
 Flags:
     {--sourcemap:b}                              Include `//line` in Go code for stack traces

--- a/crates/cli/src/handlers/mod.rs
+++ b/crates/cli/src/handlers/mod.rs
@@ -12,6 +12,7 @@ mod new;
 mod project;
 pub(crate) mod reconciliation;
 mod run;
+mod script;
 mod sync;
 mod test;
 

--- a/crates/cli/src/handlers/project.rs
+++ b/crates/cli/src/handlers/project.rs
@@ -113,14 +113,9 @@ pub(crate) enum FileTarget {
     },
 }
 
-/// Resolves the unit `file`, which must exist, is compiled as.
+/// Resolves the unit `file`, which must exist, is compiled as. A named file is
+/// always source, so an extensionless script in `~/bin` is a script.
 pub(crate) fn resolve_file_target(file: &Path) -> FileTarget {
-    if file.extension() != Some(OsStr::new("lis")) {
-        return FileTarget::Script {
-            inside_project: false,
-        };
-    }
-
     let absolute = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
 
     let Some(root) = deps::find_project_root(&absolute) else {
@@ -132,6 +127,11 @@ pub(crate) fn resolve_file_target(file: &Path) -> FileTarget {
     let outside = FileTarget::Script {
         inside_project: true,
     };
+
+    if file.extension() != Some(OsStr::new("lis")) {
+        return outside;
+    }
+
     let Ok(relative) = absolute.strip_prefix(&root) else {
         return outside;
     };

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -1,17 +1,10 @@
-use std::collections::hash_map::DefaultHasher;
-use std::fs;
-use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::process::Command;
 
 use crate::cli_error;
 use crate::go_cli;
 use crate::handlers::project::FileTarget;
-use diagnostics::render::{self, Filter};
-use lisette::pipeline::{
-    CompileConfig, CompileEntry, CompileInput, CompileMode, CompileScope, ProjectKind, compile,
-};
-use semantics::loader::MemoryLoader;
+use lisette::pipeline::ProjectKind;
 
 fn exec_binary(output_path: &Path, args: &[String], heading: &str) -> i32 {
     match Command::new(output_path).args(args).status() {
@@ -36,17 +29,17 @@ pub fn run(
     let target = target.unwrap_or_else(|| ".".to_string());
     let target_path = Path::new(&target);
 
-    if !target.ends_with(".lis") {
-        return run_project(target_path, args, sourcemap, &go_flags);
+    if !target_path.exists() {
+        cli_error!(
+            "Nothing to run",
+            format!("Path `{}` does not exist", target),
+            "Check the path and try again"
+        );
+        return 1;
     }
 
     if !target_path.is_file() {
-        cli_error!(
-            "Failed to run script",
-            format!("File `{}` does not exist", target),
-            "Check the file path and try again"
-        );
-        return 1;
+        return run_project(target_path, args, sourcemap, &go_flags);
     }
 
     match super::project::resolve_file_target(target_path) {
@@ -133,122 +126,14 @@ fn run_script(
     go_flags: &[String],
     inside_project: bool,
 ) -> i32 {
-    let file_path = Path::new(file);
-
-    let source = match fs::read_to_string(file_path) {
-        Ok(s) => s,
-        Err(e) => {
-            cli_error!(
-                "Failed to run script",
-                format!("Failed to read `{}`: {}", file, e),
-                "Check file permissions"
-            );
-            return 1;
-        }
-    };
-
-    let absolute_path = file_path
-        .canonicalize()
-        .unwrap_or_else(|_| file_path.to_path_buf());
-    let mut hasher = DefaultHasher::new();
-    absolute_path.hash(&mut hasher);
-    let hash = hasher.finish();
-    let temp_dir = std::env::temp_dir().join(format!("lis-script-{:x}", hash));
-
-    if let Err(e) = fs::create_dir_all(&temp_dir) {
-        cli_error!(
-            "Failed to run script",
-            format!("Failed to create temporary directory: {}", e),
-            "Check permissions on temp directory"
-        );
-        return 1;
-    }
-
-    // Absolute path required: a relative `TMPDIR` would break the `-o`/exec contract.
-    let temp_dir = match temp_dir.canonicalize() {
-        Ok(p) => p,
-        Err(e) => {
-            cli_error!(
-                "Failed to run script",
-                format!("Failed to resolve temporary directory: {}", e),
-                "Check permissions on temp directory"
-            );
-            return 1;
-        }
-    };
-
-    let locator = deps::TypedefLocator::default();
-    let compile_config = CompileConfig {
-        mode: CompileMode::Emit { sourcemap },
-        go_module: "lis-script",
-        entry_package_name: "main",
-        scope: CompileScope::Script { inside_project },
-        locator: &locator,
-    };
-
-    let entry_name = file_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or(file)
-        .to_string();
-    let entry_display = lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file.to_string());
-
-    let no_loader = MemoryLoader::new();
-    let result = compile(
-        CompileInput::Binary(CompileEntry {
-            source: &source,
-            filename: &entry_name,
-            display_path: &entry_display,
-        }),
-        compile_config,
-        &no_loader,
-    );
-
-    let filter = Filter::All;
-
-    let counts = render::render_all(
-        &result.diagnostics,
-        render::SourceCache::new(|file_id| {
-            result
-                .sources
-                .get(&file_id)
-                .map(|info| (info.source.clone(), info.filename.clone()))
-        }),
-        result.user_file_count,
-        &filter,
-    );
-
-    if counts.errors > 0 {
-        return 1;
-    }
-
-    if let Err(e) = go_cli::write_go_mod(&temp_dir, "lis-script", &locator) {
-        cli_error!("Failed to run script", e, "Check file permissions");
-        return 1;
-    }
-
     let heading = "Failed to run script";
-
-    let emit = match go_cli::write_go_outputs(&temp_dir, &result.output) {
-        Ok(emit) => emit,
-        Err(e) => {
-            cli_error!(heading, e.message, e.hint);
-            return 1;
-        }
+    let build = match super::script::prepare(Path::new(file), sourcemap, inside_project, heading) {
+        Ok(build) => build,
+        Err(code) => return code,
     };
 
-    let target = locator.target();
-    let import_set_hash = go_cli::compute_import_set_hash(&emit.new_manifest, "lis-script");
-
-    if let Err(e) = go_cli::finalize_go_dir(&temp_dir, target, &emit.changed, import_set_hash) {
-        cli_error!(heading, e.message, e.hint);
-        return 1;
-    }
-
-    go_cli::write_emit_manifest(&temp_dir, &emit.new_manifest);
-
-    let output_path = temp_dir.join(go_cli::run_binary_name(target));
-    if let Err(e) = go_cli::build_binary(&temp_dir, &output_path, target, go_flags) {
+    let output_path = build.dir.join(go_cli::run_binary_name(build.target));
+    if let Err(e) = go_cli::build_binary(&build.dir, &output_path, build.target, go_flags) {
         cli_error!(heading, e.message, e.hint);
         return 1;
     }

--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -1,0 +1,470 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Component, Path, PathBuf};
+
+use crate::cli_error;
+use crate::go_cli;
+use diagnostics::render::{self, Filter};
+use lisette::pipeline::{
+    CompileConfig, CompileEntry, CompileInput, CompileMode, CompileResult, CompileScope, compile,
+};
+use semantics::loader::MemoryLoader;
+
+const GO_MODULE: &str = "lis-script";
+
+pub(super) struct ScriptBuild {
+    pub(super) dir: PathBuf,
+    pub(super) target: stdlib::Target,
+    diagnostics_shown: bool,
+}
+
+pub(super) fn prepare(
+    file: &Path,
+    sourcemap: bool,
+    inside_project: bool,
+    heading: &str,
+) -> Result<ScriptBuild, i32> {
+    let locator = deps::TypedefLocator::default();
+    let (mut result, diagnostics_shown) =
+        compile_file(file, sourcemap, inside_project, &locator, heading)?;
+    let dir = build_dir(file, heading)?;
+    let target = locator.target();
+
+    for file in &mut result.output {
+        if let Some(staged) = stage_name(&file.name) {
+            file.name = staged;
+        }
+    }
+
+    if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
+        cli_error!(heading, e, "Check file permissions");
+        return Err(1);
+    }
+
+    let emit = match go_cli::write_go_outputs(&dir, &result.output) {
+        Ok(emit) => emit,
+        Err(e) => {
+            cli_error!(heading, e.message, e.hint);
+            return Err(1);
+        }
+    };
+
+    prune_stale_go(&dir, &emit.new_manifest);
+
+    let import_set_hash = go_cli::compute_import_set_hash(&emit.new_manifest, GO_MODULE);
+    if let Err(e) = go_cli::finalize_go_dir(&dir, target, &emit.changed, import_set_hash) {
+        cli_error!(heading, e.message, e.hint);
+        return Err(1);
+    }
+
+    go_cli::write_emit_manifest(&dir, &emit.new_manifest);
+
+    Ok(ScriptBuild {
+        dir,
+        target,
+        diagnostics_shown,
+    })
+}
+
+pub(super) fn emit(
+    file: &Path,
+    sourcemap: bool,
+    output: Option<&str>,
+    inside_project: bool,
+) -> i32 {
+    let heading = "Failed to emit script";
+    let requested = match output {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(format!("{}.go", stem(file))),
+    };
+    let destination = match check_destination(file, &requested, heading) {
+        Ok(destination) => destination,
+        Err(code) => return code,
+    };
+
+    let locator = deps::TypedefLocator::default();
+    let Ok((result, diagnostics_shown)) =
+        compile_file(file, sourcemap, inside_project, &locator, heading)
+    else {
+        return 1;
+    };
+
+    let [go_file] = result.output.as_slice() else {
+        cli_error!(
+            heading,
+            format!("A script emits one Go file, got {}", result.output.len()),
+            "Report this as a bug"
+        );
+        return 1;
+    };
+
+    if let Some(parent) = destination.parent().filter(|p| !p.as_os_str().is_empty())
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        cli_error!(
+            heading,
+            format!("Failed to create `{}`: {}", parent.display(), e),
+            "Check directory permissions"
+        );
+        return 1;
+    }
+
+    if let Err(e) = fs::write(&destination, go_file.to_go()) {
+        cli_error!(
+            heading,
+            format!("Failed to write `{}`: {}", destination.display(), e),
+            "Check directory permissions"
+        );
+        return 1;
+    }
+
+    report_written("Go file", &destination, diagnostics_shown);
+    0
+}
+
+pub(super) fn build(
+    file: &Path,
+    sourcemap: bool,
+    go_flags: &[String],
+    output: Option<&str>,
+    inside_project: bool,
+) -> i32 {
+    let heading = "Failed to build script";
+    if let Some(flag) = go_flags.iter().find(|flag| go_cli::is_go_output_flag(flag)) {
+        cli_error!(
+            "Unsupported flag",
+            format!(
+                "`{}` cannot be passed to a script build via `--go-flags`",
+                flag
+            ),
+            "Use `lis build <file> -o <path>` to choose where the binary lands"
+        );
+        return 1;
+    }
+
+    let target = stdlib::Target::host();
+    let requested = match output {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(go_cli::binary_name(stem(file), target)),
+    };
+    let destination = match check_destination(file, &requested, heading) {
+        Ok(destination) => destination,
+        Err(code) => return code,
+    };
+
+    let build = match prepare(file, sourcemap, inside_project, heading) {
+        Ok(build) => build,
+        Err(code) => return code,
+    };
+
+    if let Err(e) = go_cli::build_binary(&build.dir, &destination, build.target, go_flags) {
+        cli_error!(heading, e.message, e.hint);
+        return 1;
+    }
+
+    report_written("Binary", &destination, build.diagnostics_shown);
+    0
+}
+
+fn compile_file(
+    file: &Path,
+    sourcemap: bool,
+    inside_project: bool,
+    locator: &deps::TypedefLocator,
+    heading: &str,
+) -> Result<(CompileResult, bool), i32> {
+    let source = match fs::read_to_string(file) {
+        Ok(source) => source,
+        Err(e) => {
+            cli_error!(
+                heading,
+                format!("Failed to read `{}`: {}", file.display(), e),
+                "Check file permissions"
+            );
+            return Err(1);
+        }
+    };
+
+    let entry_name = file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("main.lis")
+        .to_string();
+    let entry_display =
+        lisette::fs::relative_to_cwd(file).unwrap_or_else(|| file.display().to_string());
+
+    let result = compile(
+        CompileInput::Binary(CompileEntry {
+            source: &source,
+            filename: &entry_name,
+            display_path: &entry_display,
+        }),
+        CompileConfig {
+            mode: CompileMode::Emit { sourcemap },
+            go_module: GO_MODULE,
+            entry_package_name: "main",
+            scope: CompileScope::Script { inside_project },
+            locator,
+        },
+        &MemoryLoader::new(),
+    );
+
+    let counts = render::render_all(
+        &result.diagnostics,
+        render::SourceCache::new(|file_id| {
+            result
+                .sources
+                .get(&file_id)
+                .map(|info| (info.source.clone(), info.filename.clone()))
+        }),
+        result.user_file_count,
+        &Filter::All,
+    );
+
+    if counts.errors > 0 {
+        return Err(1);
+    }
+
+    Ok((result, counts.warnings + counts.info > 0))
+}
+
+fn build_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
+    let absolute = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+    let mut hasher = DefaultHasher::new();
+    absolute.hash(&mut hasher);
+    let dir = std::env::temp_dir().join(format!("lis-script-{:x}", hasher.finish()));
+
+    if let Err(e) = fs::create_dir_all(&dir) {
+        cli_error!(
+            heading,
+            format!("Failed to create temporary directory: {}", e),
+            "Check permissions on temp directory"
+        );
+        return Err(1);
+    }
+
+    // Absolute path required: a relative `TMPDIR` would break the `-o`/exec contract.
+    dir.canonicalize().map_err(|e| {
+        cli_error!(
+            heading,
+            format!("Failed to resolve temporary directory: {}", e),
+            "Check permissions on temp directory"
+        );
+        1
+    })
+}
+
+fn absolute(path: &Path) -> Option<PathBuf> {
+    if path.is_absolute() {
+        return Some(path.to_path_buf());
+    }
+    Some(std::env::current_dir().ok()?.join(path))
+}
+
+fn prune_stale_go(dir: &Path, manifest: &[go_cli::ManifestEntry]) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.ends_with(".go") && !manifest.iter().any(|entry| entry.name == name) {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+fn stage_name(name: &str) -> Option<String> {
+    name.starts_with(['_', '.', '-'])
+        .then(|| format!("lis{}", name))
+}
+
+fn stem(file: &Path) -> &str {
+    file.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("main")
+}
+
+/// Write to the returned path: checking one path and writing another is how a
+/// symlinked parent slips through.
+fn check_destination(input: &Path, output: &Path, heading: &str) -> Result<PathBuf, i32> {
+    if demands_a_directory(output) {
+        cli_error!(
+            heading,
+            format!("`{}` names a directory", output.display()),
+            "Drop the trailing separator or `.` to write a file"
+        );
+        return Err(1);
+    }
+
+    let destination = match resolve(output) {
+        Ok(destination) => destination,
+        Err(PathError::NotADirectory(blocker)) => {
+            cli_error!(
+                heading,
+                format!("`{}` is not a directory", shown(&blocker)),
+                "Every path component before the filename must be a directory"
+            );
+            return Err(1);
+        }
+        Err(PathError::Unresolvable) => {
+            cli_error!(
+                heading,
+                format!("Failed to resolve `{}`", output.display()),
+                "Check the output path"
+            );
+            return Err(1);
+        }
+    };
+
+    // `go build -o <dir>` writes inside it, so the reported path would not be
+    // the artifact.
+    if destination.is_dir() {
+        cli_error!(
+            heading,
+            format!("`{}` is a directory", shown(output)),
+            "Pass `-o <path>` naming the file to write"
+        );
+        return Err(1);
+    }
+
+    let same = is_same_file_on_disk(input, &destination)
+        || resolve(input).is_ok_and(|input| input == destination);
+    if same {
+        cli_error!(
+            heading,
+            format!("`{}` is the script being compiled", shown(output)),
+            "Pass `-o <path>` to write somewhere else"
+        );
+        return Err(1);
+    }
+
+    Ok(destination)
+}
+
+/// True for a trailing separator or a terminal `.`, which `Path::components()`
+/// drops, so this reads the path as written.
+fn demands_a_directory(path: &Path) -> bool {
+    let text = path.as_os_str().to_string_lossy();
+    if text.ends_with(std::path::is_separator) {
+        return true;
+    }
+
+    text.strip_suffix('.')
+        .is_some_and(|rest| rest.is_empty() || rest.ends_with(std::path::is_separator))
+}
+
+enum PathError {
+    Unresolvable,
+    /// What the kernel answers with `ENOTDIR` rather than folding the `..` away.
+    NotADirectory(PathBuf),
+}
+
+/// Each component resolves as soon as it exists, so a symlink is followed
+/// before the `..` crossing it. The tail folds lexically.
+fn resolve(path: &Path) -> Result<PathBuf, PathError> {
+    let absolute = absolute(path).ok_or(PathError::Unresolvable)?;
+    let mut components = absolute.components().peekable();
+    let mut resolved = PathBuf::new();
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            other => resolved.push(other),
+        }
+        if let Ok(canonical) = resolved.canonicalize() {
+            resolved = canonical;
+        }
+        if components.peek().is_some() && resolved.exists() && !resolved.is_dir() {
+            return Err(PathError::NotADirectory(resolved));
+        }
+    }
+
+    Ok(resolved)
+}
+
+#[cfg(unix)]
+fn is_same_file_on_disk(left: &Path, right: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let (Ok(left), Ok(right)) = (left.metadata(), right.metadata()) else {
+        return false;
+    };
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn is_same_file_on_disk(left: &Path, right: &Path) -> bool {
+    file_identity(left).is_some_and(|left| file_identity(right) == Some(left))
+}
+
+/// Windows exposes no file index on stable, so identity comes from the handle.
+#[cfg(windows)]
+fn file_identity(path: &Path) -> Option<(u32, u64)> {
+    use std::ffi::c_void;
+    use std::os::windows::io::AsRawHandle;
+
+    #[derive(Clone, Copy, Default)]
+    #[repr(C)]
+    struct FileTime {
+        low: u32,
+        high: u32,
+    }
+
+    #[derive(Default)]
+    #[repr(C)]
+    struct ByHandleFileInformation {
+        attributes: u32,
+        creation_time: FileTime,
+        last_access_time: FileTime,
+        last_write_time: FileTime,
+        volume_serial_number: u32,
+        file_size_high: u32,
+        file_size_low: u32,
+        number_of_links: u32,
+        file_index_high: u32,
+        file_index_low: u32,
+    }
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        #[link_name = "GetFileInformationByHandle"]
+        fn get_file_information_by_handle(
+            file: *mut c_void,
+            info: *mut ByHandleFileInformation,
+        ) -> i32;
+    }
+
+    let file = fs::File::open(path).ok()?;
+    let mut info = ByHandleFileInformation::default();
+    // SAFETY: the owned file handle remains live for the call, and `info`
+    // exactly matches the Windows BY_HANDLE_FILE_INFORMATION layout.
+    let result = unsafe { get_file_information_by_handle(file.as_raw_handle().cast(), &mut info) };
+    if result == 0 {
+        return None;
+    }
+
+    let index = (u64::from(info.file_index_high) << 32) | u64::from(info.file_index_low);
+    Some((info.volume_serial_number, index))
+}
+
+fn shown(path: &Path) -> String {
+    lisette::fs::relative_to_cwd(path).unwrap_or_else(|| path.display().to_string())
+}
+
+fn report_written(what: &str, path: &Path, diagnostics_shown: bool) {
+    if !diagnostics_shown {
+        eprintln!();
+    }
+    let path = shown(path);
+    if crate::output::use_color() {
+        use owo_colors::OwoColorize;
+        eprintln!("  ✓ {} at {}", what, path.bright_magenta());
+    } else {
+        eprintln!("  ✓ {} at `{}`", what, path);
+    }
+}

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -6,7 +6,7 @@ use crate::command::TestSelection;
 use crate::go_cli;
 use crate::output::{terminal_width, use_color};
 
-use super::build::{BuildPurpose, build_locked, with_locked_project};
+use super::build::{BuildPurpose, build_locked, project_root_for, with_locked_project};
 
 mod failed;
 mod report;
@@ -16,7 +16,9 @@ use report::{
 
 pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelection) -> i32 {
     crate::output::print_preview_notice("Test runner", false);
-    with_locked_project(path, |prep| {
+    let target = path.unwrap_or_else(|| ".".to_string());
+    let root = project_root_for(std::path::Path::new(&target));
+    with_locked_project(&root, |prep| {
         let outcome = match build_locked(prep, BuildPurpose::Test) {
             Ok(outcome) => outcome,
             Err(code) => return code,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,8 +63,13 @@ fn main() {
             path,
             sourcemap,
             go_flags,
-        } => handlers::build(path, sourcemap, go_flags),
-        Command::Emit { path, sourcemap } => handlers::emit(path, sourcemap),
+            output,
+        } => handlers::build(path, sourcemap, go_flags, output),
+        Command::Emit {
+            path,
+            sourcemap,
+            output,
+        } => handlers::emit(path, sourcemap, output),
         Command::Run {
             target,
             args,

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1491,7 +1491,10 @@ fn a_non_lisette_file_under_src_is_not_a_project_target() {
         !output.status.success(),
         "naming a non-`.lis` file must not build its directory's project:\n{combined}"
     );
-    assert!(combined.contains("Not a project directory"), "{combined}");
+    assert!(
+        !combined.contains("Emit completed"),
+        "the project must not be built:\n{combined}"
+    );
 }
 
 #[test]
@@ -1522,6 +1525,416 @@ fn a_tree_walk_reports_a_nested_project_with_no_sources() {
         assert!(
             combined.contains("No Lisette sources"),
             "{label}: {combined}"
+        );
+    }
+}
+
+fn lis_in(cwd: &Path, args: &[&str]) -> std::process::Output {
+    let manifest = repo().join("Cargo.toml");
+    Command::new("cargo")
+        .args(["run", "--quiet", "--manifest-path"])
+        .arg(&manifest)
+        .args(["-p", "lisette", "--"])
+        .args(args)
+        .current_dir(cwd)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to invoke lisette")
+}
+
+fn combined(output: &std::process::Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+const GREETER: &str = "import \"go:fmt\"\n\nfn main() {\n  fmt.Println(\"hi\")\n}\n";
+
+#[test]
+fn emit_writes_one_go_file_beside_no_target_dir() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    let output = lis_in(dir, &["emit", "greet.lis"]);
+
+    assert!(output.status.success(), "{}", combined(&output));
+    let go = fs::read_to_string(dir.join("greet.go")).expect("greet.go must exist");
+    assert!(go.contains("package main"), "{go}");
+    assert!(
+        !dir.join("target").exists(),
+        "a script emit must not create `target/`"
+    );
+}
+
+#[test]
+fn emit_output_flag_chooses_the_path() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    let output = lis_in(dir, &["emit", "greet.lis", "-o", "out/custom.go"]);
+
+    assert!(output.status.success(), "{}", combined(&output));
+    assert!(dir.join("out/custom.go").is_file());
+    assert!(!dir.join("greet.go").exists());
+}
+
+#[test]
+fn build_links_a_runnable_binary_into_the_working_dir() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    let output = lis_in(dir, &["build", "greet.lis"]);
+    assert!(output.status.success(), "{}", combined(&output));
+    assert!(
+        !dir.join("target").exists(),
+        "a script build must not create `target/`"
+    );
+
+    let ran = Command::new(dir.join("greet"))
+        .output()
+        .expect("the built binary must run");
+    assert_eq!(String::from_utf8_lossy(&ran.stdout).trim(), "hi");
+}
+
+#[test]
+fn an_extensionless_script_runs_checks_and_builds() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("backup"), GREETER).unwrap();
+
+    let checked = lis_in(dir, &["check", "backup"]);
+    assert!(checked.status.success(), "{}", combined(&checked));
+
+    let ran = lis_in(dir, &["run", "backup"]);
+    assert!(ran.status.success(), "{}", combined(&ran));
+    assert_eq!(String::from_utf8_lossy(&ran.stdout).trim(), "hi");
+
+    let built = lis_in(dir, &["build", "backup", "-o", "backup.bin"]);
+    assert!(built.status.success(), "{}", combined(&built));
+    assert!(dir.join("backup.bin").is_file());
+}
+
+#[test]
+fn build_refuses_to_overwrite_the_script_it_compiles() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("backup"), GREETER).unwrap();
+
+    let output = lis_in(dir, &["build", "backup"]);
+
+    assert!(!output.status.success(), "{}", combined(&output));
+    assert!(
+        combined(&output).contains("is the script being compiled"),
+        "{}",
+        combined(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("backup")).unwrap(),
+        GREETER,
+        "the source must survive a refused build"
+    );
+}
+
+#[test]
+fn output_flag_aimed_at_any_input_file_is_refused() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    for args in [
+        vec!["emit", "greet.lis", "-o", "greet.lis"],
+        vec!["build", "greet.lis", "-o", "greet.lis"],
+    ] {
+        let output = lis_in(dir, &args);
+        assert!(!output.status.success(), "{args:?}: {}", combined(&output));
+        assert_eq!(
+            fs::read_to_string(dir.join("greet.lis")).unwrap(),
+            GREETER,
+            "{args:?} must leave the source untouched"
+        );
+    }
+}
+
+#[test]
+fn a_script_named_the_way_go_ignores_still_builds() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+
+    for name in ["_leading.lis", ".hidden.lis", "-dashed.lis", "..."] {
+        fs::write(dir.join(name), GREETER).unwrap();
+        let relative = format!("./{name}");
+
+        let ran = lis_in(dir, &["run", &relative]);
+        assert_eq!(
+            String::from_utf8_lossy(&ran.stdout).trim(),
+            "hi",
+            "`{name}`: {}",
+            combined(&ran)
+        );
+
+        let built = lis_in(dir, &["build", &relative, "-o", "out.bin"]);
+        assert!(built.status.success(), "`{name}`: {}", combined(&built));
+    }
+}
+
+#[test]
+fn a_stale_go_file_in_the_build_directory_is_pruned() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    let scratch_tmp = dir.join("tmp");
+    fs::create_dir(&scratch_tmp).unwrap();
+    let build = || {
+        let manifest = repo().join("Cargo.toml");
+        Command::new("cargo")
+            .args(["run", "--quiet", "--manifest-path"])
+            .arg(&manifest)
+            .args(["-p", "lisette", "--", "build", "greet.lis", "-o", "out.bin"])
+            .current_dir(dir)
+            .env("NO_COLOR", "1")
+            .env("TMPDIR", &scratch_tmp)
+            .env("TMP", &scratch_tmp)
+            .env("TEMP", &scratch_tmp)
+            .output()
+            .expect("failed to invoke lisette")
+    };
+
+    let first = build();
+    assert!(first.status.success(), "{}", combined(&first));
+
+    let build_dir = fs::read_dir(&scratch_tmp)
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.join("greet.go").is_file())
+        .expect("the build directory must sit under the test's own TMPDIR");
+    fs::write(
+        build_dir.join("orphan.go"),
+        "package main\n\nfunc dupe() {}\n",
+    )
+    .unwrap();
+
+    let second = build();
+    assert!(second.status.success(), "{}", combined(&second));
+    assert!(
+        !build_dir.join("orphan.go").exists(),
+        "a Go file outside the emit must not survive into `go build`"
+    );
+}
+
+#[test]
+fn a_hard_link_to_the_script_is_refused() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+    fs::hard_link(dir.join("greet.lis"), dir.join("linked.go")).unwrap();
+
+    let output = lis_in(dir, &["emit", "greet.lis", "-o", "linked.go"]);
+
+    assert!(!output.status.success(), "{}", combined(&output));
+    assert_eq!(
+        fs::read_to_string(dir.join("greet.lis")).unwrap(),
+        GREETER,
+        "a hard link shares no pathname with its source, and still is it"
+    );
+}
+
+#[test]
+fn a_path_through_a_missing_directory_cannot_reach_the_script() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+
+    for args in [
+        vec!["emit", "greet.lis", "-o", "missing/../greet.lis"],
+        vec!["build", "greet.lis", "-o", "missing/../greet.lis"],
+    ] {
+        let output = lis_in(dir, &args);
+        assert!(!output.status.success(), "{args:?}: {}", combined(&output));
+        assert_eq!(
+            fs::read_to_string(dir.join("greet.lis")).unwrap(),
+            GREETER,
+            "{args:?} must not reach the source through a directory made later"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlinked_parent_cannot_reach_the_script() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::create_dir(dir.join("real")).unwrap();
+    std::os::unix::fs::symlink("real", dir.join("link")).unwrap();
+    fs::write(dir.join("real/greet.lis"), GREETER).unwrap();
+
+    for args in [
+        vec!["emit", "greet.lis", "-o", "../link/missing/../greet.lis"],
+        vec!["build", "greet.lis", "-o", "../link/missing/../greet.lis"],
+    ] {
+        let output = lis_in(&dir.join("real"), &args);
+        assert!(!output.status.success(), "{args:?}: {}", combined(&output));
+        assert_eq!(
+            fs::read_to_string(dir.join("real/greet.lis")).unwrap(),
+            GREETER,
+            "{args:?} must not reach the source by crossing a symlink with `..`"
+        );
+    }
+}
+
+#[test]
+fn a_path_that_can_only_name_a_directory_is_refused() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+    fs::write(dir.join("victim"), "precious\n").unwrap();
+
+    for args in [
+        vec!["emit", "greet.lis", "-o", "fresh/"],
+        vec!["emit", "greet.lis", "-o", "victim/"],
+        vec!["build", "greet.lis", "-o", "fresh/"],
+        vec!["emit", "greet.lis", "-o", "fresh/."],
+        vec!["emit", "greet.lis", "-o", "victim/."],
+        vec!["build", "greet.lis", "-o", "fresh/."],
+    ] {
+        let output = lis_in(dir, &args);
+        let text = combined(&output);
+        assert!(!output.status.success(), "{args:?}: {text}");
+        assert!(text.contains("names a directory"), "{args:?}: {text}");
+    }
+
+    assert!(
+        !dir.join("fresh").exists(),
+        "these paths name a directory, so no file `fresh` may appear"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("victim")).unwrap(),
+        "precious\n",
+        "these are paths the kernel refuses, so the file must survive"
+    );
+
+    let ordinary = lis_in(dir, &["emit", "greet.lis", "-o", "./out.go"]);
+    assert!(ordinary.status.success(), "{}", combined(&ordinary));
+    assert!(
+        dir.join("out.go").is_file(),
+        "a `.` inside a path is still an ordinary path"
+    );
+}
+
+#[test]
+fn a_path_leading_through_a_file_is_refused() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+    fs::write(dir.join("blocker"), "not a directory\n").unwrap();
+
+    for args in [
+        vec!["emit", "greet.lis", "-o", "blocker/../out.go"],
+        vec!["build", "greet.lis", "-o", "blocker/../out"],
+    ] {
+        let output = lis_in(dir, &args);
+        let text = combined(&output);
+        assert!(!output.status.success(), "{args:?}: {text}");
+        assert!(text.contains("is not a directory"), "{args:?}: {text}");
+    }
+
+    assert!(
+        !dir.join("out.go").exists() && !dir.join("out").exists(),
+        "a path the kernel answers with ENOTDIR must not be folded into a sibling write"
+    );
+}
+
+#[test]
+fn a_directory_destination_is_refused_rather_than_written_into() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet.lis"), GREETER).unwrap();
+    fs::create_dir(dir.join("greet")).unwrap();
+    fs::create_dir(dir.join("dest")).unwrap();
+
+    for args in [
+        vec!["build", "greet.lis"],
+        vec!["build", "greet.lis", "-o", "dest"],
+        vec!["emit", "greet.lis", "-o", "dest"],
+    ] {
+        let output = lis_in(dir, &args);
+        let text = combined(&output);
+        assert!(!output.status.success(), "{args:?}: {text}");
+        assert!(text.contains("is a directory"), "{args:?}: {text}");
+    }
+
+    assert!(
+        fs::read_dir(dir.join("greet")).unwrap().next().is_none(),
+        "nothing may be written inside the colliding directory"
+    );
+    assert!(
+        fs::read_dir(dir.join("dest")).unwrap().next().is_none(),
+        "nothing may be written inside the named directory"
+    );
+}
+
+#[test]
+fn a_nonexistent_target_names_the_path() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+
+    for subcommand in ["run", "emit", "build"] {
+        let output = lis_in(dir, &[subcommand, "nope"]);
+        let text = combined(&output);
+        assert!(!output.status.success(), "{subcommand}: {text}");
+        assert!(
+            text.contains("Path `nope` does not exist"),
+            "{subcommand}: {text}"
+        );
+    }
+}
+
+#[test]
+fn project_emit_and_build_reject_the_output_flag() {
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"outflag\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/main.lis"), "fn main() {}\n").unwrap();
+
+    for subcommand in ["emit", "build"] {
+        let output = lis_in(&project, &[subcommand, ".", "-o", "somewhere"]);
+        let text = combined(&output);
+        assert!(!output.status.success(), "{subcommand}: {text}");
+        assert!(
+            text.contains("has no meaning for a project"),
+            "{subcommand}: {text}"
         );
     }
 }


### PR DESCRIPTION
`lis build` and `lis emit` can now build a binary and emit a Go file, respectively, from a single `.lis` file, for scripting purposes. Both place their output in the current working dir. Pass `-o, --output <path>` to set the destination.

Until now, only `lis run`, `lis check`, and `lis format` supported single-file operation.

```sh
lis build greet.lis                   # compiles ./greet binary
lis build greet.lis -o bin/greet      # compiles ./bin/greet binary
lis emit greet.lis                    # writes ./greet.go
lis emit greet.lis -o demo/greet.go   # writes ./demo/greet.go
```

Relates to #776
