### PR TITLE
perf: share one LSP analysis per package

### DIFF
--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -6,7 +6,7 @@ use emit::{EmitOptions, OutputFile, Planner};
 
 use passes::analyze;
 use semantics::cache::EmitStamp;
-use semantics::{AnalyzeInput, EntryFile};
+use semantics::{AnalyzeInput, EntryFile, RecoverTarget};
 
 use semantics::CompilePhase;
 use semantics::loader::Loader;
@@ -142,6 +142,7 @@ pub fn compile(
         locator,
         go_module,
         disable_cache,
+        recover_target: RecoverTarget::None,
     });
     let failed = analysis.failed();
     let emit_result = match mode.emit_options() {
@@ -520,6 +521,7 @@ mod tests {
             locator: &locator,
             go_module: "test",
             disable_cache: false,
+            recover_target: RecoverTarget::None,
         });
 
         let mut cached: Vec<String> = result.emit_input.cached_packages.iter().cloned().collect();
@@ -617,6 +619,7 @@ mod tests {
             locator: &locator,
             go_module: "test",
             disable_cache: false,
+            recover_target: RecoverTarget::None,
         });
         let mut names: Vec<String> = output
             .emit_input

--- a/crates/cli/src/typedef_scan.rs
+++ b/crates/cli/src/typedef_scan.rs
@@ -75,7 +75,7 @@ fn scan_file_imports(path: PathBuf) -> Result<Vec<ScannedImport>, SourceScanErro
         Err(e) => return Err(SourceScanError::Read { path, error: e }),
     };
     let parse_result = Parser::lex_and_parse_file(&source, 0);
