### PR TITLE
fix: reject dot-named package dirs

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -737,7 +737,7 @@ pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayou
         return None;
     }
 
-    if let Some((heading, reason, hint)) = go_ignored_shape(&src, "src", &sources) {
+    if let Some((heading, reason, hint)) = rejected_source_shape(&src, "src", &sources) {
         cli_error!(heading, reason, hint);
         return None;
     }
@@ -808,7 +808,7 @@ pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayou
     }
 
     if let Some((heading, reason, hint)) =
-        go_ignored_shape(&tests_dir, EXTERNAL_TESTS_DIR, &test_sources)
+        rejected_source_shape(&tests_dir, EXTERNAL_TESTS_DIR, &test_sources)
     {
         cli_error!(heading, reason, hint);
         return None;
@@ -916,7 +916,7 @@ fn go_platform_suffix(go_filename: &str) -> Option<String> {
     None
 }
 
-fn go_ignored_shape(
+fn rejected_source_shape(
     root: &Path,
     root_label: &str,
     sources: &[PathBuf],
@@ -928,7 +928,7 @@ fn go_ignored_shape(
         let Some(name) = rel.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        if name.ends_with(".d.lis") {
+        if semantics::loader::is_typedef_file(name) {
             continue;
         }
 
@@ -946,6 +946,18 @@ fn go_ignored_shape(
                             segment
                         ),
                         "Rename it: Go skips `testdata`, `vendor`, and directories beginning with `.` or `_`".to_string(),
+                    ));
+                }
+
+                if segment.contains('.') {
+                    return Some((
+                        "Dotted package directory",
+                        format!(
+                            "`{root_label}/{}` sits under `{}`, and package paths cannot contain `.`",
+                            rel.display(),
+                            segment
+                        ),
+                        "Rename it: `.` separates a package path from the name it qualifies, as in `v1.VConf`".to_string(),
                     ));
                 }
             }

--- a/crates/diagnostics/src/package_graph.rs
+++ b/crates/diagnostics/src/package_graph.rs
@@ -79,6 +79,14 @@ pub fn invalid_package_path(package_name: &str, span: Span, is_blank: bool) -> L
         .with_help(help)
 }
 
