### PR TITLE
refactor: lower branch-assigned temps to direct returns and `:=`

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -9,6 +9,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{
     OPTION_SOME_TAG, PARTIAL_ERR_TAG, PARTIAL_OK_TAG, RESULT_OK_TAG,
 };
+use crate::control_flow::propagation::plain_return;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoweredBlock, LoweredStatement, ReturnForm, ReturnStatementPlan,
 };
@@ -278,6 +279,24 @@ impl Planner<'_> {
             self.lower_abi_wrapping(raw_value, abi, result_ty, WrapperTarget::FreshSlot);
         (wrap, outcome.expect("wrapper produced no slot"))
     }
+
+    /// Wrap a callable's physical Go result and return it in each wrapper branch.
+    pub(crate) fn lower_abi_to_tagged_return(
+        &mut self,
+        raw_value: &str,
+        abi: &CallableReturnAbi,
+        result_ty: &Type,
+    ) -> Vec<LoweredStatement> {
+        if abi.is_passthrough() || matches!(abi, CallableReturnAbi::Tuple { .. }) {
+            let (mut statements, value) = self.lower_abi_to_tagged(raw_value, abi, result_ty);
+            statements.push(plain_return(value));
+            return statements;
+        }
+        let (statements, outcome) =
+            self.lower_abi_wrapping(raw_value, abi, result_ty, WrapperTarget::Return);
+        debug_assert!(outcome.is_none(), "Return target emits its own returns");
+        statements
+    }
 }
 
 /// Wrap a tagged-return callback into a Go body producing the lowered Go
@@ -512,13 +531,15 @@ pub(crate) fn emit_fn_arg_shape_adapter(
 
     let outer_ret = planner.render_lowered_return_ty(target_abi, arg_ret);
 
-    let (wrap_statements, tagged) = planner.lower_abi_to_tagged(&inner_call, arg_abi, arg_ret);
-    let mut body = Renderer.render_setup(&wrap_statements);
-    if target_abi.is_passthrough() {
-        write_line!(body, "return {}", tagged);
+    let body = if target_abi.is_passthrough() {
+        let statements = planner.lower_abi_to_tagged_return(&inner_call, arg_abi, arg_ret);
+        Renderer.render_setup(&statements)
     } else {
+        let (wrap_statements, tagged) = planner.lower_abi_to_tagged(&inner_call, arg_abi, arg_ret);
+        let mut body = Renderer.render_setup(&wrap_statements);
         render_lowered_result_return(planner, &mut body, &tagged, arg_ret, target_abi);
-    }
+        body
+    };
 
     Some(format!(
         "func({}) {} {{\n{}}}",
@@ -552,9 +573,8 @@ pub(crate) fn lower_arg_to_tagged(
     let inner_call = format!("{}({})", arg_name, inner_arg_names.join(", "));
     let tagged_ret = planner.go_type_string(inner_ret);
 
-    let (wrap_statements, result_var) = planner.lower_abi_to_tagged(&inner_call, &abi, inner_ret);
-    let mut body = Renderer.render_setup(&wrap_statements);
-    write_line!(body, "return {}", result_var);
+    let wrap_statements = planner.lower_abi_to_tagged_return(&inner_call, &abi, inner_ret);
+    let body = Renderer.render_setup(&wrap_statements);
 
     let tagged_var = planner.fresh_var(Some("tagged"));
     planner.declare(&tagged_var);

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -665,11 +665,11 @@ impl Planner<'_> {
         if let Some(plan) = self.plan_call(expression)
             && !plan.resolved.abi.result.is_passthrough()
         {
-            let (setup, result_var) = self
-                .lower_go_abi_wrapped_call(expression, &plan.resolved.abi, return_ty)
-                .into_parts();
-            statements.extend(setup);
             if let Some(shape) = lowered {
+                let (setup, result_var) = self
+                    .lower_go_abi_wrapped_call(expression, &plan.resolved.abi, return_ty)
+                    .into_parts();
+                statements.extend(setup);
                 statements.extend(transition::emit_lowered_result_return(
                     self,
                     &result_var,
@@ -677,7 +677,27 @@ impl Planner<'_> {
                     shape,
                 ));
             } else {
-                statements.push(plain_return(result_var));
+                let abi = plan.resolved.abi.clone();
+                let unbridged = self.go_tuple_result_bridges(&abi, return_ty).is_none()
+                    && self.go_result_layout_bridge(&abi, return_ty).is_none()
+                    && self.go_return_payload_bridge(&abi, return_ty).is_none();
+                if unbridged {
+                    let (setup, call_str) = self
+                        .lower_call(expression, None, ExpressionContext::value())
+                        .into_parts();
+                    statements.extend(setup);
+                    statements.extend(self.lower_abi_to_tagged_return(
+                        &call_str,
+                        &abi.result,
+                        return_ty,
+                    ));
+                } else {
+                    let (setup, result_var) = self
+                        .lower_go_abi_wrapped_call(expression, &abi, return_ty)
+                        .into_parts();
+                    statements.extend(setup);
+                    statements.push(plain_return(result_var));
+                }
             }
             return statements;
         }

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -410,21 +410,21 @@ impl Planner<'_> {
 
         let logical_ty = self.facts.peel_alias(return_type);
         let go_ret = self.render_lowered_return_ty(interface_abi, return_type);
+        if interface_abi.is_passthrough() {
+            let statements = self.lower_abi_to_tagged_return(inner_call, user_abi, &logical_ty);
+            return (go_ret, crate::Renderer.render_setup(&statements));
+        }
         let (setup, tagged) = self.lower_abi_to_tagged(inner_call, user_abi, &logical_ty);
         let mut body = crate::Renderer.render_setup(&setup);
-        if interface_abi.is_passthrough() {
-            write_line!(body, "return {}", tagged);
+        let subject = if user_abi.is_passthrough() {
+            let res = self.fresh_var(Some("res"));
+            self.declare(&res);
+            write_line!(body, "{} := {}", res, tagged);
+            res
         } else {
-            let subject = if user_abi.is_passthrough() {
-                let res = self.fresh_var(Some("res"));
-                self.declare(&res);
-                write_line!(body, "{} := {}", res, tagged);
-                res
-            } else {
-                tagged
-            };
-            render_lowered_result_return(self, &mut body, &subject, &logical_ty, interface_abi);
-        }
+            tagged
+        };
+        render_lowered_result_return(self, &mut body, &subject, &logical_ty, interface_abi);
         (go_ret, body)
     }
 }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -11,7 +11,9 @@ use crate::plan::bodies::{
     LoopTransfer, LoweredBlock, LoweredStatement, MatchStatementPlan, PlacePlan, WhileLetPlan,
     directed,
 };
-use crate::plan::placement::{requires_temp_var, try_elide_tail_let};
+use crate::plan::placement::{
+    collapse_boolean_branch_assign, collapse_declare_assign, requires_temp_var, try_elide_tail_let,
+};
 use crate::plan::values::ValuePlan;
 use crate::utils::wrap_if_struct_literal;
 use syntax::ast::{
@@ -91,11 +93,9 @@ impl Planner<'_> {
                 target_ty: Some(ty),
             },
         );
-        ValuePlan::name(
-            vec![declaration, LoweredStatement::If(plan)],
-            result_var,
-            false,
-        )
+        let mut setup = vec![declaration, LoweredStatement::If(plan)];
+        collapse_boolean_branch_assign(&mut setup, &result_var);
+        ValuePlan::name(setup, result_var, false)
     }
 
     /// Lower a value-position `if let`/`match`/`select` to a fresh operand-temp
