### PR TITLE
feat: auto-import Go package completions in LSP

### DIFF
--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -40,7 +40,7 @@ pub use project_manifest::{
 };
 pub use typedef_locator::{
     Bindgen, BindgenFailure, BindgenGuard, BindgenSession, BindgenSetup, DeclarationStatus,
-    ResolvedReplacement, TypedefLocator, TypedefLocatorResult, TypedefOrigin,
+    ImportablePackage, ResolvedReplacement, TypedefLocator, TypedefLocatorResult, TypedefOrigin,
 };
 
 pub fn is_third_party(pkg: &str) -> bool {

--- a/crates/deps/src/local_source.rs
+++ b/crates/deps/src/local_source.rs
@@ -6,12 +6,10 @@ use std::path::{Path, PathBuf};
 
 use crate::project_manifest::{GoDependency, ReplacementSource};
 
-/// Hash of every declared local module's content plus every entry's identity,
-/// covering all inputs that can change what bindgen emits. Content, never
-/// mtime: a `git checkout` can move mtimes backwards.
-pub(crate) fn local_stamp_hash(
-    project_root: &Path,
+/// Content, never mtime: a `git checkout` can move mtimes backwards.
+pub(crate) fn stamp_hash(
     deps: &BTreeMap<String, GoDependency>,
+    local_source: Option<&Path>,
 ) -> String {
     let mut hash = Fnv::new();
     for (module, dep) in deps {
@@ -30,7 +28,9 @@ pub(crate) fn local_stamp_hash(
                 ..
             } => {
                 hash.write(path.as_bytes());
-                hash_local_module(&mut hash, &project_root.join(path));
+                if let Some(project_root) = local_source {
+                    hash_local_module(&mut hash, &project_root.join(path));
+                }
             }
         }
     }
@@ -99,15 +99,20 @@ fn stamp_path_for_typedef(typedef_path: &Path) -> PathBuf {
     typedef_path.with_file_name(format!("{}.stamp", stem))
 }
 
+pub(crate) fn local_typedef_is_fresh(typedef_path: &Path, stamp: &str) -> bool {
+    std::fs::read_to_string(stamp_path_for_typedef(typedef_path))
+        .is_ok_and(|existing| existing == stamp)
+}
+
 /// On stamp mismatch, delete the typedef so resolution reroutes into the
 /// regenerate-on-miss path. A failed eviction (e.g. a file lock on Windows) is
 /// returned so the caller refuses the stale read, and keeps the old stamp so
 /// eviction retries next time.
 pub(crate) fn gate_local_typedef(typedef_path: &Path, stamp: &str) -> Result<(), std::io::Error> {
-    let stamp_path = stamp_path_for_typedef(typedef_path);
-    if std::fs::read_to_string(&stamp_path).is_ok_and(|existing| existing == stamp) {
+    if local_typedef_is_fresh(typedef_path, stamp) {
         return Ok(());
     }
+    let stamp_path = stamp_path_for_typedef(typedef_path);
     match std::fs::remove_file(typedef_path) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -177,15 +182,15 @@ mod tests {
         write(root, "foo/foo_test.go", "package foo\n");
         let deps = deps_with(vec![("example.com/me/foo", local_dep("foo"))]);
 
-        let before = local_stamp_hash(root, &deps);
+        let before = stamp_hash(&deps, Some(root));
 
         write(root, "foo/foo_test.go", "package foo // edited\n");
-        assert_eq!(before, local_stamp_hash(root, &deps), "test files ignored");
+        assert_eq!(before, stamp_hash(&deps, Some(root)), "test files ignored");
 
         write(root, "foo/foo.go", "package foo // edited\n");
         assert_ne!(
             before,
-            local_stamp_hash(root, &deps),
+            stamp_hash(&deps, Some(root)),
             "source edits detected"
         );
     }
@@ -205,16 +210,16 @@ mod tests {
             ("example.com/me/foo", local_dep("foo")),
             ("github.com/google/uuid", remote("v1.6.0")),
         ]);
-        let before = local_stamp_hash(root, &deps);
+        let before = stamp_hash(&deps, Some(root));
 
         let bumped = deps_with(vec![
             ("example.com/me/foo", local_dep("foo")),
             ("github.com/google/uuid", remote("v1.7.0")),
         ]);
-        assert_ne!(before, local_stamp_hash(root, &bumped));
+        assert_ne!(before, stamp_hash(&bumped, Some(root)));
 
         write(root, "foo/go.mod", "module example.com/me/foo\n\ngo 1.25\n");
-        assert_ne!(before, local_stamp_hash(root, &deps));
+        assert_ne!(before, stamp_hash(&deps, Some(root)));
     }
 
     #[test]
@@ -231,9 +236,9 @@ mod tests {
         write(root, "foo/child/child.go", "package child\n");
         let deps = deps_with(vec![("example.com/me/foo", local_dep("foo"))]);
 
-        let before = local_stamp_hash(root, &deps);
+        let before = stamp_hash(&deps, Some(root));
         write(root, "foo/child/child.go", "package child // edited\n");
-        assert_eq!(before, local_stamp_hash(root, &deps));
+        assert_eq!(before, stamp_hash(&deps, Some(root)));
     }
 
     #[test]

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -96,6 +96,46 @@ pub enum DeclarationStatus {
     UndeclaredImport,
 }
 
+#[derive(Debug)]
+pub struct ImportablePackage {
+    /// Import path without the `go:` prefix, e.g. `net/http`.
+    pub path: String,
+    typedef: PackageTypedef,
+}
+
+#[derive(Debug)]
+enum PackageTypedef {
+    Embedded(&'static str),
+    Cached(PathBuf),
+}
+
+impl ImportablePackage {
+    pub fn typedef_source(&self) -> Option<Cow<'static, str>> {
+        match &self.typedef {
+            PackageTypedef::Embedded(source) => Some(Cow::Borrowed(source)),
+            PackageTypedef::Cached(path) => std::fs::read_to_string(path).ok().map(Cow::Owned),
+        }
+    }
+
+    pub fn declared_package_name(&self) -> Option<String> {
+        match &self.typedef {
+            PackageTypedef::Embedded(source) => {
+                stdlib::declared_package_name(source).map(str::to_string)
+            }
+            PackageTypedef::Cached(path) => {
+                let mut reader = std::io::BufReader::new(std::fs::File::open(path).ok()?);
+                let mut header = String::new();
+                for _ in 0..stdlib::HEADER_LINES {
+                    if std::io::BufRead::read_line(&mut reader, &mut header).ok()? == 0 {
+                        break;
+                    }
+                }
+                stdlib::declared_package_name(&header).map(str::to_string)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedefOrigin {
     Stdlib,
@@ -172,6 +212,17 @@ impl TypedefLocator {
         }
     }
 
+    pub fn declared_stamp(&self) -> String {
+        crate::local_source::stamp_hash(&self.deps, None)
+    }
+
+    pub fn with_fresh_local_stamp(&self) -> Self {
+        Self {
+            local_stamp: Arc::new(OnceLock::new()),
+            ..self.clone()
+        }
+    }
+
     /// The stamp value gating local typedefs, `None` when none are declared.
     pub fn local_stamp_value(&self) -> Option<&str> {
         self.local_stamp
@@ -186,7 +237,7 @@ impl TypedefLocator {
                         }
                     )
                 });
-                has_local.then(|| crate::local_source::local_stamp_hash(project_root, &self.deps))
+                has_local.then(|| crate::local_source::stamp_hash(&self.deps, Some(project_root)))
             })
             .as_deref()
     }
@@ -306,6 +357,51 @@ impl TypedefLocator {
             },
             None => DeclarationStatus::UndeclaredImport,
         }
