### PR TITLE
refactor: emit `v, ok :=` when matching on comma-ok calls

### DIFF
--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -1,0 +1,230 @@
+use crate::Planner;
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use crate::calls::dispatch::extract_native_method_name;
+use crate::calls::go_interop::NilGuard;
+use crate::context::expression::ExpressionContext;
+use crate::plan::bodies::LoweredStatement;
+use crate::plan::calls::CallableOrigin;
+use crate::types::native::NativeGoType;
+use syntax::ast::Expression;
+use syntax::types::Type;
+
+/// How an Option-typed scrutinee produces its Go comma-ok pair.
+enum CommaOkPair {
+    /// Call whose lowered ABI is already `(T, bool)`.
+    LoweredCall,
+    /// `m.get(k)` lowered as `m[k]`.
+    MapIndex,
+    /// `assert_type<T>(x)` lowered as `x.(T)`.
+    TypeAssert,
+}
+
+pub(crate) struct CommaOkSource {
+    pair: CommaOkPair,
+    /// Nil test the tagged wrap would apply on top of `ok`.
+    nil_guard: Option<NilGuard>,
+}
+
+impl CommaOkSource {
+    pub(crate) fn has_nil_guard(&self) -> bool {
+        self.nil_guard.is_some()
+    }
+}
+
+/// What the caller needs from the pair's value slot.
+pub(crate) enum CommaOkValueSlot {
+    /// Bind this Go name (already freshened and declared).
+    Named(String),
+    /// Allocate a fresh temporary.
+    Temp,
+    /// No payload use. The value is still captured when the nil guard needs it.
+    Unused,
+}
+
+/// A bound comma-ok pair: setup statements ending in the `value, ok :=` line.
+pub(crate) struct LoweredCommaOk {
+    pub(crate) statements: Vec<LoweredStatement>,
+    pub(crate) value: Option<String>,
+    pub(crate) ok: String,
+    nil_guard: Option<NilGuard>,
+}
+
+impl Planner<'_> {
+    /// Recognize a call whose Option value comes from a comma-ok pair.
+    pub(crate) fn comma_ok_source(&self, expression: &Expression) -> Option<CommaOkSource> {
+        let plan = self.plan_call(expression)?;
+        let Expression::Call {
+            expression: function,
+            args,
+            spread,
+            ..
+        } = expression
+        else {
+            return None;
+        };
+        let expression_ty = expression.get_type();
+        match &plan.resolved.origin {
+            CallableOrigin::AssertType => {
+                let [operand] = args.as_slice() else {
+                    return None;
+                };
+                let operand_ty = operand.get_type();
+                let asserts_on_interface = self.facts.is_interface_or_unknown(&operand_ty)
+                    || self.facts.peel_alias(&operand_ty).is_error();
+                asserts_on_interface.then_some(CommaOkSource {
+                    pair: CommaOkPair::TypeAssert,
+                    nil_guard: None,
+                })
+            }
+            CallableOrigin::NativeMethod(kind)
+                if matches!(NativeGoType::from_kind(*kind), NativeGoType::Map)
+                    && extract_native_method_name(function) == "get"
+                    && args.len() == 1
+                    && spread.is_none() =>
+            {
+                Some(CommaOkSource {
+                    pair: CommaOkPair::MapIndex,
+                    nil_guard: None,
+                })
+            }
+            _ => {
+                if !matches!(
+                    plan.resolved.abi.result,
+                    CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
+                        payload: PayloadLayout::Packed,
+                    })
+                ) {
+                    return None;
+                }
+                let ok_ty = self.facts.peel_alias(&expression_ty).ok_type();
+                if ok_ty.is_unit() || matches!(self.facts.peel_alias(&ok_ty), Type::Tuple(_)) {
+                    return None;
+                }
+                if self
+                    .go_return_payload_bridge(&plan.resolved.abi, &expression_ty)
+                    .is_some()
+                {
+                    return None;
+                }
+                let nil_guard = if self.is_interface_option(&expression_ty) {
+                    Some(NilGuard::Interface)
+                } else if self.facts.is_nullable_option(&expression_ty) {
+                    Some(NilGuard::Pointer)
+                } else {
+                    None
+                };
+                Some(CommaOkSource {
+                    pair: CommaOkPair::LoweredCall,
+                    nil_guard,
+                })
+            }
+        }
+    }
+
+    /// Bind a recognized pair to its value and ok variables.
+    pub(crate) fn bind_comma_ok_pair(
+        &mut self,
+        expression: &Expression,
+        source: CommaOkSource,
+        slot: CommaOkValueSlot,
+    ) -> LoweredCommaOk {
+        let value = match slot {
+            CommaOkValueSlot::Named(name) => Some(name),
+            CommaOkValueSlot::Temp => Some(self.fresh_comma_ok_value()),
+            CommaOkValueSlot::Unused => source
+                .nil_guard
+                .is_some()
+                .then(|| self.fresh_comma_ok_value()),
+        };
+        let ok = self.fresh_var(Some("ok"));
+        self.declare(&ok);
+        let (mut statements, pair) = self.lower_comma_ok_pair(expression, &source.pair);
+        statements.push(LoweredStatement::RawGo(format!(
+            "{}, {} := {}\n",
+            value.as_deref().unwrap_or("_"),
+            ok,
+            pair
+        )));
+        LoweredCommaOk {
+            statements,
+            value,
+            ok,
+            nil_guard: source.nil_guard,
+        }
+    }
+
+    fn fresh_comma_ok_value(&mut self) -> String {
+        let v = self.fresh_var(Some("ret"));
+        self.declare(&v);
+        v
+    }
+
+    /// The Some-branch test: `ok` plus the wrap's nil guard.
+    pub(crate) fn comma_ok_some_condition(&mut self, pair: &LoweredCommaOk) -> String {
+        match pair.nil_guard {
+            Some(guard) => {
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                let value = pair
+                    .value
+                    .as_deref()
+                    .expect("nil guard requires the value var");
+                format!("{} && {}", pair.ok, guard.non_nil(value))
+            }
+            None => pair.ok.clone(),
+        }
+    }
+
+    /// The negated Some-branch test.
+    pub(crate) fn comma_ok_none_condition(&mut self, pair: &LoweredCommaOk) -> String {
+        match pair.nil_guard {
+            Some(guard) => {
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                let value = pair
+                    .value
+                    .as_deref()
+                    .expect("nil guard requires the value var");
+                format!("!{} || {}", pair.ok, guard.is_nil(value))
+            }
+            None => format!("!{}", pair.ok),
+        }
+    }
+
+    /// Lower the pair-producing Go expression.
+    fn lower_comma_ok_pair(
+        &mut self,
+        expression: &Expression,
+        pair: &CommaOkPair,
+    ) -> (Vec<LoweredStatement>, String) {
+        match pair {
+            CommaOkPair::LoweredCall => self
+                .lower_call(expression, None, ExpressionContext::value())
+                .into_parts(),
+            CommaOkPair::MapIndex => self.lower_map_index_pair(expression),
+            CommaOkPair::TypeAssert => {
+                let Expression::Call { args, .. } = expression else {
+                    unreachable!("comma_ok_source only accepts Call expressions");
+                };
+                let (setup, operand) = self
+                    .lower_composite_value(&args[0], ExpressionContext::value())
+                    .into_parts();
+                let operand = parenthesize_prefixed(operand);
+                let target_ty = self.facts.peel_alias(&expression.get_type()).ok_type();
+                let target = self.go_type_string(&target_ty);
+                (setup, format!("{}.({})", operand, target))
+            }
+        }
+    }
+}
+
+/// `*x` and `&x` bind looser than a postfix `[k]` or `.(T)`.
+pub(super) fn parenthesize_prefixed(operand: String) -> String {
+    if operand.starts_with('*') || operand.starts_with('&') {
+        format!("({operand})")
+    } else {
+        operand
+    }
+}

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -1,4 +1,5 @@
 mod clone;
