### PR TITLE
fix: treat `Unknown` as a Go interface when emitting

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -539,7 +539,8 @@ fn aggregate_rebuild(planner: &Planner<'_>, from: &Type, to: &Type) -> Option<Co
 
 fn widening_element_plan(planner: &Planner<'_>, from: &Type, to: &Type) -> Option<CoercionPlan> {
     let plan = CoercionPlan::internal(planner, from, to);
-    (from != to && (planner.facts.is_interface(to) || !plan.is_identity())).then_some(plan)
+    (from != to && (planner.facts.is_interface_or_unknown(to) || !plan.is_identity()))
+        .then_some(plan)
 }
 
 fn needs_newtype_wrap(planner: &Planner<'_>, from: &Type, to: &Type) -> bool {

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -152,6 +152,10 @@ impl<'a> EmitFacts<'a> {
         as_interface(self.definitions, ty).is_some()
     }
 
+    pub(crate) fn is_interface_or_unknown(&self, ty: &Type) -> bool {
+        self.is_interface(ty) || self.resolves_to_unknown(ty)
+    }
+
     pub(crate) fn is_nilable_go_type(&self, ty: &Type) -> bool {
         is_nilable_go_type(self.definitions, ty)
     }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -663,7 +663,7 @@ impl Planner<'_> {
         }
         params
             .iter()
-            .any(|p| self.facts.is_interface(p) || self.is_function_alias(p))
+            .any(|p| self.facts.is_interface_or_unknown(p) || self.is_function_alias(p))
             .then(|| self.format_type_args(params))
     }
 }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -327,7 +327,10 @@ impl Planner<'_> {
 
     pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> String {
         self.require_stdlib();
-        if !slot_types.iter().any(|slot| self.facts.is_interface(slot)) {
+        if !slot_types
+            .iter()
+            .any(|slot| self.facts.is_interface_or_unknown(slot))
+        {
             return format!("lisette.MakeTuple{}", arity);
         }
         let rendered: Vec<String> = slot_types

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -25,7 +25,7 @@ fn needs_explicit_type_declaration(
     value: &Expression,
     binding_ty: &Type,
 ) -> bool {
-    if planner.facts.as_interface(binding_ty).is_some() {
+    if planner.facts.is_interface_or_unknown(binding_ty) {
         let value_ty = value.get_type();
         if *binding_ty != value_ty {
             return true;
@@ -75,7 +75,7 @@ fn resolve_let_temp_declaration_ty(
         }
         return binding_ty.clone();
     }
-    if planner.facts.is_interface(binding_ty) && *binding_ty != value_ty {
+    if planner.facts.is_interface_or_unknown(binding_ty) && *binding_ty != value_ty {
         return binding_ty.clone();
     }
     value_ty
@@ -156,7 +156,7 @@ impl Planner<'_> {
         };
         let go_identifier = self.choose_let_go_name(identifier, raw_go_name, false);
         let widens_to_interface =
-            self.facts.is_interface(binding_ty) && *binding_ty != value.get_type();
+            self.facts.is_interface_or_unknown(binding_ty) && *binding_ty != value.get_type();
         let mut statements = Vec::new();
         if widens_to_interface {
             let var_ty = self.go_type_string(binding_ty);
@@ -229,30 +229,32 @@ impl Planner<'_> {
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
         statements.extend(coercion_setup);
 
-        let go_identifier = self.scope.bind(identifier, raw_go_name);
-        let is_new = self.try_declare(&go_identifier);
-
-        if !is_new || self.scope.is_active_assign_target(&go_identifier) {
+        let bound = self.scope.bind(identifier, raw_go_name);
+        let is_new = self.try_declare(&bound);
+        let go_identifier = if !is_new || self.scope.is_active_assign_target(&bound) {
             let fresh = self.fresh_var(Some(identifier));
             self.scope.bind(identifier, &fresh);
             self.try_declare(&fresh);
-            statements.push(LoweredStatement::TempBind {
-                name: fresh,
-                value: value_expression,
-            });
-        } else if needs_explicit_type_declaration(self, value, binding_ty) {
-            let var_ty = self.go_type_string(binding_ty);
-            statements.push(LoweredStatement::VarDecl {
-                name: go_identifier,
-                go_type: var_ty,
-                value: Some(value_expression),
-            });
+            fresh
         } else {
-            statements.push(LoweredStatement::TempBind {
-                name: go_identifier,
-                value: value_expression,
-            });
-        }
+            bound
+        };
+
+        statements.push(
+            if needs_explicit_type_declaration(self, value, binding_ty) {
+                let var_ty = self.go_type_string(binding_ty);
+                LoweredStatement::VarDecl {
+                    name: go_identifier,
+                    go_type: var_ty,
+                    value: Some(value_expression),
+                }
+            } else {
+                LoweredStatement::TempBind {
+                    name: go_identifier,
+                    value: value_expression,
+                }
+            },
+        );
         statements
     }
 

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -1662,6 +1662,27 @@ fn test(items: Slice<int>) -> int {
 }
 
 #[test]
+fn shadowing_let_keeps_its_annotated_type() {
+    let input = r#"
+fn take(v: int64) -> int64 {
+  v
+}
+
+fn test() {
+  let x = 1
+  if x != 1 {
+    panic("outer binding was clobbered")
+  }
+  let x: int64 = 5
+  if take(x) != 5 {
+    panic("shadowing binding lost its annotated type")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn parameter_shadows_go_builtin() {
     let input = r#"
 fn test(len: int) -> int {

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -819,6 +819,19 @@ fn test() -> Map<string, int> {
 }
 
 #[test]
+fn map_from_pairs_with_unknown_value() {
+    let input = r#"
+fn test() {
+  let m = Map.from<string, Unknown>([("one", "two")])
+  if m.length() != 1 {
+    panic("Map.from lost its entry when widening values to Unknown")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_with_void_function_value() {
     let input = r#"
 fn test() -> Map<string, fn()> {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1024,6 +1024,23 @@ fn test() {
 }
 
 #[test]
+fn option_with_unknown_type_param() {
+    let input = r#"
+fn take(value: Option<Unknown>) -> bool {
+  value.is_some()
+}
+
+fn test() {
+  let boxed: Option<Unknown> = Some(1)
+  if !take(boxed) {
+    panic("Option<Unknown> lost its widened type argument")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_of_option_interface() {
     let input = r#"
 interface Printable {

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn identity(value: int) -> int {
+    value
+  }
+  
+  fn describe(value: Unknown) -> string {
+    match assert_type<string>(value) {
+      Some(text) => text,
+      None => "",
+    }
+  }
+  
+  fn test() {
+    let mut value: Unknown = identity(1)
+    value = "two"
+    if describe(value) != "two" {
+      panic("annotated Unknown binding was declared at the concrete type")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func identity(value int) int {
+	return value
+}
+
+func describe(value any) string {
+	subject_1 := lisette.AssertType[string](value)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return ""
+}
+
+func test() {
+	var value any = identity(1)
+	value = "two"
+	if describe(value) != "two" {
+		panic("annotated Unknown binding was declared at the concrete type")
+	}
+}

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -1,0 +1,78 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn fallible() -> Result<int, error> {
+    Ok(1)
+  }
+  
+  fn describe(value: Unknown) -> string {
+    match assert_type<string>(value) {
+      Some(text) => text,
+      None => "",
+    }
+  }
+  
+  fn run() -> Result<string, error> {
+    let mut value: Unknown = fallible()?
+    value = "two"
+    Ok(describe(value))
+  }
+  
+  fn test() {
+    let text = match run() {
+      Ok(text) => text,
+      Err(_) => "",
+    }
+    if text != "two" {
+      panic("propagated Unknown binding was declared at the concrete type")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func fallible() (int, error) {
+	return 1, nil
+}
+
+func describe(value any) string {
+	subject_1 := lisette.AssertType[string](value)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return ""
+}
+
+func run() (string, error) {
+	var value any
+	ret_1, ret_2 := fallible()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	check_4 := result_3
+	if check_4.Tag != lisette.ResultOk {
+		return "", check_4.ErrVal
+	}
+	value = check_4.OkVal
+	value = "two"
+	return describe(value), nil
+}
+
+func test() {
+	var text_1 string
+	ret_2, ret_3 := run()
+	if ret_3 == nil {
+		text := ret_2
+		text_1 = text
+	} else {
+		text_1 = ""
+	}
+	if text_1 != "two" {
+		panic("propagated Unknown binding was declared at the concrete type")
+	}
+}

--- a/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn identity(value: int) -> int {
+    value
+  }
+  
+  fn describe(value: Unknown) -> string {
+    match assert_type<string>(value) {
+      Some(text) => text,
+      None => "",
+    }
+  }
+  
+  fn test() {
+    let value = 1
+    let mut value: Unknown = identity(value)
+    value = "two"
+    if describe(value) != "two" {
+      panic("shadowing Unknown binding was declared at the concrete type")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func identity(value int) int {
+	return value
+}
+
+func describe(value any) string {
+	subject_1 := lisette.AssertType[string](value)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return ""
+}
+
+func test() {
+	value := 1
+	var value_1 any = identity(value)
+	value_1 = "two"
+	if describe(value_1) != "two" {
+		panic("shadowing Unknown binding was declared at the concrete type")
+	}
+}

--- a/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
+++ b/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() {
+    let m = Map.from<string, Unknown>([("one", "two")])
+    if m.length() != 1 {
+      panic("Map.from lost its entry when widening values to Unknown")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test() {
+	tup_1 := lisette.MakeTuple2("one", "two")
+	m := lisette.MapFrom[string, any]([]lisette.Tuple2[string, any]{lisette.MakeTuple2[string, any](tup_1.First, tup_1.Second)})
+	if len(m) != 1 {
+		panic("Map.from lost its entry when widening values to Unknown")
+	}
+}

--- a/tests/spec/emit/snapshots/option_with_unknown_type_param.snap
+++ b/tests/spec/emit/snapshots/option_with_unknown_type_param.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn take(value: Option<Unknown>) -> bool {
+    value.is_some()
+  }
+  
+  fn test() {
+    let boxed: Option<Unknown> = Some(1)
+    if !take(boxed) {
+      panic("Option<Unknown> lost its widened type argument")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func take(value lisette.Option[any]) bool {
+	return value.IsSome()
+}
+
+func test() {
+	boxed := lisette.MakeOptionSome[any](1)
+	if !take(boxed) {
+		panic("Option<Unknown> lost its widened type argument")
+	}
+}

--- a/tests/spec/emit/snapshots/shadowing_let_keeps_its_annotated_type.snap
+++ b/tests/spec/emit/snapshots/shadowing_let_keeps_its_annotated_type.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn take(v: int64) -> int64 {
+    v
+  }
+  
+  fn test() {
+    let x = 1
+    if x != 1 {
+      panic("outer binding was clobbered")
+    }
+    let x: int64 = 5
+    if take(x) != 5 {
+      panic("shadowing binding lost its annotated type")
+    }
+  }
+---
+package main
+
+func take(v int64) int64 {
+	return v
+}
+
+func test() {
+	x := 1
+	if x != 1 {
+		panic("outer binding was clobbered")
+	}
+	var x_1 int64 = 5
+	if take(x_1) != 5 {
+		panic("shadowing binding lost its annotated type")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn describe(pair: (int, Unknown)) -> string {
+    match assert_type<string>(pair.1) {
+      Some(text) => text,
+      None => "",
+    }
+  }
+  
+  fn test() {
+    if describe((1, "two")) != "two" {
+      panic("tuple argument lost its Unknown element")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func describe(pair lisette.Tuple2[int, any]) string {
+	subject_1 := lisette.AssertType[string](pair.Second)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return ""
+}
+
+func test() {
+	tup_1 := lisette.MakeTuple2(1, "two")
+	if describe(lisette.MakeTuple2[int, any](tup_1.First, tup_1.Second)) != "two" {
+		panic("tuple argument lost its Unknown element")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn second(pair: (string, Unknown)) -> int {
+    match assert_type<int>(pair.1) {
+      Some(value) => value,
+      None => 0,
+    }
+  }
+  
+  fn test() {
+    let pairs: Slice<(string, Unknown)> = [("one", 2)]
+    if second(pairs[0]) != 2 {
+      panic("slice element lost its Unknown element")
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func second(pair lisette.Tuple2[string, any]) int {
+	subject_1 := lisette.AssertType[int](pair.Second)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return 0
+}
+
+func test() {
+	tup_1 := lisette.MakeTuple2("one", 2)
+	pairs := []lisette.Tuple2[string, any]{lisette.MakeTuple2[string, any](tup_1.First, tup_1.Second)}
+	if second(pairs[0]) != 2 {
+		panic("slice element lost its Unknown element")
+	}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -4695,6 +4695,129 @@ type Cb = fn() -> Unknown;
 }
 
 #[test]
+fn tuple_of_concrete_widens_to_unknown_elements_in_argument_position() {
+    let input = r#"
+fn describe(pair: (int, Unknown)) -> string {
+  match assert_type<string>(pair.1) {
+    Some(text) => text,
+    None => "",
+  }
+}
+
+fn test() {
+  if describe((1, "two")) != "two" {
+    panic("tuple argument lost its Unknown element")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_of_concrete_widens_to_unknown_elements_in_slice_literal() {
+    let input = r#"
+fn second(pair: (string, Unknown)) -> int {
+  match assert_type<int>(pair.1) {
+    Some(value) => value,
+    None => 0,
+  }
+}
+
+fn test() {
+  let pairs: Slice<(string, Unknown)> = [("one", 2)]
+  if second(pairs[0]) != 2 {
+    panic("slice element lost its Unknown element")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_annotated_unknown_declares_any_for_concrete_value() {
+    let input = r#"
+fn identity(value: int) -> int {
+  value
+}
+
+fn describe(value: Unknown) -> string {
+  match assert_type<string>(value) {
+    Some(text) => text,
+    None => "",
+  }
+}
+
+fn test() {
+  let mut value: Unknown = identity(1)
+  value = "two"
+  if describe(value) != "two" {
+    panic("annotated Unknown binding was declared at the concrete type")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_shadowing_annotated_unknown_declares_any() {
+    let input = r#"
+fn identity(value: int) -> int {
+  value
+}
+
+fn describe(value: Unknown) -> string {
+  match assert_type<string>(value) {
+    Some(text) => text,
+    None => "",
+  }
+}
+
+fn test() {
+  let value = 1
+  let mut value: Unknown = identity(value)
+  value = "two"
+  if describe(value) != "two" {
+    panic("shadowing Unknown binding was declared at the concrete type")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_annotated_unknown_declares_any_for_propagated_value() {
+    let input = r#"
+fn fallible() -> Result<int, error> {
+  Ok(1)
+}
+
+fn describe(value: Unknown) -> string {
+  match assert_type<string>(value) {
+    Some(text) => text,
+    None => "",
+  }
+}
+
+fn run() -> Result<string, error> {
+  let mut value: Unknown = fallible()?
+  value = "two"
+  Ok(describe(value))
+}
+
+fn test() {
+  let text = match run() {
+    Ok(text) => text,
+    Err(_) => "",
+  }
+  if text != "two" {
+    panic("propagated Unknown binding was declared at the concrete type")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn option_in_go_unknown_struct_field_stays_tagged() {
     let input = r#"
 import "go:example.com/dyn"


### PR DESCRIPTION
Constructing a value typed `Unknown` no longer emits Go that infers the concrete type instead:

```rs
fn main() {
  let m = Map.from<string, Unknown>([("one", "two")])
  let pairs: Slice<(int, Unknown)> = [(1, 2)]
}
```

The same gap affected `Option<Unknown>` and `let value: Unknown = <concrete>`, where the binding was declared at the concrete type and rejected any later reassignment.

Fix #1221
