### PR TITLE
fix: drop `else` arms that render no output

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -130,10 +130,7 @@ impl Planner<'_> {
             then_body: LoweredBlock {
                 statements: payload_setup,
             },
-            else_arm: ElseArm::Else {
-                body: leaf_block(&sink, &none_wrapper),
-                inline: false,
-            },
+            else_arm: ElseArm::from_body(leaf_block(&sink, &none_wrapper), false),
         }));
         (statements, outcome)
     }
@@ -407,12 +404,12 @@ impl Planner<'_> {
             then_body: LoweredBlock {
                 statements: then_statements,
             },
-            else_arm: ElseArm::Else {
-                body: LoweredBlock {
+            else_arm: ElseArm::from_body(
+                LoweredBlock {
                     statements: vec![LoweredStatement::RawGo(format!("{option} = {none}\n"))],
                 },
-                inline: false,
-            },
+                false,
+            ),
         }));
         option
     }
@@ -521,14 +518,14 @@ impl Planner<'_> {
                 )));
                 let needs_nil_else = matches!(source_layout, ValueLayout::Map { .. }) || pointer;
                 let else_arm = if needs_nil_else {
-                    ElseArm::Else {
-                        body: LoweredBlock {
+                    ElseArm::from_body(
+                        LoweredBlock {
                             statements: vec![LoweredStatement::RawGo(format!(
                                 "{output}[{index}] = nil\n"
                             ))],
                         },
-                        inline: false,
-                    }
+                        false,
+                    )
                 } else {
                     ElseArm::None
                 };
@@ -589,14 +586,14 @@ impl Planner<'_> {
                         then_body: LoweredBlock {
                             statements: then_statements,
                         },
-                        else_arm: ElseArm::Else {
-                            body: LoweredBlock {
+                        else_arm: ElseArm::from_body(
+                            LoweredBlock {
                                 statements: vec![LoweredStatement::RawGo(format!(
                                     "{output}[{index}] = {none}\n"
                                 ))],
                             },
-                            inline: false,
-                        },
+                            false,
+                        ),
                     })],
                 }
             }

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -360,10 +360,7 @@ impl Planner<'_> {
                     &sink,
                     &format!("{PARTIAL_ERR_CTOR}[{type_params}]({err_var})"),
                 ),
-                else_arm: ElseArm::Else {
-                    body: both_body,
-                    inline: false,
-                },
+                else_arm: ElseArm::from_body(both_body, false),
             };
             LoweredBlock {
                 statements: vec![LoweredStatement::If(inner)],
@@ -372,10 +369,7 @@ impl Planner<'_> {
             both_body
         };
 
-        let else_arm = ElseArm::Else {
-            body: ok_body,
-            inline: false,
-        };
+        let else_arm = ElseArm::from_body(ok_body, false);
 
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -493,16 +487,10 @@ impl Planner<'_> {
                 condition_setup: Vec::new(),
                 condition: nil_condition,
                 then_body: leaf_block(&sink, &nil_err),
-                else_arm: ElseArm::Else {
-                    body: ok_body,
-                    inline: false,
-                },
+                else_arm: ElseArm::from_body(ok_body, false),
             }))
         } else {
-            ElseArm::Else {
-                body: ok_body,
-                inline: false,
-            }
+            ElseArm::from_body(ok_body, false)
         };
 
         statements.push(LoweredStatement::If(IfPlan {
@@ -566,10 +554,7 @@ impl Planner<'_> {
             let mut fe = FalliblePlanner::new(self, fallible);
             fe.emit_success("struct{}{}")
         };
-        let else_arm = ElseArm::Else {
-            body: leaf_block(&sink, &ok_wrapper),
-            inline: false,
-        };
+        let else_arm = ElseArm::from_body(leaf_block(&sink, &ok_wrapper), false);
 
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -254,10 +254,7 @@ impl Planner<'_> {
             }
         } else {
             let else_arm = match else_block {
-                Some(body) => ElseArm::Else {
-                    body,
-                    inline: false,
-                },
+                Some(body) => ElseArm::from_body(body, false),
                 None => ElseArm::None,
             };
             IfPlan {
@@ -324,10 +321,7 @@ impl Planner<'_> {
         });
 
         let else_arm = match self.build_ok_else_block(ctx) {
-            Some(body) => ElseArm::Else {
-                body,
-                inline: false,
-            },
+            Some(body) => ElseArm::from_body(body, false),
             None => ElseArm::None,
         };
         let receive_vars = format!("{}, {}", receiver_var, ok_var);
@@ -625,10 +619,7 @@ fn build_receive_arms_plan(
             condition_setup: Vec::new(),
             condition: ok_var.to_string(),
             then_body: some,
-            else_arm: ElseArm::Else {
-                body: none,
-                inline: false,
-            },
+            else_arm: ElseArm::from_body(none, false),
         }),
         (Some(some), None) => Some(IfPlan {
             condition_setup: Vec::new(),

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -221,10 +221,7 @@ impl Planner<'_> {
             condition_setup: Vec::new(),
             condition,
             then_body,
-            else_arm: ElseArm::Else {
-                body: else_body,
-                inline: false,
-            },
+            else_arm: ElseArm::from_body(else_body, false),
         }));
         Some(statements)
     }
