### PR TITLE
refactor: color operands in test failure labels

### DIFF
--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -1100,7 +1100,7 @@ fn render_failure(
     } else {
         let label = match values.as_slice() {
             [] => record.message.clone(),
-            [only] => only.clone(),
+            [only] => format!("`{}`", only),
             _ => stacked_operand_label(&record.operands, &values),
         };
         diagnostic = diagnostic.with_span_primary_label(&span, label);
@@ -1145,7 +1145,7 @@ fn stacked_operand_label(operands: &[Operand], values: &[String]) -> String {
         .zip(values)
         .map(|(operand, value)| {
             let token = format!("{}:", operand.label);
-            format!("{token:<label_width$} {value}")
+            format!("{token:<label_width$} `{value}`")
         })
         .collect::<Vec<_>>()
         .join("\n")


### PR DESCRIPTION
Operands are now consistently colored in labels in test failure reports:

<img width="500"  alt="Capture 2026-08-09 at 13 59 10@2x" src="https://github.com/user-attachments/assets/121306b8-2042-4094-bfdd-cb9cc15f5831" />