@@ -116,6 +116,8 @@ impl Planner<'_> {
         );
         let mut setup = vec![declaration];
         setup.extend(block.statements);
+        collapse_declare_assign(&mut setup, &result_var);
+        collapse_boolean_branch_assign(&mut setup, &result_var);
         ValuePlan::name(setup, result_var, false)
     }
 

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -6,7 +6,7 @@ use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::expressions::staging::SpreadSequenceOptions;
 use crate::plan::bodies::{
-    AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, LoopTransfer, LoweredBlock,
+    AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, ElseArm, LoopTransfer, LoweredBlock,
     LoweredStatement, PlacePlan,
 };
 use crate::plan::calls::plan_variadic_spread;
@@ -58,6 +58,140 @@ pub(crate) fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatem
             value,
         },
     })
+}
+
+/// Collapse `var x T` + one unconditional `x = v` into `x := v`, when `:=`
+/// infers T identically (a `float64` context can hold an untyped int literal).
+pub(crate) fn collapse_declare_assign(statements: &mut Vec<LoweredStatement>, name: &str) {
+    let [
+        LoweredStatement::VarDecl {
+            name: declared,
+            go_type,
+            value: None,
+        },
+        LoweredStatement::Assign(assign),
+    ] = statements.as_slice()
+    else {
+        return;
+    };
+    if declared != name || !matches!(go_type.as_str(), "int" | "string" | "bool") {
+        return;
+    }
+    let AssignForm::Simple {
+        target_capture,
+        target_str,
+        value,
+    } = &assign.form
+    else {
+        return;
+    };
+    if target_str != name
+        || !target_capture.is_empty()
+        || !value.setup.is_empty()
+        || value.expression.contains_deferred_evaluation()
+    {
+        return;
+    }
+    let Some(LoweredStatement::Assign(assign)) = statements.pop() else {
+        unreachable!("shape checked above");
+    };
+    let AssignForm::Simple { value, .. } = assign.form else {
+        unreachable!("shape checked above");
+    };
+    statements[0] = LoweredStatement::TempBind {
+        name: name.to_string(),
+        value: value.expression.rendered(),
+    };
+}
+
+/// Collapse `var x bool` + `if c { x = a } else { x = b }` with a literal arm
+/// into `x := <condition>`. Short-circuit keeps the other arm conditional.
+pub(crate) fn collapse_boolean_branch_assign(statements: &mut Vec<LoweredStatement>, name: &str) {
+    let [
+        LoweredStatement::VarDecl {
+            name: declared,
+            go_type,
+            value: None,
+        },
+        LoweredStatement::If(plan),
+    ] = statements.as_slice()
+    else {
+        return;
+    };
+    if declared != name || go_type != "bool" || !plan.condition_setup.is_empty() {
+        return;
+    }
+    let ElseArm::Else {
+        body: else_body, ..
+    } = &plan.else_arm
+    else {
+        return;
+    };
+    let Some(then_value) = single_simple_assign_value(&plan.then_body, name) else {
+        return;
+    };
+    let Some(else_value) = single_simple_assign_value(else_body, name) else {
+        return;
+    };
+    let Some(joined) = join_boolean_branches(&plan.condition, &then_value, &else_value) else {
+        return;
+    };
+    statements.pop();
+    statements[0] = LoweredStatement::TempBind {
+        name: name.to_string(),
+        value: joined,
+    };
+}
+
+/// The rendered value of a body that is exactly one plain `name = value`.
+fn single_simple_assign_value(body: &LoweredBlock, name: &str) -> Option<String> {
+    let [LoweredStatement::Assign(assign)] = body.statements.as_slice() else {
+        return None;
+    };
+    let AssignForm::Simple {
+        target_capture,
+        target_str,
+        value,
+    } = &assign.form
+    else {
+        return None;
+    };
+    (target_str == name
+        && target_capture.is_empty()
+        && value.setup.is_empty()
+        && !value.expression.contains_deferred_evaluation())
+    .then(|| value.expression.rendered())
+}
+
+fn join_boolean_branches(condition: &str, then_value: &str, else_value: &str) -> Option<String> {
+    Some(match (then_value, else_value) {
+        ("true", "false") => condition.to_string(),
+        ("false", "true") => negate_condition(condition),
+        // Both-literal same-value arms would drop the condition's evaluation.
+        ("true", "true") | ("false", "false") => return None,
+        (value, "false") => format!("{} && {}", and_operand(condition), and_operand(value)),
+        ("true", value) => format!("{} || {}", condition, value),
+        ("false", value) => format!("{} && {}", negate_condition(condition), and_operand(value)),
+        (value, "true") => format!("{} || {}", negate_condition(condition), value),
+        _ => return None,
+    })
+}
+
+fn negate_condition(condition: &str) -> String {
+    if crate::names::go_name::is_plain_identifier(condition) {
+        format!("!{}", condition)
+    } else {
+        format!("!({})", condition)
+    }
+}
+
+/// Parenthesize a synthesized `&&` operand, keeping bare identifiers bare.
+fn and_operand(operand: &str) -> String {
+    if crate::names::go_name::is_plain_identifier(operand) {
+        operand.to_string()
+    } else {
+        format!("({})", operand)
+    }
 }
 
 pub(crate) fn requires_temp_var(expression: &Expression) -> bool {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -8,7 +8,10 @@ use crate::escape_reserved;
 use crate::patterns::sites::{AnnotatedPattern, PatternSubject};
 use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CallableOrigin;
-use crate::plan::placement::{expression_contains_binding, is_unit_call, requires_temp_var};
+use crate::plan::placement::{
+    collapse_boolean_branch_assign, collapse_declare_assign, expression_contains_binding,
+    is_unit_call, requires_temp_var,
+};
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
 use syntax::types::Type;
 
@@ -310,6 +313,8 @@ impl Planner<'_> {
             self.try_declare(name);
         }
         statements.extend(self.lower_assign(value, name, Some(binding_ty)));