-    if parse_result.failed() {
+    if parse_result.has_errors() {
         return Err(SourceScanError::Parse {
             path,
             message: parse_result.errors[0].message.clone(),

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -967,7 +967,7 @@ fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
 
 fn validate_typedef_parses(pkg_path: &str, typedef: &str) -> Result<(), String> {
     let parse = Parser::lex_and_parse_file(typedef, 0);
-    if !parse.failed() {
+    if !parse.has_errors() {
         return Ok(());
     }
     Err(format!(

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, PoisonError};
 
 use crate::protocol::*;
 use rustc_hash::FxHashMap;
@@ -7,17 +7,25 @@ use rustc_hash::FxHashMap;
 use deps::TypedefLocator;
 use diagnostics::LisetteDiagnostic;
 use passes::analyze;
-use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, ProjectKind};
+use semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, ProjectKind, RecoverTarget};
 use syntax::types::{CompoundKind, Type};
 
 use crate::imports::PackageResolver;
+use crate::loader::ProjectAnalysis;
+use crate::paths::uri_to_package_file;
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
-use crate::state::{AnalysisRequest, DocumentState, SharedState};
+use crate::state::{AnalysisKey, SharedState, Workspace};
 
-enum AnalysisError {
+pub(crate) enum AnalysisError {
     Diagnostics(Vec<Diagnostic>),
     Superseded,
+}
+
+struct BuildInput {
+    project: ProjectAnalysis,
+    entry: Option<(String, String)>,
+    uri: Option<Url>,
 }
 
 fn dotted_directory_reaches_package_graph(uri: &Url, filename: &str, root: &Path) -> bool {
@@ -96,46 +104,80 @@ pub(crate) fn find_package_by_alias(
 }
 
 impl SharedState {
-    fn run_analysis(&self, uri: &Url) -> Result<AnalysisSnapshot, Vec<Diagnostic>> {
-        let project = self.project.for_analysis(uri).ok_or_else(Vec::new)?;
-        let config = project.config;
-        let filename = project.filename;
-        let loader = project.loader;
-        let external_test = project.external_test;
+    pub(crate) fn key_for(&self, uri: &Url) -> Option<AnalysisKey> {
+        let config = self.project.config_for(uri)?;
+        let (package_id, filename, external_test) = uri_to_package_file(&config, uri)?;
+        let filtered_from_package =
+            !external_test && (filename.ends_with("_test.lis") || filename.ends_with(".d.lis"));
+        if config.is_script() || filtered_from_package {
+            return Some(AnalysisKey::Document { uri: uri.clone() });
+        }
+        Some(AnalysisKey::Package {
+            external_test,
+            package_id,
+        })
+    }
 
-        let source = self
-            .documents()
-            .get(uri)
-            .map(|document| document.content().to_string())
-            .ok_or_else(Vec::new)?;
+    pub(crate) fn validate(&self, uri: &Url) -> Option<LisetteDiagnostic> {
+        let config = self.project.config_for(uri)?;
+        let (package_id, filename, external_test) = uri_to_package_file(&config, uri)?;
 
-        if let Some(dotted) = project
-            .package_id
+        if let Some(dotted) = package_id
             .split('/')
             .find(|segment| segment.contains('.'))
             .filter(|_| dotted_directory_reaches_package_graph(uri, &filename, config.root()))
         {
-            return Err(vec![convert_diagnostic(
-                &diagnostics::package_graph::dotted_package_directory(dotted),
-                &LineIndex::new(&source),
-            )]);
+            return Some(diagnostics::package_graph::dotted_package_directory(dotted));
         }
 
-        if external_test && let Some(issue) = semantics::loader::external_test_file_issue(&filename)
-        {
-            let diagnostic = match issue {
-                semantics::loader::ExternalTestFileIssue::WrongSuffix => {
-                    diagnostics::package_graph::wrong_test_file_suffix(&filename)
-                }
-                semantics::loader::ExternalTestFileIssue::NotATestFile => {
-                    diagnostics::package_graph::non_test_file_under_tests(&filename)
-                }
-            };
-            return Err(vec![convert_diagnostic(
-                &diagnostic,
-                &LineIndex::new(&source),
-            )]);
+        if external_test {
+            return semantics::loader::external_test_file_issue(&filename).map(
+                |issue| match issue {
+                    semantics::loader::ExternalTestFileIssue::WrongSuffix => {
+                        diagnostics::package_graph::wrong_test_file_suffix(&filename)
+                    }
+                    semantics::loader::ExternalTestFileIssue::NotATestFile => {
+                        diagnostics::package_graph::non_test_file_under_tests(&filename)
+                    }
+                },
+            );
         }
+
+        None
+    }
+
+    fn capture_build_input(&self, key: &AnalysisKey, workspace: &Workspace) -> Option<BuildInput> {
+        let project = self.project.for_key(key)?;
+        let (entry, uri) = match key {
+            AnalysisKey::Document { uri } => {
+                let config = self.project.config_for(uri)?;
+                let (_, filename, _) = uri_to_package_file(&config, uri)?;
+                let source = workspace.documents.get(uri)?.content().to_string();
+                (Some((source, filename)), Some(uri.clone()))
+            }
+            AnalysisKey::Package { .. } => (None, None),
+        };
+        Some(BuildInput {
+            project,
+            entry,
+            uri,
+        })
+    }
+
+    fn run_analysis(
+        &self,
+        key: &AnalysisKey,
+        input: BuildInput,
+    ) -> Result<AnalysisSnapshot, Vec<Diagnostic>> {
+        let BuildInput {
+            project,
+            entry,
+            uri,
+        } = input;
+        let config = project.config;
+        let loader = project.loader;
+        let external_test = project.external_test;
+        let entry_dir = project.entry_dir;
 
         let script = config.is_script();
         let (locator, manifest_error) = if script {
@@ -147,14 +189,15 @@ impl SharedState {
             }
         };
 
-        let script_path = uri.to_file_path().ok();
+        let script_path = uri.as_ref().and_then(|uri| uri.to_file_path().ok());
         let script_setup = self
             .bindgen_setup
             .as_ref()
             .filter(|_| script && manifest_error.is_none())
-            .zip(script_path.as_deref());
+            .zip(script_path.as_deref())
+            .zip(entry.as_ref());
         let (locator, script_session, script_error) = match script_setup {
-            Some((setup, path)) => match setup.for_script(&source, path) {
+            Some(((setup, path), (source, _))) => match setup.for_script(source, path) {
                 Ok((resolved, session)) => (resolved, session, None),
                 Err(msg) => (locator, None, Some(msg)),
             },
@@ -194,16 +237,15 @@ impl SharedState {
                 AnalysisScope::Project(config.root().to_path_buf())
             },
             loader: &loader,
-            entry: if external_test {
-                None
-            } else {
-                Some(EntryFile::recovering(source, filename.clone(), filename))
-            },
+            entry: entry.map(|(source, filename)| {
+                EntryFile::recovering(source, filename.clone(), filename)
+            }),
             compile_phase: CompilePhase::Check,
             project_kind,
             locator: &locator,
             go_module: "",
             disable_cache: external_test,
+            recover_target: recover_target(key),
         });
         let entry_parse_failed = analysis.entry_parse_failed();
 
@@ -254,37 +296,96 @@ impl SharedState {
         Ok(AnalysisSnapshot::new(
             analysis,
             &config,
-            uri,
+            &entry_dir,
             external_test,
             packages,
         ))
     }
 
-    fn run_analysis_cached(&self, uri: &Url) -> Result<Arc<AnalysisSnapshot>, AnalysisError> {
-        let documents = self.documents();
-        let document = documents.get(uri).ok_or(AnalysisError::Superseded)?;
-        let request = document.request_analysis();
-        drop(documents);
-
-        let revision = match request {
-            AnalysisRequest::Cached(snapshot) => return Ok(snapshot),
-            AnalysisRequest::Required(revision) => revision,
-        };
-
-        let snapshot = Arc::new(self.run_analysis(uri).map_err(AnalysisError::Diagnostics)?);
-
-        if let Some(document) = self.documents_mut().get_mut(uri)
-            && document.cache_analysis(&revision, Arc::clone(&snapshot))
-        {
+    pub(crate) fn analysis_for(
+        &self,
+        key: &AnalysisKey,
+    ) -> Result<Arc<AnalysisSnapshot>, AnalysisError> {
+        if let Some(snapshot) = self.workspace().snapshot(key) {
             return Ok(snapshot);
         }
 
-        Err(AnalysisError::Superseded)
+        let build = self
+            .workspace()
+            .build_lock(key)
+            .ok_or(AnalysisError::Superseded)?;
+        let _guard = build.lock().unwrap_or_else(PoisonError::into_inner);
+
+        let (generation, input) = {
+            let workspace = self.workspace();
+            if !workspace
+                .build_lock(key)
+                .is_some_and(|current| Arc::ptr_eq(&current, &build))
+            {
+                return Err(AnalysisError::Superseded);
+            }
+            if let Some(snapshot) = workspace.snapshot(key) {
+                return Ok(snapshot);
+            }
+            let input = self
+                .capture_build_input(key, &workspace)
+                .ok_or(AnalysisError::Superseded)?;
+            (workspace.generation(), input)
+        };
+
+        let built = self.run_analysis(key, input);
+
+        let mut workspace = self.workspace_mut();
+        if workspace.generation() != generation {
+            return Err(AnalysisError::Superseded);
+        }
+        let snapshot = Arc::new(built.map_err(AnalysisError::Diagnostics)?);
+        if !workspace.install(key, generation, Arc::clone(&snapshot)) {
+            return Err(AnalysisError::Superseded);
+        }
+
+        let recipients: Vec<Url> = workspace
+            .documents
+            .keys()
+            .filter(|uri| self.key_for(uri).as_ref() == Some(key))
+            .filter(|uri| self.validate(uri).is_none())
+            .filter(|uri| snapshot.is_usable(uri))
+            .cloned()
+            .collect();
+        for uri in recipients {
+            if let Some(document) = workspace.documents.get_mut(&uri) {
+                document.set_last_usable(Arc::clone(&snapshot));
+            }
+        }
+        Ok(snapshot)
     }
 
-    pub(crate) fn analyze_and_convert(&self, uri: &Url) -> Option<Vec<Diagnostic>> {
-        let snapshot = match self.run_analysis_cached(uri) {
-            Ok(s) => s,
+    pub(crate) fn get_snapshot(&self, uri: &Url) -> Option<Arc<AnalysisSnapshot>> {
+        let fallback = || self.workspace().documents.get(uri)?.last_usable();
+
+        if self.validate(uri).is_some() {
+            return fallback();
+        }
+
+        let key = self.key_for(uri)?;
+        match self.analysis_for(&key) {
+            Ok(snapshot) if snapshot.is_usable(uri) => Some(snapshot),
+            _ => fallback(),
+        }
+    }
+
+    pub(crate) fn diagnostics_for(&self, uri: &Url) -> Option<Vec<Diagnostic>> {
+        if let Some(diagnostic) = self.validate(uri) {
+            let source = self.workspace().documents.get(uri)?.content().to_string();
+            return Some(vec![convert_diagnostic(
+                &diagnostic,
+                &LineIndex::new(&source),
+            )]);
+        }
+
+        let key = self.key_for(uri)?;
+        let snapshot = match self.analysis_for(&key) {
+            Ok(snapshot) => snapshot,
             Err(AnalysisError::Diagnostics(diagnostics)) => return Some(diagnostics),
             Err(AnalysisError::Superseded) => return None,
         };
@@ -307,24 +408,36 @@ impl SharedState {
         )
     }
 
-    pub(crate) fn get_snapshot(&self, uri: &Url) -> Option<Arc<AnalysisSnapshot>> {
-        match self.run_analysis_cached(uri) {
-            Ok(snapshot) => Some(snapshot),
-            Err(_) => self
-                .documents()
-                .get(uri)
-                .and_then(DocumentState::last_valid_analysis),
-        }
-    }
-
     pub(crate) fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
-        self.documents()
-            .values()
-            .filter_map(|document| match document.request_analysis() {
-                AnalysisRequest::Cached(snapshot) => Some(snapshot),
-                AnalysisRequest::Required(_) => None,
-            })
+        let uris: Vec<Url> = self.workspace().documents.keys().cloned().collect();
+        let mut keys: Vec<AnalysisKey> = Vec::new();
+        for uri in uris {
+            if self.validate(&uri).is_some() {
+                continue;
+            }
+            if let Some(key) = self.key_for(&uri)
+                && !keys.contains(&key)
+            {
+                keys.push(key);
+            }
+        }
+        keys.iter()
+            .filter_map(|key| self.analysis_for(key).ok())
             .collect()
+    }
+}
+
+fn recover_target(key: &AnalysisKey) -> RecoverTarget {
+    match key {
+        AnalysisKey::Package {
+            external_test: true,
+            package_id,
+        } => RecoverTarget::Package(package_id.clone()),
+        AnalysisKey::Package {
+            external_test: false,
+            ..
+        } => RecoverTarget::Package(crate::paths::ENTRY_PACKAGE_ID.to_string()),
+        AnalysisKey::Document { .. } => RecoverTarget::None,
     }
 }
 

--- a/crates/lsp/src/document.rs
+++ b/crates/lsp/src/document.rs
@@ -4,18 +4,65 @@ use std::time::Duration;
 
 use crate::protocol::Url;
 
-use crate::state::{CancellationToken, DocumentState, SharedState};
+use crate::state::{AnalysisKey, CancellationToken, DocumentState, SharedState};
 
 impl SharedState {
-    pub(crate) fn update_document(&self, uri: Url, content: String, version: i32) {
+    pub(crate) fn open_document(self: &Arc<Self>, uri: Url, content: String, version: i32) {
+        let mut workspace = self.workspace_mut();
         self.project.update_overlay(&uri, content.clone());
-
-        let mut documents = self.documents_mut();
-        if let Some(document) = documents.get_mut(&uri) {
-            document.update(content, version);
-        } else {
-            documents.insert(uri, DocumentState::new(content, version));
+        let key = self.key_for(&uri);
+        workspace
+            .documents
+            .insert(uri, DocumentState::new(content, version));
+        if let Some(key) = key {
+            workspace.ensure(&key);
         }
+        workspace.invalidate_all();
+        drop(workspace);
+
+        self.reschedule_all();
+    }
+
+    pub(crate) fn change_document(self: &Arc<Self>, uri: Url, content: String, version: i32) {
+        let mut workspace = self.workspace_mut();
+        self.project.update_overlay(&uri, content.clone());
+        let key = self.key_for(&uri);
+        match workspace.documents.get_mut(&uri) {
+            Some(document) => document.update(content, version),
+            None => {
+                workspace
+                    .documents
+                    .insert(uri.clone(), DocumentState::new(content, version));
+            }
+        }
+        if let Some(key) = key {
+            workspace.ensure(&key);
+        }
+        workspace.invalidate_all();
+        drop(workspace);
+
+        self.reschedule_all();
+    }
+
+    pub(crate) fn close_document(self: &Arc<Self>, uri: &Url) {
+        let mut workspace = self.workspace_mut();
+        let key = self.key_for(uri);
+        self.project.remove_overlay(uri);
+        workspace.documents.remove(uri);
+        if let Some(key) = key {
+            let still_open = workspace
+                .documents
+                .keys()
+                .any(|open| self.key_for(open).as_ref() == Some(&key));
+            if !still_open {
+                workspace.evict(&key);
+            }
+        }
+        workspace.invalidate_all();
+        drop(workspace);
+
+        self.client.publish_diagnostics(uri.clone(), vec![], None);
+        self.reschedule_all();
     }
 
     pub(crate) fn publish_diagnostics(&self, uri: Url) {
@@ -27,53 +74,60 @@ impl SharedState {
             return;
         }
 
-        let version = self.documents().get(&uri).map(DocumentState::version);
+        let (version, generation) = {
+            let workspace = self.workspace();
+            let Some(document) = workspace.documents.get(&uri) else {
+                return;
+            };
+            (document.version(), workspace.generation())
+        };
 
-        let Some(diagnostics) = self.analyze_and_convert(&uri) else {
+        let Some(diagnostics) = self.diagnostics_for(&uri) else {
             return;
         };
 
-        let current_version = self.documents().get(&uri).map(DocumentState::version);
-        if version != current_version {
-            return; // Discard stale results
-        }
-
-        self.client.publish_diagnostics(uri, diagnostics, version);
-    }
-
-    pub(crate) fn recheck_open_documents(self: &Arc<Self>) {
-        let mut documents = self.documents_mut();
-        let mut uris = Vec::with_capacity(documents.len());
-        for (uri, document) in documents.iter_mut() {
-            document.invalidate_analysis();
-            uris.push(uri.clone());
-        }
-        drop(documents);
-        for uri in uris {
-            self.schedule_diagnostics(uri);
-        }
-    }
-
-    fn schedule_diagnostics(self: &Arc<Self>, uri: Url) {
-        let mut documents = self.documents_mut();
-        let Some(document) = documents.get_mut(&uri) else {
+        let workspace = self.workspace();
+        if workspace.generation() != generation || !workspace.documents.contains_key(&uri) {
             return;
-        };
+        }
+        self.client
+            .publish_diagnostics(uri, diagnostics, Some(version));
+    }
 
+    fn reschedule_all(self: &Arc<Self>) {
+        let keys = self.workspace().keys();
+        for key in keys {
+            self.schedule_diagnostics(key);
+        }
+    }
+
+    fn schedule_diagnostics(self: &Arc<Self>, key: AnalysisKey) {
         let state = Arc::clone(self);
-        let diagnostics_uri = uri.clone();
         let token = CancellationToken::new();
         let run_token = token.clone();
+        let run_key = key.clone();
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(300));
             if run_token.is_cancelled() {
                 return;
             }
-            state.publish_diagnostics(diagnostics_uri.clone());
-            if let Some(document) = state.documents_mut().get_mut(&diagnostics_uri) {
-                document.finish_diagnostics(&run_token);
+            for uri in state.documents_for(&run_key) {
+                if run_token.is_cancelled() {
+                    return;
+                }
+                state.publish_diagnostics(uri);
             }
+            state
+                .workspace_mut()
+                .finish_diagnostics(&run_key, &run_token);
         });
-        document.set_pending_diagnostics(token);
+        self.workspace_mut().set_pending_diagnostics(&key, token);
+    }
+
+    fn documents_for(&self, key: &AnalysisKey) -> Vec<Url> {
+        let uris: Vec<Url> = self.workspace().documents.keys().cloned().collect();
+        uris.into_iter()
+            .filter(|uri| self.key_for(uri).as_ref() == Some(key))
+            .collect()
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -117,17 +117,18 @@ impl Backend {
     }
 
     fn did_open(&self, params: DidOpenTextDocumentParams) {
-        let uri = params.text_document.uri;
-        let content = params.text_document.text;
-        self.update_document(uri.clone(), content, params.text_document.version);
-        self.publish_diagnostics(uri);
+        self.shared_state.open_document(
+            params.text_document.uri,
+            params.text_document.text,
+            params.text_document.version,
+        );
     }
 
     fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         if let Some(change) = params.content_changes.into_iter().last() {
-            self.update_document(uri, change.text, params.text_document.version);
-            self.shared_state.recheck_open_documents();
+            self.shared_state
+                .change_document(uri, change.text, params.text_document.version);
         }
     }
 
@@ -136,22 +137,14 @@ impl Backend {
     }
 
     fn did_close(&self, params: DidCloseTextDocumentParams) {
-        let uri = &params.text_document.uri;
-        self.documents_mut().remove(uri);
-
-        let overlay_removed = self.project.remove_overlay(uri);
-
-        self.client.publish_diagnostics(uri.clone(), vec![], None);
-
-        if overlay_removed {
-            self.shared_state.recheck_open_documents();
-        }
+        self.shared_state.close_document(&params.text_document.uri);
     }
 
     fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let uri = &params.text_document.uri;
         let (source, end_position) = {
-            let documents = self.documents();
+            let workspace = self.workspace();
+            let documents = &workspace.documents;
             let Some(doc) = documents.get(uri) else {
                 return Ok(None);
             };
@@ -977,7 +970,8 @@ impl Backend {
     }
 
     fn edit_target(&self, uri: &Url, position: Position) -> Option<EditTarget> {
-        let documents = self.documents();
+        let workspace = self.workspace();
+        let documents = &workspace.documents;
         let document = documents.get(uri)?;
         let line_index = document.line_index();
         let offset = line_index.position_to_offset(position)? as usize;

--- a/crates/lsp/src/loader.rs
+++ b/crates/lsp/src/loader.rs
@@ -6,8 +6,9 @@ use std::sync::{PoisonError, RwLock, RwLockWriteGuard};
 use crate::protocol::Url;
 use semantics::loader::{DiscoveredPackages, FileContent, Files, Loader};
 
-use crate::paths::{ENTRY_PACKAGE_ID, package_id_to_dir, uri_to_package_file};
+use crate::paths::{ENTRY_PACKAGE_ID, package_id_to_dir, source_package_dir, uri_to_package_file};
 use crate::project::{ProjectConfig, find_project_root, resolve_script_root};
+use crate::state::AnalysisKey;
 
 pub(crate) struct ProjectState {
     loader: RwLock<Option<OverlayLoader>>,
@@ -15,8 +16,7 @@ pub(crate) struct ProjectState {
 
 pub(crate) struct ProjectAnalysis {
     pub(crate) config: ProjectConfig,
-    pub(crate) package_id: String,
-    pub(crate) filename: String,
+    pub(crate) entry_dir: PathBuf,
     pub(crate) external_test: bool,
     pub(crate) loader: AnalysisLoader,
 }
@@ -68,31 +68,48 @@ impl ProjectState {
         true
     }
 
-    pub(crate) fn for_analysis(&self, uri: &Url) -> Option<ProjectAnalysis> {
+    pub(crate) fn config_for(&self, uri: &Url) -> Option<ProjectConfig> {
         let guard = self.loader_for(uri)?;
         let project = guard.as_ref().expect("loader_for initializes the loader");
-        let (package_id, filename, external_test) = uri_to_package_file(&project.config, uri)?;
+        Some(project.config.clone())
+    }
 
-        let (entry_package_path, external_test_root) = if external_test {
-            (
-                package_id_to_dir(&project.config, ENTRY_PACKAGE_ID),
+    pub(crate) fn for_key(&self, key: &AnalysisKey) -> Option<ProjectAnalysis> {
+        let guard = match key {
+            AnalysisKey::Document { uri } => self.loader_for(uri)?,
+            AnalysisKey::Package { .. } => {
+                self.loader.write().unwrap_or_else(PoisonError::into_inner)
+            }
+        };
+        let project = guard.as_ref()?;
+
+        let (entry_dir, external_test_root, external_test) = match key {
+            AnalysisKey::Package {
+                external_test: true,
+                package_id,
+            } => (
+                source_package_dir(&project.config, ENTRY_PACKAGE_ID),
                 Some(package_id.clone()),
-            )
-        } else {
-            let dir = uri
-                .to_file_path()
-                .ok()
-                .and_then(|path| path.parent().map(Path::to_path_buf))
-                .unwrap_or_else(|| package_id_to_dir(&project.config, &package_id));
-            (dir, None)
+                true,
+            ),
+            AnalysisKey::Package {
+                external_test: false,
+                package_id,
+            } => (source_package_dir(&project.config, package_id), None, false),
+            AnalysisKey::Document { uri } => {
+                let dir = uri
+                    .to_file_path()
+                    .ok()
+                    .and_then(|path| path.parent().map(Path::to_path_buf))?;
+                (dir, None, false)
+            }
         };
 
         Some(ProjectAnalysis {
             config: project.config.clone(),
-            package_id,
-            filename,
+            entry_dir: entry_dir.clone(),
             external_test,
-            loader: project.for_analysis(entry_package_path, external_test_root),
+            loader: project.for_analysis(entry_dir, external_test_root),
         })
     }
 }
@@ -250,15 +267,22 @@ mod tests {
         let project = ProjectState::new();
         project.update_overlay(&first_uri, "memory".to_string());
 
-        let analysis = project.for_analysis(&first_uri).unwrap();
+        let key = AnalysisKey::Document {
+            uri: first_uri.clone(),
+        };
+        let analysis = project.for_key(&key).unwrap();
         assert_eq!(
             analysis.loader.scan_folder(ENTRY_PACKAGE_ID)["main.lis"].source,
             "memory"
         );
-        assert!(project.for_analysis(&second_uri).is_none());
+        assert_eq!(
+            project.config_for(&second_uri).unwrap().root(),
+            first_root,
+            "the loader stays rooted where it was initialized"
+        );
 
         assert!(project.remove_overlay(&first_uri));
-        let analysis = project.for_analysis(&first_uri).unwrap();
+        let analysis = project.for_key(&key).unwrap();
         assert_eq!(
             analysis.loader.scan_folder(ENTRY_PACKAGE_ID)["main.lis"].source,
             "disk"

--- a/crates/lsp/src/paths.rs
+++ b/crates/lsp/src/paths.rs
@@ -26,6 +26,15 @@ pub(crate) fn package_id_to_dir(config: &ProjectConfig, package_id: &str) -> Pat
     }
 }
 
+pub(crate) fn source_package_dir(config: &ProjectConfig, package_id: &str) -> PathBuf {
+    let source_root = config.source_root();
+    if package_id == ENTRY_PACKAGE_ID {
+        source_root
+    } else {
+        source_root.join(package_id)
+    }
+}
+
 pub(crate) fn package_file_to_path(
     config: &ProjectConfig,
     package_id: &str,

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::protocol::{Position, Url};
 use passes::Analysis;
 use semantics::facts::{BindingFact, Usage};
+use syntax::FileParseStatus::Failed;
 use syntax::ast::BindingId;
 use syntax::program::{Definition, File};
 use syntax::types::Symbol;
@@ -40,32 +41,17 @@ impl AnalysisSnapshot {
     pub(crate) fn new(
         analysis: Analysis,
         config: &ProjectConfig,
-        analyzed_uri: &Url,
+        entry_dir: &std::path::Path,
         external_test: bool,
         packages: PackageResolver,
     ) -> Self {
         let mut sources = HashMap::default();
 
-        let analyzed_path = analyzed_uri.to_file_path().ok();
-        let analyzed_filename = analyzed_path
-            .as_ref()
-            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()));
-        let analyzed_dir = analyzed_path
-            .as_ref()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-
         for (file_id, file) in &analysis.emit_input.files {
             let uri = if !external_test && file.package_id == ENTRY_PACKAGE_ID {
-                if analyzed_filename.as_deref() == Some(&file.name) {
-                    analyzed_uri.clone()
-                } else if let Some(ref dir) = analyzed_dir {
-                    let sibling_path = dir.join(&file.name);
-                    match Url::from_file_path(&sibling_path) {
-                        Ok(uri) => uri,
-                        Err(_) => continue,
-                    }
-                } else {
-                    continue;
+                match Url::from_file_path(entry_dir.join(&file.name)) {
+                    Ok(uri) => uri,
+                    Err(_) => continue,
                 }
             } else if let Some(typedef_path) = &file.source_path {
                 // The synthetic `file.name` for go: typedefs does not match the
@@ -150,7 +136,8 @@ impl AnalysisSnapshot {
         &self.analysis.emit_input.definitions
     }
 
-    pub(crate) fn has_parse_errors(&self) -> bool {
-        self.analysis.has_parse_errors()
+    pub(crate) fn is_usable(&self, uri: &Url) -> bool {
+        self.document(uri)
+            .is_some_and(|document| self.analysis.parse_status(document.file_id) != Failed)
     }
 }

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, Mutex, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::protocol::{Client, Url};
 use deps::BindgenSetup;
@@ -13,23 +13,121 @@ use crate::snapshot::AnalysisSnapshot;
 pub struct SharedState {
     pub(crate) client: Client,
     pub(crate) project: ProjectState,
-    documents: RwLock<HashMap<Url, DocumentState>>,
+    workspace: RwLock<Workspace>,
     pub(crate) bindgen_setup: Option<Arc<dyn BindgenSetup>>,
     pub(crate) packages: Arc<PackageIndex>,
     pub(crate) insert_replace_support: AtomicBool,
 }
 
 impl SharedState {
-    pub(crate) fn documents(&self) -> RwLockReadGuard<'_, HashMap<Url, DocumentState>> {
-        self.documents
+    pub(crate) fn workspace(&self) -> RwLockReadGuard<'_, Workspace> {
+        self.workspace
             .read()
             .unwrap_or_else(PoisonError::into_inner)
     }
 
-    pub(crate) fn documents_mut(&self) -> RwLockWriteGuard<'_, HashMap<Url, DocumentState>> {
-        self.documents
+    pub(crate) fn workspace_mut(&self) -> RwLockWriteGuard<'_, Workspace> {
+        self.workspace
             .write()
             .unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Under one lock so a build installs against a document set that cannot
+/// shift underneath it.
+#[derive(Default)]
+pub(crate) struct Workspace {
+    pub(crate) documents: HashMap<Url, DocumentState>,
+    analyses: HashMap<AnalysisKey, SharedAnalysis>,
+    generation: u64,
+}
+
+/// What an analysis is determined by, and so what it can be shared across.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) enum AnalysisKey {
+    Package {
+        external_test: bool,
+        package_id: String,
+    },
+    /// Scripts, and files the package loader excludes from sibling loading.
+    Document { uri: Url },
+}
+
+#[derive(Default)]
+struct SharedAnalysis {
+    current: Option<Arc<AnalysisSnapshot>>,
+    pending_diagnostics: Option<CancellationToken>,
+    build: Arc<Mutex<()>>,
+}
+
+impl Workspace {
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn keys(&self) -> Vec<AnalysisKey> {
+        self.analyses.keys().cloned().collect()
+    }
+
+    pub(crate) fn snapshot(&self, key: &AnalysisKey) -> Option<Arc<AnalysisSnapshot>> {
+        self.analyses.get(key)?.current.clone()
+    }
+
+    pub(crate) fn ensure(&mut self, key: &AnalysisKey) {
+        self.analyses.entry(key.clone()).or_default();
+    }
+
+    pub(crate) fn build_lock(&self, key: &AnalysisKey) -> Option<Arc<Mutex<()>>> {
+        Some(Arc::clone(&self.analyses.get(key)?.build))
+    }
+
+    pub(crate) fn install(
+        &mut self,
+        key: &AnalysisKey,
+        generation: u64,
+        snapshot: Arc<AnalysisSnapshot>,
+    ) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        let Some(analysis) = self.analyses.get_mut(key) else {
+            return false;
+        };
+        analysis.current = Some(snapshot);
+        true
+    }
+
+    pub(crate) fn invalidate_all(&mut self) {
+        self.generation += 1;
+        for analysis in self.analyses.values_mut() {
+            analysis.current = None;
+        }
+    }
+
+    pub(crate) fn set_pending_diagnostics(&mut self, key: &AnalysisKey, token: CancellationToken) {
+        let Some(analysis) = self.analyses.get_mut(key) else {
+            token.cancel();
+            return;
+        };
+        if let Some(previous) = analysis.pending_diagnostics.replace(token) {
+            previous.cancel();
+        }
+    }
+
+    pub(crate) fn finish_diagnostics(&mut self, key: &AnalysisKey, token: &CancellationToken) {
+        if let Some(analysis) = self.analyses.get_mut(key)
+            && analysis.pending_diagnostics.as_ref() == Some(token)
+        {
+            analysis.pending_diagnostics = None;
+        }
+    }
+
+    pub(crate) fn evict(&mut self, key: &AnalysisKey) {
+        if let Some(analysis) = self.analyses.remove(key)
+            && let Some(token) = analysis.pending_diagnostics
+        {
+            token.cancel();
+        }
     }
 }
 
@@ -72,104 +170,7 @@ impl std::ops::Deref for Backend {
 pub(crate) struct DocumentState {
     line_index: LineIndex,
     version: i32,
-    analysis: DocumentAnalysis,
-    pending_diagnostics: Option<CancellationToken>,
-}
-
-struct DocumentAnalysis {
-    revision: AnalysisRevision,
-    result: AnalysisResult,
-}
-
-#[derive(Clone)]
-pub(crate) struct AnalysisRevision(Arc<()>);
-
-pub(crate) enum AnalysisRequest {
-    Cached(Arc<AnalysisSnapshot>),
-    Required(AnalysisRevision),
-}
-
-#[derive(Default)]
-enum AnalysisResult {
-    #[default]
-    Empty,
-    Stale(Arc<AnalysisSnapshot>),
-    Valid(Arc<AnalysisSnapshot>),
-    Invalid {
-        current: Arc<AnalysisSnapshot>,
-        last_valid: Option<Arc<AnalysisSnapshot>>,
-    },
-}
-
-impl Default for DocumentAnalysis {
-    fn default() -> Self {
-        Self {
-            revision: AnalysisRevision(Arc::new(())),
-            result: AnalysisResult::default(),
-        }
-    }
-}
-
-impl DocumentAnalysis {
-    fn current(&self) -> Option<Arc<AnalysisSnapshot>> {
-        match &self.result {
-            AnalysisResult::Valid(snapshot)
-            | AnalysisResult::Invalid {
-                current: snapshot, ..
-            } => Some(Arc::clone(snapshot)),
-            AnalysisResult::Empty | AnalysisResult::Stale(_) => None,
-        }
-    }
-
-    fn last_valid(&self) -> Option<Arc<AnalysisSnapshot>> {
-        match &self.result {
-            AnalysisResult::Stale(snapshot) | AnalysisResult::Valid(snapshot) => {
-                Some(Arc::clone(snapshot))
-            }
-            AnalysisResult::Invalid { last_valid, .. } => last_valid.clone(),
-            AnalysisResult::Empty => None,
-        }
-    }
-
-    fn request(&self) -> AnalysisRequest {
-        match self.current() {
-            Some(snapshot) => AnalysisRequest::Cached(snapshot),
-            None => AnalysisRequest::Required(self.revision.clone()),
-        }
-    }
-
-    fn invalidate(&mut self) {
-        self.revision = AnalysisRevision(Arc::new(()));
-        let current = std::mem::take(&mut self.result);
-        self.result = match current {
-            AnalysisResult::Valid(snapshot) | AnalysisResult::Stale(snapshot) => {
-                AnalysisResult::Stale(snapshot)
-            }
-            AnalysisResult::Invalid {
-                last_valid: Some(snapshot),
-                ..
-            } => AnalysisResult::Stale(snapshot),
-            AnalysisResult::Empty
-            | AnalysisResult::Invalid {
-                last_valid: None, ..
-            } => AnalysisResult::Empty,
-        };
-    }
-
-    fn update(&mut self, revision: &AnalysisRevision, snapshot: Arc<AnalysisSnapshot>) -> bool {
-        if !Arc::ptr_eq(&self.revision.0, &revision.0) {
-            return false;
-        }
-        if snapshot.has_parse_errors() {
-            self.result = AnalysisResult::Invalid {
-                current: snapshot,
-                last_valid: self.last_valid(),
-            };
-        } else {
-            self.result = AnalysisResult::Valid(snapshot);
-        }
-        true
-    }
+    last_usable: Option<Arc<AnalysisSnapshot>>,
 }
 
 impl DocumentState {
@@ -177,15 +178,13 @@ impl DocumentState {
         Self {
             line_index: LineIndex::new(&content),
             version,
-            analysis: DocumentAnalysis::default(),
-            pending_diagnostics: None,
+            last_usable: None,
         }
     }
 
     pub(crate) fn update(&mut self, content: String, version: i32) {
         self.line_index = LineIndex::new(&content);
         self.version = version;
-        self.analysis.invalidate();
     }
 
     pub(crate) fn content(&self) -> &str {
@@ -200,47 +199,12 @@ impl DocumentState {
         self.version
     }
 
-    pub(crate) fn request_analysis(&self) -> AnalysisRequest {
-        self.analysis.request()
+    pub(crate) fn last_usable(&self) -> Option<Arc<AnalysisSnapshot>> {
+        self.last_usable.clone()
     }
 
-    pub(crate) fn last_valid_analysis(&self) -> Option<Arc<AnalysisSnapshot>> {
-        self.analysis.last_valid()
-    }
-
-    pub(crate) fn cache_analysis(
-        &mut self,
-        revision: &AnalysisRevision,
-        snapshot: Arc<AnalysisSnapshot>,
-    ) -> bool {
-        self.analysis.update(revision, snapshot)
-    }
-
-    pub(crate) fn invalidate_analysis(&mut self) {
-        self.analysis.invalidate();
-    }
-
-    pub(crate) fn abort_pending_diagnostics(&mut self) {
-        if let Some(token) = self.pending_diagnostics.take() {
-            token.cancel();
-        }
-    }
-
-    pub(crate) fn set_pending_diagnostics(&mut self, token: CancellationToken) {
-        self.abort_pending_diagnostics();
-        self.pending_diagnostics = Some(token);
-    }
-
-    pub(crate) fn finish_diagnostics(&mut self, token: &CancellationToken) {
-        if self.pending_diagnostics.as_ref() == Some(token) {
-            self.pending_diagnostics = None;
-        }
-    }
-}
-
-impl Drop for DocumentState {
-    fn drop(&mut self) {
-        self.abort_pending_diagnostics();
+    pub(crate) fn set_last_usable(&mut self, snapshot: Arc<AnalysisSnapshot>) {
+        self.last_usable = Some(snapshot);
     }
 }
 
@@ -250,7 +214,7 @@ impl Backend {
             shared_state: Arc::new(SharedState {
                 client,
                 project: ProjectState::new(),
-                documents: RwLock::new(HashMap::new()),
+                workspace: RwLock::default(),
                 bindgen_setup,
                 packages: Arc::default(),
                 insert_replace_support: AtomicBool::new(false),
@@ -263,39 +227,77 @@ impl Backend {
 mod tests {
     use super::*;
 
-    #[test]
-    fn dropping_document_cancels_pending_diagnostics() {
-        let token = CancellationToken::new();
-        let mut document = DocumentState::new(String::new(), 1);
-        document.set_pending_diagnostics(token.clone());
-
-        drop(document);
-
-        assert!(token.is_cancelled());
+    fn key() -> AnalysisKey {
+        AnalysisKey::Package {
+            external_test: false,
+            package_id: "_entry_".to_string(),
+        }
     }
 
     #[test]
     fn replacing_pending_diagnostics_cancels_previous_run() {
         let old_token = CancellationToken::new();
         let new_token = CancellationToken::new();
-        let mut document = DocumentState::new(String::new(), 1);
-        document.set_pending_diagnostics(old_token.clone());
+        let mut workspace = Workspace::default();
+        workspace.ensure(&key());
+        workspace.set_pending_diagnostics(&key(), old_token.clone());
 
-        document.set_pending_diagnostics(new_token.clone());
+        workspace.set_pending_diagnostics(&key(), new_token.clone());
 
         assert!(old_token.is_cancelled());
         assert!(!new_token.is_cancelled());
     }
 
     #[test]
-    fn invalidation_rejects_an_in_flight_analysis() {
-        let mut document = DocumentState::new(String::new(), 1);
-        let AnalysisRequest::Required(revision) = document.request_analysis() else {
-            panic!("new document should require analysis");
-        };
+    fn eviction_cancels_pending_diagnostics() {
+        let token = CancellationToken::new();
+        let mut workspace = Workspace::default();
+        workspace.ensure(&key());
+        workspace.set_pending_diagnostics(&key(), token.clone());
 
-        document.invalidate_analysis();
+        workspace.evict(&key());
 
-        assert!(!Arc::ptr_eq(&document.analysis.revision.0, &revision.0));
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn invalidation_moves_the_generation_an_in_flight_build_captured() {
+        let mut workspace = Workspace::default();
+        workspace.ensure(&key());
+        let generation = workspace.generation();
+
+        workspace.invalidate_all();
+
+        assert_ne!(workspace.generation(), generation);
+    }
+
+    #[test]
+    fn reopening_an_evicted_key_installs_a_different_build_lock() {
+        let mut workspace = Workspace::default();
+        workspace.ensure(&key());
+        let held = workspace.build_lock(&key()).unwrap();
+
+        workspace.evict(&key());
+        workspace.ensure(&key());
+
+        let current = workspace.build_lock(&key()).unwrap();
+        assert!(
+            !Arc::ptr_eq(&current, &held),
+            "a waiter on the old lock must be able to tell it is stale"
+        );
+    }
+
+    #[test]
+    fn an_evicted_key_is_not_recreated_by_a_late_caller() {
+        let mut workspace = Workspace::default();
+        workspace.ensure(&key());
+        workspace.evict(&key());
+
+        let token = CancellationToken::new();
+        workspace.set_pending_diagnostics(&key(), token.clone());
+
+        assert!(workspace.build_lock(&key()).is_none());
+        assert!(workspace.keys().is_empty());
+        assert!(token.is_cancelled());
     }
 }

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -13267,3 +13267,314 @@ fn completion_after_an_unknown_prefix_dot_offers_nothing() {
 
     client.shutdown();
 }
+
+fn project_with(root: &std::path::Path, files: &[(&str, &str)]) {
+    std::fs::write(
+        root.join("lisette.toml"),
+        "[project]\nname = \"example.com/you/app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    for (relative, content) in files {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+}
+
+fn uri_of(root: &std::path::Path, relative: &str) -> String {
+    Url::from_file_path(root.join(relative))
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn declarations_in_a_broken_sibling_still_resolve() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let caller = "fn main() {\n  let n = shared()\n}\n";
+    let broken = "fn shared() -> int { 42 }\n\nfn oops(\n";
+    project_with(
+        root,
+        &[("src/main.lis", caller), ("src/broken.lis", broken)],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let caller_uri = uri_of(root, "src/main.lis");
+    client.open(&caller_uri, caller);
+    client.open(&uri_of(root, "src/broken.lis"), broken);
+
+    let diagnostics = client
+        .await_diagnostics_for(&caller_uri)
+        .unwrap_or_default();
+
+    assert!(
+        !diagnostics.iter().any(|d| d.message.contains("shared")),
+        "a declaration before a sibling's parse error stays visible: {diagnostics:?}"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_document_with_parse_errors_keeps_its_own_partial_ast() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let partial = "pub fn intact() -> int { 7 }\n\nfn broken(\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/partial.lis", partial),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let partial_uri = uri_of(root, "src/partial.lis");
+    client.open(&uri_of(root, "src/main.lis"), "fn main() {}\n");
+    client.open(&partial_uri, partial);
+
+    let hover = client.hover(&partial_uri, 0, 8);
+    let diagnostics = client
+        .await_diagnostics_for(&partial_uri)
+        .unwrap_or_default();
+
+    assert!(
+        hover.is_some(),
+        "declarations before a parse error stay hoverable"
+    );
+    assert!(
+        !diagnostics.is_empty(),
+        "the parse error is still reported: {diagnostics:?}"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_document_broken_on_open_serves_no_stale_disk_features() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let on_disk = "pub fn helper() -> int { 42 }\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/helper.lis", on_disk),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let helper_uri = uri_of(root, "src/helper.lis");
+    client.open(&uri_of(root, "src/main.lis"), "fn main() {}\n");
+    client.open(&helper_uri, "fn helper() -> int { \"unterminated\n");
+
+    let hover = client.hover(&helper_uri, 0, 8);
+
+    assert!(
+        hover.is_none(),
+        "a buffer that fails to lex must not be served from its disk contents: {hover:?}"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_lexer_failure_falls_back_to_the_last_usable_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let good = "pub fn helper() -> int { 42 }\n";
+    project_with(
+        root,
+        &[("src/main.lis", "fn main() {}\n"), ("src/helper.lis", good)],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let helper_uri = uri_of(root, "src/helper.lis");
+    client.open(&uri_of(root, "src/main.lis"), "fn main() {}\n");
+    client.open(&helper_uri, good);
+    assert!(client.hover(&helper_uri, 0, 8).is_some());
+
+    client.change(&helper_uri, "pub fn helper() -> int { \"oops\n", 2);
+
+    assert!(
+        client.hover(&helper_uri, 0, 8).is_some(),
+        "features fall back to the snapshot this document was last usable in"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn staggered_failures_keep_separate_fallbacks() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let b = "pub fn from_b() -> int { 1 }\n";
+    let c = "pub fn from_c() -> int { 2 }\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/b.lis", b),
+            ("src/c.lis", c),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let b_uri = uri_of(root, "src/b.lis");
+    let c_uri = uri_of(root, "src/c.lis");
+    client.open(&uri_of(root, "src/main.lis"), "fn main() {}\n");
+    client.open(&b_uri, b);
+    client.open(&c_uri, c);
+    assert!(client.hover(&b_uri, 0, 8).is_some());
+    assert!(client.hover(&c_uri, 0, 8).is_some());
+
+    client.change(&b_uri, "pub fn from_b() -> int { \"broken\n", 2);
+    client.change(&c_uri, "pub fn from_c() -> int { 3 }\n", 2);
+    client.change(&c_uri, "pub fn from_c() -> int { \"broken\n", 3);
+
+    assert!(
+        client.hover(&b_uri, 0, 8).is_some(),
+        "b keeps the snapshot from before b broke"
+    );
+    assert!(
+        client.hover(&c_uri, 0, 8).is_some(),
+        "c keeps the snapshot from before c broke, a later one than b's"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn an_invalid_external_test_file_does_not_stop_its_package() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let valid = "fn check() -> int { 1 }\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("tests/valid.test.lis", valid),
+            ("tests/invalid.lis", "fn stray() -> int { 2 }\n"),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let invalid_uri = uri_of(root, "tests/invalid.lis");
+    let valid_uri = uri_of(root, "tests/valid.test.lis");
+    client.open(&invalid_uri, "fn stray() -> int { 2 }\n");
+    client.open(&valid_uri, valid);
+
+    let invalid_diagnostics = client
+        .await_diagnostics_for(&invalid_uri)
+        .unwrap_or_default();
+
+    assert!(
+        invalid_diagnostics
+            .iter()
+            .any(|d| d.message.contains("test file")),
+        "the invalidly named file reports its own problem: {invalid_diagnostics:?}"
+    );
+    assert!(
+        client.hover(&valid_uri, 0, 3).is_some(),
+        "its validly named sibling still analyzes"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_production_test_suffix_file_still_analyzes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let content = "fn helper() -> int { 42 }\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/thing_test.lis", content),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let uri = uri_of(root, "src/thing_test.lis");
+    client.open(&uri, content);
+
+    let diagnostics = client.await_diagnostics_for(&uri).unwrap_or_default();
+
+    assert!(
+        diagnostics.iter().any(|d| d.message.contains("_test.lis")),
+        "the wrong-suffix diagnostic still reaches a file the package loader skips: {diagnostics:?}"
+    );
+    assert!(
+        client.hover(&uri, 0, 3).is_some(),
+        "and its features keep working"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_project_typedef_file_still_analyzes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let content = "pub struct Point { pub x: int }\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/shapes.d.lis", content),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let uri = uri_of(root, "src/shapes.d.lis");
+    client.open(&uri, content);
+
+    assert!(
+        client.document_symbol(&uri).is_some(),
+        "a .d.lis the entry package skips is analyzed under its own key"
+    );
+    client.shutdown();
+}
+
+#[test]
+fn a_closed_document_gets_no_diagnostics_from_a_surviving_sibling_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let broken = "fn f() -> int {\n  missing_symbol()\n}\n";
+    project_with(
+        root,
+        &[
+            ("src/main.lis", "fn main() {}\n"),
+            ("src/other.lis", broken),
+        ],
+    );
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let main_uri = uri_of(root, "src/main.lis");
+    let other_uri = uri_of(root, "src/other.lis");
+    client.open(&main_uri, "fn main() {}\n");
+    client.open(&other_uri, broken);
+    assert!(
+        client
+            .await_diagnostics_for(&other_uri)
+            .is_some_and(|d| !d.is_empty())
+    );
+
+    client.close(&other_uri);
+    assert_eq!(
+        client.await_diagnostics_for(&other_uri),
+        Some(vec![]),
+        "closing clears the document's diagnostics"
+    );
+    client.save(&other_uri);
+
+    assert_eq!(
+        client.await_diagnostics_for(&other_uri),
+        None,
+        "a closed document must not be republished from disk through its package key"
+    );
+    client.shutdown();
+}

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -200,6 +200,13 @@ impl TestClient {
         );
     }
 
+    pub fn save(&mut self, uri: &str) {
+        self.notify(
+            "textDocument/didSave",
+            json!({"textDocument": {"uri": uri}}),
+        );
+    }
+
     pub fn close(&mut self, uri: &str) {
         self.notify(
             "textDocument/didClose",

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LisetteDiagnostic;
+use syntax::FileParseStatus;
 use syntax::ast::BindingId;
 use syntax::program::{EmitInput, MutationInfo, UnusedInfo, is_internal_package_id};
 
@@ -22,6 +23,7 @@ pub struct Analysis {
     usages: HashSet<Usage>,
     diagnostics: Vec<LisetteDiagnostic>,
     entry_parse_status: semantics::EntryParseStatus,
+    parse_statuses: HashMap<u32, FileParseStatus>,
 }
 
 impl Analysis {
@@ -66,6 +68,13 @@ impl Analysis {
 
     pub fn has_parse_errors(&self) -> bool {
         self.entry_parse_status != semantics::EntryParseStatus::Clean
+    }
+
+    pub fn parse_status(&self, file_id: u32) -> FileParseStatus {
+        self.parse_statuses
+            .get(&file_id)
+            .copied()
+            .unwrap_or_default()
     }
 
     pub fn entry_parse_failed(&self) -> bool {
@@ -157,6 +166,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         }
     }
 
+    let parse_statuses = store.parse_statuses.clone();
     let mut files = HashMap::default();
     let mut definitions = HashMap::default();
 
@@ -207,6 +217,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         usages,
         diagnostics: order_diagnostics_by_severity(all_diagnostics),
         entry_parse_status,
+        parse_statuses,
     }
 }
 
@@ -263,6 +274,7 @@ mod tests {
             locator: &locator,
             go_module: "",
             disable_cache: true,
+            recover_target: semantics::RecoverTarget::None,
         });
 
         let value_span = analysis

--- a/crates/semantics/src/analysis/entry.rs
+++ b/crates/semantics/src/analysis/entry.rs
@@ -65,6 +65,16 @@ pub(super) fn register_entry_file(
             ));
         }
     }
+
+    store.record_parse_status(
+        ENTRY_FILE_ID,
+        match outcome.status() {
+            EntryParseStatus::Clean => FileParseStatus::Clean,
+            EntryParseStatus::Recovered => FileParseStatus::Recovered,
+            EntryParseStatus::Failed => FileParseStatus::Failed,
+        },
+    );
+
     store.store_entry_file(
         &entry.filename,
         &entry.display_path,
@@ -80,52 +90,19 @@ pub(super) fn register_entry_file(
 }
 
 fn parse_entry_file(source: &str, mode: EntryParseMode) -> ParsedEntry {
-    match mode {
-        EntryParseMode::Strict => {
-            let ParseResult {
-                ast,
-                errors,
-                file_comment,
-                ..
-            } = syntax::build_ast(source, ENTRY_FILE_ID);
-            let outcome = if errors.is_empty() {
-                EntryParseOutcome::Clean
-            } else {
-                EntryParseOutcome::Failed(errors)
-            };
-            ParsedEntry {
-                ast,
-                file_comment,
-                outcome,
-            }
-        }
-        EntryParseMode::Recover => {
-            let lex_result = Lexer::new(source, ENTRY_FILE_ID).lex();
-            if lex_result.failed() {
-                return ParsedEntry {
-                    ast: Vec::new(),
-                    file_comment: None,
-                    outcome: EntryParseOutcome::Failed(lex_result.errors),
-                };
-            }
-
-            let ParseResult {
-                ast,
-                errors,
-                file_comment,
-                ..
-            } = Parser::new(lex_result.tokens, source).parse();
-            let outcome = if errors.is_empty() {
-                EntryParseOutcome::Clean
-            } else {
-                EntryParseOutcome::Recovered(errors)
-            };
-            ParsedEntry {
-                ast,
-                file_comment,
-                outcome,
-            }
-        }
+    let result = match mode {
+        EntryParseMode::Strict => syntax::build_ast(source, ENTRY_FILE_ID),
+        EntryParseMode::Recover => syntax::build_ast_recovering(source, ENTRY_FILE_ID),
+    };
+    let outcome = match result.status {
+        FileParseStatus::Clean => EntryParseOutcome::Clean,
+        FileParseStatus::Recovered => EntryParseOutcome::Recovered(result.errors),
+        FileParseStatus::Failed => EntryParseOutcome::Failed(result.errors),
+    };
+    ParsedEntry {
+        ast: result.ast,
+        file_comment: result.file_comment,
+        outcome,
     }
 }
 
@@ -136,6 +113,7 @@ pub(super) fn load_sibling_files(
     loader: &dyn Loader,
     entry_filename: Option<&str>,
     include_tests: bool,
+    recover: bool,
 ) {
     for (filename, content) in loader.scan_folder(ENTRY_PACKAGE_ID) {
         if Some(filename.as_str()) == entry_filename {
@@ -154,7 +132,12 @@ pub(super) fn load_sibling_files(
             continue;
         }
         let file_id = store.new_file_id();
-        let result = syntax::build_ast(&content.source, file_id);
+        let result = if recover {
+            syntax::build_ast_recovering(&content.source, file_id)
+        } else {
+            syntax::build_ast(&content.source, file_id)
+        };
+        store.record_parse_status(file_id, result.status);
         sink.extend_parse_errors(result.errors);
         store.store_file(File {
             id: file_id,

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -12,9 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use diagnostics::LocalSink;
+use syntax::FileParseStatus;
 use syntax::ParseError;
-use syntax::lex::Lexer;
-use syntax::parse::{ParseResult, Parser};
 use syntax::program::{File, Package};
 
 use deps::TypedefLocator;
@@ -191,6 +190,26 @@ pub struct AnalyzeInput<'a> {
     /// When true, `analyze` skips both cache load and save. Set by the CLI for
     /// `--sourcemap` Emit so cwd-decorated Go files are not reused across cwds.
     pub disable_cache: bool,
+    /// Which package keeps partial ASTs through parse errors, so that one
+    /// broken file does not blank out everything around it.
+    pub recover_target: RecoverTarget,
+}
+
+/// The one package, if any, that parses with error recovery.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RecoverTarget {
+    #[default]
+    None,
+    Package(String),
+}
+
+impl RecoverTarget {
+    pub(crate) fn covers(&self, package_id: &str) -> bool {
+        match self {
+            Self::None => false,
+            Self::Package(target) => target == package_id,
+        }
+    }
 }
 
 pub const PARALLEL_THRESHOLD: usize = 4;
@@ -350,6 +369,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             input.loader,
             entry.filename(),
             include_tests,
+            input.recover_target.covers(ENTRY_PACKAGE_ID),
         );
     }
 
@@ -423,6 +443,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             locator: input.locator,
             scope: &input.scope,
             project_kind: input.project_kind,
+            recover_target: &input.recover_target,
         },
     );
 

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -18,11 +18,12 @@ struct UnparsedPackage {
 struct ParsedPackage {
     files: Vec<File>,
     errors: Vec<ParseError>,
+    statuses: Vec<(u32, syntax::FileParseStatus)>,
     pending: PendingPackage,
 }
 
 impl UnparsedPackage {
-    fn parse(self) -> ParsedPackage {
+    fn parse(self, recover_target: &RecoverTarget) -> ParsedPackage {
         let Self {
             files: scanned,
             rewrite_root_import,
@@ -30,13 +31,16 @@ impl UnparsedPackage {
         } = self;
 
         let package_id = pending.package_id();
+        let recover = recover_target.covers(package_id);
         let mut files = Vec::with_capacity(scanned.len());
         let mut errors = Vec::new();
+        let mut statuses = Vec::new();
         for scanned_file in scanned {
-            let (mut file, file_errors) = scanned_file.parse(package_id);
+            let (mut file, file_errors, status) = scanned_file.parse(package_id, recover);
             if rewrite_root_import {
                 file.rewrite_import(crate::loader::ROOT_IMPORT, ENTRY_PACKAGE_ID);
             }
+            statuses.push((file.id, status));
             files.push(file);
             errors.extend(file_errors);
         }
@@ -44,6 +48,7 @@ impl UnparsedPackage {
         ParsedPackage {
             files,
             errors,
+            statuses,
             pending,
         }
     }
@@ -98,6 +103,7 @@ pub(super) struct PackageInferenceInput<'a> {
     pub(super) locator: &'a TypedefLocator,
     pub(super) scope: &'a AnalysisScope,
     pub(super) project_kind: ProjectKind,
+    pub(super) recover_target: &'a RecoverTarget,
 }
 
 pub(super) struct PackageInferenceOutput {
@@ -199,7 +205,12 @@ pub(super) fn infer_all_packages(
             dep_hashes,
         });
 
-        match (input.cache.package_root(), compiled) {
+        let cache_root = input
+            .cache
+            .package_root()
+            .filter(|_| !input.recover_target.covers(&package_id));
+
+        match (cache_root, compiled) {
             (Some(_), Some(compiled)) => candidates.push(CacheCandidate {
                 pending: CompiledPendingPackage {
                     package: compiled,
@@ -238,9 +249,15 @@ pub(super) fn infer_all_packages(
     cached_packages.extend(cache_load.cached);
     unparsed.extend(cache_load.missed);
 
-    let has_parse_errors = parse_and_store_packages(&mut checker, store, unparsed, &mut to_infer);
+    let has_parse_errors = parse_and_store_packages(
+        &mut checker,
+        store,
+        unparsed,
+        &mut to_infer,
+        input.recover_target,
+    );
     let uninferred = input.files;
-    store_uninferred_packages(&mut checker, store, uninferred);
+    store_uninferred_packages(&mut checker, store, uninferred, input.recover_target);
 
     for pending in &to_infer {
         checker.predeclare_package_types(store, pending.package_id());
@@ -309,14 +326,18 @@ fn parse_and_store_packages(
     store: &mut Store,
     unparsed: Vec<UnparsedPackage>,
     to_infer: &mut Vec<PendingPackage>,
+    recover_target: &RecoverTarget,
 ) -> bool {
     let file_count: usize = unparsed.iter().map(|package| package.files.len()).sum();
     let parsed: Vec<ParsedPackage> = if file_count < PARALLEL_THRESHOLD {
-        unparsed.into_iter().map(UnparsedPackage::parse).collect()
+        unparsed
+            .into_iter()
+            .map(|package| package.parse(recover_target))
+            .collect()
     } else {
         unparsed
             .into_par_iter()
-            .map(UnparsedPackage::parse)
+            .map(|package| package.parse(recover_target))
             .collect()
     };
 
@@ -324,6 +345,9 @@ fn parse_and_store_packages(
     for package in parsed {
         has_parse_errors |= !package.errors.is_empty();
         checker.sink.extend_parse_errors(package.errors);
+        for (file_id, status) in package.statuses {
+            store.record_parse_status(file_id, status);
+        }
         store.store_package(package.pending.package_id(), package.files);
         to_infer.push(package.pending);
     }
@@ -334,18 +358,25 @@ fn store_uninferred_packages(
     checker: &mut TaskState,
     store: &mut Store,
     packages: HashMap<String, Vec<ScannedFile>>,
+    recover_target: &RecoverTarget,
 ) {
     for (package_id, scanned) in packages {
         if scanned.is_empty() {
             continue;
         }
+        let recover = recover_target.covers(&package_id);
         let mut files = Vec::with_capacity(scanned.len());
         let mut parsed = true;
+        let mut statuses = Vec::with_capacity(files.capacity());
         for scanned_file in scanned {
-            let (file, errors) = scanned_file.parse(&package_id);
+            let (file, errors, status) = scanned_file.parse(&package_id, recover);
             parsed &= errors.is_empty();
             checker.sink.extend_parse_errors(errors);
+            statuses.push((file.id, status));
             files.push(file);
+        }
+        for (file_id, status) in statuses {
+            store.record_parse_status(file_id, status);
         }
         let exports = if parsed {
             UninferredExports::Known(

--- a/crates/semantics/src/checker/registration/go.rs
+++ b/crates/semantics/src/checker/registration/go.rs
@@ -29,7 +29,7 @@ impl TaskState {
         let filename = format!("{}.d.lis", package_id.replace('/', "_"));
 
         let build_result = syntax::build_ast(source, file_id);
-        if build_result.failed() {
+        if build_result.has_errors() {
             let discarded = cache_path.as_deref().is_some_and(|path| {
                 locator.discard_typedef(path);
                 !path.exists()

--- a/crates/semantics/src/lib.rs
+++ b/crates/semantics/src/lib.rs
@@ -14,5 +14,5 @@ pub mod zero;
 
 pub use analysis::{
     AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, EntryParseOutcome, EntryParseStatus,
-    InferenceOutput, PARALLEL_THRESHOLD, ProjectKind, run_inference,
+    InferenceOutput, PARALLEL_THRESHOLD, ProjectKind, RecoverTarget, run_inference,
 };

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -195,8 +195,17 @@ impl ScannedFile {
         syntax::program::is_test_file(&self.name)
     }
 
-    pub fn parse(self, package_id: &str) -> (File, Vec<syntax::ParseError>) {
-        let result = syntax::build_ast(&self.source, self.file_id);
+    pub fn parse(
+        self,
+        package_id: &str,
+        recover: bool,
+    ) -> (File, Vec<syntax::ParseError>, syntax::FileParseStatus) {
+        let result = if recover {
+            syntax::build_ast_recovering(&self.source, self.file_id)
+        } else {
+            syntax::build_ast(&self.source, self.file_id)
+        };
+        let status = result.status;
         let file = File {
             id: self.file_id,
             package_id: package_id.to_string(),
@@ -207,7 +216,7 @@ impl ScannedFile {
             items: result.ast,
             file_comment: result.file_comment,
         };
-        (file, result.errors)
+        (file, result.errors, status)
     }
 }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use syntax::FileParseStatus;
 use syntax::ast::{EnumVariant, Expression, StructFieldDefinition};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, Method, Methods, Package,
@@ -28,6 +29,8 @@ pub struct Store {
     next_file_id: AtomicU32,
     pub equality_index: EqualityIndex,
     pub test_index: TestIndex,
+    /// Files that parsed to less than their full contents. Absent means clean.
+    pub parse_statuses: HashMap<u32, FileParseStatus>,
 }
 
 impl Clone for Store {
@@ -39,6 +42,7 @@ impl Clone for Store {
             next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
             equality_index: self.equality_index.clone(),
             test_index: self.test_index.clone(),
+            parse_statuses: self.parse_statuses.clone(),
         }
     }
 }
@@ -68,6 +72,13 @@ impl Store {
             next_file_id: AtomicU32::new(2), // 0 = entrypoint, 1 = prelude
             equality_index: Default::default(),
             test_index: Default::default(),
+            parse_statuses: Default::default(),
+        }
+    }
+
+    pub fn record_parse_status(&mut self, file_id: u32, status: FileParseStatus) {
+        if status != FileParseStatus::Clean {
+            self.parse_statuses.insert(file_id, status);
         }
     }
 
@@ -261,6 +272,7 @@ impl Store {
             next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
             equality_index: EqualityIndex::default(),
             test_index: TestIndex::default(),
+            parse_statuses: HashMap::default(),
         }
     }
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -11,7 +11,7 @@ pub mod program;
 pub mod types;
 
 pub use ecow::EcoString;
-pub use parse::ParseError;
+pub use parse::{FileParseStatus, ParseError};
 
 pub const ENTRY_PACKAGE_ID: &str = "_entry_";
 pub const ROOT_IMPORT: &str = "root";
@@ -30,37 +30,49 @@ mod size_assertions {
 const MAX_SOURCE_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
 
 pub fn build_ast(source: &str, file_id: u32) -> AstBuildResult {
-    if source.len() > MAX_SOURCE_BYTES {
-        return parse::ParseResult {
-            ast: vec![],
-            errors: vec![
-                ParseError::new(
-                    "File too large",
-                    ast::Span::new(file_id, 0, 0),
-                    format!(
-                        "file is {} bytes, maximum is {} bytes",
-                        source.len(),
-                        MAX_SOURCE_BYTES,
-                    ),
-                )
-                .with_parse_code("file_too_large"),
-            ],
-            file_comment: None,
-            truncated: true,
-        };
-    }
-
-    let parse_result = parse::Parser::lex_and_parse_file(source, file_id);
-    if parse_result.failed() {
+    let parse_result = match oversize(source, file_id) {
+        Some(result) => return result,
+        None => parse::Parser::lex_and_parse_file(source, file_id),
+    };
+    if parse_result.has_errors() {
         return parse::ParseResult {
             ast: vec![],
             errors: parse_result.errors,
             file_comment: None,
             truncated: true,
+            status: FileParseStatus::Failed,
         };
     }
 
     parse_result
+}
+
+pub fn build_ast_recovering(source: &str, file_id: u32) -> AstBuildResult {
+    match oversize(source, file_id) {
+        Some(result) => result,
+        None => parse::Parser::lex_and_parse_file(source, file_id),
+    }
+}
+
+fn oversize(source: &str, file_id: u32) -> Option<AstBuildResult> {
+    (source.len() > MAX_SOURCE_BYTES).then(|| parse::ParseResult {
+        ast: vec![],
+        errors: vec![
+            ParseError::new(
+                "File too large",
+                ast::Span::new(file_id, 0, 0),
+                format!(
+                    "file is {} bytes, maximum is {} bytes",
+                    source.len(),
+                    MAX_SOURCE_BYTES,
+                ),
+            )
+            .with_parse_code("file_too_large"),
+        ],
+        file_comment: None,
+        truncated: true,
+        status: FileParseStatus::Failed,
+    })
 }
 
 #[cfg(test)]
@@ -75,6 +87,29 @@ mod tests {
                 ..
             }
         ) || expression.children().into_iter().any(contains_pipeline)
+    }
+
+    #[test]
+    fn a_parser_error_before_any_item_is_recovered_not_failed() {
+        let result = super::build_ast_recovering(")", 0);
+
+        assert!(!result.errors.is_empty() && result.ast.is_empty());
+        assert_eq!(result.status, super::FileParseStatus::Recovered);
+    }
+
+    #[test]
+    fn a_lexer_failure_is_the_only_recovering_failure() {
+        let result = super::build_ast_recovering("fn main() { \"unterminated }", 0);
+
+        assert_eq!(result.status, super::FileParseStatus::Failed);
+    }
+
+    #[test]
+    fn a_strict_parse_error_discards_the_ast() {
+        let result = super::build_ast("fn valid() {}\nfn broken(", 0);
+
+        assert!(result.ast.is_empty());
+        assert_eq!(result.status, super::FileParseStatus::Failed);
     }
 
     #[test]

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -42,10 +42,20 @@ pub struct ParseResult {
     pub errors: Vec<ParseError>,
     pub file_comment: Option<std::string::String>,
     pub truncated: bool,
+    pub status: FileParseStatus,
+}
+
+/// How much of a file survived parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FileParseStatus {
+    #[default]
+    Clean,
+    Recovered,
+    Failed,
 }
 
 impl ParseResult {
-    pub fn failed(&self) -> bool {
+    pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 }
@@ -99,6 +109,7 @@ impl<'source> Parser<'source> {
                 errors: lex_result.errors,
                 file_comment: None,
                 truncated: true,
+                status: FileParseStatus::Failed,
             };
         }
 
@@ -152,12 +163,18 @@ impl<'source> Parser<'source> {
         }
 
         let truncated = !self.at_eof();
+        let status = if self.errors.is_empty() {
+            FileParseStatus::Clean
+        } else {
+            FileParseStatus::Recovered
+        };
 
         ParseResult {
             ast: top_items,
             errors: self.errors,
             file_comment,
             truncated,
+            status,
         }
     }
 

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -571,7 +571,7 @@ mod tests {
 
     fn parse_bounded(source: &str) -> u32 {
         let result = Parser::lex_and_parse_file(source, 0);
-        assert!(result.failed(), "expected a nesting error");
+        assert!(result.has_errors(), "expected a nesting error");
         result.ast.iter().map(depth).max().unwrap_or(0)
     }
 

--- a/fuzz/fuzz_targets/infer.rs
+++ b/fuzz/fuzz_targets/infer.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let mut ast_result = lisette_syntax::build_ast(source, 0);
-    if ast_result.failed() {
+    if ast_result.has_errors() {
         return;
     }
 

--- a/fuzz/fuzz_targets/scan_imports.rs
+++ b/fuzz/fuzz_targets/scan_imports.rs
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
     let scanned = scan_imports(source, 0);
 
     let result = lisette_syntax::build_ast(source, 0);
-    if result.failed() {
+    if result.has_errors() {
         return;
     }
 

--- a/playground/wasm/src/lib.rs
+++ b/playground/wasm/src/lib.rs
@@ -8,7 +8,9 @@ use wasm_bindgen::prelude::*;
 
 use lisette_passes::{Analysis, analyze};
 use lisette_semantics::loader::MemoryLoader;
-use lisette_semantics::{AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, ProjectKind};
+use lisette_semantics::{
+    AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, ProjectKind, RecoverTarget,
+};
 use lisette_syntax::ast::{Expression, IdentifierResolution, Span};
 use lisette_syntax::program::{Definition, DefinitionBody};
 use lisette_syntax::types::{Type, unqualified_name};
@@ -166,6 +168,7 @@ fn run_analysis(code: &str) -> AnalysisResult {
         project_kind: ProjectKind::Binary,
         go_module: "",
         disable_cache: false,
+        recover_target: RecoverTarget::None,
     };
 
     let analysis = analyze(input);
@@ -206,6 +209,7 @@ fn run_pipeline(
         locator: &lisette_deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: false,
+        recover_target: RecoverTarget::None,
     };
 
     let analysis = analyze(input);

--- a/tests/_embed_harness/lisette_answer.rs
+++ b/tests/_embed_harness/lisette_answer.rs
@@ -157,6 +157,7 @@ fn check(source: &str) -> Checked {
         project_kind: semantics::ProjectKind::Binary,
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     let parse_failed = output.has_parse_errors();

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -441,7 +441,7 @@ mod tests {
             ] {
                 let result = syntax::build_ast(&src, 0);
                 assert!(
-                    !result.failed(),
+                    !result.has_errors(),
                     "{} ({label}) failed to parse: {:?}\n--- source ---\n{src}",
                     scenario.name,
                     result.errors
@@ -456,7 +456,7 @@ mod tests {
                    interface N0 {\n  embed N1\n  fn A() -> int\n  fn B() -> string\n}\n";
         let result = syntax::build_ast(src, 0);
         assert!(
-            !result.failed(),
+            !result.has_errors(),
             "multi-member interface parse: {:?}",
             result.errors
         );

--- a/tests/_embed_harness/run_check.rs
+++ b/tests/_embed_harness/run_check.rs
@@ -195,6 +195,7 @@ fn emit_and_write(
         project_kind: semantics::ProjectKind::Binary,
         go_module: &package,
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
     if output.has_parse_errors() {
         return Ok(Emit::NotRunnable(vec!["parse".to_string()]));

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -32,6 +32,7 @@ fn compile_with(
         project_kind: semantics::ProjectKind::Binary,
         go_module: "",
         disable_cache: false,
+        recover_target: semantics::RecoverTarget::None,
     })
 }
 
@@ -70,6 +71,7 @@ pub fn compile_script_entry(
         project_kind: semantics::ProjectKind::Binary,
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     })
 }
 
@@ -156,6 +158,7 @@ pub fn try_compile_project_files_with_tests(
         project_kind: semantics::ProjectKind::Binary,
         go_module,
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
     assert!(
         analysis.errors().is_empty(),

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -85,7 +85,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
             let files = files
                 .into_iter()
                 .map(|file| {
-                    let (file, errors) = file.parse(&package_id);
+                    let (file, errors, _) = file.parse(&package_id, false);
                     sink.extend_parse_errors(errors);
                     file
                 })

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -25,7 +25,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     }
 
     let parse_result = Parser::new(lex_result.tokens, source).parse();
-    if parse_result.failed() {
+    if parse_result.has_errors() {
         panic!("Parsing failed in lint test: {:?}", parse_result.errors);
     }
 

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -61,7 +61,7 @@ impl TestPipeline {
         }
 
         let parse_result = Parser::new(lex_result.tokens, &self.source).parse();
-        if parse_result.failed() {
+        if parse_result.has_errors() {
             panic!("Parsing failed in test: {:?}", parse_result.errors);
         }
 

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -309,6 +309,7 @@ fn analyze_importer_of_cycle(entry_source: &str) -> passes::Analysis {
         locator: &deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     })
 }
 
@@ -436,6 +437,7 @@ fn cycle_reads_the_exports_of_a_declaration_only_module() {
         locator: &deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert_eq!(error_codes(&output), vec!["resolve.import_cycle"]);
@@ -507,6 +509,7 @@ fn cycle_keeps_unregistered_go_modules_out_of_the_store() {
         locator: &deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert!(
@@ -624,6 +627,7 @@ fn check_analyzes_orphan_and_surfaces_its_error() {
         locator: &deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert!(
@@ -672,6 +676,7 @@ fn check_analyzes_tests_in_declaration_only_package() {
         locator: &deps::TypedefLocator::default(),
         go_module: "",
         disable_cache: true,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert!(
@@ -1027,6 +1032,7 @@ fn main() {
         locator: &resolver,
         go_module: "",
         disable_cache: false,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     let impl_errors: Vec<_> = result
@@ -1111,6 +1117,7 @@ fn main() {
         locator: &resolver,
         go_module: "",
         disable_cache: false,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert!(
@@ -1133,6 +1140,7 @@ fn main() {
         locator: &resolver,
         go_module: "",
         disable_cache: false,
+        recover_target: semantics::RecoverTarget::None,
     });
 
     assert!(


### PR DESCRIPTION
The LSP server now keeps one analysis per package instead of one analysis per open document.

Until now several open files in the same pkg held near-identical analysis copies, all of them rebuilt on every keystroke. Editing a 9-file project with all files open settled at 82 MB RSS and peaked at 157 MB during typing. The same session now settles at 50 MB and peaks at 58 MB.

Scripts, test files, and typedefs keep analysis per-document. Each is excluded from ordinary pkg loading, as sharing one would leak its contents into every sibling's view.