+    }
+
+    pub fn importable_packages(&self) -> Vec<ImportablePackage> {
+        let mut packages: Vec<ImportablePackage> = stdlib::get_go_stdlib_packages(self.target)
+            .into_iter()
+            .filter_map(|path| {
+                Some(ImportablePackage {
+                    path: path.to_string(),
+                    typedef: PackageTypedef::Embedded(stdlib::get_go_stdlib_typedef(
+                        path,
+                        self.target,
+                    )?),
+                })
+            })
+            .collect();
+
+        let Some(project_root) = &self.project_root else {
+            return packages;
+        };
+        let cache_dir = typedef_cache_dir(project_root);
+
+        for module_path in self.deps.keys() {
+            let Some((module, version, replacement)) = self.module_for_package(module_path) else {
+                continue;
+            };
+            let pkg = GoPackage {
+                module: GoModule {
+                    path: &module,
+                    version: &version,
+                    replacement: replacement.as_ref().map(ResolvedReplacement::as_target),
+                },
+                package: &module,
+            };
+            let local_stamp = match replacement {
+                Some(ResolvedReplacement::Local) => self.local_stamp_value(),
+                _ => None,
+            };
+
+            let root_typedef = pkg.typedef_path(&cache_dir, self.target);
+            if let Some(module_dir) = root_typedef.parent() {
+                collect_cached_packages(module_dir, &module, local_stamp, &mut packages);
+            }
+        }
+
+        packages
     }
 
     /// Resolve a `go:` package: stdlib -> on-disk cache -> bindgen runner if set.
@@ -430,6 +526,46 @@ impl TypedefLocator {
     }
 }
 
+fn collect_cached_packages(
+    dir: &Path,
+    package_path: &str,
+    local_stamp: Option<&str>,
+    out: &mut Vec<ImportablePackage>,
+) {
+    let last_segment = package_path.rsplit('/').next().unwrap_or(package_path);
+    let typedef = dir.join(format!("{last_segment}.d.lis"));
+    let fresh = local_stamp
+        .is_none_or(|stamp| crate::local_source::local_typedef_is_fresh(&typedef, stamp));
+    if fresh && typedef.is_file() {
+        out.push(ImportablePackage {
+            path: package_path.to_string(),
+            typedef: PackageTypedef::Cached(typedef),
+        });
+    }
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name == "internal" {
+            continue;
+        }
+        collect_cached_packages(
+            &entry.path(),
+            &format!("{package_path}/{name}"),
+            local_stamp,
+            out,
+        );
+    }
+}
+
 enum ReadOutcome {
     Found(String),
     Missing,
@@ -463,6 +599,70 @@ fn read_cached_typedef(path: &Path) -> Option<TypedefLocatorResult> {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    fn write_typedef(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn importable_packages_walk_a_cached_module_tree() {
+        let project = tempfile::tempdir().unwrap();
+        let mut deps = BTreeMap::new();
+        deps.insert(
+            "github.com/example/go-lib".to_string(),
+            GoDependency::Remote {
+                version: "v1.2.0".to_string(),
+                via: None,
+            },
+        );
+        let locator = TypedefLocator::new(deps, Some(project.path().to_path_buf()), Target::host());
+
+        let module_dir = typedef_cache_dir(project.path())
+            .join(Target::host().cache_segment())
+            .join("github.com/example/go-lib@v1.2.0");
+        write_typedef(&module_dir.join("go-lib.d.lis"), "// Package: lib\n");
+        write_typedef(&module_dir.join("mux/mux.d.lis"), "pub fn New() -> int\n");
+        write_typedef(&module_dir.join("internal/hide/hide.d.lis"), "pub fn X()\n");
+
+        let mut found: Vec<(String, Option<String>)> = locator
+            .importable_packages()
+            .into_iter()
+            .filter(|package| crate::is_third_party(&package.path))
+            .map(|package| (package.path.clone(), package.declared_package_name()))
+            .collect();
+        found.sort();
+
+        assert_eq!(
+            found,
+            vec![
+                (
+                    "github.com/example/go-lib".to_string(),
+                    Some("lib".to_string())
+                ),
+                ("github.com/example/go-lib/mux".to_string(), None),
+            ],
+            "subpackages come along, another module's internal packages do not"
+        );
+    }
+
+    #[test]
+    fn importable_packages_include_the_stdlib_with_its_embedded_typedef() {
+        let locator = TypedefLocator::new(BTreeMap::new(), None, Target::host());
+
+        let strings = locator
+            .importable_packages()
+            .into_iter()
+            .find(|package| package.path == "strings")
+            .expect("the stdlib is importable without a project");
+
+        assert!(
+            strings
+                .typedef_source()
+                .is_some_and(|source| source.contains("pub fn ToLower")),
+            "the embedded typedef comes with the package"
+        );
+    }
 
     #[test]
     fn replace_diagnostic_shows_replacement_version_not_synthetic() {
@@ -606,5 +806,86 @@ mod tests {
             edited.find_typedef_content(module),
             TypedefLocatorResult::MissingTypedef { local: true, .. }
         ));
+    }
+
+    #[test]
+    fn a_refreshed_locator_rereads_local_source_an_older_one_has_already_seen() {
+        let module = "example.com/me/foo";
+        let (project, locator) = local_project(module, "foo");
+
+        let pkg = GoPackage {
+            module: GoModule {
+                path: module,
+                version: "v0.0.0",
+                replacement: Some(crate::ReplacementTarget::LocalDirectory),
+            },
+            package: module,
+        };
+        let typedef_path = pkg.typedef_path(&typedef_cache_dir(project.path()), Target::host());
+        write_typedef(&typedef_path, "pub fn Old() -> int\n");
+        let stamp = locator
+            .local_stamp_value()
+            .expect("a local module is declared");
+        std::fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
+
+        let is_offered = |locator: &TypedefLocator| {
+            locator
+                .importable_packages()
+                .iter()
+                .any(|package| package.path == module)
+        };
+        assert!(is_offered(&locator));
+
+        std::fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
+        assert!(
+            is_offered(&locator),
+            "this locator answered once already and holds that answer"
+        );
+        assert!(
+            !is_offered(&locator.with_fresh_local_stamp()),
+            "a copy that has yet to look sees the edit, so a periodic re-walk \
+             cannot keep serving what an earlier analysis saw"
+        );
+    }
+
+    #[test]
+    fn importable_packages_drop_a_local_module_whose_source_moved_on() {
+        let module = "example.com/me/foo";
+        let (project, locator) = local_project(module, "foo");
+
+        let pkg = GoPackage {
+            module: GoModule {
+                path: module,
+                version: "v0.0.0",
+                replacement: Some(crate::ReplacementTarget::LocalDirectory),
+            },
+            package: module,
+        };
+        let typedef_path = pkg.typedef_path(&typedef_cache_dir(project.path()), Target::host());
+        write_typedef(&typedef_path, "pub fn Old() -> int\n");
+        let stamp = locator
+            .local_stamp_value()
+            .expect("a declared local module has a stamp");
+        std::fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
+
+        let is_offered = |locator: &TypedefLocator| {
+            locator
+                .importable_packages()
+                .iter()
+                .any(|package| package.path == module)
+        };
+        assert!(is_offered(&locator), "a stamped typedef is current");
+
+        std::fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
+        let edited = TypedefLocator::new(
+            locator.deps().clone(),
+            Some(project.path().to_path_buf()),
+            Target::host(),
+        );
+        assert!(
+            !is_offered(&edited),
+            "the typedef describes source that no longer exists, so completing from it \
+             would suggest gone packages and insert an import that fails to analyse"
+        );
     }
 }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -10,6 +10,7 @@ use passes::analyze;
 use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, ProjectKind};
 use syntax::types::{CompoundKind, Type};
 
+use crate::imports::PackageResolver;
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
 use crate::state::{AnalysisRequest, DocumentState, SharedState};
@@ -146,6 +147,9 @@ impl SharedState {
             }
         };
 
