### PR TITLE
refactor: reword the `Map<K, Unknown>` type mismatch help

### DIFF
--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -848,14 +848,11 @@ impl InferCtx<'_> {
         if self.store.contains_unknown(expected) && !self.store.contains_unknown(actual) {
             use syntax::types::CompoundKind::{Map, Slice};
             return match expected.as_compound() {
-                Some((Map, args))
-                    if args
-                        .get(1)
-                        .is_some_and(|ty| self.store.resolves_to_unknown(ty)) =>
-                {
+                Some((Map, [key, value])) if self.store.resolves_to_unknown(value) => {
                     format!(
-                        "Build the map with `Map.new()` plus indexed assignment: `let mut m: {} = Map.new(); m[k] = v`",
-                        expected_name
+                        "Build the map at `Map<{0}, {1}>`, e.g. `Map.from<{0}, {1}>([(k, v)])`",
+                        key.stringify(),
+                        value.stringify()
                     )
                 }
                 Some((Slice, args))

--- a/tests/ui/errors/snapshots/infer_unknown_map_invariant.snap
+++ b/tests/ui/errors/snapshots/infer_unknown_map_invariant.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·                                ╰── expected `Map<string, Unknown>`, found `Map<string, string>`
  4 │ }
    ╰────
-  help: Build the map with `Map.new()` plus indexed assignment: `let mut m: Map<string, Unknown> = Map.new(); m[k] = v` · code: [infer.type_mismatch]
+  help: Build the map at `Map<string, Unknown>`, e.g. `Map.from<string, Unknown>([(k, v)])` · code: [infer.type_mismatch]


### PR DESCRIPTION
The type mismatch help for `Map<K, Unknown>` steered users into building the map imperatively, which predates `Map.from` working for `Unknown` values. It now points at the single-expression form.