### PR TITLE
feat: diagnostic for unprefixed f-strings

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -1080,6 +1080,15 @@ pub fn uninterpolated_fstring(span: &Span) -> LisetteDiagnostic {
         .with_help("Remove the `f` prefix. A string without interpolations does not need to be a format string")
 }
 
+pub fn unprefixed_fstring(span: &Span, name: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::warn("Unprefixed f-string")
+        .with_lint_code("unprefixed_fstring")
+        .with_span_label(span, format!("`{name}` will not be interpolated"))
+        .with_help(format!(
+            "Add the `f` prefix to interpolate `{name}`. Without it the braces stay literal text"
+        ))
+}
+
 pub fn nested_fstring(span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::info("Nested f-string")
         .with_lint_code("nested_fstring")

--- a/crates/passes/src/passes/checks/interpolation_stringer.rs
+++ b/crates/passes/src/passes/checks/interpolation_stringer.rs
@@ -2,7 +2,6 @@
 
 use diagnostics::LocalSink;
 use syntax::ast::{Expression, FormatStringPart, Literal};
-use syntax::program::{Definition, DefinitionBody, File};
 use syntax::types::Type;
 
 use crate::passes::walk::visit_ast;
@@ -31,57 +30,20 @@ fn check_expression(expression: &Expression, store: &Store, sink: &LocalSink) {
 }
 
 fn check_interpolation(inner: &Expression, store: &Store, sink: &LocalSink) {
-    let peeled = store.peel_alias(&inner.get_type());
+    let ty = inner.get_type();
+    if store.is_interpolatable(&ty) {
+        return;
+    }
+    let peeled = store.peel_alias(&ty);
     let Type::Nominal { id, .. } = &peeled else {
         return;
     };
     let Some(definition) = store.get_definition(id.as_str()) else {
         return;
     };
-    if !matches!(
-        definition.body,
-        DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. }
-    ) {
-        return;
-    }
-    if is_foreign(definition, id.as_str(), store) || has_stringer(definition, id.as_str(), store) {
-        return;
-    }
     sink.push(diagnostics::infer::interpolation_without_stringer(
         id.last_segment(),
         inner.get_span(),
-        is_pointer_newtype(definition, store),
+        definition.is_pointer_backed_newtype(|id| store.get_definition(id)),
     ));
-}
-
-fn is_foreign(definition: &Definition, id: &str, store: &Store) -> bool {
-    if let Some(module) = store.module_for_qualified_name(id)
-        && (module == "prelude" || module.starts_with("go:"))
-    {
-        return true;
-    }
-    definition
-        .name_span
-        .and_then(|span| store.get_file(span.file_id))
-        .is_some_and(File::is_d_lis)
-}
-
-fn has_stringer(definition: &Definition, id: &str, store: &Store) -> bool {
-    if is_pointer_newtype(definition, store) {
-        return false;
-    }
-    if definition.is_display() {
-        return true;
-    }
-    let Some(methods) = store.get_own_methods(id) else {
-        return false;
-    };
-    ["string", "String"].iter().any(|name| {
-        methods.get(*name).is_some_and(Type::is_stringer_signature)
-            && !definition.is_ufcs_method(name)
-    })
-}
-
-fn is_pointer_newtype(definition: &Definition, store: &Store) -> bool {
-    definition.is_pointer_backed_newtype(|id| store.get_definition(id))
 }

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -81,6 +81,7 @@ pub(crate) fn run(
     collect_overused_references(facts, &mut diagnostics);
     collect_always_failing_try_blocks(facts, &mut diagnostics);
     collect_expression_only_fstrings(store, facts, &mut diagnostics);
+    collect_unprefixed_fstrings(store, facts, &mut diagnostics);
 
     diagnostics.sort_by(LisetteDiagnostic::sort_key);
     sink.extend(diagnostics);
@@ -111,6 +112,21 @@ fn fstring_inner(store: &Store, span: Span) -> Option<&str> {
     let text = source.get(span.byte_offset as usize..span.end() as usize)?;
     let inner = text.strip_prefix("f\"")?.strip_suffix('"')?.trim();
     Some(inner.strip_prefix('{')?.strip_suffix('}')?.trim())
+}
+
+fn collect_unprefixed_fstrings(store: &Store, facts: &Facts, out: &mut Vec<LisetteDiagnostic>) {
+    let produced: Vec<LisetteDiagnostic> = facts
+        .unprefixed_fstrings
+        .iter()
+        .map(|fact| {
+            let before = Span::new(fact.span.file_id, fact.span.byte_offset, 0);
+            diagnostics::lint::unprefixed_fstring(&fact.span, &fact.name).with_fix(Fix::new(
+                "Add the `f` prefix",
+                Edit::replacement(before, "f"),
+            ))
+        })
+        .collect();
+    push_suppressible(store, produced, out);
 }
 
 fn erroring_function_spans(facts: &Facts, sink: &LocalSink) -> Vec<Span> {
@@ -200,6 +216,14 @@ fn collect_shadowed_captures(store: &Store, facts: &Facts, out: &mut Vec<Lisette
             ))
         })
         .collect();
