### PR TITLE
refactor: emit `if err != nil` when propagating with `?`

### DIFF
--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,6 +1,7 @@
 use crate::Planner;
-use crate::abi::callable::{CallableReturnAbi, PayloadLayout};
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::transition;
+use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::is_go_never;
@@ -8,7 +9,6 @@ use crate::plan::bodies::{
     AssignForm, AssignPlan, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm,
     ReturnStatementPlan,
 };
-use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -62,8 +62,7 @@ impl Planner<'_> {
             return (statements, String::new());
         }
 
-        if let Some(fused) =
-            self.try_lower_fused_go_propagate(expression, &fallible, result_var_name)
+        if let Some(fused) = self.try_lower_fused_propagate(expression, &fallible, result_var_name)
         {
             return fused;
         }
@@ -177,36 +176,50 @@ impl Planner<'_> {
         (setup, values)
     }
 
-    /// Fuse `go_call()?` into `v, err := call(); if err != nil { return ... }`,
-    /// skipping the `lisette.Result`.
-    fn try_lower_fused_go_propagate(
+    /// Fuse `call()?` on a lowered-ABI callee into a direct failure check
+    /// (`if err != nil` / `if !ok`), skipping the tagged round trip.
+    fn try_lower_fused_propagate(
         &mut self,
         expression: &Expression,
         fallible: &Fallible,
         result_var_name: Option<&str>,
     ) -> Option<(Vec<LoweredStatement>, String)> {
         let plan = self.plan_call(expression)?;
-        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop)
-            || !matches!(
-                plan.resolved.abi.result,
-                CallableReturnAbi::Result {
-                    payload: PayloadLayout::Packed,
-                    ..
+        let expression_ty = expression.get_type();
+        let ok_ty = self.facts.peel_alias(&expression_ty).ok_type();
+        let shape = plan.resolved.abi.result.clone();
+        let comma_ok = match shape {
+            CallableReturnAbi::Result {
+                payload: PayloadLayout::Packed,
+            } => {
+                if ok_ty.is_unit() {
+                    return None;
                 }
-            )
-        {
-            return None;
-        }
-        let ok_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
-        if ok_ty.is_unit() || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
-            return None;
-        }
-        if self
-            .go_return_payload_bridge(&plan.resolved.abi, &expression.get_type())
-            .is_some()
-        {
-            return None;
-        }
+                false
+            }
+            CallableReturnAbi::BareError => false,
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
+                payload: PayloadLayout::Packed,
+            }) => true,
+            _ => return None,
+        };
+        let has_value_slot = !matches!(shape, CallableReturnAbi::BareError);
+        let nil_guard = if comma_ok {
+            if self.is_interface_option(&expression_ty) {
+                Some(NilGuard::Interface)
+            } else if self.facts.is_nullable_option(&expression_ty) {
+                Some(NilGuard::Pointer)
+            } else {
+                None
+            }
+        } else if has_value_slot {
+            self.result_nil_guard(&ok_ty)
+        } else {
+            None
+        };
+        let payload_bridge = has_value_slot
+            .then(|| self.go_return_payload_bridge(&plan.resolved.abi, &expression_ty))
+            .flatten();
         let return_ctx = self.return_ctx();
         let has_fallible_return = return_ctx.lowered_shape().is_some()
             || return_ctx
@@ -215,55 +228,85 @@ impl Planner<'_> {
         if !has_fallible_return {
             return None;
         }
-        let nil_guard = self.result_nil_guard(&ok_ty);
 
         let want_value = !matches!(result_var_name, Some("_"));