+        collapse_declare_assign(&mut statements, name);
+        collapse_boolean_branch_assign(&mut statements, name);
         statements
     }
 

--- a/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
+++ b/tests/spec/build/snapshots/adapter_type_name_freshens_against_active_scope.snap
@@ -49,8 +49,7 @@ type _lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0 any] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0_[_lisAdapter_Bar_Box_0]) get() lisette.Option[_lisAdapter_Bar_Box_0] {
-	option_1 := lisette.OptionFromCommaOk[_lisAdapter_Bar_Box_0](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[_lisAdapter_Bar_Box_0](a.inner.get())
 }
 
 type _lisAdapter_Bar_Box_1 struct {
@@ -58,8 +57,7 @@ type _lisAdapter_Bar_Box_1 struct {
 }
 
 func (a _lisAdapter_Bar_Box_1) get() lisette.Option[int] {
-	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[int](a.inner.get())
 }
 
 type _lisAdapter_Bar_Box_2 struct {
@@ -67,6 +65,5 @@ type _lisAdapter_Bar_Box_2 struct {
 }
 
 func (a _lisAdapter_Bar_Box_2) get() lisette.Option[int] {
-	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[int](a.inner.get())
 }

--- a/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
@@ -22,17 +22,15 @@ func Holder_Resolve[T any, R any, E any](self Holder[T], f func(T) lisette.Parti
 }
 
 func main() {
-	_arg_5 := Holder[int]{Val: 4}
+	_arg_4 := Holder[int]{Val: 4}
 	cb_1 := Fallible
-	rez := Holder_Resolve(_arg_5, func(arg0 int) lisette.Partial[int, Face] {
+	rez := Holder_Resolve(_arg_4, func(arg0 int) lisette.Partial[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Partial[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakePartialBoth[int, Face](ret_2, ret_3)
+			return lisette.MakePartialBoth[int, Face](ret_2, ret_3)
 		} else {
-			result_4 = lisette.MakePartialOk[int, Face](ret_2)
+			return lisette.MakePartialOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 	_ = rez
 }

--- a/tests/spec/build/snapshots/bound_result_from_generic_callee_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_callee_keeps_tagged_return.snap
@@ -21,13 +21,11 @@ func main() {
 	cb_1 := Resultant
 	rez := Resolve(42, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+			return lisette.MakeResultErr[int, Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+			return lisette.MakeResultOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 	_ = rez
 }

--- a/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
@@ -22,17 +22,15 @@ func Holder_Resolve[R any, E any](self Holder, f func(int) lisette.Result[R, E])
 }
 
 func main() {
-	_arg_5 := Holder{N: 4}
+	_arg_4 := Holder{N: 4}
 	cb_1 := Resultant
-	rez := Holder_Resolve(_arg_5, func(arg0 int) lisette.Result[int, Face] {
+	rez := Holder_Resolve(_arg_4, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+			return lisette.MakeResultErr[int, Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+			return lisette.MakeResultOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 	_ = rez
 }

--- a/tests/spec/build/snapshots/cross_package_result_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/cross_package_result_fn_arg_adapts_to_tagged_generic_param.snap
@@ -13,13 +13,11 @@ func main() {
 	cb_1 := resolver.Resultant
 	rez := resolver.Resolve(42, func(arg0 int) lisette.Result[int, resolver.Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, resolver.Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, resolver.Face](ret_3)
+			return lisette.MakeResultErr[int, resolver.Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, resolver.Face](ret_2)
+			return lisette.MakeResultOk[int, resolver.Face](ret_2)
 		}
-		return result_4
 	})
 	_ = rez
 }

--- a/tests/spec/build/snapshots/generic_adapter_freshens_method_names_against_type_parameters.snap
+++ b/tests/spec/build/snapshots/generic_adapter_freshens_method_names_against_type_parameters.snap
@@ -33,6 +33,5 @@ type _lisAdapter_Bar_Box_0[a any, arg0 any] struct {
 }
 
 func (a_1 _lisAdapter_Bar_Box_0[a, arg0]) get(arg0_2 int) lisette.Option[a] {
-	option_3 := lisette.OptionFromCommaOk[a](a_1.inner.get(arg0_2))
-	return option_3
+	return lisette.OptionFromCommaOk[a](a_1.inner.get(arg0_2))
 }

--- a/tests/spec/build/snapshots/generic_adapter_instantiates_renamed_impl_parameters.snap
+++ b/tests/spec/build/snapshots/generic_adapter_instantiates_renamed_impl_parameters.snap
@@ -33,6 +33,5 @@ type _lisAdapter_Bar_Box_0 struct {
 }
 
 func (a _lisAdapter_Bar_Box_0) get() lisette.Option[int] {
-	option_1 := lisette.OptionFromCommaOk[int](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[int](a.inner.get())
 }

--- a/tests/spec/build/snapshots/generic_adapter_uses_validated_receiver_context.snap
+++ b/tests/spec/build/snapshots/generic_adapter_uses_validated_receiver_context.snap
@@ -39,6 +39,5 @@ type _lisAdapter_Keyed_Box_0[T comparable] struct {
 }
 
 func (a _lisAdapter_Keyed_Box_0[T]) get() lisette.Option[[2]T] {
-	option_1 := lisette.OptionFromCommaOk[[2]T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[[2]T](a.inner.get())
 }

--- a/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_partial_fn_arg_adapts_to_tagged_generic_param.snap
@@ -21,12 +21,10 @@ func main() {
 	cb_1 := Fallible
 	_ = Resolve(42, func(arg0 int) lisette.Partial[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Partial[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakePartialBoth[int, Face](ret_2, ret_3)
+			return lisette.MakePartialBoth[int, Face](ret_2, ret_3)
 		} else {
-			result_4 = lisette.MakePartialOk[int, Face](ret_2)
+			return lisette.MakePartialOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 }

--- a/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_pointer_err_fn_arg_adapts_to_tagged_generic_param.snap
@@ -21,12 +21,10 @@ func main() {
 	cb_1 := Parser
 	_ = Resolve(0, func(arg0 int) lisette.Result[int, *strconv.NumError] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, *strconv.NumError]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, *strconv.NumError](ret_3)
+			return lisette.MakeResultErr[int, *strconv.NumError](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, *strconv.NumError](ret_2)
+			return lisette.MakeResultOk[int, *strconv.NumError](ret_2)
 		}
-		return result_4
 	})
 }

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_through_variadic_generic_param.snap
@@ -21,12 +21,10 @@ func main() {
 	cb_1 := Resultant
 	_ = Resolve(0, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+			return lisette.MakeResultErr[int, Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+			return lisette.MakeResultOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 }

--- a/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_fn_arg_adapts_to_tagged_generic_param.snap
@@ -21,12 +21,10 @@ func main() {
 	cb_1 := Resultant
 	_ = Resolve(42, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+			return lisette.MakeResultErr[int, Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+			return lisette.MakeResultOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 }

--- a/tests/spec/build/snapshots/lowered_result_lambda_arg_adapts_to_tagged_generic_param.snap
+++ b/tests/spec/build/snapshots/lowered_result_lambda_arg_adapts_to_tagged_generic_param.snap
@@ -19,12 +19,10 @@ func main() {
 	}
 	_ = Resolve(42, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
-		var result_4 lisette.Result[int, Face]
 		if ret_3 != nil {
-			result_4 = lisette.MakeResultErr[int, Face](ret_3)
+			return lisette.MakeResultErr[int, Face](ret_3)
 		} else {
-			result_4 = lisette.MakeResultOk[int, Face](ret_2)
+			return lisette.MakeResultOk[int, Face](ret_2)
 		}
-		return result_4
 	})
 }

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
@@ -21,22 +21,20 @@ func Holder_Resolve[R any, E any](_ Holder, default_ R, _ ...func(int) lisette.R
 
 func main() {
 	fns := []func(int) (int, Face){Resultant}
-	_arg_8 := Holder{}
+	_arg_7 := Holder{}
 	src_1 := fns
 	adapted_2 := make([]func(int) lisette.Result[int, Face], len(src_1))
 	for i, cb_3 := range src_1 {
 		cb_4 := cb_3
 		adapted_2[i] = func(arg0 int) lisette.Result[int, Face] {
 			ret_5, ret_6 := cb_4(arg0)
-			var result_7 lisette.Result[int, Face]
 			if ret_6 != nil {
-				result_7 = lisette.MakeResultErr[int, Face](ret_6)
+				return lisette.MakeResultErr[int, Face](ret_6)
 			} else {
-				result_7 = lisette.MakeResultOk[int, Face](ret_5)
+				return lisette.MakeResultOk[int, Face](ret_5)
 			}
-			return result_7
 		}
 	}
-	rez := Holder_Resolve[int, Face](_arg_8, 0, adapted_2...)
+	rez := Holder_Resolve[int, Face](_arg_7, 0, adapted_2...)
 	_ = rez
 }

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_param_adapts_each_element.snap
@@ -25,13 +25,11 @@ func main() {
 		cb_4 := cb_3
 		adapted_2[i] = func(arg0 int) lisette.Result[int, Face] {
 			ret_5, ret_6 := cb_4(arg0)
-			var result_7 lisette.Result[int, Face]
 			if ret_6 != nil {
-				result_7 = lisette.MakeResultErr[int, Face](ret_6)
+				return lisette.MakeResultErr[int, Face](ret_6)
 			} else {
-				result_7 = lisette.MakeResultOk[int, Face](ret_5)
+				return lisette.MakeResultOk[int, Face](ret_5)
 			}
-			return result_7
 		}
 	}
 	_ = Resolve[int, Face](0, adapted_2...)

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -949,6 +949,50 @@ fn test() -> int {
 }
 
 #[test]
+fn boolean_branch_assign_collapses_to_condition() {
+    let input = r#"
+fn test(a: int, b: int) -> bool {
+  let direct = if a > 0 { true } else { false }
+  let and_arm = if a > 0 { b > 1 } else { false }
+  let or_arm = if a > 0 { true } else { b > 1 }
+  let negated = if a > 0 { false } else { true }
+  direct && and_arm && or_arm && negated
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn float_binding_from_block_keeps_var_declaration() {
+    let input = r#"
+fn test() -> float64 {
+  let scaled: float64 = { 42 }
+  scaled
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn boolean_match_assign_collapses_to_condition() {
+    let input = r#"
+enum Node {
+  Number(int),
+  Null,
+}
+
+fn test(node: Node) -> bool {
+  let matched = match node {
+    Number(n) => n == 42,
+    _ => false,
+  }
+  matched
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn match_multiple_with_same_vars() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
+++ b/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
@@ -17,15 +17,14 @@ func double(x int) (int, bool) {
 }
 
 func run() (int, bool) {
-	_arg_4 := lisette.MakeOptionSome(2)
+	_arg_3 := lisette.MakeOptionSome(2)
 	cb_1 := double
-	tagged_3 := func(arg0 int) lisette.Option[int] {
-		option_2 := lisette.OptionFromCommaOk[int](cb_1(arg0))
-		return option_2
+	tagged_2 := func(arg0 int) lisette.Option[int] {
+		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	v_5 := lisette.OptionAndThen(_arg_4, tagged_3)
-	if v_5.Tag == lisette.OptionSome {
-		return v_5.SomeVal, true
+	v_4 := lisette.OptionAndThen(_arg_3, tagged_2)
+	if v_4.Tag == lisette.OptionSome {
+		return v_4.SomeVal, true
 	}
 	return 0, false
 }

--- a/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
+++ b/tests/spec/emit/snapshots/aliased_result_return_adapts_to_generic_interface.snap
@@ -55,11 +55,9 @@ type _lisAdapter_Bar_Foo_0 struct {
 
 func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
 	ret_1, ret_2 := a.inner.get()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		return lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return lisette.MakeResultOk[int, error](ret_1)
 	}
-	return result_3
 }

--- a/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_return_wraps_concrete_result_impl.snap
@@ -58,11 +58,9 @@ type _lisAdapter_Bar_Foo_0 struct {
 
 func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
 	ret_1, ret_2 := a.inner.get()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		return lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return lisette.MakeResultOk[int, error](ret_1)
 	}
-	return result_3
 }

--- a/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
+++ b/tests/spec/emit/snapshots/bare_param_interface_wraps_nullable_option_impl.snap
@@ -64,6 +64,5 @@ type _lisAdapter_Bar_Box_0 struct {
 
 func (a _lisAdapter_Bar_Box_0) get() lisette.Option[*Thing] {
 	raw_1 := a.inner.get()
-	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
-	return option_2
+	return lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
 }

--- a/tests/spec/emit/snapshots/boolean_branch_assign_collapses_to_condition.snap
+++ b/tests/spec/emit/snapshots/boolean_branch_assign_collapses_to_condition.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(a: int, b: int) -> bool {
+    let direct = if a > 0 { true } else { false }
+    let and_arm = if a > 0 { b > 1 } else { false }
+    let or_arm = if a > 0 { true } else { b > 1 }
+    let negated = if a > 0 { false } else { true }
+    direct && and_arm && or_arm && negated
+  }
+---
+package main
+
+func test(a, b int) bool {
+	direct := a > 0
+	and_arm := (a > 0) && (b > 1)
+	or_arm := a > 0 || b > 1
+	negated := !(a > 0)
+	return direct && and_arm && or_arm && negated
+}

--- a/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
+++ b/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  enum Node {
+    Number(int),
+    Null,
+  }
+  
+  fn test(node: Node) -> bool {
+    let matched = match node {
+      Number(n) => n == 42,
+      _ => false,
+    }
+    matched
+  }
+---
+package main
+
+func MakeNodeNumber(arg0 int) Node {
+	return Node{Tag: NodeNumber, Number: arg0}
+}
+
+func MakeNodeNull() Node {
+	return Node{Tag: NodeNull}
+}
+
+type NodeTag int
+
+const (
+	NodeNumber NodeTag = iota
+	NodeNull
+)
+
+type Node struct {
+	Tag    NodeTag
+	Number int
+}
+
+func test(node Node) bool {
+	matched := (node.Tag == NodeNumber) && (node.Number == 42)
+	return matched
+}

--- a/tests/spec/emit/snapshots/float_binding_from_block_keeps_var_declaration.snap
+++ b/tests/spec/emit/snapshots/float_binding_from_block_keeps_var_declaration.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test() -> float64 {
+    let scaled: float64 = { 42 }
+    scaled
+  }
+---
+package main
+
+func test() float64 {
+	var scaled float64
+	scaled = 42
+	return scaled
+}

--- a/tests/spec/emit/snapshots/generic_adapter_captures_alias_parameter_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_alias_parameter_bound.snap
@@ -72,6 +72,5 @@ type _lisAdapter_Bar_Box_0[T comparable] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[Wrapped[T]] {
-	option_1 := lisette.OptionFromCommaOk[Wrapped[T]](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[Wrapped[T]](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_captures_complete_caller_context.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_complete_caller_context.snap
@@ -88,6 +88,5 @@ type _lisAdapter_Bar_Box_0[U any, T Holder[U]] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0[U, T]) get() lisette.Option[T] {
-	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_captures_interface_parameter_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_captures_interface_parameter_bound.snap
@@ -91,11 +91,9 @@ type _lisAdapter_Bar_Box_0[T comparable] struct {
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[Foo[T]] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[Foo[T]]
 	if ret_2 && !lisette.IsNilInterface(ret_1) {
-		option_3 = lisette.MakeOptionSome[Foo[T]](ret_1)
+		return lisette.MakeOptionSome[Foo[T]](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[Foo[T]]()
+		return lisette.MakeOptionNone[Foo[T]]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_copies_context_bound_for_composite_arg.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_copies_context_bound_for_composite_arg.snap
@@ -68,6 +68,5 @@ type _lisAdapter_Keyed_Box_0[T comparable] struct {
 }
 
 func (a _lisAdapter_Keyed_Box_0[T]) get() lisette.Option[[2]T] {
-	option_1 := lisette.OptionFromCommaOk[[2]T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[[2]T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_copies_sibling_referencing_bound.snap
@@ -93,6 +93,5 @@ type _lisAdapter_Wrap_Box_0[A any, B Holder[A]] struct {
 }
 
 func (a _lisAdapter_Wrap_Box_0[A, B]) get() lisette.Option[A] {
-	option_1 := lisette.OptionFromCommaOk[A](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[A](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_declares_nested_type_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_declares_nested_type_parameter.snap
@@ -66,6 +66,5 @@ type _lisAdapter_Bar_Box_0[T any] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[[]T] {
-	option_1 := lisette.OptionFromCommaOk[[]T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[[]T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_declares_repeated_type_parameter_once.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_declares_repeated_type_parameter_once.snap
@@ -71,6 +71,5 @@ type _lisAdapter_Pair_Box_0[T any] struct {
 }
 
 func (a _lisAdapter_Pair_Box_0[T]) get() lisette.Option[T] {
-	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
@@ -94,11 +94,9 @@ type _lisAdapter_Bar_Box_0[T comparable] struct {
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[map[Maybe[T]]int] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[map[Maybe[T]]int]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[map[Maybe[T]]int](ret_1)
+		return lisette.MakeOptionSome[map[Maybe[T]]int](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[map[Maybe[T]]int]()
+		return lisette.MakeOptionNone[map[Maybe[T]]int]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_pointer_map_key_stays_unconstrained.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_pointer_map_key_stays_unconstrained.snap
@@ -75,11 +75,9 @@ type _lisAdapter_Bar_Box_0[T any] struct {
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[map[*T]int] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[map[*T]int]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[map[*T]int](ret_1)
+		return lisette.MakeOptionSome[map[*T]int](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[map[*T]int]()
+		return lisette.MakeOptionNone[map[*T]int]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_preserves_nested_parameter_constraint.snap
@@ -67,11 +67,9 @@ type _lisAdapter_Bar_Box_0[K comparable, V any] struct {
 
 func (a _lisAdapter_Bar_Box_0[K, V]) get() lisette.Option[map[K]V] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[map[K]V]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[map[K]V](ret_1)
+		return lisette.MakeOptionSome[map[K]V](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[map[K]V]()
+		return lisette.MakeOptionNone[map[K]V]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_struct_map_key_requires_field_comparability.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_struct_map_key_requires_field_comparability.snap
@@ -79,11 +79,9 @@ type _lisAdapter_Bar_Box_0[A comparable, B comparable] struct {
 
 func (a _lisAdapter_Bar_Box_0[A, B]) get() lisette.Option[map[Pair[A, B]]int] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[map[Pair[A, B]]int]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[map[Pair[A, B]]int](ret_1)
+		return lisette.MakeOptionSome[map[Pair[A, B]]int](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[map[Pair[A, B]]int]()
+		return lisette.MakeOptionNone[map[Pair[A, B]]int]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_receiver_generic_bounds.snap
@@ -79,11 +79,9 @@ type _lisAdapter_Bar_Box_0[K comparable] struct {
 
 func (a _lisAdapter_Bar_Box_0[K]) get() lisette.Option[map[K]int] {
 	ret_1, ret_2 := a.inner.get()
-	var option_3 lisette.Option[map[K]int]
 	if ret_2 && ret_1 != nil {
-		option_3 = lisette.MakeOptionSome[map[K]int](ret_1)
+		return lisette.MakeOptionSome[map[K]int](ret_1)
 	} else {
-		option_3 = lisette.MakeOptionNone[map[K]int]()
+		return lisette.MakeOptionNone[map[K]int]()
 	}
-	return option_3
 }

--- a/tests/spec/emit/snapshots/generic_adapter_uses_separate_caller_contexts.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_uses_separate_caller_contexts.snap
@@ -80,8 +80,7 @@ type _lisAdapter_Bar_Box_0[T comparable] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[T] {
-	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[T](a.inner.get())
 }
 
 type _lisAdapter_Bar_Box_1[T any] struct {
@@ -89,6 +88,5 @@ type _lisAdapter_Bar_Box_1[T any] struct {
 }
 
 func (a _lisAdapter_Bar_Box_1[T]) get() lisette.Option[T] {
-	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_adapts_concrete_result_impl.snap
@@ -51,11 +51,9 @@ type _lisAdapter_Bar_Foo_0 struct {
 
 func (a _lisAdapter_Bar_Foo_0) get() lisette.Result[int, error] {
 	ret_1, ret_2 := a.inner.get()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		return lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return lisette.MakeResultOk[int, error](ret_1)
 	}
-	return result_3
 }

--- a/tests/spec/emit/snapshots/generic_error_interface_consumed_generically.snap
+++ b/tests/spec/emit/snapshots/generic_error_interface_consumed_generically.snap
@@ -66,11 +66,9 @@ type _lisAdapter_Bar_Foo_0 struct {
 
 func (a _lisAdapter_Bar_Foo_0) get(arg0 bool) lisette.Result[int, error] {
 	ret_1, ret_2 := a.inner.get(arg0)
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		return lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return lisette.MakeResultOk[int, error](ret_1)
 	}
-	return result_3
 }

--- a/tests/spec/emit/snapshots/generic_struct_adapter_declares_its_type_parameters.snap
+++ b/tests/spec/emit/snapshots/generic_struct_adapter_declares_its_type_parameters.snap
@@ -70,6 +70,5 @@ type _lisAdapter_Bar_Box_0[T any] struct {
 }
 
 func (a _lisAdapter_Bar_Box_0[T]) get() lisette.Option[T] {
-	option_1 := lisette.OptionFromCommaOk[T](a.inner.get())
-	return option_1
+	return lisette.OptionFromCommaOk[T](a.inner.get())
 }

--- a/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
+++ b/tests/spec/emit/snapshots/match_multiple_with_same_vars.snap
@@ -22,10 +22,8 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
 	pair := lisette.MakeTuple2[int, int](10, 20)
-	var first int
-	first = pair.First + pair.Second
+	first := pair.First + pair.Second
 	nested := lisette.MakeTuple2[lisette.Tuple2[int, int], lisette.Tuple2[int, int]](lisette.MakeTuple2[int, int](1, 2), lisette.MakeTuple2[int, int](3, 4))
-	var second int
-	second = nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
+	second := nested.First.First + nested.First.Second + nested.Second.First + nested.Second.Second
 	return first + second
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_struct_no_outer_leak.snap
@@ -28,7 +28,6 @@ func test() int {
 		F0: 1,
 		F1: 2,
 	}
-	var sum int
-	sum = p.F0 + p.F1
+	sum := p.F0 + p.F1
 	return a + b + sum
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
@@ -23,12 +23,11 @@ func main() {
 		return 0, false
 	}
 	opt := lisette.MakeOptionSome(1)
-	_arg_6 := opt
+	_arg_5 := opt
 	cb_3 := g
-	tagged_5 := func(arg0 int) lisette.Option[int] {
-		option_4 := lisette.OptionFromCommaOk[int](cb_3(arg0))
-		return option_4
+	tagged_4 := func(arg0 int) lisette.Option[int] {
+		return lisette.OptionFromCommaOk[int](cb_3(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_6, tagged_5)
+	r := lisette.OptionAndThen(_arg_5, tagged_4)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
@@ -21,12 +21,11 @@ func doubler(x int) (int, bool) {
 func main() {
 	g := doubler
 	opt := lisette.MakeOptionSome(1)
-	_arg_4 := opt
+	_arg_3 := opt
 	cb_1 := g
-	tagged_3 := func(arg0 int) lisette.Option[int] {
-		option_2 := lisette.OptionFromCommaOk[int](cb_1(arg0))
-		return option_2
+	tagged_2 := func(arg0 int) lisette.Option[int] {
+		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_4, tagged_3)
+	r := lisette.OptionAndThen(_arg_3, tagged_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
@@ -19,12 +19,11 @@ func doubler(x int) (int, bool) {
 
 func main() {
 	opt := lisette.MakeOptionSome(1)
-	_arg_4 := opt
+	_arg_3 := opt
 	cb_1 := doubler
-	tagged_3 := func(arg0 int) lisette.Option[int] {
-		option_2 := lisette.OptionFromCommaOk[int](cb_1(arg0))
-		return option_2
+	tagged_2 := func(arg0 int) lisette.Option[int] {
+		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_4, tagged_3)
+	r := lisette.OptionAndThen(_arg_3, tagged_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
+++ b/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
@@ -15,19 +15,18 @@ import lisette "github.com/ivov/lisette/prelude"
 func main() {
 	cb_1 := lisette.OptionAndThen[int, int]
 	f := func(arg0 lisette.Option[int], arg1 func(int) (int, bool)) (int, bool) {
-		tagged_3 := func(arg0 int) lisette.Option[int] {
-			option_2 := lisette.OptionFromCommaOk[int](arg1(arg0))
-			return option_2
+		tagged_2 := func(arg0 int) lisette.Option[int] {
+			return lisette.OptionFromCommaOk[int](arg1(arg0))
 		}
-		opt_4 := cb_1(arg0, tagged_3)
-		if opt_4.Tag == lisette.OptionSome {
-			return opt_4.SomeVal, true
+		opt_3 := cb_1(arg0, tagged_2)
+		if opt_3.Tag == lisette.OptionSome {
+			return opt_3.SomeVal, true
 		}
 		return 0, false
 	}
-	option_5 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) (int, bool) {
+	option_4 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) (int, bool) {
 		return v * 2, true
 	}))
-	x := option_5
+	x := option_4
 	_ = x
 }

--- a/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
@@ -89,11 +89,9 @@ type _lisAdapter_Boom_Failing_0 struct {
 
 func (a _lisAdapter_Boom_Failing_0) get() lisette.Result[int, error] {
 	ret_2, ret_3 := a.inner.get()
-	var result_4 lisette.Result[int, error]
 	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[int, error](ret_3)
+		return lisette.MakeResultErr[int, error](ret_3)
 	} else {
-		result_4 = lisette.MakeResultOk[int, error](ret_2)
+		return lisette.MakeResultOk[int, error](ret_2)
 	}
-	return result_4
 }

--- a/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
@@ -56,11 +56,9 @@ type _lisAdapter_Boom_Failing_0 struct {
 
 func (a _lisAdapter_Boom_Failing_0) get() lisette.Result[int, error] {
 	ret_1, ret_2 := a.inner.get()
-	var result_3 lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		return lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		return lisette.MakeResultOk[int, error](ret_1)
 	}
-	return result_3
 }

--- a/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
+++ b/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
@@ -68,6 +68,5 @@ type _lisAdapter_Bar_Box_0 struct {
 
 func (a _lisAdapter_Bar_Box_0) get() lisette.Option[*Thing] {
 	raw_1 := a.inner.get()
-	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
-	return option_2
+	return lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
 }


### PR DESCRIPTION
Result temps that were declared, assigned in each branch, and then consumed now collapse into their direct form.

Before:

```go
ret_1, ret_2 := a.inner.get()
var result_3 lisette.Result[int, error]
if ret_2 != nil {
	result_3 = lisette.MakeResultErr[int, error](ret_2)
} else {
	result_3 = lisette.MakeResultOk[int, error](ret_1)
}
return result_3
```

After:

```go
ret_1, ret_2 := a.inner.get()
if ret_2 != nil {
	return lisette.MakeResultErr[int, error](ret_2)
} else {
	return lisette.MakeResultOk[int, error](ret_1)
}
```

