### PR TITLE
fix: prune a script build dir against its own emit

### DIFF
--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -50,15 +50,23 @@ pub(super) fn prepare(
         }
     };
 
-    prune_stale_go(&dir, &emit.new_manifest);
+    let emitted: Vec<&str> = result
+        .output
+        .iter()
+        .map(|file| file.name.as_str())
+        .collect();
+    prune_stale_go(&dir, &emitted);
 
-    let import_set_hash = go_cli::compute_import_set_hash(&emit.new_manifest, GO_MODULE);
+    let mut manifest = emit.new_manifest;
+    manifest.retain(|entry| emitted.contains(&entry.name.as_str()));
+
+    let import_set_hash = go_cli::compute_import_set_hash(&manifest, GO_MODULE);
     if let Err(e) = go_cli::finalize_go_dir(&dir, target, &emit.changed, import_set_hash) {
         cli_error!(heading, e.message, e.hint);
         return Err(1);
     }
 
-    go_cli::write_emit_manifest(&dir, &emit.new_manifest);
+    go_cli::write_emit_manifest(&dir, &manifest);
 
     Ok(ScriptBuild {
         dir,
@@ -262,14 +270,14 @@ fn absolute(path: &Path) -> Option<PathBuf> {
     Some(std::env::current_dir().ok()?.join(path))
 }
 
-fn prune_stale_go(dir: &Path, manifest: &[go_cli::ManifestEntry]) {
+fn prune_stale_go(dir: &Path, emitted: &[&str]) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
-        if name.ends_with(".go") && !manifest.iter().any(|entry| entry.name == name) {
+        if name.ends_with(".go") && !emitted.contains(&name) {
             let _ = fs::remove_file(entry.path());
         }
     }

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1746,6 +1746,58 @@ fn a_stale_go_file_in_the_build_directory_is_pruned() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn a_symlink_named_apart_from_its_target_still_runs() {
+    if !go_available() {
+        return;
+    }
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let dir = scratch.path();
+    fs::write(dir.join("greet-tool.lis"), GREETER).unwrap();
+    std::os::unix::fs::symlink(dir.join("greet-tool.lis"), dir.join("greet")).unwrap();
+
+    let scratch_tmp = dir.join("tmp");
+    fs::create_dir(&scratch_tmp).unwrap();
+    let run = |target: &str| {
+        let manifest = repo().join("Cargo.toml");
+        Command::new("cargo")
+            .args(["run", "--quiet", "--manifest-path"])
+            .arg(&manifest)
+            .args(["-p", "lisette", "--", "run", target])
+            .current_dir(dir)
+            .env("NO_COLOR", "1")
+            .env("TMPDIR", &scratch_tmp)
+            .env("TMP", &scratch_tmp)
+            .env("TEMP", &scratch_tmp)
+            .output()
+            .expect("failed to invoke lisette")
+    };
+
+    for target in ["greet", "greet-tool.lis", "greet"] {
+        let output = run(target);
+        assert!(output.status.success(), "`{target}`: {}", combined(&output));
+    }
+
+    let build_dir = fs::read_dir(&scratch_tmp)
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.join("go.mod").is_file())
+        .expect("the build directory must sit under the test's own TMPDIR");
+    let go_files: Vec<String> = fs::read_dir(&build_dir)
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.ends_with(".go"))
+        .collect();
+    assert_eq!(
+        go_files.len(),
+        1,
+        "one script must leave one Go file behind, found {go_files:?}"
+    );
+}
+
 #[test]
 fn a_hard_link_to_the_script_is_refused() {
     let scratch = tempfile::tempdir().expect("create temp dir");


### PR DESCRIPTION
Running one script through two differently named paths no longer breaks its build directory.

```sh
ln -s "$PWD/src/deploy-tool.lis" bin/deploy

lis run bin/deploy            # deploy v1
lis run src/deploy-tool.lis   # deploy v1, was `main redeclared in this block`
lis run bin/deploy            # deploy v1, was broken from here on
```

A symlink and its target share one build directory using path as they key but emit Go files named after the path given, so two `main` functions were emitted side by side and every later run through either path failed.