-        let val_var = (want_value || nil_guard.is_some()).then(|| {
+        let value_var = (has_value_slot && (want_value || nil_guard.is_some())).then(|| {
             let v = self.fresh_var(Some("ret"));
             self.declare(&v);
             v
         });
-        let err_var = self.fresh_var(Some("ret"));
-        self.declare(&err_var);
+        let outcome_var = self.fresh_var(Some("ret"));
+        self.declare(&outcome_var);
 
         let (mut statements, call_str) = self
             .lower_call(expression, None, ExpressionContext::value())
             .into_parts();
-        let bind_line = match &val_var {
-            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
-            None => format!("_, {} := {}\n", err_var, call_str),
+        let bind_line = if has_value_slot {
+            match &value_var {
+                Some(v) => format!("{}, {} := {}\n", v, outcome_var, call_str),
+                None => format!("_, {} := {}\n", outcome_var, call_str),
+            }
+        } else {
+            format!("{} := {}\n", outcome_var, call_str)
         };
         statements.push(LoweredStatement::RawGo(bind_line));
 
-        let (failure_setup, failure_values) = self.propagate_failure_values(fallible, &err_var);
-        statements.push(transition::tag_check(
-            format!("{} != nil", err_var),
-            failure_setup,
-            failure_values,
-        ));
-
-        if let Some(guard) = nil_guard {
-            let val = val_var
-                .as_deref()
-                .expect("nil guard requires the value var");
-            if guard.is_interface() {
-                self.require_stdlib();
-            }
-            self.require_errors();
-            let (nil_setup, nil_failure) =
-                self.propagate_failure_values(fallible, "errors.New(\"unexpected nil\")");
+        if comma_ok {
+            let failure_condition = match nil_guard {
+                Some(guard) => {
+                    if guard.is_interface() {
+                        self.require_stdlib();
+                    }
+                    let val = value_var
+                        .as_deref()
+                        .expect("nil guard requires the value var");
+                    format!("!{} || {}", outcome_var, guard.is_nil(val))
+                }
+                None => format!("!{}", outcome_var),
+            };
+            let (failure_setup, failure_values) =
+                self.propagate_failure_values(fallible, &outcome_var);
             statements.push(transition::tag_check(
-                guard.is_nil(val),
-                nil_setup,
-                nil_failure,
+                failure_condition,
+                failure_setup,
+                failure_values,
             ));
+        } else {
+            let (failure_setup, failure_values) =
+                self.propagate_failure_values(fallible, &outcome_var);
+            statements.push(transition::tag_check(
+                format!("{} != nil", outcome_var),
+                failure_setup,
+                failure_values,
+            ));
+            if let Some(guard) = nil_guard {
+                let val = value_var
+                    .as_deref()
+                    .expect("nil guard requires the value var");
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                self.require_errors();
+                let (nil_setup, nil_failure) =
+                    self.propagate_failure_values(fallible, "errors.New(\"unexpected nil\")");
+                statements.push(transition::tag_check(
+                    guard.is_nil(val),
+                    nil_setup,
+                    nil_failure,
+                ));
+            }
         }
 
+        let ok_value = value_var.map(|val| match &payload_bridge {
+            Some(bridge) if want_value => self.plan_layout_bridge(&mut statements, &val, bridge),
+            _ => val,
+        });
+
         let value = match result_var_name {
-            None => val_var.expect("ok value requested when result_var_name is None"),
+            None => ok_value.unwrap_or_else(|| "struct{}{}".to_string()),
             Some("_") => "_".to_string(),
             Some(name) => {
-                let v = val_var.expect("ok value requested for a named binding");
+                let v = ok_value.unwrap_or_else(|| "struct{}{}".to_string());
                 statements.push(self.bind_propagate_ok(name, &v));
                 name.to_string()
             }

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -717,7 +717,7 @@ fn main() {
 }
 
 #[test]
-fn interop_comma_ok_propagate_in_try_block_stays_boxed() {
+fn interop_comma_ok_propagate_in_try_block_fuses() {
     let input = r#"
 import "go:os"
 

--- a/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
@@ -27,8 +27,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Cell struct {
 	a int
 	b int
@@ -50,31 +48,17 @@ func bump(i *int) (int, error) {
 func run() error {
 	i := 0
 	ret_1, ret_2 := seed()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return check_4.ErrVal
-	}
-	ref_5 := &Cell{
-		a: check_4.OkVal,
+	ref_3 := &Cell{
+		a: ret_1,
 		b: i,
 	}
-	ret_6, ret_7 := bump(&i)
-	var result_8 lisette.Result[int, error]
-	if ret_7 != nil {
-		result_8 = lisette.MakeResultErr[int, error](ret_7)
-	} else {
-		result_8 = lisette.MakeResultOk[int, error](ret_6)
+	ret_4, ret_5 := bump(&i)
+	if ret_5 != nil {
+		return ret_5
 	}
-	check_9 := result_8
-	if check_9.Tag != lisette.ResultOk {
-		return check_9.ErrVal
-	}
-	Cell_add[int](ref_5, check_9.OkVal)
+	Cell_add[int](ref_3, ret_4)
 	return nil
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
@@ -14,8 +14,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func side() int {
 	return 1
 }
@@ -30,15 +28,8 @@ func add(_, _ int) int {
 
 func run() (int, error) {
 	ret_1, ret_2 := getX()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return 0, ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return 0, check_4.ErrVal
-	}
-	return add(check_4.OkVal, side()), nil
+	return add(ret_1, side()), nil
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -14,8 +14,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func side() int {
 	return 1
 }
@@ -29,17 +27,10 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	_arg_5 := side()
+	_arg_3 := side()
 	ret_1, ret_2 := getY()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return 0, ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return 0, check_4.ErrVal
-	}
-	return add(_arg_5, check_4.OkVal), nil
+	return add(_arg_3, ret_1), nil
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
@@ -27,12 +27,11 @@ import (
 
 func lookup(k string) (string, bool) {
 	tryResult_1 := func() lisette.Option[string] {
-		option_2 := lisette.OptionFromCommaOk[string](os.LookupEnv(k))
-		check_3 := option_2
-		if check_3.Tag != lisette.OptionSome {
+		ret_2, ret_3 := os.LookupEnv(k)
+		if !ret_3 {
 			return lisette.MakeOptionNone[string]()
 		}
-		v := check_3.SomeVal
+		v := ret_2
 		return lisette.MakeOptionSome[string](v)
 	}()
 	v_4 := tryResult_1

--- a/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
@@ -30,26 +30,19 @@ import (
 
 func run() error {
 	ret_1, ret_2 := aws.Make()
-	var result_3 lisette.Result[[]lisette.Option[string], error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
-	} else {
-		src_4 := ret_1
-		wrapped_5 := make([]lisette.Option[string], len(src_4))
-		for i_6, v_7 := range src_4 {
-			if v_7 != nil {
-				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
-			} else {
-				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
-			}
+		return ret_2
+	}
+	src_3 := ret_1
+	wrapped_4 := make([]lisette.Option[string], len(src_3))
+	for i_5, v_6 := range src_3 {
+		if v_6 != nil {
+			wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+		} else {
+			wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 		}
-		result_3 = lisette.MakeResultOk[[]lisette.Option[string], error](wrapped_5)
 	}
-	check_8 := result_3
-	if check_8.Tag != lisette.ResultOk {
-		return check_8.ErrVal
-	}
-	xs := check_8.OkVal
+	xs := wrapped_4
 	for _, x := range xs {
 		if x.Tag == lisette.OptionSome {
 			fmt.Println(x.SomeVal)

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -48,17 +48,10 @@ func describe(value any) string {
 func run() (string, error) {
 	var value any
 	ret_1, ret_2 := fallible()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return "", ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return "", check_4.ErrVal
-	}
-	value = check_4.OkVal
+	value = ret_1
 	value = "two"
 	return describe(value), nil
 }

--- a/tests/spec/emit/snapshots/propagate_option_in_function.snap
+++ b/tests/spec/emit/snapshots/propagate_option_in_function.snap
@@ -13,18 +13,15 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func maybeGet() (int, bool) {
 	return 0, false
 }
 
 func process() (int, bool) {
-	option_1 := lisette.OptionFromCommaOk[int](maybeGet())
-	check_2 := option_1
-	if check_2.Tag != lisette.OptionSome {
+	ret_1, ret_2 := maybeGet()
+	if !ret_2 {
 		return 0, false
 	}
-	x := check_2.SomeVal
+	x := ret_1
 	return x + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
+++ b/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"strconv"
 )
 
@@ -29,16 +28,9 @@ func parse(s string) (int, error) {
 func process() (int, error) {
 	x := 42
 	ret_2, ret_3 := parse(fmt.Sprint(x))
-	var result_4 lisette.Result[int, error]
 	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[int, error](ret_3)
-	} else {
-		result_4 = lisette.MakeResultOk[int, error](ret_2)
+		return 0, ret_3
 	}
-	check_5 := result_4
-	if check_5.Tag != lisette.ResultOk {
-		return 0, check_5.ErrVal
-	}
-	x_1 := check_5.OkVal
+	x_1 := ret_2
 	return x_1 + 1, nil
 }

--- a/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
+++ b/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
@@ -11,16 +11,13 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func maybe() (int, bool) {
 	return 1, true
 }
 
 func test() (struct{}, bool) {
-	option_1 := lisette.OptionFromCommaOk[int](maybe())
-	check_2 := option_1
-	if check_2.Tag != lisette.OptionSome {
+	_, ret_1 := maybe()
+	if !ret_1 {
 		return struct{}{}, false
 	}
 	return struct{}{}, true

--- a/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
@@ -28,10 +28,7 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 type FileError struct {
 	path string
@@ -47,17 +44,10 @@ func readValue() (int, *FileError) {
 
 func load() (int, error) {
 	ret_1, ret_2 := readValue()
-	var result_3 lisette.Result[int, *FileError]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, *FileError](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, *FileError](ret_1)
+		return 0, ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return 0, check_4.ErrVal
-	}
-	n := check_4.OkVal
+	n := ret_1
 	return n, nil
 }
 

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -14,8 +14,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func sideA() int {
 	return 1
 }
@@ -29,17 +27,10 @@ func variadic(_ int, _ ...int) int {
 }
 
 func run() (int, error) {
-	_arg_5 := sideA()
+	_arg_3 := sideA()
 	ret_1, ret_2 := getXs()
-	var result_3 lisette.Result[[]int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[[]int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[[]int, error](ret_1)
+		return 0, ret_2
 	}
-	check_4 := result_3
-	if check_4.Tag != lisette.ResultOk {
-		return 0, check_4.ErrVal
-	}
-	return variadic(_arg_5, check_4.OkVal...), nil
+	return variadic(_arg_3, ret_1...), nil
 }

--- a/tests/spec/emit/snapshots/try_block_option.snap
+++ b/tests/spec/emit/snapshots/try_block_option.snap
@@ -28,12 +28,11 @@ func maybeGet() (int, bool) {
 func test() int {
 	var opt lisette.Option[int]
 	tryResult_1 := func() lisette.Option[int] {
-		option_2 := lisette.OptionFromCommaOk[int](maybeGet())
-		check_3 := option_2
-		if check_3.Tag != lisette.OptionSome {
+		ret_2, ret_3 := maybeGet()
+		if !ret_3 {
 			return lisette.MakeOptionNone[int]()
 		}
-		x := check_3.SomeVal
+		x := ret_2
 		return lisette.MakeOptionSome[int](x + 1)
 	}()
 	opt = tryResult_1


### PR DESCRIPTION
Propagating with `?` from a callee that already returns Go's `(T, error)` or `(T, bool)` shape now lowers to a `if err != nil` (or `if !ok`) check, instead of boxing the pair into a `lisette.Result` and immediately unboxing it.

Before:

```go
ret_1, ret_2 := fallible()
var result_3 lisette.Result[int, error]
if ret_2 != nil {
	result_3 = lisette.MakeResultErr[int, error](ret_2)
} else {
	result_3 = lisette.MakeResultOk[int, error](ret_1)
}
check_4 := result_3
if check_4.Tag != lisette.ResultOk {
	return "", check_4.ErrVal
}
value = check_4.OkVal
```

After:

```go
ret_1, ret_2 := fallible()
if ret_2 != nil {
	return "", ret_2
}
value = ret_1
```
