### PR TITLE
fix: emit explicit tuple type arguments for adapted literals

### DIFF
--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -327,10 +327,7 @@ impl Planner<'_> {
 
     pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> String {
         self.require_stdlib();
-        if !slot_types
-            .iter()
-            .any(|slot| self.facts.is_interface_or_unknown(slot))
-        {
+        if slot_types.len() != arity {
             return format!("lisette.MakeTuple{}", arity);
         }
         let rendered: Vec<String> = slot_types

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -3878,6 +3878,29 @@ fn main() {
 }
 
 #[test]
+fn adapted_numeric_literal_in_tuple_slot_compiles() {
+    let mut fs = MockFileSystem::new();
+
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        r#"
+import "go:fmt"
+
+fn main() {
+  let runes: Slice<(int, int)> = [('A', 2)]
+  let wide: Slice<(float64, int)> = [(90071992547409, 1)]
+  let narrow: Slice<(uint8, int)> = [(200, 1)]
+  let single: Slice<(float32, int)> = [(1.5, 1)]
+  fmt.Println(runes, wide, narrow, single)
+}
+"#,
+    );
+
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn cross_package_generic_function_value_instantiated() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/build/snapshots/adapted_numeric_literal_in_tuple_slot_compiles.snap
+++ b/tests/spec/build/snapshots/adapted_numeric_literal_in_tuple_slot_compiles.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	runes := []lisette.Tuple2[int, int]{lisette.MakeTuple2[int, int]('A', 2)}
+	wide := []lisette.Tuple2[float64, int]{lisette.MakeTuple2[float64, int](90071992547409, 1)}
+	narrow := []lisette.Tuple2[uint8, int]{lisette.MakeTuple2[uint8, int](200, 1)}
+	single := []lisette.Tuple2[float32, int]{lisette.MakeTuple2[float32, int](1.5, 1)}
+	fmt.Println(runes, wide, narrow, single)
+}

--- a/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
+++ b/tests/spec/build/snapshots/non_tail_tuple_branch_widens_temp_to_match_assignment.snap
@@ -24,10 +24,10 @@ func (r Reader2) Read(_ []uint8) (int, error) {
 func pick(flag bool) (io.Reader, int) {
 	var result lisette.Tuple2[io.Reader, int]
 	if flag {
-		tup_1 := lisette.MakeTuple2(Reader1{}, 1)
+		tup_1 := lisette.MakeTuple2[Reader1, int](Reader1{}, 1)
 		result = lisette.MakeTuple2[io.Reader, int](tup_1.First, tup_1.Second)
 	} else {
-		tup_2 := lisette.MakeTuple2(Reader2{}, 2)
+		tup_2 := lisette.MakeTuple2[Reader2, int](Reader2{}, 2)
 		result = lisette.MakeTuple2[io.Reader, int](tup_2.First, tup_2.Second)
 	}
 	tup_3 := result

--- a/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
+++ b/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, []int]{lisette.MakeTuple2("k", []int{1, 2})})
+	m := lisette.MapFrom([]lisette.Tuple2[string, []int]{lisette.MakeTuple2[string, []int]("k", []int{1, 2})})
 	m2 := lisette.MapCloneFunc(m, func(e_1 []int) []int { return slices.Clone(e_1) })
 	m2["k"] = []int{9}
 	_ = m

--- a/tests/spec/emit/snapshots/clone_slice_of_tuples_deep.snap
+++ b/tests/spec/emit/snapshots/clone_slice_of_tuples_deep.snap
@@ -18,12 +18,12 @@ import (
 )
 
 func main() {
-	a := []lisette.Tuple2[int, []int]{lisette.MakeTuple2(1, []int{2, 3})}
+	a := []lisette.Tuple2[int, []int]{lisette.MakeTuple2[int, []int](1, []int{2, 3})}
 	b := lisette.SliceCloneFunc(a, func(e_1 lisette.Tuple2[int, []int]) lisette.Tuple2[int, []int] {
 		e_1.Second = slices.Clone(e_1.Second)
 		return e_1
 	})
-	b[0] = lisette.MakeTuple2(4, []int{5})
+	b[0] = lisette.MakeTuple2[int, []int](4, []int{5})
 	_ = a
 	_ = b
 }

--- a/tests/spec/emit/snapshots/complex_pattern_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/complex_pattern_temp_no_collision.snap
@@ -16,7 +16,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
-	tmp_1 := lisette.MakeTuple2(1, lisette.MakeTuple2(2, 3))
+	tmp_1 := lisette.MakeTuple2[int, lisette.Tuple2[int, int]](1, lisette.MakeTuple2[int, int](2, 3))
 	a := tmp_1.First
 	b := tmp_1.Second.First
 	c := tmp_1.Second.Second

--- a/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
+++ b/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
@@ -24,6 +24,6 @@ func run() int {
 		return v
 	}
 	_v_1 := Box(x)
-	r := lisette.MakeTuple2(_v_1, bump(5))
+	r := lisette.MakeTuple2[Box, int](_v_1, bump(5))
 	return int(r.First) + r.Second
 }

