### PR TITLE
fix: ignore local-only `mut` in function unification

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -5,6 +5,7 @@ use syntax::ast::Span;
 use syntax::types::{Bound, CompoundKind, Type, TypeVarId};
 
 use crate::checker::infer::InferCtx;
+use crate::checker::infer::carry_mut::can_carry_mutation_across_fn_boundary;
 use crate::checker::type_env::VarState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -557,17 +558,6 @@ impl InferCtx<'_> {
             return Err(UnifyError::ArityMismatch);
         }
 
-        // A function with `mut` params cannot unify with one without (or vice versa),
-        // since that would let callers bypass the `let mut` requirement.
-        if f1
-            .params
-            .iter()
-            .zip(&f2.params)
-            .any(|(left, right)| left.mutable != right.mutable)
-        {
-            return Err(UnifyError::TypeMismatch);
-        }
-
         let (params_result, return_type_result) = self.in_invariant_position(|this| {
             let params_result = this.unify_pairs(
                 f1.params
@@ -579,6 +569,15 @@ impl InferCtx<'_> {
             let return_type_result = this.try_unify(&f1.return_type, &f2.return_type, span);
             (params_result, return_type_result)
         });
+
+        if params_result.is_ok()
+            && f1.params.iter().zip(&f2.params).any(|(left, right)| {
+                left.mutable != right.mutable
+                    && (self.mut_reaches_caller(&left.ty) || self.mut_reaches_caller(&right.ty))
+            })
+        {
+            return Err(UnifyError::TypeMismatch);
+        }
 
         for bound in &f1.bounds {
             self.check_function_bound(bound, &f1.params, span);
@@ -597,6 +596,12 @@ impl InferCtx<'_> {
             (Ok(()), Err(e2)) => Err(e2),
             (Err(e1), Err(e2)) => Err(UnifyError::Multiple(Box::new(vec![e1, e2]))),
         }
+    }
+
+    fn mut_reaches_caller(&self, ty: &Type) -> bool {
+        let resolved = self.store.peel_alias(&ty.resolve_in(&self.env));
+        can_carry_mutation_across_fn_boundary(&resolved, &self.env, self.store)
+            || self.store.is_interface(&resolved)
     }
 
     fn bounds_equivalent(&self, bounds1: &[Bound], bounds2: &[Bound]) -> bool {
@@ -877,6 +882,12 @@ impl InferCtx<'_> {
             return "Remove the `()` so that the type matches".to_string();
         }
 