+        // No bindgen runner on this copy: a keystroke must never shell out to Go.
+        let packages = PackageResolver::new(locator.clone(), Arc::clone(&self.packages));
+
         let (locator, session, bindgen_error) = if script || manifest_error.is_some() {
             (locator, None, None)
         } else if let Some(setup) = self.bindgen_setup.as_ref() {
@@ -222,7 +226,13 @@ impl SharedState {
         // Release the target lock before the lock-free snapshot construction.
         drop(session);
 
-        Ok(AnalysisSnapshot::new(analysis, &config, uri, external_test))
+        Ok(AnalysisSnapshot::new(
+            analysis,
+            &config,
+            uri,
+            external_test,
+            packages,
+        ))
     }
 
     fn run_analysis_cached(&self, uri: &Url) -> Result<Arc<AnalysisSnapshot>, AnalysisError> {

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -12,12 +12,16 @@ use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::{find_enclosing_impl_type, find_expression_at};
 use crate::type_name;
 
-pub(crate) fn get_package_prefix(source: &str, offset: usize) -> Option<&str> {
+/// The identifier before the dot, with that dot's offset, whether the cursor
+/// sits right after it or partway through the member.
+pub(crate) fn get_package_prefix(source: &str, offset: usize) -> Option<(&str, usize)> {
     let before = &source[..offset];
+    let before = before.trim_end_matches(|c: char| c.is_alphanumeric() || c == '_');
     if !before.ends_with('.') {
         return None;
     }
-    let before_dot = &before[..before.len() - 1];
+    let dot_offset = before.len() - 1;
+    let before_dot = &before[..dot_offset];
 
     let base = if before_dot.ends_with(']') {
         let bracket_start = before_dot.rfind('[')?;
@@ -26,15 +30,16 @@ pub(crate) fn get_package_prefix(source: &str, offset: usize) -> Option<&str> {
         before_dot
     };
 
+    // A multi-byte boundary character would otherwise leave `start` inside it.
     let start = base
         .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-        .map(|i| i + 1)
+        .map(|index| index + base[index..].chars().next().map_or(1, char::len_utf8))
         .unwrap_or(0);
     let identifier = base[start..].trim();
     if identifier.is_empty() || !identifier.starts_with(|c: char| c.is_alphabetic() || c == '_') {
         return None;
     }
-    Some(identifier)
+    Some((identifier, dot_offset))
 }
 
 pub(crate) fn definition_to_completion_kind(
@@ -725,6 +730,49 @@ fn skip_stacked_attribute(after: &[Token], mut i: usize) -> usize {
         i += 1;
     }
     i
+}
+
+#[cfg(test)]
+mod package_prefix_tests {
+    use super::get_package_prefix;
+
+    fn prefix_at(source_with_cursor: &str) -> Option<String> {
+        let offset = source_with_cursor
+            .find('|')
+            .expect("test input needs a `|` cursor");
+        let source = source_with_cursor.replacen('|', "", 1);
+        get_package_prefix(&source, offset).map(|(prefix, dot)| {
+            assert_eq!(&source[dot..dot + 1], ".", "the offset should be the dot");
+            prefix.to_string()
+        })
+    }
+
+    #[test]
+    fn a_dot_and_a_half_typed_member_both_resolve_to_the_qualifier() {
+        assert_eq!(prefix_at("strings.|"), Some("strings".to_string()));
+        assert_eq!(prefix_at("strings.To|"), Some("strings".to_string()));
+        assert_eq!(
+            prefix_at("let s = strings.ToLo|wer"),
+            Some("strings".to_string())
+        );
+    }
+
+    #[test]
+    fn an_indexed_element_resolves_to_the_collection() {
+        assert_eq!(prefix_at("items[0].|"), Some("items".to_string()));
+        assert_eq!(prefix_at("items[0].fi|"), Some("items".to_string()));
+    }
+
+    #[test]
+    fn a_dotless_cursor_or_a_number_resolves_to_nothing() {
+        assert!(prefix_at("let x = 1|").is_none());
+        assert!(prefix_at("let x = 1.5|").is_none());
+    }
+
+    #[test]
+    fn a_multi_byte_boundary_character_does_not_split() {
+        assert_eq!(prefix_at("→名.|"), Some("名".to_string()));
+    }
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/imports.rs
+++ b/crates/lsp/src/imports.rs
@@ -1,0 +1,664 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::{Duration, Instant};
+
+use rustc_hash::FxHashSet as HashSet;
+
+use deps::{ImportablePackage, TypedefLocator};
+use syntax::ast::Expression;
+use syntax::program::{File, FileImport, go_import_default_name};
+
+use crate::position::LineIndex;
+use crate::protocol::*;
+use crate::snapshot::AnalysisSnapshot;
+
+const UNIMPORTED_SORT_PREFIX: &str = "~";
+
+/// Typedefs also appear with no manifest edit behind them, from `lis sync` or
+/// from bindgen filling a cache miss, and no cheap key sees that.
+const REFRESH_AFTER: Duration = Duration::from_secs(2);
+
+pub(crate) struct Importable {
+    pub(crate) name: String,
+    package: ImportablePackage,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct EditTarget {
+    pub(crate) insert: Range,
+    pub(crate) replace: Range,
+    pub(crate) insert_replace_support: bool,
+}
+
+pub(crate) struct PackageIndex {
+    discovered: Mutex<Option<Discovered>>,
+    refresh_after: Duration,
+}
+
+impl Default for PackageIndex {
+    fn default() -> Self {
+        Self {
+            discovered: Mutex::default(),
+            refresh_after: REFRESH_AFTER,
+        }
+    }
+}
+
+#[cfg(test)]
+impl PackageIndex {
+    fn refreshing_always() -> Self {
+        Self {
+            refresh_after: Duration::ZERO,
+            ..Default::default()
+        }
+    }
+}
+
+struct Discovered {
+    root: Option<PathBuf>,
+    stamp: String,
+    walked: Instant,
+    packages: Arc<Vec<Importable>>,
+}
+
+pub(crate) struct PackageResolver {
+    locator: TypedefLocator,
+    index: Arc<PackageIndex>,
+}
+
+impl PackageResolver {
+    pub(crate) fn new(locator: TypedefLocator, index: Arc<PackageIndex>) -> Self {
+        Self { locator, index }
+    }
+
+    pub(crate) fn packages(&self) -> Arc<Vec<Importable>> {
+        let root = self.locator.project_root();
+        let stamp = self.locator.declared_stamp();
+
+        let mut discovered = self
+            .index
+            .discovered
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+
+        if let Some(current) = discovered.as_ref()
+            && current.root.as_deref() == root
+            && current.stamp == stamp
+            && current.walked.elapsed() < self.index.refresh_after
+        {
+            return Arc::clone(&current.packages);
+        }
+
+        let locator = root
+            .and_then(|root| TypedefLocator::from_project(root).ok())
+            .unwrap_or_else(|| self.locator.with_fresh_local_stamp());
+
+        let packages: Arc<Vec<Importable>> = Arc::new(
+            locator
+                .importable_packages()
+                .into_iter()
+                .map(|package| {
+                    let name = package
+                        .declared_package_name()
+                        .unwrap_or_else(|| go_import_default_name(&package.path).to_string());
+                    Importable { name, package }
+                })
+                .collect(),
+        );
+
+        *discovered = Some(Discovered {
+            root: root.map(std::path::Path::to_path_buf),
+            stamp,
+            walked: Instant::now(),
+            packages: Arc::clone(&packages),
+        });
+
+        packages
+    }
+}
+
+pub(crate) fn not_yet_imported<'a>(
+    packages: &'a [Importable],
+    file: &File,
+    snapshot: &AnalysisSnapshot,
+) -> Vec<&'a Importable> {
+    let imports = file.imports();
+    let go_package_names = &snapshot.analysis.emit_input.go_package_names;
+
+    let bound: HashSet<String> = imports
+        .iter()
+        .filter_map(|import| import.effective_alias(go_package_names))
+        .collect();
+    let imported: HashSet<&str> = imports
+        .iter()
+        .filter_map(|import| import.name.as_str().strip_prefix("go:"))
+        .collect();
+
+    packages
+        .iter()
+        .filter(|importable| {
+            !imported.contains(importable.package.path.as_str())
+                && !bound.contains(&importable.name)
+        })
+        .collect()
+}
+
+pub(crate) fn member_completions(
+    importable: &Importable,
+    file: &File,
+    line_index: &LineIndex,
+    target: Option<EditTarget>,
+) -> Vec<CompletionItem> {
+    let Some(source) = importable.package.typedef_source() else {
+        return Vec::new();
+    };
+    let edit = ImportSite::new(file, line_index).edit(&importable.package.path);
+    let qualifier = format!(" · go:{}", importable.package.path);
+
+    syntax::build_ast(&source, 0)
+        .ast
+        .iter()
+        .filter_map(|item| {
+            let (name, kind) = public_member(item)?;
+            Some(with_import(
+                CompletionItem {
+                    label: name,
+                    kind: Some(kind),
+                    detail: Some(signature(item, &source) + &qualifier),
+                    ..Default::default()
+                },
+                &edit,
+                target,
+            ))
+        })
+        .collect()
+}
+
+pub(crate) fn package_completions(
+    packages: &[&Importable],
+    file: &File,
+    line_index: &LineIndex,
+    target: Option<EditTarget>,
+) -> Vec<CompletionItem> {
+    let site = ImportSite::new(file, line_index);
+    packages
+        .iter()
+        .map(|importable| {
+            with_import(
+                CompletionItem {
+                    label: importable.name.clone(),
+                    kind: Some(CompletionItemKind::MODULE),
+                    detail: Some(format!("go:{}", importable.package.path)),
+                    sort_text: Some(format!("{UNIMPORTED_SORT_PREFIX}{}", importable.name)),
+                    ..Default::default()
+                },
+                &site.edit(&importable.package.path),
+                target,
+            )
+        })
+        .collect()
+}
+
+fn with_import(
+    item: CompletionItem,
+    import: &TextEdit,
+    target: Option<EditTarget>,
+) -> CompletionItem {
+    let Some(target) = target else {
+        return CompletionItem {
+            additional_text_edits: Some(vec![import.clone()]),
+            ..item
+        };
+    };
+
+    if crate::ranges_overlap(import.range, target.replace) {
+        let combined = TextEdit {
+            range: target.replace,
+            new_text: format!("{}{}", import.new_text, item.label),
+        };
+        return CompletionItem {
+            text_edit: serde_json::to_value(combined).ok(),
+            ..item
+        };
+    }
+
+    let text_edit = if target.insert_replace_support {
+        serde_json::to_value(InsertReplaceEdit {
+            new_text: item.label.clone(),
+            insert: target.insert,
+            replace: target.replace,
+        })
+    } else {
+        serde_json::to_value(TextEdit {
+            range: target.replace,
+            new_text: item.label.clone(),
+        })
+    };
+
+    CompletionItem {
+        text_edit: text_edit.ok(),
+        additional_text_edits: Some(vec![import.clone()]),
+        ..item
+    }
+}
+
+struct ImportSite<'a> {
+    imports: Vec<FileImport>,
+    source: &'a str,
+    line_index: &'a LineIndex,
+}
+
+impl<'a> ImportSite<'a> {
+    fn new(file: &'a File, line_index: &'a LineIndex) -> Self {
+        Self {
+            imports: file.imports(),
+            source: &file.source,
+            line_index,
+        }
+    }
+
+    fn edit(&self, path: &str) -> TextEdit {
+        let statement = format!("import \"go:{path}\"");
+
+        let mut go_imports = self
+            .imports
+            .iter()
+            .filter(|import| import.name.starts_with("go:"))
+            .peekable();
+
+        if go_imports.peek().is_some() {
+            let mut last_offset = 0;
+            for import in go_imports {
+                let key = format::import_sort_key(&import.name, import.alias.as_ref());
+                if key > path {
+                    return self.insertion(
+                        block_start(self.source, import.span.byte_offset, import_comment),
+                        &statement,
+                        false,
+                    );
+                }
+                last_offset = import.span.byte_offset;
+            }
+            return self.insertion(next_line_start(self.source, last_offset), &statement, false);
+        }
+
+        match self.imports.first() {
+            Some(import) => self.insertion(
+                block_start(self.source, import.span.byte_offset, import_comment),
+                &statement,
+                true,
+            ),
+            None => self.insertion(header_end(self.source), &statement, true),
+        }
+    }
+
+    fn insertion(&self, offset: u32, statement: &str, blank_line_after: bool) -> TextEdit {
+        let (before, after) = self.source.split_at(offset as usize);
+        let mut new_text = String::new();
+        if !before.is_empty() && !before.ends_with('\n') {
+            new_text.push('\n');
+        }
+        new_text.push_str(statement);
+        new_text.push('\n');
+        if blank_line_after && !after.trim().is_empty() {
+            new_text.push('\n');
+        }
+
+        let position = self.line_index.offset_to_position(offset);
+        TextEdit {
+            range: Range {
+                start: position,
+                end: position,
+            },
+            new_text,
+        }
+    }
+}
+
+/// Below the shebang and any detached comment block, above the first
+/// declaration's own.
+fn header_end(source: &str) -> u32 {
+    let mut offset = 0;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with("//") && !trimmed.starts_with("#!") {
+            return block_start(source, offset as u32, declaration_comment);
+        }
+        offset += line.len();
+    }
+    offset as u32
+}
+
+/// A blank line ends the block, and a shebang or file comment is never crossed.
+fn block_start(source: &str, offset: u32, attached: fn(&str) -> bool) -> u32 {
+    let mut start = line_start(source, offset);
+    while start > 0 {
+        let previous = line_start(source, start - 1);
+        if !attached(source[previous as usize..start as usize].trim()) {
+            break;
+        }
+        start = previous;
+    }
+    start
+}
+
+fn import_comment(line: &str) -> bool {
+    line.starts_with("//") && !line.starts_with("///") && !line.starts_with("//!")
+}
+
+fn declaration_comment(line: &str) -> bool {
+    line.starts_with("//") && !line.starts_with("//!")
+}
+
+fn line_start(source: &str, offset: u32) -> u32 {
+    source[..offset as usize]
+        .rfind('\n')
+        .map_or(0, |index| index as u32 + 1)
+}
+
+fn next_line_start(source: &str, offset: u32) -> u32 {
+    source[offset as usize..]
+        .find('\n')
+        .map_or(source.len() as u32, |index| offset + index as u32 + 1)
+}
+
+fn public_member(item: &Expression) -> Option<(String, CompletionItemKind)> {
+    let (name, visibility, kind) = match item {
+        Expression::Function {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::FUNCTION),
+        Expression::Struct {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::STRUCT),
+        Expression::Enum {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::ENUM),
+        Expression::Interface {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::INTERFACE),
+        Expression::TypeAlias {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::TYPE_PARAMETER),
+        Expression::VariableDeclaration {
+            name, visibility, ..
+        } => (name, visibility, CompletionItemKind::VARIABLE),
+        Expression::Const {
+            identifier,
+            visibility,
+            ..
+        } => (identifier, visibility, CompletionItemKind::CONSTANT),
+        _ => return None,
+    };
+    visibility.is_public().then(|| (name.to_string(), kind))
+}
+
+fn signature(item: &Expression, source: &str) -> String {
+    let span = item.get_span();
+    let start = span.byte_offset as usize;
+    let text = &source[start..start + span.byte_length as usize];
+    let text = text.split_once('{').map_or(text, |(head, _)| head);
+
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn applied(path: &str, source: &str) -> String {
+        let mut file = File::new_cached("root", "main.lis", "main.lis", source, 0);
+        file.items = syntax::build_ast(source, 0).ast;
+        let line_index = LineIndex::new(source);
+
+        let edit = ImportSite::new(&file, &line_index).edit(path);
+        let offset = line_index
+            .position_to_offset(edit.range.start)
+            .expect("edit position should be in the source") as usize;
+
+        let mut result = source[..offset].to_string();
+        result.push_str(&edit.new_text);
+        result.push_str(&source[offset..]);
+        result
+    }
+
+    fn with_import(path: &str, source: &str) -> String {
+        let result = applied(path, source);
+        let formatted = format::format_source(&result).expect("result should parse");
+        assert_eq!(
+            formatted, result,
+            "the formatter should leave the inserted import where it is"
+        );
+        result
+    }
+
+    #[test]
+    fn a_file_without_imports_takes_the_import_at_the_top() {
+        assert_eq!(
+            with_import("strings", "fn main() {\n  let name = \"lis\"\n}\n"),
+            "import \"go:strings\"\n\nfn main() {\n  let name = \"lis\"\n}\n"
+        );
+    }
+
+    #[test]
+    fn an_empty_file_takes_the_import_without_a_trailing_blank_line() {
+        assert_eq!(with_import("strings", ""), "import \"go:strings\"\n");
+    }
+
+    #[test]
+    fn the_import_goes_below_the_shebang_and_file_comments() {
+        assert_eq!(
+            with_import(
+                "strings",
+                "#!/usr/bin/env lis\n\n//! Tools.\n\nfn main() {}\n"
+            ),
+            "#!/usr/bin/env lis\n\n//! Tools.\n\nimport \"go:strings\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn the_import_goes_above_a_doc_comment() {
+        assert_eq!(
+            with_import("strings", "/// Entry point.\nfn main() {}\n"),
+            "import \"go:strings\"\n\n/// Entry point.\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn a_comment_on_the_first_declaration_stays_with_it() {
+        assert_eq!(
+            with_import("strings", "// What main does.\nfn main() {}\n"),
+            "import \"go:strings\"\n\n// What main does.\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn a_comment_the_blank_line_detaches_keeps_the_top_of_the_file() {
+        assert_eq!(
+            with_import(
+                "strings",
+                "// Copyright 2026 the authors.\n\nfn main() {}\n"
+            ),
+            "// Copyright 2026 the authors.\n\nimport \"go:strings\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn the_import_joins_the_go_group_in_sorted_order() {
+        let source = "import \"go:fmt\"\nimport \"go:os\"\n\nfn main() {}\n";
+        assert_eq!(
+            with_import("errors", source),
+            "import \"go:errors\"\nimport \"go:fmt\"\nimport \"go:os\"\n\nfn main() {}\n"
+        );
+        assert_eq!(
+            with_import("io", source),
+            "import \"go:fmt\"\nimport \"go:io\"\nimport \"go:os\"\n\nfn main() {}\n"
+        );
+        assert_eq!(
+            with_import("strings", source),
+            "import \"go:fmt\"\nimport \"go:os\"\nimport \"go:strings\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn the_import_does_not_take_over_the_next_import_s_comment() {
+        assert_eq!(
+            with_import(
+                "io",
+                "import \"go:fmt\"\n// the OS bits\nimport \"go:os\"\n\nfn main() {}\n"
+            ),
+            "import \"go:fmt\"\nimport \"go:io\"\n// the OS bits\nimport \"go:os\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn a_comment_the_blank_line_detaches_stays_above_the_block() {
+        assert_eq!(
+            with_import(
+                "errors",
+                "// What this file is.\n\nimport \"go:fmt\"\n\nfn main() {}\n"
+            ),
+            "// What this file is.\n\nimport \"go:errors\"\nimport \"go:fmt\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn a_file_comment_is_never_displaced() {
+        assert_eq!(
+            applied("errors", "//! Tools.\nimport \"go:fmt\"\n\nfn main() {}\n"),
+            "//! Tools.\nimport \"go:errors\"\nimport \"go:fmt\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn an_alias_sorts_the_import_by_the_alias_as_the_formatter_does() {
+        assert_eq!(
+            with_import("os", "import zzz \"go:fmt\"\n\nfn main() {}\n"),
+            "import \"go:os\"\nimport zzz \"go:fmt\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn the_go_group_opens_above_project_imports() {
+        assert_eq!(
+            with_import("strings", "import \"handlers\"\n\nfn main() {}\n"),
+            "import \"go:strings\"\n\nimport \"handlers\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn a_file_without_a_final_newline_still_gets_a_line_of_its_own() {
+        assert_eq!(
+            with_import("os", "import \"go:fmt\""),
+            "import \"go:fmt\"\nimport \"go:os\"\n"
+        );
+    }
+
+    fn declare(root: &std::path::Path, modules: &[&str]) {
+        let entries: String = modules
+            .iter()
+            .map(|module| format!("\"{module}\" = \"v1.0.0\"\n"))
+            .collect();
+        std::fs::write(
+            root.join("lisette.toml"),
+            format!(
+                "[project]\nname = \"t\"\nversion = \"0.0.1\"\n\n[toolchain]\nlis = \"{}\"\n\n[dependencies.go]\n{entries}",
+                env!("CARGO_PKG_VERSION")
+            ),
+        )
+        .unwrap();
+
+        for module in modules {
+            let dir = deps::typedef_cache_dir(root)
+                .join(deps::Target::host().cache_segment())
+                .join(format!("{module}@v1.0.0"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let name = module.rsplit('/').next().unwrap();
+            std::fs::write(dir.join(format!("{name}.d.lis")), "pub fn Do() -> int\n").unwrap();
+        }
+    }
+
+    fn resolver(root: &std::path::Path, index: &Arc<PackageIndex>) -> PackageResolver {
+        PackageResolver::new(
+            TypedefLocator::from_project(root).expect("the manifest should parse"),
+            Arc::clone(index),
+        )
+    }
+
+    fn paths(packages: &[Importable]) -> Vec<&str> {
+        packages
+            .iter()
+            .map(|importable| importable.package.path.as_str())
+            .filter(|path| path.starts_with("example.com/"))
+            .collect()
+    }
+
+    #[test]
+    fn discovery_is_shared_between_analyses_and_redone_for_another_project() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        declare(a.path(), &["example.com/one"]);
+        declare(b.path(), &["example.com/one"]);
+        let index = Arc::new(PackageIndex::default());
+
+        let once = resolver(a.path(), &index).packages();
+        let twice = resolver(a.path(), &index).packages();
+        assert!(
+            Arc::ptr_eq(&once, &twice),
+            "the next analysis reuses the walk instead of hitting disk again"
+        );
+
+        let other = resolver(b.path(), &index).packages();
+        assert!(
+            !Arc::ptr_eq(&once, &other),
+            "another project has its own dependencies to discover"
+        );
+    }
+
+    #[test]
+    fn a_newly_declared_dependency_shows_up_without_waiting_for_the_refresh() {
+        let project = tempfile::tempdir().unwrap();
+        let index = Arc::new(PackageIndex::default());
+
+        declare(project.path(), &["example.com/one"]);
+        let before = resolver(project.path(), &index).packages();
+        assert_eq!(paths(&before), ["example.com/one"]);
+
+        declare(project.path(), &["example.com/one", "example.com/two"]);
+        let after = resolver(project.path(), &index).packages();
+        assert_eq!(
+            paths(&after),
+            ["example.com/one", "example.com/two"],
+            "this analysis starts from different declarations, so it walks again"
+        );
+    }
+
+    #[test]
+    fn a_refresh_rereads_the_manifest_that_no_edit_told_the_server_about() {
+        let project = tempfile::tempdir().unwrap();
+        let index = Arc::new(PackageIndex::refreshing_always());
+
+        declare(project.path(), &["example.com/one"]);
+        let analysis = resolver(project.path(), &index);
+        assert_eq!(paths(&analysis.packages()), ["example.com/one"]);
+
+        declare(project.path(), &["example.com/one", "example.com/two"]);
+
+        assert_eq!(
+            paths(&analysis.packages()),
+            ["example.com/one", "example.com/two"],
+            "the walk reads the project off disk, not what this analysis captured"
+        );
+    }
+
+    #[test]
+    fn a_signature_is_one_line_and_stops_before_a_body() {
+        let source = "pub fn Verify(\n  hash: Slice<byte>,\n  sig: Slice<byte>,\n) -> bool\n\npub struct Client {\n  pub Timeout: int,\n}\n";
+        let items = syntax::build_ast(source, 0).ast;
+
+        assert_eq!(
+            signature(&items[0], source),
+            "fn Verify( hash: Slice<byte>, sig: Slice<byte>, ) -> bool"
+        );
+        assert_eq!(signature(&items[1], source), "struct Client");
+    }
+}

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -3,6 +3,7 @@ mod completion;
 mod definition;
 mod document;
 mod hover;
+mod imports;
 mod inlay_hints;
 mod loader;
 mod paths;
@@ -32,8 +33,10 @@ use crate::definition::{
     resolve_import_span, resolve_match_pattern_definition, resolve_struct_call_field,
     resolve_symbol_definition_span, resolve_word_at_offset, word_at_offset,
 };
+use crate::imports::EditTarget;
+use crate::position::LineIndex;
 use crate::project::find_project_root;
-use crate::snapshot::AnalysisSnapshot;
+use crate::snapshot::{AnalysisSnapshot, SnapshotDocument};
 use crate::traversal::find_expression_at;
 use syntax::program::File;
 
@@ -41,6 +44,15 @@ pub use crate::state::{Backend, SharedState};
 
 impl Backend {
     fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        self.insert_replace_support.store(
+            params
+                .capabilities
+                .pointer("/textDocument/completion/completionItem/insertReplaceSupport")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
         let workspace_root = params
             .root_uri
             .and_then(|uri| uri.to_file_path().ok())
@@ -439,7 +451,7 @@ impl Backend {
 
         fn expression_to_symbol(
             expression: &syntax::ast::Expression,
-            line_index: &crate::position::LineIndex,
+            line_index: &LineIndex,
         ) -> Option<DocumentSymbol> {
             use syntax::ast::Expression;
 
@@ -923,8 +935,8 @@ impl Backend {
         let Some(cursor) = snapshot.position(uri, position) else {
             return Ok(None);
         };
-        let file_id = cursor.document.file_id;
-        let file = cursor.document.file;
+        let document = &cursor.document;
+        let file = document.file;
         let offset = cursor.offset;
 
         // An in-progress `#[ ... ]` is exclusive: when the cursor is in attribute
@@ -935,9 +947,11 @@ impl Backend {
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
+        let target = self.edit_target(uri, position);
+
         let package_prefix = get_package_prefix(&file.source, offset as usize);
 
-        if let Some(package_name) = package_prefix
+        if let Some((package_name, _)) = package_prefix
             && let Some(items) = imported_package_completions(package_name, file, &snapshot)
         {
             return Ok(Some(CompletionResponse::Array(items)));
@@ -947,10 +961,9 @@ impl Backend {
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
-        if let Some(prefix) = package_prefix {
-            // A prefix that resolves to nothing still returns here: a `foo.`
-            // cursor must never fall through to the general completions below.
-            let items = package_prefix_completions(prefix, file, offset, &snapshot);
+        if let Some((prefix, dot_offset)) = package_prefix {
+            let after_dot = dot_offset as u32 + 1;
+            let items = package_prefix_completions(prefix, document, after_dot, target, &snapshot);
             return Ok(Some(CompletionResponse::Array(items)));
         }
 
@@ -959,8 +972,41 @@ impl Backend {
         }
 
         Ok(Some(CompletionResponse::Array(general_completions(
-            file, file_id, offset, &snapshot,
+            document, offset, target, &snapshot,
         ))))
+    }
+
+    fn edit_target(&self, uri: &Url, position: Position) -> Option<EditTarget> {
+        let documents = self.documents();
+        let document = documents.get(uri)?;
+        let line_index = document.line_index();
+        let offset = line_index.position_to_offset(position)? as usize;
+        let source = document.content();
+
+        let is_word = |c: char| c.is_alphanumeric() || c == '_';
+        let start = source[..offset]
+            .rfind(|c: char| !is_word(c))
+            .map(|index| index + source[index..].chars().next().map_or(1, char::len_utf8))
+            .unwrap_or(0);
+        let end = offset
+            + source[offset..]
+                .find(|c: char| !is_word(c))
+                .unwrap_or(source.len() - offset);
+        let start = line_index.offset_to_position(start as u32);
+
+        Some(EditTarget {
+            insert: Range {
+                start,
+                end: position,
+            },
+            replace: Range {
+                start,
+                end: line_index.offset_to_position(end as u32),
+            },
+            insert_replace_support: self
+                .insert_replace_support
+                .load(std::sync::atomic::Ordering::Relaxed),
+        })
     }
 
     fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
@@ -1060,10 +1106,12 @@ fn dot_context_completions(
 /// here: it must never fall through to the general completions below.
 fn package_prefix_completions(
     prefix: &str,
-    file: &File,
+    document: &SnapshotDocument,
     offset: u32,
+    target: Option<EditTarget>,
     snapshot: &AnalysisSnapshot,
 ) -> Vec<CompletionItem> {
+    let file = document.file;
     if prefix == "self" {
         if let Some(impl_type) = traversal::find_enclosing_impl_type(&file.items, offset) {
             let type_id = format!("{}.{}", file.package_id, impl_type);
@@ -1097,7 +1145,14 @@ fn package_prefix_completions(
         return get_instance_completions(&type_id, snapshot, same_package);
     }
 
-    Vec::new()
+    let packages = snapshot.importable_packages();
+    imports::not_yet_imported(&packages, file, snapshot)
+        .into_iter()
+        .filter(|importable| importable.name == prefix)
+        .flat_map(|importable| {
+            imports::member_completions(importable, file, document.line_index, target)
+        })
+        .collect()
 }
 
 /// In a struct literal's field-name position, offers the unassigned fields.
@@ -1120,11 +1175,12 @@ fn struct_literal_field_completions(
 }
 
 fn general_completions(
-    file: &File,
-    file_id: u32,
+    document: &SnapshotDocument,
     offset: u32,
+    target: Option<EditTarget>,
     snapshot: &AnalysisSnapshot,
 ) -> Vec<CompletionItem> {
+    let file = document.file;
     let mut items = Vec::new();
 
     for kw in validation::KEYWORDS {
@@ -1148,10 +1204,8 @@ fn general_completions(
         });
     }
 
-    const PRELUDE_VALUES: &[&str] = &[
-        "Some", "None", "Ok", "Err", "Unit", "println", "print", "panic", "len", "cap", "make",
-        "append", "copy",
-    ];
+    // `len`, `make` and `println` are Go builtins the compiler rejects by name.
+    const PRELUDE_VALUES: &[&str] = &["Some", "None", "Ok", "Err", "panic"];
     for val in PRELUDE_VALUES {
         items.push(CompletionItem {
             label: val.to_string(),
@@ -1175,7 +1229,7 @@ fn general_completions(
     }
 
     for binding in snapshot.bindings().values() {
-        if binding.span.file_id == file_id && binding.span.byte_offset < offset {
+        if binding.span.file_id == document.file_id && binding.span.byte_offset < offset {
             items.push(CompletionItem {
                 label: binding.name.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
@@ -1195,10 +1249,19 @@ fn general_completions(
         });
     }
 
+    let packages = snapshot.importable_packages();
+    let unimported = imports::not_yet_imported(&packages, file, snapshot);
+    items.extend(imports::package_completions(
+        &unimported,
+        file,
+        document.line_index,
+        target,
+    ));
+
     items
 }
 
-fn ranges_overlap(a: Range, b: Range) -> bool {
+pub(crate) fn ranges_overlap(a: Range, b: Range) -> bool {
     let position_le = |x: Position, y: Position| (x.line, x.character) <= (y.line, y.character);
     position_le(a.start, b.end) && position_le(b.start, a.end)
 }

--- a/crates/lsp/src/protocol/types.rs
+++ b/crates/lsp/src/protocol/types.rs
@@ -286,6 +286,9 @@ pub struct InitializeParams {
     pub root_uri: Option<Url>,
     #[serde(default)]
     pub workspace_folders: Option<Vec<WorkspaceFolder>>,
+    /// Kept raw: the server reads the few capabilities it acts on by pointer.
+    #[serde(default)]
+    pub capabilities: Value,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -454,7 +457,17 @@ pub struct CompletionItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_edit: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_text_edits: Option<Vec<TextEdit>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InsertReplaceEdit {
+    pub new_text: String,
+    pub insert: Range,
+    pub replace: Range,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -1,5 +1,7 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use std::sync::Arc;
+
 use crate::protocol::{Position, Url};
 use passes::Analysis;
 use semantics::facts::{BindingFact, Usage};
@@ -7,6 +9,7 @@ use syntax::ast::BindingId;
 use syntax::program::{Definition, File};
 use syntax::types::Symbol;
 
+use crate::imports::{Importable, PackageResolver};
 use crate::paths::{ENTRY_PACKAGE_ID, package_file_to_path};
 use crate::position::LineIndex;
 use crate::project::ProjectConfig;
@@ -14,6 +17,7 @@ use crate::project::ProjectConfig;
 pub(crate) struct AnalysisSnapshot {
     pub(crate) analysis: Analysis,
     sources: HashMap<u32, SnapshotSource>,
+    packages: PackageResolver,
 }
 
 pub(crate) struct SnapshotSource {
@@ -38,6 +42,7 @@ impl AnalysisSnapshot {
         config: &ProjectConfig,
         analyzed_uri: &Url,
         external_test: bool,
+        packages: PackageResolver,
     ) -> Self {
         let mut sources = HashMap::default();
 
@@ -89,7 +94,15 @@ impl AnalysisSnapshot {
             );
         }
 
-        Self { analysis, sources }
+        Self {
+            analysis,
+            sources,
+            packages,
+        }
+    }
+
+    pub(crate) fn importable_packages(&self) -> Arc<Vec<Importable>> {
+        self.packages.packages()
     }
 
     pub(crate) fn document(&self, uri: &Url) -> Option<SnapshotDocument<'_>> {

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::protocol::{Client, Url};
 use deps::BindgenSetup;
 
+use crate::imports::PackageIndex;
 use crate::loader::ProjectState;
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
@@ -14,6 +15,8 @@ pub struct SharedState {
     pub(crate) project: ProjectState,
     documents: RwLock<HashMap<Url, DocumentState>>,
     pub(crate) bindgen_setup: Option<Arc<dyn BindgenSetup>>,
+    pub(crate) packages: Arc<PackageIndex>,
+    pub(crate) insert_replace_support: AtomicBool,
 }
 
 impl SharedState {
@@ -249,6 +252,8 @@ impl Backend {
                 project: ProjectState::new(),
                 documents: RwLock::new(HashMap::new()),
                 bindgen_setup,
+                packages: Arc::default(),
+                insert_replace_support: AtomicBool::new(false),
             }),
         }
     }

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -2,8 +2,8 @@ mod lsp_harness;
 
 use lisette_lsp::protocol::*;
 use lsp_harness::{
-    TestClient, completion_labels, cursor, cursors, definition_location, definition_target_text,
-    doc_end, hover_content, inlay_hint_triples, symbol_names,
+    TestClient, completion_items, completion_labels, cursor, cursors, definition_location,
+    definition_target_text, doc_end, hover_content, inlay_hint_triples, symbol_names,
 };
 
 const TEST_URI: &str = "file:///test.lis";
@@ -304,6 +304,32 @@ fn completion_includes_prelude_types() {
     assert!(labels.iter().any(|l| l == "Option"));
     assert!(labels.iter().any(|l| l == "Result"));
     assert!(labels.iter().any(|l| l == "Array"));
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_omits_go_builtins_lisette_does_not_have() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(TEST_URI, "");
+
+    let labels = completion_labels(&client.completion(TEST_URI, 0, 0).unwrap());
+
+    for absent in [
+        "println", "print", "len", "cap", "make", "append", "copy", "Unit",
+    ] {
+        assert!(
+            !labels.iter().any(|l| l == absent),
+            "`{absent}` is a Go builtin the compiler rejects by name, so offering it misleads"
+        );
+    }
+    for present in ["Some", "None", "Ok", "Err", "panic"] {
+        assert!(
+            labels.iter().any(|l| l == present),
+            "`{present}` resolves and should be offered"
+        );
+    }
 
     client.shutdown();
 }
@@ -12866,4 +12892,378 @@ fn an_unsaved_test_file_in_a_dotted_directory_is_rejected() {
 
         client.shutdown();
     }
+}
+
+fn completion_item<'a>(response: &'a CompletionResponse, label: &str) -> &'a CompletionItem {
+    let items = completion_items(response);
+    items
+        .iter()
+        .find(|item| item.label == label)
+        .unwrap_or_else(|| {
+            let labels: Vec<&str> = items.iter().map(|item| item.label.as_str()).collect();
+            panic!("expected a `{label}` completion, got: {labels:?}")
+        })
+}
+
+fn import_edits(item: &CompletionItem) -> &[TextEdit] {
+    item.additional_text_edits
+        .as_deref()
+        .unwrap_or_else(|| panic!("`{}` should carry its import", item.label))
+}
+
+#[test]
+fn completion_after_unimported_go_package_offers_its_members_and_import() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("fn main() {\n  let slug = strings.~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client
+        .completion(TEST_URI, line, character)
+        .expect("a package the file has yet to import should still complete");
+
+    let lower = completion_item(&response, "ToLower");
+    assert_eq!(lower.kind, Some(CompletionItemKind::FUNCTION));
+    assert_eq!(
+        lower.detail.as_deref(),
+        Some("fn ToLower(s: string) -> string · go:strings")
+    );
+    assert_eq!(
+        import_edits(lower),
+        [TextEdit {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            new_text: "import \"go:strings\"\n\n".to_string(),
+        }]
+    );
+
+    let builder = completion_item(&response, "Builder");
+    assert_eq!(
+        builder.kind,
+        Some(CompletionItemKind::TYPE_PARAMETER),
+        "a Go named type reads as it does once the package is imported"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_after_a_shared_package_name_offers_every_package_that_answers_to_it() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("fn main() {\n  let n = rand.~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+    let details: Vec<&str> = completion_items(&response)
+        .iter()
+        .filter_map(|item| item.detail.as_deref())
+        .collect();
+
+    for package in ["go:math/rand", "go:math/rand/v2", "go:crypto/rand"] {
+        assert!(
+            details.iter().any(|detail| detail.ends_with(package)),
+            "three packages bind `rand`, so all three belong in the list: {details:?}"
+        );
+    }
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_partway_through_a_member_still_lists_the_package() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("fn main() {\n  let slug = strings.ToLo~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+
+    let lower = completion_item(&response, "ToLower");
+    assert_eq!(
+        import_edits(lower)[0].new_text,
+        "import \"go:strings\"\n\n",
+        "a half-typed member is still the package's list, import and all"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_partway_through_a_member_of_an_imported_package() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("import \"go:fmt\"\n\nfn main() {\n  fmt.Printl~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+    let println = completion_item(&response, "Println");
+
+    assert!(
+        println.additional_text_edits.is_none(),
+        "the package is imported already: {println:?}"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_at_the_import_position_folds_the_import_into_one_edit() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    client.open(TEST_URI, "");
+    client.change(TEST_URI, "strings", 2);
+
+    let response = client.completion(TEST_URI, 0, 3).unwrap();
+    let strings = completion_item(&response, "strings");
+
+    assert!(
+        strings.additional_text_edits.is_none(),
+        "a second edit here would share the item's own position: {strings:?}"
+    );
+    let edit: TextEdit = serde_json::from_value(
+        strings
+            .text_edit
+            .clone()
+            .expect("the item should carry one edit that writes both"),
+    )
+    .expect("the edit should be a TextEdit");
+    assert_eq!(edit.new_text, "import \"go:strings\"\n\nstrings");
+    assert_eq!(
+        edit.range,
+        Range {
+            start: Position::new(0, 0),
+            end: Position::new(0, 7),
+        },
+        "the whole word, which only the buffer knows, or the tail survives as \
+         `stringsings`"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_offers_unimported_go_packages_by_name() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("fn main() {\n  let x = str~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+
+    let strings = completion_item(&response, "strings");
+    assert_eq!(strings.kind, Some(CompletionItemKind::MODULE));
+    assert_eq!(strings.detail.as_deref(), Some("go:strings"));
+    assert_eq!(
+        import_edits(strings)[0].new_text,
+        "import \"go:strings\"\n\n"
+    );
+
+    let edit: TextEdit = serde_json::from_value(
+        strings
+            .text_edit
+            .clone()
+            .expect("an item carrying an import states where its own text goes"),
+    )
+    .expect("a client without insertReplaceSupport gets a plain edit");
+    assert_eq!(edit.new_text, "strings");
+    assert_eq!(
+        edit.range,
+        Range {
+            start: Position::new(1, 10),
+            end: Position::new(1, 13),
+        },
+        "the typed prefix, not a range the editor guesses at"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_mid_word_rewrites_the_word_for_a_client_that_states_no_preference() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    client.open(TEST_URI, "fn main() {\n  let x = strings\n}\n");
+
+    let response = client.completion(TEST_URI, 1, 13).unwrap();
+    let edit: TextEdit = serde_json::from_value(
+        completion_item(&response, "strings")
+            .text_edit
+            .clone()
+            .expect("the item states its own edit"),
+    )
+    .unwrap();
+
+    assert_eq!(edit.new_text, "strings");
+    assert_eq!(
+        edit.range,
+        Range {
+            start: Position::new(1, 10),
+            end: Position::new(1, 17),
+        },
+        "an edit stopping at the cursor would leave `stringsings` behind"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_hands_both_ranges_to_a_client_that_takes_them() {
+    let mut client = TestClient::new();
+    client.initialize_with_capabilities(serde_json::json!({
+        "textDocument": {"completion": {"completionItem": {"insertReplaceSupport": true}}}
+    }));
+
+    client.open(TEST_URI, "fn main() {\n  let x = strings\n}\n");
+
+    let response = client.completion(TEST_URI, 1, 13).unwrap();
+    let edit: InsertReplaceEdit = serde_json::from_value(
+        completion_item(&response, "strings")
+            .text_edit
+            .clone()
+            .expect("the item states its own edit"),
+    )
+    .expect("a client with insertReplaceSupport gets both ranges");
+
+    assert_eq!(edit.new_text, "strings");
+    assert_eq!(edit.insert.end, Position::new(1, 13), "stops at the cursor");
+    assert_eq!(
+        edit.replace.end,
+        Position::new(1, 17),
+        "takes the whole word"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_leaves_an_imported_package_alone() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) =
+        cursor("import \"go:strings\"\n\nfn main() {\n  let x = str~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+    let offered: Vec<&CompletionItem> = completion_items(&response)
+        .iter()
+        .filter(|item| item.label == "strings")
+        .collect();
+
+    assert_eq!(
+        offered.len(),
+        1,
+        "an imported package is one completion, not one per import edit: {offered:?}"
+    );
+    assert!(
+        offered[0].additional_text_edits.is_none(),
+        "an imported package needs no import: {:?}",
+        offered[0]
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_leaves_a_blank_imported_package_alone() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) =
+        cursor("import _ \"go:image/png\"\n\nfn main() {\n  let x = pn~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+
+    assert!(
+        !completion_items(&response)
+            .iter()
+            .any(|item| item.label == "png"),
+        "a blank import binds no name, but importing the path again is still a duplicate"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_after_unimported_third_party_package_offers_its_members_and_import() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let manifest = format!(
+        "[project]\nname = \"test\"\nversion = \"0.0.1\"\n\n[toolchain]\nlis = \"{}\"\n\n[dependencies.go]\n\"github.com/example/go-lib\" = \"v1.0.0\"\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(root.join("lisette.toml"), manifest).unwrap();
+
+    let pkg = deps::GoPackage {
+        module: deps::GoModule {
+            path: "github.com/example/go-lib",
+            version: "v1.0.0",
+            replacement: None,
+        },
+        package: "github.com/example/go-lib",
+    };
+    let typedef_path = pkg.typedef_path(&deps::typedef_cache_dir(root), stdlib::Target::host());
+    std::fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &typedef_path,
+        "// Generated by Lisette bindgen\n// Package: lib\n\npub fn DoStuff(n: int) -> int\n",
+    )
+    .unwrap();
+
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    let (content, line, character) = cursor("fn main() {\n  let n = lib.~\n}\n");
+    let main_path = src.join("main.lis");
+    std::fs::write(&main_path, &content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+
+    let main_uri = Url::from_file_path(&main_path).unwrap().to_string();
+    client.open(&main_uri, &content);
+
+    let response = client.completion(&main_uri, line, character).unwrap();
+
+    let do_stuff = completion_item(&response, "DoStuff");
+    assert_eq!(
+        do_stuff.detail.as_deref(),
+        Some("fn DoStuff(n: int) -> int · go:github.com/example/go-lib")
+    );
+    assert_eq!(
+        import_edits(do_stuff)[0].new_text,
+        "import \"go:github.com/example/go-lib\"\n\n"
+    );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_after_an_unknown_prefix_dot_offers_nothing() {
+    let mut client = TestClient::new();
+    client.initialize();
+
+    let (source, line, character) = cursor("fn main() {\n  let x = nosuchpackage.~\n}\n");
+    client.open(TEST_URI, &source);
+
+    let response = client.completion(TEST_URI, line, character).unwrap();
+
+    assert!(
+        completion_items(&response).is_empty(),
+        "a prefix that names nothing must not fall through to package members: {:?}",
+        completion_labels(&response)
+    );
+
+    client.shutdown();
 }

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -111,9 +111,13 @@ impl TestClient {
     }
 
     pub fn initialize(&mut self) -> InitializeResult {
+        self.initialize_with_capabilities(json!({}))
+    }
+
+    pub fn initialize_with_capabilities(&mut self, capabilities: Value) -> InitializeResult {
         let result = self.request(
             "initialize",
-            json!({"processId": null, "capabilities": {}, "rootUri": null}),
+            json!({"processId": null, "capabilities": capabilities, "rootUri": null}),
         );
         self.notify("initialized", json!({}));
         result
@@ -442,6 +446,13 @@ pub fn definition_target_text(location: &Location) -> String {
         .nth(location.range.start.line as usize)
         .expect("range line should exist");
     line[location.range.start.character as usize..].to_string()
+}
+
+pub fn completion_items(response: &CompletionResponse) -> &[CompletionItem] {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => &list.items,
+    }
 }
 
 pub fn completion_labels(response: &CompletionResponse) -> Vec<String> {


### PR DESCRIPTION
Adds completions for Go packages that have not been imported yet, from the Go stdlib and from third-party Go deps, when typing the pkg name or a member behind its dot. Picking one auto-adds the import, in the spot `lis fmt` would add it.

Close #1225
