### PR TITLE
feat: qualify type names in diagnostics

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1261,11 +1261,12 @@ pub fn binary_operator_type_mismatch(
     right_ty: &Type,
     span: Span,
 ) -> LisetteDiagnostic {
+    let (left_name, right_name) = Type::stringify_pair(left_ty, right_ty);
     let label_msg = format!(
         "cannot {} `{}` and `{}`",
         operator_verb(operator),
-        left_ty,
-        right_ty
+        left_name,
+        right_name
     );
 
     LisetteDiagnostic::error("Type mismatch")
@@ -1511,11 +1512,16 @@ pub fn branch_type_mismatch(
     branch_span: Span,
     result_ty: &Type,
 ) -> LisetteDiagnostic {
+    let (branch_name, result_name) = Type::stringify_pair(branch_ty, result_ty);
+
     LisetteDiagnostic::error("Type mismatch")
         .with_infer_code("type_mismatch")
         .with_span_label(
             &branch_span,
-            format!("this branch produces `{}`, not `{}`", branch_ty, result_ty),
+            format!(
+                "this branch produces `{}`, not `{}`",
+                branch_name, result_name
+            ),
         )
         .with_help("All branches must produce the same type when used as a value")
 }

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LisetteDiagnostic;
 use syntax::ast::BindingId;
-use syntax::program::{EmitInput, MutationInfo, UnusedInfo};
+use syntax::program::{EmitInput, MutationInfo, UnusedInfo, is_internal_package_id};
 
 use semantics::AnalyzeInput;
 use semantics::cache::{EmitStamp, save_package_cache};
@@ -170,7 +170,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
     for (_, package) in store.packages {
         // Worker views are gone by now, so this unwraps without cloning.
         let package = Arc::try_unwrap(package).unwrap_or_else(|shared| (*shared).clone());
-        let is_internal = package.is_internal();
+        let is_internal = is_internal_package_id(&package.id);
         definitions.extend(package.definitions);
 
         // Internal typedef files remain available so the LSP can map their IDs

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap as HashMap;
 use semantics::facts::{Facts, Usage};
 use semantics::store::Store;
 use syntax::ast::{Expression, Pattern, Span};
-use syntax::program::Package;
+use syntax::program::{Package, is_internal_package_id};
 
 use attributes::{check_attributes, check_enum_attributes, check_struct_attributes};
 use checks::{
@@ -232,7 +232,7 @@ pub(crate) fn run(store: &Store, facts: &Facts) -> Vec<LisetteDiagnostic> {
         .packages
         .values()
         .map(Arc::as_ref)
-        .filter(|m| !m.is_internal())
+        .filter(|m| !is_internal_package_id(&m.id))
         .collect();
     packages.sort_unstable_by(|a, b| a.id.cmp(&b.id));
 

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -17,8 +17,8 @@ use semantics::store::Store;
 use syntax::ast::{Attribute, AttributeArg, Expression, Span, StructFieldDefinition, Visibility};
 use syntax::program::EqualityIndex;
 use syntax::program::File;
-use syntax::program::Package;
 use syntax::program::UnusedInfo;
+use syntax::program::{Package, is_internal_package_id};
 
 use extract::{AliasMap, is_upper, walk_expression};
 use redundant_import_alias::check_redundant_aliases;
@@ -39,7 +39,7 @@ pub(crate) fn run(store: &Store, facts: &Facts) -> (Vec<LisetteDiagnostic>, Unus
         .packages
         .values()
         .map(Arc::as_ref)
-        .filter(|m| !m.is_internal())
+        .filter(|m| !is_internal_package_id(&m.id))
         .collect();
     packages.sort_unstable_by(|a, b| a.id.cmp(&b.id));
 

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -736,18 +736,27 @@ impl InferCtx<'_> {
                         );
                 }
 
+                let (expected_name, actual_name) = Type::stringify_pair(expected, actual);
+
                 LisetteDiagnostic::error("Type mismatch")
                     .with_infer_code("type_mismatch")
-                    .with_span_label(span, format!("expected `{}`, found `{}`", expected, actual))
+                    .with_span_label(
+                        span,
+                        format!("expected `{}`, found `{}`", expected_name, actual_name),
+                    )
                     .with_help("The function types must have the same number of parameters")
             }
 
             UnifyError::TypeMismatch | UnifyError::Multiple(_) => {
-                let help = self.help(expected, actual);
+                let (expected_name, actual_name) = Type::stringify_pair(expected, actual);
+                let help = self.help(expected, actual, &expected_name, &actual_name);
 
                 LisetteDiagnostic::error("Type mismatch")
                     .with_infer_code("type_mismatch")
-                    .with_span_label(span, format!("expected `{}`, found `{}`", expected, actual))
+                    .with_span_label(
+                        span,
+                        format!("expected `{}`, found `{}`", expected_name, actual_name),
+                    )
                     .with_help(help)
             }
 
@@ -757,18 +766,24 @@ impl InferCtx<'_> {
         }
     }
 