+    push_suppressible(store, produced, out);
+}
+
+fn push_suppressible(
+    store: &Store,
+    produced: Vec<LisetteDiagnostic>,
+    out: &mut Vec<LisetteDiagnostic>,
+) {
     if produced.is_empty() {
         return;
     }

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -98,6 +98,14 @@ impl InferCtx<'_> {
                     string_ty
                 };
 
+                if !raw
+                    && let Some(names) = interpolation_holes(&value)
+                    && names.iter().all(|name| self.hole_would_interpolate(name))
+                {
+                    self.facts
+                        .add_unprefixed_fstring(span, names[0].to_string());
+                }
+
                 Expression::Literal {
                     literal: Literal::String { value, raw },
                     ty,
@@ -230,6 +238,14 @@ impl InferCtx<'_> {
         }
     }
 
+    fn hole_would_interpolate(&self, name: &str) -> bool {
+        self.scopes.lookup_binding_id(name).is_some()
+            && self
+                .scopes
+                .lookup_value(name)
+                .is_some_and(|ty| self.store.is_interpolatable(&ty.resolve_in(&self.env)))
+    }
+
     pub(super) fn infer_unit(&mut self, span: Span, expected_ty: &Type) -> Expression {
         let new_ty = self.new_type_var();
         let unit_ty = self.type_unit();
@@ -237,6 +253,48 @@ impl InferCtx<'_> {
         self.unify(expected_ty, &new_ty, &span);
         Expression::Unit { ty: new_ty, span }
     }
