### PR TITLE
fix: prevent cascading parse errors from missing tokens

### DIFF
--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -54,6 +54,92 @@ struct TraversalContext {
     dot_access_base: bool,
     in_pattern: bool,
     let_binding_rhs: bool,
+    expectation: Option<Expectation>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct Expectation {
+    pub(super) role: ExpectationRole,
+    pub(super) span: Span,
+    pub(super) expected_ty: Type,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum ExpectationRole {
+    CallArgument {
+        callee_label: String,
+        index: usize,
+        parameter_name: Option<String>,
+    },
+    TailReturn {
+        function_name: String,
+        return_annotation_span: Span,
+    },
+    MatchArm,
+}
+
+impl Expectation {
+    pub(super) fn help(&self, expected_name: &str, actual_name: &str) -> String {
+        match &self.role {
+            ExpectationRole::CallArgument {
+                callee_label,
+                index,
+                parameter_name: Some(parameter_name),
+            } => format!(
+                "{} expects `{}` for its {} argument `{}`. Convert the value to `{}`, or change the parameter type.",
+                callee_label,
+                expected_name,
+                ordinal(*index),
+                parameter_name,
+                expected_name,
+            ),
+            ExpectationRole::CallArgument {
+                callee_label,
+                index,
+                parameter_name: None,
+            } => format!(
+                "{} expects `{}` for its {} argument. Convert the value to `{}`.",
+                callee_label,
+                expected_name,
+                ordinal(*index),
+                expected_name,
+            ),
+            ExpectationRole::TailReturn { function_name, .. } => format!(
+                "`{}` declares return type `{}`, but this tail expression has type `{}`. Change the value, or declare `-> {}`.",
+                function_name, expected_name, actual_name, actual_name,
+            ),
+            ExpectationRole::MatchArm => format!(
+                "Every `match` arm must produce the same type. This arm produces `{}`, but the `match` is expected to produce `{}`.",
+                actual_name, expected_name,
+            ),
+        }
+    }
+}
+
+fn ordinal(n: usize) -> String {
+    let word = match n {
+        1 => "first",
+        2 => "second",
+        3 => "third",
+        4 => "fourth",
+        5 => "fifth",
+        6 => "sixth",
+        7 => "seventh",
+        8 => "eighth",
+        9 => "ninth",
+        10 => "tenth",
+        _ => {
+            let suffix = match (n % 100, n % 10) {
+                (11..=13, _) => "th",
+                (_, 1) => "st",
+                (_, 2) => "nd",
+                (_, 3) => "rd",
+                _ => "th",
+            };
+            return format!("{n}{suffix}");
+        }
+    };
+    word.to_string()
 }
 
 #[derive(Debug, Clone)]
@@ -217,6 +303,24 @@ impl<'a> InferCtx<'a> {
 
     pub(super) fn with_value_context<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         self.with_use_context(UseContext::Value, f)
+    }
+
+    pub(super) fn with_expectation<T>(
+        &mut self,
+        expectation: Expectation,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let previous = self.traversal.expectation.replace(expectation);
+        let result = f(self);
+        self.traversal.expectation = previous;
+        result
+    }
+
+    pub(super) fn expectation_at(&self, span: &Span) -> Option<&Expectation> {
+        self.traversal
+            .expectation
+            .as_ref()
+            .filter(|expectation| expectation.span == *span)
     }
 
     pub(super) fn with_dot_access_base<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {

--- a/crates/semantics/src/checker/infer/expressions/branches.rs
+++ b/crates/semantics/src/checker/infer/expressions/branches.rs
@@ -1,5 +1,5 @@
 use crate::checker::EnvResolve;
-use crate::checker::infer::context::{BranchArm, BranchSubsumption};
+use crate::checker::infer::context::{BranchArm, BranchSubsumption, Expectation, ExpectationRole};
 use syntax::ast::BindingKind;
 use syntax::ast::{Expression, IfLetAlternative, MatchArm, Pattern, Span};
 use syntax::types::Type;
@@ -379,6 +379,9 @@ impl InferCtx<'_> {
         let needs_reconciliation =
             !arms_independent && result_ty.resolve_in(&self.env).is_variable();
 
+        let frame_match_arm =
+            matches!(kind, MatchArmsKind::Match) && !arms_independent && !needs_reconciliation;
+
         let new_arms = arms
             .into_iter()
             .map(|a| {
@@ -398,7 +401,18 @@ impl InferCtx<'_> {
                         &result_ty
                     };
                     // Arm body is a tail-like context where Never calls are valid.
-                    let new_expression = this.infer_root_expression(*a.expression, arm_expected);
+                    let new_expression = if frame_match_arm {
+                        let expectation = Expectation {
+                            role: ExpectationRole::MatchArm,
+                            span: a.expression.get_span(),
+                            expected_ty: result_ty.clone(),
+                        };
+                        this.with_expectation(expectation, |this| {
+                            this.infer_root_expression(*a.expression, arm_expected)
+                        })
+                    } else {
+                        this.infer_root_expression(*a.expression, arm_expected)
+                    };
 
                     MatchArm {
                         pattern: new_pattern,

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -8,6 +8,7 @@ use syntax::types::{
     unqualified_name,
 };
 
+use super::super::context::{Expectation, ExpectationRole};
 use super::super::unify::Dispatched;
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
@@ -196,12 +197,13 @@ impl InferCtx<'_> {
 
         let substring_range_idx =
             self.substring_carve_out_param_idx(call_kind, &callee_expression, &parameters);
+        let variadic_start = variadic.as_ref().map(|variadic| variadic.first_index);
         let new_args = if let Some(idx) = substring_range_idx {
             let mut adjusted = parameters.clone();
             adjusted[idx] = adjusted[idx].with_type(self.new_type_var());
-            self.infer_call_arguments(args, &adjusted)
+            self.infer_call_arguments(args, &adjusted, variadic_start, &callee_expression)
         } else {
-            self.infer_call_arguments(args, &parameters)
+            self.infer_call_arguments(args, &parameters, variadic_start, &callee_expression)
         };
         self.check_call_arity(&parameters, &new_args, &callee_expression, &span);
         self.check_mut_param_arguments(&new_args, &parameters, &callee_expression);
@@ -954,15 +956,33 @@ impl InferCtx<'_> {
         &mut self,
         args: Vec<Expression>,
         parameters: &[FunctionParameter],
+        variadic_start: Option<usize>,
+        callee_expression: &Expression,
     ) -> Vec<Expression> {
+        let callee = callee_label(callee_expression);
         args.into_iter()
             .enumerate()
             .map(|(i, arg)| {
-                let expected_ty = parameters
-                    .get(i)
-                    .map(|param| param.ty.clone())
-                    .unwrap_or_else(|| self.new_type_var());
-                self.with_value_context(|s| s.infer_expression(arg, &expected_ty))
+                let Some(param) = parameters.get(i) else {
+                    let expected_ty = self.new_type_var();
+                    return self.with_value_context(|s| s.infer_expression(arg, &expected_ty));
+                };
+                let expected_ty = param.ty.clone();
+                if variadic_start.is_some_and(|start| i >= start) {
+                    return self.with_value_context(|s| s.infer_expression(arg, &expected_ty));
+                }
+                let expectation = Expectation {
+                    role: ExpectationRole::CallArgument {
+                        callee_label: callee.clone(),
+                        index: i + 1,
+                        parameter_name: param.name.as_ref().map(|name| name.to_string()),
+                    },
+                    span: arg.get_span(),
+                    expected_ty: expected_ty.clone(),
+                };
+                self.with_expectation(expectation, |s| {
+                    s.with_value_context(|s| s.infer_expression(arg, &expected_ty))
+                })
             })
             .collect()
     }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -4,6 +4,7 @@ use syntax::types::{FunctionParameter, Type};
 
 use crate::analysis::ProjectKind;
 use crate::checker::infer::InferCtx;
+use crate::checker::infer::context::{Expectation, ExpectationRole};
 use crate::checker::registration::test_functions::normalize_test_params;
 use crate::store::ENTRY_PACKAGE_ID;
 
@@ -123,7 +124,13 @@ impl InferCtx<'_> {
             };
 
             let new_body = body.map_definition(|body| {
-                this.infer_function_body(Box::new(body), &body_ty, &return_annotation, &return_ty)
+                this.infer_function_body(
+                    Box::new(body),
+                    &body_ty,
+                    &return_annotation,
+                    &return_ty,
+                    Some(name.as_str()),
+                )
             });
 
             this.check_deferred_map_key_bounds(store);
@@ -220,7 +227,7 @@ impl InferCtx<'_> {
                 return_ty.clone()
             };
             let new_body = this.without_enclosing_loop(|this| {
-                this.infer_function_body(body, &body_ty, &return_annotation, &return_ty)
+                this.infer_function_body(body, &body_ty, &return_annotation, &return_ty, None)
             });
 
             this.check_deferred_map_key_bounds(store);
@@ -244,6 +251,7 @@ impl InferCtx<'_> {
         body_ty: &Type,
         return_annotation: &Annotation,
         return_ty: &Type,
+        function_name: Option<&str>,
     ) -> Expression {
         if let Expression::Block {
             items,
@@ -264,6 +272,22 @@ impl InferCtx<'_> {
                 ty: self.type_unit(),
                 span: *body_span,
             };
+        }
+
+        if let Some(function_name) = function_name
+            && *return_annotation != Annotation::Unknown
+            && let Expression::Block { items, .. } = body.as_ref()
+            && let Some(tail) = items.last()
+        {
+            let expectation = Expectation {
+                role: ExpectationRole::TailReturn {
+                    function_name: function_name.to_string(),
+                    return_annotation_span: return_annotation.get_span(),
+                },
+                span: tail.get_span(),
+                expected_ty: body_ty.clone(),
+            };
+            return self.with_expectation(expectation, |s| s.infer_expression(*body, body_ty));
         }
 
         self.infer_expression(*body, body_ty)

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -601,6 +601,7 @@ impl InferCtx<'_> {
         FindDef: FnMut(&mut Self, &StructFieldAssignment) -> Option<&'a Type>,
     {
         let mut matched = HashSet::default();
+        let mut unknown_fields: Vec<EcoString> = vec![];
         let new_assignments: Vec<StructFieldAssignment> = ctx
             .field_assignments
             .iter()
@@ -613,6 +614,7 @@ impl InferCtx<'_> {
                     None => {
                         let available: Vec<String> =
                             ctx.all_fields.clone().map(|(n, _)| n.to_string()).collect();
+                        unknown_fields.push(field.name.clone());
                         self.sink.push(diagnostics::infer::member_not_found(
                             ctx.target_ty,
                             &field.name,
@@ -641,6 +643,18 @@ impl InferCtx<'_> {
                 .filter(|(n, _)| !matched.contains(n.as_str()))
                 .map(|(n, _)| n.to_string())
                 .collect();
+            if !unknown_fields.is_empty() {
+                let all_field_names: Vec<String> =
+                    ctx.all_fields.clone().map(|(n, _)| n.to_string()).collect();
+                for unknown in &unknown_fields {
+                    if let Some(suggested) =
+                        diagnostics::infer::find_similar_name(unknown, &all_field_names)
+                        && let Some(position) = missing.iter().position(|f| f == &suggested)
+                    {
+                        missing.remove(position);
+                    }
+                }
+            }
             if !missing.is_empty() {
                 missing.sort();
                 self.sink.push(diagnostics::infer::struct_missing_fields(

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -6,6 +6,7 @@ use syntax::types::{Bound, CompoundKind, Type, TypeVarId};
 
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::carry_mut::can_carry_mutation_across_fn_boundary;
+use crate::checker::infer::context::{Expectation, ExpectationRole};
 use crate::checker::type_env::VarState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -742,15 +743,30 @@ impl InferCtx<'_> {
 
             UnifyError::TypeMismatch | UnifyError::Multiple(_) => {
                 let (expected_name, actual_name) = Type::stringify_pair(expected, actual);
-                let help = self.help(expected, actual, &expected_name, &actual_name);
+                let expectation = self.site_expectation(span, &t1_normalized);
+                let help = self.help(expected, actual, &expected_name, &actual_name, expectation);
 
-                LisetteDiagnostic::error("Type mismatch")
+                let mut diagnostic = LisetteDiagnostic::error("Type mismatch")
                     .with_infer_code("type_mismatch")
                     .with_span_label(
                         span,
                         format!("expected `{}`, found `{}`", expected_name, actual_name),
                     )
-                    .with_help(help)
+                    .with_help(help);
+                if let Some(Expectation {
+                    role:
+                        ExpectationRole::TailReturn {
+                            return_annotation_span,
+                            ..
+                        },
+                    ..
+                }) = expectation
+                {
+                    let return_annotation_span = *return_annotation_span;
+                    diagnostic = diagnostic
+                        .with_span_label(&return_annotation_span, "return type declared here");
+                }
+                diagnostic
             }
 
             UnifyError::AlreadyReported => {
@@ -759,12 +775,19 @@ impl InferCtx<'_> {
         }
     }
 
+    fn site_expectation(&self, span: &Span, expected_resolved: &Type) -> Option<&Expectation> {
+        self.expectation_at(span).filter(|expectation| {
+            expectation.expected_ty.resolve_in(&self.env) == *expected_resolved
+        })
+    }
+
     fn help(
         &self,
         expected: &Type,
         actual: &Type,
         expected_name: &str,
         actual_name: &str,
+        expectation: Option<&Expectation>,
     ) -> String {
         if actual.is_unknown() {
             return format!(
@@ -888,6 +911,10 @@ impl InferCtx<'_> {
 
         if let Some(widening) = self.container_widening_help(expected, actual, expected_name) {
             return widening;
+        }
+
+        if let Some(expectation) = expectation {
+            return expectation.help(expected_name, actual_name);
         }
 
         format!(

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -17,8 +17,29 @@ impl<'source> Parser<'source> {
     }
 
     fn parse_annotation_inner(&mut self) -> Annotation {
+        if self.at_recovery_boundary() {
+            self.track_error("expected a type", "Add the missing type");
+            return Annotation::Unknown;
+        }
+
         match self.current_token().kind {
-            Function => self.parse_function_annotation(),
+            Function if self.stream.peek_ahead(1).kind == LeftParen => {
+                self.parse_function_annotation()
+            }
+            Function => {
+                let start = self.current_token();
+                self.track_error(
+                    "incomplete function type",
+                    "A function type is written `fn(int) -> int`",
+                );
+                self.next();
+                let return_type = self.parse_function_return_annotation();
+                Annotation::Function {
+                    params: vec![],
+                    return_type: return_type.into(),
+                    span: self.span_from_offset(start.byte_offset),
+                }
+            }
             LeftParen => self.parse_tuple_annotation(),
             LeftSquareBracket => {
                 let start = self.current_token();
@@ -222,16 +243,21 @@ impl<'source> Parser<'source> {
 
         let mut params = vec![];
 
-        while self.is_not(RightParen) {
+        while self.is_not(RightParen) && !self.at_recovery_boundary() {
+            let start_position = self.stream.position;
             let mutable = self.advance_if(Mut);
             params.push(crate::ast::FunctionAnnotationParameter {
                 annotation: self.parse_annotation(),
                 mutable,
             });
+            if self.at_recovery_boundary() {
+                break;
+            }
             self.expect_comma_or(RightParen);
+            self.ensure_progress(start_position, RightParen);
         }
 
-        self.ensure(RightParen);
+        self.ensure_in_place(RightParen);
 
         let return_type = self.parse_function_return_annotation();
 
@@ -249,13 +275,18 @@ impl<'source> Parser<'source> {
         let mut annotations = vec![];
         let mut has_trailing_comma = false;
 
-        while self.is_not(RightParen) {
+        while self.is_not(RightParen) && !self.at_recovery_boundary() {
+            let start_position = self.stream.position;
             annotations.push(self.parse_annotation());
             has_trailing_comma = self.is(Comma);
+            if self.at_recovery_boundary() {
+                break;
+            }
             self.expect_comma_or(RightParen);
+            self.ensure_progress(start_position, RightParen);
         }
 
-        self.ensure(RightParen);
+        self.ensure_in_place(RightParen);
 
         let span = self.span_from_offset(start.byte_offset);
 

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -367,8 +367,11 @@ impl<'source> Parser<'source> {
             let name_token = self.current_token();
             let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
             let name = self.read_identifier();
-            self.ensure(Colon);
-            let annotation = self.parse_annotation();
+            let annotation = if self.ensure_in_place(Colon) || self.can_recover_annotation() {
+                self.parse_annotation()
+            } else {
+                Annotation::Unknown
+            };
 
             if let Some((_, first_span)) = seen_fields.iter().find(|(n, _)| n == &name) {
                 self.error_duplicate_struct_field(&name, *first_span, name_span);
@@ -549,14 +552,18 @@ impl<'source> Parser<'source> {
         let name_span = Span::new(self.file_id, name_token.byte_offset, name_token.byte_length);
         let name = self.read_identifier();
 
-        self.ensure(Colon);
+        let annotation = if self.ensure_in_place(Colon) || self.can_recover_annotation() {
+            self.parse_annotation()
+        } else {
+            Annotation::Unknown
+        };
 
         Some(StructFieldDefinition {
             doc,
             visibility,
             name,
             name_span,
-            annotation: self.parse_annotation(),
+            annotation,
             ty: Type::uninferred(),
             kind: StructFieldKind::Named { attributes },
         })
@@ -668,8 +675,11 @@ impl<'source> Parser<'source> {
             return self.recover_var_initializer(start);
         }
 
-        self.ensure(Colon);
-        let annotation = self.parse_annotation();
+        let annotation = if self.ensure_in_place(Colon) || self.can_recover_annotation() {
+            self.parse_annotation()
+        } else {
+            Annotation::Unknown
+        };
 
         if self.advance_if(Equal) {
             return self.recover_var_initializer(start);

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -887,12 +887,15 @@ impl<'source> Parser<'source> {
 
         let mut params = vec![];
 
-        while self.is_not(RightParen) {
+        while self.is_not(RightParen) && !self.at_parameter_recovery_boundary() {
             params.push(self.parse_binding_with_type(mode, params.is_empty()));
+            if self.at_parameter_recovery_boundary() {
+                break;
+            }
             self.expect_comma_or(RightParen);
         }
 
-        self.ensure(RightParen);
+        self.ensure_in_place(RightParen);
 
         params
     }

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -447,7 +447,8 @@ impl<'source> Parser<'source> {
     }
 
     fn recover_to_comma_or(&mut self, closing: TokenKind) {
-        while !self.at_eof() && !self.is(Comma) && !self.is(closing) && !self.at_item_boundary() {
+        while !self.at_eof() && !self.is(Comma) && !self.is(closing) && !self.at_recovery_boundary()
+        {
             self.next();
         }
 
@@ -493,6 +494,16 @@ impl<'source> Parser<'source> {
         }
 
         self.next();
+    }
+
+    fn ensure_in_place(&mut self, token_kind: TokenKind) -> bool {
+        if self.is(token_kind) {
+            self.next();
+            return true;
+        }
+
+        self.track_ensure_error(token_kind);
+        false
     }
 
     fn ensure_progress(&mut self, start_position: usize, closing: TokenKind) {
@@ -754,6 +765,30 @@ impl<'source> Parser<'source> {
             self.current_token().kind,
             Identifier | Function | LeftParen | Integer
         )
+    }
+
+    fn can_recover_annotation(&self) -> bool {
+        !self.at_recovery_boundary() && self.can_start_annotation()
+    }
+
+    fn at_recovery_boundary(&self) -> bool {
+        if self.is(Function) {
+            return self.at_function_declaration();
+        }
+        matches!(self.current_token().kind, DocComment | Hash | Pub) || self.at_item_boundary()
+    }
+
+    fn at_parameter_recovery_boundary(&self) -> bool {
+        self.at_recovery_boundary() && self.stream.peek_ahead(1).kind != Colon
+    }
+
+    fn at_function_declaration(&self) -> bool {
+        self.is(Function)
+            && self.stream.peek_ahead(1).kind == Identifier
+            && matches!(
+                self.stream.peek_ahead(2).kind,
+                LeftParen | LeftAngleBracket | Dot
+            )
     }
 
     fn at_item_boundary(&self) -> bool {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -700,7 +700,15 @@ impl<'source> Parser<'source> {
             };
         }
 
-        self.ensure(Colon);
+        if !self.ensure_in_place(Colon) && !self.can_recover_annotation() {
+            return Binding {
+                pattern,
+                annotation: None,
+                ty: Type::uninferred(),
+                mut_span,
+            };
+        }
+
         let annotation = self.parse_annotation();
 
         Binding {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -14220,3 +14220,549 @@ fn main() {
     let result = infer_package("main", fs);
     assert_multipackage_infer_error_snapshot!(result, source);
 }
+
+fn parse_expecting_errors(
+    input: &str,
+    expected_errors: usize,
+    context: &str,
+) -> syntax::parse::ParseResult {
+    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
+    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    assert!(
+        parse_result.errors.len() == expected_errors,
+        "Expected exactly {} errors for {}, got {}: {:?}",
+        expected_errors,
+        context,
+        parse_result.errors.len(),
+        parse_result
+            .errors
+            .iter()
+            .map(|e| &e.message)
+            .collect::<Vec<_>>()
+    );
+    parse_result
+}
+
+#[test]
+fn parse_missing_param_colon_reports_once() {
+    let input = r#"
+fn id(x) {
+  x
+}
+
+fn main() {
+  let _ = id(42)
+}
+"#;
+
+    parse_expecting_errors(input, 1, "a missing parameter colon");
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_missing_param_colon_recovers_annotation() {
+    let input = r#"
+fn f(x int) -> int {
+  x
+}
+
+fn main() {
+  let _ = f(1)
+}
+"#;
+
+    parse_expecting_errors(input, 1, "the annotation following a missing colon");
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_missing_struct_field_colon_reports_once() {
+    let input = r#"
+struct User {
+  name string,
+  age: int,
+}
+"#;
+
+    parse_expecting_errors(input, 1, "a missing struct field colon");
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_missing_variant_field_colon_reports_once() {
+    let input = r#"
+enum Shape {
+  Rect { width float64, height: float64 },
+}
+"#;
+
+    parse_expecting_errors(input, 1, "a missing variant field colon");
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_params_stop_at_next_declaration() {
+    let input = r#"
+fn id(x:
+
+fn main() {
+  let _ = 1
+}
+"#;
+
+    let parse_result = parse_expecting_errors(input, 2, "unclosed params before a declaration");
+    assert!(parse_result.ast.iter().any(
+        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
+    ));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_typed_params_preserve_next_declaration() {
+    let input = r#"
+fn id(x: int
+
+fn main() {
+  let _ = 1
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 2, "unclosed typed params before a declaration");
+    assert!(parse_result.ast.iter().any(
+        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
+    ));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_function_type_preserves_next_declaration() {
+    let input = r#"
+fn f(g: fn(int
+
+fn main() {
+  let _ = 1
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 3, "an unclosed function type before a declaration");
+    assert!(parse_result.ast.iter().any(
+        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
+    ));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_tuple_type_preserves_next_declaration() {
+    let input = r#"
+fn f(p: (int,
+
+fn main() {
+  let _ = 1
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 3, "an unclosed tuple type before a declaration");
+    assert!(parse_result.ast.iter().any(
+        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
+    ));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_missing_comma_before_pub_field_reports() {
+    let input = r#"
+struct S {
+  a: int pub b: int,
+}
+"#;
+
+    let parse_result = parse_expecting_errors(input, 1, "a missing comma before a pub field");
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Struct {
+            fields: syntax::ast::StructFields::Record(fields),
+            ..
+        } if fields.len() == 2 && fields[1].visibility.is_public()
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_params_preserve_next_struct_declaration() {
+    let input = r#"
+fn id(x:
+
+struct S {
+  a: int,
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 2, "unclosed params before a struct declaration");
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Struct { name, .. } if name == "S"
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_params_preserve_pub_declaration() {
+    let input = r#"
+fn id(x:
+
+pub fn helper() -> int {
+  1
+}
+"#;
+
+    let parse_result = parse_expecting_errors(input, 2, "unclosed params before a pub declaration");
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Function {
+            name,
+            visibility: syntax::ast::Visibility::Public,
+            ..
+        } if name == "helper"
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_params_preserve_attributed_declaration() {
+    let input = r#"
+fn id(x:
+
+#[test]
+fn checks() {
+  let _ = 1
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 2, "unclosed params before an attributed declaration");
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Function { name, attributes, .. }
+            if name == "checks" && attributes.iter().any(|a| a.name == "test")
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_params_preserve_documented_declaration() {
+    let input = r#"
+fn id(x:
+
+/// Documented.
+fn documented() {
+  let _ = 1
+}
+"#;
+
+    let parse_result =
+        parse_expecting_errors(input, 2, "unclosed params before a documented declaration");
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Function { name, doc: Some(_), .. } if name == "documented"
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_function_type_preserve_pub_declaration() {
+    let input = r#"
+fn f(g: fn(int
+
+pub fn helper() -> int {
+  1
+}
+"#;
+
+    let parse_result = parse_expecting_errors(
+        input,
+        3,
+        "an unclosed function type before a pub declaration",
+    );
+    assert!(parse_result.ast.iter().any(|item| matches!(
+        item,
+        syntax::ast::Expression::Function {
+            name,
+            visibility: syntax::ast::Visibility::Public,
+            ..
+        } if name == "helper"
+    )));
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_malformed_function_type_recovers_in_place() {
+    let input = r#"
+fn f(x: fn -> int) -> int {
+  x()
+}
+
+fn main() {
+  let _ = f(|| 1)
+}
+"#;
+
+    let parse_result = parse_expecting_errors(input, 1, "a function type without parens");
+    for expected_fn in ["f", "main"] {
+        assert!(parse_result.ast.iter().any(
+            |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == expected_fn)
+        ));
+    }
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_keyword_param_keeps_reserved_error() {
+    let input = r#"
+fn f(type: int) -> int {
+  1
+}
+"#;
+
+    parse_expecting_errors(input, 1, "a keyword parameter name");
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_unclosed_struct_pattern_before_declaration_terminates() {
+    let input = r#"
+fn main() {
+  match u {
+    User {
+
+fn other() {}
+"#;
+
+    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
+    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    assert!(!parse_result.errors.is_empty());
+
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_literal_typo_does_not_claim_sibling_missing_field() {
+    let input = r#"
+struct User {
+  name: string,
+  names: Slice<string>,
+}
+
+fn test() -> string {
+  let u = User { name: "x", nam: "y" }
+  u.name
+}
+"#;
+
+    let result = infer(input);
+    assert_eq!(result.errors.len(), 2);
+    assert!(
+        result.errors[1]
+            .code_str()
+            .is_some_and(|c| c.contains("missing_struct_fields"))
+    );
+
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_literal_field_typo_claims_missing_field() {
+    let input = r#"
+struct User { name: string, age: int }
+
+fn test() -> string {
+  let u = User { nam: "ada", age: 36 }
+  u.name
+}
+"#;
+
+    let result = infer(input);
+    assert_eq!(result.errors.len(), 1);
+
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_literal_typo_of_written_field_keeps_missing_field() {
+    let input = r#"
+struct User { name: string, age: int }
+
+fn test() -> string {
+  let u = User { name: "a", nam: "x" }
+  u.name
+}
+"#;
+
+    let result = infer(input);
+    assert_eq!(result.errors.len(), 2);
+    assert!(
+        result.errors[1]
+            .code_str()
+            .is_some_and(|c| c.contains("missing_struct_fields"))
+    );
+
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_struct_literal_two_typos_claim_one_missing_field() {
+    let input = r#"
+struct User { name: string, age: int }
+
+fn test() -> string {
+  let u = User { nam: "a", naem: "b", age: 1 }
+  u.name
+}
+"#;
+
+    let result = infer(input);
+    assert_eq!(result.errors.len(), 2);
+    assert!(
+        result
+            .errors
+            .iter()
+            .all(|e| { e.code_str().is_some_and(|c| c.contains("member_not_found")) })
+    );
+
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_call_argument_mismatch_names_callee_and_parameter() {
+    let input = r#"
+fn double(n: int) -> int {
+  n * 2
+}
+
+fn test() -> int {
+  double("four")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_call_argument_mismatch_unnamed_parameter() {
+    let input = r#"
+fn test(f: fn(int) -> int) -> int {
+  f("x")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_nested_argument_mismatch_frames_inner_call() {
+    let input = r#"
+fn inner(n: int) -> int {
+  n
+}
+
+fn double(n: int) -> int {
+  n * 2
+}
+
+fn test() -> int {
+  double(inner("x"))
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_tail_return_mismatch_names_function_and_declared_type() {
+    let input = r#"
+fn returns() -> int {
+  "four"
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_match_arm_mismatch_names_match_expectation() {
+    let input = r#"
+fn arms(b: bool) -> int {
+  match b {
+    true => 1,
+    false => "two",
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_fixed_argument_mismatch_keeps_role_help() {
+    let input = r#"
+fn join(sep: string, parts: VarArgs<string>) -> string {
+  let _ = parts
+  sep
+}
+
+fn test() -> string {
+  join(1, "a")
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_variadic_tail_argument_mismatch_keeps_generic_help() {
+    let input = r#"
+fn join(sep: string, parts: VarArgs<string>) -> string {
+  let _ = parts
+  sep
+}
+
+fn test() -> string {
+  join(",", 5)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_unary_operand_mismatch_keeps_generic_help() {
+    let input = r#"
+fn f() -> int {
+  !1
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_let_annotation_mismatch_keeps_annotation_help() {
+    let input = r#"
+fn test() {
+  let x: int = "four"
+  let _ = x
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/infer_call_argument_mismatch_names_callee_and_parameter.snap
+++ b/tests/ui/errors/snapshots/infer_call_argument_mismatch_names_callee_and_parameter.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:7:10]
+ 6 │ fn test() -> int {
+ 7 │   double("four")
+   ·          ───┬──
+   ·             ╰── expected `int`, found `string`
+ 8 │ }
+   ╰────
+  help: `double()` expects `int` for its first argument `n`. Convert the value to `int`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_call_argument_mismatch_unnamed_parameter.snap
+++ b/tests/ui/errors/snapshots/infer_call_argument_mismatch_unnamed_parameter.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:3:5]
+ 2 │ fn test(f: fn(int) -> int) -> int {
+ 3 │   f("x")
+   ·     ─┬─
+   ·      ╰── expected `int`, found `string`
+ 4 │ }
+   ╰────
+  help: `f()` expects `int` for its first argument. Convert the value to `int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_explicit_unit_return_type_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_explicit_unit_return_type_mismatch.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·    ╰── expected `()`, found `int`
  4 │ }
    ╰────
-  help: Change the type annotation to `int` or convert the value to `()` · code: [infer.type_mismatch]
+  help: `foo` declares return type `()`, but this tail expression has type `int`. Change the value, or declare `-> int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_if_without_else_is_unit.snap
+++ b/tests/ui/errors/snapshots/infer_if_without_else_is_unit.snap
@@ -2,11 +2,14 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
-   ╭─[test.lis:3:3]
+   ╭─[test.lis:2:14]
+ 1 │ 
  2 │ fn test() -> int {
+   ·              ─┬─
+   ·               ╰── return type declared here
  3 │   if true { 42 }
    ·   ───────┬──────
    ·          ╰── expected `int`, found `()`
  4 │ }
    ╰────
-  help: Change the type annotation to `()` or convert the value to `int` · code: [infer.type_mismatch]
+  help: `test` declares return type `int`, but this tail expression has type `()`. Change the value, or declare `-> ()` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_interface_value_where_concrete_return_expected.snap
+++ b/tests/ui/errors/snapshots/infer_interface_value_where_concrete_return_expected.snap
@@ -2,10 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
-   ╭─[test.lis:8:35]
+   ╭─[test.lis:8:24]
  7 │ 
  8 │ fn unwrap(e: error) -> FooError { e }
-   ·                                   ┬
-   ·                                   ╰── expected `FooError`, found `error`
+   ·                        ────┬───   ┬
+   ·                            │      ╰── expected `FooError`, found `error`
+   ·                            ╰── return type declared here
    ╰────
   help: An interface value does not carry its concrete type. Narrow it with `assert_type`, e.g. `let value = assert_type<FooError>(value)?` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_let_annotation_mismatch_keeps_annotation_help.snap
+++ b/tests/ui/errors/snapshots/infer_let_annotation_mismatch_keeps_annotation_help.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:3:16]
+ 2 │ fn test() {
+ 3 │   let x: int = "four"
+   ·                ───┬──
+   ·                   ╰── expected `int`, found `string`
+ 4 │   let _ = x
+   ╰────
+  help: Change the type annotation to `string` or convert the value to `int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_match_arm_mismatch_names_match_expectation.snap
+++ b/tests/ui/errors/snapshots/infer_match_arm_mismatch_names_match_expectation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:5:14]
+ 4 │     true => 1,
+ 5 │     false => "two",
+   ·              ──┬──
+   ·                ╰── expected `int`, found `string`
+ 6 │   }
+   ╰────
+  help: Every `match` arm must produce the same type. This arm produces `string`, but the `match` is expected to produce `int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_method_without_parens.snap
+++ b/tests/ui/errors/snapshots/infer_method_without_parens.snap
@@ -2,11 +2,14 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
-   ╭─[test.lis:3:3]
+   ╭─[test.lis:2:27]
+ 1 │ 
  2 │ fn test(s: Slice<int>) -> int {
+   ·                           ─┬─
+   ·                            ╰── return type declared here
  3 │   s.length
    ·   ────┬───
    ·       ╰── expected `int`, found `fn () -> int`
  4 │ }
    ╰────
-  help: Change the type annotation to `fn () -> int` or convert the value to `int` · code: [infer.type_mismatch]
+  help: `test` declares return type `int`, but this tail expression has type `fn () -> int`. Change the value, or declare `-> fn () -> int` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_nested_argument_mismatch_frames_inner_call.snap
+++ b/tests/ui/errors/snapshots/infer_nested_argument_mismatch_frames_inner_call.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:11:16]
+ 10 │ fn test() -> int {
+ 11 │   double(inner("x"))
+    ·                ─┬─
+    ·                 ╰── expected `int`, found `string`
+ 12 │ }
+    ╰────
+  help: `inner()` expects `int` for its first argument `n`. Convert the value to `int`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_never_in_generic_expected_position.snap
+++ b/tests/ui/errors/snapshots/infer_never_in_generic_expected_position.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                                      ╰── expected `Never`, found `int`
  9 │ }
    ╰────
-  help: Change the type annotation to `int` or convert the value to `Never` · code: [infer.type_mismatch]
+  help: `MyOk()` expects `Never` for its first argument. Convert the value to `Never` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_slice_of_interface_where_slice_of_concrete_expected.snap
+++ b/tests/ui/errors/snapshots/infer_slice_of_interface_where_slice_of_concrete_expected.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·           ╰── expected `Slice<Cat>`, found `Slice<Animal>`
  17 │ }
     ╰────
-  help: Change the type annotation to `Slice<Animal>` or convert the value to `Slice<Cat>` · code: [infer.type_mismatch]
+  help: `take()` expects `Slice<Cat>` for its first argument `cats`. Convert the value to `Slice<Cat>`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_struct_literal_field_typo_claims_missing_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_literal_field_typo_claims_missing_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Member not found
+   ╭─[test.lis:5:11]
+ 4 │ fn test() -> string {
+ 5 │   let u = User { nam: "ada", age: 36 }
+   ·           ──────────────┬─────────────
+   ·                         ╰── no member `nam` on type `User`
+ 6 │   u.name
+   ╰────
+  help: Did you mean `name`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_struct_literal_two_typos_claim_one_missing_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_literal_two_typos_claim_one_missing_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Member not found
+   ╭─[test.lis:5:11]
+ 4 │ fn test() -> string {
+ 5 │   let u = User { nam: "a", naem: "b", age: 1 }
+   ·           ──────────────────┬─────────────────
+   ·                             ╰── no member `nam` on type `User`
+ 6 │   u.name
+   ╰────
+  help: Did you mean `name`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_struct_literal_typo_does_not_claim_sibling_missing_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_literal_typo_does_not_claim_sibling_missing_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Member not found
+   ╭─[test.lis:8:11]
+ 7 │ fn test() -> string {
+ 8 │   let u = User { name: "x", nam: "y" }
+   ·           ──────────────┬─────────────
+   ·                         ╰── no member `nam` on type `User`
+ 9 │   u.name
+   ╰────
+  help: Did you mean `name`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_struct_literal_typo_of_written_field_keeps_missing_field.snap
+++ b/tests/ui/errors/snapshots/infer_struct_literal_typo_of_written_field_keeps_missing_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Member not found
+   ╭─[test.lis:5:11]
+ 4 │ fn test() -> string {
+ 5 │   let u = User { name: "a", nam: "x" }
+   ·           ──────────────┬─────────────
+   ·                         ╰── no member `nam` on type `User`
+ 6 │   u.name
+   ╰────
+  help: Did you mean `name`? · code: [infer.member_not_found]

--- a/tests/ui/errors/snapshots/infer_tail_return_mismatch_names_function_and_declared_type.snap
+++ b/tests/ui/errors/snapshots/infer_tail_return_mismatch_names_function_and_declared_type.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:2:17]
+ 1 │ 
+ 2 │ fn returns() -> int {
+   ·                 ─┬─
+   ·                  ╰── return type declared here
+ 3 │   "four"
+   ·   ───┬──
+   ·      ╰── expected `int`, found `string`
+ 4 │ }
+   ╰────
+  help: `returns` declares return type `int`, but this tail expression has type `string`. Change the value, or declare `-> string` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_entry_package_shares_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_entry_package_shares_a_leaf_name.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                  ╰── expected `alpha.Config`, found `Config`
  11 │ }
     ╰────
-  help: Change the type annotation to `Config` or convert the value to `alpha.Config` · code: [infer.type_mismatch]
+  help: `take()` expects `alpha.Config` for its first argument `c`. Convert the value to `alpha.Config`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_go_and_project_type_share_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_go_and_project_type_share_a_leaf_name.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                     ╰── expected `bytes.Buffer`, found `Buffer`
  11 │ }
     ╰────
-  help: Change the type annotation to `Buffer` or convert the value to `bytes.Buffer` · code: [infer.type_mismatch]
+  help: `take_go()` expects `bytes.Buffer` for its first argument `b`. Convert the value to `bytes.Buffer`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_go_type_named_after_a_builtin.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_go_type_named_after_a_builtin.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                ╰── expected `go/types.Tuple`, found `int`
  8 │ }
    ╰────
-  help: Change the type annotation to `int` or convert the value to `go/types.Tuple` · code: [infer.type_mismatch]
+  help: `take()` expects `go/types.Tuple` for its first argument `t`. Convert the value to `go/types.Tuple`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_mismatch_two_packages_share_a_leaf_name.snap
+++ b/tests/ui/errors/snapshots/infer_type_mismatch_two_packages_share_a_leaf_name.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
     ·                ╰── expected `alpha.Config`, found `beta.Config`
  10 │ }
     ╰────
-  help: Change the type annotation to `beta.Config` or convert the value to `alpha.Config` · code: [infer.type_mismatch]
+  help: `take()` expects `alpha.Config` for its first argument `c`. Convert the value to `alpha.Config`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_unary_operand_mismatch_keeps_generic_help.snap
+++ b/tests/ui/errors/snapshots/infer_unary_operand_mismatch_keeps_generic_help.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:3:3]
+ 2 │ fn f() -> int {
+ 3 │   !1
+   ·   ─┬
+   ·    ╰── expected `bool`, found `int`
+ 4 │ }
+   ╰────
+  help: Change the type annotation to `int` or convert the value to `bool` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_variadic_fixed_argument_mismatch_keeps_role_help.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_fixed_argument_mismatch_keeps_role_help.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:8:8]
+ 7 │ fn test() -> string {
+ 8 │   join(1, "a")
+   ·        ┬
+   ·        ╰── expected `string`, found `int`
+ 9 │ }
+   ╰────
+  help: `join()` expects `string` for its first argument `sep`. Convert the value to `string`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_variadic_tail_argument_mismatch_keeps_generic_help.snap
+++ b/tests/ui/errors/snapshots/infer_variadic_tail_argument_mismatch_keeps_generic_help.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:8:13]
+ 7 │ fn test() -> string {
+ 8 │   join(",", 5)
+   ·             ┬
+   ·             ╰── expected `string`, found `int`
+ 9 │ }
+   ╰────
+  help: Change the type annotation to `int` or convert the value to `string` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/parse_keyword_param_keeps_reserved_error.snap
+++ b/tests/ui/errors/snapshots/parse_keyword_param_keeps_reserved_error.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Reserved keyword
+   ╭─[test.lis:2:6]
+ 1 │ 
+ 2 │ fn f(type: int) -> int {
+   ·      ──┬─
+   ·        ╰── cannot be used as a binding name
+ 3 │   1
+   ╰────
+  help: Rename this binding. `type` is a keyword reserved for declaring named types · code: [parse.keyword_as_binding]

--- a/tests/ui/errors/snapshots/parse_malformed_function_type_recovers_in_place.snap
+++ b/tests/ui/errors/snapshots/parse_malformed_function_type_recovers_in_place.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:9]
+ 1 │ 
+ 2 │ fn f(x: fn -> int) -> int {
+   ·         ─┬
+   ·          ╰── incomplete function type
+ 3 │   x()
+   ╰────
+  help: A function type is written `fn(int) -> int` · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_missing_comma_before_pub_field_reports.snap
+++ b/tests/ui/errors/snapshots/parse_missing_comma_before_pub_field_reports.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:10]
+ 2 │ struct S {
+ 3 │   a: int pub b: int,
+   ·          ─┬─
+   ·           ╰── expected `,` or `}`
+ 4 │ }
+   ╰────
+  help: Add a comma between elements · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_missing_param_colon_recovers_annotation.snap
+++ b/tests/ui/errors/snapshots/parse_missing_param_colon_recovers_annotation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ fn f(x int) -> int {
+   ·        ─┬─
+   ·         ╰── expected `:`
+ 3 │   x
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_param_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_param_colon_reports_once.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ fn id(x) {
+   ·        ┬
+   ·        ╰── expected `:`
+ 3 │   x
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_struct_field_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_struct_field_colon_reports_once.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:8]
+ 2 │ struct User {
+ 3 │   name string,
+   ·        ───┬──
+   ·           ╰── expected `:`
+ 4 │   age: int,
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_variant_field_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_variant_field_colon_reports_once.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:3:16]
+ 2 │ enum Shape {
+ 3 │   Rect { width float64, height: float64 },
+   ·                ───┬───
+   ·                   ╰── expected `:`
+ 4 │ }
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_function_type_preserve_pub_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_function_type_preserve_pub_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ fn f(g: fn(int
+   ·               ▲
+   ·               ╰── expected `,` or `)`
+ 3 │ 
+   ╰────
+  help: Add a comma between elements · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_function_type_preserves_next_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_function_type_preserves_next_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:15]
+ 1 │ 
+ 2 │ fn f(g: fn(int
+   ·               ▲
+   ·               ╰── expected `,` or `)`
+ 3 │ 
+   ╰────
+  help: Add a comma between elements · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_params_preserve_attributed_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_params_preserve_attributed_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ #[test]
+   · ┬
+   · ╰── expected a type
+ 5 │ fn checks() {
+   ╰────
+  help: Add the missing type · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_params_preserve_documented_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_params_preserve_documented_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ /// Documented.
+   · ───────┬───────
+   ·        ╰── expected a type
+ 5 │ fn documented() {
+   ╰────
+  help: Add the missing type · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_params_preserve_next_struct_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_params_preserve_next_struct_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ struct S {
+   · ───┬──
+   ·    ╰── expected a type
+ 5 │   a: int,
+   ╰────
+  help: Add the missing type · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_params_preserve_pub_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_params_preserve_pub_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ pub fn helper() -> int {
+   · ─┬─
+   ·  ╰── expected a type
+ 5 │   1
+   ╰────
+  help: Add the missing type · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_params_stop_at_next_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_params_stop_at_next_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ fn main() {
+   · ─┬
+   ·  ╰── expected a type
+ 5 │   let _ = 1
+   ╰────
+  help: Add the missing type · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_unclosed_struct_pattern_before_declaration_terminates.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_struct_pattern_before_declaration_terminates.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:6:1]
+ 5 │ 
+ 6 │ fn other() {}
+   · ─┬
+   ·  ╰── expected identifier
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_tuple_type_preserves_next_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_tuple_type_preserves_next_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:4:1]
+ 3 │ 
+ 4 │ fn main() {
+   · ─┬
+   ·  ╰── expected `)`
+ 5 │   let _ = 1
+   ╰────
+  help:  · code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_typed_params_preserve_next_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_typed_params_preserve_next_declaration.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:13]
+ 1 │ 
+ 2 │ fn id(x: int
+   ·             ▲
+   ·             ╰── expected `,` or `)`
+ 3 │ 
+   ╰────
+  help: Add a comma between elements · code: [parse.syntax_error]


### PR DESCRIPTION
A missing `:`, `)`, or `,` no longer causes cascading diagnostics. The parser reports the missing token once, recovers when the next token allows it, and stops at the start of the next declaration instead of consuming it.

```rs
fn f(x int) -> int {
  x
}
```

This used to report 11 errors, now it reports the missing colon once and the parameter recovers as `x: int`