+pub fn dotted_package_directory(package_id: &str) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Dotted package directory `{}`", package_id))
+        .with_resolve_code("dotted_package_directory")
+        .with_help(
+            "Rename the directory. `.` separates a package path from the name it qualifies, as in `v1.VConf`, so a package path cannot contain one.",
+        )
+}
+
 pub fn missing_go_prefix(package_name: &str, span: Span, is_blank: bool) -> LisetteDiagnostic {
     let suggestion = if is_blank {
         format!("import _ \"go:{}\"", package_name)

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::protocol::*;
@@ -16,6 +17,46 @@ use crate::state::{AnalysisRequest, DocumentState, SharedState};
 enum AnalysisError {
     Diagnostics(Vec<Diagnostic>),
     Superseded,
+}
+
+fn dotted_directory_reaches_package_graph(uri: &Url, filename: &str, root: &Path) -> bool {
+    if !semantics::loader::is_typedef_file(filename) {
+        return true;
+    }
+
+    let Ok(file) = uri.to_file_path() else {
+        return true;
+    };
+
+    let mut outermost = None;
+    let mut walk = file.parent();
+    while let Some(dir) = walk.filter(|dir| *dir != root && dir.starts_with(root)) {
+        if dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.contains('.'))
+        {
+            outermost = Some(dir);
+        }
+        walk = dir.parent();
+    }
+
+    outermost.is_none_or(tree_has_compiled_source)
+}
+
+fn tree_has_compiled_source(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return true;
+    };
+    entries.flatten().any(|entry| {
+        if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            return tree_has_compiled_source(&entry.path());
+        }
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.ends_with(".lis") && !semantics::loader::is_typedef_file(name))
+    })
 }
 
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
@@ -66,6 +107,18 @@ impl SharedState {
             .get(uri)
             .map(|document| document.content().to_string())
             .ok_or_else(Vec::new)?;
+
+        if let Some(dotted) = project
+            .package_id
+            .split('/')
+            .find(|segment| segment.contains('.'))
+            .filter(|_| dotted_directory_reaches_package_graph(uri, &filename, config.root()))
+        {
+            return Err(vec![convert_diagnostic(
+                &diagnostics::package_graph::dotted_package_directory(dotted),
+                &LineIndex::new(&source),
+            )]);
+        }
 
         if external_test && let Some(issue) = semantics::loader::external_test_file_issue(&filename)
         {

--- a/crates/lsp/src/loader.rs
+++ b/crates/lsp/src/loader.rs
@@ -15,6 +15,7 @@ pub(crate) struct ProjectState {
 
 pub(crate) struct ProjectAnalysis {
     pub(crate) config: ProjectConfig,
+    pub(crate) package_id: String,
     pub(crate) filename: String,
     pub(crate) external_test: bool,
     pub(crate) loader: AnalysisLoader,
@@ -75,7 +76,7 @@ impl ProjectState {
         let (entry_package_path, external_test_root) = if external_test {
             (
                 package_id_to_dir(&project.config, ENTRY_PACKAGE_ID),
-                Some(package_id),
+                Some(package_id.clone()),
             )
         } else {
             let dir = uri
@@ -88,6 +89,7 @@ impl ProjectState {
 
         Some(ProjectAnalysis {
             config: project.config.clone(),
+            package_id,
             filename,
             external_test,
             loader: project.for_analysis(entry_package_path, external_test_root),

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -12594,3 +12594,234 @@ fn a_file_with_no_project_above_it_is_told_how_to_make_one() {
 
     client.shutdown();
 }
+
+#[test]
+fn a_dotted_project_directory_is_not_a_dotted_package() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("my.app");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("lisette.toml"),
+        "[project]\nname = \"github.com/acme/myapp\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    let content = "pub struct VConf { pub a: int }\n";
+    let path = root.join("src/conf.lis");
+    std::fs::write(&path, content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(&root);
+    let uri = Url::from_file_path(&path).unwrap().to_string();
+    client.open(&uri, content);
+
+    let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+    assert!(
+        !diags.iter().any(|d| d.code
+            == Some(NumberOrString::String(
+                "resolve.dotted_package_directory".to_string()
+            ))),
+        "the dot is in the project directory, not a package path: {diags:?}"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn a_typedef_file_under_a_dotted_directory_is_exempt() {
+    let (_dir, root) = geo_library_project();
+    let content = "pub fn Ext() -> int\n";
+    std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+    let path = root.join("src/v1.2/api.d.lis");
+    std::fs::write(&path, content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(&root);
+    let uri = Url::from_file_path(&path).unwrap().to_string();
+    client.open(&uri, content);
+
+    let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+    assert!(
+        !diags.iter().any(|d| d.code
+            == Some(NumberOrString::String(
+                "resolve.dotted_package_directory".to_string()
+            ))),
+        "a typedef file puts no directory in the package graph, and `lis build` accepts this project: {diags:?}"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn a_typedef_beside_a_compiled_sibling_under_a_dotted_directory_is_rejected() {
+    for sibling in ["s.lis", "api.test.lis"] {
+        let (_dir, root) = geo_library_project();
+        std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+        let content = "pub fn Ext() -> int\n";
+        let path = root.join("src/v1.2/api.d.lis");
+        std::fs::write(&path, content).unwrap();
+        std::fs::write(
+            root.join("src/v1.2").join(sibling),
+            "pub struct S { pub a: int }\n",
+        )
+        .unwrap();
+
+        let mut client = TestClient::new();
+        client.initialize_with_root(&root);
+        let uri = Url::from_file_path(&path).unwrap().to_string();
+        client.open(&uri, content);
+
+        let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+        assert!(
+            diags.iter().any(|d| d.code
+                == Some(NumberOrString::String(
+                    "resolve.dotted_package_directory".to_string()
+                ))),
+            "`{sibling}` puts `v1.2` in the package graph and `lis build` rejects it: {diags:?}"
+        );
+
+        client.shutdown();
+    }
+}
+
+#[test]
+fn a_typedef_tree_under_a_dotted_directory_tracks_the_whole_subtree() {
+    let dotted_code = Some(NumberOrString::String(
+        "resolve.dotted_package_directory".to_string(),
+    ));
+    let typedef = "pub fn Ext() -> int\n";
+
+    for (open_at, compiled_at) in [
+        ("src/v1.2/api.d.lis", "src/v1.2/sub/x.lis"),
+        ("src/v1.2/sub/api.d.lis", "src/v1.2/x.lis"),
+        ("src/v1.2/sub/api.d.lis", "src/v1.2/sub/x.lis"),
+    ] {
+        let (_dir, root) = geo_library_project();
+        std::fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
+        std::fs::write(root.join(open_at), typedef).unwrap();
+        std::fs::write(root.join(compiled_at), "pub fn f() -> int { 1 }\n").unwrap();
+
+        let mut client = TestClient::new();
+        client.initialize_with_root(&root);
+        let uri = Url::from_file_path(root.join(open_at)).unwrap().to_string();
+        client.open(&uri, typedef);
+
+        let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+        assert!(
+            diags.iter().any(|d| d.code == dotted_code),
+            "`{compiled_at}` puts `v1.2` in the package graph while `{open_at}` is open: {diags:?}"
+        );
+
+        client.shutdown();
+    }
+
+    let (_dir, root) = geo_library_project();
+    std::fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
+    std::fs::write(root.join("src/v1.2/api.d.lis"), typedef).unwrap();
+    std::fs::write(root.join("src/v1.2/sub/other.d.lis"), typedef).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(&root);
+    let uri = Url::from_file_path(root.join("src/v1.2/api.d.lis"))
+        .unwrap()
+        .to_string();
+    client.open(&uri, typedef);
+
+    let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+    assert!(
+        !diags.iter().any(|d| d.code == dotted_code),
+        "a tree of nothing but typedefs reaches no package and `lis build` accepts it: {diags:?}"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn dotted_external_test_directory_is_rejected() {
+    let (_dir, root) = geo_library_project();
+    let content = "struct VConf { a: int }\n\n#[test]\nfn value() {\n  let c = VConf { a: 1 }\n  assert c.a == 1\n}\n";
+    std::fs::create_dir_all(root.join("tests/v1.2")).unwrap();
+    let test_path = root.join("tests/v1.2/api.test.lis");
+    std::fs::write(&test_path, content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(&root);
+    let uri = Url::from_file_path(&test_path).unwrap().to_string();
+    client.open(&uri, content);
+
+    let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+    assert!(
+        diags.iter().any(|d| d.code
+            == Some(NumberOrString::String(
+                "resolve.dotted_package_directory".to_string()
+            ))),
+        "a dotted directory under tests/ must be rejected, not crash registration: {diags:?}"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn dotted_source_directory_is_rejected() {
+    let (_dir, root) = geo_library_project();
+    let content = "pub struct VConf { pub a: int }\n";
+    std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+    let path = root.join("src/v1.2/vconf.lis");
+    std::fs::write(&path, content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(&root);
+    let uri = Url::from_file_path(&path).unwrap().to_string();
+    client.open(&uri, content);
+
+    let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+    let dotted = diags
+        .iter()
+        .find(|d| {
+            d.code
+                == Some(NumberOrString::String(
+                    "resolve.dotted_package_directory".to_string(),
+                ))
+        })
+        .unwrap_or_else(|| {
+            panic!("the editor must agree with what `lis build` rejects: {diags:?}")
+        });
+    assert!(dotted.message.contains("`v1.2`"), "got: {dotted:?}");
+
+    client.shutdown();
+}
+
+#[test]
+fn an_unsaved_test_file_in_a_dotted_directory_is_rejected() {
+    let content = "struct VConf { a: int }\n\n#[test]\nfn t() {\n  let c = VConf { a: 1 }\n  assert c.a == 1\n}\n";
+
+    for on_disk in [None, Some("api.d.lis")] {
+        let (_dir, root) = geo_library_project();
+        std::fs::create_dir_all(root.join("tests/v1.2")).unwrap();
+        if let Some(sibling) = on_disk {
+            std::fs::write(
+                root.join("tests/v1.2").join(sibling),
+                "pub fn Ext() -> int\n",
+            )
+            .unwrap();
+        }
+
+        let mut client = TestClient::new();
+        client.initialize_with_root(&root);
+        let uri = Url::from_file_path(root.join("tests/v1.2/api.test.lis"))
+            .unwrap()
+            .to_string();
+        client.open(&uri, content);
+
+        let diags = client.await_diagnostics_for(&uri).unwrap_or_default();
+        assert!(
+            diags.iter().any(|d| d.code
+                == Some(NumberOrString::String(
+                    "resolve.dotted_package_directory".to_string()
+                ))),
+            "the open buffer is the compiled source, saved or not, and reaching registration \
+             through the overlay crashes the server: {diags:?}"
+        );
+
+        client.shutdown();
+    }
+}

--- a/crates/semantics/src/loader.rs
+++ b/crates/semantics/src/loader.rs
@@ -28,7 +28,11 @@ fn counts_for_internal_test_root(name: &str) -> bool {
 /// The predicate package discovery roots on. Shared so callers that pre-scan
 /// `src/` cannot disagree with the graph about what a production package is.
 pub fn is_production_package_file(name: &str) -> bool {
-    name.ends_with(".lis") && !name.ends_with(".test.lis") && !name.ends_with(".d.lis")
+    name.ends_with(".lis") && !name.ends_with(".test.lis") && !is_typedef_file(name)
+}
+
+pub fn is_typedef_file(name: &str) -> bool {
+    name.ends_with(".d.lis")
 }
 
 pub const EXTERNAL_TESTS_DIR: &str = "tests";

--- a/tests/e2e_external_tests.rs
+++ b/tests/e2e_external_tests.rs
@@ -297,6 +297,25 @@ fn go_ignored_shape_under_tests_is_rejected() {
 }
 
 #[test]
+fn dotted_directory_under_tests_is_rejected() {
+    let (_dir, project) = scaffold_binary_with_math("extdot");
+    fs::create_dir_all(project.join("tests/v1.2")).unwrap();
+    fs::write(
+        project.join("tests/v1.2/api.test.lis"),
+        "struct VConf { a: int }\n#[test]\nfn t() {}\n",
+    )
+    .unwrap();
+
+    let check = lis(&project, &["check"]);
+    let out = combined(&check);
+    assert!(!check.status.success(), "expected failure: {out}");
+    assert!(
+        out.contains("Dotted package directory") && !out.contains("INTERNAL COMPILER ERROR"),
+        "got: {out}"
+    );
+}
+
+#[test]
 fn library_project_runs_external_tests() {
     if !go_available() {
         eprintln!("skipping: `go` not found");

--- a/tests/e2e_library.rs
+++ b/tests/e2e_library.rs
@@ -236,6 +236,54 @@ fn library_rejects_go_ignored_package_directory() {
 }
 
 #[test]
+fn library_rejects_dotted_package_directory() {
+    for bad in ["v1.2", "api/v1.2", "v2."] {
+        let (_dir, project) = scaffold("github.com/acme/dotted");
+        fs::write(
+            project.join("src/dotted.lis"),
+            "pub fn top() -> int { 1 }\n",
+        )
+        .unwrap();
+        fs::create_dir_all(project.join("src").join(bad)).unwrap();
+        fs::write(
+            project.join("src").join(bad).join("x.lis"),
+            "pub struct VConf { pub a: int }\n",
+        )
+        .unwrap();
+        let build = lis(&project, &["build"]);
+        let output = combined(&build);
+        assert!(!build.status.success(), "`{bad}` should be rejected");
+        assert!(
+            output.contains("Dotted package directory"),
+            "`{bad}` should be rejected, got: {output}"
+        );
+        assert!(
+            !output.contains("INTERNAL COMPILER ERROR"),
+            "`{bad}` must not reach type registration, got: {output}"
+        );
+    }
+}
+
+#[test]
+fn binary_check_rejects_dotted_package_directory() {
+    let (_dir, project) = scaffold("github.com/acme/dottedbin");
+    fs::write(project.join("src/main.lis"), "fn main() { () }\n").unwrap();
+    fs::create_dir_all(project.join("src/v1.2")).unwrap();
+    fs::write(
+        project.join("src/v1.2/vconf.lis"),
+        "pub enum Mode { On, Off }\n",
+    )
+    .unwrap();
+    let check = lis(&project, &["check"]);
+    let output = combined(&check);
+    assert!(!check.status.success());
+    assert!(
+        output.contains("Dotted package directory") && !output.contains("INTERNAL COMPILER ERROR"),
+        "got: {output}"
+    );
+}
+
+#[test]
 fn library_rejects_platform_suffixed_source() {
     for bad in [
         "api_windows.lis",


### PR DESCRIPTION
A package dir whose name contains a dot, e.g. `src/v1.2/`, now reports an error instead of crashing the compiler. The LSP server reached the same panic through its own pkg discovery.

```rs
// src/v1.2/vconf.lis
pub struct VConf { pub a: int }
```