--- a/tests/spec/emit/snapshots/for_enumerate_complex_all_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_all_unused.snap
@@ -14,7 +14,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4)}
+	items := []lisette.Tuple2[int, int]{
+		lisette.MakeTuple2[int, int](1, 2),
+		lisette.MakeTuple2[int, int](3, 4),
+	}
 	for key_1, value_2 := range items {
 		_ = value_2
 		_ = key_1

--- a/tests/spec/emit/snapshots/for_enumerate_complex_key_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_key_unused.snap
@@ -16,7 +16,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4)}
+	items := []lisette.Tuple2[int, int]{
+		lisette.MakeTuple2[int, int](1, 2),
+		lisette.MakeTuple2[int, int](3, 4),
+	}
 	sum := 0
 	for key_1, value_2 := range items {
 		_ = key_1

--- a/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
+++ b/tests/spec/emit/snapshots/for_enumerate_complex_value_unused.snap
@@ -16,7 +16,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4)}
+	items := []lisette.Tuple2[int, int]{
+		lisette.MakeTuple2[int, int](1, 2),
+		lisette.MakeTuple2[int, int](3, 4),
+	}
 	sum := 0
 	for key_1, value_2 := range items {
 		_ = value_2

--- a/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})
+	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})
 	for k, v := range maps.All(m) {
 		fmt.Printf("%s=%d\n", k, v)
 	}

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})
+	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})
 	for k := range maps.Keys(m) {
 		fmt.Println(k)
 	}