+pub(crate) mod comma_ok;
 pub(crate) mod dispatch;
 pub(crate) mod go_interop;
 pub(crate) mod native;

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -722,6 +722,40 @@ impl Planner<'_> {
         )
     }
 
+    /// Lower `m.get(k)` to the native comma-ok index expression `m[k]`.
+    pub(super) fn lower_map_index_pair(
+        &mut self,
+        expression: &Expression,
+    ) -> (Vec<LoweredStatement>, String) {
+        let Expression::Call {
+            expression: function,
+            args,
+            type_arguments,
+            ..
+        } = expression
+        else {
+            unreachable!("lower_map_index_pair requires a Call expression");
+        };
+        let resolved_type_args = type_arguments
+            .resolved_types()
+            .expect("emission requires checked call type arguments");
+        let native_type = NativeGoType::Map;
+        let ctx = NativeCallContext {
+            function,
+            args,
+            spread: None,
+            resolved_type_args,
+            call_ty: None,
+            native_type: &native_type,
+            method: "get",
+            capture_boundary: CaptureBoundary::SiblingSequence,
+            retired_receiver: None,
+        };
+        let (setup, receiver, emitted_args, _, _) = self.stage_native_dot_access_call(&ctx);
+        let receiver = super::comma_ok::parenthesize_prefixed(receiver);
+        (setup, format!("{}[{}]", receiver, emitted_args[0]))
+    }
+
     pub(super) fn lower_native_method_identifier(
         &mut self,
         ctx: &NativeCallContext,

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -1,6 +1,7 @@
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::abi::transition;
+use crate::calls::comma_ok::CommaOkValueSlot;
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
@@ -647,6 +648,18 @@ impl Planner<'_> {
                 .into_parts();
             statements.extend(setup);
             statements.push(plain_return(call));
+            return statements;
+        }
+        if let Some(CallableReturnAbi::Option(OptionReturnAbi::CommaOk {
+            payload: PayloadLayout::Packed,
+        })) = lowered
+            && let Some(source) = self.comma_ok_source(expression)
+            && !source.has_nil_guard()
+        {
+            let pair = self.bind_comma_ok_pair(expression, source, CommaOkValueSlot::Temp);
+            let value = pair.value.expect("Temp slot always captures the value");
+            let mut statements = pair.statements;
+            statements.push(transition::multi_value_return(vec![value, pair.ok]));
             return statements;
         }
         if let Some(plan) = self.plan_call(expression)

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
 use crate::abi::callable::CallableReturnAbi;
