### PR TITLE
feat: SSA parameter nilability analysis for bindgen

### DIFF
--- a/bindgen/README.md
+++ b/bindgen/README.md
@@ -244,14 +244,16 @@ Bindgen accepts a config file with per-package overrides:
         },
       },
 
-      // Turn `Ref<T>` parameter into `Option<Ref<T>>` for Go APIs that accept
-      // nil to mean "use the default"
+      // Force `Ref<T>` parameter to `Option<Ref<T>>` when inference did not
       // e.g. `rp` in `mongo.Client.Ping(ctx, rp)` accepts nil
       "nilable_param": {
         "go.mongodb.org/mongo-driver/v2/mongo": {
           "Client.Ping": ["rp"],
         },
       },
+
+      // Keep `Ref<T>` parameter when inference wrongly proved it accepts nil
+      "non_nilable_param": {},
 
       // Allow constructing a type at its Go zero value, verified against Go's docs.
       // Applies to types with no visible fields, which are refused by default

--- a/bindgen/internal/config/config.go
+++ b/bindgen/internal/config/config.go
@@ -40,6 +40,9 @@ type TypeOverrides struct {
 	// (e.g. `nil` means "use the default"), so they should be `Option<Ref<T>>`
 	// instead of `Ref<T>`.
 	NilableParam map[string]map[string][]string `json:"nilable_param"`
+	// NonNilableParam cancels a wrong inference, keeping a parameter `Ref<T>`
+	// when the analysis proved it accepts nil.
+	NonNilableParam map[string]map[string][]string `json:"non_nilable_param"`
 	// SentinelMinusOne declares int-returning functions that signal
 	// "absent" with `-1`. Bindgen rewrites the return to `Option<int>`
 	// and emits `#[go(sentinel_minus_one)]`.
@@ -214,6 +217,16 @@ func (c *Config) NilableParams(pkg, name string) []string {
 		return nil
 	}
 	return nestedParams(c.Overrides.Types.NilableParam, pkg, name)
+}
+
+// NonNilableParams returns the list of parameter names that must stay `Ref<>`
+// for the given function or method, cancelling an inference, or nil if none
+// are configured.
+func (c *Config) NonNilableParams(pkg, name string) []string {
+	if c == nil {
+		return nil
+	}
+	return nestedParams(c.Overrides.Types.NonNilableParam, pkg, name)
 }
 
 // IsPartialResult returns true if the given function or method in the given