--- a/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
@@ -58,7 +58,7 @@ func pass[K comparable, V any](b Bar[map[K]V]) {
 }
 
 func main() {
-	pass(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})})
+	pass(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})})
 }
 
 type _lisAdapter_Bar_Box_0[K comparable, V any] struct {

--- a/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
@@ -70,7 +70,7 @@ func (r Runner[K]) Run(b Bar[map[K]int]) {
 
 func main() {
 	r := Runner[string]{k: "x"}
-	r.Run(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2("a", 1)})})
+	r.Run(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})})
 }
 
 type _lisAdapter_Bar_Box_0[K comparable] struct {

--- a/tests/spec/emit/snapshots/go_multi_return_rhs_uses_shadowed_binding.snap
+++ b/tests/spec/emit/snapshots/go_multi_return_rhs_uses_shadowed_binding.snap
@@ -20,5 +20,5 @@ import (
 func main() {
 	x := 1.25
 	x_1, y := math.Modf(x)
-	_ = lisette.MakeTuple2(x_1, y)
+	_ = lisette.MakeTuple2[float64, float64](x_1, y)
 }

--- a/tests/spec/emit/snapshots/go_multi_return_tuple_destructuring_shadow.snap
+++ b/tests/spec/emit/snapshots/go_multi_return_tuple_destructuring_shadow.snap
@@ -22,5 +22,5 @@ func main() {
 	x := "hi"
 	_ = x
 	x_1, y := math.Modf(1.25)
-	_ = lisette.MakeTuple2(x_1, y)
+	_ = lisette.MakeTuple2[float64, float64](x_1, y)
 }

--- a/tests/spec/emit/snapshots/interop_result_tuple_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_element.snap
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	t := lisette.MakeTuple2(strconv.Atoi, 1)
+	t := lisette.MakeTuple2[func(string) (int, error), int](strconv.Atoi, 1)
 	ret_1, ret_2 := t.First("1")
 	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {

--- a/tests/spec/emit/snapshots/let_tuple_all_unused_bindings.snap
+++ b/tests/spec/emit/snapshots/let_tuple_all_unused_bindings.snap
@@ -11,5 +11,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	_ = lisette.MakeTuple2(1, 2)
+	_ = lisette.MakeTuple2[int, int](1, 2)
 }

--- a/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
@@ -28,7 +28,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
-	return lisette.MakeTuple2(a, b), nil
+	return lisette.MakeTuple2[A, B](a, b), nil
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
@@ -23,7 +23,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
-	return lisette.MakeTuple2(a, b), nil
+	return lisette.MakeTuple2[A, B](a, b), nil
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
+++ b/tests/spec/emit/snapshots/lvalue_capturing_tuple_field.snap
@@ -27,7 +27,7 @@ func makeI() int {
 }
 
 func main() {
-	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2(0, 0)}
+	items := []lisette.Tuple2[int, int]{lisette.MakeTuple2[int, int](0, 0)}
 	base_2 := items
 	idx_3 := makeI()
 	var tmp_1 int

--- a/tests/spec/emit/snapshots/map_entry_slice_append_tuple_field.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_tuple_field.snap
@@ -19,8 +19,8 @@ import (
 
 func main() {
 	m := make(map[string]lisette.Tuple2[[]int, int])
-	m["a"] = lisette.MakeTuple2([]int{1}, 2)
-	entry := lisette.MakeTuple2(slices.Clone(m["a"].First), m["a"].Second)
+	m["a"] = lisette.MakeTuple2[[]int, int]([]int{1}, 2)
+	entry := lisette.MakeTuple2[[]int, int](slices.Clone(m["a"].First), m["a"].Second)
 	entry.First = append(entry.First, 3)
 	m["a"] = entry
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
@@ -44,7 +44,7 @@ func makeKey(counter *int) Key {
 
 func main() {
 	counter := 0
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("a", Box{x: 1})})
+	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
 	key := makeKey(&counter).k
 	entry := m[key]
 	entry.x = 2

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -21,7 +21,7 @@ type Box struct {
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("k", Box{x: 0})})
+	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("k", Box{x: 0})})
 	r := &m
 	entry := (*r)["k"]
 	entry.x = 1

--- a/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
@@ -20,7 +20,7 @@ type Box struct {
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("a", Box{x: 1})})
+	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
@@ -27,7 +27,7 @@ type Box struct {
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2("a", Box{x: 1})})
+	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_tuple_field.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_tuple_field.snap
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	m := make(map[string]lisette.Tuple2[int, int])
-	m["k"] = lisette.MakeTuple2(0, 0)
+	m["k"] = lisette.MakeTuple2[int, int](0, 0)
 	entry := m["k"]
 	entry.First = 1
 	m["k"] = entry

--- a/tests/spec/emit/snapshots/map_from_pairs.snap
+++ b/tests/spec/emit/snapshots/map_from_pairs.snap
@@ -12,7 +12,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test() map[string]int {
 	return lisette.MapFrom([]lisette.Tuple2[string, int]{
-		lisette.MakeTuple2("alice", 95),
-		lisette.MakeTuple2("bob", 82),
+		lisette.MakeTuple2[string, int]("alice", 95),
+		lisette.MakeTuple2[string, int]("bob", 82),
 	})
 }