+use crate::calls::comma_ok::CommaOkValueSlot;
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::is_plain_identifier;
@@ -54,6 +55,11 @@ impl Planner<'_> {
             return LoweredBlock { statements };
         }
 
+        if let Some(fused) = self.lower_fused_option_match(subject, arms, place) {
+            statements.extend(fused);
+            return LoweredBlock { statements };
+        }
+
         let subject_ty = subject.get_type();
         let (subject_var, declaration) =
             self.lower_match_subject_var(&mut statements, subject, arms);
@@ -98,8 +104,8 @@ impl Planner<'_> {
     }
 
     /// The shape a match subject fuses against: lowered Lisette `Result` callees
-    /// and single-value Go `(T, error)` calls. `None` keeps the lift-then-match
-    /// path (Partial, Option, comma-ok, flattened multi-returns).
+    /// and single-value Go `(T, error)` calls. `None` falls through to the
+    /// Partial and Option fuses or the lift-then-match path.
     fn fusable_result_shape(
         &self,
         subject: &Expression,
@@ -328,7 +334,51 @@ impl Planner<'_> {
         Some(statements)
     }
 
-    fn lower_fused_arm(
+    /// Fuse the wrap+match into a direct pair test for simple `Some`/`None` arms.
+    fn lower_fused_option_match(
+        &mut self,
+        subject: &Expression,
+        arms: &[MatchArm],
+        place: &PlacePlan,
+    ) -> Option<Vec<LoweredStatement>> {
+        let source = self.comma_ok_source(subject)?;
+        let arms = classify_option_arms(arms)?;
+
+        let slot = if arms.some_binding.is_some() {
+            CommaOkValueSlot::Temp
+        } else {
+            CommaOkValueSlot::Unused
+        };
+        let pair = self.bind_comma_ok_pair(subject, source, slot);
+
+        let (then_body, _) = self.lower_fused_arm(
+            &[arms.some_binding.zip(pair.value.as_deref())],
+            arms.some_body,
+            place,
+        );
+        let (else_body, _) = self.lower_fused_arm(&[], arms.none_body, place);
+
+        let plan = if then_body.renders_empty() && !else_body.renders_empty() {
+            IfPlan {
+                condition_setup: Vec::new(),
+                condition: self.comma_ok_none_condition(&pair),
+                then_body: else_body,
+                else_arm: ElseArm::None,
+            }
+        } else {
+            IfPlan {
+                condition_setup: Vec::new(),
+                condition: self.comma_ok_some_condition(&pair),
+                then_body,
+                else_arm: ElseArm::from_body(else_body, false),
+            }
+        };
+        let mut statements = pair.statements;
+        statements.push(LoweredStatement::If(plan));
+        Some(statements)
+    }
+
+    pub(super) fn lower_fused_arm(
         &mut self,
         bindings: &[Option<(&str, &str)>],
         body: &Expression,
@@ -476,7 +526,88 @@ fn classify_partial_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm, &Ma
     Some((ok?, both?, err?))
 }
 
-fn field_binding(pattern: &Pattern) -> Option<&str> {
+struct OptionArms<'a> {
+    /// `None` when the Some arm binds no payload.
+    some_binding: Option<&'a str>,
+    some_body: &'a Expression,
+    none_body: &'a Expression,
+}
+
+enum OptionArmKind<'a> {
+    Some(Option<&'a str>),
+    None,
+    WildCard,
+}
+
+fn option_arm_kind(arm: &MatchArm) -> Option<OptionArmKind<'_>> {
+    use OptionArmKind as ArmKind;
+    if matches!(arm.pattern, Pattern::WildCard { .. }) {
+        return Some(ArmKind::WildCard);
+    }
+    if let Some(field) = some_pattern_field(&arm.pattern) {
+        let binding = field_binding(field)?;
+        return Some(ArmKind::Some((binding != "_").then_some(binding)));
+    }
+    let Pattern::EnumVariant {
+        identifier,
+        fields,
+        rest,
+        ..
+    } = &arm.pattern
+    else {
+        return None;
+    };
+    (!*rest && fields.is_empty() && matches!(identifier.as_str(), "None" | "Option.None"))
+        .then_some(ArmKind::None)
+}
+
+/// `[Some(<binding>), None]` in either order, plus the if-let wildcard desugars.
+fn classify_option_arms(arms: &[MatchArm]) -> Option<OptionArms<'_>> {
+    use OptionArmKind as ArmKind;
+    if arms.len() != 2 || arms.iter().any(|a| a.has_guard()) {
+        return None;
+    }
+    match (option_arm_kind(&arms[0])?, option_arm_kind(&arms[1])?) {
+        (ArmKind::Some(binding), ArmKind::None | ArmKind::WildCard) => Some(OptionArms {
+            some_binding: binding,
+            some_body: &arms[0].expression,
+            none_body: &arms[1].expression,
+        }),
+        (ArmKind::None, ArmKind::Some(binding)) => Some(OptionArms {
+            some_binding: binding,
+            some_body: &arms[1].expression,
+            none_body: &arms[0].expression,
+        }),
+        (ArmKind::None, ArmKind::WildCard) => Some(OptionArms {
+            some_binding: None,
+            some_body: &arms[1].expression,
+            none_body: &arms[0].expression,
+        }),
+        _ => None,
+    }
+}
+
+/// The single payload field of a `Some(<identifier|_>)` pattern.
+pub(super) fn some_pattern_field(pattern: &Pattern) -> Option<&Pattern> {
+    let Pattern::EnumVariant {
+        identifier,
+        fields,
+        rest,
+        ..
+    } = pattern
+    else {
+        return None;
+    };
+    if *rest || !matches!(identifier.as_str(), "Some" | "Option.Some") {
+        return None;
+    }
+    let [field] = fields.as_slice() else {
+        return None;
+    };
+    matches!(field, Pattern::Identifier { .. } | Pattern::WildCard { .. }).then_some(field)
+}
+
+pub(super) fn field_binding(pattern: &Pattern) -> Option<&str> {
     match pattern {
         Pattern::Identifier { identifier, .. } => Some(identifier.as_str()),
         Pattern::WildCard { .. } => Some("_"),

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -5,6 +5,7 @@ use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::Type;
 
 use crate::Planner;
+use crate::calls::comma_ok::CommaOkValueSlot;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
@@ -13,6 +14,7 @@ use crate::patterns::binding_emit::{
     tree_assignment_statements, tree_binding_statements, with_tree_bindings,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
+use crate::patterns::matching::{field_binding, some_pattern_field};
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
 };
@@ -201,6 +203,13 @@ impl Planner<'_> {
         scrutinee: &Expression,
         fail: RefutableFail,
     ) -> Vec<LoweredStatement> {
+        if let RefutableFail::ElseBlock(else_block) = fail
+            && let Some(statements) =
+                self.lower_fused_option_let_else(ap.pattern, scrutinee, else_block)
+        {
+            return statements;
+        }
+
         let value_ty = scrutinee.get_type();
         let mut statements = Vec::new();
         let resolved = self.resolve_pattern_subject(
@@ -229,6 +238,48 @@ impl Planner<'_> {
         }
         statements.extend(body_block.statements);
         statements
+    }
+
+    /// Fuse `let Some(x) = <comma-ok source> else { ... }` into a direct pair test.
+    fn lower_fused_option_let_else(
+        &mut self,
+        pattern: &Pattern,
+        scrutinee: &Expression,
+        else_block: &Expression,
+    ) -> Option<Vec<LoweredStatement>> {
+        let source = self.comma_ok_source(scrutinee)?;
+        let field = some_pattern_field(pattern)?;
+
+        let binding = self.go_name_for_binding(field).map(|name| {
+            let escaped = go_name::escape_reserved(&name).into_owned();
+            let go_name = if self.is_declared(&escaped) {
+                self.fresh_var(Some(&name))
+            } else {
+                escaped
+            };
+            self.declare(&go_name);
+            (name, go_name)
+        });
+        let slot = match &binding {
+            Some((_, go_name)) => CommaOkValueSlot::Named(go_name.clone()),
+            None => CommaOkValueSlot::Unused,
+        };
+        let pair = self.bind_comma_ok_pair(scrutinee, source, slot);
+
+        let fail_condition = self.comma_ok_none_condition(&pair);
+        // The else block sees the enclosing scope, so it lowers before the binding installs.
+        let fail_body = self.lower_block_as_body(else_block);
+        let mut statements = pair.statements;
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: fail_condition,
+            then_body: fail_body,
+            else_arm: ElseArm::None,
+        }));
+        if let Some((name, go_name)) = binding {
+            self.scope.bind(name, go_name);
+        }
+        Some(statements)
     }
 
     /// Resolve a while-let scrutinee to its loop-subject var, returning any
