### PR TITLE
fix: reject dependency paths Go would refuse

### DIFF
--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -1,4 +1,5 @@
 mod local_source;
+mod module_path;
 mod project_manifest;
 mod typedef_locator;
 
@@ -57,24 +58,44 @@ pub fn placeholder_require_version(module_path: &str) -> String {
 }
 
 pub fn check_version_matches_path(module_path: &str, version: &str) -> Result<(), String> {
+    let Some((_, path_major)) = crate::module_path::split_path_version(module_path) else {
+        return Ok(());
+    };
+    let path_major = path_major.strip_suffix("-unstable").unwrap_or(path_major);
+
+    if version.starts_with("v0.0.0-") && path_major == ".v1" {
+        return Ok(());
+    }
+
     let Some(actual) = version_major(version) else {
         return Ok(());
     };
-    let ok = match path_major(module_path) {
-        Some(required) => actual == required,
-        None => actual <= 1,
+
+    let expected = match path_major.strip_prefix(['/', '.']) {
+        Some(required) => required,
+        None => {
+            // `+incompatible` is how a pre-modules v2 or later declares itself.
+            if actual <= 1 || build_metadata(version) == Some("incompatible") {
+                return Ok(());
+            }
+            return Err(format!(
+                "version `{}` is not valid for module path `{}` (expected v0.x or v1.x)",
+                version, module_path
+            ));
+        }
     };
-    if ok {
+
+    if expected.strip_prefix('v').and_then(parse_major_digits) == Some(actual) {
         return Ok(());
     }
-    let expected = match path_major(module_path) {
-        Some(required) => format!("v{}.x", required),
-        None => "v0.x or v1.x".to_string(),
-    };
     Err(format!(
-        "version `{}` is not valid for module path `{}` (expected {})",
+        "version `{}` is not valid for module path `{}` (expected {}.x)",
         version, module_path, expected
     ))
+}
+
+fn build_metadata(version: &str) -> Option<&str> {
+    version.split_once('+').map(|(_, build)| build)
 }
 
 fn version_major(version: &str) -> Option<u64> {
@@ -88,13 +109,13 @@ fn version_major(version: &str) -> Option<u64> {
 
 /// The major a path's suffix demands: `/vN` (N >= 2), or gopkg.in `.vN` (any N).
 fn path_major(module_path: &str) -> Option<u64> {
-    let last = module_path.rsplit('/').next()?;
-    if module_path.starts_with("gopkg.in/") {
-        let (_, digits) = last.rsplit_once(".v")?;
-        return parse_major_digits(digits);
-    }
-    let digits = last.strip_prefix('v')?;
-    parse_major_digits(digits).filter(|&major| major >= 2)
+    let (_, path_major) = crate::module_path::split_path_version(module_path)?;
+    let digits = path_major
+        .strip_suffix("-unstable")
+        .unwrap_or(path_major)
+        .strip_prefix(['/', '.'])?
+        .strip_prefix('v')?;
+    parse_major_digits(digits)
 }
 
 fn parse_major_digits(digits: &str) -> Option<u64> {
@@ -455,6 +476,20 @@ mod tests {
     #[test]
     fn check_version_matches_path_enforces_major_suffix() {
         // /vN path requires vN
+        assert!(
+            check_version_matches_path("github.com/hashicorp/consul", "v2.1.0+incompatible")
+                .is_ok()
+        );
+        assert!(
+            check_version_matches_path("github.com/docker/docker", "v20.10.24+incompatible")
+                .is_ok()
+        );
+        assert!(
+            check_version_matches_path("gopkg.in/check.v1", "v0.0.0-20161208181325-20d25e280405")
+                .is_ok()
+        );
+        assert!(check_version_matches_path("gopkg.in/pkg.v3-unstable", "v3.1.0").is_ok());
+        assert!(check_version_matches_path("github.com/you/mux", "v2.1.0+build.1").is_err());
         assert!(check_version_matches_path("example.com/lib/v2", "v2.3.0").is_ok());
         assert!(check_version_matches_path("example.com/lib/v2", "v1.0.0").is_err());
         // gopkg.in .vN path requires vN

--- a/crates/deps/src/module_path.rs
+++ b/crates/deps/src/module_path.rs
@@ -1,0 +1,297 @@
+//! Ported from `golang.org/x/mod/module`, rather than shelled out to, because
+//! this runs inside `lis check` and the language server, where the Go toolchain
+//! must not be invoked.
+
+const BAD_WINDOWS_NAMES: [&str; 22] = [
+    "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+    "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
+/// Go's `module.CheckPath`.
+pub fn check_module_path(path: &str) -> Result<(), String> {
+    check_path_elements(path)?;
+
+    let first = path.split('/').next().unwrap_or(path);
+    if first.is_empty() {
+        return Err("leading slash".to_string());
+    }
+    if !first.contains('.') {
+        return Err("missing dot in first path element".to_string());
+    }
+    if path.starts_with('-') {
+        return Err("leading dash in first path element".to_string());
+    }
+    if let Some(bad) = first.chars().find(|&c| !first_path_ok(c)) {
+        return Err(format!("invalid char `{}` in first path element", bad));
+    }
+    if split_path_version(path).is_none() {
+        return Err("invalid major version suffix".to_string());
+    }
+    Ok(())
+}
+
+fn check_path_elements(path: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err("empty path".to_string());
+    }
+    if path.starts_with('-') {
+        return Err("leading dash".to_string());
+    }
+    if path.contains("//") {
+        return Err("double slash".to_string());
+    }
+    if path.ends_with('/') {
+        return Err("trailing slash".to_string());
+    }
+    for element in path.split('/') {
+        check_element(element)?;
+    }
+    Ok(())
+}
+
+fn check_element(element: &str) -> Result<(), String> {
+    if element.is_empty() {
+        return Err("empty path element".to_string());
+    }
+    if element.chars().all(|c| c == '.') {
+        return Err(format!("invalid path element `{}`", element));
+    }
+    if element.starts_with('.') {
+        return Err("leading dot in path element".to_string());
+    }
+    if element.ends_with('.') {
+        return Err("trailing dot in path element".to_string());
+    }
+    if let Some(bad) = element.chars().find(|&c| !mod_path_ok(c)) {
+        return Err(format!("invalid char `{}`", bad));
+    }
+
+    let short = element.split('.').next().unwrap_or(element);
+    if let Some(bad) = BAD_WINDOWS_NAMES
+        .iter()
+        .find(|name| name.eq_ignore_ascii_case(short))
+    {
+        return Err(format!(
+            "`{}` disallowed as a path element component on Windows",
+            bad
+        ));
+    }
+
+    // A Windows short-name ends in a tilde and digits.
+    if let Some(tilde) = short.rfind('~')
+        && tilde < short.len() - 1
+        && short[tilde + 1..].bytes().all(|b| b.is_ascii_digit())
+    {
+        return Err("trailing tilde and digits in path element".to_string());
+    }
+    Ok(())
+}
+
+fn mod_path_ok(c: char) -> bool {
+    matches!(c, '-' | '.' | '_' | '~') || c.is_ascii_alphanumeric()
+}
+
+fn first_path_ok(c: char) -> bool {
+    matches!(c, '-' | '.') || c.is_ascii_digit() || c.is_ascii_lowercase()
+}
+
+/// Go's `module.SplitPathVersion`. `None` means a suffix present but malformed.
+pub(crate) fn split_path_version(path: &str) -> Option<(&str, &str)> {
+    if path.starts_with("gopkg.in/") {
+        return split_gopkg_in(path);
+    }
+
+    let bytes = path.as_bytes();
+    let mut i = bytes.len();
+    let mut dot = false;
+    while i > 0 && (bytes[i - 1].is_ascii_digit() || bytes[i - 1] == b'.') {
+        dot |= bytes[i - 1] == b'.';
+        i -= 1;
+    }
+    if i <= 1 || i == bytes.len() || bytes[i - 1] != b'v' || bytes[i - 2] != b'/' {
+        return Some((path, ""));
+    }
+
+    let path_major = &path[i - 2..];
+    if dot || path_major.len() <= 2 || path_major.as_bytes()[2] == b'0' || path_major == "/v1" {
+        return None;
+    }
+    Some((&path[..i - 2], path_major))
+}
+
+/// Any major is legal here, `.v0` included, unlike a leading zero elsewhere.
+fn split_gopkg_in(path: &str) -> Option<(&str, &str)> {
+    let bytes = path.as_bytes();
+    let mut i = path.len();
+    if path.ends_with("-unstable") {
+        i -= "-unstable".len();
+    }
+    while i > 0 && bytes[i - 1].is_ascii_digit() {
+        i -= 1;
+    }
+    if i <= 1 || bytes[i - 1] != b'v' || bytes[i - 2] != b'.' {
+        return None;
+    }
+    let path_major = &path[i - 2..];
+    if path_major.len() <= 2 || (path_major.as_bytes()[2] == b'0' && path_major != ".v0") {
+        return None;
+    }
+    Some((&path[..i - 2], path_major))
+}
+
+#[cfg(test)]
+mod module_path_tests {
+    use super::*;
+
+    /// Go's `checkPathTests` from x/mod v0.38.0, read against its `ok` column.
+    /// Its 105th case, `x.y/\xFFz`, tests invalid UTF-8, which a `&str` cannot
+    /// hold.
+    #[test]
+    fn agrees_with_go_check_path() {
+        const GO_TABLE: [(&str, bool); 104] = [
+            ("x.y/z", true),
+            ("x.y", true),
+            ("", false),
+            ("/x.y/z", false),
+            ("x./z", false),
+            (".x/z", false),
+            ("-x/z", false),
+            ("x..y/z", true),
+            ("x.y/z/../../w", false),
+            ("x.y//z", false),
+            ("x.y/z//w", false),
+            ("x.y/z/", false),
+            ("x.y/z/v0", false),
+            ("x.y/z/v1", false),
+            ("x.y/z/v2", true),
+            ("x.y/z/v2.0", false),
+            ("X.y/z", false),
+            ("!x.y/z", false),
+            ("_x.y/z", false),
+            ("x.y!/z", false),
+            ("x.y\"/z", false),
+            ("x.y#/z", false),
+            ("x.y$/z", false),
+            ("x.y%/z", false),
+            ("x.y&/z", false),
+            ("x.y'/z", false),
+            ("x.y(/z", false),
+            ("x.y)/z", false),
+            ("x.y*/z", false),
+            ("x.y+/z", false),
+            ("x.y,/z", false),
+            ("x.y-/z", true),
+            ("x.y./zt", false),
+            ("x.y:/z", false),
+            ("x.y;/z", false),
+            ("x.y</z", false),
+            ("x.y=/z", false),
+            ("x.y>/z", false),
+            ("x.y?/z", false),
+            ("x.y@/z", false),
+            ("x.y[/z", false),
+            ("x.y\\/z", false),
+            ("x.y]/z", false),
+            ("x.y^/z", false),
+            ("x.y_/z", false),
+            ("x.y`/z", false),
+            ("x.y{/z", false),
+            ("x.y}/z", false),
+            ("x.y~/z", false),
+            ("x.y/z!", false),
+            ("x.y/z\"", false),
+            ("x.y/z#", false),
+            ("x.y/z$", false),
+            ("x.y/z%", false),
+            ("x.y/z&", false),
+            ("x.y/z'", false),
+            ("x.y/z(", false),
+            ("x.y/z)", false),
+            ("x.y/z*", false),
+            ("x.y/z++", false),
+            ("x.y/z,", false),
+            ("x.y/z-", true),
+            ("x.y/z.t", true),
+            ("x.y/z/t", true),
+            ("x.y/z:", false),
+            ("x.y/z;", false),
+            ("x.y/z<", false),
+            ("x.y/z=", false),
+            ("x.y/z>", false),
+            ("x.y/z?", false),
+            ("x.y/z@", false),
+            ("x.y/z[", false),
+            ("x.y/z\\", false),
+            ("x.y/z]", false),
+            ("x.y/z^", false),
+            ("x.y/z_", true),
+            ("x.y/z`", false),
+            ("x.y/z{", false),
+            ("x.y/z}", false),
+            ("x.y/z~", true),
+            ("x.y/x.foo", true),
+            ("x.y/aux.foo", false),
+            ("x.y/prn", false),
+            ("x.y/prn2", true),
+            ("x.y/com", true),
+            ("x.y/com1", false),
+            ("x.y/com1.txt", false),
+            ("x.y/calm1", true),
+            ("x.y/z~", true),
+            ("x.y/z~0", false),
+            ("x.y/z~09", false),
+            ("x.y/z09", true),
+            ("x.y/z09~", true),
+            ("x.y/z09~09z", true),
+            ("x.y/z09~09z~09", false),
+            ("github.com/!123/logrus", false),
+            ("github.com/user/unicode/испытание", false),
+            ("../x", false),
+            ("./y", false),
+            ("x:y", false),
+            (r"\temp\foo", false),
+            (".gitignore", false),
+            (".github/ISSUE_TEMPLATE", false),
+            ("x☺y", false),
+        ];
+
+        for (path, ok) in GO_TABLE {
+            let result = check_module_path(path);
+            assert_eq!(result.is_ok(), ok, "{path:?} gave {result:?}");
+        }
+    }
+
+    #[test]
+    fn splits_the_major_suffix_as_go_does() {
+        assert_eq!(split_path_version("x.y/z"), Some(("x.y/z", "")));
+        assert_eq!(split_path_version("x.y/v2"), Some(("x.y", "/v2")));
+        assert_eq!(split_path_version("x.y/v22"), Some(("x.y", "/v22")));
+        assert_eq!(
+            split_path_version("gopkg.in/yaml.v2"),
+            Some(("gopkg.in/yaml", ".v2"))
+        );
+        assert_eq!(
+            split_path_version("gopkg.in/check.v1"),
+            Some(("gopkg.in/check", ".v1"))
+        );
+        assert_eq!(
+            split_path_version("gopkg.in/user/pkg.v3"),
+            Some(("gopkg.in/user/pkg", ".v3"))
+        );
+        assert_eq!(
+            split_path_version("gopkg.in/pkg.v3-unstable"),
+            Some(("gopkg.in/pkg", ".v3-unstable"))
+        );
+
+        assert_eq!(split_path_version("x.y/v1"), None);
+        assert_eq!(split_path_version("x.y/v02"), None);
+        assert_eq!(split_path_version("x.y/v2.0"), None);
+        assert_eq!(
+            split_path_version("gopkg.in/pkg.v0"),
+            Some(("gopkg.in/pkg", ".v0"))
+        );
+        assert_eq!(split_path_version("gopkg.in/pkg.v01"), None);
+        assert!(check_module_path("gopkg.in/pkg.v0").is_ok());
+        assert!(check_module_path("gopkg.in/user/pkg.v0").is_ok());
+    }
+}

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -203,33 +203,52 @@ pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
     Ok(manifest)
 }
 
-/// A replaced entry's key (the original module) and its `replace` target must
-/// both be third-party module paths, or resolution silently misclassifies them
-/// (a dotless key reads as the Go standard library).
+/// A dotless path is reported first and by name, since it reads as the Go
+/// standard library rather than as a malformed path.
 fn validate_go_dep_paths(manifest: &Manifest) -> Result<(), String> {
     for (key, dep) in &manifest.go_deps() {
-        let GoDependency::Replaced { source, .. } = dep else {
-            continue;
-        };
-        if !crate::is_third_party(key) {
-            return Err(match source {
-                ReplacementSource::Module { .. } => format!(
-                    "`{}` in `[dependencies.go]` has a `replace` but is not a third-party module path (its first path segment needs a dot)",
-                    key
-                ),
-                ReplacementSource::Local { .. } => format!(
-                    "`{}` in `[dependencies.go]` has a local `path` but no dot in its first path segment; lisette reads dotless paths as Go standard library packages, so a local module needs a dotted module path like `example.com/{}` (a lisette limitation, not a Go rule)",
-                    key, key
-                ),
-            });
+        if let GoDependency::Replaced { source, .. } = dep {
+            if !crate::is_third_party(key) {
+                return Err(match source {
+                    ReplacementSource::Module { .. } => format!(
+                        "`{}` in `[dependencies.go]` has a `replace` but is not a third-party module path (its first path segment needs a dot)",
+                        key
+                    ),
+                    ReplacementSource::Local { .. } => format!(
+                        "`{}` in `[dependencies.go]` has a local `path` but no dot in its first path segment; lisette reads dotless paths as Go standard library packages, so a local module needs a dotted module path like `example.com/{}` (a lisette limitation, not a Go rule)",
+                        key, key
+                    ),
+                });
+            }
+            if let ReplacementSource::Module { path, .. } = source
+                && !crate::is_third_party(path)
+            {
+                return Err(format!(
+                    "the `replace` target `{}` for `{}` is not a third-party module path",
+                    path, key
+                ));
+            }
         }
-        if let ReplacementSource::Module { path, .. } = source
-            && !crate::is_third_party(path)
+
+        crate::module_path::check_module_path(key).map_err(|reason| {
+            format!(
+                "`{}` in `[dependencies.go]` is not a Go module path: {}",
+                key, reason
+            )
+        })?;
+
+        // A local `path` names a directory, not a module.
+        if let GoDependency::Replaced {
+            source: ReplacementSource::Module { path, .. },
+            ..
+        } = dep
         {
-            return Err(format!(
-                "the `replace` target `{}` for `{}` is not a third-party module path",
-                path, key
-            ));
+            crate::module_path::check_module_path(path).map_err(|reason| {
+                format!(
+                    "the `replace` target `{}` for `{}` is not a Go module path: {}",
+                    path, key, reason
+                )
+            })?;
         }
     }
     Ok(())
@@ -607,6 +626,57 @@ mod tests {
         let orphan = outside.path().join("loose.lis");
         std::fs::write(&orphan, "fn main() {}\n").unwrap();
         assert_eq!(find_project_root(&orphan), None);
+    }
+
+    #[test]
+    fn a_key_go_would_refuse_is_not_a_dependency() {
+        for key in [
+            "fmt",
+            "github.com//x",
+            "GitHub.com/x/y",
+            "example.com/lib/v1",
+        ] {
+            let dir = project_with(&format!(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies.go]\n\"{}\" = \"v1.0.0\"\n",
+                key
+            ));
+            let error = parse_manifest(dir.path()).unwrap_err();
+            assert!(
+                error.contains("not a Go module path"),
+                "{key} gave: {error}"
+            );
+        }
+
+        let dir = project_with(
+            "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies.go]\n\"gopkg.in/yaml.v3\" = \"v3.0.1\"\n\"example.com/lib/v2\" = \"v2.0.0\"\n",
+        );
+        assert!(parse_manifest(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn a_replacement_is_held_to_the_same_module_path_rule() {
+        for entry in [
+            "\"github.com//x\" = { replacement = \"example.com/y@v1.0.0\" }",
+            "\"example.com/lib/v1\" = { replacement = \"example.com/y@v1.0.0\" }",
+            "\"example.com/lib\" = { replacement = \"github.com//y@v1.0.0\" }",
+            "\"example.com/lib\" = { replacement = \"example.com/y/v1@v1.0.0\" }",
+            "\"github.com//x\" = { path = \"../local\" }",
+        ] {
+            let dir = project_with(&format!(
+                "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies.go]\n{}\n",
+                entry
+            ));
+            let error = parse_manifest(dir.path()).unwrap_err();
+            assert!(
+                error.contains("not a Go module path"),
+                "{entry} gave: {error}"
+            );
+        }
+
+        let dir = project_with(
+            "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies.go]\n\"example.com/lib\" = { replacement = \"github.com/you/lib@v1.0.0\" }\n\"example.com/other\" = { path = \"../local\" }\n",
+        );
+        assert!(parse_manifest(dir.path()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Every entry in `[dependencies.go]` is now checked against Go's own module path rules, so a path Go would refuse fails at `lis check` instead of partway through a build.

```toml
[dependencies.go]
"fmt" = "v1.0.0"                  # rejected: missing dot in first path element
"github.com//x" = "v1.0.0"        # rejected: double slash
"example.com/lib/v1" = "v1.0.0"   # rejected: invalid major version suffix
```

