### PR TITLE
refactor: make bindgen failure messages clearer

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -650,12 +650,16 @@ fn reconcile_target_manifest(
         &emit.changed,
         import_set_hash,
     ) {
-        let message = super::reconciliation::augment_go_error_with_local_hint(
-            e.message,
+        let remedy = super::reconciliation::local_child_remedy(
+            &e.message,
             &prep.project_path,
             &prep.target_dir,
             &prep.manifest,
         );
+        let message = match remedy {
+            Some(remedy) => format!("{}\n · {}", e.message, remedy),
+            None => e.message,
+        };
         cli_error!(heading, message, e.hint);
         return Err(1);
     }

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -497,7 +497,7 @@ impl LocalChildHint {
             )
         } else {
             format!(
-                "local module `{}` resolves `{}` from `{}`, but `{}` is not declared in `lisette.toml`",
+                "Local module `{}` resolves `{}` from `{}`, but `{}` is not declared in `lisette.toml`",
                 self.parent_module,
                 self.child_module,
                 self.directory.display(),
@@ -694,37 +694,32 @@ fn report_unresolved_transitives(
     Ok(())
 }
 
-/// Go ignores a dependency's replace directives, so a local child fails
-/// resolution until declared itself. Appends the `lis add --path` remedy.
-pub(crate) fn augment_go_error_with_local_hint(
-    error: String,
+/// Go ignores a dependency's replace directives, so a local child stays unresolved until declared.
+pub(crate) fn local_child_remedy(
+    error: &str,
     project_root: &Path,
     target_dir: &Path,
     manifest: &deps::Manifest,
-) -> String {
+) -> Option<String> {
     let replacements = declared_replacements(manifest);
     let locals = declared_local_dirs(&replacements, project_root);
     if locals.is_empty() {
-        return error;
+        return None;
     }
     let workspace = GoWorkspace::new(target_dir, target_dir, Target::host());
     let hint = find_local_child(&workspace, &locals, |old| {
-        message_names_module(&error, old) && !replacements.contains_key(old)
+        message_names_module(error, old) && !replacements.contains_key(old)
     })
     .or_else(|| {
         nested_local_candidates(&locals)
             .into_iter()
-            .find(|candidate| message_names_module(&error, &candidate.child_module))
-    });
-    match hint {
-        Some(hint) => format!(
-            "{}\n · {}. Run `lis add --path {}`",
-            error,
-            hint.describe(),
-            hint.directory.display()
-        ),
-        None => error,
-    }
+            .find(|candidate| message_names_module(error, &candidate.child_module))
+    })?;
+    Some(format!(
+        "{}. Run `lis add --path {}`",
+        hint.describe(),
+        hint.directory.display()
+    ))
 }
 
 /// The declared replacement redirects, keyed by original module path.

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -1098,21 +1098,12 @@ fn render_failure(
             .unwrap_or_else(|| stacked_operand_label(&record.operands, &values));
         diagnostic = diagnostic.with_span_primary_label(&span, label);
     } else {
-        let label = values
-            .first()
-            .cloned()
-            .unwrap_or_else(|| record.message.clone());
+        let label = match values.as_slice() {
+            [] => record.message.clone(),
+            [only] => only.clone(),
+            _ => stacked_operand_label(&record.operands, &values),
+        };
         diagnostic = diagnostic.with_span_primary_label(&span, label);
-        let notes: Vec<String> = record
-            .operands
-            .iter()
-            .zip(&values)
-            .skip(1)
-            .map(|(operand, value)| format!("{}: {}", operand.label, value))
-            .collect();
-        if !notes.is_empty() {
-            diagnostic = diagnostic.with_note(notes.join("\n"));
-        }
     }
     let rendered =
         diagnostics::render::render_to_string(&diagnostic, &info.source, &info.filename, color, 2);

--- a/crates/cli/src/typedef_regen.rs
+++ b/crates/cli/src/typedef_regen.rs
@@ -66,12 +66,15 @@ pub fn prewarm_typedef_cache(
                             pkg_label(&pkg, &module, &version)
                         ));
                     }
