### PR TITLE
fix: stop suggesting `let mut` on function parameters

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1,5 +1,5 @@
 use crate::LisetteDiagnostic;
-use syntax::ast::{Annotation, BinaryOperator, Span};
+use syntax::ast::{Annotation, BinaryOperator, BindingKind, Span};
 use syntax::types::{SimpleKind, Type};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -511,7 +511,7 @@ pub fn disallowed_mutation(
     variable_name: &str,
     span: Span,
     self_type_name: Option<&str>,
-    is_pattern_binding: bool,
+    binding_kind: Option<BindingKind>,
     is_const_binding: bool,
 ) -> LisetteDiagnostic {
     if variable_name == "self" {
@@ -535,7 +535,7 @@ pub fn disallowed_mutation(
             .with_help(format!(
                 "`const` bindings are immutable. Rebind with `let mut {variable_name} = {variable_name}` to mutate a local copy"
             ))
-    } else if is_pattern_binding {
+    } else if binding_kind.is_some_and(|kind| kind.is_pattern_position()) {
         LisetteDiagnostic::error("Immutable variable")
             .with_infer_code("immutable")
             .with_span_label(&span, "patterns cannot bind with `mut`")
@@ -543,15 +543,18 @@ pub fn disallowed_mutation(
                 "Rebind with `let mut {variable_name} = {variable_name}`, then mutate that"
             ))
     } else {
+        let help = if binding_kind.is_some_and(|kind| kind.is_param()) {
+            "Declare the parameter with `mut` to mutate it".to_string()
+        } else {
+            format!("Declare using `let mut {variable_name}` to make the variable mutable")
+        };
         LisetteDiagnostic::error("Immutable variable")
             .with_infer_code("immutable")
             .with_span_label(
                 &span,
                 format!("`{variable_name}` was declared without `mut`"),
             )
-            .with_help(format!(
-                "Declare using `let mut {variable_name}` to make the variable mutable"
-            ))
+            .with_help(help)
     }
 }
 

--- a/crates/semantics/src/checker/infer/expressions/call_effects.rs
+++ b/crates/semantics/src/checker/infer/expressions/call_effects.rs
@@ -238,17 +238,17 @@ impl InferCtx<'_> {
             && !self.scopes.lookup_mutable(&var_name)
             && self.imports.namespace(&var_name).is_none()
         {
-            let is_pattern_binding = self
+            let binding_kind = self
                 .scopes
                 .lookup_binding_id(&var_name)
                 .and_then(|id| self.facts.bindings.get(&id))
-                .is_some_and(|b| b.kind.is_pattern_position());
+                .map(|b| b.kind);
             let is_const = self.is_const_var(store, &var_name);
             self.sink.push(diagnostics::infer::disallowed_mutation(
                 &var_name,
                 *span,
                 None,
-                is_pattern_binding,
+                binding_kind,
                 is_const,
             ));
         }

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -403,17 +403,17 @@ impl InferCtx<'_> {
             } else {
                 None
             };
-            let is_pattern_binding = self
+            let binding_kind = self
                 .scopes
                 .lookup_binding_id(&var_name)
                 .and_then(|id| self.facts.bindings.get(&id))
-                .is_some_and(|b| b.kind.is_pattern_position());
+                .map(|b| b.kind);
             let is_const = self.is_const_var(store, &var_name);
             self.sink.push(diagnostics::infer::disallowed_mutation(
                 &var_name,
                 *span,
                 self_type_name.as_deref(),
-                is_pattern_binding,
+                binding_kind,
                 is_const,
             ));
         }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -509,17 +509,17 @@ impl InferCtx<'_> {
         } else {
             None
         };
-        let is_pattern_binding = self
+        let binding_kind = self
             .scopes
             .lookup_binding_id(var_name)
             .and_then(|id| self.facts.bindings.get(&id))
