### PR TITLE
refactor: lower `Map.from` to a Go map literal

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -14,7 +14,7 @@ use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
-use syntax::ast::{Expression, ResolvedCallTypeArguments, StructFields};
+use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments, StructFields};
 use syntax::program::{CallKind, Definition, DefinitionBody};
 use syntax::types::{
     CompoundKind, FunctionParameter, SimpleKind, Type, build_substitution_map, substitute,
@@ -23,6 +23,16 @@ use syntax::types::{
 struct TupleStructTarget {
     go_ty: String,
     field_tys: Vec<Type>,
+}
+
+fn is_checked_literal_key(key: &Expression) -> bool {
+    matches!(
+        key.unwrap_parens(),
+        Expression::Literal {
+            literal: Literal::Boolean(_) | Literal::String { .. },
+            ..
+        }
+    )
 }
 
 /// The shape of a call's value arguments, used to decide which type parameters
@@ -122,20 +132,24 @@ impl Planner<'_> {
         type_args: ResolvedCallTypeArguments<'_>,
         call_ty: Option<&Type>,
     ) -> (String, String) {
+        let (key, value) = self.resolve_map_lisette_types(function, type_args, call_ty);
+        (self.go_type_string(&key), self.go_type_string(&value))
+    }
+
+    fn resolve_map_lisette_types(
+        &self,
+        function: &Expression,
+        type_args: ResolvedCallTypeArguments<'_>,
+        call_ty: Option<&Type>,
+    ) -> (Type, Type) {
         if type_args.len() >= 2 {
-            return (
-                self.go_type_string(&type_args[0]),
-                self.go_type_string(&type_args[1]),
-            );
+            return (type_args[0].clone(), type_args[1].clone());
         }
         if let Some(call_result_ty) = call_ty
             && let Some(params) = call_result_ty.get_type_params()
             && params.len() >= 2
         {
-            return (
-                self.go_type_string(&params[0]),
-                self.go_type_string(&params[1]),
-            );
+            return (params[0].clone(), params[1].clone());
         }
         let ty = function.get_type();
         let Some(f) = ty.as_function_type() else {
@@ -145,10 +159,7 @@ impl Planner<'_> {
             .return_type
             .get_type_params()
             .expect("MapNew must return a type with type arguments");
-        (
-            self.go_type_string(&params[0]),
-            self.go_type_string(&params[1]),
-        )
+        (params[0].clone(), params[1].clone())
     }
 
     fn stage_size_argument(
@@ -208,6 +219,7 @@ impl Planner<'_> {
                     self.native_constructor_effect(ctx, EvaluationEffect::Pure),
                 ))
             }
+            (NativeGoType::Map, "from") => self.try_lower_map_from_pairs(ctx),
             (NativeGoType::Slice, "new") => {
                 let element =
                     self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
@@ -259,6 +271,94 @@ impl Planner<'_> {
             }
             _ => None,
         }