-                    BindgenFailure::InvocationFailed { stderr } => {
+                    BindgenFailure::InvocationFailed { stderr, hint } => {
                         print_warning(&format!(
                             "bindgen failed for {}: {}",
                             pkg_label(&pkg, &module, &version),
                             stderr.trim()
                         ));
+                        if let Some(hint) = hint {
+                            print_warning(&hint);
+                        }
                     }
                 }
                 had_failure = true;

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -566,11 +566,11 @@ fn translate_go_error(args: &[&str], stderr: &str) -> String {
     if stderr.contains("errors parsing go.mod") {
         if let Some(culprit) = extract_invalid_pin(stderr) {
             return format!(
-                "`lisette.toml` has an invalid Go version for `{}` (`{}`); fix the pin and retry",
+                "`lisette.toml` has an invalid Go version for `{}` (`{}`). Fix the pin and retry",
                 culprit.0, culprit.1
             );
         }
-        return "`lisette.toml` contains an invalid Go version; fix the offending pin and retry"
+        return "`lisette.toml` contains an invalid Go version. Fix the offending pin and retry"
             .to_string();
     }
     // Must precede the generic `invalid version` branch below; Go's
@@ -597,7 +597,7 @@ fn translate_go_error(args: &[&str], stderr: &str) -> String {
             && !rest.contains('/')
         {
             return format!(
-                "`{}` is missing the repository segment; try `github.com/{}/<repo>`",
+                "`{}` is missing the repository segment. Try `github.com/{}/<repo>`",
                 module, rest
             );
         }
@@ -608,7 +608,7 @@ fn translate_go_error(args: &[&str], stderr: &str) -> String {
     }
     if let Some((found, missing)) = extract_missing_subpackage(stderr) {
         return format!(
-            "Module `{}` exists but does not contain package `{}`; v1 Go modules do not use a `/v1` suffix (only v2+ require the major-version suffix)",
+            "Module `{}` exists but does not contain package `{}`. A v1 Go module does not use a `/v1` suffix (only v2+ require the major-version suffix)",
             found, missing
         );
     }
@@ -618,7 +618,7 @@ fn translate_go_error(args: &[&str], stderr: &str) -> String {
         return format!("No module provides package `{}`", module);
     }
     if stderr.contains("existing contents have changed since last read") {
-        return "Another `lis add` is in progress against this project; wait for it to finish and retry".to_string();
+        return "Another `lis add` is in progress against this project. Wait for it to finish and retry".to_string();
     }
     if stderr.contains("unable to access") || stderr.contains("requested URL returned error: 4") {
         return format!(
@@ -628,26 +628,26 @@ fn translate_go_error(args: &[&str], stderr: &str) -> String {
     }
     if stderr.contains("module lookup disabled by GOPROXY") {
         return format!(
-            "Module `{}` is not in the local cache and `GOPROXY=off` disables remote lookups; unset `GOPROXY` or set it to a working proxy",
+            "Module `{}` is not in the local cache and `GOPROXY=off` disables remote lookups. Unset `GOPROXY` or set it to a working proxy",
             module
         );
     }
     if stderr.contains("modules disabled by GO111MODULE") {
-        return "`GO111MODULE=off` disables Go modules entirely; unset `GO111MODULE` (Go modules are required by lisette)".to_string();
+        return "`GO111MODULE=off` disables Go modules entirely. Unset `GO111MODULE` (Go modules are required by lisette)".to_string();
     }
     if stderr.contains("-insecure flag is no longer supported") {
-        return "`-insecure` is no longer a valid Go flag; remove it from `GOFLAGS` or set `GOINSECURE` instead".to_string();
+        return "`-insecure` is no longer a valid Go flag. Remove it from `GOFLAGS` or set `GOINSECURE` instead".to_string();
     }
     if stderr.contains("unrecognized import path") {
         let offender = extract_unrecognized_path(stderr).unwrap_or(module.to_string());
         return format!(
-            "`{}` is not a recognized Go module path; the host does not serve `go-import` metadata",
+            "`{}` is not a recognized Go module path. The host does not serve `go-import` metadata",
             offender
         );
     }
     if stderr.contains("updates to go.mod needed") {
         return format!(
-            "Resolving `{}` requires updates to `target/go.mod` that lisette could not perform; please file an issue",
+            "Resolving `{}` requires updates to `target/go.mod` that lisette could not perform. Please file an issue",
             target
         );
     }
@@ -971,7 +971,7 @@ fn validate_typedef_parses(pkg_path: &str, typedef: &str) -> Result<(), String> 
         return Ok(());
     }
     Err(format!(
-        "Bindgen produced unparseable typedef for `{}`: {} parse error(s); first: {}",
+        "Bindgen produced unparseable typedef for `{}`: {} parse error(s). First: {}",
         pkg_path,
         parse.errors.len(),
         parse.errors[0].message,
@@ -1109,22 +1109,18 @@ impl Bindgen for WorkspaceBindgen {
         match workspace.reconcile_package(module, pkg.package) {
             Ok(_stubs) => Ok(()),
             Err(stderr) => {
-                let stderr = self.with_local_child_hint(stderr);
-                Err(BindgenFailure::InvocationFailed { stderr })
+                let hint = self.local_child_remedy(&stderr);
+                Err(BindgenFailure::InvocationFailed { stderr, hint })
             }
         }
     }
 }
 
 impl WorkspaceBindgen {
-    fn with_local_child_hint(&self, stderr: String) -> String {
-        let Some(project_root) = self.target_dir.parent() else {
-            return stderr;
-        };
-        let Ok(manifest) = deps::parse_manifest(project_root) else {
-            return stderr;
-        };
-        crate::handlers::reconciliation::augment_go_error_with_local_hint(
+    fn local_child_remedy(&self, stderr: &str) -> Option<String> {
+        let project_root = self.target_dir.parent()?;
+        let manifest = deps::parse_manifest(project_root).ok()?;
+        crate::handlers::reconciliation::local_child_remedy(
             stderr,
             project_root,
             &self.target_dir,

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -66,8 +66,11 @@ pub enum TypedefLocatorResult {
 pub enum BindgenFailure {
     /// `go` is not installed or not on PATH.
     GoToolchainMissing,
-    /// The bindgen subprocess failed; `stderr` is the trimmed message.
-    InvocationFailed { stderr: String },
+    /// The bindgen subprocess failed.
+    InvocationFailed {
+        stderr: String,
+        hint: Option<String>,
+    },
 }
 
 /// Classification of a `go:` import path without touching the cache.
@@ -536,6 +539,7 @@ impl TypedefLocator {
                                     "bindgen reported success but `{}` was not written",
                                     typedef_path.display()
                                 ),
+                                hint: None,
                             },
                         }
                     }),

--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -1124,7 +1124,7 @@ pub fn invisible_in_string(
         (
             "Bidirectional character in string",
             "bidi_in_string",
-            "Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\\u` escape so it is visible in source; otherwise remove it.",
+            "Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\\u` escape so it is visible in source. Otherwise remove it.",
         )
     } else {
         (

--- a/crates/diagnostics/src/package_graph.rs
+++ b/crates/diagnostics/src/package_graph.rs
@@ -416,37 +416,64 @@ pub fn go_toolchain_missing(go_pkg: &str, span: Span) -> LisetteDiagnostic {
     .with_help("Install Go from https://go.dev/dl/")
 }
 
-pub fn bindgen_failed(
-    go_pkg: &str,
-    module: &str,
-    version: &str,
-    stderr: &str,
-    span: Span,
-    script: bool,
-) -> LisetteDiagnostic {
-    let trimmed = stderr.trim();
-    let stderr_block = if trimmed.is_empty() {
-        String::new()
-    } else {
-        format!("\n\n{}", trimmed)
-    };
-    let lead = if script {
-        String::new()
-    } else {
-        format!(
+fn indent_reported_output(reported: &str) -> String {
+    let mut block = String::from("bindgen reported:");
+    for line in reported.lines() {
+        let expanded = line.replace('\t', "    ");
+        block.push_str("\n  ");
+        block.push_str(expanded.trim_end());
+    }
+    block
+}
+
+pub struct BindgenFailureDetails<'a> {
+    pub go_pkg: &'a str,
+    pub module: &'a str,
+    pub version: &'a str,
+    pub stderr: &'a str,
+    pub hint: Option<&'a str>,
+    pub script: bool,
+}
+
+pub fn bindgen_failed(details: BindgenFailureDetails<'_>, span: Span) -> LisetteDiagnostic {
+    let BindgenFailureDetails {
+        go_pkg,
+        module,
+        version,
+        stderr,
+        hint,
+        script,
+    } = details;
+
+    let reported = stderr.trim();
+    let advice = match (hint, script) {
+        (Some(hint), _) => hint.to_string(),
+        (None, true) => String::new(),
+        (None, false) => format!(
             "Re-run with `lis bindgen {}` to inspect the failure in isolation.",
             go_pkg
-        )
+        ),
     };
-    let help = match (lead.is_empty(), stderr_block.is_empty()) {
-        (true, true) => format!("Check that `{}` exists in {} {}", go_pkg, module, version),
-        (true, false) => trimmed.to_string(),
-        _ => format!("{}{}", lead, stderr_block),
+    let help = match (reported, advice.as_str()) {
+        ("", "") => format!("Check that `{}` exists in {} {}", go_pkg, module, version),
+        ("", advice) => advice.to_string(),
+        (reported, "") if reported.contains('\n') => indent_reported_output(reported),
+        (reported, "") => reported.to_string(),
+        (reported, advice) if reported.contains('\n') => {
+            format!("{}\n{}", advice, indent_reported_output(reported))
+        }
+        (reported, advice) => format!("{}. {}", reported, advice),
+    };
+
+    let origin = if go_pkg == module {
+        version.to_string()
+    } else {
+        format!("{} {}", module, version)
     };
 
     LisetteDiagnostic::error(format!(
-        "Failed to generate Go typedef for `{}` ({} {})",
-        go_pkg, module, version
+        "Failed to generate Go typedef for `{}` ({})",
+        go_pkg, origin
     ))
     .with_resolve_code("bindgen_failed")
     .with_span_label(&span, "bindgen failed for this import")

--- a/crates/semantics/src/diagnostics.rs
+++ b/crates/semantics/src/diagnostics.rs
@@ -94,14 +94,17 @@ pub(crate) fn emit_for_locator_result(
                     go_pkg, span,
                 ));
             }
-            BindgenFailure::InvocationFailed { stderr } => {
+            BindgenFailure::InvocationFailed { stderr, hint } => {
                 sink.push(diagnostics::package_graph::bindgen_failed(
-                    go_pkg,
-                    module,
-                    version,
-                    stderr,
+                    diagnostics::package_graph::BindgenFailureDetails {
+                        go_pkg,
+                        module,
+                        version,
+                        stderr,
+                        hint: hint.as_deref(),
+                        script: script.is_some(),
+                    },
                     span,
-                    script.is_some(),
                 ));
             }
         },

--- a/tests/ui/lint/snapshots/invisible_in_string_right_to_left_override.snap
+++ b/tests/ui/lint/snapshots/invisible_in_string_right_to_left_override.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·                  ╰── contains U+202E (right-to-left override)
  4 │ }
    ╰────
-  help: Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\u` escape so it is visible in source; otherwise remove it · code: [lint.bidi_in_string]
+  help: Bidirectional control characters can reorder surrounding text and enable source-spoofing attacks. If intentional, write it as a `\u` escape so it is visible in source. Otherwise remove it · code: [lint.bidi_in_string]


### PR DESCRIPTION
When bindgen fails, we now lead with a remedy and keep captured Go output separate from Lisette's own advice.