### PR TITLE
refactor: resolve script imports from declared dependencies

### DIFF
--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -14,11 +14,12 @@ use stdlib::Target;
 pub fn go_command(target: Target) -> Command {
     let mut c = Command::new("go");
     // Isolate from any user-side env that would change Go's mode against
-    // lisette's `target/`: a stray `go.work` (workspace mode) or a stray
-    // `GOFLAGS=-mod=vendor` (vendor mode) both turn into multi-line errors
-    // for unrelated `lis add` invocations otherwise.
+    // lisette's `target/`: a stray `go.work` (workspace mode), a stray
+    // `GOFLAGS=-mod=vendor` (vendor mode), or `GO111MODULE=off` (GOPATH mode)
+    // all turn into unrelated errors otherwise.
     c.env("GOWORK", "off");
     c.env("GOFLAGS", "");
+    c.env("GO111MODULE", "on");
     c.env("GOOS", target.goos);
     c.env("GOARCH", target.goarch);
     c
@@ -122,6 +123,11 @@ pub fn go_fmt_paths(paths: &[PathBuf]) -> Result<(), String> {
 }
 
 pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> Result<(), String> {
+    let content = go_mod_content(module_name, locator)?;
+    write_go_mod_content(dir, &content)
+}
+
+pub fn go_mod_content(module_name: &str, locator: &TypedefLocator) -> Result<String, String> {
     let prelude_version = env!("CARGO_PKG_VERSION");
 
     let mut requires = vec![format!("\t{} v{}", PRELUDE_IMPORT_PATH, prelude_version)];
@@ -179,6 +185,10 @@ pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> 
         }
     }
 