--- a/bindgen/internal/convert/converters.go
+++ b/bindgen/internal/convert/converters.go
@@ -166,8 +166,8 @@ func (c *Converter) applySentinelInt(result *ConvertResult, qualifiedName string
 
 func (c *Converter) convertParams(sig *types.Signature, obj types.Object, lookupName, methodName string, paramOverrides map[int]string, directEligible bool, substitutions map[string]string) ([]FunctionParameter, *SkipReason) {
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, lookupName)
-	nilableParams := c.cfg.NilableParams(c.currentPkgPath, lookupName)
 	mutation, _ := c.mutation.Function(obj)
+	declaring, _ := obj.(*types.Func)
 
 	params := sig.Params()
 	usedNames := collectNamedParams(params)
@@ -186,7 +186,8 @@ func (c *Converter) convertParams(sig *types.Signature, obj types.Object, lookup
 		if named, ok := c.directHandleIfEligible(param.Type(), directEligible); ok {
 			paramType = TypeResult{LisetteType: named.Obj().Name()}
 		} else {
-			paramType = convertParamType(param.Type(), name, nilableParams, c, substitutions)
+			optional := declaring != nil && c.nilness.Params().Optional(declaring, i)
+			paramType = convertParamType(param.Type(), optional, c, substitutions)
 		}
 		if paramType.SkipReason != nil {
 			return nil, paramType.SkipReason

--- a/bindgen/internal/convert/nilness.go
+++ b/bindgen/internal/convert/nilness.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/types"
 	"os"
-	"slices"
 	"sort"
 
 	"github.com/ivov/lisette/bindgen/internal/config"
@@ -39,11 +38,15 @@ type NilnessAnalysis struct {
 	verdicts       map[*types.Func]FunctionNilness
 	summaries      map[*ssa.Function]*nilnessSummary
 	staticRecovers map[*ssa.Function]bool
+	// inProgress: a summary read while on the stack is partial
+	inProgress map[*ssa.Function]bool
 	// summaryDepth bounds acyclic recursion; cycles hit the memo placeholder
 	summaryDepth int
 
 	globalUsages map[*ssa.Global]*globalUsage
 	globalFacts  map[*ssa.Global]nilness
+
+	params *ParameterNilability
 }
 
 // NewNilnessAnalysis returns nil when SSA construction fails, leaving
@@ -73,6 +76,7 @@ func NewNilnessAnalysis(roots []*packages.Package, cfg *config.Config) (analysis
 		verdicts:       make(map[*types.Func]FunctionNilness),
 		summaries:      make(map[*ssa.Function]*nilnessSummary),
 		staticRecovers: make(map[*ssa.Function]bool),
+		inProgress:     make(map[*ssa.Function]bool),
 		globalFacts:    make(map[*ssa.Global]nilness),
 	}
 
@@ -81,6 +85,7 @@ func NewNilnessAnalysis(roots []*packages.Package, cfg *config.Config) (analysis
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].PkgPath < sorted[j].PkgPath })
 
 	// cycle verdicts depend on summarization order, so fix it here
+	var bound []*types.Func
 	for _, pkg := range sorted {
 		if pkg.Types == nil {
 			continue
@@ -89,7 +94,7 @@ func NewNilnessAnalysis(roots []*packages.Package, cfg *config.Config) (analysis
 		for _, name := range scope.Names() {
 			switch obj := scope.Lookup(name).(type) {
 			case *types.Func:
-				analysis.record(obj)
+				bound = append(bound, obj)
 			case *types.TypeName:
 				named, ok := obj.Type().(*types.Named)
 				if !ok {
@@ -97,14 +102,26 @@ func NewNilnessAnalysis(roots []*packages.Package, cfg *config.Config) (analysis
 				}
 				for sel := range program.MethodSets.MethodSet(types.NewPointer(named)).Methods() {
 					if fn, ok := sel.Obj().(*types.Func); ok {
-						analysis.record(fn)
+						bound = append(bound, fn)
 					}
 				}
 			}
 		}
 	}
 
+	analysis.params = newParameterNilability(analysis, bound, sorted)
+	for _, fn := range bound {
+		analysis.record(fn)
+	}
+
 	return analysis
+}
+
+func (a *NilnessAnalysis) Params() *ParameterNilability {
+	if a == nil {
+		return nil
+	}
+	return a.params
 }
 
 func (a *NilnessAnalysis) Function(obj types.Object) (FunctionNilness, bool) {
@@ -128,11 +145,12 @@ func (a *NilnessAnalysis) record(fn *types.Func) {
 		a.verdicts[fn] = FunctionNilness{}
 		return
 	}
-	var nilableParams []string
-	if a.cfg != nil && fn.Pkg() != nil {
-		nilableParams = a.cfg.NilableParams(fn.Pkg().Path(), qualifiedFunctionName(fn))
+	body := functionBody(ssaFn)
+	if body == nil {
+		a.verdicts[fn] = FunctionNilness{}
+		return
 	}
-	a.verdicts[fn] = a.analyze(ssaFn, nilableParams)
+	a.verdicts[fn] = a.analyze(ssaFn, a.withdrawnPositions(fn, body))
 }
 
 // qualifiedFunctionName matches the config key format.
@@ -151,7 +169,7 @@ func qualifiedFunctionName(fn *types.Func) string {
 	return fn.Name()
 }
 
-func (a *NilnessAnalysis) analyze(fn *ssa.Function, nilableParams []string) FunctionNilness {
+func (a *NilnessAnalysis) analyze(fn *ssa.Function, withdrawn []bool) FunctionNilness {
 	body := functionBody(fn)
 	if body == nil {
 		return FunctionNilness{}
@@ -179,14 +197,14 @@ func (a *NilnessAnalysis) analyze(fn *ssa.Function, nilableParams []string) Func
 
 	merged := nilnessValue{n: nilnessNonNil}
 
-	sawReturn := a.walkReturnSites(body, a.boundaryAxioms(body, nilableParams), func(ret *ssa.Return, dominating []nilnessFact, values []nilnessValue) {
+	sawReturn := a.walkReturnSites(body, a.boundaryAxioms(body, withdrawn), func(ret *ssa.Return, dominating []nilnessFact, values []nilnessValue) {
 		// NilWithNilError needs a provable (nil, nil): a bare inherited
 		// witness is usually a lost error correlation.
 		for i := range values {
 			if values[i].witness {
 				facts.NilWitness[i] = true
 			}
-			if values[i].n == nilnessNil && lastIsError && values[resultCount-1].n == nilnessNil {
+			if (values[i].n == nilnessNil || values[i].boundaryNil) && lastIsError && values[resultCount-1].n == nilnessNil {
 				facts.NilWithNilError[i] = true
 			}
 		}
@@ -218,8 +236,9 @@ func (a *NilnessAnalysis) analyze(fn *ssa.Function, nilableParams []string) Func
 func (a *NilnessAnalysis) walkReturnSites(body *ssa.Function, axioms []nilnessFact, visit func(*ssa.Return, []nilnessFact, []nilnessValue)) bool {
 	resultCount := body.Signature.Results().Len()
 	sawReturn := false
-	a.walk(body, axioms, func(ret *ssa.Return, dominating []nilnessFact) {
-		if len(ret.Results) != resultCount {
+	a.walk(body, axioms, func(instr ssa.Instruction, dominating []nilnessFact) {
+		ret, ok := instr.(*ssa.Return)
+		if !ok || len(ret.Results) != resultCount {
 			return
 		}
 		values, ok := a.siteValues(body, ret, dominating)
@@ -260,17 +279,40 @@ func (a *NilnessAnalysis) forwardedNilNil(ret *ssa.Return, values []nilnessValue
 	return out
 }
 
-// boundaryAxioms: Lisette passes pointers and interfaces as non-nil Ref<T>
-// and interface values. A Lisette empty slice may be a nil Go slice.
-func (a *NilnessAnalysis) boundaryAxioms(fn *ssa.Function, nilableParams []string) []nilnessFact {
+// boundaryAxioms: a parameter is assumed non-nil exactly when Lisette cannot
+// pass nil to it. Withdrawal seeds a fact rather than omitting one, since
+// omitting reads as ignorance rather than as a caller who can pass None.
+func (a *NilnessAnalysis) boundaryAxioms(fn *ssa.Function, withdrawn []bool) []nilnessFact {
 	var out []nilnessFact
-	for _, param := range fn.Params {
-		if slices.Contains(nilableParams, param.Name()) {
-			continue
-		}
+	for position, param := range fn.Params {
 		switch param.Type().Underlying().(type) {
 		case *types.Pointer, *types.Interface:
-			out = append(out, nilnessFact{param, nilnessNonNil})
+		default:
+			continue
+		}
+		if position < len(withdrawn) && withdrawn[position] {
+			out = append(out, nilnessFact{value: param, n: nilnessUnknown, boundaryNil: true})
+			continue
+		}
+		out = append(out, nilnessFact{value: param, n: nilnessNonNil})
+	}
+	return out
+}
+
+// withdrawnPositions marks the SSA positions whose surface is Option<Ref<T>>.
+func (a *NilnessAnalysis) withdrawnPositions(fn *types.Func, body *ssa.Function) []bool {
+	out := make([]bool, len(body.Params))
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return out
+	}
+	offset := 0
+	if sig.Recv() != nil {
+		offset = 1
+	}
+	for position := range out {
+		if index := position - offset; index >= 0 {
+			out[position] = a.params.Optional(fn, index)
 		}
 	}
 	return out

--- a/bindgen/internal/convert/nilness_eval.go
+++ b/bindgen/internal/convert/nilness_eval.go
@@ -19,8 +19,9 @@ const (
 
 // witness: a concrete nil-producing path exists, not mere ignorance.
 type nilnessValue struct {
-	n       nilness
-	witness bool
+	n           nilness
+	witness     bool
+	boundaryNil bool
 }
 
 func meetNilness(a, b nilnessValue) nilnessValue {
@@ -28,12 +29,13 @@ func meetNilness(a, b nilnessValue) nilnessValue {
 	if a.n != b.n {
 		n = nilnessUnknown
 	}
-	return nilnessValue{n, a.witness || b.witness}
+	return nilnessValue{n, a.witness || b.witness, a.boundaryNil || b.boundaryNil}
 }
 
 type nilnessFact struct {
-	value ssa.Value
-	n     nilness
+	value       ssa.Value
+	n           nilness
+	boundaryNil bool
 }
 
 func nilComparison(b *ssa.BasicBlock) (op *ssa.BinOp, trueSucc, falseSucc *ssa.BasicBlock) {
@@ -54,8 +56,7 @@ func nilComparison(b *ssa.BasicBlock) (op *ssa.BinOp, trueSucc, falseSucc *ssa.B
 	return nil, nil, nil
 }
 
-// walk mirrors the x/tools nilness pass: dominator order, edge facts.
-func (a *NilnessAnalysis) walk(fn *ssa.Function, axioms []nilnessFact, found func(*ssa.Return, []nilnessFact)) {
+func (a *NilnessAnalysis) walk(fn *ssa.Function, axioms []nilnessFact, found func(ssa.Instruction, []nilnessFact)) {
 	if fn.Blocks == nil {
 		return
 	}
@@ -68,9 +69,7 @@ func (a *NilnessAnalysis) walk(fn *ssa.Function, axioms []nilnessFact, found fun
 		seen[b.Index] = true
 
 		for _, instr := range b.Instrs {
-			if ret, ok := instr.(*ssa.Return); ok {
-				found(ret, stack)
-			}
+			found(instr, stack)
 		}
 
 		if binop, trueSucc, falseSucc := nilComparison(b); binop != nil {
@@ -107,9 +106,9 @@ func (a *NilnessAnalysis) walk(fn *ssa.Function, axioms []nilnessFact, found fun
 						// own logical length
 						switch d {
 						case trueSucc:
-							s = append(stack, nilnessFact{v, nilnessNil})
+							s = append(stack, nilnessFact{value: v, n: nilnessNil})
 						case falseSucc:
-							s = append(stack, nilnessFact{v, nilnessNonNil})
+							s = append(stack, nilnessFact{value: v, n: nilnessNonNil})
 						}
 					}
 					visit(d, s)
@@ -143,10 +142,10 @@ func edgeFact(pred, succ *ssa.BasicBlock) (nilnessFact, bool) {
 		return nilnessFact{}, false
 	}
 	if succ == trueSucc {
-		return nilnessFact{v, nilnessNil}, true
+		return nilnessFact{value: v, n: nilnessNil}, true
 	}
 	if succ == falseSucc {
-		return nilnessFact{v, nilnessNonNil}, true
+		return nilnessFact{value: v, n: nilnessNonNil}, true
 	}
 	return nilnessFact{}, false
 }
@@ -160,7 +159,8 @@ func (a *NilnessAnalysis) eval(v ssa.Value, stack []nilnessFact, visiting map[ss
 
 	for i := len(stack) - 1; i >= 0; i-- {
 		if stack[i].value == v {
-			return nilnessValue{stack[i].n, stack[i].n == nilnessNil}
+			f := stack[i]
+			return nilnessValue{f.n, f.n == nilnessNil || f.boundaryNil, f.boundaryNil}
 		}
 	}
 
@@ -179,7 +179,7 @@ func (a *NilnessAnalysis) eval(v ssa.Value, stack []nilnessFact, visiting map[ss
 
 	case *ssa.Const:
 		if v.IsNil() {
-			return nilnessValue{nilnessNil, true}
+			return nilnessValue{n: nilnessNil, witness: true}
 		}
 		return nilnessValue{}
 

--- a/bindgen/internal/convert/nilness_summary.go
+++ b/bindgen/internal/convert/nilness_summary.go
@@ -19,23 +19,32 @@ type nilnessSummary struct {
 	exclusive bool
 	// nilWithNilError[i]: some site returns result i nil with a nil error
 	nilWithNilError []bool
+	// incomplete: cut short by depth or read mid-build, so an empty delegates
+	// means "not computed" rather than "nothing delegated"
+	incomplete bool
 }
 
 const nilnessMaxDepth = 32
 
-// summarize memoizes; a function on the summarization stack yields the
-// zero summary.
+// summarize memoizes. A function on the summarization stack yields the partial
+// summary built so far, flagged incomplete.
 func (a *NilnessAnalysis) summarize(fn *ssa.Function) *nilnessSummary {
 	if s, ok := a.summaries[fn]; ok {
+		if a.inProgress[fn] {
+			s.incomplete = true
+		}
 		return s
 	}
 	if a.summaryDepth > nilnessMaxDepth {
-		return &nilnessSummary{} // not memoized: shallow by depth, not by content
+		// not memoized: shallow by depth, not by content
+		return &nilnessSummary{incomplete: true}
 	}
 	a.summaryDepth++
 	defer func() { a.summaryDepth-- }()
 	s := &nilnessSummary{}
 	a.summaries[fn] = s
+	a.inProgress[fn] = true
+	defer delete(a.inProgress, fn)
 
 	body := functionBody(fn)
 	if body == nil {
@@ -253,6 +262,15 @@ func (a *NilnessAnalysis) callResult(s *nilnessSummary, index int, args []ssa.Va
 			r = meetNilness(r, a.eval(args[j], dominating, visiting))
 		} else {
 			r = meetNilness(r, nilnessValue{})
+		}
+	}
+	if s.incomplete {
+		for _, arg := range args {
+			if a.eval(arg, dominating, visiting).boundaryNil {
+				r.witness = true
+				r.boundaryNil = true
+				break
+			}
 		}
 	}
 	return r

--- a/bindgen/internal/convert/param_nilability.go
+++ b/bindgen/internal/convert/param_nilability.go
@@ -1,0 +1,418 @@
+// SSA parameter-nilability analysis: which parameters a function accepts as nil.
+package convert
+
+import (
+	"go/token"
+	"go/types"
+	"slices"
+
+	"github.com/ivov/lisette/bindgen/internal/config"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/ssa"
+)
+
+// FunctionParamNilability is indexed by Go signature parameter.
+type FunctionParamNilability struct {
+	ToleratesNil []bool
+}
+
+func (f FunctionParamNilability) Tolerates(index int) bool {
+	return index < len(f.ToleratesNil) && f.ToleratesNil[index]
+}
+
+// ParameterNilability is precomputed before the return verdicts that read it,
+// and read-only afterwards, since `generate_std` converts concurrently.
+type ParameterNilability struct {
+	nilness  *NilnessAnalysis
+	cfg      *config.Config
+	verdicts map[*types.Func]FunctionParamNilability
+	shapes   declaredShapes
+}
+
+// declaredShapes are signatures written down elsewhere: interface methods and
+// named function types. Both lack a body, so their parameters never flip, and
+// flipping an implementation alone breaks the match.
+type declaredShapes struct {
+	methods   map[string][]*types.Signature // by method name
+	funcTypes []*types.Signature            // e.g. http.HandlerFunc
+}
+
+func newParameterNilability(nilness *NilnessAnalysis, bound []*types.Func, pkgs []*packages.Package) *ParameterNilability {
+	analysis := &ParameterNilability{
+		nilness:  nilness,
+		cfg:      nilness.cfg,
+		verdicts: make(map[*types.Func]FunctionParamNilability),
+		shapes:   indexDeclaredShapes(pkgs),
+	}
+	for _, fn := range bound {
+		analysis.record(fn)
+	}
+	return analysis
+}
+
+// indexDeclaredShapes walks the roots and everything they import, since the
+// shape is usually declared in another package.
+func indexDeclaredShapes(pkgs []*packages.Package) declaredShapes {
+	out := declaredShapes{methods: make(map[string][]*types.Signature)}
+	seen := make(map[string]bool)
+
+	var visit func(pkg *packages.Package)
+	visit = func(pkg *packages.Package) {
+		if pkg == nil || pkg.Types == nil || seen[pkg.PkgPath] {
+			return
+		}
+		seen[pkg.PkgPath] = true
+
+		scope := pkg.Types.Scope()
+		for _, name := range scope.Names() {
+			obj, ok := scope.Lookup(name).(*types.TypeName)
+			if !ok {
+				continue
+			}
+			switch underlying := obj.Type().Underlying().(type) {
+			case *types.Interface:
+				for method := range underlying.Methods() {
+					if sig, ok := method.Type().(*types.Signature); ok {
+						out.methods[method.Name()] = append(out.methods[method.Name()], sig)
+					}
+				}
+			case *types.Signature:
+				out.funcTypes = append(out.funcTypes, underlying)
+			}
+		}
+		for _, imported := range pkg.Imports {
+			visit(imported)
+		}
+	}
+	for _, pkg := range pkgs {
+		visit(pkg)
+	}
+	return out
+}
+
+// hasDeclaredShape tests signature identity rather than `types.Implements` on
+// the receiver, since a method usually satisfies an interface through the
+// struct embedding it. It over-rejects a coincidental match.
+func (a *ParameterNilability) hasDeclaredShape(fn *types.Func) bool {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	bare := types.NewSignatureType(nil, nil, nil, sig.Params(), sig.Results(), sig.Variadic())
+	for _, declared := range a.shapes.methods[fn.Name()] {
+		if types.Identical(bare, declared) {
+			return true
+		}
+	}
+	for _, declared := range a.shapes.funcTypes {
+		if types.Identical(bare, declared) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *ParameterNilability) Function(obj types.Object) (FunctionParamNilability, bool) {
+	if a == nil {
+		return FunctionParamNilability{}, false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return FunctionParamNilability{}, false
+	}
+	facts, ok := a.verdicts[fn]
+	return facts, ok
+}
+
+// Optional is shared by the conversion and the axiom seed, and answers from
+// the config this analysis was built with, so neither caller can supply one the
+// other did not see.
+func (a *ParameterNilability) Optional(fn *types.Func, index int) bool {
+	if a == nil {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || index < 0 || index >= sig.Params().Len() {
+		return false
+	}
+	param := sig.Params().At(index)
+	if !isNilableGoType(param.Type()) {
+		return false
+	}
+	if sig.Variadic() && index == sig.Params().Len()-1 {
+		return false
+	}
+	if forced, decided := a.configOptional(fn, index); decided {
+		return forced
+	}
+	if a.hasDeclaredShape(fn) {
+		return false
+	}
+	verdict, _ := a.Function(fn)
+	return verdict.Tolerates(index)
+}
+
+// configOptional answers from config alone, reporting whether it decided.
+// Overrides sit under the declaring type. The return pin runs before
+// `nilable_param`, or an override would slip past it.
+func (a *ParameterNilability) configOptional(fn *types.Func, index int) (optional, decided bool) {
+	cfg := a.cfg
+	if cfg == nil || fn.Pkg() == nil {
+		return false, false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || index < 0 || index >= sig.Params().Len() {
+		return false, false
+	}
+	name := sig.Params().At(index).Name()
+	pkg, key := fn.Pkg().Path(), qualifiedFunctionName(fn)
+	if name != "" && slices.Contains(cfg.NonNilableParams(pkg, key), name) {
+		return false, true
+	}
+	if cfg.IsNonNilableReturn(pkg, key) {
+		return false, true
+	}
+	if name != "" && slices.Contains(cfg.NilableParams(pkg, key), name) {
+		return true, true
+	}
+	return false, false
+}
+
+func (a *ParameterNilability) record(fn *types.Func) {
+	if _, done := a.verdicts[fn]; done {
+		return
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return
+	}
+	facts := FunctionParamNilability{ToleratesNil: make([]bool, sig.Params().Len())}
+
+	ssaFn := a.nilness.program.FuncValue(fn)
+	if ssaFn == nil {
+		a.verdicts[fn] = facts
+		return
+	}
+	body := functionBody(ssaFn)
+	if body == nil {
+		a.verdicts[fn] = facts
+		return
+	}
+
+	// An SSA method carries its receiver as parameter 0, which is skipped.
+	offset := 0
+	if sig.Recv() != nil {
+		offset = 1
+	}
+
+	// A forced parameter never walks, so neighbours prove against it being nil.
+	var forced []*ssa.Parameter
+	for index := range facts.ToleratesNil {
+		if optional, decided := a.configOptional(fn, index); decided && optional {
+			if position := index + offset; position < len(body.Params) {
+				forced = append(forced, body.Params[position])
+			}
+		}
+	}
+
+	for index := range facts.ToleratesNil {
+		if sig.Variadic() && index == sig.Params().Len()-1 {
+			continue
+		}
+		position := index + offset
+		if position >= len(body.Params) {
+			continue
+		}
+		param := body.Params[position]
+		if !isNilableGoType(param.Type()) {
+			continue
+		}
+		facts.ToleratesNil[index] = a.provenTolerant(body, param, forced)
+	}
+	a.verdicts[fn] = facts
+}
+
+// provenTolerant pins `param` nil and leaves neighbours unconstrained, so the
+// proof holds for any combination of None arguments. Any rejection vetoes.
+func (a *ParameterNilability) provenTolerant(body *ssa.Function, param *ssa.Parameter, forced []*ssa.Parameter) bool {
+	axioms := []nilnessFact{{value: param, n: nilnessNil}}
+	mayNil := append([]*ssa.Parameter{param}, forced...)
+	reject := false
+	ordinary := false
+
+	a.nilness.walk(body, axioms, func(instr ssa.Instruction, dominating []nilnessFact) {
+		if reject {
+			return
+		}
+		if ret, ok := instr.(*ssa.Return); ok {
+			if isOrdinaryReturn(body, ret) {
+				ordinary = true
+			} else {
+				reject = true
+			}
+			return
+		}
+		if a.rejects(instr, dominating, mayNil) {
+			reject = true
+		}
+	})
+
+	return !reject && ordinary
+}
+
+// rejects is default-deny: touching the tracked value rejects unless `safeUse`
+// allows it, since a forgotten dangerous form would read as tolerance. A panic
+// is judged by reachability, having no provenance to attribute it.
+func (a *ParameterNilability) rejects(instr ssa.Instruction, dominating []nilnessFact, mayNil []*ssa.Parameter) bool {
+	if _, isPanic := instr.(*ssa.Panic); isPanic {
+		return true
+	}
+	if closure, ok := instr.(*ssa.MakeClosure); ok {
+		for _, binding := range closure.Bindings {
+			if a.bindingCarries(binding, dominating, mayNil) {
+				return true
+			}
+		}
+	}
+	if !a.touches(instr, dominating, mayNil) {
+		return false
+	}
+	return !a.safeUse(instr, dominating, mayNil)
+}
+
+func (a *ParameterNilability) touches(instr ssa.Instruction, dominating []nilnessFact, mayNil []*ssa.Parameter) bool {
+	var operands [8]*ssa.Value
+	for _, operand := range instr.Operands(operands[:0]) {
+		if operand == nil || *operand == nil {
+			continue
+		}
+		if a.carries(*operand, dominating, mayNil, make(map[ssa.Value]bool)) {
+			return true
+		}
+	}
+	return false
+}
+
+// safeUse lists what a possibly-nil value tolerates: cannot fault on nil, or
+// yields a value `carries` keeps tracking.
+func (a *ParameterNilability) safeUse(instr ssa.Instruction, dominating []nilnessFact, mayNil []*ssa.Parameter) bool {
+	switch typed := instr.(type) {
+	case *ssa.BinOp:
+		return typed.Op == token.EQL || typed.Op == token.NEQ
+
+	case *ssa.Phi, *ssa.ChangeInterface, *ssa.ChangeType, *ssa.Convert, *ssa.MakeInterface,
+		*ssa.Extract, *ssa.Return, *ssa.DebugRef:
+		return true
+
+	case *ssa.Lookup:
+		return true // nil map reads yield the zero value, nil keys are ordinary
+
+	case *ssa.TypeAssert:
+		return typed.CommaOk // failure yields the zero value instead of panicking
+
+	case *ssa.Store:
+		// Writing through the parameter dereferences it, and a heap cell outlives
+		// the call.
+		return !a.carries(typed.Addr, dominating, mayNil, make(map[ssa.Value]bool)) && isFrameSlot(typed.Addr)
+
+	case *ssa.UnOp:
+		return typed.Op == token.MUL && isFrameSlot(typed.X) // load back out of a spill
+
+	case ssa.CallInstruction:
+		builtin, ok := typed.Common().Value.(*ssa.Builtin)
+		if !ok {
+			return false // any call the parameter reaches ends the proof
+		}
+		return builtin.Name() == "len" || builtin.Name() == "cap"
+	}
+	return false
+}
+
+// isFrameSlot reports a cell that dies with the frame.
+func isFrameSlot(v ssa.Value) bool {
+	alloc, ok := v.(*ssa.Alloc)
+	return ok && !alloc.Heap
+}
+
+// carries reports whether v may hold a tracked nil. Evaluation decides it when
+// conclusive, which lets `if p == nil { p = &T{} }` pass.
+func (a *ParameterNilability) carries(v ssa.Value, dominating []nilnessFact, mayNil []*ssa.Parameter, seen map[ssa.Value]bool) bool {
+	if v == nil || seen[v] {
+		return false
+	}
+	seen[v] = true
+	switch a.nilness.eval(v, dominating, make(map[ssa.Value]bool)).n {
+	case nilnessNil:
+		return true
+	case nilnessNonNil:
+		if _, wraps := v.(*ssa.MakeInterface); !wraps {
+			return false
+		}
+	}
+	if param, ok := v.(*ssa.Parameter); ok && slices.Contains(mayNil, param) {
+		return true
+	}
+
+	switch typed := v.(type) {
+	case *ssa.MakeInterface:
+		return a.carries(typed.X, dominating, mayNil, seen)
+	case *ssa.ChangeInterface:
+		return a.carries(typed.X, dominating, mayNil, seen)
+	case *ssa.ChangeType:
+		return a.carries(typed.X, dominating, mayNil, seen)
+	case *ssa.Convert:
+		return a.carries(typed.X, dominating, mayNil, seen)
+	case *ssa.Slice:
+		return a.carries(typed.X, dominating, mayNil, seen)
+	case *ssa.Phi:
+		for _, edge := range typed.Edges {
+			if a.carries(edge, dominating, mayNil, seen) {
+				return true
+			}
+		}
+	case *ssa.Extract:
+		if assert, ok := typed.Tuple.(*ssa.TypeAssert); ok {
+			return a.carries(assert.X, dominating, mayNil, seen)
+		}
+	case *ssa.UnOp:
+		if spilled := resolveSpill(typed); spilled != ssa.Value(typed) {
+			return a.carries(spilled, dominating, mayNil, seen)
+		}
+	}
+	return false
+}
+
+func (a *ParameterNilability) bindingCarries(v ssa.Value, dominating []nilnessFact, mayNil []*ssa.Parameter) bool {
+	if a.carries(v, dominating, mayNil, make(map[ssa.Value]bool)) {
+		return true
+	}
+	alloc, ok := v.(*ssa.Alloc)
+	if !ok || alloc.Referrers() == nil {
+		return false
+	}
+	for _, ref := range *alloc.Referrers() {
+		if store, ok := ref.(*ssa.Store); ok && store.Addr == ssa.Value(alloc) {
+			if a.carries(store.Val, dominating, mayNil, make(map[ssa.Value]bool)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isOrdinaryReturn: no error result, or a nil error constant at this site.
+func isOrdinaryReturn(body *ssa.Function, ret *ssa.Return) bool {
+	results := body.Signature.Results()
+	count := results.Len()
+	if count == 0 {
+		return true
+	}
+	if !isErrorType(results.At(count - 1).Type()) {
+		return true
+	}
+	if len(ret.Results) != count {
+		return false
+	}
+	last := ret.Results[count-1]
+	return isNilConst(last) || isNilConst(resolveSpill(last))
+}

--- a/bindgen/internal/convert/param_nilability_test.go
+++ b/bindgen/internal/convert/param_nilability_test.go
@@ -1,0 +1,517 @@
+package convert
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go/types"
+	"testing"
+
+	"github.com/ivov/lisette/bindgen/internal/config"
+	"golang.org/x/tools/go/packages"
+)
+
+func nilabilitySource(t *testing.T, source string, bindgenConfig *config.Config) (*NilnessAnalysis, *packages.Package) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module probe\n\ngo 1.25\n")
+	write("probe.go", "package probe\n\n"+source+shared)
+
+	cfg := &packages.Config{Mode: packages.LoadAllSyntax, Dir: dir}
+	pkgs, err := packages.Load(cfg, "probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || len(pkgs[0].Errors) > 0 {
+		t.Fatalf("load failed: %v", pkgs)
+	}
+	nilness := NewNilnessAnalysis(pkgs, bindgenConfig)
+	if nilness == nil {
+		t.Fatal("SSA build failed")
+	}
+	return nilness, pkgs[0]
+}
+
+func tolerantParams(t *testing.T, nilness *NilnessAnalysis, pkg *packages.Package, name string) []string {
+	t.Helper()
+	obj := lookupFunc(t, pkg, name)
+	sig, ok := obj.Type().(*types.Signature)
+	if !ok {
+		t.Fatalf("%q is not a function", name)
+	}
+	var out []string
+	for i := 0; i < sig.Params().Len(); i++ {
+		if nilness.Params().Optional(obj, i) {
+			out = append(out, sig.Params().At(i).Name())
+		}
+	}
+	return out
+}
+
+func lookupFunc(t *testing.T, pkg *packages.Package, name string) *types.Func {
+	t.Helper()
+	typeName, methodName, isMethod := strings.Cut(name, ".")
+	if !isMethod {
+		obj, _ := pkg.Types.Scope().Lookup(name).(*types.Func)
+		if obj == nil {
+			t.Fatalf("no function %q", name)
+		}
+		return obj
+	}
+	named, _ := pkg.Types.Scope().Lookup(typeName).(*types.TypeName)
+	if named == nil {
+		t.Fatalf("no type %q", typeName)
+	}
+	for method := range named.Type().(*types.Named).Methods() {
+		if method.Name() == methodName {
+			return method
+		}
+	}
+	t.Fatalf("no method %q", name)
+	return nil
+}
+
+func assertTolerant(t *testing.T, source, fn string, want ...string) {
+	t.Helper()
+	nilness, pkg := nilabilitySource(t, source, nil)
+	got := tolerantParams(t, nilness, pkg, fn)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("%s: tolerant params = %v, want %v", fn, got, want)
+	}
+}
+
+const shared = `
+type T struct{ x int }
+type Node struct{ left, right *Node }
+`
+
+func TestToleratesDefaultOnNil(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) int {
+	if p == nil {
+		p = &T{}
+	}
+	return p.x
+}
+`, "Use", "p")
+}
+
+func TestRejectsDereference(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) int { return p.x }
+`, "Use")
+}
+
+func TestRejectsConstructedErrorReturn(t *testing.T) {
+	assertTolerant(t, `
+import "errors"
+
+func Use(p *T) error {
+	if p == nil {
+		return errors.New("p required")
+	}
+	return nil
+}
+`, "Use")
+}
+
+func TestRejectsPanic(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) {
+	if p == nil {
+		panic("p required")
+	}
+}
+`, "Use")
+}
+
+func TestRejectsMixedOutcome(t *testing.T) {
+	assertTolerant(t, `
+import "errors"
+
+func Use(p *T, flag bool) error {
+	if p == nil {
+		if flag {
+			return nil
+		}
+		return errors.New("p required")
+	}
+	return nil
+}
+`, "Use")
+}
+
+// (None, None) would dereference nil.
+func TestJointDereference(t *testing.T) {
+	assertTolerant(t, `
+func Use(p, q *T) int {
+	if p == nil {
+		return q.x
+	}
+	return p.x
+}
+`, "Use", "p")
+}
+
+func TestJointErrorGuard(t *testing.T) {
+	assertTolerant(t, `
+import "errors"
+
+func Use(p, q *T) error {
+	if p == nil && q == nil {
+		return errors.New("invalid")
+	}
+	return nil
+}
+`, "Use")
+}
+
+func TestRejectsEscapeIntoField(t *testing.T) {
+	assertTolerant(t, `
+type Holder struct{ p *T }
+
+func Use(h *Holder, p *T) { h.p = p }
+`, "Use")
+}
+
+func TestRejectsEscapeIntoGlobal(t *testing.T) {
+	assertTolerant(t, `
+var sink *T
+
+func Use(p *T) { sink = p }
+`, "Use")
+}
+
+func TestRejectsEscapeIntoChannel(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T, ch chan *T) { ch <- p }
+`, "Use")
+}
+
+func TestRejectsEscapeIntoClosure(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) func() int {
+	return func() int { return p.x }
+}
+`, "Use")
+}
+
+func TestRejectsEscapeIntoMap(t *testing.T) {
+	assertTolerant(t, `
+func Use(m map[string]*T, p *T) { m["k"] = p }
+`, "Use")
+}
+
+// A returned nil is the return side's business.
+func TestReturningParameterIsNotEscape(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) *T { return p }
+`, "Use", "p")
+}
+
+func TestRejectsCalleeDereference(t *testing.T) {
+	assertTolerant(t, `
+func helper(p *T) int { return p.x }
+
+func Use(p *T) int { return helper(p) }
+`, "Use")
+}
+
+func TestRejectsCalleePanicWithoutTouching(t *testing.T) {
+	assertTolerant(t, `
+func check(p *T) {
+	if p == nil {
+		panic("p required")
+	}
+}
+
+func Use(p *T) int {
+	check(p)
+	return 0
+}
+`, "Use")
+}
+
+func TestRejectsCalleeJointGuard(t *testing.T) {
+	assertTolerant(t, `
+func h(p, q *T) {
+	if p == nil && q == nil {
+		panic("invalid")
+	}
+}
+
+func Use(p, q *T) { h(p, q) }
+`, "Use")
+}
+
+func TestRejectsDereferenceOfDelegatedResult(t *testing.T) {
+	assertTolerant(t, `
+func identity(p *T) *T { return p }
+
+func Use(p *T) int {
+	q := identity(p)
+	return q.x
+}
+`, "Use")
+}
+
+func TestRejectsThroughDefer(t *testing.T) {
+	assertTolerant(t, `
+func helper(p *T) int { return p.x }
+
+func Use(p *T) { defer helper(p) }
+`, "Use")
+}
+
+func TestRejectsThroughGo(t *testing.T) {
+	assertTolerant(t, `
+func helper(p *T) int { return p.x }
+
+func Use(p *T) { go helper(p) }
+`, "Use")
+}
+
+func TestHelperMediatedToleranceIsNotProven(t *testing.T) {
+	assertTolerant(t, `
+func present(p *T) bool { return p != nil }
+
+func Use(p *T) bool { return present(p) }
+`, "Use")
+}
+
+func TestAcceptsRecursiveWalk(t *testing.T) {
+	assertTolerant(t, `
+func Walk(n *Node) {
+	if n == nil {
+		return
+	}
+	Walk(n.left)
+	Walk(n.right)
+}
+`, "Walk", "n")
+}
+
+func TestMutualRecursionSettles(t *testing.T) {
+	assertTolerant(t, `
+func a(p *T) { b(p) }
+
+func b(p *T) {
+	if p == nil {
+		panic("p required")
+	}
+	a(p)
+}
+
+func Use(p *T) { a(p) }
+`, "Use")
+}
+
+func TestRejectsNilReceiverCallee(t *testing.T) {
+	assertTolerant(t, `
+func (t *T) Check() {
+	if t == nil {
+		panic("nil")
+	}
+}
+
+func Use(t *T) { t.Check() }
+`, "Use")
+}
+
+func TestReceiverNeverFlips(t *testing.T) {
+	assertTolerant(t, `
+func (t *T) Describe() string {
+	if t == nil {
+		return "none"
+	}
+	return "some"
+}
+`, "T.Describe")
+}
+
+func TestVariadicNeverFlips(t *testing.T) {
+	assertTolerant(t, `
+func Use(ps ...*T) int { return len(ps) }
+`, "Use")
+}
+
+func TestRejectsBodylessCallee(t *testing.T) {
+	assertTolerant(t, `
+import "unsafe"
+
+func opaque(p unsafe.Pointer)
+
+func Use(p *T) { opaque(unsafe.Pointer(p)) }
+`, "Use")
+}
+
+func TestRejectsCommaOkAssertThenDereference(t *testing.T) {
+	assertTolerant(t, `
+type Iface interface{ M() }
+
+func (t *T) M() {}
+
+func Use(v Iface) int {
+	p, _ := v.(*T)
+	return p.x
+}
+`, "Use")
+}
+
+func TestRejectsSliceOfNilPointerToArray(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *[1]int) []int { return p[:] }
+`, "Use")
+}
+
+func TestRejectsStoreIntoHeapLocal(t *testing.T) {
+	assertTolerant(t, `
+func Use(p *T) **T {
+	q := p
+	return &q
+}
+`, "Use")
+}
+
+func TestReturnPinBeatsNilableParamOverride(t *testing.T) {
+	source := `
+func Use(p *T) *T {
+	if p == nil {
+		return nil
+	}
+	return p
+}
+`
+	optionalUnder := func(cfg *config.Config) bool {
+		t.Helper()
+		nilness, pkg := nilabilitySource(t, source, cfg)
+		return nilness.Params().Optional(lookupFunc(t, pkg, "Use"), 0)
+	}
+
+	forced := &config.Config{}
+	forced.Overrides.Types.NilableParam = map[string]map[string][]string{
+		"probe": {"Use": {"p"}},
+	}
+	if !optionalUnder(forced) {
+		t.Fatal("nilable_param alone should force the flip")
+	}
+
+	pinned := &config.Config{}
+	pinned.Overrides.Types.NilableParam = forced.Overrides.Types.NilableParam
+	pinned.Overrides.Types.NonNilableReturn = map[string][]string{"probe": {"Use"}}
+	if optionalUnder(pinned) {
+		t.Fatal("a non_nilable_return pin must block the flip even when nilable_param forces it")
+	}
+
+	cancelled := &config.Config{}
+	cancelled.Overrides.Types.NonNilableParam = map[string]map[string][]string{
+		"probe": {"Use": {"p"}},
+	}
+	if optionalUnder(cancelled) {
+		t.Fatal("non_nilable_param must cancel an inference")
+	}
+}
+
+func TestForcedOptionalNeighbourBlocksInference(t *testing.T) {
+	source := `
+func F(p, q *T) int {
+	if q == nil {
+		return p.x
+	}
+	return 0
+}
+`
+	plain, pkg := nilabilitySource(t, source, nil)
+	fn := lookupFunc(t, pkg, "F")
+	if plain.Params().Optional(fn, 0) {
+		t.Fatal("p dereferences on a live path, so it must not be proven")
+	}
+	if !plain.Params().Optional(fn, 1) {
+		t.Fatal("q is tolerated when p is a real pointer")
+	}
+
+	forced := &config.Config{}
+	forced.Overrides.Types.NilableParam = map[string]map[string][]string{
+		fn.Pkg().Path(): {"F": {"p"}},
+	}
+	withOverride, pkg := nilabilitySource(t, source, forced)
+	fn = lookupFunc(t, pkg, "F")
+	if !withOverride.Params().Optional(fn, 0) {
+		t.Fatal("nilable_param must force p optional")
+	}
+	if withOverride.Params().Optional(fn, 1) {
+		t.Fatal("q must not stay proven once p can be None: F(None, None) panics")
+	}
+}
+
+func TestInterfaceMethodDoesNotFlip(t *testing.T) {
+	assertTolerant(t, `
+type Sink interface{ Accept(p *T) bool }
+
+type Impl struct{}
+
+func (i *Impl) Accept(p *T) bool { return p != nil }
+
+var _ Sink = (*Impl)(nil)
+`, "Impl.Accept")
+}
+
+func TestNonInterfaceMethodStillFlips(t *testing.T) {
+	assertTolerant(t, `
+type Lone struct{}
+
+func (l *Lone) Accept(p *T) bool { return p != nil }
+`, "Lone.Accept", "p")
+}
+
+func TestNamedFuncTypeShapeDoesNotFlip(t *testing.T) {
+	assertTolerant(t, `
+type Handler func(p *T) bool
+
+func Accept(p *T) bool { return p != nil }
+
+var _ Handler = Accept
+`, "Accept")
+}
+
+func TestPromotedInterfaceMethodDoesNotFlip(t *testing.T) {
+	assertTolerant(t, `
+type Sink interface {
+	Accept(p *T) bool
+	Extra()
+}
+
+type inner struct{}
+
+func (i inner) Accept(p *T) bool { return p != nil }
+
+type Outer struct {
+	inner
+}
+
+func (o Outer) Extra() {}
+
+var _ Sink = Outer{}
+`, "inner.Accept")
+}
+
+func TestOptionalWithoutAnalysis(t *testing.T) {
+	_, pkg := nilabilitySource(t, `
+func Use(p *T) int {
+	if p == nil {
+		return 0
+	}
+	return p.x
+}
+`, nil)
+	var absent *ParameterNilability
+	if absent.Optional(lookupFunc(t, pkg, "Use"), 0) {
+		t.Fatal("no analysis means nothing is proven")
+	}
+}

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -3,7 +3,6 @@ package convert
 import (
 	"fmt"
 	"go/types"
-	"slices"
 	"strings"
 
 	"github.com/ivov/lisette/bindgen/internal/extract"
@@ -38,10 +37,10 @@ func ToLisetteNilable(t types.Type, conv *Converter) TypeResult {
 	return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv, nil)
 }
 
-// convertParamType wraps a `*T` parameter in `Option<>` when the param's name
-// appears in `nilable` — used for Go APIs where passing nil means "use default".
-func convertParamType(t types.Type, name string, nilable []string, conv *Converter, substitutions map[string]string) TypeResult {
-	if slices.Contains(nilable, name) {
+// convertParamType wraps a `*T` parameter in `Option<>` when it was proven to
+// accept nil, for Go APIs where nil means "use the default".
+func convertParamType(t types.Type, optional bool, conv *Converter, substitutions map[string]string) TypeResult {
+	if optional {
 		return toLisetteNilableRecursive(t, make(map[types.Type]bool), conv, substitutions)
 	}
 	return toLisetteWithSubstitutions(t, conv, substitutions)

--- a/bindgen/tests/testdata/snapshots/interface_typed_var.d.lis
+++ b/bindgen/tests/testdata/snapshots/interface_typed_var.d.lis
@@ -7,7 +7,7 @@
 import "go:io"
 
 /// Discard forces the io import so io.Writer is a reachable candidate interface.
-pub fn Discard(w: io.Writer)
+pub fn Discard(w: Option<io.Writer>)
 
 /// AnonParamIface is exported but not representable in Lisette: its method takes
 /// a tagged anonymous struct, which gates. A singleton implementing only it must

--- a/bindgen/tests/testdata/snapshots/opaque_handle.d.lis
+++ b/bindgen/tests/testdata/snapshots/opaque_handle.d.lis
@@ -7,7 +7,7 @@
 pub type chest
 
 /// Direct consumer: eligible.
-pub fn NewMenu(submittable: Submittable, name: string, c: chest) -> Menu
+pub fn NewMenu(submittable: Option<Submittable>, name: string, c: chest) -> Menu
 
 // SKIPPED: TakesCallback - opaque-unexported-struct
 // underlying type "chest" is unexported

--- a/bindgen/tests/testdata/snapshots/partial_io_methods.d.lis
+++ b/bindgen/tests/testdata/snapshots/partial_io_methods.d.lis
@@ -13,9 +13,9 @@ pub type NotSink
 pub type Sink
 
 impl NotSink {
-  fn ReadFrom(self: Ref<NotSink>, r: io.Reader) -> Result<string, error>
+  fn ReadFrom(self: Ref<NotSink>, r: Option<io.Reader>) -> Result<string, error>
   fn WriteString(self: Ref<NotSink>, str: string) -> Result<(), error>
-  fn WriteTo(self: Ref<NotSink>, w: io.Writer) -> Result<string, error>
+  fn WriteTo(self: Ref<NotSink>, w: Option<io.Writer>) -> Result<string, error>
 }
 
 impl Sink {

--- a/bindgen/tests/testdata/snapshots/prelude_collision.d.lis
+++ b/bindgen/tests/testdata/snapshots/prelude_collision.d.lis
@@ -5,7 +5,7 @@
 
 pub fn NewOption<T: Comparable>(key: string, value: T) -> prelude_collision.Option<T>
 
-pub fn TakeField(f: Field)
+pub fn TakeField(f: Option<Field>)
 
 /// WithWidth returns the interface itself; the nilable return becomes the prelude
 /// `Option<Field>` wrapper.

--- a/crates/stdlib/typedefs/container/ring.d.lis
+++ b/crates/stdlib/typedefs/container/ring.d.lis
@@ -40,7 +40,7 @@ impl Ring {
   /// them creates a single ring with the elements of s inserted
   /// after r. The result points to the element following the
   /// last element of s after insertion.
-  fn Link(self: Ref<Ring>, s: Ref<Ring>) -> Ref<Ring>
+  fn Link(self: Ref<Ring>, s: Option<Ref<Ring>>) -> Ref<Ring>
 
   /// Move moves n % r.Len() elements backward (n < 0) or forward (n >= 0)
   /// in the ring and returns that ring element. r must not be empty.

--- a/crates/stdlib/typedefs/crypto/x509.d.lis
+++ b/crates/stdlib/typedefs/crypto/x509.d.lis
@@ -665,7 +665,7 @@ impl CertPool {
   fn Clone(self: Ref<CertPool>) -> Ref<CertPool>
 
   /// Equal reports whether s and other are equal.
-  fn Equal(self: Ref<CertPool>, other: Ref<CertPool>) -> bool
+  fn Equal(self: Ref<CertPool>, other: Option<Ref<CertPool>>) -> bool
 
   /// Subjects returns a list of the DER-encoded subjects of
   /// all of the certificates in the pool.
@@ -715,7 +715,7 @@ impl Certificate {
     expiry: time.Time,
   ) -> Result<Slice<byte>, error>
 
-  fn Equal(self: Ref<Certificate>, other: Ref<Certificate>) -> bool
+  fn Equal(self: Ref<Certificate>, other: Option<Ref<Certificate>>) -> bool
 
   /// Verify attempts to verify c by building one or more chains from c to a
   /// certificate in opts.Roots, using certificates in opts.Intermediates if

--- a/crates/stdlib/typedefs/go/types.d.lis
+++ b/crates/stdlib/typedefs/go/types.d.lis
@@ -196,7 +196,7 @@ pub fn DefPredeclaredTestFuncs()
 /// Default returns the default "typed" type for an "untyped" type;
 /// it returns the incoming type for all other types. The default type
 /// for untyped nil is untyped nil.
-pub fn Default(t: Type) -> Type
+pub fn Default(t: Option<Type>) -> Option<Type>
 
 /// Eval returns the type and, if constant, the value for the
 /// expression expr, evaluated at position pos of package pkg,
@@ -222,7 +222,7 @@ pub fn ExprString(x: ast.Expr) -> string
 
 /// Id returns name if it is exported, otherwise it
 /// returns the name qualified with the package path.
-pub fn Id(pkg: Ref<Package>, name: string) -> string
+pub fn Id(pkg: Option<Ref<Package>>, name: string) -> string
 
 /// Identical reports whether x and y are identical types.
 /// Receivers of [Signature] types are ignored.
@@ -378,10 +378,10 @@ pub fn NewChan(dir: ChanDir, elem: Type) -> Ref<Chan>
 /// NewChecker returns a new [Checker] instance for a given package.
 /// [Package] files may be added incrementally via checker.Files.
 pub fn NewChecker(
-  conf: Ref<Config>,
+  conf: Option<Ref<Config>>,
   fset: Ref<token.FileSet>,
   pkg: Ref<Package>,
-  info: Ref<Info>,
+  info: Option<Ref<Info>>,
 ) -> Ref<Checker>
 
 /// NewConst returns a new constant with value val.
@@ -1208,7 +1208,7 @@ impl Info {
   /// it defines, not the type (*[TypeName]) it uses.
   /// 
   /// Precondition: the Uses and Defs maps are populated.
-  fn ObjectOf(self: Ref<Info>, id: Ref<ast.Ident>) -> Option<Object>
+  fn ObjectOf(self: Ref<Info>, id: Option<Ref<ast.Ident>>) -> Option<Object>
 
   /// PkgNameOf returns the local package name defined by the import,
   /// or nil if not found.
@@ -1220,7 +1220,7 @@ impl Info {
 
   /// TypeOf returns the type of expression e, or nil if not found.
   /// Precondition: the Types, Uses and Defs maps are populated.
-  fn TypeOf(self: Ref<Info>, e: ast.Expr) -> Option<Type>
+  fn TypeOf(self: Ref<Info>, e: Option<ast.Expr>) -> Option<Type>
 }
 
 impl Initializer {

--- a/crates/stdlib/typedefs/io/fs.d.lis
+++ b/crates/stdlib/typedefs/io/fs.d.lis
@@ -7,7 +7,7 @@ import "go:time"
 
 /// FileInfoToDirEntry returns a [DirEntry] that returns information from info.
 /// If info is nil, FileInfoToDirEntry returns nil.
-pub fn FileInfoToDirEntry(info: FileInfo) -> DirEntry
+pub fn FileInfoToDirEntry(info: Option<FileInfo>) -> Option<DirEntry>
 
 /// FormatDirEntry returns a formatted version of dir for human readability.
 /// Implementations of [DirEntry] can call this from a String method.

--- a/crates/stdlib/typedefs/log/slog.d.lis
+++ b/crates/stdlib/typedefs/log/slog.d.lis
@@ -158,7 +158,7 @@ pub fn New(h: Handler) -> Ref<Logger>
 /// NewJSONHandler creates a [JSONHandler] that writes to w,
 /// using the given options.
 /// If opts is nil, the default options are used.
-pub fn NewJSONHandler(w: io.Writer, opts: Ref<HandlerOptions>) -> Ref<JSONHandler>
+pub fn NewJSONHandler(w: io.Writer, opts: Option<Ref<HandlerOptions>>) -> Ref<JSONHandler>
 
 /// NewLogLogger returns a new [log.Logger] such that each call to its Output method
 /// dispatches a Record to the specified handler. The logger acts as a bridge from
@@ -175,7 +175,7 @@ pub fn NewRecord(t: time.Time, level: Level, msg: string, pc: uintptr) -> Record
 /// NewTextHandler creates a [TextHandler] that writes to w,
 /// using the given options.
 /// If opts is nil, the default options are used.
-pub fn NewTextHandler(w: io.Writer, opts: Ref<HandlerOptions>) -> Ref<TextHandler>
+pub fn NewTextHandler(w: io.Writer, opts: Option<Ref<HandlerOptions>>) -> Ref<TextHandler>
 
 /// SetDefault makes l the default [Logger], which is used by
 /// the top-level functions [Info], [Debug] and so on.

--- a/crates/stdlib/typedefs/math/big.d.lis
+++ b/crates/stdlib/typedefs/math/big.d.lis
@@ -269,7 +269,7 @@ impl Float {
   /// 
   /// x and mant may be the same in which case x is set to its
   /// mantissa value.
-  fn MantExp(self: Ref<Float>, mant: Ref<Float>) -> int
+  fn MantExp(self: Ref<Float>, mant: Option<Ref<Float>>) -> int
 
   /// MarshalText implements the [encoding.TextMarshaler] interface.
   /// Only the [Float] value is marshaled (in full precision), other

--- a/crates/stdlib/typedefs/net/http.d.lis
+++ b/crates/stdlib/typedefs/net/http.d.lis
@@ -2223,7 +2223,7 @@ impl Transport {
   /// Deprecated: Use [Request.WithContext] to create a request with a
   /// cancelable context instead. CancelRequest cannot cancel HTTP/2
   /// requests. This may become a no-op in a future release of Go.
-  fn CancelRequest(self: Ref<Transport>, req: Ref<Request>)
+  fn CancelRequest(self: Ref<Transport>, req: Option<Ref<Request>>)
 
   /// Clone returns a deep copy of t's exported fields.
   fn Clone(self: Ref<Transport>) -> Ref<Transport>

--- a/crates/stdlib/typedefs/net/http/cookiejar.d.lis
+++ b/crates/stdlib/typedefs/net/http/cookiejar.d.lis
@@ -8,7 +8,7 @@ import "go:net/url"
 
 /// New returns a new cookie jar. A nil [*Options] is equivalent to a zero
 /// Options.
-pub fn New(o: Ref<Options>) -> Result<Ref<Jar>, error>
+pub fn New(o: Option<Ref<Options>>) -> Result<Ref<Jar>, error>
 
 /// Jar implements the http.CookieJar interface from the net/http package.
 pub type Jar

--- a/crates/stdlib/typedefs/regexp/syntax.d.lis
+++ b/crates/stdlib/typedefs/regexp/syntax.d.lis
@@ -262,7 +262,7 @@ impl Regexp {
   fn CapNames(self: Ref<Regexp>) -> Slice<string>
 
   /// Equal reports whether x and y have identical structure.
-  fn Equal(self: Ref<Regexp>, y: Ref<Regexp>) -> bool
+  fn Equal(self: Ref<Regexp>, y: Option<Ref<Regexp>>) -> bool
 
   /// MaxCap walks the regexp to find the maximum capture index.
   fn MaxCap(self: Ref<Regexp>) -> int

--- a/crates/stdlib/typedefs/runtime/debug.d.lis
+++ b/crates/stdlib/typedefs/runtime/debug.d.lis
@@ -48,7 +48,7 @@ pub fn ReadGCStats(stats: Ref<GCStats>)
 /// To disable this additional crash output, call SetCrashOutput(nil).
 /// If called concurrently with a crash, some in-progress output may be written
 /// to the old file even after an overriding SetCrashOutput returns.
-pub fn SetCrashOutput(f: Ref<os.File>, opts: CrashOptions) -> Result<(), error>
+pub fn SetCrashOutput(f: Option<Ref<os.File>>, opts: CrashOptions) -> Result<(), error>
 
 /// SetGCPercent sets the garbage collection target percentage:
 /// a collection is triggered when the ratio of freshly allocated data

--- a/crates/stdlib/typedefs/text/template/parse.d.lis
+++ b/crates/stdlib/typedefs/text/template/parse.d.lis
@@ -49,7 +49,7 @@ pub const NodeVariable: NodeType = 18
 pub const NodeWith: NodeType = 19
 
 /// IsEmptyTree reports whether this tree (node) is empty of everything but space or comments.
-pub fn IsEmptyTree(n: Node) -> bool
+pub fn IsEmptyTree(n: Option<Node>) -> bool
 
 /// New allocates a new parse tree with the given name.
 pub fn New(name: string, funcs: VarArgs<Map<string, Unknown>>) -> Ref<Tree>


### PR DESCRIPTION
Derives bindgen's parameter nilability from [SSA analysis](https://pkg.go.dev/golang.org/x/tools/go/ssa).

Every Go pointer or interface arriving from Lis is typed either `Ref<T>`, which the caller must always supply, or `Option<Ref<T>>`, which lets the caller pass `None`. Until now every param was assumed non-nil unless a hand-written override said otherwise, so a Go fn documenting nil as "use the default" could not be called that way.

Bindgen now reuses the existing SSA setup and re-walks the body with the param assumed nil. A param becomes `Option<Ref<T>>` only when no dereference, escape, panic, or error return is reachable. The same verdict feeds the return analysis from #1133, so a param that can be `None` is no longer assumed non-nil while proving what the fn returns.

```rs
// net/http/cookiejar documents: "A nil [*Options] is equivalent to a zero Options"

// before
pub fn New(o: Ref<Options>) -> Result<Ref<Jar>, error>

// after
pub fn New(o: Option<Ref<Options>>) -> Result<Ref<Jar>, error>
```

18 params across 17 stdlib signatures become `Option`. Two of them also demote their return as a consequence. A param whose sig is fixed by an interface method or a named function type (e.g. `http.HandlerFunc`) keeps `Ref<T>`, so implementations stay assignable.

Follow-up to #1133, #1149, #1163