@@ -264,6 +315,10 @@ impl Planner<'_> {
         scrutinee: &Expression,
         body: &Expression,
     ) -> LoweredBlock {
+        if let Some(fused) = self.lower_fused_option_while_let(pattern, scrutinee, body) {
+            return fused;
+        }
+
         let scrutinee_ty = scrutinee.get_type();
         let (subject_var, subject_setup) = self.while_let_subject(pattern, scrutinee);
 
@@ -345,6 +400,56 @@ impl Planner<'_> {
         LoweredBlock {
             statements: vec![LoweredStatement::Loop(plan)],
         }
+    }
+
+    /// Fuse `while let Some(x) = <comma-ok source>` into a per-iteration pair test.
+    fn lower_fused_option_while_let(
+        &mut self,
+        pattern: &Pattern,
+        scrutinee: &Expression,
+        body: &Expression,
+    ) -> Option<LoweredBlock> {
+        let source = self.comma_ok_source(scrutinee)?;
+        let field = some_pattern_field(pattern)?;
+        let binding = field_binding(field).filter(|b| *b != "_");
+
+        let slot = if binding.is_some() {
+            CommaOkValueSlot::Temp
+        } else {
+            CommaOkValueSlot::Unused
+        };
+        let pair = self.bind_comma_ok_pair(scrutinee, source, slot);
+
+        let condition = self.comma_ok_none_condition(&pair);
+        let mut loop_body = pair.statements;
+        loop_body.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition,
+            then_body: LoweredBlock {
+                statements: vec![LoweredStatement::Break(
+                    self.current_loop_id()
+                        .map_or(LoopTransfer::Unlabeled, LoopTransfer::Source),
+                )],
+            },
+            else_arm: ElseArm::None,
+        }));
+        let (body_block, _) = self.lower_fused_arm(
+            &[binding.zip(pair.value.as_deref())],
+            body,
+            &PlacePlan::Statement,
+        );
+        loop_body.extend(body_block.statements);
+
+        let plan = self.build_source_loop(
+            Vec::new(),
+            "for {\n".to_string(),
+            LoweredBlock {
+                statements: loop_body,
+            },
+        );
+        Some(LoweredBlock {
+            statements: vec![LoweredStatement::Loop(plan)],
+        })
     }
 
     fn lower_refutable_fail(&mut self, fail: RefutableFail, subject_var: &str) -> LoweredBlock {

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -6,15 +6,15 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"github.com/user/myproject/store"
 )
 
 func main() {
 	raw := store.GetValue("count")
-	subject_1 := lisette.AssertType[int](raw)
-	if subject_1.Tag == lisette.OptionSome {
-		fmt.Print(subject_1.SomeVal)
+	ret_1, ok_2 := raw.(int)
+	if ok_2 {
+		n := ret_1
+		fmt.Print(n)
 	} else {
 		fmt.Print("not an int")
 	}

--- a/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
+++ b/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
@@ -6,16 +6,15 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"sync"
 )
 
 func main() {
 	m := sync.Map{}
 	m.Store("key", "value")
-	option_2 := lisette.OptionFromCommaOk[any](m.Load("key"))
-	if option_2.Tag == lisette.OptionSome {
-		v := option_2.SomeVal
+	ret_1, ok_2 := m.Load("key")
+	if ok_2 {
+		v := ret_1
 		fmt.Printf("got: %v\n", v)
 	} else {
 		fmt.Println("not found")

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -2029,6 +2029,24 @@ fn test() {
 }
 
 #[test]
+fn if_let_none_on_comma_ok_call() {
+    let input = r#"
+import "go:fmt"
+
+fn divide(a: int, b: int) -> Option<int> {
+  if b == 0 { None } else { Some(a / b) }
+}
+
+fn test() {
+  if let None = divide(100, 0) {
+    let _ = fmt.Print("division by zero\n");
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn if_let_result_without_else_branch() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -4168,6 +4168,16 @@ fn main() {
 }
 
 #[test]
+fn assert_type_boundary_return_fuses() {
+    let input = r#"
+fn test(value: Unknown) -> Option<int> {
+  assert_type<int>(value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unit_call_as_map_index_key() {
     let input = r#"
 fn noop() {}

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -165,6 +165,21 @@ fn main() {
 }
 
 #[test]
+fn interop_comma_ok_match_subject_fuses() {
+    let input = r#"
+import "go:os"
+
+fn main() {
+  match os.LookupEnv("HOME") {
+    Some(v) => { let _ = v },
+    None => { let _ = "" },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_comma_ok_let_call() {
     let input = r#"
 import "go:os"

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -447,6 +447,66 @@ fn test(m: Map<string, int>, key: string) -> Option<int> {
 }
 
 #[test]
+fn map_get_match_subject_fuses() {
+    let input = r#"
+import "go:fmt"
+
+fn test(m: Map<string, int>, key: string) -> int {
+  match m.get(key) {
+    Some(v) => v,
+    None => { fmt.Print("missing\n"); 0 },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_get_let_else_shadowed_binding_freshens() {
+    let input = r#"
+fn test(m: Map<string, string>, v: int) -> string {
+  let _ = v + 1
+  let Some(v) = m.get("a") else {
+    return ""
+  }
+  v
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_get_let_else_shadow_outer_visible_in_else() {
+    let input = r#"
+fn test(m: Map<string, string>, x: int) -> string {
+  let Some(x) = m.get("a") else {
+    if x > 0 {
+      return "positive"
+    }
+    return "negative"
+  }
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_get_let_else_reserved_name_binding() {
+    let input = r#"
+fn test(m: Map<string, int>) -> int {
+  let len = 3
+  let _ = len + 1
+  let Some(len) = m.get("a") else {
+    return 0
+  }
+  len
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_append() {
     let input = r#"
 fn test(s: Slice<int>) -> Slice<int> {

--- a/tests/spec/emit/snapshots/assert_type_boundary_return_fuses.snap
+++ b/tests/spec/emit/snapshots/assert_type_boundary_return_fuses.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn test(value: Unknown) -> Option<int> {
+    assert_type<int>(value)
+  }
+---
+package main
+
+func test(value any) (int, bool) {
+	ret_1, ok_2 := value.(int)
+	return ret_1, ok_2
+}

--- a/tests/spec/emit/snapshots/deref_map_value_method_call.snap
+++ b/tests/spec/emit/snapshots/deref_map_value_method_call.snap
@@ -17,8 +17,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Counter struct {
 	count int
 }
@@ -28,10 +26,9 @@ func (c *Counter) increment() {
 }
 
 func test(m map[string]*Counter) {
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	c, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	c := subject_1.SomeVal
 	c.increment()
 }

--- a/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
+++ b/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
@@ -14,16 +14,15 @@ description: |
 ---
 package main
 
-import (
-	"container/ring"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "container/ring"
 
 func test() int {
 	r := ring.Ring{Value: 1}
-	subject_1 := lisette.AssertType[int](r.Value)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := r.Value.(int)
+	if ok_2 {
+		n := ret_1
+		return n
+	} else {
+		return 0
 	}
-	return 0
 }

--- a/tests/spec/emit/snapshots/if_let_none_on_comma_ok_call.snap
+++ b/tests/spec/emit/snapshots/if_let_none_on_comma_ok_call.snap
@@ -9,8 +9,8 @@ description: |
   }
   
   fn test() {
-    if let Some(x) = divide(100, 10) {
-      let _ = fmt.Print(f"Result: {x}\n");
+    if let None = divide(100, 0) {
+      let _ = fmt.Print("division by zero\n");
     }
   }
 ---
@@ -26,9 +26,8 @@ func divide(a, b int) (int, bool) {
 }
 
 func test() {
-	ret_1, ok_2 := divide(100, 10)
-	if ok_2 {
-		x := ret_1
-		fmt.Printf("Result: %d\n", x)
+	_, ok_1 := divide(100, 0)
+	if !ok_1 {
+		fmt.Print("division by zero\n")
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
@@ -18,17 +18,16 @@ description: |
 ---
 package main
 
-import (
-	lisette "github.com/ivov/lisette/prelude"
-	"os"
-)
+import "os"
 
 func apply(f func(string) (string, bool), key string) string {
-	option_2 := lisette.OptionFromCommaOk[string](f(key))
-	if option_2.Tag == lisette.OptionSome {
-		return option_2.SomeVal
+	ret_1, ok_2 := f(key)
+	if ok_2 {
+		v := ret_1
+		return v
+	} else {
+		return "unset"
 	}
-	return "unset"
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
@@ -13,20 +13,12 @@ description: |
 ---
 package main
 
-import (
-	"example.com/reg"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/reg"
 
 func main() {
-	ret_2, ret_3 := reg.Lookup("a")
-	var option_4 lisette.Option[map[string]int]
-	if ret_3 && ret_2 != nil {
-		option_4 = lisette.MakeOptionSome[map[string]int](ret_2)
-	} else {
-		option_4 = lisette.MakeOptionNone[map[string]int]()
-	}
-	if option_4.Tag == lisette.OptionSome {
-		_ = len(option_4.SomeVal)
+	ret_1, ok_2 := reg.Lookup("a")
+	if ok_2 && ret_1 != nil {
+		m := ret_1
+		_ = len(m)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:os"
+  
+  fn main() {
+    match os.LookupEnv("HOME") {
+      Some(v) => { let _ = v },
+      None => { let _ = "" },
+    }
+  }
+---
+package main
+
+import "os"
+
+func main() {
+	ret_1, ok_2 := os.LookupEnv("HOME")
+	if ok_2 {
+		v := ret_1
+		_ = v
+	}
+}

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
@@ -42,8 +42,9 @@ func lookup(k string) (string, bool) {
 }
 
 func main() {
-	option_2 := lisette.OptionFromCommaOk[string](lookup("HOME"))
-	if option_2.Tag == lisette.OptionSome {
-		_ = option_2.SomeVal
+	ret_1, ok_2 := lookup("HOME")
+	if ok_2 {
+		v := ret_1
+		_ = v
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -35,19 +35,17 @@ type Holder struct {
 func main() {
 	m := make(map[string]Holder)
 	m["a"] = Holder{f: strconv.Atoi}
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	found, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	found := subject_1.SomeVal
 	entry := found
 	entry.f = strconv.Atoi
 	m["a"] = entry
-	subject_2 := lisette.MapGet(m, "a")
-	if subject_2.Tag != lisette.OptionSome {
+	h, ok_2 := m["a"]
+	if !ok_2 {
 		return
 	}
-	h := subject_2.SomeVal
 	ret_3, ret_4 := h.f("1")
 	var result_5 lisette.Result[int, error]
 	if ret_4 != nil {

--- a/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
@@ -18,17 +18,16 @@ description: |
 ---
 package main
 
-import (
-	"example.com/idx"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/idx"
 
 func apply(f func(string, string) (int, bool), s string) int {
-	option_2 := lisette.OptionFromCommaOk[int](f(s, "ll"))
-	if option_2.Tag == lisette.OptionSome {
-		return option_2.SomeVal
+	ret_1, ok_2 := f(s, "ll")
+	if ok_2 {
+		v := ret_1
+		return v
+	} else {
+		return -2
 	}
-	return -2
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
@@ -23,18 +23,18 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func identity(value int) int {
 	return value
 }
 
 func describe(value any) string {
-	subject_1 := lisette.AssertType[string](value)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := value.(string)
+	if ok_2 {
+		text := ret_1
+		return text
+	} else {
+		return ""
 	}
-	return ""
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -31,18 +31,18 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func fallible() (int, error) {
 	return 1, nil
 }
 
 func describe(value any) string {
-	subject_1 := lisette.AssertType[string](value)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := value.(string)
+	if ok_2 {
+		text := ret_1
+		return text
+	} else {
+		return ""
 	}
-	return ""
 }
 
 func run() (string, error) {

--- a/tests/spec/emit/snapshots/let_else_option_direct_call.snap
+++ b/tests/spec/emit/snapshots/let_else_option_direct_call.snap
@@ -13,8 +13,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func getValue(s string) (int, bool) {
 	if s == "ok" {
 		return 42, true
@@ -23,11 +21,9 @@ func getValue(s string) (int, bool) {
 }
 
 func test() int {
-	option_2 := lisette.OptionFromCommaOk[int](getValue("ok"))
-	subject_1 := option_2
-	if subject_1.Tag != lisette.OptionSome {
+	x, ok_1 := getValue("ok")
+	if !ok_1 {
 		return 0
 	}
-	x := subject_1.SomeVal
 	return x
 }

--- a/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
@@ -24,18 +24,18 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func identity(value int) int {
 	return value
 }
 
 func describe(value any) string {
-	subject_1 := lisette.AssertType[string](value)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := value.(string)
+	if ok_2 {
+		text := ret_1
+		return text
+	} else {
+		return ""
 	}
-	return ""
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
+++ b/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
@@ -24,8 +24,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func maybe(flag bool) (int, bool) {
 	if flag {
 		return 42, true
@@ -41,12 +39,10 @@ func test() int {
 			break
 		}
 		if count == 1 {
-			option_2 := lisette.OptionFromCommaOk[int](maybe(true))
-			subject_1 := option_2
-			if subject_1.Tag != lisette.OptionSome {
+			v, ok_1 := maybe(true)
+			if !ok_1 {
 				break
 			}
-			v := subject_1.SomeVal
 			_ = v
 		}
 	}

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -15,8 +15,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Outer struct {
 	items *[]int
 }
@@ -25,11 +23,10 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	o, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	o := subject_1.SomeVal
 	ref_2 := o.items
 	*ref_2 = append(*o.items, 2)
 	_ = items

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
@@ -15,8 +15,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Outer struct {
 	items *[]int
 }
@@ -25,11 +23,10 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	o, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	o := subject_1.SomeVal
 	var tmp_2 []int
 	recv_3 := *o.items
 	tmp_2 = append(recv_3[:len(recv_3):len(recv_3)], 2)

--- a/tests/spec/emit/snapshots/map_get.snap
+++ b/tests/spec/emit/snapshots/map_get.snap
@@ -8,12 +8,7 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func test(m map[string]int, key string) (int, bool) {
-	v_1 := lisette.MapGet(m, key)
-	if v_1.Tag == lisette.OptionSome {
-		return v_1.SomeVal, true
-	}
-	return 0, false
+	ret_1, ok_2 := m[key]
+	return ret_1, ok_2
 }

--- a/tests/spec/emit/snapshots/map_get_let_else_reserved_name_binding.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_reserved_name_binding.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(m: Map<string, int>) -> int {
+    let len = 3
+    let _ = len + 1
+    let Some(len) = m.get("a") else {
+      return 0
+    }
+    len
+  }
+---
+package main
+
+func test(m map[string]int) int {
+	len_ := 3
+	_ = len_ + 1
+	len_1, ok_2 := m["a"]
+	if !ok_2 {
+		return 0
+	}
+	return len_1
+}

--- a/tests/spec/emit/snapshots/map_get_let_else_shadow_outer_visible_in_else.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_shadow_outer_visible_in_else.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(m: Map<string, string>, x: int) -> string {
+    let Some(x) = m.get("a") else {
+      if x > 0 {
+        return "positive"
+      }
+      return "negative"
+    }
+    x
+  }
+---
+package main
+
+func test(m map[string]string, x int) string {
+	x_1, ok_2 := m["a"]
+	if !ok_2 {
+		if x > 0 {
+			return "positive"
+		}
+		return "negative"
+	}
+	return x_1
+}

--- a/tests/spec/emit/snapshots/map_get_let_else_shadowed_binding_freshens.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_shadowed_binding_freshens.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(m: Map<string, string>, v: int) -> string {
+    let _ = v + 1
+    let Some(v) = m.get("a") else {
+      return ""
+    }
+    v
+  }
+---
+package main
+
+func test(m map[string]string, v int) string {
+	_ = v + 1
+	v_1, ok_2 := m["a"]
+	if !ok_2 {
+		return ""
+	}
+	return v_1
+}

--- a/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(m: Map<string, int>, key: string) -> int {
+    match m.get(key) {
+      Some(v) => v,
+      None => { fmt.Print("missing\n"); 0 },
+    }
+  }
+---
+package main
+
+import "fmt"
+
+func test(m map[string]int, key string) int {
+	ret_1, ok_2 := m[key]
+	if ok_2 {
+		v := ret_1
+		return v
+	} else {
+		fmt.Print("missing\n")
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
@@ -15,19 +15,16 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Wrap int
 
 func main() {
 	w := Wrap(1)
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	r, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	r := subject_1.SomeVal
 	*r = Wrap(2)
 	_ = w
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
@@ -19,10 +19,7 @@ description: |
 ---
 package main
 
-import (
-	lisette "github.com/ivov/lisette/prelude"
-	"slices"
-)
+import "slices"
 
 type Inner struct {
 	items []int
@@ -38,11 +35,10 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	o, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	o := subject_1.SomeVal
 	inner := Inner{items: slices.Clone(Inner(*o.w).items)}
 	inner.items = append(inner.items, 2)
 	*o.w = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
@@ -19,8 +19,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Inner struct {
 	x int
 }
@@ -35,11 +33,10 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	o, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	o := subject_1.SomeVal
 	inner := Inner(*o.w)
 	inner.x = 2
 	*o.w = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
@@ -18,10 +18,7 @@ description: |
 ---
 package main
 
-import (
-	lisette "github.com/ivov/lisette/prelude"
-	"slices"
-)
+import "slices"
 
 type Inner struct {
 	items []int
@@ -33,11 +30,10 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	r, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	r := subject_1.SomeVal
 	inner := Inner{items: slices.Clone(Inner(*r).items)}
 	inner.items = append(inner.items, 2)
 	*r = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
@@ -18,8 +18,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Inner struct {
 	x int
 }
@@ -30,11 +28,10 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	r, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	r := subject_1.SomeVal
 	inner := Inner(*r)
 	inner.x = 1
 	*r = Wrap(inner)

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -15,19 +15,16 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 type Wrap []int
 
 func main() {
 	w := Wrap([]int{1})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	subject_1 := lisette.MapGet(m, "a")
-	if subject_1.Tag != lisette.OptionSome {
+	r, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	r := subject_1.SomeVal
 	ref_3 := r
 	recv_2 := []int(*r)
 	*ref_3 = Wrap(append(recv_2[:len(recv_2):len(recv_2)], 2))

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -30,9 +30,10 @@ func safeDivide(a, b float64) (float64, bool) {
 
 func parseAndDivide(a, b float64) lisette.Result[string, string] {
 	var result float64
-	option_2 := lisette.OptionFromCommaOk[float64](safeDivide(a, b))
-	if option_2.Tag == lisette.OptionSome {
-		result = option_2.SomeVal
+	ret_1, ok_2 := safeDivide(a, b)
+	if ok_2 {
+		v := ret_1
+		result = v
 	} else {
 		return lisette.MakeResultErr[string, string]("division by zero")
 	}

--- a/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
@@ -17,8 +17,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func noop() {}
 
 func maybe(b bool) (int, bool) {
@@ -29,8 +27,8 @@ func maybe(b bool) (int, bool) {
 }
 
 func test() {
-	option_2 := lisette.OptionFromCommaOk[int](maybe(true))
-	if option_2.Tag == lisette.OptionSome {
+	_, ok_1 := maybe(true)
+	if ok_1 {
 		noop()
 	} else {
 		noop()

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
@@ -20,11 +20,13 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func describe(pair lisette.Tuple2[int, any]) string {
-	subject_1 := lisette.AssertType[string](pair.Second)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := pair.Second.(string)
+	if ok_2 {
+		text := ret_1
+		return text
+	} else {
+		return ""
 	}
-	return ""
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
@@ -21,11 +21,13 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func second(pair lisette.Tuple2[string, any]) int {
-	subject_1 := lisette.AssertType[int](pair.Second)
-	if subject_1.Tag == lisette.OptionSome {
-		return subject_1.SomeVal
+	ret_1, ok_2 := pair.Second.(int)
+	if ok_2 {
+		value := ret_1
+		return value
+	} else {
+		return 0
 	}
-	return 0
 }
 
 func test() {

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -18,10 +18,7 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 func nextItem(counter int) (int, bool) {
 	if counter < 5 {
@@ -33,14 +30,12 @@ func nextItem(counter int) (int, bool) {
 func test() {
 	i := 0
 	for {
-		option_2 := lisette.OptionFromCommaOk[int](nextItem(i))
-		subject_1 := option_2
-		if subject_1.Tag == lisette.OptionSome {
-			x := subject_1.SomeVal
-			fmt.Printf("Got: %d\n", x)
-			i++
-		} else {
+		ret_1, ok_2 := nextItem(i)
+		if !ok_2 {
 			break
 		}
+		x := ret_1
+		fmt.Printf("Got: %d\n", x)
+		i++
 	}
 }


### PR DESCRIPTION
Matching on an `Option` built from a Go comma-ok pair now lowers to a direct `v, ok :=` test, instead of wrapping the pair into a tagged `lisette.Option` and testing its tag.

Before:

```go
subject_1 := lisette.MapGet(m, "a")
if subject_1.Tag != lisette.OptionSome {
	return
}
c := subject_1.SomeVal
```

After:

```go
c, ok_1 := m["a"]
if !ok_1 {
	return
}
```
