### PR TITLE
refactor: reshape interface conformance diagnostics

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -167,42 +167,23 @@ impl fmt::Display for LisetteDiagnostic {
 
 impl std::error::Error for LisetteDiagnostic {}
 
-struct HelpText<'a> {
-    help: Option<&'a str>,
-    note: Option<&'a str>,
-    diagnostic_code: Option<&'a str>,
-    use_color: bool,
+fn style_help(text: &str, use_color: bool) -> String {
+    if use_color {
+        format_with_backticks(text, true, |s| format!("{}", s.dimmed()))
+    } else {
+        text.to_string()
+    }
 }
 
-impl fmt::Display for HelpText<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let use_color = self.use_color;
-        let has_code = self.diagnostic_code.is_some();
-
-        let combined = combine_help_and_note(self.help, self.note, has_code).unwrap_or_default();
-
-        if !combined.is_empty() {
-            if use_color {
-                let styled = format_with_backticks(&combined, true, |s| format!("{}", s.dimmed()));
-                write!(f, "{}", styled)?;
-            } else {
-                write!(f, "{}", combined)?;
-            }
-        }
-
-        if let Some(code) = self.diagnostic_code {
-            let is_listing = self
-                .help
-                .is_some_and(|h| h.lines().skip(1).any(|line| line.starts_with("  ")));
-            let prefix = if is_listing { "\ncode: " } else { " · code: " };
-            if use_color {
-                write!(f, "{}{}", prefix.dimmed(), format!("[{}]", code).dimmed())?;
-            } else {
-                write!(f, "{}[{}]", prefix, code)?;
-            }
-        }
-
-        Ok(())
+fn style_code(code: &str, prefix: &str, use_color: bool) -> String {
+    if use_color {
+        format!(
+            "{}{}",
+            format!("{}code: ", prefix).dimmed(),
+            format!("[{}]", code).dimmed()
+        )
+    } else {
+        format!("{}code: [{}]", prefix, code)
     }
 }
 
@@ -359,19 +340,43 @@ impl LisetteDiagnostic {
         }
     }
 
-    pub(crate) fn styled_help_text(&self, use_color: bool) -> Option<String> {
-        if self.help.is_none() && self.note.is_none() && self.code.is_none() {
-            return None;
-        }
-        Some(
-            HelpText {
-                help: self.help.as_deref(),
-                note: self.note.as_deref(),
-                diagnostic_code: self.code.as_deref(),
-                use_color,
-            }
-            .to_string(),
+    pub(crate) fn styled_help_parts(&self, use_color: bool) -> (Option<String>, Option<String>) {
+        let combined = combine_help_and_note(
+            self.help.as_deref(),
+            self.note.as_deref(),
+            self.code.is_some(),
         )
+        .filter(|text| !text.is_empty());
+        let code = self.code.as_deref();
+
+        match (combined, code) {
+            (None, None) => (None, None),
+            (None, Some(code)) => (None, Some(style_code(code, "", use_color))),
+            (Some(text), None) => (Some(style_help(&text, use_color)), None),
+            (Some(text), Some(code)) if text.contains('\n') => (
+                Some(style_help(&text, use_color)),
+                Some(style_code(code, "", use_color)),
+            ),
+            (Some(text), Some(code)) => (
+                Some(format!(
+                    "{}{}",
+                    style_help(&text, use_color),
+                    style_code(code, " · ", use_color)
+                )),
+                None,
+            ),
+        }
+    }
+
+    pub fn secondary_labels(&self) -> impl Iterator<Item = (Span, &str)> {
+        self.labels
+            .iter()
+            .skip(1)
+            .map(|label| (label.span, label.text.as_str()))
+    }
+
+    pub fn label_count(&self) -> usize {
+        self.labels.len()
     }
 
     pub(crate) fn label_file_ids(&self) -> Vec<u32> {

--- a/crates/diagnostics/src/graphical.rs
+++ b/crates/diagnostics/src/graphical.rs
@@ -182,6 +182,7 @@ pub(crate) struct FrameReport<'a> {
     pub message: &'a str,
     pub sources: &'a [FrameSource],
     pub help: Option<&'a str>,
+    pub code: Option<&'a str>,
 }
 
 pub(crate) fn render_report(
@@ -203,6 +204,9 @@ pub(crate) fn render_report(
     }
     if let Some(help) = report.help {
         render_help(output, help, theme)?;
+    }
+    if let Some(code) = report.code {
+        writeln!(output, "  {}", code)?;
     }
     Ok(())
 }

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2174,6 +2174,7 @@ pub enum InterfaceMethodViolation {
         name: String,
         expected: Type,
         actual: Type,
+        impl_span: Option<Span>,
     },
 }
 
@@ -2205,96 +2206,298 @@ pub fn sealed_interface_not_satisfiable(
     ))
 }
 