-    fn help(&self, expected: &Type, actual: &Type) -> String {
+    fn help(
+        &self,
+        expected: &Type,
+        actual: &Type,
+        expected_name: &str,
+        actual_name: &str,
+    ) -> String {
         if actual.is_unknown() {
             return format!(
                 "The `Unknown` type cannot be used directly. Use `assert_type` to narrow it down to a concrete type. Example: `let value = assert_type<{}>(...)?`",
-                expected
+                expected_name
             );
         }
 
         if expected.is_unknown() {
             return format!(
                 "The `Unknown` type cannot be used directly. Use `assert_type` to narrow it down to a concrete type.  Example: `let value = assert_type<{}>(...)?`",
-                actual
+                actual_name
             );
         }
 
@@ -802,7 +817,7 @@ impl InferCtx<'_> {
 
         if array_to_slice_help_applies(expected, actual) {
             return format!(
-                "Call `.to_slice()` to copy the elements into a new slice, or change the receiving type to `{actual}`"
+                "Call `.to_slice()` to copy the elements into a new slice, or change the receiving type to `{actual_name}`"
             );
         }
 
@@ -824,7 +839,7 @@ impl InferCtx<'_> {
                 {
                     format!(
                         "Build the map with `Map.new()` plus indexed assignment: `let mut m: {} = Map.new(); m[k] = v`",
-                        expected
+                        expected_name
                     )
                 }
                 Some((Slice, args))
@@ -832,7 +847,7 @@ impl InferCtx<'_> {
                         .first()
                         .is_some_and(|ty| self.store.resolves_to_unknown(ty)) =>
                 {
-                    format!("Annotate the slice literal: `let xs: {} = [v1, v2, ...]`", expected)
+                    format!("Annotate the slice literal: `let xs: {} = [v1, v2, ...]`", expected_name)
                 }
                 _ if self.store.resolve_to_function_type(expected).is_some()
                     && self.store.resolve_to_function_type(actual).is_some() =>
@@ -840,7 +855,7 @@ impl InferCtx<'_> {
                     "Function types must match exactly, and `Unknown` matches only `Unknown`. Declare the function with the expected signature and narrow with `assert_type` inside, or wrap it in a closure that narrows at the call site".to_string()
                 }
                 _ => format!(
-                    "`Unknown` matches only `Unknown`, never a concrete type. Build `{expected}` from a value already annotated as `Unknown`, e.g. `let value: Unknown = ...`, or change the expected type to `{actual}`"
+                    "`Unknown` matches only `Unknown`, never a concrete type. Build `{expected_name}` from a value already annotated as `Unknown`, e.g. `let value: Unknown = ...`, or change the expected type to `{actual_name}`"
                 ),
             };
         }
@@ -848,12 +863,12 @@ impl InferCtx<'_> {
         if self.store.is_interface(actual) && !self.store.is_interface(expected) {
             return format!(
                 "An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<{}>(value)?`",
-                expected
+                expected_name
             );
         }
 
         if self.store.is_numeric_compatible_with(expected, actual) {
-            return format!("Cast with `as`, e.g. `value as {}`", expected);
+            return format!("Cast with `as`, e.g. `value as {}`", expected_name);
         }
 
         if let Some(Type::Function(function)) = self.store.resolve_to_function_type(expected)
@@ -872,17 +887,22 @@ impl InferCtx<'_> {
             None => {}
         }
 
-        if let Some(widening) = self.container_widening_help(expected, actual) {
+        if let Some(widening) = self.container_widening_help(expected, actual, expected_name) {
             return widening;
         }
 
         format!(
             "Change the type annotation to `{}` or convert the value to `{}`",
-            actual, expected
+            actual_name, expected_name
         )
     }
 