@@ -316,16 +313,10 @@ impl Planner<'_> {
                     condition_setup: Vec::new(),
                     condition: check,
                     then_body: err_body,
-                    else_arm: ElseArm::Else {
-                        body: both_body,
-                        inline: false,
-                    },
+                    else_arm: ElseArm::from_body(both_body, false),
                 }))
             }
-            None => ElseArm::Else {
-                body: both_body,
-                inline: false,
-            },
+            None => ElseArm::from_body(both_body, false),
         };
 
         statements.push(LoweredStatement::If(IfPlan {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -324,15 +324,15 @@ impl Planner<'_> {
             then_body: LoweredBlock {
                 statements: then_body,
             },
-            else_arm: ElseArm::Else {
-                body: LoweredBlock {
+            else_arm: ElseArm::from_body(
+                LoweredBlock {
                     statements: vec![LoweredStatement::Break(
                         self.current_loop_id()
                             .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
                     )],
                 },
-                inline: false,
-            },
+                false,
+            ),
         }));
 
         let plan = self.build_source_loop(
@@ -702,10 +702,7 @@ impl Planner<'_> {
             },
         );
         let else_arm = match failure(self) {
-            Some(body) => ElseArm::Else {
-                body,
-                inline: false,
-            },
+            Some(body) => ElseArm::from_body(body, false),
             None => ElseArm::None,
         };
         statements.push(LoweredStatement::If(IfPlan {
@@ -788,10 +785,7 @@ fn assemble_if_else_chain(
     mut pieces: Vec<(String, LoweredBlock)>,
     terminal: LoweredBlock,
 ) -> LoweredStatement {
-    let mut else_arm = ElseArm::Else {
-        body: terminal,
-        inline: false,
-    };
+    let mut else_arm = ElseArm::from_body(terminal, false);
     while pieces.len() > 1 {
         let (condition, then_body) = pieces.pop().expect("len > 1");
         else_arm = ElseArm::ElseIf(Box::new(IfPlan {

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -597,20 +597,14 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         if preceding_diverges {
             let mut body: Vec<LoweredStatement> = Vec::new();
             self.walk(&mut body, decision, ctx);
-            return ElseArm::Else {
-                body: LoweredBlock { statements: body },
-                inline: true,
-            };
+            return ElseArm::from_body(LoweredBlock { statements: body }, true);
         }
         let body = self.with_scope(|this| {
             let mut body: Vec<LoweredStatement> = Vec::new();
             this.walk(&mut body, decision, ctx);
             body
         });
-        ElseArm::Else {
-            body: LoweredBlock { statements: body },
-            inline: false,
-        }
+        ElseArm::from_body(LoweredBlock { statements: body }, false)
     }
 
     fn is_empty_leaf(&self, decision: &Decision) -> bool {

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -428,6 +428,15 @@ pub(crate) enum ElseArm {
     },
 }
 
+impl ElseArm {
+    pub(crate) fn from_body(body: LoweredBlock, inline: bool) -> Self {
+        if body.renders_empty() {
+            return ElseArm::None;
+        }
+        ElseArm::Else { body, inline }
+    }
+}
+
 impl LoweredBlock {
     /// Whether the block's last rendered line is `break`, `continue`,
     /// `return`, or `panic(...)`.

--- a/crates/emit/src/plan/invariants.rs
+++ b/crates/emit/src/plan/invariants.rs
@@ -86,7 +86,12 @@ fn walk_else(arm: &ElseArm, issues: &mut Vec<String>, path: &str) {
     match arm {
         ElseArm::None => {}
         ElseArm::ElseIf(plan) => walk_if(plan, issues, path),
-        ElseArm::Else { body, .. } => walk_block(body, issues, path),
+        ElseArm::Else { body, .. } => {
+            if body.renders_empty() {
+                issues.push(format!("{}: else arm renders no output", path));
+            }
+            walk_block(body, issues, path)
+        }
     }
 }
 

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -974,13 +974,6 @@ impl Planner<'_> {
         let Some(alternative) = alternative else {
             return ElseArm::None;
         };
-        let is_empty_alternative = match alternative {
-            Expression::Block { items, .. } => items.is_empty(),
-            _ => false,
-        };
-        if is_empty_alternative {
-            return ElseArm::None;
-        }
 
         if let Expression::If {
             condition,
@@ -1030,13 +1023,10 @@ impl Planner<'_> {
         } else if preceding_diverges {
             let body =
                 self.with_binding_frame(|this| this.lower_block_to_place(alternative, place));
-            ElseArm::Else { body, inline: true }
+            ElseArm::from_body(body, true)
         } else {
             let body = self.with_scope(|this| this.lower_block_to_place(alternative, place));
-            ElseArm::Else {
-                body,
-                inline: false,
-            }
+            ElseArm::from_body(body, false)
         }
     }
 }

--- a/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
+++ b/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
@@ -39,7 +39,6 @@ func test() {
 			result_3 = lisette.MakeResultOk[int, error](ret_1)
 		}
 		if result_3.IsOk() {
-		} else {
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
@@ -32,6 +32,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_discarded_with_mismatched_branches.snap
+++ b/tests/spec/emit/snapshots/if_let_discarded_with_mismatched_branches.snap
@@ -14,6 +14,5 @@ import lisette "github.com/ivov/lisette/prelude"
 func test(opt lisette.Option[int]) {
 	if opt.Tag == lisette.OptionSome {
 		_ = opt.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/if_with_else.snap
+++ b/tests/spec/emit/snapshots/if_with_else.snap
@@ -14,6 +14,5 @@ package main
 
 func test(x int) {
 	if x > 10 {
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_direct_call.snap
@@ -23,6 +23,5 @@ func main() {
 	r := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
@@ -26,6 +26,5 @@ func main() {
 	r := option_1
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
@@ -28,6 +28,5 @@ func main() {
 	}
 	if option_4.Tag == lisette.OptionSome {
 		_ = len(option_4.SomeVal)
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_stays_boxed.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_stays_boxed.snap
@@ -46,6 +46,5 @@ func main() {
 	option_2 := lisette.OptionFromCommaOk[string](lookup("HOME"))
 	if option_2.Tag == lisette.OptionSome {
 		_ = option_2.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
@@ -34,6 +34,5 @@ func main() {
 	r := option_1
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
@@ -23,6 +23,5 @@ func main() {
 	option_3 := lisette.OptionFromNilable[chan int](raw_2, raw_2 == nil)
 	if option_3.Tag == lisette.OptionSome {
 		_ = lisette.ChannelReceive(option_3.SomeVal)
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_map_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_map_return.snap
@@ -23,6 +23,5 @@ func main() {
 	option_3 := lisette.OptionFromNilable[map[string]int](raw_2, raw_2 == nil)
 	if option_3.Tag == lisette.OptionSome {
 		_ = len(option_3.SomeVal)
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
@@ -23,6 +23,5 @@ func main() {
 	option_3 := lisette.OptionFromNilable[reg.Index](raw_2, raw_2 == nil)
 	if option_3.Tag == lisette.OptionSome {
 		_ = option_3.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
@@ -66,6 +66,5 @@ func main() {
 	first := urls[0]
 	if first.Tag == lisette.OptionSome {
 		_ = first.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
@@ -31,6 +31,5 @@ func main() {
 	v := option_2
 	if v.Tag == lisette.OptionSome {
 		_ = v.SomeVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_alias_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_alias_call.snap
@@ -34,6 +34,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_assignment.snap
@@ -40,6 +40,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_break_value.snap
+++ b/tests/spec/emit/snapshots/interop_result_break_value.snap
@@ -47,6 +47,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_call_arg.snap
@@ -38,6 +38,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_direct_call.snap
@@ -29,6 +29,5 @@ func main() {
 	}
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -20,6 +20,5 @@ func main() {
 	if ret_2 == nil {
 		stored := ret_1
 		_ = stored
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_if_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_if_assignment.snap
@@ -41,6 +41,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_let_call.snap
@@ -32,6 +32,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -58,6 +58,5 @@ func main() {
 	r := result_5
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_native_method_arg.snap
@@ -33,6 +33,5 @@ func main() {
 	subject_3 := ys[0]
 	if subject_3.Tag == lisette.ResultOk {
 		_ = subject_3.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
@@ -53,8 +53,6 @@ func main() {
 		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
-		} else {
 		}
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -52,6 +52,5 @@ func main() {
 	if ret_2 == nil {
 		n := ret_1
 		_ = n
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -64,6 +64,5 @@ func main() {
 	if ret_2 == nil {
 		v := ret_1
 		_ = v
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_result_return_pos.snap
@@ -40,6 +40,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_element.snap
@@ -32,6 +32,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_struct_field.snap
+++ b/tests/spec/emit/snapshots/interop_result_struct_field.snap
@@ -38,6 +38,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_try_block.snap
@@ -67,8 +67,6 @@ func main() {
 		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
-		} else {
 		}
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_element.snap
@@ -32,6 +32,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -45,6 +45,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
@@ -46,6 +46,5 @@ func main() {
 	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
-	} else {
 	}
 }

--- a/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/match_subject_temp_var_no_collision.snap
@@ -20,7 +20,6 @@ func main() {
 	opt := lisette.MakeOptionSome(1)
 	if opt.Tag == lisette.OptionSome {
 		_ = opt.SomeVal
-	} else {
 	}
 	subject_1 := 7
 	_ = subject_1

--- a/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
@@ -47,7 +47,6 @@ func main() {
 	_, ret_1 := bail()
 	if ret_1 == nil {
 		panic("expected error")
-	} else {
 	}
 }
 


### PR DESCRIPTION
An `else` branch whose body compiles away no longer leaves an empty block in the emitted Go.