-            .is_some_and(|b| b.kind.is_pattern_position());
+            .map(|b| b.kind);
         let is_const = self.is_const_var(store, var_name);
         self.sink.push(diagnostics::infer::disallowed_mutation(
             var_name,
             span,
             self_type_name.as_deref(),
-            is_pattern_binding,
+            binding_kind,
             is_const,
         ));
     }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3449,6 +3449,68 @@ fn test() {
 }
 
 #[test]
+fn infer_param_not_mutable() {
+    let input = r#"
+fn test(count: int) {
+  count = 20;
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_param_not_mutable_for_ref_receiver_method() {
+    let input = r#"
+struct Counter { count: int }
+
+impl Counter {
+  fn increment(self: Ref<Counter>) {
+    self.count = self.count + 1;
+  }
+}
+
+fn test(counter: Counter) {
+  counter.increment()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_destructured_param_not_mutable() {
+    let input = r#"
+fn test((x, y): (int, int)) -> int {
+  x = 1
+  x + y
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_destructured_struct_param_not_mutable() {
+    let input = r#"
+struct Point { x: int, y: int }
+
+fn test(Point { x, y }: Point) -> int {
+  x = 1
+  x + y
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_param_not_mutable_for_map_delete() {
+    let input = r#"
+fn test(scores: Map<string, int>) {
+  scores.delete("a")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_mut_binding_aliases_slice() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_destructured_param_not_mutable.snap
+++ b/tests/ui/errors/snapshots/infer_destructured_param_not_mutable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable variable
+   ╭─[test.lis:3:3]
+ 2 │ fn test((x, y): (int, int)) -> int {
+ 3 │   x = 1
+   ·   ──┬──
+   ·     ╰── `x` was declared without `mut`
+ 4 │   x + y
+   ╰────
+  help: Declare the parameter with `mut` to mutate it · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_destructured_struct_param_not_mutable.snap
+++ b/tests/ui/errors/snapshots/infer_destructured_struct_param_not_mutable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable variable
+   ╭─[test.lis:5:3]
+ 4 │ fn test(Point { x, y }: Point) -> int {
+ 5 │   x = 1
+   ·   ──┬──
+   ·     ╰── `x` was declared without `mut`
+ 6 │   x + y
+   ╰────
+  help: Declare the parameter with `mut` to mutate it · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_param_not_mutable.snap
+++ b/tests/ui/errors/snapshots/infer_param_not_mutable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable variable
+   ╭─[test.lis:3:3]
+ 2 │ fn test(count: int) {
+ 3 │   count = 20;
+   ·   ─────┬────
+   ·        ╰── `count` was declared without `mut`
+ 4 │ }
+   ╰────
+  help: Declare the parameter with `mut` to mutate it · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_param_not_mutable_for_map_delete.snap
+++ b/tests/ui/errors/snapshots/infer_param_not_mutable_for_map_delete.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable variable
+   ╭─[test.lis:3:3]
+ 2 │ fn test(scores: Map<string, int>) {
+ 3 │   scores.delete("a")
+   ·   ─────────┬────────
+   ·            ╰── `scores` was declared without `mut`
+ 4 │ }
+   ╰────
+  help: Declare the parameter with `mut` to mutate it · code: [infer.immutable]

--- a/tests/ui/errors/snapshots/infer_param_not_mutable_for_ref_receiver_method.snap
+++ b/tests/ui/errors/snapshots/infer_param_not_mutable_for_ref_receiver_method.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable variable
+    ╭─[test.lis:11:3]
+ 10 │ fn test(counter: Counter) {
+ 11 │   counter.increment()
+    ·   ────────┬────────
+    ·           ╰── `counter` was declared without `mut`
+ 12 │ }
+    ╰────
+  help: Declare the parameter with `mut` to mutate it · code: [infer.immutable]


### PR DESCRIPTION
Noticed the `infer.immutable` error was suggesting `let mut x` on a fn param. It now points at the parameter itself.