+    Ok(content)
+}
+
+fn write_go_mod_content(dir: &Path, content: &str) -> Result<(), String> {
     let go_mod_path = dir.join("go.mod");
     let lisette_dir = dir.join(".lisette");
     let stamp_path = lisette_dir.join("go.mod.stamp");
@@ -188,11 +198,11 @@ pub fn write_go_mod(dir: &Path, module_name: &str, locator: &TypedefLocator) -> 
         && fs::read_to_string(&stamp_path).is_ok_and(|existing| existing == content);
 
     if !stamp_matches {
-        fs::write(&go_mod_path, &content).map_err(|e| format!("Failed to write go.mod: {}", e))?;
+        fs::write(&go_mod_path, content).map_err(|e| format!("Failed to write go.mod: {}", e))?;
         let _ = fs::remove_file(dir.join("go.sum"));
         let _ = fs::remove_file(lisette_dir.join("go.mod.tidy"));
         let _ = fs::create_dir_all(&lisette_dir);
-        let _ = fs::write(&stamp_path, &content);
+        let _ = fs::write(&stamp_path, content);
     }
 
     Ok(())

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -86,6 +86,36 @@ pub fn check(
     check_loose_dir(target_path, &options)
 }
 
+struct Snapshot {
+    source: Option<String>,
+    locator: TypedefLocator,
+}
+
+impl Snapshot {
+    fn read(file: &Path) -> Self {
+        let Ok(source) = std::fs::read_to_string(file) else {
+            return Self {
+                source: None,
+                locator: TypedefLocator::default(),
+            };
+        };
+        let locator =
+            super::script::script_locator(&source, file, super::script_deps::Mode::Offline)
+                .map_or_else(|_| TypedefLocator::default(), |(locator, _)| locator);
+        Self {
+            source: Some(source),
+            locator,
+        }
+    }
+
+    fn of(locator: TypedefLocator) -> Self {
+        Self {
+            source: None,
+            locator,
+        }
+    }
+}
+
 fn check_file(file_path: &Path, options: &CheckOptions) -> i32 {
     match super::project::resolve_file_target(file_path) {
         FileTarget::ProjectEntry { root } | FileTarget::ProjectPackage { root } => {
@@ -95,7 +125,7 @@ fn check_file(file_path: &Path, options: &CheckOptions) -> i32 {
             file_path,
             options,
             CompileScope::Script { inside_project },
-            TypedefLocator::default(),
+            Snapshot::read(file_path),
             "main",
             None,
         ),
@@ -172,7 +202,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
                 &src_main,
                 options,
                 CompileScope::Project(project_path.to_path_buf()),
-                locator,
+                Snapshot::of(locator),
                 &go_module,
                 Some(scanned),
             )
@@ -199,12 +229,12 @@ fn check_single_file(
     file_path: &Path,
     options: &CheckOptions,
     scope: CompileScope,
-    locator: TypedefLocator,
+    snapshot: Snapshot,
     go_module: &str,
     scanned: Option<ScannedSources>,
 ) -> i32 {
     let start = Instant::now();
-    let result = match compile_single_file(file_path, scope, locator, go_module, scanned) {
+    let result = match compile_single_file(file_path, scope, snapshot, go_module, scanned) {
         Ok(result) => result,
         Err(ReadFailure) => return 1,
     };
@@ -261,11 +291,12 @@ fn report_check(result: &CompileResult, options: &CheckOptions, start: Instant) 
 fn compile_single_file(
     file_path: &Path,
     scope: CompileScope,
-    locator: TypedefLocator,
+    snapshot: Snapshot,
     go_module: &str,
     scanned: Option<ScannedSources>,
 ) -> Result<CompileResult, ReadFailure> {
-    let source = match fs::read_to_string(file_path) {
+    let Snapshot { source, locator } = snapshot;
+    let source = match source.ok_or(()).or_else(|_| fs::read_to_string(file_path)) {
         Ok(s) => s,
         Err(e) => {
             cli_error!(
@@ -403,7 +434,7 @@ fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
         let Ok(compiled) = compile_single_file(
             file,
             CompileScope::Script { inside_project },
-            TypedefLocator::default(),
+            Snapshot::read(file),
             "main",
             None,
         ) else {

--- a/crates/cli/src/handlers/mod.rs
+++ b/crates/cli/src/handlers/mod.rs
@@ -13,8 +13,14 @@ mod project;
 pub(crate) mod reconciliation;
 mod run;
 mod script;
+mod script_deps;
 mod sync;
 mod test;
+
+#[cfg(test)]
+pub(crate) use script::script_build_dir;
+pub(crate) use script::script_locator;
+pub(crate) use script_deps::Mode as ScriptResolveMode;
 
 pub use add::add;
 pub use bindgen::bindgen;

--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use crate::cli_error;
 use crate::go_cli;
 use diagnostics::render::{self, Filter};
+use emit::PRELUDE_IMPORT_PATH;
 use lisette::pipeline::{
     CompileConfig, CompileEntry, CompileInput, CompileMode, CompileResult, CompileScope, compile,
 };
@@ -25,21 +26,22 @@ pub(super) fn prepare(
     inside_project: bool,
     heading: &str,
 ) -> Result<ScriptBuild, i32> {
-    let locator = deps::TypedefLocator::default();
-    let (mut result, diagnostics_shown) =
-        compile_file(file, sourcemap, inside_project, &locator, heading)?;
     let dir = build_dir(file, heading)?;
+    let source = read_source(file, heading)?;
+    let locator = resolve_locator(&source, &dir);
+    if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
+        cli_error!(heading, e, "Check file permissions");
+        return Err(1);
+    }
+
+    let (mut result, diagnostics_shown) =
+        compile_file(file, &source, sourcemap, inside_project, &locator)?;
     let target = locator.target();
 
     for file in &mut result.output {
         if let Some(staged) = stage_name(&file.name) {
             file.name = staged;
         }
-    }
-
-    if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
-        cli_error!(heading, e, "Check file permissions");
-        return Err(1);
     }
 
     let emit = match go_cli::write_go_outputs(&dir, &result.output) {
@@ -91,9 +93,19 @@ pub(super) fn emit(
         Err(code) => return code,
     };
 
-    let locator = deps::TypedefLocator::default();
+    let Ok(dir) = build_dir(file, heading) else {
+        return 1;
+    };
+    let Ok(source) = read_source(file, heading) else {
+        return 1;
+    };
+    let locator = resolve_locator(&source, &dir);
+    if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
+        cli_error!(heading, e, "Check file permissions");
+        return 1;
+    }
     let Ok((result, diagnostics_shown)) =
-        compile_file(file, sourcemap, inside_project, &locator, heading)
+        compile_file(file, &source, sourcemap, inside_project, &locator)
     else {
         return 1;
     };
@@ -118,7 +130,10 @@ pub(super) fn emit(
         return 1;
     }
 
-    if let Err(e) = fs::write(&destination, go_file.to_go()) {
+    let go_source = go_file.to_go();
+    let needs_module = !locator.deps().is_empty() || go_source.contains(PRELUDE_IMPORT_PATH);
+
+    if let Err(e) = fs::write(&destination, go_source) {
         cli_error!(
             heading,
             format!("Failed to write `{}`: {}", destination.display(), e),
@@ -128,6 +143,9 @@ pub(super) fn emit(
     }
 
     report_written("Go file", &destination, diagnostics_shown);
+    if needs_module {
+        report_module_needed(&locator);
+    }
     0
 }
 
@@ -175,24 +193,64 @@ pub(super) fn build(
     0
 }
 
+pub(crate) fn script_locator(
+    source: &str,
+    file: &Path,
+    mode: super::script_deps::Mode,
+) -> Result<(deps::TypedefLocator, Option<PathBuf>), String> {
+    let dir = script_build_dir(file);
+    let deps = super::script_deps::script_deps(source);
+
+    if deps.is_empty() {
+        return Ok((
+            super::script_deps::locator(Default::default(), &dir, mode),
+            None,
+        ));
+    }
+
+    ensure_build_dir(&dir)?;
+    Ok((super::script_deps::locator(deps, &dir, mode), Some(dir)))
+}
+
+fn report_module_needed(locator: &deps::TypedefLocator) {
+    let Ok(content) = go_cli::go_mod_content(GO_MODULE, locator) else {
+        return;
+    };
+
+    eprintln!("\n  This Go needs a module. Write `go.mod` beside it:\n");
+    for line in content.lines() {
+        eprintln!("      {}", line);
+    }
+    eprintln!("\n  then run `go mod tidy` to record the checksums.");
+}
+
+fn read_source(file: &Path, heading: &str) -> Result<String, i32> {
+    fs::read_to_string(file).map_err(|e| {
+        cli_error!(
+            heading,
+            format!("Failed to read `{}`: {}", file.display(), e),
+            "Check file permissions"
+        );
+        1
+    })
+}
+
+fn resolve_locator(source: &str, dir: &Path) -> deps::TypedefLocator {
+    super::script_deps::locator(
+        super::script_deps::script_deps(source),
+        dir,
+        super::script_deps::Mode::Online,
+    )
+}
+
 fn compile_file(
     file: &Path,
+    source: &str,
     sourcemap: bool,
     inside_project: bool,
     locator: &deps::TypedefLocator,
-    heading: &str,
 ) -> Result<(CompileResult, bool), i32> {
-    let source = match fs::read_to_string(file) {
-        Ok(source) => source,
-        Err(e) => {
-            cli_error!(
-                heading,
-                format!("Failed to read `{}`: {}", file.display(), e),
-                "Check file permissions"
-            );
-            return Err(1);
-        }
-    };
+    let source = source.to_string();
 
     let entry_name = file
         .file_name()
@@ -237,17 +295,32 @@ fn compile_file(
     Ok((result, counts.warnings + counts.info > 0))
 }
 
-fn build_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
+fn ensure_build_dir(dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("Failed to create `{}`: {}", dir.display(), e))
+}
+
+const BUILD_DIR_PREFIX: &str = "lis-script-";
+
+pub(crate) fn script_build_dir(file: &Path) -> PathBuf {
     let absolute = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
     let mut hasher = DefaultHasher::new();
     absolute.hash(&mut hasher);
-    let dir = std::env::temp_dir().join(format!("lis-script-{:x}", hasher.finish()));
+    std::env::temp_dir().join(format!("{}{:x}", BUILD_DIR_PREFIX, hasher.finish()))
+}
+
+fn build_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
+    let dir = script_build_dir(file);
 
     if let Err(e) = fs::create_dir_all(&dir) {
+        let hint = if dir.exists() {
+            "Remove it: the build directory's name is derived from the script's path"
+        } else {
+            "Check permissions on temp directory"
+        };
         cli_error!(
             heading,
-            format!("Failed to create temporary directory: {}", e),
-            "Check permissions on temp directory"
+            format!("Failed to create `{}`: {}", dir.display(), e),
+            hint
         );
         return Err(1);
     }

--- a/crates/cli/src/handlers/script_deps.rs
+++ b/crates/cli/src/handlers/script_deps.rs
@@ -1,0 +1,92 @@
+//! A script's `[dependencies.go]` table as the map a `TypedefLocator` wants.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use deps::{GoDependency, TypedefLocator};
+use stdlib::Target;
+
+/// Whether resolution may reach the network.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mode {
+    /// `check` and the editor.
+    Offline,
+    /// `run` and `build`.
+    Online,
+}
+
+pub(crate) fn script_deps(source: &str) -> BTreeMap<String, GoDependency> {
+    let Some(block) = deps_block(source) else {
+        return BTreeMap::new();
+    };
+    let Ok(table) = deps::parse_dependency_table(&block.text) else {
+        return BTreeMap::new();
+    };
+    table
+        .deps
+        .into_iter()
+        .filter(|(module_path, dep)| deps::validate_script_entry(module_path, dep).is_ok())
+        .collect()
+}
+
+pub(crate) fn deps_block(source: &str) -> Option<syntax::dependency_block::DependencyBlock> {
+    syntax::dependency_block::scan_dependency_blocks(source, 0)
+        .into_iter()
+        .next()
+}
+
+pub(crate) fn locator(
+    deps: BTreeMap<String, GoDependency>,
+    dir: &Path,
+    mode: Mode,
+) -> TypedefLocator {
+    let target = Target::host();
+    let locator = TypedefLocator::new(deps, Some(dir.to_path_buf()), target);
+    if mode == Mode::Offline || locator.deps().is_empty() {
+        return locator;
+    }
+
+    locator.with_bindgen(std::sync::Arc::new(
+        crate::workspace::WorkspaceBindgen::new(dir.to_path_buf(), typedef_dir(dir), target),
+    ))
+}
+
+pub(crate) fn typedef_dir(dir: &Path) -> std::path::PathBuf {
+    deps::typedef_cache_dir(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TABLE: &str = "// [dependencies.go]\n// \"golang.org/x/text\" = \"v0.21.0\"\n\nimport \"go:golang.org/x/text/cases\"\n";
+
+    #[test]
+    fn one_entry_covers_every_package_in_its_module() {
+        let deps = script_deps(TABLE);
+
+        assert_eq!(deps.len(), 1);
+        assert!(deps.contains_key("golang.org/x/text"));
+    }
+
+    #[test]
+    fn transitive_entries_are_ordinary_rows() {
+        let source = "// [dependencies.go]\n// \"github.com/spf13/cobra\" = \"v1.8.1\"\n// \"github.com/spf13/pflag\" = { version = \"v1.0.5\", via = [\"github.com/spf13/cobra\"] }\n";
+        let deps = script_deps(source);
+
+        assert_eq!(deps.len(), 2);
+        assert!(deps.contains_key("github.com/spf13/pflag"));
+    }
+
+    #[test]
+    fn a_script_with_no_table_has_no_dependencies() {
+        assert!(script_deps("import \"go:fmt\"\n").is_empty());
+    }
+
+    #[test]
+    fn an_invalid_entry_is_dropped_rather_than_guessed() {
+        let source = "// [dependencies.go]\n// \"github.com/google/uuid\" = \"latest\"\n";
+
+        assert!(script_deps(source).is_empty());
+    }
+}

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1060,6 +1060,23 @@ impl BindgenSetup for WorkspaceBindgenSetup {
 
         Ok(BindgenSession::new(bindgen, Box::new(lock)))
     }
+
+    fn for_script(
+        &self,
+        source: &str,
+        file: &Path,
+    ) -> Result<(deps::TypedefLocator, Option<deps::ScriptSession>), String> {
+        let (locator, dir) = crate::handlers::script_locator(
+            source,
+            file,
+            crate::handlers::ScriptResolveMode::Offline,
+        )?;
+        let session = dir
+            .map(|dir| crate::lock::acquire_target_lock_quiet(&dir))
+            .transpose()?
+            .map(|lock| deps::ScriptSession::new(Box::new(lock)));
+        Ok((locator, session))
+    }
 }
 
 impl Bindgen for WorkspaceBindgen {
@@ -1145,6 +1162,20 @@ mod tests {
             version: MODULE_VERSION,
             replacement: None,
         }
+    }
+
+    #[test]
+    fn a_dependency_free_script_gets_no_build_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("main.lis");
+        stdfs::write(&file, "import \"go:fmt\"\n").unwrap();
+
+        let (_, dir) = WorkspaceBindgenSetup
+            .for_script("import \"go:fmt\"\n", &file)
+            .unwrap();
+
+        assert!(dir.is_none());
+        assert!(!crate::handlers::script_build_dir(&file).exists());
     }
 
     fn valid_typedef() -> String {

--- a/crates/deps/src/dependency_table.rs
+++ b/crates/deps/src/dependency_table.rs
@@ -1,0 +1,232 @@
+//! Parses a bare `[dependencies.go]` table, as a script writes it.
+
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+use crate::GoDependency;
+
+#[derive(Debug)]
+pub struct DependencyTable {
+    pub deps: BTreeMap<String, GoDependency>,
+    pub spans: BTreeMap<String, Range<usize>>,
+}
+
+pub struct TableError {
+    pub message: String,
+    pub range: Option<Range<usize>>,
+}
+
+impl TableError {
+    fn plain(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            range: None,
+        }
+    }
+}
+
+const TABLE: &str = "dependencies";
+const GO: &str = "go";
+
+pub fn parse_dependency_table(text: &str) -> Result<DependencyTable, TableError> {
+    let document = toml_edit::ImDocument::parse(text).map_err(|error| TableError {
+        message: error.message().to_string(),
+        range: error.span(),
+    })?;
+
+    for (key, _) in document.iter() {
+        if key != TABLE {
+            return Err(TableError::plain(format!(
+                "`[{}]` is not allowed here, only `[dependencies.go]`",
+                key
+            )));
+        }
+    }
+
+    let Some(dependencies) = document.get(TABLE) else {
+        return Ok(DependencyTable {
+            deps: BTreeMap::new(),
+            spans: BTreeMap::new(),
+        });
+    };
+    for (key, _) in dependencies.as_table().into_iter().flat_map(|t| t.iter()) {
+        if key != GO {
+            return Err(TableError::plain(format!(
+                "`[dependencies.{}]` is not allowed here, only `[dependencies.go]`",
+                key
+            )));
+        }
+    }
+
+    let (deps, spans) = match dependencies.get(GO) {
+        Some(go) => (deserialize_go_table(go)?, entry_spans(go)),
+        None => (BTreeMap::new(), BTreeMap::new()),
+    };
+
+    Ok(DependencyTable { deps, spans })
+}
+
+pub(crate) fn deserialize_go_table(
+    go: &toml_edit::Item,
+) -> Result<BTreeMap<String, GoDependency>, TableError> {
+    let mut document = toml_edit::DocumentMut::new();
+    document.insert(GO, go.clone());
+    Ok(toml_edit::de::from_document::<Wrapper>(document)
+        .map_err(|error| TableError {
+            message: error.message().to_string(),
+            range: error.span(),
+        })?
+        .go)
+}
+
+fn entry_spans(go: &toml_edit::Item) -> BTreeMap<String, Range<usize>> {
+    let Some(table) = go.as_table() else {
+        return BTreeMap::new();
+    };
+    table
+        .iter()
+        .filter_map(|(name, item)| {
+            let key = table.key(name)?.span()?;
+            let end = item.as_value().and_then(toml_edit::Value::span);
+            Some((name.to_string(), key.start..end.map_or(key.end, |v| v.end)))
+        })
+        .collect()
+}
+
+#[derive(serde::Deserialize)]
+struct Wrapper {
+    go: BTreeMap<String, GoDependency>,
+}
+
+pub fn validate_script_entry(module_path: &str, dep: &GoDependency) -> Result<(), String> {
+    crate::module_path::check_module_path(module_path)
+        .map_err(|reason| format!("`{}` is not a Go module path: {}", module_path, reason))?;
+
+    let version = match dep {
+        GoDependency::Remote { version, .. } => version,
+        GoDependency::Replaced { .. } => {
+            return Err(format!(
+                "`{}` uses `replace`, which a script cannot do. Only a project can redirect a module",
+                module_path
+            ));
+        }
+    };
+
+    if !crate::is_exact_version(version) {
+        return Err(format!(
+            "`{}` is pinned to `{}`, which is not an exact version. Write a full version such as `v1.2.3`",
+            module_path, version
+        ));
+    }
+    crate::check_version_matches_path(module_path, version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(text: &str) -> BTreeMap<String, GoDependency> {
+        parse_dependency_table(text)
+            .unwrap_or_else(|e| panic!("{}", e.message))
+            .deps
+    }
+
+    #[test]
+    fn reads_every_shape_a_manifest_holds() {
+        let deps = table(
+            "[dependencies.go]\n\"go.uber.org/zap\" = \"v1.28.0\"\n\"go.uber.org/multierr\" = { version = \"v1.10.0\", via = [\"go.uber.org/zap\"] }\n",
+        );
+
+        assert_eq!(deps.len(), 2);
+        assert_eq!(
+            deps["go.uber.org/multierr"].via(),
+            Some(["go.uber.org/zap".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn an_entry_span_covers_key_and_value() {
+        let text =
+            "[dependencies.go]\n\"a.b/c\" = \"v1.0.0\"\n\"d.e/f\" = { version = \"v2.0.0\" }\n";
+        let table = parse_dependency_table(text).ok().unwrap();
+
+        assert_eq!(
+            &text[table.spans["a.b/c"].clone()],
+            "\"a.b/c\" = \"v1.0.0\""
+        );
+        assert_eq!(
+            &text[table.spans["d.e/f"].clone()],
+            "\"d.e/f\" = { version = \"v2.0.0\" }"
+        );
+    }
+
+    #[test]
+    fn an_empty_table_is_not_an_error() {
+        assert!(table("[dependencies.go]\n").is_empty());
+    }
+
+    #[test]
+    fn a_toml_error_carries_a_range() {
+        let error = parse_dependency_table("[dependencies.go]\n\"x.y/z\" = \n").unwrap_err();
+
+        assert!(error.range.is_some());
+    }
+
+    #[test]
+    fn other_sections_are_rejected_by_name() {
+        for text in [
+            "[project]\nname = \"x\"\n",
+            "[dependencies.rust]\n\"x\" = \"1\"\n",
+        ] {
+            let error = parse_dependency_table(text).unwrap_err();
+            assert!(error.message.contains("only `[dependencies.go]`"), "{text}");
+        }
+    }
+
+    fn remote(version: &str) -> GoDependency {
+        GoDependency::Remote {
+            version: version.to_string(),
+            via: None,
+        }
+    }
+
+    #[test]
+    fn script_entries_must_be_exact_and_well_formed() {
+        assert!(validate_script_entry("github.com/google/uuid", &remote("v1.6.0")).is_ok());
+        assert!(
+            validate_script_entry(
+                "github.com/docker/docker",
+                &remote("v20.10.24+incompatible")
+            )
+            .is_ok()
+        );
+
+        assert!(validate_script_entry("fmt", &remote("v1.0.0")).is_err());
+        assert!(validate_script_entry("github.com//x", &remote("v1.0.0")).is_err());
+        assert!(validate_script_entry("github.com/google/uuid", &remote("latest")).is_err());
+        assert!(validate_script_entry("github.com/google/uuid", &remote("v1")).is_err());
+        assert!(validate_script_entry("example.com/lib/v2", &remote("v1.0.0")).is_err());
+    }
+
+    #[test]
+    fn a_nested_module_is_an_ordinary_entry() {
+        for (module_path, version) in [
+            ("go.opentelemetry.io/otel", "v1.32.0"),
+            ("go.opentelemetry.io/otel/sdk/metric", "v1.32.0"),
+        ] {
+            assert!(validate_script_entry(module_path, &remote(version)).is_ok());
+        }
+    }
+
+    #[test]
+    fn a_replace_is_project_only() {
+        let dep = GoDependency::Replaced {
+            source: crate::ReplacementSource::Local {
+                path: "../local".to_string(),
+            },
+            via: None,
+        };
+
+        assert!(validate_script_entry("example.com/lib", &dep).is_err());
+    }
+}

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -1,3 +1,4 @@
+mod dependency_table;
 mod local_source;
 mod module_path;
 mod project_manifest;
@@ -34,6 +35,9 @@ fn typedef_home() -> Option<PathBuf> {
     }
 }
 
+pub use dependency_table::{
+    DependencyTable, TableError, parse_dependency_table, validate_script_entry,
+};
 pub use project_manifest::{
     GoDependency, Manifest, ManifestDocument, ReplacementSource, TrimmedVia, ViaChanges,
     check_no_subpackage_deps, check_toolchain_version, finalize_via, find_project_root,
@@ -43,7 +47,8 @@ pub use project_manifest::{
 pub use toml_edit::DocumentMut;
 pub use typedef_locator::{
     Bindgen, BindgenFailure, BindgenGuard, BindgenSession, BindgenSetup, DeclarationStatus,
-    ImportablePackage, ResolvedReplacement, TypedefLocator, TypedefLocatorResult, TypedefOrigin,
+    ImportablePackage, ResolvedReplacement, ScriptSession, TypedefLocator, TypedefLocatorResult,
+    TypedefOrigin,
 };
 
 pub fn is_third_party(pkg: &str) -> bool {
@@ -125,6 +130,62 @@ fn parse_major_digits(digits: &str) -> Option<u64> {
         && digits.bytes().all(|b| b.is_ascii_digit())
         && (digits.len() == 1 || !digits.starts_with('0'));
     is_canonical.then(|| digits.parse().ok()).flatten()
+}
+
+pub fn is_exact_version(version: &str) -> bool {
+    let Some(rest) = version.strip_prefix('v') else {
+        return false;
+    };
+
+    let (rest, build) = match rest.split_once('+') {
+        Some((rest, build)) => (rest, Some(build)),
+        None => (rest, None),
+    };
+    let (core, pre_release) = match rest.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (rest, None),
+    };
+
+    let mut numbers = core.split('.');
+    let (Some(major), Some(minor), Some(patch), None) = (
+        numbers.next(),
+        numbers.next(),
+        numbers.next(),
+        numbers.next(),
+    ) else {
+        return false;
+    };
+    if ![major, minor, patch].iter().all(|part| is_numeric_id(part)) {
+        return false;
+    }
+
+    pre_release.is_none_or(|section| section.split('.').all(is_pre_release_id))
+        && build.is_none_or(|section| section.split('.').all(is_semver_id))
+}
+
+fn is_numeric_id(part: &str) -> bool {
+    !part.is_empty()
+        && part.bytes().all(|b| b.is_ascii_digit())
+        && (part == "0" || !part.starts_with('0'))
+}
+
+fn is_pre_release_id(part: &str) -> bool {
+    if part.bytes().all(|b| b.is_ascii_digit()) {
+        return is_numeric_id(part);
+    }
+    is_semver_id(part)
+}
+
+fn is_semver_id(part: &str) -> bool {
+    !part.is_empty() && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+pub fn is_valid_package_path(pkg: &str) -> bool {
+    !pkg.is_empty()
+        && !pkg.contains('@')
+        && pkg
+            .split('/')
+            .all(|segment| !matches!(segment, "" | "." | ".."))
 }
 
 pub fn is_stdlib(pkg: &str) -> bool {
@@ -542,5 +603,48 @@ mod tests {
             &home.join("project/src/main.lis")
         ));
         assert!(!is_generated_typedef_path(Path::new("/etc/passwd")));
+    }
+}
+
+#[cfg(test)]
+mod exact_version_tests {
+    use super::is_exact_version;
+
+    #[test]
+    fn accepts_go_module_versions() {
+        for version in [
+            "v1.6.0",
+            "v0.0.0-20191109021931-daa7c04131f5",
+            "v2.1.0+incompatible",
+            "v1.2.3-rc.1",
+            "v1.2.3+001",
+            "v0.21.0",
+        ] {
+            assert!(is_exact_version(version), "{version}");
+        }
+    }
+
+    #[test]
+    fn rejects_inexact_or_malformed_versions() {
+        for version in [
+            "latest",
+            "master",
+            "",
+            "v1",
+            "v1.6",
+            "1.6.0",
+            "vx.y.z",
+            "v01.2.3",
+            "v1.2.3-",
+            "v1.2.3+",
+            "v1.2.3-rc..1",
+            "v1.2.3-rc_1",
+            "v1.2.3-01",
+            "v1.2.3-rc.007",
+            "v1.2.3.4",
+            "v-1.2.3",
+        ] {
+            assert!(!is_exact_version(version), "{version}");
+        }
     }
 }

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -174,6 +174,16 @@ impl BindgenSession {
     }
 }
 
+pub struct ScriptSession {
+    _guard: Box<dyn BindgenGuard>,
+}
+
+impl ScriptSession {
+    pub fn new(guard: Box<dyn BindgenGuard>) -> Self {
+        Self { _guard: guard }
+    }
+}
+
 pub trait BindgenGuard: sealed::Sealed + Send {}
 
 mod sealed {
@@ -185,6 +195,12 @@ impl BindgenGuard for std::fs::File {}
 
 pub trait BindgenSetup: Send + Sync {
     fn for_project(&self, project_root: &Path, target: Target) -> Result<BindgenSession, String>;
+
+    fn for_script(
+        &self,
+        source: &str,
+        file: &Path,
+    ) -> Result<(TypedefLocator, Option<ScriptSession>), String>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -303,6 +319,15 @@ impl TypedefLocator {
                 (module, synthetic, Some(replacement))
             }
         })
+    }
+
+    pub fn discard_typedef(&self, path: &Path) {
+        let Some(root) = self.project_root.as_deref() else {
+            return;
+        };
+        if path.starts_with(crate::typedef_cache_dir(root)) {
+            let _ = std::fs::remove_file(path);
+        }
     }
 
     /// Classify a `go:` import path without touching the cache or bindgen.

--- a/crates/diagnostics/src/package_graph.rs
+++ b/crates/diagnostics/src/package_graph.rs
@@ -25,13 +25,13 @@ pub fn package_not_found(
         MissingPackageReason::Script {
             inside_project: false,
         } => {
-            "A file compiled on its own may import only from the Go standard library. To import packages normally, use `lis new` to create a project."
+            "A file compiled on its own has no packages beside it, only the Go ones it imports. Use `lis new` to create a project."
                 .to_string()
         }
         MissingPackageReason::Script {
             inside_project: true,
         } => {
-            "A file compiled on its own may import only from the Go standard library. This file sits inside a project but outside its `src/`, so it is not part of it. Move it under `src/` to import the project's packages."
+            "A file compiled on its own has no packages beside it, only the Go ones it imports. This file sits inside a project but outside its `src/`, so it is not part of it. Move it under `src/` to import the project's packages."
                 .to_string()
         }
         MissingPackageReason::NotFound => {
@@ -55,20 +55,29 @@ pub fn is_go_package_shaped(package_name: &str) -> bool {
         && rest.split('/').all(|segment| !segment.is_empty())
 }
 
-pub fn invalid_package_path(package_name: &str, span: Span, is_blank: bool) -> LisetteDiagnostic {
+pub fn invalid_package_path(
+    package_name: &str,
+    span: Span,
+    is_blank: bool,
+    script: bool,
+) -> LisetteDiagnostic {
     let help = if is_go_package_shaped(package_name) {
-        let suggestion = if is_blank {
-            format!("import _ \"go:{}\"", package_name)
+        let blank = if is_blank { "_ " } else { "" };
+        if script {
+            format!(
+                "Go packages are imported with the `go:` prefix: `import {}\"go:{}\"`, with the module that provides it declared in the `[dependencies.go]` table",
+                blank, package_name
+            )
         } else {
-            format!("import \"go:{}\"", package_name)
-        };
-        let add_argument = package_name
-            .strip_prefix("github.com/")
-            .unwrap_or(package_name);
-        format!(
-            "Go packages are imported with the `go:` prefix: `{}`. Add it first with `lis add {}`",
-            suggestion, add_argument
-        )
+            format!(
+                "Go packages are imported with the `go:` prefix: `import {}\"go:{}\"`. Add it first with `lis add {}`",
+                blank,
+                package_name,
+                package_name
+                    .strip_prefix("github.com/")
+                    .unwrap_or(package_name)
+            )
+        }
     } else {
         "Project imports use bare folder names like `import \"util\"` or `import \"nested/deep/package\"`. Relative-path syntax (`./sub`, `../sub`) is not supported.".to_string()
     };
@@ -201,6 +210,84 @@ pub fn go_stdlib_unavailable_on_target(
         ))
 }
 
+pub fn unknown_go_stdlib_package(go_pkg: &str, span: Span, script: bool) -> LisetteDiagnostic {
+    let third_party = if script {
+        "a third-party one needs its full module path, and an entry in the `[dependencies.go]` table"
+    } else {
+        "a third-party one needs its full module path, and `lis add` to declare it"
+    };
+
+    LisetteDiagnostic::error(format!("`{}` is not a Go standard library package", go_pkg))
+        .with_resolve_code("unknown_go_stdlib_package")
+        .with_span_label(&span, "no such package in the Go standard library")
+        .with_help(format!("Check the spelling: {}", third_party))
+}
+
+pub fn empty_import_path(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Empty import path")
+        .with_resolve_code("empty_import_path")
+        .with_span_label(&span, "no package named")
+        .with_help(
+            "Name the package after `go:`, as `import \"go:fmt\"` or `import \"go:github.com/google/uuid\"`",
+        )
+}
+
+pub fn invalid_go_package_path(go_pkg: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Invalid Go package path `{}`", go_pkg))
+        .with_resolve_code("invalid_go_package_path")
+        .with_span_label(&span, "not a path Go can resolve")
+        .with_help(
+            "Write the path as Go does, with no empty, `.`, or `..` segments, such as `github.com/google/uuid`",
+        )
+}
+
+pub fn invalid_dependency_table(message: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Invalid dependency table")
+        .with_resolve_code("invalid_dependency_table")
+        .with_span_label(&span, "not a valid entry")
+        .with_help(format!(
+            "{}. The table holds one Go module per line, as `\"github.com/google/uuid\" = \"v1.6.0\"`",
+            message.trim_end_matches('.')
+        ))
+}
+
+pub fn duplicate_dependency_table(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Duplicate dependency table")
+        .with_resolve_code("duplicate_dependency_table")
+        .with_span_label(&span, "a second `[dependencies.go]` table")
+        .with_help("Merge the entries into the first table and delete this one")
+}
+
+pub fn dependency_table_in_project(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Dependency table in a project file")
+        .with_resolve_code("dependency_table_in_project")
+        .with_span_label(&span, "not read here")
+        .with_help(
+            "A project records dependencies in `lisette.toml`. Move these entries there, where `lis add` and `lis sync` maintain them",
+        )
+}
+
+pub fn script_undeclared_dependency(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Undeclared Go dependency")
+        .with_resolve_code("script_undeclared_dependency")
+        .with_span_label(&span, "not in this script's dependency table")
+        .with_help("Declare the module that provides it in the `[dependencies.go]` table")
+}
+
+pub fn script_transitive_go_dependency(
+    go_pkg: &str,
+    importer: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Undeclared transitive Go dependency")
+        .with_resolve_code("script_transitive_go_dependency")
+        .with_span_label(&span, "not in this script's dependency table")
+        .with_help(format!(
+            "`{}` appears in `{}`'s API, so the `[dependencies.go]` table has to declare its module too",
+            go_pkg, importer
+        ))
+}
+
 pub fn undeclared_go_import(go_pkg: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Undeclared Go dependency")
         .with_resolve_code("undeclared_go_import")
@@ -265,11 +352,17 @@ pub fn missing_go_typedef(
     version: &str,
     replacement_path: Option<&str>,
     span: Span,
+    script: bool,
 ) -> LisetteDiagnostic {
     let help = if let Some(replacement_path) = replacement_path {
         format!(
             "Module `{}` is sourced via `replace` from `{}@{}` but has no typedef. Run `lis sync` to regenerate it.",
             module, replacement_path, version
+        )
+    } else if script {
+        format!(
+            "Module `{}` {} resolved but its typedef is missing. Run `lis run` or `lis build` on this file to generate it.",
+            module, version
         )
     } else if go_pkg == module {
         format!(
@@ -286,6 +379,23 @@ pub fn missing_go_typedef(
     LisetteDiagnostic::error("Missing Go typedef")
         .with_resolve_code("missing_go_typedef")
         .with_span_label(&span, "no .d.lis file found")
+        .with_help(help)
+}
+
+pub fn corrupt_go_typedef(go_pkg: &str, discarded: bool, script: bool) -> LisetteDiagnostic {
+    let regenerate = if script {
+        "Run `lis run` or `lis build` on this file again to regenerate it"
+    } else {
+        "Run `lis sync` to regenerate it"
+    };
+    let help = if discarded {
+        format!("The cached typedef has been discarded. {}", regenerate)
+    } else {
+        format!("Delete the cached typedef. {}", regenerate)
+    };
+
+    LisetteDiagnostic::error(format!("Corrupt Go typedef for `{}`", go_pkg))
+        .with_resolve_code("corrupt_go_typedef")
         .with_help(help)
 }
 
@@ -312,12 +422,26 @@ pub fn bindgen_failed(
     version: &str,
     stderr: &str,
     span: Span,
+    script: bool,
 ) -> LisetteDiagnostic {
     let trimmed = stderr.trim();
     let stderr_block = if trimmed.is_empty() {
         String::new()
     } else {
         format!("\n\n{}", trimmed)
+    };
+    let lead = if script {
+        String::new()
+    } else {
+        format!(
+            "Re-run with `lis bindgen {}` to inspect the failure in isolation.",
+            go_pkg
+        )
+    };
+    let help = match (lead.is_empty(), stderr_block.is_empty()) {
+        (true, true) => format!("Check that `{}` exists in {} {}", go_pkg, module, version),
+        (true, false) => trimmed.to_string(),
+        _ => format!("{}{}", lead, stderr_block),
     };
 
     LisetteDiagnostic::error(format!(
@@ -326,10 +450,7 @@ pub fn bindgen_failed(
     ))
     .with_resolve_code("bindgen_failed")
     .with_span_label(&span, "bindgen failed for this import")
-    .with_help(format!(
-        "Re-run with `lis bindgen {}` to inspect the failure in isolation.{}",
-        go_pkg, stderr_block
-    ))
+    .with_help(help)
 }
 
 pub fn unreachable_package(package_id: &str) -> LisetteDiagnostic {
@@ -389,7 +510,8 @@ mod tests {
 
     #[test]
     fn invalid_package_path_suggests_go_import_for_go_shaped_path() {
-        let diagnostic = invalid_package_path("github.com/gorilla/mux", Span::new(0, 0, 1), false);
+        let diagnostic =
+            invalid_package_path("github.com/gorilla/mux", Span::new(0, 0, 1), false, false);
         let help = diagnostic.plain_help().unwrap_or_default();
         assert!(help.contains("import \"go:github.com/gorilla/mux\""));
         assert!(help.contains("lis add gorilla/mux"));
@@ -397,7 +519,8 @@ mod tests {
 
     #[test]
     fn invalid_package_path_preserves_blank_alias_in_suggestion() {
-        let diagnostic = invalid_package_path("github.com/gorilla/mux", Span::new(0, 0, 1), true);
+        let diagnostic =
+            invalid_package_path("github.com/gorilla/mux", Span::new(0, 0, 1), true, false);
         let help = diagnostic.plain_help().unwrap_or_default();
         assert!(
             help.contains("import _ \"go:github.com/gorilla/mux\""),
@@ -408,10 +531,45 @@ mod tests {
 
     #[test]
     fn invalid_package_path_keeps_full_path_for_non_github_host() {
-        let diagnostic = invalid_package_path("go.uber.org/zap", Span::new(0, 0, 1), false);
+        let diagnostic = invalid_package_path("go.uber.org/zap", Span::new(0, 0, 1), false, false);
         let help = diagnostic.plain_help().unwrap_or_default();
         assert!(help.contains("import \"go:go.uber.org/zap\""));
         assert!(help.contains("lis add go.uber.org/zap"));
+    }
+
+    #[test]
+    fn an_undeclared_dependency_points_at_the_table() {
+        let direct = script_undeclared_dependency(Span::new(0, 0, 1));
+        assert!(
+            direct
+                .plain_help()
+                .unwrap_or_default()
+                .contains("[dependencies.go]")
+        );
+
+        let transitive = script_transitive_go_dependency(
+            "github.com/spf13/pflag",
+            "github.com/spf13/cobra",
+            Span::new(0, 0, 1),
+        );
+        let help = transitive.plain_help().unwrap_or_default();
+        assert!(help.contains("[dependencies.go]"), "help was: {}", help);
+        assert!(
+            help.contains("github.com/spf13/cobra"),
+            "help was: {}",
+            help
+        );
+    }
+
+    #[test]
+    fn invalid_package_path_points_a_script_at_its_table() {
+        let diagnostic =
+            invalid_package_path("github.com/gorilla/mux", Span::new(0, 0, 1), false, true);
+        let help = diagnostic.plain_help().unwrap_or_default();
+
+        assert!(help.contains("import \"go:github.com/gorilla/mux\""));
+        assert!(help.contains("[dependencies.go]"), "help was: {}", help);
+        assert!(!help.contains("lis add"), "help was: {}", help);
     }
 
     #[test]
@@ -425,7 +583,7 @@ mod tests {
     #[test]
     fn invalid_package_path_keeps_folder_help_for_relative_path() {
         for path in ["./sub", "../sub"] {
-            let diagnostic = invalid_package_path(path, Span::new(0, 0, 1), false);
+            let diagnostic = invalid_package_path(path, Span::new(0, 0, 1), false, false);
             let help = diagnostic.plain_help().unwrap_or_default();
             assert!(help.contains("Relative-path syntax"), "help was: {}", help);
         }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -147,6 +147,20 @@ impl SharedState {
             }
         };
 
+        let script_path = uri.to_file_path().ok();
+        let script_setup = self
+            .bindgen_setup
+            .as_ref()
+            .filter(|_| script && manifest_error.is_none())
+            .zip(script_path.as_deref());
+        let (locator, script_session, script_error) = match script_setup {
+            Some((setup, path)) => match setup.for_script(&source, path) {
+                Ok((resolved, session)) => (resolved, session, None),
+                Err(msg) => (locator, None, Some(msg)),
+            },
+            None => (locator, None, None),
+        };
+
         // No bindgen runner on this copy: a keystroke must never shell out to Go.
         let packages = PackageResolver::new(locator.clone(), Arc::clone(&self.packages));
 
@@ -213,6 +227,16 @@ impl SharedState {
             analysis.push_error(LisetteDiagnostic::error(msg).with_resolve_code("manifest_error"));
         }
 
+        if let Some(msg) = script_error {
+            analysis.push_error(
+                LisetteDiagnostic::error(format!(
+                    "Could not resolve this script's dependencies: {}",
+                    msg
+                ))
+                .with_resolve_code("script_setup_failed"),
+            );
+        }
+
         if let Some(msg) = bindgen_error {
             analysis.push_error(
                 LisetteDiagnostic::error(format!(
@@ -225,6 +249,7 @@ impl SharedState {
 
         // Release the target lock before the lock-free snapshot construction.
         drop(session);
+        drop(script_session);
 
         Ok(AnalysisSnapshot::new(
             analysis,

--- a/crates/lsp/src/imports.rs
+++ b/crates/lsp/src/imports.rs
@@ -322,11 +322,19 @@ fn header_end(source: &str) -> u32 {
     for line in source.split_inclusive('\n') {
         let trimmed = line.trim();
         if !trimmed.is_empty() && !trimmed.starts_with("//") && !trimmed.starts_with("#!") {
-            return block_start(source, offset as u32, declaration_comment);
+            return block_start(source, offset as u32, declaration_comment).max(table_end(source));
         }
         offset += line.len();
     }
     offset as u32
+}
+
+fn table_end(source: &str) -> u32 {
+    syntax::dependency_block::scan_dependency_blocks(source, 0)
+        .iter()
+        .map(|block| block.span.byte_offset + block.span.byte_length)
+        .max()
+        .unwrap_or(0)
 }
 
 /// A blank line ends the block, and a shebang or file comment is never crossed.
@@ -442,6 +450,28 @@ mod tests {
     #[test]
     fn an_empty_file_takes_the_import_without_a_trailing_blank_line() {
         assert_eq!(with_import("strings", ""), "import \"go:strings\"\n");
+    }
+
+    #[test]
+    fn the_import_goes_below_the_dependency_table() {
+        assert_eq!(
+            with_import(
+                "strings",
+                "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n\nfn main() {}\n"
+            ),
+            "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n\nimport \"go:strings\"\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn the_import_goes_below_a_dependency_table_with_no_blank_line() {
+        assert_eq!(
+            with_import(
+                "strings",
+                "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\nfn main() {}\n"
+            ),
+            "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\nimport \"go:strings\"\n\nfn main() {}\n"
+        );
     }
 
     #[test]

--- a/crates/lsp/src/project.rs
+++ b/crates/lsp/src/project.rs
@@ -26,7 +26,12 @@ impl ProjectConfig {
 }
 
 pub(crate) fn find_project_root(start_path: &Path) -> Option<ProjectConfig> {
-    deps::find_project_root(start_path).map(ProjectConfig::Workspace)
+    let root = deps::find_project_root(start_path)?;
+    let belongs = start_path.extension().is_some_and(|ext| ext == "lis")
+        && start_path
+            .strip_prefix(&root)
+            .is_ok_and(|relative| relative.starts_with("src") || relative.starts_with("tests"));
+    belongs.then_some(ProjectConfig::Workspace(root))
 }
 
 pub(crate) fn resolve_script_root(file_path: &Path) -> ProjectConfig {

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -329,7 +329,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     store.init_entry_package();
     let entry = register_entry_file(&mut store, &sink, input.entry, include_tests);
     if entry.parse.is_failed() {
-        let checker = TaskState::with_sink(sink, input.project_kind);
+        let checker = TaskState::with_sink(sink, input.project_kind, input.scope.script_unit());
         return InferenceOutput {
             store,
             facts: checker.facts,

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -115,7 +115,8 @@ pub(super) fn infer_all_packages(
     store: &mut Store,
     mut input: PackageInferenceInput,
 ) -> PackageInferenceOutput {
-    let mut checker = TaskState::with_sink(input.sink, input.project_kind);
+    let mut checker =
+        TaskState::with_sink(input.sink, input.project_kind, input.scope.script_unit());
 
     let mut package_hashes: HashMap<String, u64> = HashMap::default();
     let mut cached_packages: HashSet<String> = HashSet::default();
@@ -394,12 +395,12 @@ fn register_go_package(
             emit_for_locator_result(
                 &other,
                 &GoImportSite {
-                    import_name: package_id,
                     go_pkg,
                     name_span: None,
                     target: locator.target(),
                     script,
                     replace_importer: None,
+                    transitive_importer: None,
                 },
                 &checker.sink,
             );

--- a/crates/semantics/src/checker/registration/go.rs
+++ b/crates/semantics/src/checker/registration/go.rs
@@ -30,9 +30,16 @@ impl TaskState {
 
         let build_result = syntax::build_ast(source, file_id);
         if build_result.failed() {
-            for error in &build_result.errors {
-                eprintln!("bindgen: error parsing {}: {:?}", filename, error);
-            }
+            let discarded = cache_path.as_deref().is_some_and(|path| {
+                locator.discard_typedef(path);
+                !path.exists()
+            });
+            self.sink
+                .push(diagnostics::package_graph::corrupt_go_typedef(
+                    package_id.strip_prefix("go:").unwrap_or(package_id),
+                    discarded,
+                    self.script.is_some(),
+                ));
         }
 
         let file = File {
@@ -86,12 +93,12 @@ impl TaskState {
                         emit_for_locator_result(
                             &other,
                             &GoImportSite {
-                                import_name: &import.name,
                                 go_pkg,
                                 name_span: Some(import.name_span),
                                 target: locator.target(),
-                                script: None,
+                                script: self.script,
                                 replace_importer,
+                                transitive_importer: package_id.strip_prefix("go:"),
                             },
                             &self.sink,
                         );

--- a/crates/semantics/src/checker/state.rs
+++ b/crates/semantics/src/checker/state.rs
@@ -43,6 +43,7 @@ pub(crate) struct TaskOutput {
 pub(crate) struct TaskSeed {
     binding_ids: Arc<BindingIdAllocator>,
     project_kind: crate::analysis::ProjectKind,
+    script: Option<crate::analysis::ScriptUnit>,
 }
 
 impl TaskSeed {
@@ -51,6 +52,7 @@ impl TaskSeed {
             self.binding_ids.clone(),
             LocalSink::new(),
             self.project_kind,
+            self.script,
         )
     }
 }
@@ -64,6 +66,7 @@ pub struct TaskState {
     pub sink: LocalSink,
     pub facts: Facts,
     pub(crate) project_kind: crate::analysis::ProjectKind,
+    pub(crate) script: Option<crate::analysis::ScriptUnit>,
     /// Recursion guard for interface satisfaction. Prevents
     /// `collect_interface_violations` from diverging when a bound on `T`
     /// transitively requires checking `T` against the same interface.
@@ -83,6 +86,7 @@ impl TaskState {
         binding_ids: Arc<BindingIdAllocator>,
         sink: LocalSink,
         project_kind: crate::analysis::ProjectKind,
+        script: Option<crate::analysis::ScriptUnit>,
     ) -> Self {
         Self {
             env: TypeEnv::new(),
@@ -92,6 +96,7 @@ impl TaskState {
             sink,
             facts: Facts::new(binding_ids),
             project_kind,
+            script,
             satisfying_stack: rustc_hash::FxHashSet::default(),
             inferred_files: Vec::new(),
             pending_equality_attributes: Vec::new(),
@@ -105,11 +110,21 @@ impl TaskState {
             Arc::new(BindingIdAllocator::new()),
             LocalSink::new(),
             crate::analysis::ProjectKind::Binary,
+            None,
         )
     }
 
-    pub(crate) fn with_sink(sink: LocalSink, project_kind: crate::analysis::ProjectKind) -> Self {
-        Self::new(Arc::new(BindingIdAllocator::new()), sink, project_kind)
+    pub(crate) fn with_sink(
+        sink: LocalSink,
+        project_kind: crate::analysis::ProjectKind,
+        script: Option<crate::analysis::ScriptUnit>,
+    ) -> Self {
+        Self::new(
+            Arc::new(BindingIdAllocator::new()),
+            sink,
+            project_kind,
+            script,
+        )
     }
 
     pub(crate) fn with_scope<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
@@ -123,6 +138,7 @@ impl TaskState {
         TaskSeed {
             binding_ids: self.facts.allocator(),
             project_kind: self.project_kind,
+            script: self.script,
         }
     }
 
@@ -135,6 +151,7 @@ impl TaskState {
             sink,
             facts,
             project_kind: _,
+            script: _,
             satisfying_stack: _,
             inferred_files,
             pending_equality_attributes,

--- a/crates/semantics/src/diagnostics.rs
+++ b/crates/semantics/src/diagnostics.rs
@@ -13,7 +13,6 @@ pub(crate) enum ReplaceImporter<'a> {
 
 /// The import site a typedef-resolution diagnostic refers to.
 pub(crate) struct GoImportSite<'a> {
-    pub(crate) import_name: &'a str,
     pub(crate) go_pkg: &'a str,
     pub(crate) name_span: Option<Span>,
     pub(crate) target: Target,
@@ -21,6 +20,7 @@ pub(crate) struct GoImportSite<'a> {
     /// Set when reached through a replaced module's typedef, so the hint names
     /// the right reconciliation command.
     pub(crate) replace_importer: Option<ReplaceImporter<'a>>,
+    pub(crate) transitive_importer: Option<&'a str>,
 }
 
 pub(crate) fn emit_for_locator_result(
@@ -29,21 +29,28 @@ pub(crate) fn emit_for_locator_result(
     sink: &LocalSink,
 ) -> bool {
     let GoImportSite {
-        import_name,
         go_pkg,
         name_span,
         target,
         script,
         replace_importer,
+        transitive_importer,
     } = *site;
     let span = name_span.unwrap_or_else(|| Span::new(0, 0, 0));
     match result {
         TypedefLocatorResult::Found { .. } => return true,
         TypedefLocatorResult::UnknownStdlib => {
-            emit_unknown_stdlib(import_name, go_pkg, span, target, script, sink);
+            emit_unknown_stdlib(go_pkg, span, target, script, sink);
         }
         TypedefLocatorResult::UndeclaredImport => {
-            emit_undeclared(import_name, go_pkg, span, script, replace_importer, sink);
+            emit_undeclared(
+                go_pkg,
+                span,
+                script,
+                replace_importer,
+                transitive_importer,
+                sink,
+            );
         }
         TypedefLocatorResult::InternalPackage { module } => {
             sink.push(diagnostics::package_graph::internal_go_package(
@@ -67,6 +74,7 @@ pub(crate) fn emit_for_locator_result(
                     version,
                     replacement_path.as_deref(),
                     span,
+                    script.is_some(),
                 ));
             }
         }
@@ -88,7 +96,12 @@ pub(crate) fn emit_for_locator_result(
             }
             BindgenFailure::InvocationFailed { stderr } => {
                 sink.push(diagnostics::package_graph::bindgen_failed(
-                    go_pkg, module, version, stderr, span,
+                    go_pkg,
+                    module,
+                    version,
+                    stderr,
+                    span,
+                    script.is_some(),
                 ));
             }
         },
@@ -103,11 +116,11 @@ pub(crate) fn emit_for_declaration_status(
     sink: &LocalSink,
 ) -> bool {
     let GoImportSite {
-        import_name,
         go_pkg,
         name_span,
         target,
         script,
+        transitive_importer,
         ..
     } = *site;
     let span = name_span.unwrap_or_else(|| Span::new(0, 0, 0));
@@ -117,11 +130,11 @@ pub(crate) fn emit_for_declaration_status(
         | DeclarationStatus::DeclaredReplacement { .. }
         | DeclarationStatus::DeclaredLocal { .. } => true,
         DeclarationStatus::UnknownStdlib => {
-            emit_unknown_stdlib(import_name, go_pkg, span, target, script, sink);
+            emit_unknown_stdlib(go_pkg, span, target, script, sink);
             false
         }
         DeclarationStatus::UndeclaredImport => {
-            emit_undeclared(import_name, go_pkg, span, script, None, sink);
+            emit_undeclared(go_pkg, span, script, None, transitive_importer, sink);
             false
         }
         DeclarationStatus::InternalPackage { module } => {
@@ -134,7 +147,6 @@ pub(crate) fn emit_for_declaration_status(
 }
 
 fn emit_unknown_stdlib(
-    import_name: &str,
     go_pkg: &str,
     span: Span,
     target: Target,
@@ -149,34 +161,29 @@ fn emit_unknown_stdlib(
             span,
         ));
     } else {
-        sink.push(diagnostics::package_graph::package_not_found(
-            import_name,
+        sink.push(diagnostics::package_graph::unknown_go_stdlib_package(
+            go_pkg,
             span,
-            match script {
-                Some(unit) => diagnostics::package_graph::MissingPackageReason::Script {
-                    inside_project: unit.inside_project,
-                },
-                None => diagnostics::package_graph::MissingPackageReason::NotFound,
-            },
+            script.is_some(),
         ));
     }
 }
 
 fn emit_undeclared(
-    import_name: &str,
     go_pkg: &str,
     span: Span,
     script: Option<ScriptUnit>,
     replace_importer: Option<ReplaceImporter>,
+    transitive_importer: Option<&str>,
     sink: &LocalSink,
 ) {
-    if let Some(unit) = script {
-        sink.push(diagnostics::package_graph::package_not_found(
-            import_name,
+    if let (Some(_), Some(importer)) = (script, transitive_importer) {
+        sink.push(diagnostics::package_graph::script_transitive_go_dependency(
+            go_pkg, importer, span,
+        ));
+    } else if script.is_some() {
+        sink.push(diagnostics::package_graph::script_undeclared_dependency(
             span,
-            diagnostics::package_graph::MissingPackageReason::Script {
-                inside_project: unit.inside_project,
-            },
         ));
     } else if let Some(ReplaceImporter::Module(replaced_module)) = replace_importer {
         sink.push(

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -315,13 +315,28 @@ impl<'a> GraphBuilder<'a> {
 
             for package_id in &batch {
                 let package_files = scanned.remove(package_id).unwrap_or_default();
+                let stored = self.store.get_package(package_id);
                 let file_imports = if !package_files.is_empty() {
                     classify_scanned_imports(&package_files)
-                } else if let Some(package) = self.store.get_package(package_id) {
+                } else if let Some(package) = stored {
                     classify_file_imports(package.files.values())
                 } else {
                     Vec::new()
                 };
+
+                let sources: Vec<(u32, &str)> = if !package_files.is_empty() {
+                    package_files
+                        .iter()
+                        .map(|file| (file.file_id, file.source.as_str()))
+                        .collect()
+                } else {
+                    stored
+                        .into_iter()
+                        .flat_map(|package| package.files.values())
+                        .map(|file| (file.id, file.source.as_str()))
+                        .collect()
+                };
+                check_dependency_blocks(&sources, self.scope, self.sink);
                 let root_has_production = self
                     .files
                     .get(ENTRY_PACKAGE_ID)
@@ -576,6 +591,100 @@ struct ImportContext<'a> {
     locator: &'a TypedefLocator,
 }
 
+fn check_import_paths<'a>(
+    file_imports: &'a [ClassifiedImport],
+    sink: &LocalSink,
+) -> HashSet<&'a str> {
+    let mut unresolvable = HashSet::default();
+
+    for classified in file_imports {
+        let file_import = &classified.import;
+        let Some(go_pkg) = file_import.name.strip_prefix("go:") else {
+            continue;
+        };
+
+        if go_pkg.is_empty() {
+            sink.push(diagnostics::package_graph::empty_import_path(
+                file_import.name_span,
+            ));
+            unresolvable.insert(file_import.name.as_str());
+            continue;
+        }
+
+        if !deps::is_valid_package_path(go_pkg) {
+            sink.push(diagnostics::package_graph::invalid_go_package_path(
+                go_pkg,
+                file_import.name_span,
+            ));
+            unresolvable.insert(file_import.name.as_str());
+            continue;
+        }
+    }
+
+    unresolvable
+}
+
+pub(crate) fn check_dependency_blocks(
+    sources: &[(u32, &str)],
+    scope: &AnalysisScope,
+    sink: &LocalSink,
+) {
+    let script = scope.script_unit().is_some();
+
+    for (file_id, source) in sources {
+        let blocks = syntax::dependency_block::scan_dependency_blocks(source, *file_id);
+        let Some((first, rest)) = blocks.split_first() else {
+            continue;
+        };
+        for extra in rest {
+            sink.push(diagnostics::package_graph::duplicate_dependency_table(
+                extra.span,
+            ));
+        }
+        if !script {
+            sink.push(diagnostics::package_graph::dependency_table_in_project(
+                first.span,
+            ));
+            continue;
+        }
+
+        let table = match deps::parse_dependency_table(&first.text) {
+            Ok(table) => table,
+            Err(error) => {
+                let span = error
+                    .range
+                    .map_or(first.span, |range| first.map_span(range, *file_id));
+                sink.push(diagnostics::package_graph::invalid_dependency_table(
+                    &error.message,
+                    span,
+                ));
+                continue;
+            }
+        };
+
+        for (module_path, dep) in &table.deps {
+            if let Err(message) = deps::validate_script_entry(module_path, dep) {
+                let span = entry_span(first, &table, module_path, *file_id);
+                sink.push(diagnostics::package_graph::invalid_dependency_table(
+                    &message, span,
+                ));
+            }
+        }
+    }
+}
+
+fn entry_span(
+    block: &syntax::dependency_block::DependencyBlock,
+    table: &deps::DependencyTable,
+    module_path: &str,
+    file_id: u32,
+) -> Span {
+    match table.spans.get(module_path) {
+        Some(range) => block.map_span(range.clone(), file_id),
+        None => block.span,
+    }
+}
+
 fn process_file_imports(
     file_imports: Vec<ClassifiedImport>,
     ctx: ImportContext<'_>,
@@ -588,6 +697,8 @@ fn process_file_imports(
         project_kind,
         locator,
     } = ctx;
+    let unresolvable = check_import_paths(&file_imports, sink);
+
     let mut imports = HashMap::default();
     let mut pending_go_imports: HashMap<&str, Dependency> = HashMap::default();
     for classified in &file_imports {
@@ -684,18 +795,21 @@ fn process_file_imports(
             let Some(pending) = pending_go_imports.remove(file_import.name.as_str()) else {
                 continue;
             };
+            if unresolvable.contains(file_import.name.as_str()) {
+                continue;
+            }
             let ok = match pending.usage {
                 ImportUse::Referenced => {
                     let result = locator.find_typedef_content(go_pkg);
                     emit_for_locator_result(
                         &result,
                         &GoImportSite {
-                            import_name: &file_import.name,
                             go_pkg,
                             name_span: Some(pending.span),
                             target: locator.target(),
                             script: scope.script_unit(),
                             replace_importer: None,
+                            transitive_importer: None,
                         },
                         sink,
                     )
@@ -705,12 +819,12 @@ fn process_file_imports(
                     emit_for_declaration_status(
                         &status,
                         &GoImportSite {
-                            import_name: &file_import.name,
                             go_pkg,
                             name_span: Some(pending.span),
                             target: locator.target(),
                             script: scope.script_unit(),
                             replace_importer: None,
+                            transitive_importer: None,
                         },
                         sink,
                     )
@@ -742,6 +856,7 @@ fn process_file_imports(
                 &file_import.name,
                 file_import.name_span,
                 blank_span.is_some(),
+                scope.script_unit().is_some(),
             ));
         }
         if let Some(span) = blank_span
@@ -806,7 +921,6 @@ mod tests {
             },
         );
 
-        assert!(!sink.has_errors());
         resolved
             .get("go:fmt")
             .is_some_and(|dependency| dependency.usage == ImportUse::LinkOnly)

--- a/crates/syntax/src/dependency_block.rs
+++ b/crates/syntax/src/dependency_block.rs
@@ -1,0 +1,233 @@
+//! Finds a script's `[dependencies.go]` table, written as `//` comments the
+//! lexer never sees. Line offsets are kept, for mapping a TOML error back.
+
+use crate::ast::Span;
+
+pub const HEADER: &str = "[dependencies.go]";
+
+#[derive(Debug, Clone)]
+pub struct DependencyBlock {
+    pub text: String,
+    line_starts: Vec<u32>,
+    pub span: Span,
+}
+
+impl DependencyBlock {
+    pub fn map_span(&self, range: std::ops::Range<usize>, file_id: u32) -> Span {
+        let Some(line) = self.line_of(range.start) else {
+            return self.span;
+        };
+        let column = (range.start - self.line_offset(line)) as u32;
+        let line_end = self.text[range.start..]
+            .find('\n')
+            .map_or(self.text.len(), |offset| range.start + offset);
+        let length = (range.end.min(line_end).saturating_sub(range.start)).max(1) as u32;
+        Span::new(file_id, self.line_starts[line] + column, length)
+    }
+
+    fn line_of(&self, byte: usize) -> Option<usize> {
+        if byte > self.text.len() {
+            return None;
+        }
+        let count = self.text[..byte].bytes().filter(|&b| b == b'\n').count();
+        (count < self.line_starts.len()).then_some(count)
+    }
+
+    fn line_offset(&self, line: usize) -> usize {
+        self.text
+            .split_inclusive('\n')
+            .take(line)
+            .map(str::len)
+            .sum()
+    }
+}
+
+pub fn scan_dependency_blocks(source: &str, file_id: u32) -> Vec<DependencyBlock> {
+    let mut blocks = Vec::new();
+    let mut offset = prologue_start(source);
+
+    while offset < source.len() {
+        let line = line_at(source, offset);
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+
+        if trimmed.trim().is_empty() {
+            offset += line.len();
+            continue;
+        }
+        if trimmed.starts_with("//!") {
+            offset += line.len();
+            continue;
+        }
+        if !trimmed.starts_with("//") {
+            break;
+        }
+        match comment_content(trimmed).map(str::trim) {
+            Some(HEADER) => {
+                let block = take_block(source, offset, file_id);
+                offset = block.span.byte_offset as usize + block.span.byte_length as usize;
+                blocks.push(block);
+            }
+            _ => offset += line.len(),
+        }
+    }
+    blocks
+}
+
+/// Minus the prefix and at most one space. A wider indent TOML tolerates.
+fn comment_content(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("//")?;
+    if rest.starts_with("!") {
+        return None;
+    }
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
+}
+
+/// From the header to the first line that is not a plain `//` comment.
+fn take_block(source: &str, start: usize, file_id: u32) -> DependencyBlock {
+    let mut text = String::new();
+    let mut line_starts = Vec::new();
+    let mut offset = start;
+
+    while offset < source.len() {
+        let line = line_at(source, offset);
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        let Some(content) = comment_content(trimmed) else {
+            break;
+        };
+
+        let prefix = trimmed.len() - content.len();
+        line_starts.push((offset + prefix) as u32);
+        text.push_str(content);
+        text.push('\n');
+        offset += line.len();
+    }
+
+    DependencyBlock {
+        text,
+        line_starts,
+        span: Span::new(file_id, start as u32, (offset - start) as u32),
+    }
+}
+
+fn line_at(source: &str, offset: usize) -> &str {
+    let rest = &source[offset..];
+    match rest.find('\n') {
+        Some(end) => &rest[..end + 1],
+        None => rest,
+    }
+}
+
+fn prologue_start(source: &str) -> usize {
+    let bom = crate::lex::bom_len(source);
+    bom + crate::lex::shebang_len(&source[bom..]).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn only(source: &str) -> DependencyBlock {
+        let mut blocks = scan_dependency_blocks(source, 0);
+        assert_eq!(blocks.len(), 1, "expected one block in {source:?}");
+        blocks.remove(0)
+    }
+
+    #[test]
+    fn reads_a_table_after_a_shebang() {
+        let source = "#!/usr/bin/env lis\n\n// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n\nimport \"go:fmt\"\n";
+        let block = only(source);
+
+        assert_eq!(block.text, "[dependencies.go]\n\"x.y/z\" = \"v1.0.0\"\n");
+    }
+
+    #[test]
+    fn the_header_is_recognised_whatever_surrounds_it() {
+        for header in [
+            "// [dependencies.go]",
+            "//[dependencies.go]",
+            "//   [dependencies.go]",
+            "// [dependencies.go]   ",
+            "//\t[dependencies.go]\t",
+        ] {
+            let source = format!("{}\n// \"x.y/z\" = \"v1.0.0\"\n", header);
+            let blocks = scan_dependency_blocks(&source, 0);
+
+            assert_eq!(blocks.len(), 1, "not found in {header:?}");
+            assert!(blocks[0].text.contains("x.y/z"), "empty in {header:?}");
+        }
+    }
+
+    #[test]
+    fn reads_a_table_with_no_shebang_and_no_leading_space() {
+        let source = "//[dependencies.go]\n//\"x.y/z\" = \"v1.0.0\"\n";
+        let block = only(source);
+
+        assert_eq!(block.text, "[dependencies.go]\n\"x.y/z\" = \"v1.0.0\"\n");
+    }
+
+    #[test]
+    fn a_blank_line_ends_the_block() {
+        let source =
+            "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n\n// \"x.y/w\" = \"v2.0.0\"\n";
+        let block = only(source);
+
+        assert!(!block.text.contains("x.y/w"));
+    }
+
+    #[test]
+    fn a_file_doc_comment_does_not_open_or_extend_a_block() {
+        let source =
+            "//! A script.\n// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n//! trailing\n";
+        let block = only(source);
+
+        assert_eq!(block.text, "[dependencies.go]\n\"x.y/z\" = \"v1.0.0\"\n");
+    }
+
+    #[test]
+    fn a_comment_after_code_is_not_a_block() {
+        let source = "import \"go:fmt\"\n\n// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n";
+
+        assert!(scan_dependency_blocks(source, 0).is_empty());
+    }
+
+    #[test]
+    fn two_blocks_are_both_returned() {
+        let source = "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\n\n// [dependencies.go]\n// \"x.y/w\" = \"v2.0.0\"\n";
+
+        assert_eq!(scan_dependency_blocks(source, 0).len(), 2);
+    }
+
+    #[test]
+    fn maps_a_toml_range_back_to_the_source() {
+        let source = "#!/usr/bin/env lis\n\n// [dependencies.go]\n//   \"x.y/z\" = \"bad\"\n";
+        let block = only(source);
+        let value = block.text.find("\"bad\"").unwrap();
+        let span = block.map_span(value..value + 5, 0);
+
+        let start = span.byte_offset as usize;
+        assert_eq!(&source[start..start + span.byte_length as usize], "\"bad\"");
+    }
+
+    #[test]
+    fn a_range_crossing_a_line_break_stops_at_the_break() {
+        let source = "// [dependencies.go]\n// \"x.y/z\" = [\n//   1, 2,\n";
+        let block = only(source);
+        let entry = block.text.find("\"x.y/z\"").unwrap();
+        let span = block.map_span(entry..block.text.len(), 0);
+
+        let start = span.byte_offset as usize;
+        let underlined = &source[start..start + span.byte_length as usize];
+        assert_eq!(underlined, "\"x.y/z\" = [");
+    }
+
+    #[test]
+    fn the_span_covers_the_whole_block() {
+        let source = "// [dependencies.go]\n// \"x.y/z\" = \"v1.0.0\"\nimport \"go:fmt\"\n";
+        let block = only(source);
+        let start = block.span.byte_offset as usize;
+        let text = &source[start..start + block.span.byte_length as usize];
+
+        assert!(text.starts_with("// [dependencies.go]"));
+        assert!(text.trim_end().ends_with("\"v1.0.0\""));
+    }
+}

--- a/crates/syntax/src/imports.rs
+++ b/crates/syntax/src/imports.rs
@@ -49,8 +49,9 @@ impl<'source> Scanner<'source> {
     }
 
     fn skip_shebang(&mut self) {
-        if let Some(length) = crate::lex::shebang_len(self.source) {
-            self.offset = length;
+        self.offset = crate::lex::bom_len(self.source);
+        if let Some(length) = crate::lex::shebang_len(&self.source[self.offset..]) {
+            self.offset += length;
         }
     }
 

--- a/crates/syntax/src/lex/mod.rs
+++ b/crates/syntax/src/lex/mod.rs
@@ -10,6 +10,15 @@ mod errors;
 mod token;
 mod types;
 
+pub(crate) fn bom_len(source: &str) -> usize {
+    const BOM: char = '\u{feff}';
+    if source.starts_with(BOM) {
+        BOM.len_utf8()
+    } else {
+        0
+    }
+}
+
 pub(crate) fn shebang_len(source: &str) -> Option<usize> {
     let rest = source.strip_prefix("#!")?;
     if matches!(rest.as_bytes().first()?, b'[' | b'\r' | b'\n') {
@@ -48,6 +57,7 @@ impl<'source> Lexer<'source> {
 
     pub fn lex(mut self) -> LexResult<'source> {
         let mut tokens = Vec::new();
+        self.current_offset = bom_len(self.input);
 
         if let Some(shebang) = self.lex_shebang() {
             tokens.push(shebang);
@@ -1247,13 +1257,14 @@ impl<'source> Lexer<'source> {
     }
 
     fn lex_shebang(&mut self) -> Option<Token<'source>> {
-        let length = shebang_len(self.input)?;
-        self.current_offset = length;
+        let start = self.current_offset;
+        let length = shebang_len(&self.input[start..])?;
+        self.current_offset = start + length;
 
         Some(Token {
             kind: TokenKind::Shebang,
-            text: &self.input[..length],
-            byte_offset: 0,
+            text: &self.input[start..start + length],
+            byte_offset: start as u32,
             byte_length: length as u32,
         })
     }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod ast;
 pub mod attributes;
 pub mod containment;
+pub mod dependency_block;
 mod display;
 pub mod go_names;
 pub mod imports;

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -211,7 +211,50 @@ impl File {
 
 #[cfg(test)]
 mod tests {
-    use super::go_import_default_name;
+    use super::{FileImport, Span, go_import_default_name};
+    use crate::ast::ImportAlias;
+
+    fn import(raw: &str) -> FileImport {
+        let span = Span::new(0, 7, raw.len() as u32 + 2);
+        FileImport {
+            name: raw.into(),
+            name_span: span,
+            alias: None,
+            span,
+        }
+    }
+
+    #[test]
+    fn an_import_path_is_kept_whole() {
+        assert_eq!(
+            import("go:github.com/google/uuid").name,
+            "go:github.com/google/uuid"
+        );
+        assert_eq!(
+            import("go:github.com/google/uuid@v1.6.0").name,
+            "go:github.com/google/uuid@v1.6.0"
+        );
+        assert_eq!(import("helper@v1.0.0").name, "helper@v1.0.0");
+    }
+
+    #[test]
+    fn a_blank_alias_is_preserved() {
+        let span = Span::new(0, 0, 1);
+        let blank = FileImport {
+            name: "go:fmt".into(),
+            name_span: span,
+            alias: Some(ImportAlias::Blank(span)),
+            span,
+        };
+
+        assert!(matches!(blank.alias, Some(ImportAlias::Blank(_))));
+    }
+
+    #[test]
+    fn default_names_come_from_the_last_segment() {
+        assert_eq!(go_import_default_name("go:github.com/google/uuid"), "uuid");
+        assert_eq!(go_import_default_name("go:encoding/json"), "json");
+    }
 
     #[test]
     fn major_version_suffix_resolves_to_preceding_segment() {

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -685,7 +685,7 @@ fn check_analyzes_tests_in_declaration_only_package() {
 }
 
 #[test]
-fn graph_script_third_party_go_import_uses_package_not_found() {
+fn graph_script_third_party_go_import_is_undeclared() {
     let mut fs = MockFileSystem::new();
     fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
 
@@ -699,7 +699,10 @@ fn graph_script_third_party_go_import_uses_package_not_found() {
     );
 
     assert!(sink.has_errors());
-    assert!(has_diagnostic_code(&sink, "resolve.package_not_found"));
+    assert!(has_diagnostic_code(
+        &sink,
+        "resolve.script_undeclared_dependency"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Script import resolution now works the same as a project's. A script can consume Go modules declared in a `[dependencies.go]` table in its prologue, and imports resolve as they do against a manifest in a project.