+struct LabelledMethod<'a> {
+    interface: &'a str,
+    name: &'a str,
+    span: Span,
+    expected: &'a Type,
+    actual: &'a Type,
+}
+
+fn labelled_methods<'a>(
+    violations: &'a [InterfaceViolation],
+    file_id: u32,
+) -> Option<Vec<LabelledMethod<'a>>> {
+    let mut methods = Vec::new();
+    for violation in violations {
+        for method in &violation.methods {
+            let InterfaceMethodViolation::Incompatible {
+                name,
+                expected,
+                actual,
+                impl_span,
+            } = method
+            else {
+                return None;
+            };
+            let span = (*impl_span)?;
+            if span.file_id != file_id {
+                return None;
+            }
+            methods.push(LabelledMethod {
+                interface: &violation.interface_name,
+                name,
+                span,
+                expected,
+                actual,
+            });
+        }
+    }
+    (!methods.is_empty() && methods.len() <= 2).then_some(methods)
+}
+
+fn ordinal(index: usize) -> String {
+    match index {
+        0 => "first".to_string(),
+        1 => "second".to_string(),
+        2 => "third".to_string(),
+        3 => "fourth".to_string(),
+        4 => "fifth".to_string(),
+        other => format!("{}th", other + 1),
+    }
+}
+
+fn count_word(count: usize) -> String {
+    match count {
+        1 => "One".to_string(),
+        2 => "Two".to_string(),
+        3 => "Three".to_string(),
+        4 => "Four".to_string(),
+        5 => "Five".to_string(),
+        6 => "Six".to_string(),
+        7 => "Seven".to_string(),
+        8 => "Eight".to_string(),
+        9 => "Nine".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn change_sentence(method: &LabelledMethod<'_>) -> String {
+    let (Type::Function(expected), Type::Function(actual)) = (method.expected, method.actual)
+    else {
+        return format!("Change `{}` to `{}`", method.name, method.expected);
+    };
+
+    if expected.params.len() != actual.params.len() {
+        let plural = if expected.params.len() == 1 { "" } else { "s" };
+        return format!(
+            "`{}` requires `{}` to take {} parameter{}, not {}",
+            method.interface,
+            method.name,
+            expected.params.len(),
+            plural,
+            actual.params.len()
+        );
+    }
+
+    let diverged: Vec<usize> = expected
+        .params
+        .iter()
+        .zip(&actual.params)
+        .enumerate()
+        .filter(|(_, (expected, actual))| expected.ty != actual.ty)
+        .map(|(index, _)| index)
+        .collect();
+    let return_diverged = expected.return_type != actual.return_type;
+
+    match (diverged.as_slice(), return_diverged) {
+        ([], true) => format!(
+            "Change `{}` to return `{}`",
+            method.name, expected.return_type
+        ),
+        ([index], false) => {
+            let parameter = expected.params[*index].name.as_ref().map_or_else(
+                || format!("{} parameter", ordinal(*index)),
+                |name| format!("`{}` parameter", name),
+            );
+            format!(
+                "Change the {} of `{}` to `{}`",
+                parameter, method.name, expected.params[*index].ty
+            )
+        }
+        _ => format!("Change `{}` to `{}`", method.name, method.expected),
+    }
+}
+
+fn declaration(name: &str, signature: &Type, receiver: Option<&str>) -> String {
+    let Type::Function(function) = signature else {
+        return format!("{}: {}", name, signature);
+    };
+
+    let mut params: Vec<String> = receiver
+        .map(|receiver| format!("self: {}", receiver))
+        .into_iter()
+        .collect();
+    for (index, param) in function.params.iter().enumerate() {
+        let name = param
+            .name
+            .as_ref()
+            .map_or_else(|| format!("arg{}", index + 1), ToString::to_string);
+        let mutable = if param.mutable { "mut " } else { "" };
+        params.push(format!("{}{}: {}", mutable, name, param.ty));
+    }
+
+    format!(
+        "fn {}({}) -> {}",
+        name,
+        params.join(", "),
+        function.return_type
+    )
+}
+
+fn attribution(violation: &InterfaceViolation) -> String {
+    match &violation.parent_of {
+        Some(parent) => format!(
+            "from `{}`, embedded in `{}`",
+            violation.interface_name, parent
+        ),
+        None => format!("from `{}`", violation.interface_name),
+    }
+}
+
+fn list_lead(
+    interface_name: &str,
+    type_name: &str,
+    violations: &[InterfaceViolation],
+    foreign_package: Option<&str>,
+) -> String {
+    let missing = violations
+        .iter()
+        .flat_map(|violation| &violation.methods)
+        .filter(|method| matches!(method, InterfaceMethodViolation::Missing(_)))
+        .count();
+    let total: usize = violations
+        .iter()
+        .map(|violation| violation.methods.len())
+        .sum();
+
+    if let Some(package) = foreign_package {
+        let noun = if missing > 0 { "missing" } else { "required" };
+        let plural = if total == 1 { "" } else { "s" };
+        return format!(
+            "`{}` comes from `{}`, so methods cannot be added to it. Wrap it in a local struct \
+             that embeds it and declares the {} method{}:",
+            type_name, package, noun, plural
+        );
+    }
+
+    let embedded: Vec<&str> = violations
+        .iter()
+        .filter(|violation| violation.interface_name != interface_name)
+        .map(|violation| violation.interface_name.as_str())
+        .collect();
+    match embedded.as_slice() {
+        [] => {
+            let plural = if total == 1 { " does" } else { "s do" };
+            format!(
+                "{} method{} not satisfy `{}`:",
+                count_word(total),
+                plural,
+                interface_name
+            )
+        }
+        [single] => format!(
+            "`{}` embeds `{}`, so both contracts apply:",
+            interface_name, single
+        ),
+        _ => format!(
+            "`{}` embeds other interfaces, so their requirements apply too:",
+            interface_name
+        ),
+    }
+}
+
 pub fn interface_not_implemented(
     interface_name: &str,
     type_name: &str,
     violations: &[InterfaceViolation],
+    foreign_package: Option<&str>,
     span: Span,
 ) -> LisetteDiagnostic {
-    let mut help_lines = Vec::new();
+    let mut diagnostic = LisetteDiagnostic::error(format!(
+        "`{}` does not implement `{}`",
+        type_name, interface_name
+    ))
+    .with_infer_code("interface_not_implemented")
+    .with_span_label(&span, format!("`{}` needed here", interface_name));
 
-    let mut missing_sections: Vec<(String, Vec<String>)> = Vec::new();
-    let mut incompatible_sections: Vec<(String, Vec<String>)> = Vec::new();
-
-    for violation in violations {
-        let header = if let Some(ref parent) = violation.parent_of {
-            format!(
-                "From `{}` (required by `{}`)",
-                violation.interface_name, parent
-            )
-        } else {
-            format!("From `{}`", violation.interface_name)
-        };
-
-        let missing: Vec<String> = violation
-            .methods
-            .iter()
-            .filter_map(|method| match method {
-                InterfaceMethodViolation::Missing(method) => Some(method),
-                InterfaceMethodViolation::Incompatible { .. } => None,
-            })
-            .flat_map(|method| {
-                std::iter::once(format!("  - {}: {}", method.name, method.signature)).chain(
-                    method.private_candidate.iter().map(|private_name| {
-                        format!(
-                            "    (add `pub` to the private method `{}` to satisfy this)",
-                            private_name
-                        )
-                    }),
-                )
-            })
-            .collect();
-        if !missing.is_empty() {
-            missing_sections.push((header.clone(), missing));
+    if let Some(methods) = labelled_methods(violations, span.file_id) {
+        let sentences: Vec<String> = methods.iter().map(change_sentence).collect();
+        for method in &methods {
+            diagnostic = diagnostic.with_span_label(
+                &method.span,
+                format!("`{}` requires `{}`", method.interface, method.expected),
+            );
         }
+        return diagnostic.with_help(sentences.join(". "));
+    }
 
-        let incompatible: Vec<String> = violation
-            .methods
-            .iter()
-            .filter_map(|method| match method {
-                InterfaceMethodViolation::Missing(_) => None,
+    let receiver = foreign_package.is_none().then_some(type_name);
+    let attribute = violations
+        .iter()
+        .any(|violation| violation.interface_name != interface_name);
+
+    let mut missing: Vec<(String, Option<String>, Option<String>)> = Vec::new();
+    let mut incompatible: Vec<(String, Option<String>)> = Vec::new();
+    for violation in violations {
+        let attributed = attribute.then(|| attribution(violation));
+        for method in &violation.methods {
+            match method {
+                InterfaceMethodViolation::Missing(method) => missing.push((
+                    declaration(&method.name, &method.signature, receiver),
+                    method.private_candidate.clone(),
+                    attributed.clone(),
+                )),
                 InterfaceMethodViolation::Incompatible {
                     name,
                     expected,
                     actual,
-                } => Some(format!(
-                    "  - {}: expected `{}`, found `{}`",
-                    name, expected, actual
+                    ..
+                } => incompatible.push((
+                    format!("{}: expected `{}`, found `{}`", name, expected, actual),
+                    attributed.clone(),
                 )),
-            })
-            .collect();
-        if !incompatible.is_empty() {
-            incompatible_sections.push((header, incompatible));
-        }
-    }
-
-    if !missing_sections.is_empty() {
-        help_lines.push("Missing methods:".to_string());
-        for (header, methods) in &missing_sections {
-            help_lines.push(format!("  {}", header));
-            for method in methods {
-                help_lines.push(format!("  {}", method));
             }
         }
     }
 
-    if !incompatible_sections.is_empty() {
-        help_lines.push("Incompatible methods:".to_string());
-        for (header, methods) in &incompatible_sections {
-            help_lines.push(format!("  {}", header));
-            for method in methods {
-                help_lines.push(format!("  {}", method));
+    let width = missing
+        .iter()
+        .map(|(row, _, _)| row.chars().count())
+        .chain(incompatible.iter().map(|(row, _)| row.chars().count()))
+        .max()
+        .unwrap_or(0);
+    let pad = |row: &str, attributed: &Option<String>| match attributed {
+        Some(attributed) => format!("  {:<width$}  {}", row, attributed, width = width),
+        None => format!("  {}", row),
+    };
+
+    let mut help = vec![list_lead(
+        interface_name,
+        type_name,
+        violations,
+        foreign_package,
+    )];
+    if !missing.is_empty() {
+        help.push("Missing:".to_string());
+        for (row, private_candidate, attributed) in &missing {
+            help.push(pad(row, attributed));
+            if let Some(private) = private_candidate {
+                help.push(format!(
+                    "    (add `pub` to the private method `{}` to satisfy this)",
+                    private
+                ));
             }
         }
     }
+    if !incompatible.is_empty() {
+        help.push("Incompatible:".to_string());
+        for (row, attributed) in &incompatible {
+            help.push(pad(row, attributed));
+        }
+    }
 
-    LisetteDiagnostic::error("Interface not implemented")
-        .with_infer_code("interface_not_implemented")
-        .with_span_label(
-            &span,
-            format!("`{}` does not implement `{}`", type_name, interface_name),
-        )
-        .with_help(help_lines.join("\n"))
+    diagnostic.with_help(help.join("\n"))
 }
 
 pub fn cannot_propagate_error(declared: &str, operand: &str, span: Span) -> LisetteDiagnostic {

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -174,7 +174,7 @@ pub fn render_with_sources<F: Fn(u32) -> Option<(String, String)>>(
         })
         .collect();
 
-    let help = diagnostic.styled_help_text(use_color);
+    let (help, code) = diagnostic.styled_help_parts(use_color);
     let mut output = String::new();
     let _ = graphical::render_report(
         &mut output,
@@ -182,6 +182,7 @@ pub fn render_with_sources<F: Fn(u32) -> Option<(String, String)>>(
             message: &diagnostic.styled_message(use_color),
             sources: &frames,
             help: help.as_deref(),
+            code: code.as_deref(),
         },
         &frame_theme(diagnostic, use_color),
         context_lines,

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -403,7 +403,7 @@ impl SharedState {
                     let fid = d.file_id();
                     fid == Some(document.file_id) || fid.is_none()
                 })
-                .map(|d| convert_diagnostic(d, document.line_index))
+                .map(|d| convert_diagnostic_in(d, document.line_index, Some(uri)))
                 .collect(),
         )
     }
@@ -442,12 +442,44 @@ fn recover_target(key: &AnalysisKey) -> RecoverTarget {
 }
 
 pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Diagnostic {
+    convert_diagnostic_in(d, index, None)
+}
+
+fn related_information(
+    d: &LisetteDiagnostic,
+    index: &LineIndex,
+    uri: &Url,
+    anchor_file: Option<u32>,
+) -> Option<Vec<serde_json::Value>> {
+    let related: Vec<serde_json::Value> = d
+        .secondary_labels()
+        .filter(|(span, text)| !text.is_empty() && Some(span.file_id) == anchor_file)
+        .map(|(span, text)| {
+            serde_json::json!({
+                "location": {
+                    "uri": uri.to_string(),
+                    "range": index.span_to_range(span),
+                },
+                "message": text,
+            })
+        })
+        .collect();
+    (!related.is_empty()).then_some(related)
+}
+
+pub(crate) fn convert_diagnostic_in(
+    d: &LisetteDiagnostic,
+    index: &LineIndex,
+    uri: Option<&Url>,
+) -> Diagnostic {
     let range = d
         .first_label_span()
         .map(|(offset, length)| index.offset_len_to_range(offset, length))
         .unwrap_or_default();
+    let related = uri.and_then(|uri| related_information(d, index, uri, d.file_id()));
 
     Diagnostic {
+        related_information: related,
         range,
         severity: Some(if d.is_error() {
             DiagnosticSeverity::ERROR
@@ -457,9 +489,11 @@ pub(crate) fn convert_diagnostic(d: &LisetteDiagnostic, index: &LineIndex) -> Di
             DiagnosticSeverity::WARNING
         }),
         message: {
+            let structured =
+                d.label_count() >= 2 || d.plain_help().is_some_and(|help| help.contains('\n'));
             let mut msg = match d.plain_label() {
-                Some(label) => label.to_string(),
-                None => d.plain_message().to_string(),
+                Some(label) if !structured => label.to_string(),
+                _ => d.plain_message().to_string(),
             };
             if let Some(first) = msg.chars().next()
                 && first.is_ascii_lowercase()
@@ -512,6 +546,48 @@ mod tests {
         assert_eq!(
             diagnostic.message,
             "Never called · Call or remove this function"
+        );
+    }
+
+    #[test]
+    fn multi_label_diagnostic_leads_with_the_message_and_reports_related_locations() {
+        let index = LineIndex::new("fn write() {}\nfn call() {}\n");
+        let uri = Url::parse("file:///x.lis").unwrap();
+        let diagnostic = convert_diagnostic_in(
+            &LisetteDiagnostic::error("`File` does not implement `Writer`")
+                .with_span_label(&syntax::ast::Span::new(0, 17, 4), "`Writer` needed here")
+                .with_span_label(
+                    &syntax::ast::Span::new(0, 3, 5),
+                    "`Writer` requires `fn () -> int`",
+                ),
+            &index,
+            Some(&uri),
+        );
+
+        assert_eq!(diagnostic.message, "`File` does not implement `Writer`");
+        let related = diagnostic
+            .related_information
+            .expect("a second label should become related information");
+        assert_eq!(related.len(), 1);
+        assert_eq!(related[0]["message"], "`Writer` requires `fn () -> int`");
+        assert_eq!(related[0]["location"]["uri"], "file:///x.lis");
+    }
+
+    #[test]
+    fn multi_line_help_leads_with_the_message() {
+        let span = syntax::ast::Span::new(0, 0, 1);
+        let diagnostic = convert_diagnostic(
+            &LisetteDiagnostic::error("`File` does not implement `ReadWriter`")
+                .with_span_label(&span, "`ReadWriter` needed here")
+                .with_help("Two methods do not satisfy `ReadWriter`:\nMissing:\n  fn read(self: File) -> string"),
+            &LineIndex::new("x"),
+        );
+        assert!(
+            diagnostic
+                .message
+                .starts_with("`File` does not implement `ReadWriter` · Two methods"),
+            "got: {}",
+            diagnostic.message
         );
     }
 

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -193,11 +193,16 @@ impl InferCtx<'_> {
             let type_name = resolved
                 .get_name()
                 .map_or_else(|| resolved.to_string(), str::to_owned);
+            let foreign_package = resolved
+                .get_qualified_id()
+                .filter(|id| id.starts_with("go:"))
+                .and_then(|id| id.rsplit_once('.').map(|(package, _)| package));
             self.sink
                 .push(diagnostics::infer::interface_not_implemented(
                     unqualified_name(interface_qualified_id),
                     &type_name,
                     &violations,
+                    foreign_package,
                     *span,
                 ));
         }
@@ -554,6 +559,10 @@ impl InferCtx<'_> {
                     );
                 }
                 SignatureCheck::Incompatible { expected, actual } => {
+                    let impl_span = site
+                        .symbol_methods
+                        .get(impl_method_name.as_str())
+                        .and_then(|method| method.name_span);
                     check.push_violation(
                         interface_qualified_id,
                         requirement.parent_of.as_ref(),
@@ -561,6 +570,7 @@ impl InferCtx<'_> {
                             name: method_name.to_string(),
                             expected,
                             actual,
+                            impl_span,
                         },
                     );
                 }

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -349,7 +349,7 @@ pub interface Wrap<T: box.Box<Plain>> {}
         "import \"wrap\"\n\nfn main() {}\n",
     )
     .unwrap();
-    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+    assert_rejected_at_check(&lis(&project, "check"), "does not implement");
 }
 
 #[test]
@@ -404,7 +404,7 @@ pub fn call() {
     )
     .unwrap();
 
-    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+    assert_rejected_at_check(&lis(&project, "check"), "does not implement");
 }
 
 #[test]
@@ -463,7 +463,7 @@ pub fn call() {
     )
     .unwrap();
 
-    assert_rejected_at_check(&lis(&project, "check"), "Interface not implemented");
+    assert_rejected_at_check(&lis(&project, "check"), "does not implement");
 }
 
 #[test]

--- a/tests/spec/infer/snapshots/propagate_missing_custom_interface_method_lists_the_gap.snap
+++ b/tests/spec/infer/snapshots/propagate_missing_custom_interface_method_lists_the_gap.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/spec/infer/try.rs
 ---
-  ✕ Interface not implemented
+  ✕ `DbError` does not implement `AppError`
     ╭─[test.lis:16:17]
  15 │     fn handler() -> Result<int, AppError> {
  16 │       let row = query()?
     ·                 ────┬───
-    ·                     ╰── `DbError` does not implement `AppError`
+    ·                     ╰── `AppError` needed here
  17 │       Ok(row.length())
     ╰────
-  help: Missing methods:
-          From `AppError`
-            - status: fn () -> int
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `AppError`:
+        Missing:
+          fn status(self: DbError) -> int
+  code: [infer.interface_not_implemented]

--- a/tests/spec/infer/snapshots/propagate_without_error_method_names_the_missing_method.snap
+++ b/tests/spec/infer/snapshots/propagate_without_error_method_names_the_missing_method.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/spec/infer/try.rs
 ---
-  ✕ Interface not implemented
+  ✕ `PlainError` does not implement `error`
    ╭─[test.lis:7:15]
  6 │     fn load() -> Result<int, error> {
  7 │       let n = fetch()?
    ·               ────┬───
-   ·                   ╰── `PlainError` does not implement `error`
+   ·                   ╰── `error` needed here
  8 │       Ok(n)
    ╰────
-  help: Missing methods:
-          From `error`
-            - Error: fn () -> string
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `error`:
+        Missing:
+          fn Error(self: PlainError) -> string
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4603,6 +4603,25 @@ fn test() {
 }
 
 #[test]
+fn infer_go_type_cannot_implement_local_interface() {
+    let input = r#"
+import "go:strings"
+
+interface Show {
+  fn show() -> string;
+}
+
+fn use_show(s: Show) {}
+
+fn test() {
+  let builder = strings.Builder {}
+  use_show(builder)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_interface_bound_incompatible_signature() {
     let input = r#"
 interface Writer {

--- a/tests/ui/errors/snapshots/infer_function_type_does_not_implement_interface.snap
+++ b/tests/ui/errors/snapshots/infer_function_type_does_not_implement_interface.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `fn (int) -> int` does not implement `Display`
     ╭─[test.lis:15:15]
  14 │ fn main() {
  15 │   print_value(some_func);
     ·               ────┬────
-    ·                   ╰── `fn (int) -> int` does not implement `Display`
+    ·                   ╰── `Display` needed here
  16 │ }
     ╰────
-  help: Missing methods:
-          From `Display`
-            - show: fn () -> string
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `Display`:
+        Missing:
+          fn show(self: fn (int) -> int) -> string
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_go_type_cannot_implement_local_interface.snap
+++ b/tests/ui/errors/snapshots/infer_go_type_cannot_implement_local_interface.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `Builder` does not implement `Show`
+    ╭─[test.lis:12:12]
+ 11 │   let builder = strings.Builder {}
+ 12 │   use_show(builder)
+    ·            ───┬───
+    ·               ╰── `Show` needed here
+ 13 │ }
+    ╰────
+  help: `Builder` comes from `go:strings`, so methods cannot be added to it. Wrap it in a local struct that embeds it and declares the missing method:
+        Missing:
+          fn show() -> string
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_bound_incompatible_signature.snap
+++ b/tests/ui/errors/snapshots/infer_interface_bound_incompatible_signature.snap
@@ -1,15 +1,19 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `File` does not implement `Writer`
+    ╭─[test.lis:9:6]
+  8 │ impl File {
+  9 │   fn write(self: File, data: string) -> string {
+    ·      ──┬──
+    ·        ╰── `Writer` requires `fn (string) -> int`
+ 10 │     return "ok";
+    ╰────
     ╭─[test.lis:19:14]
  18 │ fn test() {
  19 │   use_writer(File { path: "test.txt" })
     ·              ────────────┬────────────
-    ·                          ╰── `File` does not implement `Writer`
+    ·                          ╰── `Writer` needed here
  20 │ }
     ╰────
-  help: Incompatible methods:
-          From `Writer`
-            - write: expected `fn (string) -> int`, found `fn (string) -> string`
-        code: [infer.interface_not_implemented]
+  help: Change `write` to return `int` · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_bound_multiple_issues.snap
+++ b/tests/ui/errors/snapshots/infer_interface_bound_multiple_issues.snap
@@ -1,18 +1,17 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `File` does not implement `ReadWriter`
     ╭─[test.lis:20:10]
  19 │ fn test() {
  20 │   use_rw(File { path: "test.txt" })
     ·          ────────────┬────────────
-    ·                      ╰── `File` does not implement `ReadWriter`
+    ·                      ╰── `ReadWriter` needed here
  21 │ }
     ╰────
-  help: Missing methods:
-          From `ReadWriter`
-            - read: fn () -> string
-        Incompatible methods:
-          From `ReadWriter`
-            - write: expected `fn (string) -> int`, found `fn (string) -> string`
-        code: [infer.interface_not_implemented]
+  help: Two methods do not satisfy `ReadWriter`:
+        Missing:
+          fn read(self: File) -> string
+        Incompatible:
+          write: expected `fn (string) -> int`, found `fn (string) -> string`
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_bound_wrong_arity.snap
+++ b/tests/ui/errors/snapshots/infer_interface_bound_wrong_arity.snap
@@ -1,15 +1,19 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `File` does not implement `Writer`
+    ╭─[test.lis:9:6]
+  8 │ impl File {
+  9 │   fn write(self: File) -> int {
+    ·      ──┬──
+    ·        ╰── `Writer` requires `fn (string) -> int`
+ 10 │     return 0;
+    ╰────
     ╭─[test.lis:19:14]
  18 │ fn test() {
  19 │   use_writer(File { path: "test.txt" })
     ·              ────────────┬────────────
-    ·                          ╰── `File` does not implement `Writer`
+    ·                          ╰── `Writer` needed here
  20 │ }
     ╰────
-  help: Incompatible methods:
-          From `Writer`
-            - write: expected `fn (string) -> int`, found `fn () -> int`
-        code: [infer.interface_not_implemented]
+  help: `Writer` requires `write` to take 1 parameter, not 0 · code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_inheritance_both_missing.snap
+++ b/tests/ui/errors/snapshots/infer_interface_inheritance_both_missing.snap
@@ -1,17 +1,16 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `File` does not implement `Logger`
     ╭─[test.lis:18:14]
  17 │ fn test() {
  18 │   use_logger(File { path: "test.txt" })
     ·              ────────────┬────────────
-    ·                          ╰── `File` does not implement `Logger`
+    ·                          ╰── `Logger` needed here
  19 │ }
     ╰────
-  help: Missing methods:
-          From `Logger`
-            - log: fn () -> ()
-          From `Display` (required by `Logger`)
-            - show: fn () -> string
-        code: [infer.interface_not_implemented]
+  help: `Logger` embeds `Display`, so both contracts apply:
+        Missing:
+          fn log(self: File) -> ()       from `Logger`
+          fn show(self: File) -> string  from `Display`, embedded in `Logger`
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_hint.snap
+++ b/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_hint.snap
@@ -1,16 +1,16 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `Shouter` does not implement `Writer`
     ╭─[test.lis:14:15]
  13 │   let mut shouter = Shouter { written: [] }
  14 │   fmt.Fprintf(&shouter, "x")
     ·               ────┬───
-    ·                   ╰── `Shouter` does not implement `Writer`
+    ·                   ╰── `Writer` needed here
  15 │ }
     ╰────
-  help: Missing methods:
-          From `Writer`
-            - Write: fn (Slice<byte>) -> Partial<int, error>
-              (add `pub` to the private method `write` to satisfy this)
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `Writer`:
+        Missing:
+          fn Write(self: Shouter, p: Slice<byte>) -> Partial<int, error>
+            (add `pub` to the private method `write` to satisfy this)
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_wrong_signature.snap
+++ b/tests/ui/errors/snapshots/infer_interface_missing_method_private_candidate_wrong_signature.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `Shouter` does not implement `Writer`
     ╭─[test.lis:14:15]
  13 │   let mut shouter = Shouter {}
  14 │   fmt.Fprintf(&shouter, "x")
     ·               ────┬───
-    ·                   ╰── `Shouter` does not implement `Writer`
+    ·                   ╰── `Writer` needed here
  15 │ }
     ╰────
-  help: Missing methods:
-          From `Writer`
-            - Write: fn (Slice<byte>) -> Partial<int, error>
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `Writer`:
+        Missing:
+          fn Write(self: Shouter, p: Slice<byte>) -> Partial<int, error>
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_interface_not_implemented_ref_argument_resolves.snap
+++ b/tests/ui/errors/snapshots/infer_interface_not_implemented_ref_argument_resolves.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `Sink` does not implement `Writer`
    ╭─[test.lis:8:15]
  7 │   let mut sink = Sink {}
  8 │   fmt.Fprintf(&sink, "x")
    ·               ──┬──
-   ·                 ╰── `Sink` does not implement `Writer`
+   ·                 ╰── `Writer` needed here
  9 │ }
    ╰────
-  help: Missing methods:
-          From `Writer`
-            - Write: fn (Slice<byte>) -> Partial<int, error>
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `Writer`:
+        Missing:
+          fn Write(self: Sink, p: Slice<byte>) -> Partial<int, error>
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/infer_reference_aliases_sibling.snap
+++ b/tests/ui/errors/snapshots/infer_reference_aliases_sibling.snap
@@ -12,4 +12,5 @@ source: tests/ui/errors/mod.rs
     ╰────
   help: Make evaluation order explicit by choosing which value the read should see:
         - for the value before `&total` runs, copy it first with `let before = total` and read `before`
-        - for the value after, bind the reference-taking operand to a variable first, then read `total` · code: [infer.reference_aliases_sibling]
+        - for the value after, bind the reference-taking operand to a variable first, then read `total`
+  code: [infer.reference_aliases_sibling]

--- a/tests/ui/errors/snapshots/infer_refutable_enum_pattern_in_let.snap
+++ b/tests/ui/errors/snapshots/infer_refutable_enum_pattern_in_let.snap
@@ -18,4 +18,4 @@ source: tests/ui/errors/mod.rs
                 Some(x) => ...,
                 None => ...,
             }
-        code: [infer.refutable_pattern]
+  code: [infer.refutable_pattern]

--- a/tests/ui/errors/snapshots/infer_refutable_slice_pattern_in_let.snap
+++ b/tests/ui/errors/snapshots/infer_refutable_slice_pattern_in_let.snap
@@ -14,4 +14,4 @@ source: tests/ui/errors/mod.rs
                 [a, b] => ...,
                 _ => ...,
             }
-        code: [infer.refutable_pattern]
+  code: [infer.refutable_pattern]

--- a/tests/ui/errors/snapshots/infer_tuple_does_not_implement_interface.snap
+++ b/tests/ui/errors/snapshots/infer_tuple_does_not_implement_interface.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Interface not implemented
+  ✕ `(int, int)` does not implement `Display`
     ╭─[test.lis:12:15]
  11 │   let tuple = (1, 2);
  12 │   print_value(tuple);
     ·               ──┬──
-    ·                 ╰── `(int, int)` does not implement `Display`
+    ·                 ╰── `Display` needed here
  13 │ }
     ╰────
-  help: Missing methods:
-          From `Display`
-            - show: fn () -> string
-        code: [infer.interface_not_implemented]
+  help: One method does not satisfy `Display`:
+        Missing:
+          fn show(self: (int, int)) -> string
+  code: [infer.interface_not_implemented]

--- a/tests/ui/errors/snapshots/parse_error_function_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_function_unclosed_generic_at_eof.snap
@@ -5,4 +5,4 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:6]
  1 │ fn f<
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_impl_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_impl_unclosed_generic_at_eof.snap
@@ -5,4 +5,4 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:6]
  1 │ impl<
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_struct_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_struct_unclosed_generic_at_eof.snap
@@ -5,4 +5,4 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:10]
  1 │ struct S<
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_error_type_alias_unclosed_generic_at_eof.snap
+++ b/tests/ui/errors/snapshots/parse_error_type_alias_unclosed_generic_at_eof.snap
@@ -5,4 +5,4 @@ source: tests/ui/errors/mod.rs
    ╭─[test.lis:1:8]
  1 │ type T<
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_param_colon_recovers_annotation.snap
+++ b/tests/ui/errors/snapshots/parse_missing_param_colon_recovers_annotation.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·         ╰── expected `:`
  3 │   x
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_param_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_param_colon_reports_once.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·        ╰── expected `:`
  3 │   x
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_struct_field_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_struct_field_colon_reports_once.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·           ╰── expected `:`
  4 │   age: int,
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_missing_variant_field_colon_reports_once.snap
+++ b/tests/ui/errors/snapshots/parse_missing_variant_field_colon_reports_once.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                   ╰── expected `:`
  4 │ }
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_or_pattern_in_select.snap
+++ b/tests/ui/errors/snapshots/parse_or_pattern_in_select.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·           ╰── expected `=`
  5 │   }
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_self_after_other_parameter_rejected.snap
+++ b/tests/ui/errors/snapshots/parse_self_after_other_parameter_rejected.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                    ╰── expected `:`
  4 │ }
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_struct_pattern_before_declaration_terminates.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_struct_pattern_before_declaration_terminates.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    · ─┬
    ·  ╰── expected identifier
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_tuple_struct_recovers_at_fn_definition.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_tuple_struct_recovers_at_fn_definition.snap
@@ -8,4 +8,4 @@ source: tests/ui/errors/mod.rs
    · ─┬
    ·  ╰── expected `)`
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]