+    }
+
+    fn try_lower_map_from_pairs(&mut self, ctx: &NativeCallContext) -> Option<ValuePlan> {
+        if ctx.spread.is_some() {
+            return None;
+        }
+        let [argument] = ctx.args else {
+            return None;
+        };
+        let Expression::Literal {
+            literal: Literal::Slice(entries),
+            ..
+        } = argument.unwrap_parens()
+        else {
+            return None;
+        };
+        let pairs = entries
+            .iter()
+            .map(|entry| match entry.unwrap_parens() {
+                Expression::Tuple { elements, .. } => match elements.as_slice() {
+                    [key, value] => Some((key, value)),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        if !pairs.iter().all(|(key, _)| is_checked_literal_key(key)) {
+            return None;
+        }
+
+        let (key_ty, value_ty) =
+            self.resolve_map_lisette_types(ctx.function, ctx.resolved_type_args, ctx.call_ty);
+        let map_ty = format!(
+            "map[{}]{}",
+            self.go_type_string(&key_ty),
+            self.go_type_string(&value_ty)
+        );
+
+        if pairs.is_empty() {
+            return Some(ValuePlan::computed(
+                Vec::new(),
+                GoExpression::composite_literal(format!("{map_ty}{{}}"), false),
+                self.native_constructor_effect(ctx, EvaluationEffect::Pure),
+            ));
+        }
+
+        let stages: Vec<ValuePlan> = pairs
+            .iter()
+            .flat_map(|(key, value)| [*key, *value])
+            .map(|e| self.stage_composite(e, ExpressionContext::value()))
+            .collect();
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_entry");
+        let effect = sequenced.effect;
+        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
+        let (mut setup, rendered) = sequenced.into_rendered();
+
+        let mut lowered = Vec::with_capacity(pairs.len());
+        for ((key, value), staged) in pairs.iter().zip(rendered.chunks_exact(2)) {
+            let [staged_key, staged_value] = staged else {
+                unreachable!("each pair stages exactly two values")
+            };
+            let (key_setup, coerced_key) = CoercionPlan::internal(self, &key.get_type(), &key_ty)
+                .lower(self, staged_key.clone());
+            setup.extend(key_setup);
+            let (value_setup, coerced_value) =
+                CoercionPlan::internal(self, &value.get_type(), &value_ty)
+                    .lower(self, staged_value.clone());
+            setup.extend(value_setup);
+            lowered.push(format!("{coerced_key}: {coerced_value}"));
+        }
+
+        let value = if lowered.len() > 1 && lowered.iter().any(|entry| entry.len() > 30) {
+            let indented = lowered
+                .iter()
+                .map(|entry| format!("\t{}", entry))
+                .collect::<Vec<_>>()
+                .join(",\n");
+            format!("{map_ty}{{\n{indented},\n}}")
+        } else {
+            format!("{map_ty}{{ {} }}", lowered.join(", "))
+        };
+
+        Some(ValuePlan::computed(
+            setup,
+            GoExpression::composite_literal(value, contains_deferred_evaluation),
+            self.native_constructor_effect(ctx, effect),
+        ))
     }
 
     fn native_constructor_effect(

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -832,6 +832,28 @@ fn test() {
 }
 
 #[test]
+fn map_from_non_literal_keys_keeps_prelude_call() {
+    let input = r#"
+const KEY = "a"
+
+fn test() -> Map<string, int> {
+  Map.from([(KEY, 1), (KEY, 2)])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_from_numeric_keys_keeps_prelude_call() {
+    let input = r#"
+fn test() -> Map<int, int> {
+  Map.from([(65, 1), ('A', 2)])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_with_void_function_value() {
     let input = r#"
 fn test() -> Map<string, fn()> {

--- a/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
+++ b/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, []int]{lisette.MakeTuple2[string, []int]("k", []int{1, 2})})
+	m := map[string][]int{"k": []int{1, 2}}
 	m2 := lisette.MapCloneFunc(m, func(e_1 []int) []int { return slices.Clone(e_1) })
 	m2["k"] = []int{9}
 	_ = m

--- a/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq2_key_value.snap
@@ -16,12 +16,11 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"maps"
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})
+	m := map[string]int{"a": 1}
 	for k, v := range maps.All(m) {
 		fmt.Printf("%s=%d\n", k, v)
 	}

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_single_value.snap
@@ -16,12 +16,11 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"maps"
 )
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})
+	m := map[string]int{"a": 1}
 	for k := range maps.Keys(m) {
 		fmt.Println(k)
 	}

--- a/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
@@ -58,7 +58,7 @@ func pass[K comparable, V any](b Bar[map[K]V]) {
 }
 
 func main() {
-	pass(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})})
+	pass(Bar[map[string]int]{m: map[string]int{"a": 1}})
 }
 
 type _lisAdapter_Bar_Box_0[K comparable, V any] struct {

--- a/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
@@ -70,7 +70,7 @@ func (r Runner[K]) Run(b Bar[map[K]int]) {
 
 func main() {
 	r := Runner[string]{k: "x"}
-	r.Run(Bar[map[string]int]{m: lisette.MapFrom([]lisette.Tuple2[string, int]{lisette.MakeTuple2[string, int]("a", 1)})})
+	r.Run(Bar[map[string]int]{m: map[string]int{"a": 1}})
 }
 
 type _lisAdapter_Bar_Box_0[K comparable] struct {

--- a/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
@@ -24,10 +24,7 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 type Key struct {
 	k string
@@ -44,7 +41,7 @@ func makeKey(counter *int) Key {
 
 func main() {
 	counter := 0
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
+	m := map[string]Box{"a": Box{x: 1}}
 	key := makeKey(&counter).k
 	entry := m[key]
 	entry.x = 2

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -14,14 +14,12 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Box struct {
 	x int
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("k", Box{x: 0})})
+	m := map[string]Box{"k": Box{x: 0}}
 	r := &m
 	entry := (*r)["k"]
 	entry.x = 1

--- a/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
@@ -13,14 +13,12 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Box struct {
 	x int
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
+	m := map[string]Box{"a": Box{x: 1}}
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
@@ -17,17 +17,14 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 type Box struct {
 	x int
 }
 
 func main() {
-	m := lisette.MapFrom([]lisette.Tuple2[string, Box]{lisette.MakeTuple2[string, Box]("a", Box{x: 1})})
+	m := map[string]Box{"a": Box{x: 1}}
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_from_non_literal_keys_keeps_prelude_call.snap
+++ b/tests/spec/emit/snapshots/map_from_non_literal_keys_keeps_prelude_call.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  const KEY = "a"
+  
+  fn test() -> Map<string, int> {
+    Map.from([(KEY, 1), (KEY, 2)])
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+const Key string = "a"
+
+func test() map[string]int {
+	return lisette.MapFrom([]lisette.Tuple2[string, int]{
+		lisette.MakeTuple2[string, int](Key, 1),
+		lisette.MakeTuple2[string, int](Key, 2),
+	})
+}

--- a/tests/spec/emit/snapshots/map_from_numeric_keys_keeps_prelude_call.snap
+++ b/tests/spec/emit/snapshots/map_from_numeric_keys_keeps_prelude_call.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> Map<int, int> {
+    Map.from([(65, 1), ('A', 2)])
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test() map[int]int {
+	return lisette.MapFrom([]lisette.Tuple2[int, int]{
+		lisette.MakeTuple2[int, int](65, 1),
+		lisette.MakeTuple2[int, int]('A', 2),
+	})
+}

--- a/tests/spec/emit/snapshots/map_from_pairs.snap
+++ b/tests/spec/emit/snapshots/map_from_pairs.snap
@@ -8,11 +8,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func test() map[string]int {
-	return lisette.MapFrom([]lisette.Tuple2[string, int]{
-		lisette.MakeTuple2[string, int]("alice", 95),
-		lisette.MakeTuple2[string, int]("bob", 82),
-	})
+	return map[string]int{"alice": 95, "bob": 82}
 }

--- a/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
+++ b/tests/spec/emit/snapshots/map_from_pairs_with_unknown_value.snap
@@ -11,11 +11,8 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func test() {
-	tup_1 := lisette.MakeTuple2[string, string]("one", "two")
-	m := lisette.MapFrom[string, any]([]lisette.Tuple2[string, any]{lisette.MakeTuple2[string, any](tup_1.First, tup_1.Second)})
+	m := map[string]any{"one": "two"}
 	if len(m) != 1 {
 		panic("Map.from lost its entry when widening values to Unknown")
 	}


### PR DESCRIPTION
`Map.from` with literal keys now emits a Go map literal.

```rs
let ages = Map.from([("Alice", 20), ("Bob", 25)])
```

```go
// before
ages := lisette.MapFrom([]lisette.Tuple2[string, int]{
	lisette.MakeTuple2[string, int]("Alice", 20),
	lisette.MakeTuple2[string, int]("Bob", 25),
})

// after
ages := map[string]int{"Alice": 20, "Bob": 25}
```

Keys that are not string or bool literals keep the `MapFrom` call, because Go rejects dupe constant keys in a map literal.