+}
+
+fn interpolation_holes(value: &str) -> Option<Vec<&str>> {
+    let bytes = value.as_bytes();
+    let mut names = Vec::new();
+    let mut at = 0;
+
+    while at < bytes.len() {
+        match bytes[at] {
+            b'\\' => at = skip_escape(value, at)?,
+            b'{' if bytes.get(at + 1) == Some(&b'{') => return None,
+            b'{' => {
+                let start = at + 1;
+                let close = start + value[start..].find('}')?;
+                let name = &value[start..close];
+                if !is_bare_identifier(name) {
+                    return None;
+                }
+                names.push(name);
+                at = close + 1;
+            }
+            b'}' => return None,
+            _ => at += 1,
+        }
+    }
+
+    (!names.is_empty()).then_some(names)
+}
+
+fn skip_escape(value: &str, at: usize) -> Option<usize> {
+    let bytes = value.as_bytes();
+    if bytes.get(at + 1) == Some(&b'u') && bytes.get(at + 2) == Some(&b'{') {
+        return Some(at + 4 + value[at + 3..].find('}')?);
+    }
+    let escaped = value[at + 1..].chars().next()?;
+    Some(at + 1 + escaped.len_utf8())
+}
+
+fn is_bare_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    chars.next().is_some_and(|c| c.is_alphabetic() || c == '_')
+        && chars.all(|c| c.is_alphanumeric() || c == '_')
 }
 
 /// Whether `expr` must be parenthesized to replace its f-string: true unless it

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -38,6 +38,7 @@ pub struct Facts {
     pub overused_references: Vec<OverusedReferenceFact>,
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
+    pub unprefixed_fstrings: Vec<UnprefixedFstringFact>,
     pub interface_satisfied_methods: HashMap<(String, String), Vec<InterfaceSatisfaction>>,
     pub(crate) test_functions: Vec<TestFunction>,
 
@@ -184,6 +185,7 @@ impl Facts {
             overused_references: Vec::new(),
             always_failing_try_blocks: Vec::new(),
             expression_only_fstrings: Vec::new(),
+            unprefixed_fstrings: Vec::new(),
             deferred: DeferredChecks::default(),
             branch_subsumptions: Vec::new(),
             select_exhaustiveness_checks: Vec::new(),
@@ -296,6 +298,11 @@ impl Facts {
             .push(ExpressionOnlyFstringFact { span, needs_parens });
     }
 
+    pub(crate) fn add_unprefixed_fstring(&mut self, span: Span, name: String) {
+        self.unprefixed_fstrings
+            .push(UnprefixedFstringFact { span, name });
+    }
+
     pub(crate) fn add_usage(&mut self, usage_span: Span, definition_span: Span) {
         self.usages.insert(Usage {
             usage_span,
@@ -349,6 +356,7 @@ impl Facts {
             overused_references,
             always_failing_try_blocks,
             expression_only_fstrings,
+            unprefixed_fstrings,
             deferred,
             branch_subsumptions,
             select_exhaustiveness_checks,
@@ -370,6 +378,7 @@ impl Facts {
             .extend(always_failing_try_blocks);
         self.expression_only_fstrings
             .extend(expression_only_fstrings);
+        self.unprefixed_fstrings.extend(unprefixed_fstrings);
         self.deferred.merge(deferred);
         self.branch_subsumptions.extend(branch_subsumptions);
         self.select_exhaustiveness_checks
@@ -393,6 +402,13 @@ impl Facts {
 pub struct ExpressionOnlyFstringFact {
     pub span: Span,
     pub needs_parens: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnprefixedFstringFact {
+    pub span: Span,
+    /// First hole, named in the diagnostic.
+    pub name: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -409,6 +409,56 @@ impl Store {
             .is_some_and(|definition| definition.is_ufcs_method(method))
     }
 
+    pub fn is_interpolatable(&self, ty: &Type) -> bool {
+        let peeled = self.peel_alias(ty);
+        let Type::Nominal { id, .. } = &peeled else {
+            return true;
+        };
+        let Some(definition) = self.get_definition(id.as_str()) else {
+            return true;
+        };
+        if !matches!(
+            definition.body,
+            DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. }
+        ) {
+            return true;
+        }
+        self.is_foreign_definition(definition, id.as_str())
+            || self.has_stringer(definition, id.as_str())
+    }
+
+    fn is_foreign_definition(&self, definition: &Definition, qualified_name: &str) -> bool {
+        if let Some(module) = self.module_for_qualified_name(qualified_name)
+            && (module == "prelude" || module.starts_with("go:"))
+        {
+            return true;
+        }
+        definition
+            .name_span
+            .and_then(|span| self.get_file(span.file_id))
+            .is_some_and(File::is_d_lis)
+    }
+
+    fn has_stringer(&self, definition: &Definition, qualified_name: &str) -> bool {
+        if self.is_pointer_backed_newtype(definition) {
+            return false;
+        }
+        if definition.is_display() {
+            return true;
+        }
+        let Some(methods) = self.get_own_methods(qualified_name) else {
+            return false;
+        };
+        ["string", "String"].iter().any(|name| {
+            methods.get(*name).is_some_and(Type::is_stringer_signature)
+                && !definition.is_ufcs_method(name)
+        })
+    }
+
+    fn is_pointer_backed_newtype(&self, definition: &Definition) -> bool {
+        definition.is_pointer_backed_newtype(|id| self.get_definition(id))
+    }
+
     pub(crate) fn get_all_methods(
         &self,
         ty: &Type,

--- a/tests/ui/lint/fixes.rs
+++ b/tests/ui/lint/fixes.rs
@@ -1508,3 +1508,17 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn fix_unprefixed_fstring() {
+    assert_fix_snapshot!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = "hello {name}";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -10433,6 +10433,224 @@ fn main() {
 }
 
 #[test]
+fn unprefixed_fstring() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = "hello {name}";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_raw_string_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = r"hello {name}\n";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_unresolved_name_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let route = "/users/{id}";
+  let _ = route
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_doubled_braces_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let name = "world";
+  let template = "{{name}}";
+  let _ = name;
+  let _ = template
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_non_identifier_hole_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let job = "api";
+  let query = "{job=\"api\"}";
+  let _ = job;
+  let _ = query
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_stray_brace_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = "}{name}";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_constant_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+const GREETING: string = "hi";
+
+fn main() {
+  let msg = "{GREETING}";
+  let _ = GREETING;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_function_name_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn name() -> int { 1 }
+
+fn main() {
+  let msg = "{name}";
+  let _ = name();
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_partially_resolved_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = "{name} {missing}";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_unicode_escape_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+fn main() {
+  let a = 1;
+  let msg = "\u{a}";
+  let _ = a;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_non_displayable_struct_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+struct Point { x: int }
+
+fn main() {
+  let p = Point { x: 1 };
+  let msg = "at {p}";
+  let _ = p.x;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_non_displayable_enum_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+enum Color { Red, Blue }
+
+fn main() {
+  let c = Color.Red;
+  let msg = "picked {c}";
+  let _ = c == Color.Blue;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_after_unicode_escape() {
+    assert_lint_snapshot!(
+        r#"
+fn main() {
+  let name = "world";
+  let msg = "\u{263A} {name}";
+  let _ = name;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_displayable_struct() {
+    assert_lint_snapshot!(
+        r#"
+#[display]
+struct Point { x: int }
+
+fn main() {
+  let p = Point { x: 1 };
+  let msg = "at {p}";
+  let _ = p.x;
+  let _ = msg
+}
+"#
+    );
+}
+
+#[test]
+fn unprefixed_fstring_allow_attribute_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+#[allow(unprefixed_fstring)]
+fn main() {
+  let id = 7;
+  let route = "/users/{id}";
+  let _ = id;
+  let _ = route
+}
+"#
+    );
+}
+
+#[test]
 fn slice_literal_uses_function() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/fix_unprefixed_fstring.snap
+++ b/tests/ui/lint/snapshots/fix_unprefixed_fstring.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/lint/fixes.rs
+---
+fn main() {
+  let name = "world";
+  let msg = "hello {name}";
+  let _ = name;
+  let _ = msg
+}
+=== fixed ===
+fn main() {
+  let name = "world";
+  let msg = f"hello {name}";
+  let _ = name;
+  let _ = msg
+}

--- a/tests/ui/lint/snapshots/unprefixed_fstring.snap
+++ b/tests/ui/lint/snapshots/unprefixed_fstring.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unprefixed f-string
+   ╭─[test.lis:4:13]
+ 3 │   let name = "world";
+ 4 │   let msg = "hello {name}";
+   ·             ───────┬──────
+   ·                    ╰── `name` will not be interpolated
+ 5 │   let _ = name;
+   ╰────
+  help: Add the `f` prefix to interpolate `name`. Without it the braces stay literal text · code: [lint.unprefixed_fstring]

--- a/tests/ui/lint/snapshots/unprefixed_fstring_after_unicode_escape.snap
+++ b/tests/ui/lint/snapshots/unprefixed_fstring_after_unicode_escape.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unprefixed f-string
+   ╭─[test.lis:4:13]
+ 3 │   let name = "world";
+ 4 │   let msg = "\u{263A} {name}";
+   ·             ────────┬────────
+   ·                     ╰── `name` will not be interpolated
+ 5 │   let _ = name;
+   ╰────
+  help: Add the `f` prefix to interpolate `name`. Without it the braces stay literal text · code: [lint.unprefixed_fstring]

--- a/tests/ui/lint/snapshots/unprefixed_fstring_displayable_struct.snap
+++ b/tests/ui/lint/snapshots/unprefixed_fstring_displayable_struct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unprefixed f-string
+   ╭─[test.lis:7:13]
+ 6 │   let p = Point { x: 1 };
+ 7 │   let msg = "at {p}";
+   ·             ────┬───
+   ·                 ╰── `p` will not be interpolated
+ 8 │   let _ = p.x;
+   ╰────
+  help: Add the `f` prefix to interpolate `p`. Without it the braces stay literal text · code: [lint.unprefixed_fstring]


### PR DESCRIPTION
Adds a warning that flags a string literal where a braced section contains a variable in scope, suggesting intent to interpolate but missing an `f` prefix.

```
  ▲ Unprefixed f-string
   ╭─[test.lis:4:13]
 3 │   let name = "world";
 4 │   let msg = "hello {name}";
   ·             ───────┬──────
   ·                    ╰── `name` will not be interpolated
 5 │   let _ = name;
   ╰────
  help: Add the `f` prefix to interpolate `name`. Without it the braces stay literal text · code: [lint.unprefixed_fstring]
```

Motivated by #1204