+        if differs_only_in_param_mutability(expected, actual) {
+            return format!(
+                "`mut` belongs to the function type when the parameter carries mutation back to the caller. Match `mut` on each differing parameter, or expect `{actual_name}` instead"
+            );
+        }
+
         match self.closure_adapter(expected, actual) {
             Some(ClosureAdapter::Widens) => {
                 return "Function types must match exactly. Wrap the value in a closure to convert at the call site, e.g. `|value| callee(value)`".to_string();
@@ -1024,6 +1035,22 @@ fn array_to_slice_help_applies(expected: &Type, actual: &Type) -> bool {
         return false;
     };
     expected_element == element.as_ref()
+}
+
+/// Whether two function types are the same but for `mut` on one or more parameters.
+fn differs_only_in_param_mutability(expected: &Type, actual: &Type) -> bool {
+    let (Function(expected), Function(actual)) = (expected, actual) else {
+        return false;
+    };
+    if expected.params.len() != actual.params.len()
+        || expected.return_type != actual.return_type
+        || expected.bounds != actual.bounds
+    {
+        return false;
+    }
+    let pairs = || expected.params.iter().zip(&actual.params);
+    pairs().all(|(left, right)| left.ty == right.ty)
+        && pairs().any(|(left, right)| left.mutable != right.mutable)
 }
 
 fn are_go_type_aliases(a: &str, b: &str) -> bool {

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2560,6 +2560,186 @@ fn main() {
 }
 
 #[test]
+fn mut_int_param_unifies_with_plain_function_type() {
+    infer(
+        r#"
+fn bump(mut n: int) -> int {
+  n += 1
+  return n
+}
+
+fn apply(f: fn(int) -> int, v: int) -> int {
+  return f(v)
+}
+
+fn main() {
+  let _ = apply(bump, 1)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_value_struct_param_unifies_with_plain_function_type() {
+    infer(
+        r#"
+struct Point { x: int, y: int }
+
+fn relocate(mut p: Point) -> Point {
+  p = Point { x: 0, y: 0 }
+  return p
+}
+
+fn apply(f: fn(Point) -> Point, p: Point) -> Point {
+  return f(p)
+}
+
+fn main() {
+  let _ = apply(relocate, Point { x: 1, y: 2 })
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_int_param_satisfies_plain_interface_method() {
+    infer(
+        r#"
+interface Counter {
+  fn bump(n: int) -> int
+}
+
+struct Impl { base: int }
+
+impl Impl {
+  fn bump(self: Ref<Impl>, mut n: int) -> int {
+    n += 1
+    return self.base + n
+  }
+}
+
+fn use_it(c: Counter) -> int {
+  return c.bump(1)
+}
+
+fn main() {
+  let it = Impl { base: 10 }
+  let _ = use_it(&it)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_slice_param_does_not_unify_with_plain_function_type() {
+    infer(
+        r#"
+fn advance(mut data: Slice<byte>) -> int {
+  data = data[1..]
+  return data.length()
+}
+
+fn apply(f: fn(Slice<byte>) -> int, v: Slice<byte>) -> int {
+  return f(v)
+}
+
+fn main() {
+  let buf = Slice.make<byte>(3)
+  let _ = apply(advance, buf)
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn mut_struct_containing_slice_param_does_not_unify_with_plain_function_type() {
+    infer(
+        r#"
+struct Box { items: Slice<int> }
+
+fn write_first(mut b: Box) {
+  b.items[0] = 99
+}
+
+fn apply(f: fn(Box), b: Box) {
+  f(b)
+}
+
+fn main() {
+  let b = Box { items: [1, 2, 3] }
+  apply(write_first, b)
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn mut_interface_param_does_not_unify_with_plain_function_type() {
+    infer(
+        r#"
+struct Counter { n: int }
+
+impl Counter {
+  fn bump(self: Ref<Counter>) { self.n += 1 }
+}
+
+interface Bumper {
+  fn bump()
+}
+
+fn use_it(mut b: Bumper) {
+  b.bump()
+}
+
+fn call(f: fn(Bumper), b: Bumper) {
+  f(b)
+}
+
+fn main() {
+  let c = Counter { n: 0 }
+  call(use_it, &c)
+}
+"#,
+    )
+    .assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn mut_slice_param_does_not_satisfy_plain_interface_method() {
+    infer(
+        r#"
+interface Sink {
+  fn write(data: Slice<byte>) -> int
+}
+
+struct Impl { total: int }
+
+impl Impl {
+  fn write(self: Ref<Impl>, mut data: Slice<byte>) -> int {
+    data = data[1..]
+    return self.total + data.length()
+  }
+}
+
+fn use_it(s: Sink) -> int {
+  return s.write(Slice.make<byte>(3))
+}
+
+fn main() {
+  let it = Impl { total: 10 }
+  let _ = use_it(&it)
+}
+"#,
+    )
+    .assert_infer_code("interface_not_implemented");
+}
+
+#[test]
 fn generic_empty_varargs_call_without_type_arg_errors() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1965,6 +1965,47 @@ fn test() {
 }
 
 #[test]
+fn infer_mut_param_function_type_mismatch() {
+    let input = r#"
+fn advance(mut data: Slice<byte>) -> int {
+  data = data[1..]
+  return data.length()
+}
+
+fn apply(f: fn(Slice<byte>) -> int, v: Slice<byte>) -> int {
+  return f(v)
+}
+
+fn test() {
+  let buf = Slice.make<byte>(3)
+  let _ = apply(advance, buf)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_opposing_mut_params_function_type_mismatch() {
+    let input = r#"
+fn advance(mut head: Slice<int>, tail: Slice<int>) -> int {
+  head = head[1..]
+  head.length() + tail.length()
+}
+
+fn apply(f: fn(Slice<int>, mut Slice<int>) -> int, a: Slice<int>, mut b: Slice<int>) -> int {
+  f(a, b)
+}
+
+fn test() {
+  let a = [1]
+  let mut b = [2]
+  let _ = apply(advance, a, b)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_function_value_with_concrete_param_where_interface_param_expected() {
     let input = r#"
 struct FooError {}

--- a/tests/ui/errors/snapshots/infer_mut_param_function_type_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_mut_param_function_type_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:13:17]
+ 12 │   let buf = Slice.make<byte>(3)
+ 13 │   let _ = apply(advance, buf)
+    ·                 ───┬───
+    ·                    ╰── expected `fn (Slice<byte>) -> int`, found `fn (mut Slice<byte>) -> int`
+ 14 │ }
+    ╰────
+  help: `mut` belongs to the function type when the parameter carries mutation back to the caller. Match `mut` on each differing parameter, or expect `fn (mut Slice<byte>) -> int` instead · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_opposing_mut_params_function_type_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_opposing_mut_params_function_type_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:14:17]
+ 13 │   let mut b = [2]
+ 14 │   let _ = apply(advance, a, b)
+    ·                 ───┬───
+    ·                    ╰── expected `fn (Slice<int>, mut Slice<int>) -> int`, found `fn (mut Slice<int>, Slice<int>) -> int`
+ 15 │ }
+    ╰────
+  help: `mut` belongs to the function type when the parameter carries mutation back to the caller. Match `mut` on each differing parameter, or expect `fn (mut Slice<int>, Slice<int>) -> int` instead · code: [infer.type_mismatch]


### PR DESCRIPTION
`mut` on a param now only changes the function's type where the mutation reaches the caller, so a function taking `mut int` fits a `fn (int) -> int` annotation and satisfies an interface that declares the method without `mut`.

```rs
fn bump(mut n: int) -> int {
  n += 1
  n
}

fn apply(f: fn(int) -> int, v: int) -> int {
  f(v)
}

fn main() {
  fmt.Println(apply(bump, 1))  // 2, previously a type mismatch
}
```

`mut` stays part of the type for `Slice<T>`, `Map<K, V>`, anything recursively containing one, and interface types, which are the params for which an immutable arg is already rejected at callsite.