--- a/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
+++ b/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
@@ -14,7 +14,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	tup_1 := lisette.MakeTuple2("one", "two")
+	tup_1 := lisette.MakeTuple2[string, string]("one", "two")
 	m := lisette.MapFrom[string, any]([]lisette.Tuple2[string, any]{lisette.MakeTuple2[string, any](tup_1.First, tup_1.Second)})
 	if len(m) != 1 {
 		panic("Map.from lost its entry when widening values to Unknown")

--- a/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
+++ b/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
@@ -21,10 +21,10 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	pair := lisette.MakeTuple2(10, 20)
+	pair := lisette.MakeTuple2[int, int](10, 20)
 	var first int
 	first = pair.First + pair.Second
-	nested := lisette.MakeTuple2(lisette.MakeTuple2(1, 2), lisette.MakeTuple2(3, 4))
+	nested := lisette.MakeTuple2[lisette.Tuple2[int, int], lisette.Tuple2[int, int]](lisette.MakeTuple2[int, int](1, 2), lisette.MakeTuple2[int, int](3, 4))
 	var second int
 	second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
 	return first + second

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
@@ -22,7 +22,7 @@ import (
 func test() string {
 	n := 50
 	s := "original"
-	pair := lisette.MakeTuple2(100, "replaced")
+	pair := lisette.MakeTuple2[int, string](100, "replaced")
 	var r string
 	{
 		n_1 := pair.First

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
@@ -63,7 +63,7 @@ func eval(e E) int {
 }
 
 func test() {
-	if eval(MakeEB(lisette.MakeTuple2(4, 9))) != 4 {
+	if eval(MakeEB(lisette.MakeTuple2[int, int](4, 9))) != 4 {
 		panic("bad")
 	}
 }

--- a/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
@@ -55,7 +55,7 @@ func eval(e E) int {
 }
 
 func test() {
-	if eval(MakeEB(lisette.MakeTuple2(4, 9))) != 4 {
+	if eval(MakeEB(lisette.MakeTuple2[int, int](4, 9))) != 4 {
 		panic("bad")
 	}
 }

--- a/tests/spec/emit/snapshots/match_tuple_nested.snap
+++ b/tests/spec/emit/snapshots/match_tuple_nested.snap
@@ -15,7 +15,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	nested := lisette.MakeTuple2(lisette.MakeTuple2(1, 2), 3)
+	nested := lisette.MakeTuple2[lisette.Tuple2[int, int], int](lisette.MakeTuple2[int, int](1, 2), 3)
 	if nested.First.First == 1 && nested.First.Second == 2 && nested.Second == 3 {
 		return 6
 	}

--- a/tests/spec/emit/snapshots/match_tuple_simple.snap
+++ b/tests/spec/emit/snapshots/match_tuple_simple.snap
@@ -16,7 +16,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	pair := lisette.MakeTuple2(1, 2)
+	pair := lisette.MakeTuple2[int, int](1, 2)
 	if pair.First == 0 && pair.Second == 0 {
 		return 0
 	} else if pair.First == 1 && pair.Second == 2 {

--- a/tests/spec/emit/snapshots/match_tuple_with_wildcard.snap
+++ b/tests/spec/emit/snapshots/match_tuple_with_wildcard.snap
@@ -17,7 +17,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	triple := lisette.MakeTuple3(1, 2, 3)
+	triple := lisette.MakeTuple3[int, int, int](1, 2, 3)
 	if triple.First == 1 {
 		return 1
 	} else if triple.Second == 2 {

--- a/tests/spec/emit/snapshots/nested_array_of_tuples_widens_to_interface_elements.snap
+++ b/tests/spec/emit/snapshots/nested_array_of_tuples_widens_to_interface_elements.snap
@@ -36,7 +36,10 @@ func first(rows [2]lisette.Tuple2[error, int]) string {
 }
 
 func test() {
-	concrete := [2]lisette.Tuple2[Boom, int]{lisette.MakeTuple2(Boom{}, 1), lisette.MakeTuple2(Boom{}, 2)}
+	concrete := [2]lisette.Tuple2[Boom, int]{
+		lisette.MakeTuple2[Boom, int](Boom{}, 1),
+		lisette.MakeTuple2[Boom, int](Boom{}, 2),
+	}
 	var boxed_1 [2]lisette.Tuple2[error, int]
 	for i_2 := range concrete {
 		tup_3 := concrete[i_2]

--- a/tests/spec/emit/snapshots/option_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/option_in_tuple_literal.snap
@@ -35,5 +35,5 @@ func maybeString(s string) (string, bool) {
 func test() {
 	option_1 := lisette.OptionFromCommaOk[int](maybeInt(5))
 	option_2 := lisette.OptionFromCommaOk[string](maybeString("hello"))
-	_ = lisette.MakeTuple2(option_1, option_2)
+	_ = lisette.MakeTuple2[lisette.Option[int], lisette.Option[string]](option_1, option_2)
 }

--- a/tests/spec/emit/snapshots/or_pattern_booleans.snap
+++ b/tests/spec/emit/snapshots/or_pattern_booleans.snap
@@ -14,7 +14,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(a, b bool) string {
-	subject_1 := lisette.MakeTuple2(a, b)
+	subject_1 := lisette.MakeTuple2[bool, bool](a, b)
 	if (subject_1.First && subject_1.Second) || (!subject_1.First && !subject_1.Second) {
 		return "same"
 	}

--- a/tests/spec/emit/snapshots/pure_constructor_does_not_force_sibling_pins.snap
+++ b/tests/spec/emit/snapshots/pure_constructor_does_not_force_sibling_pins.snap
@@ -16,6 +16,6 @@ import lisette "github.com/ivov/lisette/prelude"
 type Wrap int
 
 func run() int {
-	pair := lisette.MakeTuple2(Wrap(9), Wrap(8))
+	pair := lisette.MakeTuple2[Wrap, Wrap](Wrap(9), Wrap(8))
 	return int(pair.First) + int(pair.Second)
 }

--- a/tests/spec/emit/snapshots/result_in_tuple_literal.snap
+++ b/tests/spec/emit/snapshots/result_in_tuple_literal.snap
@@ -22,5 +22,5 @@ func tryInt(x int) lisette.Result[int, string] {
 }
 
 func test() {
-	_ = lisette.MakeTuple2(tryInt(5), tryInt(10))
+	_ = lisette.MakeTuple2[lisette.Result[int, string], lisette.Result[int, string]](tryInt(5), tryInt(10))
 }

--- a/tests/spec/emit/snapshots/tuple_access.snap
+++ b/tests/spec/emit/snapshots/tuple_access.snap
@@ -12,6 +12,6 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	tuple := lisette.MakeTuple2(42, "hello")
+	tuple := lisette.MakeTuple2[int, string](42, "hello")
 	_ = tuple.First
 }

--- a/tests/spec/emit/snapshots/tuple_access_both_elements.snap
+++ b/tests/spec/emit/snapshots/tuple_access_both_elements.snap
@@ -12,6 +12,6 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	tuple := lisette.MakeTuple2(42, "hello")
+	tuple := lisette.MakeTuple2[int, string](42, "hello")
 	return tuple.First + 1
 }

--- a/tests/spec/emit/snapshots/tuple_destructuring.snap
+++ b/tests/spec/emit/snapshots/tuple_destructuring.snap
@@ -13,7 +13,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	pair := lisette.MakeTuple2(10, 20)
+	pair := lisette.MakeTuple2[int, int](10, 20)
 	a := pair.First
 	b := pair.Second
 	return a + b

--- a/tests/spec/emit/snapshots/tuple_display_format.snap
+++ b/tests/spec/emit/snapshots/tuple_display_format.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	t := lisette.MakeTuple2(1, "hello")
+	t := lisette.MakeTuple2[int, string](1, "hello")
 	fmt.Println(t)
 	fmt.Printf("tuple: %v\n", t)
 }

--- a/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
+++ b/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
@@ -55,7 +55,7 @@ type Hand struct {
 }
 
 func (h Hand) LeftRight(other Hand) bool {
-	subject_1 := lisette.MakeTuple2(h, other)
+	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
 	if subject_1.First.Tag == HandLeft {
 		if subject_1.Second.Tag == HandRight {
 			return true
@@ -66,7 +66,7 @@ func (h Hand) LeftRight(other Hand) bool {
 }
 
 func (h Hand) LeftLeft(other Hand) bool {
-	subject_1 := lisette.MakeTuple2(h, other)
+	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
 	if subject_1.First.Tag == HandLeft {
 		if subject_1.Second.Tag == HandLeft {
 			return true
@@ -77,7 +77,7 @@ func (h Hand) LeftLeft(other Hand) bool {
 }
 
 func (h Hand) Eq(other Hand) bool {
-	subject_1 := lisette.MakeTuple2(h, other)
+	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
 	switch subject_1.First.Tag {
 	case HandLeft:
 		if subject_1.Second.Tag == HandLeft {

--- a/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
@@ -25,6 +25,6 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	_v_1 := i
-	t := lisette.MakeTuple2(_v_1, bump(&i))
+	t := lisette.MakeTuple2[int, int](_v_1, bump(&i))
 	_ = t
 }

--- a/tests/spec/emit/snapshots/tuple_field_assignment.snap
+++ b/tests/spec/emit/snapshots/tuple_field_assignment.snap
@@ -13,7 +13,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
-	pair := lisette.MakeTuple2(10, 20)
+	pair := lisette.MakeTuple2[int, int](10, 20)
 	pair.First = 99
 	return pair.First
 }

--- a/tests/spec/emit/snapshots/tuple_index_chained_with_method_call.snap
+++ b/tests/spec/emit/snapshots/tuple_index_chained_with_method_call.snap
@@ -12,7 +12,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() (int, bool) {
-	items := lisette.MakeTuple2([]int{1, 2, 3}, []int{4, 5, 6})
+	items := lisette.MakeTuple2[[]int, []int]([]int{1, 2, 3}, []int{4, 5, 6})
 	v_1 := lisette.SliceGet(items.First, 0)
 	if v_1.Tag == lisette.OptionSome {
 		return v_1.SomeVal, true

--- a/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
+++ b/tests/spec/emit/snapshots/tuple_interface_slot_implicit_coercion_assign_position.snap
@@ -41,7 +41,7 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var result lisette.Tuple2[Model, lisette.Option[func() tea.Msg]]
 	_ = msg
-	result = lisette.MakeTuple2(m, lisette.MakeOptionSome(tea.Quit))
+	result = lisette.MakeTuple2[Model, lisette.Option[func() tea.Msg]](m, lisette.MakeOptionSome(tea.Quit))
 	tup_1 := result
 	opt_2 := tup_1.Second
 	var unwrap_3 tea.Cmd

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_argument_position.snap
@@ -36,7 +36,7 @@ func describe(pair lisette.Tuple2[error, int]) string {
 }
 
 func test() {
-	concrete := lisette.MakeTuple2(Boom{}, 1)
+	concrete := lisette.MakeTuple2[Boom, int](Boom{}, 1)
 	if describe(lisette.MakeTuple2[error, int](concrete.First, concrete.Second)) != "boom" {
 		panic("tuple argument lost its interface elements")
 	}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_let_annotation.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_let_annotation.snap
@@ -36,7 +36,7 @@ func describe(pair lisette.Tuple2[error, int]) string {
 }
 
 func test() {
-	tup_1 := lisette.MakeTuple2(Boom{}, 1)
+	tup_1 := lisette.MakeTuple2[Boom, int](Boom{}, 1)
 	widened := lisette.MakeTuple2[error, int](tup_1.First, tup_1.Second)
 	if describe(widened) != "boom" {
 		panic("annotated tuple binding lost its interface elements")

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_match_arm.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_match_arm.snap
@@ -41,10 +41,10 @@ func describe(pair lisette.Tuple2[error, int]) string {
 func test() {
 	var pair lisette.Tuple2[error, int]
 	if 1 == 1 {
-		tup_1 := lisette.MakeTuple2(Boom{}, 1)
+		tup_1 := lisette.MakeTuple2[Boom, int](Boom{}, 1)
 		pair = lisette.MakeTuple2[error, int](tup_1.First, tup_1.Second)
 	} else {
-		tup_2 := lisette.MakeTuple2(Boom{}, 2)
+		tup_2 := lisette.MakeTuple2[Boom, int](Boom{}, 2)
 		pair = lisette.MakeTuple2[error, int](tup_2.First, tup_2.Second)
 	}
 	if describe(pair) != "boom" {

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_interface_elements_in_struct_field.snap
@@ -37,7 +37,7 @@ type Holder struct {
 }
 
 func test() {
-	concrete := lisette.MakeTuple2(Boom{}, 1)
+	concrete := lisette.MakeTuple2[Boom, int](Boom{}, 1)
 	holder := Holder{pair: lisette.MakeTuple2[error, int](concrete.First, concrete.Second)}
 	if holder.pair.First.Error() != "boom" {
 		panic("struct field lost its interface elements")

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
@@ -28,7 +28,7 @@ func describe(pair lisette.Tuple2[int, any]) string {
 }
 
 func test() {
-	tup_1 := lisette.MakeTuple2(1, "two")
+	tup_1 := lisette.MakeTuple2[int, string](1, "two")
 	if describe(lisette.MakeTuple2[int, any](tup_1.First, tup_1.Second)) != "two" {
 		panic("tuple argument lost its Unknown element")
 	}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
@@ -29,7 +29,7 @@ func second(pair lisette.Tuple2[string, any]) int {
 }
 
 func test() {
-	tup_1 := lisette.MakeTuple2("one", 2)
+	tup_1 := lisette.MakeTuple2[string, int]("one", 2)
 	pairs := []lisette.Tuple2[string, any]{lisette.MakeTuple2[string, any](tup_1.First, tup_1.Second)}
 	if second(pairs[0]) != 2 {
 		panic("slice element lost its Unknown element")

--- a/tests/spec/emit/snapshots/tuple_type.snap
+++ b/tests/spec/emit/snapshots/tuple_type.snap
@@ -11,5 +11,5 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	_ = lisette.MakeTuple2(42, "hello")
+	_ = lisette.MakeTuple2[int, string](42, "hello")
 }

--- a/tests/spec/emit/snapshots/unit_block_as_tuple_element_emits_struct_empty.snap
+++ b/tests/spec/emit/snapshots/unit_block_as_tuple_element_emits_struct_empty.snap
@@ -26,6 +26,6 @@ func side() {
 
 func test() int {
 	side()
-	t := lisette.MakeTuple2(struct{}{}, 1)
+	t := lisette.MakeTuple2[struct{}, int](struct{}{}, 1)
 	return t.Second
 }

--- a/tests/spec/emit/snapshots/unit_returning_call_in_tuple.snap
+++ b/tests/spec/emit/snapshots/unit_returning_call_in_tuple.snap
@@ -17,6 +17,6 @@ func doNothing() {}
 
 func main() {
 	doNothing()
-	t := lisette.MakeTuple2(42, struct{}{})
+	t := lisette.MakeTuple2[int, struct{}](42, struct{}{})
 	_ = t.First
 }

--- a/tests/spec/emit/snapshots/unit_returning_map_delete_in_tuple.snap
+++ b/tests/spec/emit/snapshots/unit_returning_map_delete_in_tuple.snap
@@ -17,6 +17,6 @@ func main() {
 	m := make(map[string]int)
 	m["a"] = 1
 	delete(m, "a")
-	t := lisette.MakeTuple2(struct{}{}, 1)
+	t := lisette.MakeTuple2[struct{}, int](struct{}{}, 1)
 	_ = t.Second
 }

--- a/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
+++ b/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
@@ -16,7 +16,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func maybePair(n int) (lisette.Tuple2[int, int], bool) {
 	if n > 0 {
-		return lisette.MakeTuple2(n, n+1), true
+		return lisette.MakeTuple2[int, int](n, n+1), true
 	}
 	return *new(lisette.Tuple2[int, int]), false
 }

--- a/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
+++ b/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
@@ -26,7 +26,7 @@ func test() {
 	i := 0
 	for {
 		_v_1 := i < 3
-		if !(lisette.MakeTuple2(_v_1, bump(&i)).First) {
+		if !(lisette.MakeTuple2[bool, int](_v_1, bump(&i)).First) {
 			break
 		}
 		_ = i


### PR DESCRIPTION
Tuple literals where the elments adapt to the slot type were passing `lis check` but failing to build, because Go inferred the tuple's type params from the untyped constants instead of the declared slot types.

```rs
let runes: Slice<(int, int)> = [('A', 2)]
let wide: Slice<(float64, int)> = [(-1, 1)]
```

These now compile, along with any slot whose Go type differs from the literal's default, e.g. `uint8`, `float32,` or `struct Meters(int)`.