--- a/tests/ui/errors/snapshots/parse_unclosed_tuple_type_preserves_next_declaration.snap
+++ b/tests/ui/errors/snapshots/parse_unclosed_tuple_type_preserves_next_declaration.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·  ╰── expected `)`
  5 │   let _ = 1
    ╰────
-  help:  · code: [parse.unexpected_token]
+  code: [parse.unexpected_token]


### PR DESCRIPTION
Interface conformance errors now name the type and the interface in the diagnostic, and missing methods arrive as declarations that can be pasted into the `impl` block.

Before:

```
  ✕ Interface not implemented
    ╭─[test.lis:20:10]
 19 │ fn test() {
 20 │   use_rw(File { path: "test.txt" })
    ·          ────────────┬────────────
    ·                      ╰── `File` does not implement `ReadWriter`
 21 │ }
    ╰────
  help: Missing methods:
          From `ReadWriter`
            - read: fn () -> string
        Incompatible methods:
          From `ReadWriter`
            - write: expected `fn (string) -> int`, found `fn (string) -> string`
        code: [infer.interface_not_implemented]
```

After:

```
  ✕ `File` does not implement `ReadWriter`
    ╭─[test.lis:20:10]
 19 │ fn test() {
 20 │   use_rw(File { path: "test.txt" })
    ·          ────────────┬────────────
    ·                      ╰── `ReadWriter` needed here
 21 │ }
    ╰────
  help: Two methods do not satisfy `ReadWriter`:
        Missing:
          fn read(self: File) -> string
        Incompatible:
          write: expected `fn (string) -> int`, found `fn (string) -> string`
  code: [infer.interface_not_implemented]
```

When the only problem is an incompatible signature, the method is labelled where it is declared and the help says what to change:

```
  ✕ `File` does not implement `Writer`
    ╭─[test.lis:9:6]
  8 │ impl File {
  9 │   fn write(self: File, data: string) -> string {
    ·      ──┬──
    ·        ╰── `Writer` requires `fn (string) -> int`
 10 │     return "ok";
    ╰────
    ╭─[test.lis:19:14]
 18 │ fn test() {
 19 │   use_writer(File { path: "test.txt" })
    ·              ────────────┬────────────
    ·                          ╰── `Writer` needed here
 20 │ }
    ╰────
  help: Change `write` to return `int` · code: [infer.interface_not_implemented]
```