-    fn container_widening_help(&self, expected: &Type, actual: &Type) -> Option<String> {
+    fn container_widening_help(
+        &self,
+        expected: &Type,
+        actual: &Type,
+        expected_name: &str,
+    ) -> Option<String> {
         let container = WideningContainer::of(expected)?;
         if WideningContainer::of(actual) != Some(container) {
             return None;
@@ -914,7 +934,7 @@ impl InferCtx<'_> {
             Widening::Value => format!("Use `.map({cast})` to widen the value"),
             Widening::Error => format!("Use `.map_err({cast})` to widen the error"),
             Widening::Entries => format!(
-                "Copy the entries into a new `{expected}`, widening each value: `widened[key] = value as {expected_element}`"
+                "Copy the entries into a new `{expected_name}`, widening each value: `widened[key] = value as {expected_element}`"
             ),
         })
     }

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -1,36 +1,69 @@
 use std::fmt;
 
-use crate::types::Type;
+use crate::program::is_internal_package_id;
+use crate::types::{GO_IMPORT_PREFIX, Symbol, Type};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Qualifier {
+    Package,
+    Path,
+}
 
 impl Type {
     pub fn stringify(&self) -> String {
+        self.stringify_as(Qualifier::Package)
+    }
+
+    pub fn stringify_pair(first: &Self, second: &Self) -> (String, String) {
+        let (named, _) = Self::remove_vars(&[first, second]);
+        let (first, second) = (&named[0], &named[1]);
+
+        let (short_first, short_second) = (first.stringify(), second.stringify());
+        if short_first != short_second {
+            return (short_first, short_second);
+        }
+
+        let wide_first = first.stringify_as(Qualifier::Path);
+        let wide_second = second.stringify_as(Qualifier::Path);
+        if wide_first == wide_second {
+            return (short_first, short_second);
+        }
+
+        (wide_first, wide_second)
+    }
+
+    fn stringify_as(&self, qualifier: Qualifier) -> String {
         match self {
             Type::Nominal {
                 id, params: args, ..
             } => {
                 let args_formatted = args
                     .iter()
-                    .map(|a| a.stringify())
+                    .map(|a| a.stringify_as(qualifier))
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                let name = id.last_segment();
+                let leaf = id.last_segment();
 
-                if name == "Unit" {
-                    return "()".to_string();
+                if !id.as_str().starts_with(GO_IMPORT_PREFIX) {
+                    if leaf == "Unit" {
+                        return "()".to_string();
+                    }
+
+                    if leaf == "bool" {
+                        return "bool".to_string();
+                    }
+
+                    if leaf.starts_with("Tuple") {
+                        return format!("({})", args_formatted);
+                    }
+
+                    if leaf == "Ref" {
+                        return format!("Ref<{}>", args_formatted);
+                    }
                 }
 
-                if name == "bool" {
-                    return "bool".to_string();
-                }
-
-                if name.starts_with("Tuple") {
-                    return format!("({})", args_formatted);
-                }
-
-                if name == "Ref" {
-                    return format!("Ref<{}>", args_formatted);
-                }
+                let name = qualified_name(id, qualifier);
 
                 if args.is_empty() {
                     return name.to_string();
@@ -54,15 +87,15 @@ impl Type {
                     .iter()
                     .map(|param| {
                         if param.mutable {
-                            format!("mut {}", param.ty.stringify())
+                            format!("mut {}", param.ty.stringify_as(qualifier))
                         } else {
-                            param.ty.stringify()
+                            param.ty.stringify_as(qualifier)
                         }
                     })
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                let ret_formatted = f.return_type.stringify();
+                let ret_formatted = f.return_type.stringify_as(qualifier);
 
                 format!("fn ({}) -> {}", args_formatted, ret_formatted)
             }
@@ -78,14 +111,14 @@ impl Type {
             Type::Tuple(elements) => {
                 let formatted = elements
                     .iter()
-                    .map(|e| e.stringify())
+                    .map(|e| e.stringify_as(qualifier))
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("({})", formatted)
             }
 
             Type::Array { length, element } => {
-                format!("Array<{}, {}>", element.stringify(), length)
+                format!("Array<{}, {}>", element.stringify_as(qualifier), length)
             }
 
             Type::Error => "<error>".to_string(),
@@ -109,7 +142,7 @@ impl Type {
             Type::Compound { kind, args } => {
                 let args_formatted = args
                     .iter()
-                    .map(|a| a.stringify())
+                    .map(|a| a.stringify_as(qualifier))
                     .collect::<Vec<_>>()
                     .join(", ");
                 if args.is_empty() {
@@ -119,6 +152,25 @@ impl Type {
                 }
             }
         }
+    }
+}
+
+fn qualified_name(id: &Symbol, qualifier: Qualifier) -> &str {
+    if let Some(path) = id.as_str().strip_prefix(GO_IMPORT_PREFIX) {
+        return path;
+    }
+
+    if qualifier == Qualifier::Package {
+        return id.last_segment();
+    }
+
+    match id.as_str().split_once('.') {
+        Some((package, _))
+            if package != crate::ENTRY_PACKAGE_ID && !is_internal_package_id(package) =>
+        {
+            id.as_str()
+        }
+        _ => id.last_segment(),
     }
 }
 

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -12,7 +12,7 @@ pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,
 };
 pub use file::{File, FileImport, go_import_default_name, is_test_file, unaliased_binding_name};
-pub use package::{Package, PackageId, UninferredExports};
+pub use package::{Package, PackageId, UninferredExports, is_internal_package_id};
 pub use resolution::{
     CallKind, ChannelOperation, DotAccessKind, DotAccessResolution, NativeTypeKind,
     ReceiverCoercion, channel_operation, resolved_definition,

--- a/crates/syntax/src/program/package.rs
+++ b/crates/syntax/src/program/package.rs
@@ -7,6 +7,10 @@ use crate::types::Symbol;
 
 pub type PackageId = String;
 
+pub fn is_internal_package_id(id: &str) -> bool {
+    id == "prelude" || id == "**test_prelude" || id == "**nominal" || id.starts_with("go:")
+}
+
 #[derive(Debug, Clone)]
 pub struct Package {
     pub id: String,
@@ -80,13 +84,6 @@ impl Package {
 
     pub fn is_typedef(&self, file_id: u32) -> bool {
         self.files.get(&file_id).is_some_and(File::is_d_lis)
-    }
-
-    pub fn is_internal(&self) -> bool {
-        self.id == "prelude"
-            || self.id == "**test_prelude"
-            || self.id == "**nominal"
-            || self.id.starts_with("go:")
     }
 
     pub fn is_empty_stub(&self) -> bool {

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -10218,3 +10218,20 @@ fn main() {}
     infer_with_go_typedefs(input, &[("go:example.com/cache", typedef)])
         .assert_infer_code("comma_ok_abi_mismatch");
 }
+
+#[test]
+fn go_type_names_its_import_path_not_a_derived_package_name() {
+    let typedef = r#"// Package: yaml
+
+pub struct Decoder { pub Strict: bool }
+"#;
+    let input = r#"
+import yaml "go:gopkg.in/yaml.v3"
+
+fn run() {
+  let _: int = yaml.Decoder { Strict: true }
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:gopkg.in/yaml.v3", typedef)])
+        .assert_error_contains("gopkg.in/yaml.v3.Decoder");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3259,6 +3259,121 @@ fn get_number() -> int {
 }
 
 #[test]
+fn infer_type_mismatch_names_go_package() {
+    let input = r#"
+import "go:time"
+
+fn test() {
+  let d: time.Duration = 5
+  let n: int = d
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_mismatch_go_type_named_after_a_builtin() {
+    let input = r#"
+import "go:go/types"
+
+fn take(t: types.Tuple) -> int { 1 }
+
+fn test() {
+  let _ = take(5)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_mismatch_go_and_project_type_share_a_leaf_name() {
+    let input = r#"
+import "go:bytes"
+
+struct Buffer { n: int }
+
+fn take_go(mut b: bytes.Buffer) -> int { b.Len() }
+
+fn test() {
+  let mine = Buffer { n: 1 }
+  let _ = take_go(mine)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_type_mismatch_two_packages_share_a_leaf_name() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file("alpha", "alpha.lis", "pub struct Config { pub n: int }\n");
+    fs.add_file("beta", "beta.lis", "pub struct Config { pub n: int }\n");
+
+    let source = r#"
+import "alpha"
+import "beta"
+
+fn take(c: alpha.Config) -> int { c.n }
+
+fn main() {
+  let b = beta.Config { n: 1 }
+  let _ = take(b)
+}
+"#;
+    fs.add_file(ENTRY_PACKAGE_ID, "main.lis", source);
+
+    let result = infer_package(ENTRY_PACKAGE_ID, fs);
+    assert_multipackage_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn infer_binary_operator_operands_share_a_leaf_name() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file("alpha", "alpha.lis", "pub struct Config { pub n: int }\n");
+    fs.add_file("beta", "beta.lis", "pub struct Config { pub n: int }\n");
+
+    let source = r#"
+import "alpha"
+import "beta"
+
+fn main() {
+  let a: Option<alpha.Config> = Some(alpha.Config { n: 1 })
+  let b: Option<beta.Config> = Some(beta.Config { n: 2 })
+  let _ = a == b
+}
+"#;
+    fs.add_file(ENTRY_PACKAGE_ID, "main.lis", source);
+
+    let result = infer_package(ENTRY_PACKAGE_ID, fs);
+    assert_multipackage_infer_error_snapshot!(result, source);
+}
+
+#[test]
+fn infer_type_mismatch_entry_package_shares_a_leaf_name() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file("alpha", "alpha.lis", "pub struct Config { pub n: int }\n");
+
+    let source = r#"
+import "alpha"
+
+struct Config { n: int }
+
+fn take(c: alpha.Config) -> int { c.n }
+
+fn main() {
+  let mine = Config { n: 1 }
+  let _ = take(mine)
+}
+"#;
+    fs.add_file(ENTRY_PACKAGE_ID, "main.lis", source);
+
+    let result = infer_package(ENTRY_PACKAGE_ID, fs);
+    assert_multipackage_infer_error_snapshot!(result, source);
+}
+
+#[test]
 fn infer_type_not_found() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_binary_operator_operands_share_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_binary_operator_operands_share_a_leaf_name.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[main.lis:8:11]
+ 7 │   let b: Option<beta.Config> = Some(beta.Config { n: 2 })
+ 8 │   let _ = a == b
+   ·           ───┬──
+   ·              ╰── cannot compare `Option<alpha.Config>` and `Option<beta.Config>`
+ 9 │ }
+   ╰────
+  help: The `==` operator requires both operands to have the same type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_go_opaque_type_no_zero_for_unverified_type.snap
+++ b/tests/ui/errors/snapshots/infer_go_opaque_type_no_zero_for_unverified_type.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ `Seed` has no zero value
+  ✕ `hash/maphash.Seed` has no zero value
    ╭─[test.lis:5:11]
  4 │ fn test() {
  5 │   let s = maphash.Seed {};
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                  ╰── no zero available
  6 │ }
    ╰────
-  help: `Seed` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]
+  help: `hash/maphash.Seed` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]

--- a/tests/ui/errors/snapshots/infer_go_partially_hidden_struct_no_zero_even_with_visible_field_set.snap
+++ b/tests/ui/errors/snapshots/infer_go_partially_hidden_struct_no_zero_even_with_visible_field_set.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ `File` has no zero value
+  ✕ `archive/zip.File` has no zero value
    ╭─[test.lis:5:11]
  4 │     fn test() {
  5 │ ╭─▶   let f = zip.File {
@@ -10,4 +10,4 @@ source: tests/ui/errors/mod.rs
    · ╰──── no zero available
  8 │     }
    ╰────
-  help: `File` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]
+  help: `archive/zip.File` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]

--- a/tests/ui/errors/snapshots/infer_go_struct_autofill_no_zero_for_field.snap
+++ b/tests/ui/errors/snapshots/infer_go_struct_autofill_no_zero_for_field.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ `Timer` has no zero value
+  ✕ `time.Timer` has no zero value
    ╭─[test.lis:5:11]
  4 │ fn test() {
  5 │   let t = time.Timer { .. };
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                   ╰── no zero available
  6 │ }
    ╰────
-  help: `Timer` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]
+  help: `time.Timer` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]

--- a/tests/ui/errors/snapshots/infer_slice_make_no_zero_for_hidden_go_state.snap
+++ b/tests/ui/errors/snapshots/infer_slice_make_no_zero_for_hidden_go_state.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ `File` has no zero value
+  ✕ `archive/zip.File` has no zero value
    ╭─[test.lis:5:15]
  4 │ fn test() {
  5 │   let files = Slice.make<zip.File>(4)
    ·               ───────────┬───────────
-   ·                          ╰── `Slice.make` zero-fills every element, but `File` has none
+   ·                          ╰── `Slice.make` zero-fills every element, but `archive/zip.File` has none
  6 │ }
    ╰────
   help: `archive/zip.File` has Go-side state hidden from Lisette, so it has no zero value. Build the slice from a list literal of values obtained from its documented Go constructor · code: [infer.slice_make_no_zero]

--- a/tests/ui/errors/snapshots/infer_struct_autofill_no_zero_for_go_interface_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_autofill_no_zero_for_go_interface_field.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                      ╰── no zero available
  8 │ }
    ╰────
-  help: Field `ctx` of type `Context` has no zero value. Provide an explicit value, or wrap the field type in `Option<T>` · code: [infer.field_no_zero]
+  help: Field `ctx` of type `context.Context` has no zero value. Provide an explicit value, or wrap the field type in `Option<T>` · code: [infer.field_no_zero]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_entry_package_shares_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_entry_package_shares_a_leaf_name.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[main.lis:10:16]
+  9 │   let mine = Config { n: 1 }
+ 10 │   let _ = take(mine)
+    ·                ──┬─
+    ·                  ╰── expected `alpha.Config`, found `Config`
+ 11 │ }
+    ╰────
+  help: Change the type annotation to `Config` or convert the value to `alpha.Config` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_go_and_project_type_share_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_go_and_project_type_share_a_leaf_name.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:10:19]
+  9 │   let mine = Buffer { n: 1 }
+ 10 │   let _ = take_go(mine)
+    ·                   ──┬─
+    ·                     ╰── expected `bytes.Buffer`, found `Buffer`
+ 11 │ }
+    ╰────
+  help: Change the type annotation to `Buffer` or convert the value to `bytes.Buffer` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_go_type_named_after_a_builtin.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_go_type_named_after_a_builtin.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:7:16]
+ 6 │ fn test() {
+ 7 │   let _ = take(5)
+   ·                ┬
+   ·                ╰── expected `go/types.Tuple`, found `int`
+ 8 │ }
+   ╰────
+  help: Change the type annotation to `int` or convert the value to `go/types.Tuple` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_names_go_package.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_names_go_package.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:6:16]
+ 5 │   let d: time.Duration = 5
+ 6 │   let n: int = d
+   ·                ┬
+   ·                ╰── expected `int`, found `time.Duration`
+ 7 │ }
+   ╰────
+  help: Cast with `as`, e.g. `value as int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_two_packages_share_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_two_packages_share_a_leaf_name.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[main.lis:9:16]
+  8 │   let b = beta.Config { n: 1 }
+  9 │   let _ = take(b)
+    ·                ┬
+    ·                ╰── expected `alpha.Config`, found `beta.Config`
+ 10 │ }
+    ╰────
+  help: Change the type annotation to `beta.Config` or convert the value to `alpha.Config` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_uncurated_struct_with_unexported_embed_no_zero.snap
+++ b/tests/ui/errors/snapshots/infer_uncurated_struct_with_unexported_embed_no_zero.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ `File` has no zero value
+  ✕ `os.File` has no zero value
    ╭─[test.lis:5:11]
  4 │ fn test() {
  5 │   let f = os.File { .. };
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                  ╰── no zero available
  6 │ }
    ╰────
-  help: `File` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]
+  help: `os.File` has Go-side state hidden from Lisette whose zero value is not safe to use directly. Construct it through its documented Go constructor instead · code: [infer.hidden_state_no_zero]


### PR DESCRIPTION
Types imported from Go now carry their import path in diagnostics:

```
  ✕ Type mismatch
   ╭─[test.lis:6:16]
 5 │   let d: time.Duration = 5
 6 │   let n: int = d
   ·                ┬
   ·                ╰── expected `int`, found `time.Duration`
 7 │ }
   ╰────
  help: Cast with `as`, e.g. `value as int` · code: [infer.type_mismatch]
```

Project packages are qualified as well where the bare name would be ambiguous:

```
 ✕ Type mismatch
    ╭─[test.lis:10:19]
  9 │   let mine = Buffer { n: 1 }
 10 │   let _ = take_go(mine)
    ·                   ──┬─
    ·                     ╰── expected `bytes.Buffer`, found `Buffer`
 11 │ }
    ╰────
  help: Change the type annotation to `Buffer` or convert the value to `bytes.Buffer` · code: [infer.type_mismatch]
```