### PR TITLE
feat: widen concrete error types through `?`

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2297,6 +2297,17 @@ pub fn interface_not_implemented(
         .with_help(help_lines.join("\n"))
 }
 
+pub fn cannot_propagate_error(declared: &str, operand: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot propagate error")
+        .with_infer_code("cannot_propagate_error")
+        .with_span_label(&span, format!("expected `{declared}`, found `{operand}`"))
+        .with_help(propagation_framing_help(declared, operand))
+}
+
+fn propagation_framing_help(declared: &str, operand: &str) -> String {
+    format!("cannot propagate `{operand}` as `{declared}`. Convert with `.map_err(...)`")
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum WrapperKind {
     Result,

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -23,14 +23,18 @@ pub(crate) fn multi_value_return(values: Vec<String>) -> LoweredStatement {
     })
 }
 
-/// An `if <condition> { return <then_values...> }` tag-check leaf (no else).
-pub(crate) fn tag_check(condition: String, then_values: Vec<String>) -> LoweredStatement {
+/// An `if <condition> { <setup...> return <then_values...> }` tag-check leaf (no else).
+pub(crate) fn tag_check(
+    condition: String,
+    setup: Vec<LoweredStatement>,
+    then_values: Vec<String>,
+) -> LoweredStatement {
+    let mut statements = setup;
+    statements.push(multi_value_return(then_values));
     LoweredStatement::If(IfPlan {
         condition_setup: Vec::new(),
         condition,
-        then_body: LoweredBlock {
-            statements: vec![multi_value_return(then_values)],
-        },
+        then_body: LoweredBlock { statements },
         else_arm: ElseArm::None,
     })
 }
@@ -136,6 +140,7 @@ pub(crate) fn emit_lowered_result_return(
         CallableReturnAbi::BareError => vec![
             tag_check(
                 format!("{p}.Tag == {RESULT_OK_TAG}"),
+                Vec::new(),
                 vec!["nil".to_string()],
             ),
             multi_value_return(vec![format!("{p}.ErrVal")]),
@@ -145,6 +150,7 @@ pub(crate) fn emit_lowered_result_return(
             vec![
                 tag_check(
                     format!("{p}.Tag == {RESULT_OK_TAG}"),
+                    Vec::new(),
                     vec![format!("{p}.OkVal"), "nil".to_string()],
                 ),
                 multi_value_return(vec![zero, format!("{p}.ErrVal")]),
@@ -155,10 +161,12 @@ pub(crate) fn emit_lowered_result_return(
             vec![
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_OK_TAG}"),
+                    Vec::new(),
                     vec![format!("{p}.OkVal"), "nil".to_string()],
                 ),
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_ERR_TAG}"),
+                    Vec::new(),
                     vec![zero, format!("{p}.ErrVal")],
                 ),
                 multi_value_return(vec![format!("{p}.OkVal"), format!("{p}.ErrVal")]),
@@ -169,6 +177,7 @@ pub(crate) fn emit_lowered_result_return(
             vec![
                 tag_check(
                     format!("{p}.Tag == {OPTION_SOME_TAG}"),
+                    Vec::new(),
                     vec![format!("{p}.SomeVal"), "true".to_string()],
                 ),
                 multi_value_return(vec![zero, "false".to_string()]),
@@ -177,6 +186,7 @@ pub(crate) fn emit_lowered_result_return(
         CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec![
             tag_check(
                 format!("{p}.Tag == {OPTION_SOME_TAG}"),
+                Vec::new(),
                 vec![format!("{p}.SomeVal")],
             ),
             multi_value_return(vec!["nil".to_string()]),

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -1,5 +1,7 @@
 use crate::Planner;
+use crate::abi::coercion::CoercionPlan;
 use crate::names::go_name;
+use crate::plan::bodies::LoweredStatement;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -72,7 +74,7 @@ impl Fallible {
         }
     }
 
-    fn err_ty(&self) -> Option<&Type> {
+    pub(crate) fn err_ty(&self) -> Option<&Type> {
         match self {
             Self::Result { err_ty, .. } => Some(err_ty),
             Self::Option { .. } => None,
@@ -129,6 +131,44 @@ impl Fallible {
                 format!("{pkg}.MakeResultOk[{}, {}]({})", inner_ty, err_ty, value)
             }
         }
+    }
+}
+
+impl Planner<'_> {
+    pub(crate) fn contextual_err_ty(&self, fallible: &Fallible) -> Option<Type> {
+        if let Some(ty) = self.return_ctx().ty() {
+            let peeled = self.facts.peel_alias(ty);
+            if peeled.is_result() {
+                return Some(peeled.err_type());
+            }
+        }
+        fallible.err_ty().cloned()
+    }
+
+    pub(crate) fn coerce_value(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: String,
+        from: &Type,
+        to: &Type,
+    ) -> String {
+        let coercion = CoercionPlan::internal(self, from, to);
+        let (setup, value) = coercion.lower(self, value);
+        statements.extend(setup);
+        value
+    }
+
+    pub(crate) fn convert_error_to_return_context(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        value: String,
+        fallible: &Fallible,
+    ) -> String {
+        let (Some(from), Some(to)) = (fallible.err_ty().cloned(), self.contextual_err_ty(fallible))
+        else {
+            return value;
+        };
+        self.coerce_value(statements, value, &from, &to)
     }
 }
 
@@ -212,13 +252,17 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
         }
     }
 
-    /// Emit a failure wrapper using the contextual ok type (from return context).
+    /// Emit a failure wrapper using the contextual ok and err types (from return context).
     pub(crate) fn emit_contextual_failure(&mut self, error_value: Option<&str>) -> String {
         self.planner.require_stdlib();
         let pkg = go_name::GO_STDLIB_PKG;
         let inner_ty = self.contextual_ok_type_string();
         if self.fallible.is_result() {
-            let err_ty = self.err_type_string().expect("Result must have error type");
+            let err_ty = self
+                .planner
+                .contextual_err_ty(self.fallible)
+                .expect("Result must have error type");
+            let err_ty = self.planner.go_type_string(&err_ty);
             format!(
                 "{pkg}.MakeResultErr[{}, {}]({})",
                 inner_ty,

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -149,14 +149,19 @@ impl Planner<'_> {
         if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
             let values = if fallible.is_result() {
-                let err_expr = err_arg.as_deref().unwrap_or("");
-                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
+                let err_expr = err_arg.unwrap_or_default();
+                let err_expr =
+                    self.convert_error_to_return_context(&mut statements, err_expr, fallible);
+                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty)
             };
             statements.push(plain_return(values.join(", ")));
         } else {
             self.require_stdlib();
+            let err_arg = err_arg.map(|value| {
+                self.convert_error_to_return_context(&mut statements, value, fallible)
+            });
             let err_return = {
                 let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_contextual_failure(err_arg.as_deref())

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -139,25 +139,42 @@ impl Planner<'_> {
         let err_field = if fallible.is_result() { ".ErrVal" } else { "" };
         let success_tag = fallible.success_tag();
         let err_expr = format!("{}{}", check_var, err_field);
-        let values = self.propagate_failure_values(fallible, &err_expr);
-        transition::tag_check(format!("{}.Tag != {}", check_var, success_tag), values)
+        let (setup, values) = self.propagate_failure_values(fallible, &err_expr);
+        transition::tag_check(
+            format!("{}.Tag != {}", check_var, success_tag),
+            setup,
+            values,
+        )
     }
 
-    fn propagate_failure_values(&mut self, fallible: &Fallible, err_expr: &str) -> Vec<String> {
+    fn propagate_failure_values(
+        &mut self,
+        fallible: &Fallible,
+        err_expr: &str,
+    ) -> (Vec<LoweredStatement>, Vec<String>) {
+        let mut setup = Vec::new();
         let return_ctx = self.return_ctx();
-        if let Some(shape) = return_ctx.lowered_shape() {
+        let values = if let Some(shape) = return_ctx.lowered_shape() {
             let return_ty = return_ctx.expect_ty();
             // Option propagation: failure carries no payload, so return a
             // shape-specific `None` rather than an err-return.
             if fallible.is_result() {
-                transition::lowered_err_values(self, &shape, &return_ty, err_expr)
+                let err_expr = self.convert_error_to_return_context(
+                    &mut setup,
+                    err_expr.to_string(),
+                    fallible,
+                );
+                transition::lowered_err_values(self, &shape, &return_ty, &err_expr)
             } else {
                 transition::lowered_none_values(self, &shape, &return_ty)
             }
         } else {
+            let err_expr =
+                self.convert_error_to_return_context(&mut setup, err_expr.to_string(), fallible);
             let mut fe = FalliblePlanner::new(self, fallible);
-            vec![fe.emit_contextual_failure(Some(err_expr))]
-        }
+            vec![fe.emit_contextual_failure(Some(&err_expr))]
+        };
+        (setup, values)
     }
 
     /// Fuse `go_call()?` into `v, err := call(); if err != nil { return ... }`,
@@ -218,9 +235,10 @@ impl Planner<'_> {
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let failure_values = self.propagate_failure_values(fallible, &err_var);
+        let (failure_setup, failure_values) = self.propagate_failure_values(fallible, &err_var);
         statements.push(transition::tag_check(
             format!("{} != nil", err_var),
+            failure_setup,
             failure_values,
         ));
 
@@ -232,9 +250,13 @@ impl Planner<'_> {
                 self.require_stdlib();
             }
             self.require_errors();
-            let nil_failure =
+            let (nil_setup, nil_failure) =
                 self.propagate_failure_values(fallible, "errors.New(\"unexpected nil\")");
-            statements.push(transition::tag_check(guard.is_nil(val), nil_failure));
+            statements.push(transition::tag_check(
+                guard.is_nil(val),
+                nil_setup,
+                nil_failure,
+            ));
         }
 
         let value = match result_var_name {
@@ -535,8 +557,13 @@ impl Planner<'_> {
                 let (setup, err_expr) = self
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
-                let values = transition::lowered_err_values(self, shape, return_ty, &err_expr);
                 statements.extend(setup);
+                let from = args[0].get_type();
+                let to = self
+                    .contextual_err_ty(fallible)
+                    .expect("Result must have error type");
+                let err_expr = self.coerce_value(&mut statements, err_expr, &from, &to);
+                let values = transition::lowered_err_values(self, shape, return_ty, &err_expr);
                 statements.push(transition::multi_value_return(values));
             }
         } else {
@@ -545,6 +572,11 @@ impl Planner<'_> {
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
+                let from = args[0].get_type();
+                let to = self
+                    .contextual_err_ty(fallible)
+                    .expect("Result must have error type");
+                let arg = self.coerce_value(&mut statements, arg, &from, &to);
                 let mut fe = FalliblePlanner::new(self, fallible);
                 fe.emit_failure(Some(&arg))
             } else {

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -4,6 +4,7 @@ use syntax::ast::{Expression, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
+use crate::checker::infer::unify::UnifyError;
 
 struct TryBlockTypes {
     ok: Type,
@@ -103,7 +104,7 @@ impl InferCtx<'_> {
             self.propagate_as_error(expected_ty, span)
         } else if tried_ty.is_result() {
             let ok_ty = tried_ty.ok_type();
-            self.unify(&try_types.error, &tried_ty.err_type(), &span);
+            self.check_propagated_error(&try_types.error, &tried_ty.err_type(), &span);
             if ok_ty.resolve_in(&self.env).is_variable() {
                 self.unify(&try_types.ok, &ok_ty, &span);
             }
@@ -149,13 +150,14 @@ impl InferCtx<'_> {
             self.propagate_as_error(expected_ty, span)
         } else if tried_ty.is_result() {
             let ok_ty = tried_ty.ok_type();
-            let resolved_fn_return = fn_return_ty.resolve_in(&self.env);
+            let resolved_fn_return = self.resolve_carrier(&fn_return_ty);
 
             if resolved_fn_return.is_result() {
-                let err_ty = tried_ty.err_type();
-                let new_ok = self.new_type_var();
-                let expected_return = self.type_result(store, new_ok, err_ty);
-                self.unify(&expected_return, &fn_return_ty, &span);
+                self.check_propagated_error(
+                    &resolved_fn_return.err_type(),
+                    &tried_ty.err_type(),
+                    &span,
+                );
             } else {
                 self.sink.push(diagnostics::infer::try_return_type_mismatch(
                     "Result<T, E>",
@@ -199,6 +201,27 @@ impl InferCtx<'_> {
         }
     }
 
+    fn resolve_carrier(&self, ty: &Type) -> Type {
+        self.store.peel_alias(&ty.resolve_in(&self.env))
+    }
+
+    fn check_propagated_error(&mut self, declared_err: &Type, operand_err: &Type, span: &Span) {
+        match self.try_unify(declared_err, operand_err, span) {
+            Ok(()) | Err(UnifyError::AlreadyReported) => {}
+            Err(_) => {
+                let declared = declared_err.resolve_in(&self.env);
+                let operand = operand_err.resolve_in(&self.env);
+                let (types, _) = Type::remove_vars(&[&declared, &operand]);
+                let (declared_name, operand_name) = Type::stringify_pair(&types[0], &types[1]);
+                self.sink.push(diagnostics::infer::cannot_propagate_error(
+                    &declared_name,
+                    &operand_name,
+                    *span,
+                ));
+            }
+        }
+    }
+
     pub(super) fn infer_try_block(
         &mut self,
         items: Vec<Expression>,
@@ -224,6 +247,11 @@ impl InferCtx<'_> {
 
         let ok_ty = self.new_type_var();
         let err_ty = self.new_type_var();
+
+        let expected_resolved = self.resolve_carrier(expected_ty);
+        if expected_resolved.is_result() {
+            self.unify(&err_ty, &expected_resolved.err_type(), &try_keyword_span);
+        }
 
         let (new_items, usage) = self.with_scope(|this| {
             let entry_loop_depth = this.loop_depth();

--- a/docs/reference/09-error-handling.md
+++ b/docs/reference/09-error-handling.md
@@ -113,6 +113,15 @@ fn validate(input: Input) -> Result<Input, ValidationError> {
 }
 ```
 
+A custom error propagates with `?` into a function that returns an `error` interface type:
+
+```rust
+fn process(input: Input) -> Result<Input, error> {
+  let valid = validate(input)? // ValidationError satisfies error
+  Ok(valid)
+}
+```
+
 📚 See [`10-methods.md`](10-methods.md)
 
 

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -1166,3 +1166,75 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn propagate_widens_error_slot_through_adapter() {
+    let input = r#"
+interface Failing<T> {
+  fn get() -> T
+}
+
+struct Boom {}
+
+impl Boom {
+  fn get(self) -> Result<int, error> {
+    Ok(1)
+  }
+}
+
+fn source() -> Result<int, Boom> {
+  Err(Boom {})
+}
+
+fn widen() -> Result<int, Failing<Result<int, error>>> {
+  let n = source()?
+  Ok(n)
+}
+
+fn main() {
+  match widen() {
+    Ok(_) => panic("expected error"),
+    Err(f) => {
+      match f.get() {
+        Ok(v) => {
+          if v != 1 {
+            panic("wrong adapted value")
+          }
+        },
+        Err(_) => panic("expected ok from get"),
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn return_err_widens_error_slot_through_adapter() {
+    let input = r#"
+interface Failing<T> {
+  fn get() -> T
+}
+
+struct Boom {}
+
+impl Boom {
+  fn get(self) -> Result<int, error> {
+    Ok(1)
+  }
+}
+
+fn bail() -> Result<int, Failing<Result<int, error>>> {
+  return Err(Boom {})
+}
+
+fn main() {
+  match bail() {
+    Ok(_) => panic("expected error"),
+    Err(_) => {},
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -1617,3 +1617,265 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn propagate_widens_concrete_error_in_lowered_return() {
+    let input = r#"
+struct ValidationError { field: string }
+
+impl ValidationError {
+  fn Error(self) -> string { f"{self.field}: required" }
+}
+
+fn validate(name: string) -> Result<string, ValidationError> {
+  if name == "" { return Err(ValidationError { field: "name" }) }
+  Ok(name)
+}
+
+fn load(name: string) -> Result<string, error> {
+  let n = validate(name)?
+  Ok(n)
+}
+
+fn test() {
+  match load("") {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "name: required" {
+        panic("wrong widened error")
+      }
+    },
+  }
+  match load("ada") {
+    Ok(v) => {
+      if v != "ada" {
+        panic("wrong ok value")
+      }
+    },
+    Err(_) => panic("expected ok"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_widens_in_annotated_try_block() {
+    let input = r#"
+struct AError { }
+
+impl AError {
+  fn Error(self) -> string { "a failed" }
+}
+
+struct BError { }
+
+impl BError {
+  fn Error(self) -> string { "b failed" }
+}
+
+fn do_a(ok: bool) -> Result<int, AError> {
+  if ok { Ok(1) } else { Err(AError {}) }
+}
+
+fn do_b(ok: bool) -> Result<int, BError> {
+  if ok { Ok(2) } else { Err(BError {}) }
+}
+
+fn test() {
+  let r: Result<int, error> = try {
+    let a = do_a(true)?
+    let b = do_b(false)?
+    a + b
+  }
+  match r {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "b failed" {
+        panic("wrong try block error")
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_widens_in_prelude_callback_lambda() {
+    let input = r#"
+struct ParseError { text: string }
+
+impl ParseError {
+  fn Error(self) -> string { f"bad: {self.text}" }
+}
+
+fn parse_word(w: string) -> Result<int, ParseError> {
+  if w == "x" { Err(ParseError { text: w }) } else { Ok(w.length()) }
+}
+
+fn test() {
+  let words = ["one", "x"]
+  let parsed = words.map(|w| -> Result<int, error> {
+    let n = parse_word(w)?
+    Ok(n)
+  })
+  match parsed[0] {
+    Ok(n) => {
+      if n != 3 {
+        panic("wrong parsed length")
+      }
+    },
+    Err(_) => panic("expected ok"),
+  }
+  match parsed[1] {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "bad: x" {
+        panic("wrong lambda error")
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_widens_to_custom_interface_with_different_ok_types() {
+    let input = r#"
+pub interface AppError {
+  fn Error() -> string
+  fn status() -> int
+}
+
+struct DbError { }
+
+impl DbError {
+  fn Error(self) -> string { "db down" }
+  pub fn status(self) -> int { 500 }
+}
+
+fn query(ok: bool) -> Result<string, DbError> {
+  if ok { Ok("row") } else { Err(DbError {}) }
+}
+
+fn handler(ok: bool) -> Result<int, AppError> {
+  let row = query(ok)?
+  Ok(row.length())
+}
+
+fn test() {
+  match handler(false) {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.status() != 500 || e.Error() != "db down" {
+        panic("wrong app error")
+      }
+    },
+  }
+  match handler(true) {
+    Ok(n) => {
+      if n != 3 {
+        panic("wrong ok length")
+      }
+    },
+    Err(_) => panic("expected ok"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn err_literal_propagate_widens() {
+    let input = r#"
+struct AError { }
+
+impl AError {
+  fn Error(self) -> string { "a failed" }
+}
+
+fn bail(flag: bool) -> Result<int, error> {
+  if flag { Err(AError {})? }
+  Ok(1)
+}
+
+fn test() {
+  match bail(true) {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "a failed" {
+        panic("wrong literal error")
+      }
+    },
+  }
+  match bail(false) {
+    Ok(v) => {
+      if v != 1 {
+        panic("wrong ok value")
+      }
+    },
+    Err(_) => panic("expected ok"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn return_err_widens_concrete_error() {
+    let input = r#"
+struct AError { }
+
+impl AError {
+  fn Error(self) -> string { "a failed" }
+}
+
+fn bail() -> Result<int, error> {
+  return Err(AError {})
+}
+
+fn test() {
+  match bail() {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "a failed" {
+        panic("wrong returned error")
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_widens_ref_with_pointer_receiver_error_method() {
+    let input = r#"
+struct FileError { path: string }
+
+impl FileError {
+  fn Error(self: Ref<FileError>) -> string { f"cannot open {self.path}" }
+}
+
+fn read_value() -> Result<int, Ref<FileError>> { Err(&FileError { path: "a.txt" }) }
+
+fn load() -> Result<int, error> {
+  let n = read_value()?
+  Ok(n)
+}
+
+fn test() {
+  match load() {
+    Ok(_) => panic("expected error"),
+    Err(e) => {
+      if e.Error() != "cannot open a.txt" {
+        panic("wrong ref error")
+      }
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
+++ b/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
@@ -1,0 +1,69 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct AError { }
+  
+  impl AError {
+    fn Error(self) -> string { "a failed" }
+  }
+  
+  fn bail(flag: bool) -> Result<int, error> {
+    if flag { Err(AError {})? }
+    Ok(1)
+  }
+  
+  fn test() {
+    match bail(true) {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "a failed" {
+          panic("wrong literal error")
+        }
+      },
+    }
+    match bail(false) {
+      Ok(v) => {
+        if v != 1 {
+          panic("wrong ok value")
+        }
+      },
+      Err(_) => panic("expected ok"),
+    }
+  }
+---
+package main
+
+type AError struct{}
+
+func (a AError) Error() string {
+	return "a failed"
+}
+
+func bail(flag bool) (int, error) {
+	if flag {
+		return 0, AError{}
+	}
+	return 1, nil
+}
+
+func test() {
+	_, ret_1 := bail(true)
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		e := ret_1
+		if e.Error() != "a failed" {
+			panic("wrong literal error")
+		}
+	}
+	ret_2, ret_3 := bail(false)
+	if ret_3 == nil {
+		v := ret_2
+		if v != 1 {
+			panic("wrong ok value")
+		}
+	} else {
+		panic("expected ok")
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
@@ -1,0 +1,90 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct ValidationError { field: string }
+  
+  impl ValidationError {
+    fn Error(self) -> string { f"{self.field}: required" }
+  }
+  
+  fn validate(name: string) -> Result<string, ValidationError> {
+    if name == "" { return Err(ValidationError { field: "name" }) }
+    Ok(name)
+  }
+  
+  fn load(name: string) -> Result<string, error> {
+    let n = validate(name)?
+    Ok(n)
+  }
+  
+  fn test() {
+    match load("") {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "name: required" {
+          panic("wrong widened error")
+        }
+      },
+    }
+    match load("ada") {
+      Ok(v) => {
+        if v != "ada" {
+          panic("wrong ok value")
+        }
+      },
+      Err(_) => panic("expected ok"),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type ValidationError struct {
+	field string
+}
+
+func (v ValidationError) Error() string {
+	return fmt.Sprintf("%s: required", v.field)
+}
+
+func validate(name string) lisette.Result[string, ValidationError] {
+	if name == "" {
+		return lisette.MakeResultErr[string, ValidationError](ValidationError{field: "name"})
+	}
+	return lisette.MakeResultOk[string, ValidationError](name)
+}
+
+func load(name string) (string, error) {
+	check_1 := validate(name)
+	if check_1.Tag != lisette.ResultOk {
+		return "", check_1.ErrVal
+	}
+	n := check_1.OkVal
+	return n, nil
+}
+
+func test() {
+	_, ret_1 := load("")
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		e := ret_1
+		if e.Error() != "name: required" {
+			panic("wrong widened error")
+		}
+	}
+	ret_2, ret_3 := load("ada")
+	if ret_3 == nil {
+		v := ret_2
+		if v != "ada" {
+			panic("wrong ok value")
+		}
+	} else {
+		panic("expected ok")
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
@@ -1,0 +1,99 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  interface Failing<T> {
+    fn get() -> T
+  }
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn get(self) -> Result<int, error> {
+      Ok(1)
+    }
+  }
+  
+  fn source() -> Result<int, Boom> {
+    Err(Boom {})
+  }
+  
+  fn widen() -> Result<int, Failing<Result<int, error>>> {
+    let n = source()?
+    Ok(n)
+  }
+  
+  fn main() {
+    match widen() {
+      Ok(_) => panic("expected error"),
+      Err(f) => {
+        match f.get() {
+          Ok(v) => {
+            if v != 1 {
+              panic("wrong adapted value")
+            }
+          },
+          Err(_) => panic("expected ok from get"),
+        }
+      },
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Failing[T any] interface {
+	get() T
+}
+
+type Boom struct{}
+
+func (b Boom) get() (int, error) {
+	return 1, nil
+}
+
+func source() lisette.Result[int, Boom] {
+	return lisette.MakeResultErr[int, Boom](Boom{})
+}
+
+func widen() (int, Failing[lisette.Result[int, error]]) {
+	check_1 := source()
+	if check_1.Tag != lisette.ResultOk {
+		return 0, _lisAdapter_Boom_Failing_0{inner: check_1.ErrVal}
+	}
+	n := check_1.OkVal
+	return n, nil
+}
+
+func main() {
+	_, ret_1 := widen()
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		f := ret_1
+		subject_2 := f.get()
+		if subject_2.Tag == lisette.ResultOk {
+			if subject_2.OkVal != 1 {
+				panic("wrong adapted value")
+			}
+		} else {
+			panic("expected ok from get")
+		}
+	}
+}
+
+type _lisAdapter_Boom_Failing_0 struct {
+	inner Boom
+}
+
+func (a _lisAdapter_Boom_Failing_0) get() lisette.Result[int, error] {
+	ret_2, ret_3 := a.inner.get()
+	var result_4 lisette.Result[int, error]
+	if ret_3 != nil {
+		result_4 = lisette.MakeResultErr[int, error](ret_3)
+	} else {
+		result_4 = lisette.MakeResultOk[int, error](ret_2)
+	}
+	return result_4
+}

--- a/tests/spec/emit/snapshots/propagate_widens_in_annotated_try_block.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_in_annotated_try_block.snap
@@ -1,0 +1,93 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct AError { }
+  
+  impl AError {
+    fn Error(self) -> string { "a failed" }
+  }
+  
+  struct BError { }
+  
+  impl BError {
+    fn Error(self) -> string { "b failed" }
+  }
+  
+  fn do_a(ok: bool) -> Result<int, AError> {
+    if ok { Ok(1) } else { Err(AError {}) }
+  }
+  
+  fn do_b(ok: bool) -> Result<int, BError> {
+    if ok { Ok(2) } else { Err(BError {}) }
+  }
+  
+  fn test() {
+    let r: Result<int, error> = try {
+      let a = do_a(true)?
+      let b = do_b(false)?
+      a + b
+    }
+    match r {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "b failed" {
+          panic("wrong try block error")
+        }
+      },
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type AError struct{}
+
+func (a AError) Error() string {
+	return "a failed"
+}
+
+type BError struct{}
+
+func (b BError) Error() string {
+	return "b failed"
+}
+
+func doA(ok bool) lisette.Result[int, AError] {
+	if ok {
+		return lisette.MakeResultOk[int, AError](1)
+	}
+	return lisette.MakeResultErr[int, AError](AError{})
+}
+
+func doB(ok bool) lisette.Result[int, BError] {
+	if ok {
+		return lisette.MakeResultOk[int, BError](2)
+	}
+	return lisette.MakeResultErr[int, BError](BError{})
+}
+
+func test() {
+	var r lisette.Result[int, error]
+	tryResult_1 := func() lisette.Result[int, error] {
+		check_2 := doA(true)
+		if check_2.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, error](check_2.ErrVal)
+		}
+		a := check_2.OkVal
+		check_3 := doB(false)
+		if check_3.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, error](check_3.ErrVal)
+		}
+		b := check_3.OkVal
+		return lisette.MakeResultOk[int, error](a + b)
+	}()
+	r = tryResult_1
+	if r.Tag == lisette.ResultOk {
+		panic("expected error")
+	}
+	if r.ErrVal.Error() != "b failed" {
+		panic("wrong try block error")
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_widens_in_prelude_callback_lambda.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_in_prelude_callback_lambda.snap
@@ -1,0 +1,86 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct ParseError { text: string }
+  
+  impl ParseError {
+    fn Error(self) -> string { f"bad: {self.text}" }
+  }
+  
+  fn parse_word(w: string) -> Result<int, ParseError> {
+    if w == "x" { Err(ParseError { text: w }) } else { Ok(w.length()) }
+  }
+  
+  fn test() {
+    let words = ["one", "x"]
+    let parsed = words.map(|w| -> Result<int, error> {
+      let n = parse_word(w)?
+      Ok(n)
+    })
+    match parsed[0] {
+      Ok(n) => {
+        if n != 3 {
+          panic("wrong parsed length")
+        }
+      },
+      Err(_) => panic("expected ok"),
+    }
+    match parsed[1] {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "bad: x" {
+          panic("wrong lambda error")
+        }
+      },
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type ParseError struct {
+	text string
+}
+
+func (p ParseError) Error() string {
+	return fmt.Sprintf("bad: %s", p.text)
+}
+
+func parseWord(w string) lisette.Result[int, ParseError] {
+	if w == "x" {
+		return lisette.MakeResultErr[int, ParseError](ParseError{text: w})
+	}
+	return lisette.MakeResultOk[int, ParseError](len(w))
+}
+
+func test() {
+	words := []string{"one", "x"}
+	parsed := lisette.SliceMap(words, func(w string) lisette.Result[int, error] {
+		check_1 := parseWord(w)
+		if check_1.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, error](check_1.ErrVal)
+		}
+		n := check_1.OkVal
+		return lisette.MakeResultOk[int, error](n)
+	})
+	subject_2 := parsed[0]
+	if subject_2.Tag == lisette.ResultOk {
+		if subject_2.OkVal != 3 {
+			panic("wrong parsed length")
+		}
+	} else {
+		panic("expected ok")
+	}
+	subject_3 := parsed[1]
+	if subject_3.Tag == lisette.ResultOk {
+		panic("expected error")
+	}
+	if subject_3.ErrVal.Error() != "bad: x" {
+		panic("wrong lambda error")
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
@@ -1,0 +1,74 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct FileError { path: string }
+  
+  impl FileError {
+    fn Error(self: Ref<FileError>) -> string { f"cannot open {self.path}" }
+  }
+  
+  fn read_value() -> Result<int, Ref<FileError>> { Err(&FileError { path: "a.txt" }) }
+  
+  fn load() -> Result<int, error> {
+    let n = read_value()?
+    Ok(n)
+  }
+  
+  fn test() {
+    match load() {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "cannot open a.txt" {
+          panic("wrong ref error")
+        }
+      },
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type FileError struct {
+	path string
+}
+
+func (f *FileError) Error() string {
+	return fmt.Sprintf("cannot open %s", f.path)
+}
+
+func readValue() (int, *FileError) {
+	return 0, &FileError{path: "a.txt"}
+}
+
+func load() (int, error) {
+	ret_1, ret_2 := readValue()
+	var result_3 lisette.Result[int, *FileError]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, *FileError](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, *FileError](ret_1)
+	}
+	check_4 := result_3
+	if check_4.Tag != lisette.ResultOk {
+		return 0, check_4.ErrVal
+	}
+	n := check_4.OkVal
+	return n, nil
+}
+
+func test() {
+	_, ret_1 := load()
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		e := ret_1
+		if e.Error() != "cannot open a.txt" {
+			panic("wrong ref error")
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
@@ -1,0 +1,99 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  pub interface AppError {
+    fn Error() -> string
+    fn status() -> int
+  }
+  
+  struct DbError { }
+  
+  impl DbError {
+    fn Error(self) -> string { "db down" }
+    pub fn status(self) -> int { 500 }
+  }
+  
+  fn query(ok: bool) -> Result<string, DbError> {
+    if ok { Ok("row") } else { Err(DbError {}) }
+  }
+  
+  fn handler(ok: bool) -> Result<int, AppError> {
+    let row = query(ok)?
+    Ok(row.length())
+  }
+  
+  fn test() {
+    match handler(false) {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.status() != 500 || e.Error() != "db down" {
+          panic("wrong app error")
+        }
+      },
+    }
+    match handler(true) {
+      Ok(n) => {
+        if n != 3 {
+          panic("wrong ok length")
+        }
+      },
+      Err(_) => panic("expected ok"),
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type AppError interface {
+	Error() string
+	Status() int
+}
+
+type DbError struct{}
+
+func (d DbError) Error() string {
+	return "db down"
+}
+
+func (d DbError) Status() int {
+	return 500
+}
+
+func query(ok bool) lisette.Result[string, DbError] {
+	if ok {
+		return lisette.MakeResultOk[string, DbError]("row")
+	}
+	return lisette.MakeResultErr[string, DbError](DbError{})
+}
+
+func handler(ok bool) (int, AppError) {
+	check_1 := query(ok)
+	if check_1.Tag != lisette.ResultOk {
+		return 0, check_1.ErrVal
+	}
+	row := check_1.OkVal
+	return len(row), nil
+}
+
+func test() {
+	_, ret_1 := handler(false)
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		e := ret_1
+		if e.Status() != 500 || e.Error() != "db down" {
+			panic("wrong app error")
+		}
+	}
+	ret_2, ret_3 := handler(true)
+	if ret_3 == nil {
+		n := ret_2
+		if n != 3 {
+			panic("wrong ok length")
+		}
+	} else {
+		panic("expected ok")
+	}
+}

--- a/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct AError { }
+  
+  impl AError {
+    fn Error(self) -> string { "a failed" }
+  }
+  
+  fn bail() -> Result<int, error> {
+    return Err(AError {})
+  }
+  
+  fn test() {
+    match bail() {
+      Ok(_) => panic("expected error"),
+      Err(e) => {
+        if e.Error() != "a failed" {
+          panic("wrong returned error")
+        }
+      },
+    }
+  }
+---
+package main
+
+type AError struct{}
+
+func (a AError) Error() string {
+	return "a failed"
+}
+
+func bail() (int, error) {
+	return 0, AError{}
+}
+
+func test() {
+	_, ret_1 := bail()
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+		e := ret_1
+		if e.Error() != "a failed" {
+			panic("wrong returned error")
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
@@ -1,0 +1,67 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  interface Failing<T> {
+    fn get() -> T
+  }
+  
+  struct Boom {}
+  
+  impl Boom {
+    fn get(self) -> Result<int, error> {
+      Ok(1)
+    }
+  }
+  
+  fn bail() -> Result<int, Failing<Result<int, error>>> {
+    return Err(Boom {})
+  }
+  
+  fn main() {
+    match bail() {
+      Ok(_) => panic("expected error"),
+      Err(_) => {},
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Failing[T any] interface {
+	get() T
+}
+
+type Boom struct{}
+
+func (b Boom) get() (int, error) {
+	return 1, nil
+}
+
+func bail() (int, Failing[lisette.Result[int, error]]) {
+	return 0, _lisAdapter_Boom_Failing_0{inner: Boom{}}
+}
+
+func main() {
+	_, ret_1 := bail()
+	if ret_1 == nil {
+		panic("expected error")
+	} else {
+	}
+}
+
+type _lisAdapter_Boom_Failing_0 struct {
+	inner Boom
+}
+
+func (a _lisAdapter_Boom_Failing_0) get() lisette.Result[int, error] {
+	ret_1, ret_2 := a.inner.get()
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	return result_3
+}

--- a/tests/spec/infer/snapshots/generic_container_still_invariant_over_interface_argument.snap
+++ b/tests/spec/infer/snapshots/generic_container_still_invariant_over_interface_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:18:16]
+ 17 │       let boxed = Box { value: Cat {} }
+ 18 │       take_box(boxed)
+    ·                ──┬──
+    ·                  ╰── expected `Box<Animal>`, found `Box<Cat>`
+ 19 │     }
+    ╰────
+  help: `take_box()` expects `Box<Animal>` for its first argument `b`. Convert the value to `Box<Animal>`, or change the parameter type · code: [infer.type_mismatch]

--- a/tests/spec/infer/snapshots/propagate_missing_custom_interface_method_lists_the_gap.snap
+++ b/tests/spec/infer/snapshots/propagate_missing_custom_interface_method_lists_the_gap.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:16:17]
+ 15 │     fn handler() -> Result<int, AppError> {
+ 16 │       let row = query()?
+    ·                 ────┬───
+    ·                     ╰── `DbError` does not implement `AppError`
+ 17 │       Ok(row.length())
+    ╰────
+  help: Missing methods:
+          From `AppError`
+            - status: fn () -> int
+        code: [infer.interface_not_implemented]

--- a/tests/spec/infer/snapshots/propagate_unrelated_concrete_errors_is_rejected.snap
+++ b/tests/spec/infer/snapshots/propagate_unrelated_concrete_errors_is_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Cannot propagate error
+    ╭─[test.lis:17:15]
+ 16 │     fn load() -> Result<int, BError> {
+ 17 │       let n = do_a()?
+    ·               ───┬───
+    ·                  ╰── expected `BError`, found `AError`
+ 18 │       Ok(n)
+    ╰────
+  help: cannot propagate `AError` as `BError`. Convert with `.map_err(...)` · code: [infer.cannot_propagate_error]

--- a/tests/spec/infer/snapshots/propagate_value_with_pointer_receiver_error_method_is_rejected.snap
+++ b/tests/spec/infer/snapshots/propagate_value_with_pointer_receiver_error_method_is_rejected.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Interface not implemented
+    ╭─[test.lis:11:15]
+ 10 │     fn load() -> Result<int, error> {
+ 11 │       let n = read_value()?
+    ·               ──────┬──────
+    ·                     ╰── `FileError` does not implement `error`
+ 12 │       Ok(n)
+    ╰────
+  help: `FileError.Error` mutates through `self: Ref<FileError>`, so `error` is satisfied by a `Ref<FileError>`, not a value. Take a reference with `&` (for example `&FileError { ... }`) · code: [infer.interface_not_implemented]

--- a/tests/spec/infer/snapshots/propagate_without_error_method_names_the_missing_method.snap
+++ b/tests/spec/infer/snapshots/propagate_without_error_method_names_the_missing_method.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Interface not implemented
+   ╭─[test.lis:7:15]
+ 6 │     fn load() -> Result<int, error> {
+ 7 │       let n = fetch()?
+   ·               ────┬───
+   ·                   ╰── `PlainError` does not implement `error`
+ 8 │       Ok(n)
+   ╰────
+  help: Missing methods:
+          From `error`
+            - Error: fn () -> string
+        code: [infer.interface_not_implemented]

--- a/tests/spec/infer/snapshots/slice_of_concrete_errors_still_rejected_for_slice_of_error.snap
+++ b/tests/spec/infer/snapshots/slice_of_concrete_errors_still_rejected_for_slice_of_error.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Type mismatch
+    ╭─[test.lis:12:19]
+ 11 │       let errors: Slice<CError> = [CError {}]
+ 12 │       take_errors(errors)
+    ·                   ───┬──
+    ·                      ╰── expected `Slice<error>`, found `Slice<CError>`
+ 13 │     }
+    ╰────
+  help: Use `.map(|value| value as error)` to widen each element · code: [infer.type_mismatch]

--- a/tests/spec/infer/snapshots/unannotated_try_block_still_binds_first_operand_error.snap
+++ b/tests/spec/infer/snapshots/unannotated_try_block_still_binds_first_operand_error.snap
@@ -1,0 +1,12 @@
+---
+source: tests/spec/infer/try.rs
+---
+  ✕ Cannot propagate error
+    ╭─[test.lis:20:17]
+ 19 │         let a = do_a()?
+ 20 │         let b = do_b()?
+    ·                 ───┬───
+    ·                    ╰── expected `AError`, found `BError`
+ 21 │         a + b
+    ╰────
+  help: cannot propagate `BError` as `AError`. Convert with `.map_err(...)` · code: [infer.cannot_propagate_error]

--- a/tests/spec/infer/try.rs
+++ b/tests/spec/infer/try.rs
@@ -1,3 +1,4 @@
+use crate::assert_infer_error_snapshot;
 use crate::spec::infer::*;
 
 #[test]
@@ -1008,4 +1009,341 @@ fn bare_ok_value_where_result_expected_still_suggests_ok() {
         "#,
     )
     .assert_error_contains("Wrap the value: `Ok(...)`");
+}
+
+#[test]
+fn propagate_widens_concrete_error_to_error_result() {
+    infer(
+        r#"
+    struct ValidationError { field: string }
+
+    impl ValidationError {
+      fn Error(self) -> string { self.field }
+    }
+
+    fn validate(name: string) -> Result<string, ValidationError> {
+      if name == "" { return Err(ValidationError { field: "name" }) }
+      Ok(name)
+    }
+
+    fn load(name: string) -> Result<string, error> {
+      let n = validate(name)?
+      Ok(n)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_widens_to_custom_interface_with_different_ok_types() {
+    infer(
+        r#"
+    pub interface AppError {
+      fn Error() -> string
+      fn status() -> int
+    }
+
+    struct DbError { }
+
+    impl DbError {
+      fn Error(self) -> string { "db down" }
+      pub fn status(self) -> int { 500 }
+    }
+
+    fn query() -> Result<string, DbError> { Err(DbError {}) }
+
+    fn handler() -> Result<int, AppError> {
+      let row = query()?
+      Ok(row.length())
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_widens_ref_with_pointer_receiver_error_method() {
+    infer(
+        r#"
+    struct FileError { path: string }
+
+    impl FileError {
+      fn Error(self: Ref<FileError>) -> string { self.path }
+    }
+
+    fn read_value() -> Result<int, Ref<FileError>> { Err(&FileError { path: "a" }) }
+
+    fn load() -> Result<int, error> {
+      let n = read_value()?
+      Ok(n)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn annotated_try_block_widens_two_concrete_errors() {
+    infer(
+        r#"
+    struct AError { }
+
+    impl AError {
+      fn Error(self) -> string { "a" }
+    }
+
+    struct BError { }
+
+    impl BError {
+      fn Error(self) -> string { "b" }
+    }
+
+    fn do_a() -> Result<int, AError> { Err(AError {}) }
+    fn do_b() -> Result<int, BError> { Err(BError {}) }
+
+    fn run() -> int {
+      let r: Result<int, error> = try {
+        let a = do_a()?
+        let b = do_b()?
+        a + b
+      }
+      match r {
+        Ok(v) => v,
+        Err(_) => 0,
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_widens_into_aliased_result_return_type() {
+    infer(
+        r#"
+    type Outcome = Result<string, error>
+
+    struct ValidationError { field: string }
+
+    impl ValidationError {
+      fn Error(self) -> string { self.field }
+    }
+
+    fn validate(name: string) -> Result<string, ValidationError> {
+      if name == "" { return Err(ValidationError { field: "name" }) }
+      Ok(name)
+    }
+
+    fn load(name: string) -> Outcome {
+      let n = validate(name)?
+      Ok(n)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn aliased_try_block_annotation_seeds_the_error_slot() {
+    infer(
+        r#"
+    type Outcome = Result<string, error>
+
+    struct AError { }
+
+    impl AError {
+      fn Error(self) -> string { "a" }
+    }
+
+    struct BError { }
+
+    impl BError {
+      fn Error(self) -> string { "b" }
+    }
+
+    fn do_a() -> Result<string, AError> { Err(AError {}) }
+    fn do_b() -> Result<string, BError> { Err(BError {}) }
+
+    fn run() -> string {
+      let r: Outcome = try {
+        let a = do_a()?
+        let b = do_b()?
+        a + b
+      }
+      match r {
+        Ok(v) => v,
+        Err(e) => e.Error(),
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_without_error_method_names_the_missing_method() {
+    assert_infer_error_snapshot!(
+        r#"
+    struct PlainError { code: int }
+
+    fn fetch() -> Result<int, PlainError> { Err(PlainError { code: 7 }) }
+
+    fn load() -> Result<int, error> {
+      let n = fetch()?
+      Ok(n)
+    }
+        "#
+    );
+}
+
+#[test]
+fn propagate_value_with_pointer_receiver_error_method_is_rejected() {
+    assert_infer_error_snapshot!(
+        r#"
+    struct FileError { path: string }
+
+    impl FileError {
+      fn Error(self: Ref<FileError>) -> string { self.path }
+    }
+
+    fn read_value() -> Result<int, FileError> { Err(FileError { path: "a" }) }
+
+    fn load() -> Result<int, error> {
+      let n = read_value()?
+      Ok(n)
+    }
+        "#
+    );
+}
+
+#[test]
+fn propagate_missing_custom_interface_method_lists_the_gap() {
+    assert_infer_error_snapshot!(
+        r#"
+    pub interface AppError {
+      fn Error() -> string
+      fn status() -> int
+    }
+
+    struct DbError { }
+
+    impl DbError {
+      fn Error(self) -> string { "db down" }
+    }
+
+    fn query() -> Result<string, DbError> { Err(DbError {}) }
+
+    fn handler() -> Result<int, AppError> {
+      let row = query()?
+      Ok(row.length())
+    }
+        "#
+    );
+}
+
+#[test]
+fn propagate_unrelated_concrete_errors_is_rejected() {
+    assert_infer_error_snapshot!(
+        r#"
+    struct AError { }
+
+    impl AError {
+      fn Error(self) -> string { "a" }
+    }
+
+    struct BError { }
+
+    impl BError {
+      fn Error(self) -> string { "b" }
+    }
+
+    fn do_a() -> Result<int, AError> { Err(AError {}) }
+
+    fn load() -> Result<int, BError> {
+      let n = do_a()?
+      Ok(n)
+    }
+        "#
+    );
+}
+
+#[test]
+fn unannotated_try_block_still_binds_first_operand_error() {
+    assert_infer_error_snapshot!(
+        r#"
+    struct AError { }
+
+    impl AError {
+      fn Error(self) -> string { "a" }
+    }
+
+    struct BError { }
+
+    impl BError {
+      fn Error(self) -> string { "b" }
+    }
+
+    fn do_a() -> Result<int, AError> { Err(AError {}) }
+    fn do_b() -> Result<int, BError> { Err(BError {}) }
+
+    fn run() -> int {
+      let r = try {
+        let a = do_a()?
+        let b = do_b()?
+        a + b
+      }
+      match r {
+        Ok(v) => v,
+        Err(_) => 0,
+      }
+    }
+        "#
+    );
+}
+
+#[test]
+fn slice_of_concrete_errors_still_rejected_for_slice_of_error() {
+    assert_infer_error_snapshot!(
+        r#"
+    struct CError { }
+
+    impl CError {
+      fn Error(self) -> string { "c" }
+    }
+
+    fn take_errors(s: Slice<error>) -> int { s.length() }
+
+    fn run() -> int {
+      let errors: Slice<CError> = [CError {}]
+      take_errors(errors)
+    }
+        "#
+    );
+}
+
+#[test]
+fn generic_container_still_invariant_over_interface_argument() {
+    assert_infer_error_snapshot!(
+        r#"
+    pub interface Animal {
+      fn speak() -> string
+    }
+
+    struct Cat { }
+
+    impl Cat {
+      pub fn speak(self) -> string { "meow" }
+    }
+
+    struct Box<T> { value: T }
+
+    fn take_box(b: Box<Animal>) -> string { b.value.speak() }
+
+    fn run() -> string {
+      let boxed = Box { value: Cat {} }
+      take_box(boxed)
+    }
+        "#
+    );
 }


### PR DESCRIPTION
A concrete error type can now propagate via `?` where the `Result` declares an interface error type, if the concrete type satisfies that interface.

```rs
struct ValidationError { field: string }

impl ValidationError {
  fn Error(self) -> string { f"{self.field}: required" }
}

fn validate(name: string) -> Result<string, ValidationError> {
  if name == "" { return Err(ValidationError { field: "name" }) }
  Ok(name)
}

fn load(name: string) -> Result<string, error> {
  let n = validate(name)?
  Ok(n)
}
```

The same rule applies inside an annotated `try` block, so several concrete error types can share one block:

```rs
let r: Result<int, error> = try {
  let a = do_a()? // fails with AError
  let b = do_b()? // fails with BError
  a + b
}
```

Unrelated concrete error types still require `.map_err(...)`
