### PR TITLE
feat: SSA return view analysis for bindgen

### DIFF
--- a/bindgen/internal/cli/generate_std.go
+++ b/bindgen/internal/cli/generate_std.go
@@ -53,7 +53,7 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 	for _, target := range targets {
 		targetGroup.Go(func() error {
 			loadStart := time.Now()
-			pkgs, err := extract.LoadStdPackages(target.goos, target.goarch, shouldSkipPackage)
+			pkgs, err := extract.LoadStdPackages(target.goos, target.goarch, SkipStdPackage)
 			if err != nil {
 				return fmt.Errorf("target %s: failed to load packages: %w", target, err)
 			}
@@ -129,7 +129,8 @@ func GenerateStd(ctx context.Context, outDir, lisetteVersion, goVersion string, 
 	}, nil
 }
 
-func shouldSkipPackage(pkg string) bool {
+// SkipStdPackage drops the std packages bindgen never binds.
+func SkipStdPackage(pkg string) bool {
 	return strings.Contains(pkg, "/internal") ||
 		strings.HasPrefix(pkg, "internal/") ||
 		strings.Contains(pkg, "/vendor/") ||

--- a/bindgen/internal/config/config.go
+++ b/bindgen/internal/config/config.go
@@ -36,6 +36,10 @@ type TypeOverrides struct {
 	NeverReturn      map[string][]string            `json:"never_return"`
 	PartialResult    map[string][]string            `json:"partial_result"`
 	MutatesParam     map[string]map[string][]string `json:"mutates_param"`
+	// ReturnsViewOf curates view aliasing the SSA result walk cannot see:
+	// "<result>:<param>" for whole-value sharing, "<result>:[<param>]" for
+	// element-level, "recv" for the receiver, an empty list for fresh.
+	ReturnsViewOf map[string]map[string][]string `json:"returns_view_of"`
 	// NilableParam declares pointer/interface parameters that accept nil in Go
 	// (e.g. `nil` means "use the default"), so they should be `Option<Ref<T>>`
 	// instead of `Ref<T>`.
@@ -208,6 +212,20 @@ func (c *Config) MutatingParams(pkg, name string) []string {
 		return nil
 	}
 	return nestedParams(c.Overrides.Types.MutatesParam, pkg, name)
+}
+
+// ViewOverrides returns the curated view-aliasing entries, and whether an
+// entry exists at all, since an empty entry asserts freshness.
+func (c *Config) ViewOverrides(pkg, name string) ([]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+	funcs, ok := lookupWithGlobNested(c.Overrides.Types.ReturnsViewOf, pkg)
+	if !ok {
+		return nil, false
+	}
+	entries, ok := funcs[name]
+	return entries, ok
 }
 
 // NilableParams returns the list of parameter names that should be wrapped in

--- a/bindgen/internal/config/config_test.go
+++ b/bindgen/internal/config/config_test.go
@@ -92,4 +92,37 @@ func TestNilConfigAccessorsDoNotPanic(t *testing.T) {
 	if cfg.IsClosedDomain("io", "Foo") {
 		t.Error("IsClosedDomain")
 	}
+	if _, ok := cfg.ViewOverrides("io", "Foo"); ok {
+		t.Error("ViewOverrides")
+	}
+}
+
+func TestViewOverridesDistinguishEmptyFromAbsent(t *testing.T) {
+	cfg := &Config{
+		Overrides: Overrides{
+			Types: TypeOverrides{
+				ReturnsViewOf: map[string]map[string][]string{
+					"syscall": {
+						"Aliasing": {"0:buf", "1:[recv]"},
+						"Fresh":    {},
+					},
+				},
+			},
+		},
+	}
+
+	entries, ok := cfg.ViewOverrides("syscall", "Aliasing")
+	if !ok || len(entries) != 2 {
+		t.Errorf("Aliasing: got %v, %v", entries, ok)
+	}
+	entries, ok = cfg.ViewOverrides("syscall", "Fresh")
+	if !ok || len(entries) != 0 {
+		t.Errorf("Fresh: got %v, %v", entries, ok)
+	}
+	if _, ok := cfg.ViewOverrides("syscall", "Absent"); ok {
+		t.Error("Absent: expected no entry")
+	}
+	if _, ok := cfg.ViewOverrides("os", "Aliasing"); ok {
+		t.Error("wrong package: expected no entry")
+	}
 }

--- a/bindgen/internal/convert/mutation.go
+++ b/bindgen/internal/convert/mutation.go
@@ -1,11 +1,15 @@
-// SSA parameter-mutation analysis: which parameters a function writes through.
+// SSA parameter-mutation analysis: which parameters a function writes through,
+// and which of its results are views of them.
 package convert
 
 import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"slices"
 	"sort"
+	"strconv"
+	"strings"
 
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
@@ -21,11 +25,90 @@ func (m FunctionMutation) Mutates(index int) bool {
 	return index < len(m.Params) && m.Params[index]
 }
 
+// ViewDepth says whether shared storage is the result itself or sits inside it.
+type ViewDepth uint8
+
+const (
+	DepthNone ViewDepth = iota
+	DepthWhole
+	DepthElement
+)
+
+// joinDepth keeps the outermost sharing.
+func joinDepth(a, b ViewDepth) ViewDepth {
+	if a == DepthNone {
+		return b
+	}
+	if b == DepthNone {
+		return a
+	}
+	return min(a, b)
+}
+
+// FunctionViews is indexed by Go signature result.
+type FunctionViews struct {
+	Results  []ResultView
+	Analyzed bool // false when SSA never saw a body
+}
+
+func (v FunctionViews) Fresh() bool {
+	for _, result := range v.Results {
+		if !result.Fresh() {
+			return false
+		}
+	}
+	return true
+}
+
+// ResultView is one result's aliasing set. Opaque: the walk met an
+// unsupported operation, so the worst case applies unless an override
+// completes it. Shared: can expose storage belonging to no argument.
+type ResultView struct {
+	Params   []ViewDepth // indexed by signature parameter, DepthNone when fresh
+	Receiver ViewDepth
+	Opaque   bool
+	Shared   bool
+}
+
+func (v ResultView) Param(index int) ViewDepth {
+	if index < len(v.Params) {
+		return v.Params[index]
+	}
+	return DepthNone
+}
+
+func (v ResultView) Fresh() bool {
+	if v.Opaque || v.Shared || v.Receiver != DepthNone {
+		return false
+	}
+	for _, depth := range v.Params {
+		if depth != DepthNone {
+			return false
+		}
+	}
+	return true
+}
+
+func (v ResultView) clone() ResultView {
+	return ResultView{Params: slices.Clone(v.Params), Receiver: v.Receiver, Opaque: v.Opaque, Shared: v.Shared}
+}
+
+func (v *ResultView) setParam(index, paramCount int, depth ViewDepth) {
+	if index < 0 || index >= paramCount {
+		return
+	}
+	if v.Params == nil {
+		v.Params = make([]ViewDepth, paramCount)
+	}
+	v.Params[index] = joinDepth(v.Params[index], depth)
+}
+
 // MutationAnalysis is precomputed at construction and read-only afterwards,
 // since `generate_std` converts packages concurrently.
 type MutationAnalysis struct {
 	program    *ssa.Program
 	verdicts   map[*types.Func]FunctionMutation
+	views      map[*types.Func]FunctionViews
 	summaries  map[*ssa.Function]*mutationSummary
 	inProgress map[*ssa.Function]bool
 	// sawCycle: a summary was read before it was finished, so settle must run.
@@ -37,6 +120,175 @@ type MutationAnalysis struct {
 type mutationSummary struct {
 	params   map[int]reachMode
 	freeVars map[int]reachMode
+	results  map[int]*aliasSources
+	// handOut: what the function passes to callees it cannot name.
+	handOut *aliasSources
+	// freeVarStores: what the function stores through each captured variable.
+	freeVarStores map[int]*captureStores
+}
+
+func (m *mutationSummary) captureStoresFor(index int) *captureStores {
+	if m.freeVarStores == nil {
+		m.freeVarStores = map[int]*captureStores{}
+	}
+	buckets, ok := m.freeVarStores[index]
+	if !ok {
+		buckets = &captureStores{}
+		m.freeVarStores[index] = buckets
+	}
+	return buckets
+}
+
+// captureStores splits capture writes by destination, since rebinding and
+// element stores sit at different depths.
+type captureStores struct {
+	rebound  *aliasSources
+	elements *aliasSources
+}
+
+func newAliasSources() *aliasSources {
+	return &aliasSources{params: map[int]viewLevel{}, freeVars: map[int]viewLevel{}}
+}
+
+func (c *captureStores) reboundSources() *aliasSources {
+	if c.rebound == nil {
+		c.rebound = newAliasSources()
+	}
+	return c.rebound
+}
+
+func (c *captureStores) elementSources() *aliasSources {
+	if c.elements == nil {
+		c.elements = newAliasSources()
+	}
+	return c.elements
+}
+
+func (c *captureStores) weight() int {
+	total := 0
+	if c.rebound != nil {
+		total += c.rebound.weight()
+	}
+	if c.elements != nil {
+		total += c.elements.weight()
+	}
+	return total
+}
+
+func (m *mutationSummary) handOutSources() *aliasSources {
+	if m.handOut == nil {
+		m.handOut = &aliasSources{params: map[int]viewLevel{}, freeVars: map[int]viewLevel{}}
+	}
+	return m.handOut
+}
+
+// aliasSources is indexed by SSA parameter (receiver is 0) and free variable.
+type aliasSources struct {
+	params   map[int]viewLevel
+	freeVars map[int]viewLevel
+	opaque   bool
+	shared   bool
+}
+
+// viewLevel counts steps inside the result, not telling deeper levels apart.
+type viewLevel uint8
+
+const (
+	levelWhole viewLevel = iota
+	levelElement
+	levelDeep
+)
+
+// maxPendingExtractions bounds the extraction debt, past which the walk goes opaque.
+const maxPendingExtractions = 2
+
+func raiseLevel(level viewLevel, steps int) viewLevel {
+	raised := int(level) + steps
+	if raised > int(levelDeep) {
+		return levelDeep
+	}
+	return viewLevel(raised)
+}
+
+func levelForSteps(steps int) viewLevel {
+	return raiseLevel(levelWhole, steps)
+}
+
+// insertLevel places contents one level in, unless a pending extraction reads them back out.
+func insertLevel(level viewLevel, pending int) (viewLevel, int) {
+	if pending > 0 {
+		return level, pending - 1
+	}
+	return raiseLevel(level, 1), 0
+}
+
+// applyLevel reports imprecise when a deep fact would need its exact count.
+func applyLevel(level viewLevel, pending int, fact viewLevel) (viewLevel, int, bool) {
+	if fact == levelDeep {
+		if pending > 0 {
+			return level, pending, false
+		}
+		return levelDeep, 0, true
+	}
+	consumed := min(pending, int(fact))
+	return raiseLevel(level, int(fact)-consumed), pending - consumed, true
+}
+
+func viewDepthForLevel(level viewLevel) ViewDepth {
+	if level == levelWhole {
+		return DepthWhole
+	}
+	return DepthElement
+}
+
+func (s *aliasSources) markOpaque() {
+	s.opaque = true
+}
+
+func (s *aliasSources) markShared() {
+	s.shared = true
+}
+
+func (s *aliasSources) addParam(index int, level viewLevel) {
+	if existing, ok := s.params[index]; !ok || level < existing {
+		s.params[index] = level
+	}
+}
+
+func (s *aliasSources) addFreeVar(index int, level viewLevel) {
+	if existing, ok := s.freeVars[index]; !ok || level < existing {
+		s.freeVars[index] = level
+	}
+}
+
+func (m *mutationSummary) result(index int) *aliasSources {
+	if m.results == nil {
+		m.results = map[int]*aliasSources{}
+	}
+	sources, ok := m.results[index]
+	if !ok {
+		sources = &aliasSources{params: map[int]viewLevel{}, freeVars: map[int]viewLevel{}}
+		m.results[index] = sources
+	}
+	return sources
+}
+
+// weight is monotone: findings only ever appear, lower toward whole, or mark.
+func (s *aliasSources) weight() int {
+	total := 0
+	for _, level := range s.params {
+		total += int(levelDeep) + 1 - int(level)
+	}
+	for _, level := range s.freeVars {
+		total += int(levelDeep) + 1 - int(level)
+	}
+	if s.opaque {
+		total++
+	}
+	if s.shared {
+		total++
+	}
+	return total
 }
 
 // reachMode says whether a write replaced what the parameter points at or wrote
@@ -65,6 +317,15 @@ func (m *mutationSummary) weight() int {
 	for _, mode := range m.freeVars {
 		total += int(mode)
 	}
+	for _, sources := range m.results {
+		total += sources.weight()
+	}
+	if m.handOut != nil {
+		total += m.handOut.weight()
+	}
+	for _, buckets := range m.freeVarStores {
+		total += buckets.weight()
+	}
 	return total
 }
 
@@ -76,6 +337,7 @@ func NewMutationAnalysis(nilness *NilnessAnalysis, roots []*packages.Package) *M
 	analysis := &MutationAnalysis{
 		program:    nilness.program,
 		verdicts:   make(map[*types.Func]FunctionMutation),
+		views:      make(map[*types.Func]FunctionViews),
 		summaries:  make(map[*ssa.Function]*mutationSummary),
 		inProgress: make(map[*ssa.Function]bool),
 	}
@@ -135,6 +397,19 @@ func (a *MutationAnalysis) Function(obj types.Object) (FunctionMutation, bool) {
 	return facts, ok
 }
 
+// Views reports the derived fact alone, before ResolveViews layers the rest on.
+func (a *MutationAnalysis) Views(obj types.Object) (FunctionViews, bool) {
+	if a == nil {
+		return FunctionViews{}, false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return FunctionViews{}, false
+	}
+	facts, ok := a.views[fn]
+	return facts, ok
+}
+
 func (a *MutationAnalysis) record(fn *types.Func) {
 	if _, done := a.verdicts[fn]; done {
 		return
@@ -148,7 +423,8 @@ func (a *MutationAnalysis) record(fn *types.Func) {
 
 	ssaFn := a.program.FuncValue(fn)
 	if ssaFn == nil || functionBody(ssaFn) == nil {
-		a.verdicts[fn] = facts // the curated map and the name heuristic decide
+		a.verdicts[fn] = facts        // the curated map and the name heuristic decide
+		a.views[fn] = FunctionViews{} // the override layer and the worst case decide
 		return
 	}
 
@@ -169,6 +445,32 @@ func (a *MutationAnalysis) record(fn *types.Func) {
 		}
 	}
 	a.verdicts[fn] = facts
+	a.views[fn] = recordedViews(summary, sig)
+}
+
+func recordedViews(summary *mutationSummary, sig *types.Signature) FunctionViews {
+	views := FunctionViews{Analyzed: true, Results: make([]ResultView, sig.Results().Len())}
+	offset := 0
+	if sig.Recv() != nil {
+		offset = 1
+	}
+	paramCount := sig.Params().Len()
+	for resultIndex, sources := range summary.results {
+		if resultIndex < 0 || resultIndex >= len(views.Results) {
+			continue
+		}
+		view := &views.Results[resultIndex]
+		view.Opaque = sources.opaque
+		view.Shared = sources.shared
+		for index, level := range sources.params {
+			if sig.Recv() != nil && index == 0 {
+				view.Receiver = joinDepth(view.Receiver, viewDepthForLevel(level))
+				continue
+			}
+			view.setParam(index-offset, paramCount, viewDepthForLevel(level))
+		}
+	}
+	return views
 }
 
 func (a *MutationAnalysis) summarize(fn *ssa.Function) *mutationSummary {
@@ -194,6 +496,12 @@ func (a *MutationAnalysis) walk(fn *ssa.Function, summary *mutationSummary) {
 	defer delete(a.inProgress, fn)
 	for _, block := range body.Blocks {
 		for _, instruction := range block.Instrs {
+			if returned, ok := instruction.(*ssa.Return); ok {
+				a.recordViews(body, returned, summary)
+				continue
+			}
+			a.recordHandOuts(body, instruction, summary)
+			a.recordCaptureStores(body, instruction, summary)
 			a.recordWrites(body, instruction, summary)
 		}
 	}
@@ -313,6 +621,1080 @@ func isReceiverMutationAxiom(method *types.Func) bool {
 		return false
 	}
 	return method.Pkg().Path() == "sort" && qualifiedFunctionName(method) == "Interface.Swap"
+}
+
+func (a *MutationAnalysis) recordViews(fn *ssa.Function, returned *ssa.Return, summary *mutationSummary) {
+	for index, operand := range returned.Results {
+		if !containerBearing(operand.Type()) {
+			continue
+		}
+		a.markValueSources(fn, operand, summary.result(index), levelWhole, 0, make(map[sourceVisit]bool))
+	}
+}
+
+// markValueSources: a copied aggregate shares only through its fields, one level in.
+func (a *MutationAnalysis) markValueSources(fn *ssa.Function, value ssa.Value, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) {
+	if value != nil && isAggregateValue(value.Type()) {
+		level, pending = insertLevel(level, pending)
+	}
+	a.markSources(fn, value, sources, level, pending, seen)
+}
+
+func isAggregateValue(t types.Type) bool {
+	if parameter, ok := t.(*types.TypeParam); ok {
+		core := coreType(parameter)
+		if core == nil {
+			return false
+		}
+		t = core
+	}
+	switch t.Underlying().(type) {
+	case *types.Struct, *types.Array:
+		return true
+	}
+	return false
+}
+
+// sourceVisit keys the visited set, since each state gives different answers.
+type sourceVisit struct {
+	value   ssa.Value
+	level   viewLevel
+	pending int
+}
+
+// markSources walks back from a returned value to the sources it can share
+// storage with. Fail-closed: every value kind is precise, fresh (nil Const),
+// shared (Global), a documented blind spot (MultiConvert, dynamic dispatch),
+// or opaque by default, never fresh.
+func (a *MutationAnalysis) markSources(fn *ssa.Function, value ssa.Value, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) {
+	visit := sourceVisit{value, level, pending}
+	if value == nil || seen[visit] || !containerBearing(value.Type()) {
+		return
+	}
+	seen[visit] = true
+	descend := func(next ssa.Value, nextLevel viewLevel) {
+		a.markSources(fn, next, sources, nextLevel, pending, seen)
+	}
+	extract := func(next ssa.Value) {
+		if pending == maxPendingExtractions {
+			sources.markOpaque()
+			return
+		}
+		a.markSources(fn, next, sources, level, pending+1, seen)
+	}
+
+	switch typed := value.(type) {
+	case *ssa.Parameter:
+		if index := parameterIndex(fn, typed); index >= 0 && recordableSource(typed.Type()) {
+			sources.addParam(index, level)
+		}
+	case *ssa.Global:
+		sources.markShared()
+	case *ssa.FreeVar:
+		if !recordableSource(typed.Type()) {
+			return
+		}
+		for index, free := range fn.FreeVars {
+			if free == typed {
+				sources.addFreeVar(index, level)
+				return
+			}
+		}
+	case *ssa.Slice:
+		descend(typed.X, level)
+	case *ssa.IndexAddr:
+		descend(typed.X, level)
+	case *ssa.FieldAddr:
+		descend(typed.X, level)
+	case *ssa.Field:
+		extract(typed.X)
+	case *ssa.Index:
+		extract(typed.X)
+	case *ssa.ChangeType:
+		descend(typed.X, level)
+	case *ssa.Convert:
+		// A string conversion allocates, so the result is storage of its own.
+		if !convertCopies(typed.X.Type(), typed.Type()) {
+			descend(typed.X, level)
+		}
+	case *ssa.SliceToArrayPointer:
+		descend(typed.X, level)
+	case *ssa.Lookup:
+		if typed.CommaOk {
+			return
+		}
+		step := keyStep(typed.Index)
+		if !a.descendLocalContents(fn, typed.X, &step, sources, level, pending, seen) {
+			extract(typed.X)
+		}
+	case *ssa.MakeInterface:
+		// Boxing copies the value.
+		a.markValueSources(fn, typed.X, sources, level, pending, seen)
+	case *ssa.ChangeInterface:
+		descend(typed.X, level)
+	case *ssa.TypeAssert:
+		descend(typed.X, level)
+	case *ssa.Extract:
+		switch tuple := typed.Tuple.(type) {
+		case *ssa.TypeAssert:
+			if typed.Index == 0 {
+				descend(tuple.X, level)
+			}
+		case *ssa.Lookup:
+			if typed.Index != 0 {
+				return
+			}
+			step := keyStep(tuple.Index)
+			if !a.descendLocalContents(fn, tuple.X, &step, sources, level, pending, seen) {
+				extract(tuple.X)
+			}
+		case *ssa.Next:
+			rang, ok := tuple.Iter.(*ssa.Range)
+			if !ok {
+				return
+			}
+			// a bearing map key is outside the fact, so opaque rather than fresh
+			if typed.Index == 1 {
+				sources.markOpaque()
+				return
+			}
+			if typed.Index != 2 {
+				return
+			}
+			step := unknownStep
+			if !a.descendLocalContents(fn, rang.X, &step, sources, level, pending, seen) {
+				extract(rang.X)
+			}
+		case *ssa.Call:
+			a.resumeResultWalk(fn, tuple, typed.Index, sources, level, pending, seen)
+		default:
+			sources.markOpaque()
+		}
+	case *ssa.Phi:
+		for _, edge := range typed.Edges {
+			descend(edge, level)
+		}
+	case *ssa.UnOp:
+		// only a load preserves storage
+		if typed.Op != token.MUL {
+			sources.markOpaque()
+			return
+		}
+		// a local read resolves to what was stored, not a step into a container
+		if a.descendLocalContents(fn, typed.X, nil, sources, level, pending, seen) {
+			return
+		}
+		if _, ok := typed.X.(*ssa.FreeVar); ok {
+			descend(typed.X, level)
+			return
+		}
+		extract(typed.X)
+	case *ssa.Alloc:
+		a.descendContents(fn, typed, sources, level, pending, seen)
+	case *ssa.MakeSlice, *ssa.MakeMap:
+		a.descendContents(fn, value, sources, level, pending, seen)
+	case *ssa.MakeClosure:
+		// an iterator holds its captures one level inside itself
+		inside, remaining := insertLevel(level, pending)
+		for _, binding := range typed.Bindings {
+			a.descendCell(fn, binding, sources, inside, remaining, seen)
+		}
+		if target, ok := typed.Fn.(*ssa.Function); ok {
+			a.consumeFunctionValue(target, sources)
+		} else {
+			sources.markOpaque()
+		}
+	case *ssa.Function:
+		a.consumeFunctionValue(typed, sources)
+	case *ssa.Call:
+		common := typed.Common()
+		if builtin, ok := common.Value.(*ssa.Builtin); ok {
+			// every other bearing-producing builtin is outside the fact
+			if builtin.Name() != "append" {
+				sources.markOpaque()
+				return
+			}
+			if len(common.Args) == 0 {
+				return
+			}
+			// only zero capacity guarantees fresh storage, since a full
+			// append hands its argument back when it appends nothing
+			if !isZeroCapacity(common.Args[0]) {
+				descend(common.Args[0], level)
+			}
+			inside, remaining := insertLevel(level, pending)
+			for _, added := range common.Args[1:] {
+				root, _ := storagePath(added)
+				switch root.(type) {
+				case *ssa.Alloc, *ssa.MakeSlice, *ssa.MakeMap:
+				default:
+					if spreadCarriesStorage(added.Type()) {
+						a.markSources(fn, added, sources, inside, remaining, seen)
+					}
+				}
+				values, helperWritten, sharesGlobal := a.containedValues(root)
+				if helperWritten {
+					sources.markOpaque()
+				}
+				if sharesGlobal {
+					sources.markShared()
+				}
+				for _, stored := range values {
+					a.markValueSources(fn, stored.value, sources, inside, remaining, seen)
+				}
+			}
+			return
+		}
+		a.resumeResultWalk(fn, typed, 0, sources, level, pending, seen)
+	case *ssa.Const:
+		// nil, so fresh
+	case *ssa.MultiConvert:
+		// the documented blind spot
+	default:
+		sources.markOpaque()
+	}
+}
+
+// consumeFunctionValue: a body can expose storage beyond its captures.
+func (a *MutationAnalysis) consumeFunctionValue(target *ssa.Function, sources *aliasSources) {
+	if functionBody(target) == nil {
+		sources.markOpaque()
+		return
+	}
+	inner := a.summarize(target)
+	consume := func(facts *aliasSources) {
+		if facts == nil {
+			return
+		}
+		if facts.opaque {
+			sources.markOpaque()
+		}
+		if facts.shared {
+			sources.markShared()
+		}
+	}
+	for _, facts := range inner.results {
+		consume(facts)
+	}
+	consume(inner.handOut)
+}
+
+// recordCaptureStores goes opaque for routes the buckets cannot account for.
+func (a *MutationAnalysis) recordCaptureStores(fn *ssa.Function, instruction ssa.Instruction, summary *mutationSummary) {
+	bucketsFor := func(address ssa.Value) (*captureStores, captureDestKind) {
+		root, kind := captureDestination(address)
+		if root == nil {
+			return nil, kind
+		}
+		for index, free := range fn.FreeVars {
+			if free == root {
+				return summary.captureStoresFor(index), kind
+			}
+		}
+		return nil, kind
+	}
+	record := func(buckets *captureStores, kind captureDestKind, value ssa.Value) {
+		switch kind {
+		case destRebound:
+			a.markValueSources(fn, value, buckets.reboundSources(), levelWhole, 0, make(map[sourceVisit]bool))
+		case destElement:
+			a.markValueSources(fn, value, buckets.elementSources(), levelWhole, 0, make(map[sourceVisit]bool))
+		default:
+			buckets.elementSources().markOpaque()
+		}
+	}
+	deepen := func(kind captureDestKind) captureDestKind {
+		if kind == destRebound {
+			return destElement
+		}
+		return destOpaque
+	}
+	switch typed := instruction.(type) {
+	case *ssa.Store:
+		if buckets, kind := bucketsFor(typed.Addr); buckets != nil {
+			record(buckets, kind, typed.Val)
+		}
+	case *ssa.MapUpdate:
+		if buckets, kind := bucketsFor(typed.Map); buckets != nil {
+			record(buckets, deepen(kind), typed.Value)
+		}
+	case *ssa.MakeClosure:
+		// a nested closure writes out of the buckets' sight
+		target, ok := typed.Fn.(*ssa.Function)
+		if !ok {
+			return
+		}
+		inner := a.summarize(target)
+		for index, binding := range typed.Bindings {
+			if _, written := inner.freeVars[index]; !written {
+				continue
+			}
+			if buckets, _ := bucketsFor(binding); buckets != nil {
+				buckets.elementSources().markOpaque()
+			}
+		}
+	case ssa.CallInstruction:
+		common := typed.Common()
+		if builtin, ok := common.Value.(*ssa.Builtin); ok {
+			if builtin.Name() == "copy" && len(common.Args) == 2 {
+				if buckets, kind := bucketsFor(common.Args[0]); buckets != nil &&
+					spreadCarriesStorage(common.Args[1].Type()) {
+					if kind == destRebound {
+						a.markSources(fn, common.Args[1], buckets.elementSources(), levelWhole, 0, make(map[sourceVisit]bool))
+					} else {
+						buckets.elementSources().markOpaque()
+					}
+				}
+			}
+			return
+		}
+		for _, argument := range common.Args {
+			if buckets, _ := bucketsFor(argument); buckets != nil && a.calleeWritesArgument(common, argument) {
+				buckets.elementSources().markOpaque()
+			}
+		}
+	}
+}
+
+// captureDestKind says where inside a capture's storage a write lands.
+type captureDestKind uint8
+
+const (
+	destRebound captureDestKind = iota
+	destElement
+	destOpaque
+)
+
+func captureDestination(address ssa.Value) (*ssa.FreeVar, captureDestKind) {
+	indexSteps := 0
+	irregular := false
+	for {
+		switch typed := address.(type) {
+		case *ssa.FreeVar:
+			switch {
+			case irregular || indexSteps > 1:
+				return typed, destOpaque
+			case indexSteps == 1:
+				return typed, destElement
+			default:
+				return typed, destRebound
+			}
+		case *ssa.FieldAddr:
+			irregular = true
+			address = typed.X
+		case *ssa.IndexAddr:
+			indexSteps++
+			address = typed.X
+		case *ssa.Slice:
+			if !sliceKeepsIndexes(typed) {
+				irregular = true
+			}
+			address = typed.X
+		case *ssa.ChangeType:
+			address = typed.X
+		case *ssa.SliceToArrayPointer:
+			address = typed.X
+		case *ssa.UnOp:
+			if typed.Op != token.MUL {
+				return nil, destOpaque
+			}
+			address = typed.X
+		default:
+			return nil, destOpaque
+		}
+	}
+}
+
+// recordHandOuts: a bodyless callee holding a function value could call it with anything.
+func (a *MutationAnalysis) recordHandOuts(fn *ssa.Function, instruction ssa.Instruction, summary *mutationSummary) {
+	call, ok := instruction.(ssa.CallInstruction)
+	if !ok {
+		return
+	}
+	common := call.Common()
+	if _, ok := common.Value.(*ssa.Builtin); ok {
+		return
+	}
+	if callee := common.StaticCallee(); callee != nil && !common.IsInvoke() {
+		if functionBody(callee) == nil {
+			for _, argument := range common.Args {
+				if _, isFunc := argument.Type().Underlying().(*types.Signature); isFunc {
+					summary.handOutSources().markOpaque()
+					return
+				}
+			}
+			return
+		}
+		a.propagateHandOuts(fn, common, callee, summary)
+		return
+	}
+	for _, argument := range common.Args {
+		if containerBearing(argument.Type()) {
+			a.markValueSources(fn, argument, summary.handOutSources(), levelWhole, 0, make(map[sourceVisit]bool))
+		}
+	}
+}
+
+func (a *MutationAnalysis) propagateHandOuts(fn *ssa.Function, common *ssa.CallCommon, callee *ssa.Function, summary *mutationSummary) {
+	inner := a.summarize(callee)
+	if inner.handOut == nil {
+		return
+	}
+	target := summary.handOutSources()
+	if inner.handOut.opaque {
+		target.markOpaque()
+	}
+	if inner.handOut.shared {
+		target.markShared()
+	}
+	for index, factLevel := range inner.handOut.params {
+		if index < len(common.Args) {
+			a.markSources(fn, common.Args[index], target, factLevel, 0, make(map[sourceVisit]bool))
+		}
+	}
+	if closure, ok := common.Value.(*ssa.MakeClosure); ok {
+		for index, factLevel := range inner.handOut.freeVars {
+			if index < len(closure.Bindings) {
+				a.descendCell(fn, closure.Bindings[index], target, factLevel, 0, make(map[sourceVisit]bool))
+			}
+		}
+	}
+}
+
+func (a *MutationAnalysis) descendContents(fn *ssa.Function, root ssa.Value, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) {
+	inside, remaining := insertLevel(level, pending)
+	values, helperWritten, sharesGlobal := a.containedValues(root)
+	if helperWritten {
+		sources.markOpaque()
+	}
+	if sharesGlobal {
+		sources.markShared()
+	}
+	for _, stored := range values {
+		a.markValueSources(fn, stored.value, sources, inside, remaining, seen)
+	}
+}
+
+func (a *MutationAnalysis) resumeResultWalk(fn *ssa.Function, call *ssa.Call, resultIndex int, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) {
+	common := call.Common()
+	if common.IsInvoke() {
+		return
+	}
+	if _, ok := common.Value.(*ssa.Builtin); ok {
+		return
+	}
+	callee := common.StaticCallee()
+	if callee == nil {
+		return
+	}
+	// a bodyless callee's summary is empty because nothing was seen
+	if functionBody(callee) == nil {
+		sources.markOpaque()
+		return
+	}
+	inner := a.summarize(callee)
+	facts := inner.results[resultIndex]
+	if facts == nil {
+		return
+	}
+	if facts.opaque {
+		sources.markOpaque()
+	}
+	if facts.shared {
+		sources.markShared()
+	}
+	for index, factLevel := range facts.params {
+		if index >= len(common.Args) {
+			continue
+		}
+		composed, remaining, precise := applyLevel(level, pending, factLevel)
+		if !precise {
+			sources.markOpaque()
+			continue
+		}
+		a.markSources(fn, common.Args[index], sources, composed, remaining, seen)
+	}
+	if closure, ok := common.Value.(*ssa.MakeClosure); ok {
+		for index, factLevel := range facts.freeVars {
+			if index >= len(closure.Bindings) {
+				continue
+			}
+			composed, remaining, precise := applyLevel(level, pending, factLevel)
+			if !precise {
+				sources.markOpaque()
+				continue
+			}
+			a.descendCell(fn, closure.Bindings[index], sources, composed, remaining, seen)
+		}
+	}
+}
+
+func (a *MutationAnalysis) descendLocalContents(fn *ssa.Function, address ssa.Value, elementStep *pathStep, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) bool {
+	base, loadPath := storagePath(address)
+	switch base.(type) {
+	case *ssa.Alloc, *ssa.MakeSlice, *ssa.MakeMap:
+	default:
+		return false
+	}
+	if elementStep != nil {
+		loadPath = append(loadPath, *elementStep)
+	}
+	stores, helperWritten, sharesGlobal := a.localStores(base)
+	if helperWritten {
+		sources.markOpaque()
+	}
+	if sharesGlobal {
+		sources.markShared()
+	}
+	for _, stored := range stores {
+		if !pathsCompatible(loadPath, stored.path) {
+			continue
+		}
+		// a store above the loaded slot passes through without the copy clamp
+		if len(stored.path) < len(loadPath) {
+			a.markSources(fn, stored.value, sources, level, pending, seen)
+			continue
+		}
+		storedLevel, remaining, precise := applyLevel(level, pending, levelForSteps(len(stored.path)-len(loadPath)))
+		if !precise {
+			sources.markOpaque()
+			continue
+		}
+		a.markValueSources(fn, stored.value, sources, storedLevel, remaining, seen)
+	}
+	return true
+}
+
+func pathsCompatible(loadPath, storePath []pathStep) bool {
+	for i := 0; i < len(loadPath) && i < len(storePath); i++ {
+		if !stepsCompatible(loadPath[i], storePath[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *MutationAnalysis) descendCell(fn *ssa.Function, cell ssa.Value, sources *aliasSources, level viewLevel, pending int, seen map[sourceVisit]bool) {
+	if alloc, ok := cell.(*ssa.Alloc); ok {
+		values, helperWritten, sharesGlobal := a.containedValues(alloc)
+		if helperWritten {
+			sources.markOpaque()
+		}
+		if sharesGlobal {
+			sources.markShared()
+		}
+		for _, stored := range values {
+			storedLevel, remaining := level, pending
+			if stored.nested {
+				storedLevel, remaining = insertLevel(level, pending)
+			}
+			a.markValueSources(fn, stored.value, sources, storedLevel, remaining, seen)
+		}
+		return
+	}
+	a.markSources(fn, cell, sources, level, pending, seen)
+}
+
+type containedValue struct {
+	value  ssa.Value
+	nested bool
+}
+
+func (a *MutationAnalysis) containedValues(root ssa.Value) ([]containedValue, bool, bool) {
+	stores, helperWritten, sharesGlobal := a.localStores(root)
+	out := make([]containedValue, len(stores))
+	for i, stored := range stores {
+		out[i] = containedValue{stored.value, len(stored.path) > 0}
+	}
+	return out, helperWritten, sharesGlobal
+}
+
+// pathStep is one step of a storage path. Unknown steps match anything.
+type pathStep struct {
+	field int            // field or constant index, -1 when unknown
+	key   constant.Value // constant map key, nil when unknown or not a map step
+}
+
+var unknownStep = pathStep{field: -1}
+
+func indexStep(index ssa.Value, shifted bool) pathStep {
+	if shifted {
+		return unknownStep
+	}
+	if value, ok := constantIndex(index); ok && value >= 0 && int64(int(value)) == value {
+		return pathStep{field: int(value)}
+	}
+	return unknownStep
+}
+
+func keyStep(key ssa.Value) pathStep {
+	if konst, ok := key.(*ssa.Const); ok && konst.Value != nil {
+		return pathStep{field: -1, key: konst.Value}
+	}
+	return unknownStep
+}
+
+func stepsCompatible(a, b pathStep) bool {
+	if a.key != nil && b.key != nil {
+		return a.key.Kind() == b.key.Kind() && constant.Compare(a.key, token.EQL, b.key)
+	}
+	return a.field == b.field || a.field == -1 || b.field == -1
+}
+
+func sliceKeepsIndexes(sliced *ssa.Slice) bool {
+	if sliced.Low == nil {
+		return true
+	}
+	low, ok := constantIndex(sliced.Low)
+	return ok && low == 0
+}
+
+type localStore struct {
+	value ssa.Value
+	path  []pathStep
+}
+
+// localStores collects every store into the given storage root, with
+// out-of-sight and shared markers. Fail-closed: every referrer extends the
+// graph, is a collected write, is a silent read, or counts as written out
+// of sight, including any unlisted use.
+func (a *MutationAnalysis) localStores(base ssa.Value) ([]localStore, bool, bool) {
+	var out []localStore
+	helperWritten := false
+	sharesGlobal := false
+	seen := map[ssa.Value]bool{}
+	var visit func(v ssa.Value, path []pathStep, shifted bool)
+	visit = func(v ssa.Value, path []pathStep, shifted bool) {
+		if v == nil || seen[v] {
+			return
+		}
+		seen[v] = true
+		referrers := v.Referrers()
+		if referrers == nil {
+			return
+		}
+		for _, ref := range *referrers {
+			switch typed := ref.(type) {
+			case *ssa.Store:
+				if typed.Addr == v {
+					out = append(out, localStore{value: typed.Val, path: path})
+					continue
+				}
+				// a non-local destination is written out of sight
+				root, _ := storagePath(typed.Addr)
+				switch root.(type) {
+				case *ssa.Alloc, *ssa.MakeSlice, *ssa.MakeMap, *ssa.FreeVar:
+					visit(typed.Addr, path, true)
+				default:
+					helperWritten = true
+				}
+			case *ssa.FieldAddr:
+				if typed.X == v {
+					visit(typed, append(slices.Clone(path), pathStep{field: typed.Field}), false)
+				}
+			case *ssa.IndexAddr:
+				if typed.X == v {
+					visit(typed, append(slices.Clone(path), indexStep(typed.Index, shifted)), false)
+				}
+			case *ssa.MapUpdate:
+				// only the value is content, since keys are outside the fact
+				switch {
+				case typed.Map == v:
+					out = append(out, localStore{value: typed.Value, path: append(slices.Clone(path), keyStep(typed.Key))})
+				case typed.Value == v || typed.Key == v:
+					helperWritten = true
+				}
+			case *ssa.Slice:
+				if typed.X == v {
+					visit(typed, path, shifted || !sliceKeepsIndexes(typed))
+				}
+			case *ssa.SliceToArrayPointer:
+				if typed.X == v {
+					visit(typed, path, shifted)
+				}
+			case *ssa.Phi:
+				// merged values keep the content graph, indexes unaligned
+				if loadedValueWritable(typed.Type()) {
+					visit(typed, path, true)
+				}
+			case *ssa.UnOp:
+				// a load aliases the same content, when it can hold a bearing value
+				if typed.Op == token.MUL && typed.X == v && loadedValueWritable(typed.Type()) {
+					visit(typed, path, shifted)
+				}
+			case *ssa.ChangeType:
+				if typed.X == v {
+					visit(typed, path, shifted)
+				}
+			case *ssa.MakeInterface, *ssa.ChangeInterface, *ssa.TypeAssert:
+				// boxing and unboxing preserve the header
+				visit(typed.(ssa.Value), path, shifted)
+			case *ssa.Extract:
+				// reachable only through a comma-ok unbox
+				if typed.Index == 0 {
+					visit(typed, path, shifted)
+				}
+			case *ssa.MakeClosure:
+				a.collectClosureStores(typed, v, path, &out, &helperWritten, &sharesGlobal)
+			case *ssa.Call:
+				a.collectCallStores(typed, v, path, shifted, &out, &helperWritten, visit)
+			case *ssa.Defer:
+				if a.calleeWritesArgument(typed.Common(), v) {
+					helperWritten = true
+				}
+			case *ssa.Go:
+				if a.calleeWritesArgument(typed.Common(), v) {
+					helperWritten = true
+				}
+			case *ssa.Convert:
+				if isUnsafePointerType(typed.Type()) {
+					helperWritten = true
+				}
+			case *ssa.Lookup, *ssa.Range, *ssa.Field, *ssa.Index,
+				*ssa.BinOp, *ssa.Return, *ssa.DebugRef:
+			default:
+				helperWritten = true
+			}
+		}
+	}
+	visit(base, nil, false)
+	return out, helperWritten, sharesGlobal
+}
+
+func (a *MutationAnalysis) collectCallStores(call *ssa.Call, v ssa.Value, path []pathStep, shifted bool, out *[]localStore, helperWritten *bool, visit func(ssa.Value, []pathStep, bool)) {
+	common := call.Common()
+	builtin, ok := common.Value.(*ssa.Builtin)
+	if !ok {
+		if a.calleeWritesArgument(common, v) {
+			*helperWritten = true
+		}
+		return
+	}
+	// copy places the source's element values, like a spread append
+	if builtin.Name() == "copy" && len(common.Args) == 2 && common.Args[0] == v {
+		if spreadCarriesStorage(common.Args[1].Type()) {
+			*out = append(*out, localStore{value: common.Args[1], path: append(slices.Clone(path), unknownStep)})
+		}
+		return
+	}
+	if builtin.Name() != "append" || len(common.Args) == 0 || common.Args[0] != v {
+		return
+	}
+	// appended elements land at positions that never align with the storage
+	if !appendMustReallocate(common.Args[0]) {
+		for _, added := range common.Args[1:] {
+			root, _ := storagePath(added)
+			visit(root, path, true)
+			switch root.(type) {
+			case *ssa.Alloc, *ssa.MakeSlice, *ssa.MakeMap:
+			default:
+				if spreadCarriesStorage(added.Type()) {
+					*out = append(*out, localStore{value: added, path: append(slices.Clone(path), unknownStep)})
+				}
+			}
+		}
+	}
+	if !isZeroCapacity(common.Args[0]) {
+		visit(call, path, shifted)
+	}
+}
+
+func isUnsafePointerType(t types.Type) bool {
+	basic, ok := t.Underlying().(*types.Basic)
+	return ok && basic.Kind() == types.UnsafePointer
+}
+
+func loadedValueWritable(t types.Type) bool {
+	if parameter, ok := t.(*types.TypeParam); ok {
+		core := coreType(parameter)
+		if core == nil {
+			return true
+		}
+		t = core
+	}
+	switch underlying := t.Underlying().(type) {
+	case *types.Slice:
+		return recordableSource(underlying.Elem())
+	case *types.Map:
+		return recordableSource(underlying.Elem())
+	case *types.Pointer:
+		return recordableSource(underlying.Elem())
+	case *types.Interface:
+		return true
+	}
+	return false
+}
+
+// collectClosureStores resolves stored parameters through direct invocations
+// only, since values arriving through a function value belong to the
+// dynamic-dispatch blind spot.
+func (a *MutationAnalysis) collectClosureStores(closure *ssa.MakeClosure, v ssa.Value, path []pathStep, out *[]localStore, opaque, shared *bool) {
+	target, ok := closure.Fn.(*ssa.Function)
+	if !ok {
+		*opaque = true
+		return
+	}
+	if functionBody(target) == nil {
+		*opaque = true
+		return
+	}
+	inner := a.summarize(target)
+	apply := func(facts *aliasSources, entryPath []pathStep) {
+		if facts == nil {
+			return
+		}
+		if facts.opaque {
+			*opaque = true
+		}
+		if facts.shared {
+			*shared = true
+		}
+		// the path encodes a fact's level as unknown steps
+		leveled := func(level viewLevel) []pathStep {
+			path := slices.Clone(entryPath)
+			for range int(level) {
+				path = append(path, unknownStep)
+			}
+			return path
+		}
+		for other, level := range facts.freeVars {
+			if other >= len(closure.Bindings) {
+				continue
+			}
+			cell := closure.Bindings[other]
+			if otherCell, ok := cell.(*ssa.Alloc); ok {
+				for _, held := range storesInto(otherCell) {
+					*out = append(*out, localStore{value: held, path: leveled(level)})
+				}
+				continue
+			}
+			*out = append(*out, localStore{value: cell, path: leveled(level)})
+		}
+		if len(facts.params) == 0 {
+			return
+		}
+		referrers := closure.Referrers()
+		if referrers == nil {
+			return
+		}
+		for _, ref := range *referrers {
+			call, ok := ref.(ssa.CallInstruction)
+			if !ok || call.Common().Value != closure {
+				continue
+			}
+			for paramIndex, level := range facts.params {
+				if paramIndex < len(call.Common().Args) {
+					*out = append(*out, localStore{value: call.Common().Args[paramIndex], path: leveled(level)})
+				}
+			}
+		}
+	}
+	for index, binding := range closure.Bindings {
+		if binding != v {
+			continue
+		}
+		buckets := inner.freeVarStores[index]
+		if buckets == nil {
+			if _, written := inner.freeVars[index]; written {
+				*opaque = true
+			}
+			continue
+		}
+		apply(buckets.rebound, path)
+		apply(buckets.elements, append(slices.Clone(path), unknownStep))
+	}
+}
+
+// calleeWritesArgument counts a bodyless callee as a possible writer.
+func (a *MutationAnalysis) calleeWritesArgument(common *ssa.CallCommon, v ssa.Value) bool {
+	if common.IsInvoke() {
+		return false
+	}
+	callee := common.StaticCallee()
+	if callee == nil {
+		return false
+	}
+	bodyless := functionBody(callee) == nil
+	inner := a.summarize(callee)
+	for i, argument := range common.Args {
+		if argument != v {
+			continue
+		}
+		if bodyless {
+			return true
+		}
+		if _, written := inner.params[i]; written {
+			return true
+		}
+	}
+	return false
+}
+
+func storagePath(value ssa.Value) (ssa.Value, []pathStep) {
+	var reversed []pathStep
+	for {
+		switch typed := value.(type) {
+		case *ssa.FieldAddr:
+			reversed = append(reversed, pathStep{field: typed.Field})
+			value = typed.X
+		case *ssa.IndexAddr:
+			reversed = append(reversed, indexStep(typed.Index, false))
+			value = typed.X
+		case *ssa.Slice:
+			if !sliceKeepsIndexes(typed) && len(reversed) > 0 {
+				reversed[len(reversed)-1] = unknownStep
+			}
+			value = typed.X
+		case *ssa.ChangeType:
+			value = typed.X
+		default:
+			slices.Reverse(reversed)
+			return value, reversed
+		}
+	}
+}
+
+func spreadCarriesStorage(t types.Type) bool {
+	if parameter, ok := t.(*types.TypeParam); ok {
+		core := coreType(parameter)
+		if core == nil {
+			return true
+		}
+		t = core
+	}
+	sliceType, ok := t.Underlying().(*types.Slice)
+	if !ok {
+		return false
+	}
+	return recordableSource(sliceType.Elem())
+}
+
+// containerBearing reports whether this type can expose a writable container.
+func containerBearing(t types.Type) bool {
+	return exposesContainer(t, true, make(map[types.Type]bool))
+}
+
+// recordableSource: a function value never records, only its captures share storage.
+func recordableSource(t types.Type) bool {
+	return exposesContainer(t, false, make(map[types.Type]bool))
+}
+
+func exposesContainer(t types.Type, funcsBear bool, seen map[types.Type]bool) bool {
+	if seen[t] {
+		return false
+	}
+	seen[t] = true
+	if parameter, ok := t.(*types.TypeParam); ok {
+		core := coreType(parameter)
+		if core == nil {
+			return true // several shapes admitted: assume one that bears
+		}
+		t = core
+	}
+	switch underlying := t.Underlying().(type) {
+	case *types.Slice, *types.Map:
+		return true
+	case *types.Interface:
+		return true // may box any container
+	case *types.Signature:
+		return funcsBear
+	case *types.Pointer:
+		return exposesContainer(underlying.Elem(), funcsBear, seen)
+	case *types.Array:
+		return exposesContainer(underlying.Elem(), funcsBear, seen)
+	case *types.Struct:
+		for i := range underlying.NumFields() {
+			if exposesContainer(underlying.Field(i).Type(), funcsBear, seen) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// ResolveViews layers overrides over the derived fact. Overrides only add,
+// unresolved results take the worst case unless a clean override completes
+// them, and invalid entries come back for the caller to surface.
+func ResolveViews(derived FunctionViews, overrides []string, hasOverride bool, sig *types.Signature) (FunctionViews, []string) {
+	resolved := FunctionViews{Analyzed: derived.Analyzed, Results: make([]ResultView, sig.Results().Len())}
+	for i := range derived.Results {
+		if i < len(resolved.Results) {
+			resolved.Results[i] = derived.Results[i].clone()
+		}
+	}
+	var invalid []string
+	for _, entry := range overrides {
+		if !applyViewOverride(&resolved, entry, sig) {
+			invalid = append(invalid, entry)
+		}
+	}
+	overridesUsable := hasOverride && len(invalid) == 0
+	for i := range resolved.Results {
+		if !containerBearing(sig.Results().At(i).Type()) {
+			continue
+		}
+		if !resolved.Results[i].Opaque && derived.Analyzed {
+			continue
+		}
+		if overridesUsable {
+			resolved.Results[i].Opaque = false
+			continue
+		}
+		resolved.Results[i].Opaque = true
+		applyWorstCaseView(&resolved.Results[i], sig)
+	}
+	return resolved, invalid
+}
+
+// applyViewOverride parses "<result>:<param>", brackets for element depth,
+// "recv" for the receiver, reporting whether the entry applied cleanly.
+func applyViewOverride(views *FunctionViews, entry string, sig *types.Signature) bool {
+	resultPart, source, ok := strings.Cut(entry, ":")
+	if !ok {
+		return false
+	}
+	resultIndex, err := strconv.Atoi(resultPart)
+	if err != nil || resultIndex < 0 || resultIndex >= len(views.Results) {
+		return false
+	}
+	depth := DepthWhole
+	if inner, bracketed := strings.CutPrefix(source, "["); bracketed {
+		inner, bracketed = strings.CutSuffix(inner, "]")
+		if !bracketed {
+			return false
+		}
+		source, depth = inner, DepthElement
+	}
+	view := &views.Results[resultIndex]
+	if source == "recv" {
+		if sig.Recv() == nil {
+			return false
+		}
+		view.Receiver = joinDepth(view.Receiver, depth)
+		return true
+	}
+	params := sig.Params()
+	for i := 0; i < params.Len(); i++ {
+		if params.At(i).Name() == source && recordableSource(params.At(i).Type()) {
+			view.setParam(i, params.Len(), depth)
+			return true
+		}
+	}
+	return false
+}
+
+// applyWorstCaseView aliases every container-exposing argument at whole depth.
+func applyWorstCaseView(view *ResultView, sig *types.Signature) {
+	params := sig.Params()
+	for j := 0; j < params.Len(); j++ {
+		if recordableSource(params.At(j).Type()) {
+			view.setParam(j, params.Len(), DepthWhole)
+		}
+	}
+	if receiver := sig.Recv(); receiver != nil && recordableSource(receiver.Type()) {
+		view.Receiver = joinDepth(view.Receiver, DepthWhole)
+	}
 }
 
 func markRoots(fn *ssa.Function, value ssa.Value, summary *mutationSummary) {

--- a/bindgen/internal/convert/mutation_views_test.go
+++ b/bindgen/internal/convert/mutation_views_test.go
@@ -1,0 +1,1045 @@
+package convert
+
+import (
+	"go/types"
+	"sort"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func functionViews(t *testing.T, analysis *MutationAnalysis, pkg *packages.Package, name string) (FunctionViews, *types.Signature) {
+	t.Helper()
+	obj, _ := pkg.Types.Scope().Lookup(name).(*types.Func)
+	if obj == nil {
+		t.Fatalf("no function %q", name)
+	}
+	views, ok := analysis.Views(obj)
+	if !ok {
+		t.Fatalf("no views for %q", name)
+	}
+	return views, obj.Type().(*types.Signature)
+}
+
+func methodViews(t *testing.T, analysis *MutationAnalysis, pkg *packages.Package, typeName, methodName string) (FunctionViews, *types.Signature) {
+	t.Helper()
+	named := pkg.Types.Scope().Lookup(typeName).(*types.TypeName).Type().(*types.Named)
+	for i := 0; i < named.NumMethods(); i++ {
+		method := named.Method(i)
+		if method.Name() != methodName {
+			continue
+		}
+		views, ok := analysis.Views(method)
+		if !ok {
+			t.Fatalf("no views for %q.%q", typeName, methodName)
+		}
+		return views, method.Type().(*types.Signature)
+	}
+	t.Fatalf("no method %q.%q", typeName, methodName)
+	return FunctionViews{}, nil
+}
+
+// viewTokens renders "s" for whole depth, "[s]" for element, "recv" for the receiver.
+func viewTokens(sig *types.Signature, view ResultView) []string {
+	var out []string
+	switch view.Receiver {
+	case DepthWhole:
+		out = append(out, "recv")
+	case DepthElement:
+		out = append(out, "[recv]")
+	}
+	for i, depth := range view.Params {
+		name := sig.Params().At(i).Name()
+		switch depth {
+		case DepthWhole:
+			out = append(out, name)
+		case DepthElement:
+			out = append(out, "["+name+"]")
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func assertOpaque(t *testing.T, views FunctionViews, resultIndex int, want bool) {
+	t.Helper()
+	if resultIndex >= len(views.Results) {
+		t.Fatalf("result %d out of range, have %d results", resultIndex, len(views.Results))
+	}
+	if views.Results[resultIndex].Opaque != want {
+		t.Errorf("result %d: Opaque = %v, want %v", resultIndex, views.Results[resultIndex].Opaque, want)
+	}
+}
+
+func assertShared(t *testing.T, views FunctionViews, resultIndex int, want bool) {
+	t.Helper()
+	if resultIndex >= len(views.Results) {
+		t.Fatalf("result %d out of range, have %d results", resultIndex, len(views.Results))
+	}
+	if views.Results[resultIndex].Shared != want {
+		t.Errorf("result %d: Shared = %v, want %v", resultIndex, views.Results[resultIndex].Shared, want)
+	}
+}
+
+func assertResultView(t *testing.T, views FunctionViews, sig *types.Signature, resultIndex int, want ...string) {
+	t.Helper()
+	if resultIndex >= len(views.Results) {
+		t.Fatalf("result %d out of range, have %d results", resultIndex, len(views.Results))
+	}
+	got := viewTokens(sig, views.Results[resultIndex])
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("result %d aliases %v, want %v", resultIndex, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("result %d aliases %v, want %v", resultIndex, got, want)
+		}
+	}
+}
+
+func TestViewsDirectReturns(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Identity(s []int) []int          { return s }
+func Tail(s []int) []int              { return s[1:] }
+func Choose(a, b []int, c bool) []int { if c { return a }; return b }
+func Fresh(n int) []int               { return make([]int, n) }
+func CloneShape(s []int) []int        { return append(s[:0:0], s...) }
+func StringCopy(s string) []byte      { return []byte(s) }
+func Count(s []int) int               { return len(s) }
+`)
+	views, sig := functionViews(t, analysis, pkg, "Identity")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "Tail")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "Choose")
+	assertResultView(t, views, sig, 0, "a", "b")
+	views, sig = functionViews(t, analysis, pkg, "Fresh")
+	assertResultView(t, views, sig, 0)
+	views, sig = functionViews(t, analysis, pkg, "CloneShape")
+	assertResultView(t, views, sig, 0)
+	views, sig = functionViews(t, analysis, pkg, "StringCopy")
+	assertResultView(t, views, sig, 0)
+	views, sig = functionViews(t, analysis, pkg, "Count")
+	assertResultView(t, views, sig, 0)
+}
+
+// A spread whose elements cannot expose a container contributes nothing.
+func TestViewsFollowAppend(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func AppendOne(dst []byte, b byte) []byte        { return append(dst, b) }
+func AppendSpread(src []byte) []byte             { return append([]byte(nil), src...) }
+func AppendRow(rows [][]byte, s []byte) [][]byte { return append(rows, s[1:]) }
+
+func GrowShape(s []int, n int) []int {
+	if n -= cap(s) - len(s); n > 0 { s = append(s[:cap(s)], make([]int, n)...)[:len(s)] }
+	return s
+}
+
+func FullAppend(s, xs []int) []int { return append(s[:cap(s)], xs...) }
+
+func AppendSpreadRows(src [][]byte) [][]byte { return append([][]byte(nil), src...) }
+`)
+	views, sig := functionViews(t, analysis, pkg, "AppendOne")
+	assertResultView(t, views, sig, 0, "dst")
+	views, sig = functionViews(t, analysis, pkg, "AppendSpread")
+	assertResultView(t, views, sig, 0)
+	views, sig = functionViews(t, analysis, pkg, "AppendRow")
+	assertResultView(t, views, sig, 0, "rows", "[s]")
+	views, sig = functionViews(t, analysis, pkg, "GrowShape")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "FullAppend")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "AppendSpreadRows")
+	assertResultView(t, views, sig, 0, "[src]")
+}
+
+func TestViewsReportEachResult(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func CutShape(s, sep []byte) ([]byte, []byte, bool) {
+	if len(sep) > 0 { return s[:1], s[1:], true }
+	return s, nil, false
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "CutShape")
+	assertResultView(t, views, sig, 0, "s")
+	assertResultView(t, views, sig, 1, "s")
+	assertResultView(t, views, sig, 2)
+}
+
+func TestViewsReportReceiverAliasing(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Buffer struct {
+	buf []byte
+	off int
+}
+
+func (b *Buffer) Bytes() []byte { return b.buf[b.off:] }
+func (b *Buffer) Len() int      { return len(b.buf) }
+
+type Header map[string][]string
+
+func (h Header) Values(key string) []string { return h[key] }
+`)
+	views, sig := methodViews(t, analysis, pkg, "Buffer", "Bytes")
+	assertResultView(t, views, sig, 0, "recv")
+	views, sig = methodViews(t, analysis, pkg, "Buffer", "Len")
+	assertResultView(t, views, sig, 0)
+	views, sig = methodViews(t, analysis, pkg, "Header", "Values")
+	assertResultView(t, views, sig, 0, "recv")
+}
+
+// A fresh container holding parameter-derived values reports element depth.
+func TestViewsReportElementDepth(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Buffer struct { buf []byte }
+
+func SplitShape(s []byte, n int) [][]byte {
+	out := make([][]byte, n)
+	for i := 0; i < n; i++ { out[i] = s[i : i+1 : i+1] }
+	return out
+}
+
+func WrapShape(buf []byte) *Buffer   { return &Buffer{buf: buf} }
+func LiteralShape(s []byte) [][]byte { return [][]byte{s} }
+
+func MapShape(s []int) map[string][]int {
+	out := map[string][]int{}
+	out["k"] = s
+	return out
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "SplitShape")
+	assertResultView(t, views, sig, 0, "[s]")
+	views, sig = functionViews(t, analysis, pkg, "WrapShape")
+	assertResultView(t, views, sig, 0, "[buf]")
+	views, sig = functionViews(t, analysis, pkg, "LiteralShape")
+	assertResultView(t, views, sig, 0, "[s]")
+	views, sig = functionViews(t, analysis, pkg, "MapShape")
+	assertResultView(t, views, sig, 0, "[s]")
+}
+
+func TestViewsReportIteratorCaptures(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func IteratorShape(s []byte) func(func([]byte) bool) {
+	return func(yield func([]byte) bool) {
+		for i := 0; i < len(s); i++ {
+			if !yield(s[i : i+1]) { return }
+		}
+	}
+}
+
+func CounterShape(n int) func() int {
+	return func() int { n++; return n }
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "IteratorShape")
+	assertResultView(t, views, sig, 0, "[s]")
+	views, sig = functionViews(t, analysis, pkg, "CounterShape")
+	assertResultView(t, views, sig, 0)
+}
+
+func TestViewsPropagateThroughCallees(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Buffer struct { buf []byte }
+
+func trim(s []byte) []byte        { return s[1:] }
+func pair(s []byte) ([]byte, int) { return s, 0 }
+func wrap(buf []byte) *Buffer     { return &Buffer{buf: buf} }
+
+func Trimmed(s []byte) []byte      { return trim(s) }
+func Extracted(s []byte) []byte    { v, _ := pair(s); return v }
+func Wrapped(s []byte) [][]byte    { return [][]byte{trim(s)} }
+func FromWrapper(buf []byte) *Buffer { return wrap(buf) }
+`)
+	views, sig := functionViews(t, analysis, pkg, "Trimmed")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "Extracted")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "Wrapped")
+	assertResultView(t, views, sig, 0, "[s]")
+	views, sig = functionViews(t, analysis, pkg, "FromWrapper")
+	assertResultView(t, views, sig, 0, "[buf]")
+}
+
+func TestViewsFollowElementCopies(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func ElementwiseCopy(src [][]byte) [][]byte {
+	out := make([][]byte, len(src))
+	for i := range src { out[i] = src[i] }
+	return out
+}
+
+func CopiedValues(m map[string][]byte) [][]byte {
+	out := make([][]byte, 0)
+	for _, v := range m { out = append(out, v) }
+	return out
+}
+
+func FirstValue(m map[string][]byte) []byte { return m["k"] }
+`)
+	views, sig := functionViews(t, analysis, pkg, "ElementwiseCopy")
+	assertResultView(t, views, sig, 0, "[src]")
+	views, sig = functionViews(t, analysis, pkg, "CopiedValues")
+	assertResultView(t, views, sig, 0, "[m]")
+	views, sig = functionViews(t, analysis, pkg, "FirstValue")
+	assertResultView(t, views, sig, 0, "m")
+}
+
+// Reads carry the stored depth and keep sibling fields apart.
+func TestViewsResolveReadsFromLocalStorage(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Wrapper struct { buf, other []byte }
+
+func FieldOfLocal(s []byte) []byte {
+	x := &Wrapper{buf: s}
+	return x.buf
+}
+
+func SiblingFieldOfLocal(s []byte) []byte {
+	x := &Wrapper{buf: s}
+	return x.other
+}
+
+func StructOfLocal(s []byte) Wrapper {
+	var tmp Wrapper
+	tmp.buf = s
+	return tmp
+}
+
+func ElementOfLocal(s []byte) []byte {
+	out := make([][]byte, 1)
+	out[0] = s
+	return out[0]
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "FieldOfLocal")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "SiblingFieldOfLocal")
+	assertResultView(t, views, sig, 0)
+	views, sig = functionViews(t, analysis, pkg, "StructOfLocal")
+	assertResultView(t, views, sig, 0, "[s]")
+	views, sig = functionViews(t, analysis, pkg, "ElementOfLocal")
+	assertResultView(t, views, sig, 0, "s")
+}
+
+// A writing callee stores out of sight, so opaque, while a writing closure
+// stays precise for the checklist iterators.
+func TestViewsMarkHelperWrittenLocalsOpaque(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func fill(dst [][]byte, v []byte) { dst[0] = v }
+func peek(dst [][]byte, v []byte) int { return len(dst) + len(v) }
+
+func FilledByCallee(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	fill(out, s)
+	return out
+}
+
+func FilledElement(s []byte) []byte {
+	out := make([][]byte, 1)
+	fill(out, s)
+	return out[0]
+}
+
+func FilledByClosure(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	func() { out[0] = s }()
+	return out
+}
+
+func FilledByClosureArgument(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	fill := func(v []byte) { out[0] = v }
+	fill(s)
+	return out
+}
+
+func ReadByCallee(a, b []byte) [][]byte {
+	out := [][]byte{a}
+	peek(out, b)
+	return out
+}
+`)
+	views, _ := functionViews(t, analysis, pkg, "FilledByCallee")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "FilledElement")
+	assertOpaque(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "FilledByClosure")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "FilledByClosureArgument")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "ReadByCallee")
+	assertOpaque(t, views, 0, false)
+	assertResultView(t, views, sig, 0, "[a]")
+}
+
+// Byte copies carry no storage.
+func TestViewsFollowCopyStoresIntoLocals(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func CopiedRows(src [][]byte) [][]byte {
+	out := make([][]byte, len(src))
+	copy(out, src)
+	return out
+}
+
+func CopiedBytes(src []byte) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+	return out
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "CopiedRows")
+	assertResultView(t, views, sig, 0, "[src]")
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "CopiedBytes")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+}
+
+// A channel result carries no fact, and a bearing receive goes opaque.
+func TestViewsKeepChannelsOutsideTheFact(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func SentInto(s []byte) chan []byte {
+	out := make(chan []byte, 1)
+	out <- s
+	return out
+}
+
+func ReceivedBack(s []byte) []byte {
+	out := make(chan []byte, 1)
+	out <- s
+	return <-out
+}
+
+func ReceivedCommaOk(s []byte) []byte {
+	out := make(chan []byte, 1)
+	out <- s
+	v, _ := <-out
+	return v
+}
+
+func ReceivedScalar(numbers chan int) int {
+	return <-numbers
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "SentInto")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "ReceivedBack")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "ReceivedCommaOk")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "ReceivedScalar")
+	assertOpaque(t, views, 0, false)
+}
+
+// A bearing result built from unsafe memory goes opaque.
+func TestViewsKeepUnsafeMemoryOutsideTheFact(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+import "unsafe"
+
+func FromPointer(p *byte, n int) []byte { return unsafe.Slice(p, n) }
+func BackingPointer(s []byte) *byte     { return unsafe.SliceData(s) }
+func ClipShape(s []byte) []byte         { return unsafe.Slice(unsafe.SliceData(s), len(s)) }
+`)
+	views, _ := functionViews(t, analysis, pkg, "FromPointer")
+	assertOpaque(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "BackingPointer")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "ClipShape")
+	assertOpaque(t, views, 0, true)
+}
+
+func TestViewsMarkSelectReceivesOpaque(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func SelectReceived(numbers chan int, payloads chan []byte) []byte {
+	select {
+	case n := <-numbers:
+		_ = n
+		return nil
+	case p := <-payloads:
+		return p
+	}
+}
+`)
+	views, _ := functionViews(t, analysis, pkg, "SelectReceived")
+	assertOpaque(t, views, 0, true)
+}
+
+// An offset reslice hides which slot an index lands in.
+func TestViewsKeepConstantSlotsApart(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func OtherIndex(a, b []byte) []byte {
+	out := make([][]byte, 2)
+	out[0] = a
+	out[1] = b
+	return out[0]
+}
+
+func OtherKey(a, b []byte) []byte {
+	out := map[string][]byte{}
+	out["a"] = a
+	out["b"] = b
+	return out["a"]
+}
+
+func ShiftedIndex(a, b []byte) []byte {
+	out := make([][]byte, 3)
+	out[0] = a
+	rest := out[1:]
+	rest[0] = b
+	return out[1]
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "OtherIndex")
+	assertResultView(t, views, sig, 0, "a")
+	views, sig = functionViews(t, analysis, pkg, "OtherKey")
+	assertResultView(t, views, sig, 0, "a")
+	views, sig = functionViews(t, analysis, pkg, "ShiftedIndex")
+	assertResultView(t, views, sig, 0, "b")
+}
+
+// A returned aggregate is a copy, so its sharing sits one level inside it.
+func TestViewsClampCopiedAggregates(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Wrapper struct { buf []byte }
+
+func Echo(w Wrapper) Wrapper          { return w }
+func EchoField(w Wrapper) []byte      { return w.buf }
+func EchoArray(a [2][]byte) [2][]byte { return a }
+func Boxed(w Wrapper) any             { return w }
+
+func BoxedCopy(w Wrapper) Wrapper {
+	x := any(w)
+	return x.(Wrapper)
+}
+
+func BoxedFieldOfCopy(w Wrapper) []byte {
+	x := any(w)
+	return x.(Wrapper).buf
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "Echo")
+	assertResultView(t, views, sig, 0, "[w]")
+	views, sig = functionViews(t, analysis, pkg, "EchoField")
+	assertResultView(t, views, sig, 0, "w")
+	views, sig = functionViews(t, analysis, pkg, "EchoArray")
+	assertResultView(t, views, sig, 0, "[a]")
+	views, sig = functionViews(t, analysis, pkg, "Boxed")
+	assertResultView(t, views, sig, 0, "[w]")
+	views, sig = functionViews(t, analysis, pkg, "BoxedCopy")
+	assertResultView(t, views, sig, 0, "[w]")
+	views, sig = functionViews(t, analysis, pkg, "BoxedFieldOfCopy")
+	assertResultView(t, views, sig, 0, "w")
+}
+
+func TestViewsReduceDepthWhenExtractingFromCalleeResults(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func wrapRows(s []byte) [][]byte { return [][]byte{s} }
+
+func FirstOfCallee(s []byte) []byte     { return wrapRows(s)[0] }
+func RewrappedCallee(s []byte) [][]byte { return [][]byte{wrapRows(s)[0]} }
+`)
+	views, sig := functionViews(t, analysis, pkg, "FirstOfCallee")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "RewrappedCallee")
+	assertResultView(t, views, sig, 0, "[s]")
+}
+
+// Extracting from a deep fact needs an exact count that is not kept.
+func TestViewsMarkExtractionFromDeepFactsOpaque(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func wrapTwice(s []byte) [][][]byte { return [][][]byte{{s}} }
+
+func DeepIntact(s []byte) [][][]byte     { return wrapTwice(s) }
+func FirstOfDeepCallee(s []byte) [][]byte { return wrapTwice(s)[0] }
+func SecondOfDeepCallee(s []byte) []byte  { return wrapTwice(s)[0][0] }
+`)
+	views, sig := functionViews(t, analysis, pkg, "DeepIntact")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "FirstOfDeepCallee")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "SecondOfDeepCallee")
+	assertOpaque(t, views, 0, true)
+}
+
+// Map keys are outside the fact.
+func TestViewsKeepMapKeysOutsideTheFact(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type box struct { data []byte }
+
+func LookedUpValue(k *int, v []byte) []byte {
+	out := map[*int][]byte{}
+	out[k] = v
+	return out[k]
+}
+
+func WholeMap(k *int, v []byte) map[*int][]byte {
+	out := map[*int][]byte{}
+	out[k] = v
+	return out
+}
+
+func PlainPointerKey(m map[*int][]byte) *int {
+	for key := range m {
+		return key
+	}
+	return nil
+}
+
+func BearingKey(m map[*box]int) *box {
+	for key := range m {
+		return key
+	}
+	return nil
+}
+
+func LocalRangedValue(k *int, v []byte) []byte {
+	out := map[*int][]byte{k: v}
+	for _, value := range out {
+		return value
+	}
+	return nil
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "LookedUpValue")
+	assertResultView(t, views, sig, 0, "v")
+	views, sig = functionViews(t, analysis, pkg, "WholeMap")
+	assertResultView(t, views, sig, 0, "[v]")
+	views, sig = functionViews(t, analysis, pkg, "PlainPointerKey")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "BearingKey")
+	assertOpaque(t, views, 0, true)
+	views, sig = functionViews(t, analysis, pkg, "LocalRangedValue")
+	assertResultView(t, views, sig, 0, "v")
+}
+
+// A loaded pointer still designates an object reachable from its container.
+func TestViewsFollowContainerBearingPointerElements(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type box struct { data []byte }
+type plain struct { n int }
+
+type holder struct { p *box }
+
+func MapPointer(m map[string]*box) *box { return m["x"] }
+func SlicePointer(list []*box) *box     { return list[0] }
+func FieldPointer(h holder) *box        { return h.p }
+func PlainPointer(list []*plain) *plain { return list[0] }
+
+func RangeInterface(list []any) any {
+	for _, v := range list { return v }
+	return nil
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "MapPointer")
+	assertResultView(t, views, sig, 0, "m")
+	views, sig = functionViews(t, analysis, pkg, "SlicePointer")
+	assertResultView(t, views, sig, 0, "list")
+	views, sig = functionViews(t, analysis, pkg, "FieldPointer")
+	assertResultView(t, views, sig, 0, "h")
+	views, sig = functionViews(t, analysis, pkg, "PlainPointer")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "RangeInterface")
+	assertResultView(t, views, sig, 0, "list")
+}
+
+// Nothing of a bodyless callee was seen, so nothing about it reads as fresh.
+func TestViewsMarkBodylessCalleesOpaque(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func external(b []byte) []byte
+func externalFill(rows [][]byte)
+
+func Wrapped(b []byte) []byte { return external(b) }
+
+func HandedLocal() [][]byte {
+	out := make([][]byte, 1)
+	externalFill(out)
+	return out
+}
+
+func HandedElement(s []byte) [][]byte {
+	out := [][]byte{s}
+	external(out[0])
+	return out
+}
+
+func BodylessValue() func([]byte) []byte { return external }
+`)
+	views, _ := functionViews(t, analysis, pkg, "Wrapped")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "HandedLocal")
+	assertOpaque(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "HandedElement")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "BodylessValue")
+	assertOpaque(t, views, 0, true)
+}
+
+// Unseen writes go opaque, discoverable aliasing stays precise, proven-fresh
+// forms stay fresh.
+func TestViewsFailClosedCategories(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func fill(dst [][]byte, v []byte) { dst[0] = v }
+func handler() {}
+
+func DeferWritten(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	defer fill(out, s)
+	return out
+}
+
+func BoxedEscape(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	var v any = out
+	v.([][]byte)[0] = s
+	return out
+}
+
+func StoredIntoParam(dst [][][]byte, s []byte) [][]byte {
+	out := [][]byte{s}
+	dst[0] = out
+	return out
+}
+
+func ArrayPointerStore(s []byte) [][]byte {
+	out := make([][]byte, 4)
+	a := (*[4][]byte)(out)
+	a[0] = s
+	return out
+}
+
+func CapturedReloadStore(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	defer func() { _ = out }()
+	out[0] = s
+	return out
+}
+
+func Handler() func()      { return handler }
+func NilRows() [][]byte    { return nil }
+`)
+	views, _ := functionViews(t, analysis, pkg, "DeferWritten")
+	assertOpaque(t, views, 0, true)
+	views, sigBoxed := functionViews(t, analysis, pkg, "BoxedEscape")
+	assertResultView(t, views, sigBoxed, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "StoredIntoParam")
+	assertOpaque(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "ArrayPointerStore")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "CapturedReloadStore")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "Handler")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "NilRows")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+}
+
+// A returned function value exposes what its body returns or hands out.
+func TestViewsAccountFunctionValueBodies(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+var cache = [][]byte{{1}}
+
+func yieldGlobal(yield func([]byte) bool) { yield(cache[0]) }
+func emit(yield func([]byte) bool)        { yield(cache[0]) }
+
+func GlobalIterator() func(func([]byte) bool) { return yieldGlobal }
+func DirectGlobal() func() []byte             { return func() []byte { return cache[0] } }
+func IndirectYield() func(func([]byte) bool) {
+	return func(yield func([]byte) bool) { emit(yield) }
+}
+func RecvClosure(ch chan []byte) func() []byte {
+	return func() []byte { return <-ch }
+}
+func CaptureYield(s []byte) func(func([]byte) bool) {
+	return func(yield func([]byte) bool) { yield(s[1:]) }
+}
+`)
+	views, _ := functionViews(t, analysis, pkg, "GlobalIterator")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "DirectGlobal")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "IndirectYield")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "RecvClosure")
+	assertOpaque(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "CaptureYield")
+	assertResultView(t, views, sig, 0, "[s]")
+	assertShared(t, views, 0, false)
+	assertOpaque(t, views, 0, false)
+}
+
+// A closure-written local resolves through the closure's actual stores.
+func TestViewsResolveClosureStoresFromTheirSources(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+var cache = [][]byte{{1}}
+
+func GlobalViaClosure() [][]byte {
+	out := make([][]byte, 1)
+	func() { out[0] = cache[0] }()
+	return out
+}
+
+func RecvViaClosure(ch chan []byte) [][]byte {
+	out := make([][]byte, 1)
+	func() { out[0] = <-ch }()
+	return out
+}
+
+func NestedViaClosure(s []byte) [][]byte {
+	out := make([][]byte, 1)
+	func() {
+		func() { out[0] = s }()
+	}()
+	return out
+}
+`)
+	views, _ := functionViews(t, analysis, pkg, "GlobalViaClosure")
+	assertShared(t, views, 0, true)
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "RecvViaClosure")
+	assertOpaque(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "NestedViaClosure")
+	assertOpaque(t, views, 0, true)
+}
+
+// Rebinding lands at whole depth and a struct-field destination goes opaque.
+func TestViewsKeepClosureStoreDestinationsApart(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+var cache = [][]byte{{1}}
+
+func ReboundWhole(x [][]byte) [][]byte {
+	var out [][]byte
+	set := func(v [][]byte) { out = v }
+	set(x)
+	return out
+}
+
+func SiblingUntouched(s []byte) []byte {
+	var p struct{ a, b []byte }
+	func() { p.a = s }()
+	return p.b
+}
+
+func ReboundNotElementTainted(s []byte) []byte {
+	out := [][]byte{s}
+	func() { out = cache }()
+	return out[0]
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "ReboundWhole")
+	assertResultView(t, views, sig, 0, "x")
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "SiblingUntouched")
+	assertOpaque(t, views, 0, true)
+	views, sig = functionViews(t, analysis, pkg, "ReboundNotElementTainted")
+	assertResultView(t, views, sig, 0, "s")
+	assertShared(t, views, 0, true)
+}
+
+// A result read from a global carries the shared marker, which no override clears.
+func TestViewsMarkGlobalStorageShared(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+var cache []byte
+var registry = map[string]int{}
+var wrapped = struct{ rows [][]byte }{}
+var sentinel error
+
+func Cached() []byte            { return cache }
+func Registry() map[string]int  { return registry }
+func WrappedRow() []byte        { return wrapped.rows[0] }
+func Sentinel() error           { return sentinel }
+func Wrapper() []byte           { return Cached() }
+func CopiedGlobal() []byte      { return append([]byte(nil), cache...) }
+`)
+	views, _ := functionViews(t, analysis, pkg, "Cached")
+	assertShared(t, views, 0, true)
+	assertOpaque(t, views, 0, false)
+	views, _ = functionViews(t, analysis, pkg, "Registry")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "WrappedRow")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "Sentinel")
+	assertShared(t, views, 0, true)
+	views, _ = functionViews(t, analysis, pkg, "Wrapper")
+	assertShared(t, views, 0, true)
+	views, sig := functionViews(t, analysis, pkg, "CopiedGlobal")
+	assertResultView(t, views, sig, 0)
+	assertShared(t, views, 0, false)
+	assertOpaque(t, views, 0, false)
+
+	derived, sig := functionViews(t, analysis, pkg, "Cached")
+	resolved, invalid := ResolveViews(derived, []string{}, true, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertShared(t, resolved, 0, true)
+	if resolved.Fresh() {
+		t.Error("an override must not clear the shared marker")
+	}
+}
+
+// Dynamic dispatch contributes nothing, the blind spot distinct from opaque.
+func TestViewsKeepDynamicDispatchAsBlindSpot(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Provider interface{ Get() []byte }
+
+func FromInterface(p Provider) []byte { return p.Get() }
+func FromFuncValue(f func() []byte) []byte { return f() }
+`)
+	views, sig := functionViews(t, analysis, pkg, "FromInterface")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+	views, sig = functionViews(t, analysis, pkg, "FromFuncValue")
+	assertResultView(t, views, sig, 0)
+	assertOpaque(t, views, 0, false)
+}
+
+func TestViewsSettleMutualRecursion(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func viewA(s []byte, n int) []byte { if n > 0 { return viewB(s, n-1) }; return s }
+func viewB(s []byte, n int) []byte { if n > 0 { return viewA(s, n-1) }; return nil }
+
+func EntryViewA(s []byte) []byte { return viewA(s, 2) }
+func EntryViewB(s []byte) []byte { return viewB(s, 2) }
+`)
+	views, sig := functionViews(t, analysis, pkg, "EntryViewA")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "EntryViewB")
+	assertResultView(t, views, sig, 0, "s")
+}
+
+func TestViewsResolveGenericCores(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+import "iter"
+
+func ClipShape[S ~[]E, E any](s S) S           { return s[:len(s):len(s)] }
+func InsertShape[S ~[]E, E any](s S, v ...E) S { return append(s, v...) }
+
+func AppendSeqShape[S ~[]E, E any](s S, seq iter.Seq[E]) S {
+	for v := range seq { s = append(s, v) }
+	return s
+}
+`)
+	views, sig := functionViews(t, analysis, pkg, "ClipShape")
+	assertResultView(t, views, sig, 0, "s")
+	views, sig = functionViews(t, analysis, pkg, "InsertShape")
+	assertResultView(t, views, sig, 0, "s", "[v]")
+	views, sig = functionViews(t, analysis, pkg, "AppendSeqShape")
+	assertResultView(t, views, sig, 0, "s")
+}
+
+func assertNoInvalidOverrides(t *testing.T, invalid []string) {
+	t.Helper()
+	if len(invalid) > 0 {
+		t.Fatalf("unexpected invalid overrides %v", invalid)
+	}
+}
+
+func TestResolveViewsAppliesWorstCaseToUnseenFunctions(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Opaque(buf []byte, n int) ([]byte, error) { return buf, nil }
+`)
+	_, sig := functionViews(t, analysis, pkg, "Opaque")
+
+	resolved, invalid := ResolveViews(FunctionViews{Results: make([]ResultView, 2)}, nil, false, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0, "buf")
+	assertResultView(t, resolved, sig, 1, "buf")
+	assertOpaque(t, resolved, 0, true)
+	assertOpaque(t, resolved, 1, true)
+
+	resolved, invalid = ResolveViews(FunctionViews{Results: make([]ResultView, 2)}, []string{}, true, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0)
+	assertResultView(t, resolved, sig, 1)
+	assertOpaque(t, resolved, 0, false)
+	assertOpaque(t, resolved, 1, false)
+	if !resolved.Fresh() {
+		t.Error("an override asserting freshness must resolve to fresh")
+	}
+}
+
+func TestResolveViewsResolvesOpaqueResults(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Opaque(a, b []byte) ([]byte, []byte) { return a, nil }
+`)
+	derived, sig := functionViews(t, analysis, pkg, "Opaque")
+	derived.Results[1].Opaque = true
+
+	resolved, invalid := ResolveViews(derived, nil, false, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0, "a")
+	assertResultView(t, resolved, sig, 1, "a", "b")
+	assertOpaque(t, resolved, 1, true)
+
+	resolved, invalid = ResolveViews(derived, []string{"1:[b]"}, true, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0, "a")
+	assertResultView(t, resolved, sig, 1, "[b]")
+	assertOpaque(t, resolved, 1, false)
+
+	resolved, _ = ResolveViews(derived, []string{"1:junk"}, true, sig)
+	assertResultView(t, resolved, sig, 1, "a", "b")
+	assertOpaque(t, resolved, 1, true)
+}
+
+func TestResolveViewsParsesOverrideEntries(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Buffer struct { buf []byte }
+
+func (b *Buffer) Opaque(dst []byte, n int) ([]byte, []byte) { return dst, nil }
+`)
+	_, sig := methodViews(t, analysis, pkg, "Buffer", "Opaque")
+
+	unseen := FunctionViews{Results: make([]ResultView, 2)}
+	resolved, invalid := ResolveViews(unseen, []string{"0:dst", "1:[recv]"}, true, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0, "dst")
+	assertResultView(t, resolved, sig, 1, "[recv]")
+
+	for _, entry := range []string{"0:n", "2:dst", "junk", "0:missing", "0:[dst"} {
+		resolved, invalid = ResolveViews(unseen, []string{entry}, true, sig)
+		if len(invalid) != 1 || invalid[0] != entry {
+			t.Errorf("entry %q: reported invalid %v, want [%s]", entry, invalid, entry)
+		}
+		assertResultView(t, resolved, sig, 0, "dst", "recv")
+		assertResultView(t, resolved, sig, 1, "dst", "recv")
+	}
+}
+
+func TestResolveViewsUnionsOverridesOntoDerivedFacts(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Partial(a, b []byte) []byte { return a }
+`)
+	derived, sig := functionViews(t, analysis, pkg, "Partial")
+
+	resolved, invalid := ResolveViews(derived, []string{"0:b"}, true, sig)
+	assertNoInvalidOverrides(t, invalid)
+	assertResultView(t, resolved, sig, 0, "a", "b")
+	assertResultView(t, derived, sig, 0, "a")
+}
+
+func TestResolveViewsReportsInvalidOverridesOnAnalyzedFunctions(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+func Partial(a, b []byte) []byte { return a }
+`)
+	derived, sig := functionViews(t, analysis, pkg, "Partial")
+
+	resolved, invalid := ResolveViews(derived, []string{"0:missing"}, true, sig)
+	if len(invalid) != 1 || invalid[0] != "0:missing" {
+		t.Errorf("reported invalid %v, want [0:missing]", invalid)
+	}
+	assertResultView(t, resolved, sig, 0, "a")
+}

--- a/bindgen/tests/provenance_test.go
+++ b/bindgen/tests/provenance_test.go
@@ -1,0 +1,377 @@
+package tests
+
+import (
+	"fmt"
+	"go/types"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ivov/lisette/bindgen/internal/cli"
+	"github.com/ivov/lisette/bindgen/internal/config"
+	"github.com/ivov/lisette/bindgen/internal/convert"
+	"github.com/ivov/lisette/bindgen/internal/extract"
+)
+
+// stdViews holds the resolved view fact per bound function, by signature
+// result index: "s" for whole-value sharing, "[s]" for element-level, "recv"
+// for the receiver.
+type stdViews struct {
+	tokens     map[string]map[int][]string
+	unanalyzed map[string]bool
+	opaque     map[string][]int
+	shared     map[string][]int
+}
+
+// TestStdReturnViews checks the derivation against the hand-audited
+// checklist and a golden file, so Go version bumps surface as diffs. The
+// strings subtest exempts the shared marker, which states io.EOF sentinels
+// outside the audited no-aliasing claim.
+func TestStdReturnViews(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stdlib view derivation in short mode")
+	}
+
+	views := deriveStdViews(t)
+
+	t.Run("Checklist", func(t *testing.T) { checkViewChecklist(t, views) })
+	t.Run("StringsStaysFresh", func(t *testing.T) {
+		for name, perResult := range views.tokens {
+			if !strings.HasPrefix(name, "strings.") {
+				continue
+			}
+			if len(perResult) > 0 {
+				t.Errorf("%s reports a view, strings results are fresh or immutable", name)
+			}
+			if len(views.opaque[name]) > 0 {
+				t.Errorf("%s went opaque, strings results are fresh or immutable", name)
+			}
+		}
+	})
+	t.Run("Golden", func(t *testing.T) { checkViewGolden(t, views) })
+}
+
+// deriveStdViews loads linux/amd64, the canonical generation target.
+func deriveStdViews(t *testing.T) stdViews {
+	t.Helper()
+	pkgs, err := extract.LoadStdPackages("linux", "amd64", cli.SkipStdPackage)
+	if err != nil {
+		t.Fatalf("failed to load std packages: %v", err)
+	}
+	cfg, err := config.LoadConfig("../bindgen.stdlib.json", nil)
+	if err != nil {
+		t.Fatalf("failed to load stdlib config: %v", err)
+	}
+	nilness := convert.NewNilnessAnalysis(pkgs, &cfg)
+	if nilness == nil {
+		t.Fatal("SSA build failed")
+	}
+	mutation := convert.NewMutationAnalysis(nilness, pkgs)
+	if mutation == nil {
+		t.Fatal("mutation analysis unavailable")
+	}
+
+	views := stdViews{
+		tokens:     map[string]map[int][]string{},
+		unanalyzed: map[string]bool{},
+		opaque:     map[string][]int{},
+		shared:     map[string][]int{},
+	}
+	record := func(pkgPath string, fn *types.Func) {
+		derived, ok := mutation.Views(fn)
+		if !ok {
+			return
+		}
+		sig := fn.Type().(*types.Signature)
+		lookupName := receiverQualifiedName(fn)
+		overrides, hasOverride := cfg.ViewOverrides(pkgPath, lookupName)
+		resolved, invalidOverrides := convert.ResolveViews(derived, overrides, hasOverride, sig)
+		if len(invalidOverrides) > 0 {
+			t.Errorf("%s.%s: invalid returns_view_of entries %v", pkgPath, lookupName, invalidOverrides)
+		}
+		if resolved.Fresh() {
+			return
+		}
+		name := pkgPath + "." + lookupName
+		perResult := map[int][]string{}
+		var opaqueResults, sharedResults []int
+		for i, result := range resolved.Results {
+			if result.Opaque {
+				opaqueResults = append(opaqueResults, i)
+			}
+			if result.Shared {
+				sharedResults = append(sharedResults, i)
+			}
+			tokens := aliasTokens(sig, result)
+			if len(tokens) > 0 {
+				perResult[i] = tokens
+			}
+		}
+		views.tokens[name] = perResult
+		if !resolved.Analyzed {
+			views.unanalyzed[name] = true
+		}
+		if len(opaqueResults) > 0 {
+			views.opaque[name] = opaqueResults
+		}
+		if len(sharedResults) > 0 {
+			views.shared[name] = sharedResults
+		}
+	}
+
+	for _, pkg := range pkgs {
+		scope := pkg.Types.Scope()
+		for _, scopeName := range scope.Names() {
+			switch obj := scope.Lookup(scopeName).(type) {
+			case *types.Func:
+				if obj.Exported() {
+					record(pkg.PkgPath, obj)
+				}
+			case *types.TypeName:
+				if !obj.Exported() {
+					continue
+				}
+				named, ok := obj.Type().(*types.Named)
+				if !ok {
+					continue
+				}
+				methodSet := types.NewMethodSet(types.NewPointer(named))
+				for i := 0; i < methodSet.Len(); i++ {
+					method, ok := methodSet.At(i).Obj().(*types.Func)
+					if ok && method.Exported() && method.Pkg() == pkg.Types {
+						record(pkg.PkgPath, method)
+					}
+				}
+			}
+		}
+	}
+	return views
+}
+
+// receiverQualifiedName matches the config key format.
+func receiverQualifiedName(fn *types.Func) string {
+	sig := fn.Type().(*types.Signature)
+	receiver := sig.Recv()
+	if receiver == nil {
+		return fn.Name()
+	}
+	receiverType := receiver.Type()
+	if pointer, ok := receiverType.(*types.Pointer); ok {
+		receiverType = pointer.Elem()
+	}
+	if named, ok := receiverType.(*types.Named); ok {
+		return named.Obj().Name() + "." + fn.Name()
+	}
+	return fn.Name()
+}
+
+func aliasTokens(sig *types.Signature, result convert.ResultView) []string {
+	var out []string
+	switch result.Receiver {
+	case convert.DepthWhole:
+		out = append(out, "recv")
+	case convert.DepthElement:
+		out = append(out, "[recv]")
+	}
+	for i := 0; i < sig.Params().Len(); i++ {
+		name := sig.Params().At(i).Name()
+		if name == "" {
+			name = fmt.Sprintf("p%d", i)
+		}
+		switch result.Param(i) {
+		case convert.DepthWhole:
+			out = append(out, name)
+		case convert.DepthElement:
+			out = append(out, "["+name+"]")
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// viewChecklist pins each audited result's exact aliasing set: every listed
+// token must derive, and anything beyond it and conservativeViewTokens fails.
+var viewChecklist = []struct {
+	name   string
+	result int
+	want   []string
+}{
+	{"slices.Clip", 0, []string{"s"}},
+	{"slices.Compact", 0, []string{"s"}},
+	{"slices.CompactFunc", 0, []string{"s"}},
+	{"slices.Delete", 0, []string{"s"}},
+	{"slices.DeleteFunc", 0, []string{"s"}},
+	{"slices.Grow", 0, []string{"s"}},
+	{"slices.Insert", 0, []string{"s", "[v]"}},
+	{"slices.Replace", 0, []string{"s", "[v]"}},
+	{"slices.AppendSeq", 0, []string{"s"}},
+
+	{"bytes.Cut", 0, []string{"s"}},
+	{"bytes.Cut", 1, []string{"s"}},
+	{"bytes.CutPrefix", 0, []string{"s"}},
+	{"bytes.CutSuffix", 0, []string{"s"}},
+	{"bytes.Trim", 0, []string{"s"}},
+	{"bytes.TrimFunc", 0, []string{"s"}},
+	{"bytes.TrimLeft", 0, []string{"s"}},
+	{"bytes.TrimLeftFunc", 0, []string{"s"}},
+	{"bytes.TrimRight", 0, []string{"s"}},
+	{"bytes.TrimRightFunc", 0, []string{"s"}},
+	{"bytes.TrimPrefix", 0, []string{"s"}},
+	{"bytes.TrimSuffix", 0, []string{"s"}},
+	{"bytes.TrimSpace", 0, []string{"s"}},
+	{"bytes.Fields", 0, []string{"[s]"}},
+	{"bytes.FieldsFunc", 0, []string{"[s]"}},
+	{"bytes.Split", 0, []string{"[s]"}},
+	{"bytes.SplitAfter", 0, []string{"[s]"}},
+	{"bytes.SplitAfterN", 0, []string{"[s]"}},
+	{"bytes.SplitN", 0, []string{"[s]"}},
+	{"bytes.SplitSeq", 0, []string{"[s]"}},
+	{"bytes.SplitAfterSeq", 0, []string{"[s]"}},
+	{"bytes.FieldsSeq", 0, []string{"[s]"}},
+	{"bytes.FieldsFuncSeq", 0, []string{"[s]"}},
+	{"bytes.Lines", 0, []string{"[s]"}},
+	{"bytes.Buffer.Bytes", 0, []string{"recv"}},
+	{"bytes.Buffer.AvailableBuffer", 0, []string{"recv"}},
+	{"bytes.Buffer.Next", 0, []string{"recv"}},
+	{"bytes.NewBuffer", 0, []string{"[buf]"}},
+	{"bytes.NewReader", 0, []string{"[b]"}},
+
+	{"bufio.ScanBytes", 1, []string{"data"}},
+	{"bufio.ScanLines", 1, []string{"data"}},
+	// ScanRunes also returns the errorRune global, stated by the shared marker
+	{"bufio.ScanRunes", 1, []string{"data"}},
+	{"bufio.ScanWords", 1, []string{"data"}},
+	{"bufio.Reader.Peek", 0, []string{"recv"}},
+	{"bufio.Reader.ReadSlice", 0, []string{"recv"}},
+	{"bufio.Reader.ReadLine", 0, []string{"recv"}},
+	{"bufio.Writer.AvailableBuffer", 0, []string{"recv"}},
+	{"bufio.Scanner.Bytes", 0, []string{"recv"}},
+
+	{"unicode/utf8.AppendRune", 0, []string{"p"}},
+
+	{"strconv.AppendBool", 0, []string{"dst"}},
+	{"strconv.AppendFloat", 0, []string{"dst"}},
+	{"strconv.AppendInt", 0, []string{"dst"}},
+	{"strconv.AppendUint", 0, []string{"dst"}},
+	{"strconv.AppendQuote", 0, []string{"dst"}},
+	{"strconv.AppendQuoteRune", 0, []string{"dst"}},
+	{"strconv.AppendQuoteRuneToASCII", 0, []string{"dst"}},
+	{"strconv.AppendQuoteRuneToGraphic", 0, []string{"dst"}},
+	{"strconv.AppendQuoteToASCII", 0, []string{"dst"}},
+	{"strconv.AppendQuoteToGraphic", 0, []string{"dst"}},
+
+	{"encoding/hex.AppendEncode", 0, []string{"dst"}},
+	{"encoding/hex.AppendDecode", 0, []string{"dst"}},
+	{"encoding/base32.Encoding.AppendEncode", 0, []string{"dst"}},
+	{"encoding/base32.Encoding.AppendDecode", 0, []string{"dst"}},
+	{"encoding/base64.Encoding.AppendEncode", 0, []string{"dst"}},
+	{"encoding/base64.Encoding.AppendDecode", 0, []string{"dst"}},
+	{"encoding/binary.Append", 0, []string{"buf"}},
+	{"encoding/binary.AppendUvarint", 0, []string{"buf"}},
+	{"encoding/binary.AppendVarint", 0, []string{"buf"}},
+
+	{"math/big.Float.Append", 0, []string{"buf"}},
+	{"math/big.Int.Append", 0, []string{"buf"}},
+	{"math/big.Int.FillBytes", 0, []string{"buf"}},
+
+	{"net/textproto.TrimBytes", 0, []string{"b"}},
+	{"net/textproto.MIMEHeader.Values", 0, []string{"recv"}},
+	{"net/http.Header.Values", 0, []string{"recv"}},
+}
+
+// conservativeViewTokens documents accepted over-approximation: iterator
+// captures are marked wholesale, so the split iterators report [sep] although
+// yielded slices view only s. Stopping deriving these keeps passing.
+var conservativeViewTokens = map[string]map[int][]string{
+	"bytes.SplitSeq":      {0: {"[sep]"}},
+	"bytes.SplitAfterSeq": {0: {"[sep]"}},
+}
+
+func checkViewChecklist(t *testing.T, views stdViews) {
+	for _, entry := range viewChecklist {
+		perResult, ok := views.tokens[entry.name]
+		if !ok {
+			t.Errorf("%s: no view derived, checklist expects result %d to alias %v",
+				entry.name, entry.result, entry.want)
+			continue
+		}
+		if views.unanalyzed[entry.name] {
+			t.Errorf("%s: fell back to the worst case, checklist expects a derived fact", entry.name)
+			continue
+		}
+		if slices.Contains(views.opaque[entry.name], entry.result) {
+			t.Errorf("%s: result %d went opaque, checklist expects a precise fact",
+				entry.name, entry.result)
+			continue
+		}
+		derived := perResult[entry.result]
+		accepted := conservativeViewTokens[entry.name][entry.result]
+		for _, want := range entry.want {
+			if !slices.Contains(derived, want) {
+				t.Errorf("%s: result %d aliases %v, checklist expects %s",
+					entry.name, entry.result, derived, want)
+			}
+		}
+		for _, token := range derived {
+			if !slices.Contains(entry.want, token) && !slices.Contains(accepted, token) {
+				t.Errorf("%s: result %d derives %s beyond the audited set %v",
+					entry.name, entry.result, token, entry.want)
+			}
+		}
+	}
+}
+
+func checkViewGolden(t *testing.T, views stdViews) {
+	renderIndexes := func(label string, indexes []int) string {
+		if len(indexes) == 0 {
+			return ""
+		}
+		rendered := make([]string, len(indexes))
+		for i, index := range indexes {
+			rendered[i] = fmt.Sprintf("r%d", index)
+		}
+		return fmt.Sprintf(" (%s %s)", label, strings.Join(rendered, " "))
+	}
+
+	var lines []string
+	for name, perResult := range views.tokens {
+		marker := ""
+		if views.unanalyzed[name] {
+			marker = " (unanalyzed)"
+		} else {
+			marker = renderIndexes("opaque", views.opaque[name]) +
+				renderIndexes("shared", views.shared[name])
+		}
+		var rendered []string
+		indexes := make([]int, 0, len(perResult))
+		for index := range perResult {
+			indexes = append(indexes, index)
+		}
+		sort.Ints(indexes)
+		for _, index := range indexes {
+			for _, token := range perResult[index] {
+				rendered = append(rendered, fmt.Sprintf("r%d<-%s", index, token))
+			}
+		}
+		lines = append(lines, fmt.Sprintf("%s%s: %s", name, marker, strings.Join(rendered, " ")))
+	}
+	sort.Strings(lines)
+	output := strings.Join(lines, "\n") + "\n"
+
+	goldenPath := "testdata/provenance_std.golden"
+	if *update {
+		if err := os.WriteFile(goldenPath, []byte(output), 0644); err != nil {
+			t.Fatalf("failed to write golden: %v", err)
+		}
+		return
+	}
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("golden not found: %s (run with -update to create)", goldenPath)
+	}
+	if diff := diffOutput(expected, []byte(output)); diff != "" {
+		t.Errorf("derived views changed:\n%s", diff)
+	}
+}

--- a/bindgen/tests/testdata/provenance_std.golden
+++ b/bindgen/tests/testdata/provenance_std.golden
@@ -1,0 +1,1738 @@
+archive/tar.FileInfoHeader (opaque r0): r0<-fi
+archive/tar.Header.FileInfo: r0<-[recv]
+archive/tar.NewReader: r0<-[r]
+archive/tar.NewWriter: r0<-[w]
+archive/tar.Reader.Next (opaque r1) (shared r0 r1): r1<-recv
+archive/tar.Reader.Read: r1<-recv
+archive/tar.Writer.Close: r0<-recv
+archive/tar.Writer.Flush: r0<-recv
+archive/tar.Writer.Write: r1<-recv
+archive/tar.Writer.WriteHeader: r0<-recv
+archive/zip.File.DataOffset (shared r1): 
+archive/zip.File.Open (shared r0 r1): r0<-[recv]
+archive/zip.File.OpenRaw (shared r1): r0<-[recv]
+archive/zip.FileHeader.FileInfo: r0<-[recv]
+archive/zip.FileHeader.ModTime (opaque r0) (shared r0): r0<-recv
+archive/zip.FileInfoHeader (opaque r0): r0<-fi
+archive/zip.NewReader (opaque r0) (shared r1): r0<-r
+archive/zip.NewWriter: r0<-[w]
+archive/zip.OpenReader (opaque r0) (shared r1): 
+archive/zip.ReadCloser.Close (shared r0): 
+archive/zip.Reader.Open (shared r0 r1): r0<-[recv]
+archive/zip.Writer.Close (shared r0): r0<-recv
+archive/zip.Writer.Copy (shared r0): 
+archive/zip.Writer.Create (opaque r0) (shared r1): r0<-recv
+archive/zip.Writer.CreateHeader (opaque r0) (shared r1): r0<-fh r0<-recv
+archive/zip.Writer.CreateRaw (opaque r0) (shared r1): r0<-fh r0<-recv
+archive/zip.Writer.Flush (shared r0): r0<-recv
+bufio.NewReadWriter: r0<-[r] r0<-[w]
+bufio.NewReader (opaque r0): r0<-rd
+bufio.NewReaderSize (opaque r0): r0<-rd
+bufio.NewScanner: r0<-[r]
+bufio.NewWriter: r0<-w
+bufio.NewWriterSize: r0<-w
+bufio.Reader.Discard (shared r1): r1<-recv
+bufio.Reader.Peek (shared r1): r0<-recv r1<-recv
+bufio.Reader.Read: r1<-recv
+bufio.Reader.ReadByte: r1<-recv
+bufio.Reader.ReadBytes (shared r1): r1<-recv
+bufio.Reader.ReadLine (shared r2): r0<-recv r2<-recv
+bufio.Reader.ReadRune: r2<-recv
+bufio.Reader.ReadSlice (shared r1): r0<-recv r1<-recv
+bufio.Reader.ReadString (shared r1): r1<-recv
+bufio.Reader.UnreadByte (shared r0): 
+bufio.Reader.UnreadRune (shared r0): 
+bufio.Reader.WriteTo: r1<-recv
+bufio.ScanBytes: r1<-data
+bufio.ScanLines: r1<-data
+bufio.ScanRunes (shared r1): r1<-data
+bufio.ScanWords: r1<-data
+bufio.Scanner.Bytes: r0<-recv
+bufio.Scanner.Err: r0<-recv
+bufio.Writer.AvailableBuffer: r0<-recv
+bufio.Writer.Flush (shared r0): r0<-recv
+bufio.Writer.ReadFrom (shared r1): r1<-recv
+bufio.Writer.Write: r1<-recv
+bufio.Writer.WriteByte: r0<-recv
+bufio.Writer.WriteRune: r1<-recv
+bufio.Writer.WriteString: r1<-recv
+bytes.Buffer.AvailableBuffer: r0<-recv
+bytes.Buffer.Bytes: r0<-recv
+bytes.Buffer.Next: r0<-recv
+bytes.Buffer.Read (shared r1): 
+bytes.Buffer.ReadByte (shared r1): 
+bytes.Buffer.ReadBytes (shared r1): 
+bytes.Buffer.ReadRune (shared r2): 
+bytes.Buffer.ReadString (shared r1): 
+bytes.Buffer.UnreadByte (shared r0): 
+bytes.Buffer.WriteTo (shared r1): 
+bytes.Cut: r0<-s r1<-s
+bytes.CutPrefix: r0<-s
+bytes.CutSuffix: r0<-s
+bytes.Fields: r0<-[s]
+bytes.FieldsFunc: r0<-[s]
+bytes.FieldsFuncSeq: r0<-[s]
+bytes.FieldsSeq: r0<-[s]
+bytes.Join (opaque r0): r0<-s r0<-sep
+bytes.Lines: r0<-[s]
+bytes.NewBuffer: r0<-[buf]
+bytes.NewReader: r0<-[b]
+bytes.Reader.Read (shared r1): 
+bytes.Reader.ReadAt (shared r1): 
+bytes.Reader.ReadByte (shared r1): 
+bytes.Reader.ReadRune (shared r2): 
+bytes.Reader.WriteTo (shared r1): 
+bytes.Repeat (opaque r0): r0<-b
+bytes.Split: r0<-[s]
+bytes.SplitAfter: r0<-[s]
+bytes.SplitAfterN: r0<-[s]
+bytes.SplitAfterSeq: r0<-[s] r0<-[sep]
+bytes.SplitN: r0<-[s]
+bytes.SplitSeq: r0<-[s] r0<-[sep]
+bytes.ToLower (opaque r0): r0<-s
+bytes.ToUpper (opaque r0): r0<-s
+bytes.Trim: r0<-s
+bytes.TrimFunc: r0<-s
+bytes.TrimLeft: r0<-s
+bytes.TrimLeftFunc: r0<-s
+bytes.TrimPrefix: r0<-s
+bytes.TrimRight: r0<-s
+bytes.TrimRightFunc: r0<-s
+bytes.TrimSpace: r0<-s
+bytes.TrimSuffix: r0<-s
+cmp.Or: r0<-vals
+compress/bzip2.NewReader (opaque r0): r0<-r
+compress/flate.NewReader (opaque r0): r0<-r
+compress/flate.NewReaderDict (opaque r0): r0<-dict r0<-r
+compress/flate.NewWriter (opaque r0): r0<-w
+compress/flate.NewWriterDict (opaque r0): r0<-dict r0<-w
+compress/flate.Writer.Close: r0<-recv
+compress/flate.Writer.Flush: r0<-recv
+compress/flate.Writer.Write: r1<-recv
+compress/gzip.NewReader (opaque r0 r1): r0<-r r1<-r
+compress/gzip.NewWriter (opaque r0): r0<-w
+compress/gzip.NewWriterLevel (opaque r0): r0<-w
+compress/gzip.Reader.Read (shared r1): r1<-recv
+compress/gzip.Reader.Reset: r0<-recv
+compress/gzip.Writer.Close: r0<-recv
+compress/gzip.Writer.Flush: r0<-recv
+compress/gzip.Writer.Write: r1<-recv
+compress/lzw.NewReader (opaque r0): r0<-r
+compress/lzw.NewWriter (opaque r0): r0<-w
+compress/lzw.Reader.Read: r1<-recv
+compress/lzw.Writer.Close (shared r0): r0<-recv
+compress/lzw.Writer.Write: r1<-recv
+compress/zlib.NewReader (opaque r0 r1): r0<-r r1<-r
+compress/zlib.NewReaderDict (opaque r0 r1): r0<-dict r0<-r r1<-dict r1<-r
+compress/zlib.NewWriter: r0<-[w]
+compress/zlib.NewWriterLevel: r0<-[w]
+compress/zlib.NewWriterLevelDict: r0<-[dict] r0<-[w]
+compress/zlib.Writer.Close: r0<-recv
+compress/zlib.Writer.Flush: r0<-recv
+compress/zlib.Writer.Write: r1<-recv
+container/list.Element.Next: r0<-recv
+container/list.Element.Prev: r0<-recv
+container/list.List.Back: r0<-recv
+container/list.List.Front: r0<-recv
+container/list.List.Init: r0<-recv
+container/list.List.InsertAfter (opaque r0): r0<-mark r0<-recv r0<-v
+container/list.List.InsertBefore (opaque r0): r0<-mark r0<-recv r0<-v
+container/list.List.PushBack (opaque r0): r0<-recv r0<-v
+container/list.List.PushFront (opaque r0): r0<-recv r0<-v
+container/list.List.Remove: r0<-e
+container/list.New (opaque r0): 
+container/ring.New (opaque r0): 
+container/ring.Ring.Link: r0<-recv
+container/ring.Ring.Move (opaque r0): r0<-recv
+container/ring.Ring.Next: r0<-recv
+container/ring.Ring.Prev: r0<-recv
+container/ring.Ring.Unlink: r0<-recv
+context.AfterFunc (opaque r0) (shared r0): r0<-ctx
+context.WithCancel (opaque r0 r1) (shared r1): r0<-parent r1<-parent
+context.WithCancelCause (opaque r0 r1) (shared r1): r0<-parent r1<-parent
+context.WithDeadline (opaque r0 r1) (shared r1): r0<-d r0<-parent r1<-d r1<-parent
+context.WithDeadlineCause (opaque r0 r1) (shared r1): r0<-cause r0<-d r0<-parent r1<-cause r1<-d r1<-parent
+context.WithTimeout (opaque r0 r1) (shared r0 r1): r0<-parent r1<-parent
+context.WithTimeoutCause (opaque r0 r1) (shared r0 r1): r0<-cause r0<-parent r1<-cause r1<-parent
+context.WithValue: r0<-[key] r0<-[parent] r0<-[val]
+context.WithoutCancel: r0<-[parent]
+crypto/cipher.NewCBCDecrypter: r0<-[b]
+crypto/cipher.NewCBCEncrypter: r0<-[b]
+crypto/cipher.NewCFBDecrypter: r0<-[block]
+crypto/cipher.NewCFBEncrypter: r0<-[block]
+crypto/cipher.NewCTR: r0<-[block]
+crypto/cipher.NewGCM: r0<-[cipher]
+crypto/cipher.NewGCMWithNonceSize: r0<-[cipher]
+crypto/cipher.NewGCMWithTagSize: r0<-[cipher]
+crypto/cipher.NewOFB: r0<-[b]
+crypto/cipher.StreamWriter.Write (shared r1): 
+crypto/dsa.GenerateKey (shared r0): 
+crypto/dsa.GenerateParameters (shared r0): 
+crypto/dsa.Sign (opaque r0 r1) (shared r2): r0<-hash r0<-priv r0<-rand r1<-hash r1<-priv r1<-rand
+crypto/ecdh.P256 (shared r0): 
+crypto/ecdh.P384 (shared r0): 
+crypto/ecdh.P521 (shared r0): 
+crypto/ecdh.PrivateKey.Curve: r0<-recv
+crypto/ecdh.PrivateKey.Public: r0<-recv
+crypto/ecdh.PrivateKey.PublicKey: r0<-recv
+crypto/ecdh.PublicKey.Curve: r0<-recv
+crypto/ecdsa.GenerateKey (opaque r0) (shared r1): r0<-c r0<-rand
+crypto/ecdsa.ParseRawPrivateKey (opaque r0): r0<-curve r0<-data
+crypto/ecdsa.ParseUncompressedPublicKey (opaque r0): r0<-curve r0<-data
+crypto/ecdsa.PrivateKey.Public: r0<-recv
+crypto/ecdsa.PrivateKey.Sign (opaque r0 r1) (shared r1): r0<-digest r0<-opts r0<-rand r0<-recv r1<-digest r1<-opts r1<-rand r1<-recv
+crypto/ecdsa.PublicKey.Bytes (opaque r0): r0<-recv
+crypto/ecdsa.Sign (opaque r0 r1 r2) (shared r2): r0<-hash r0<-priv r0<-rand r1<-hash r1<-priv r1<-rand r2<-hash r2<-priv r2<-rand
+crypto/ecdsa.SignASN1 (opaque r0 r1) (shared r1): r0<-hash r0<-priv r0<-rand r1<-hash r1<-priv r1<-rand
+crypto/ed25519.GenerateKey (shared r2): 
+crypto/elliptic.CurveParams.Add (opaque r0 r1): r0<-recv r0<-x1 r0<-x2 r0<-y1 r0<-y2 r1<-recv r1<-x1 r1<-x2 r1<-y1 r1<-y2
+crypto/elliptic.CurveParams.Double (opaque r0 r1): r0<-recv r0<-x1 r0<-y1 r1<-recv r1<-x1 r1<-y1
+crypto/elliptic.CurveParams.Params: r0<-recv
+crypto/elliptic.CurveParams.ScalarBaseMult (opaque r0 r1): r0<-k r0<-recv r1<-k r1<-recv
+crypto/elliptic.CurveParams.ScalarMult (opaque r0 r1): r0<-Bx r0<-By r0<-k r0<-recv r1<-Bx r1<-By r1<-k r1<-recv
+crypto/elliptic.GenerateKey (shared r3): 
+crypto/elliptic.Marshal (opaque r0): r0<-curve r0<-x r0<-y
+crypto/elliptic.MarshalCompressed (opaque r0): r0<-curve r0<-x r0<-y
+crypto/elliptic.P224 (shared r0): 
+crypto/elliptic.P256 (shared r0): 
+crypto/elliptic.P384 (shared r0): 
+crypto/elliptic.P521 (shared r0): 
+crypto/elliptic.Unmarshal (opaque r0 r1): r0<-curve r0<-data r1<-curve r1<-data
+crypto/elliptic.UnmarshalCompressed (opaque r0 r1): r0<-curve r0<-data r1<-curve r1<-data
+crypto/hmac.New (opaque r0): r0<-key
+crypto/mlkem.EncapsulationKey1024.Encapsulate (opaque r0): 
+crypto/mlkem.EncapsulationKey768.Encapsulate (opaque r0): 
+crypto/rand.Int (opaque r0) (shared r1): r0<-max r0<-rand
+crypto/rand.Prime (opaque r0) (shared r1): r0<-rand
+crypto/rsa.DecryptOAEP (shared r1): 
+crypto/rsa.DecryptPKCS1v15 (shared r1): 
+crypto/rsa.DecryptPKCS1v15SessionKey (shared r0): 
+crypto/rsa.EncryptOAEP (shared r1): 
+crypto/rsa.EncryptPKCS1v15 (shared r1): 
+crypto/rsa.GenerateKey (opaque r0) (shared r1): r0<-random
+crypto/rsa.GenerateMultiPrimeKey (opaque r0) (shared r1): r0<-random
+crypto/rsa.PrivateKey.Decrypt (opaque r0) (shared r1): r0<-ciphertext r0<-opts r0<-rand r0<-recv
+crypto/rsa.PrivateKey.Public: r0<-recv
+crypto/rsa.PrivateKey.Sign (shared r1): 
+crypto/rsa.SignPKCS1v15 (shared r1): 
+crypto/rsa.SignPSS (shared r1): 
+crypto/rsa.VerifyPKCS1v15 (shared r0): 
+crypto/rsa.VerifyPSS (shared r0): 
+crypto/sha3.NewCSHAKE128 (opaque r0): r0<-N r0<-S
+crypto/sha3.NewCSHAKE256 (opaque r0): r0<-N r0<-S
+crypto/sha3.SHA3.AppendBinary: r0<-p
+crypto/sha3.SHA3.Sum (opaque r0): r0<-b
+crypto/sha3.SHAKE.AppendBinary: r0<-p
+crypto/sha3.SHAKE.MarshalBinary (opaque r0): r0<-recv
+crypto/tls.CertificateRequestInfo.Context: r0<-recv
+crypto/tls.CertificateRequestInfo.SupportsCertificate (opaque r0): r0<-c r0<-recv
+crypto/tls.CertificateVerificationError.Unwrap: r0<-recv
+crypto/tls.CipherSuites (shared r0): 
+crypto/tls.Client (opaque r0) (shared r0): r0<-config r0<-conn
+crypto/tls.ClientHelloInfo.Context: r0<-recv
+crypto/tls.ClientHelloInfo.SupportsCertificate (opaque r0) (shared r0): r0<-c r0<-recv
+crypto/tls.ClientSessionState.ResumptionState: r0<-recv r1<-recv
+crypto/tls.Config.Clone: r0<-[recv]
+crypto/tls.Config.DecryptTicket (opaque r0) (shared r0): r0<-cs r0<-identity r0<-recv
+crypto/tls.Config.EncryptTicket (opaque r1) (shared r1): r1<-cs r1<-recv r1<-ss
+crypto/tls.Conn.Close (shared r0): r0<-[recv]
+crypto/tls.Conn.CloseWrite (shared r0): r0<-recv
+crypto/tls.Conn.ConnectionState (opaque r0): r0<-recv
+crypto/tls.Conn.Handshake (opaque r0): r0<-recv
+crypto/tls.Conn.HandshakeContext (opaque r0): r0<-ctx r0<-recv
+crypto/tls.Conn.NetConn: r0<-recv
+crypto/tls.Conn.OCSPResponse: r0<-recv
+crypto/tls.Conn.Read (opaque r1) (shared r1): r1<-b r1<-recv
+crypto/tls.Conn.VerifyHostname: r0<-[recv]
+crypto/tls.Conn.Write (opaque r1) (shared r1): r1<-b r1<-recv
+crypto/tls.Dial (opaque r0 r1) (shared r0 r1): r0<-config r1<-config
+crypto/tls.DialWithDialer (opaque r0 r1) (shared r0 r1): r0<-config r0<-dialer r1<-config r1<-dialer
+crypto/tls.Dialer.Dial (opaque r0 r1) (shared r0 r1): r0<-recv r1<-recv
+crypto/tls.Dialer.DialContext (opaque r0 r1) (shared r0 r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+crypto/tls.InsecureCipherSuites (shared r0): 
+crypto/tls.Listen (opaque r1) (shared r1): r0<-[config] r1<-config
+crypto/tls.LoadX509KeyPair (opaque r0 r1) (shared r0 r1): 
+crypto/tls.NewLRUClientSessionCache (opaque r0): 
+crypto/tls.NewListener: r0<-[config] r0<-[inner]
+crypto/tls.NewResumptionState: r0<-[state]
+crypto/tls.ParseSessionState (opaque r0 r1) (shared r0): r0<-data r1<-data
+crypto/tls.QUICClient (opaque r0) (shared r0): r0<-config
+crypto/tls.QUICConn.Close: r0<-recv
+crypto/tls.QUICConn.ConnectionState (opaque r0): r0<-recv
+crypto/tls.QUICConn.HandleData: r0<-recv
+crypto/tls.QUICConn.NextEvent (opaque r0): r0<-recv
+crypto/tls.QUICConn.SendSessionTicket (opaque r0) (shared r0): r0<-opts r0<-recv
+crypto/tls.QUICConn.Start: r0<-recv
+crypto/tls.QUICServer (opaque r0) (shared r0): r0<-config
+crypto/tls.Server (opaque r0) (shared r0): r0<-config r0<-conn
+crypto/tls.SessionState.Bytes (opaque r0 r1): r0<-recv r1<-recv
+crypto/tls.X509KeyPair (opaque r0 r1) (shared r0): r0<-certPEMBlock r0<-keyPEMBlock r1<-certPEMBlock r1<-keyPEMBlock
+crypto/x509.CertPool.Clone (opaque r0): r0<-recv
+crypto/x509.CertPool.Subjects: r0<-[recv]
+crypto/x509.Certificate.CheckCRLSignature (shared r0): r0<-[recv]
+crypto/x509.Certificate.CheckSignature (shared r0): r0<-[recv]
+crypto/x509.Certificate.CheckSignatureFrom (shared r0): r0<-[parent]
+crypto/x509.Certificate.CreateCRL (shared r1): 
+crypto/x509.Certificate.Verify (opaque r0) (shared r1): r0<-opts r0<-recv r1<-[opts] r1<-[recv]
+crypto/x509.Certificate.VerifyHostname: r0<-[recv]
+crypto/x509.CertificateRequest.CheckSignature (shared r0): r0<-[recv]
+crypto/x509.CreateCertificate (opaque r1) (shared r1): r1<-parent r1<-priv r1<-pub r1<-rand r1<-template
+crypto/x509.CreateCertificateRequest (shared r1): 
+crypto/x509.CreateRevocationList (shared r1): 
+crypto/x509.DecryptPEMBlock (shared r1): 
+crypto/x509.MarshalPKCS8PrivateKey: r1<-[key]
+crypto/x509.MarshalPKIXPublicKey: r1<-[pub]
+crypto/x509.OID.AppendBinary: r0<-b
+crypto/x509.OID.AppendText: r0<-b
+crypto/x509.OID.UnmarshalBinary (shared r0): 
+crypto/x509.OID.UnmarshalText (shared r0): 
+crypto/x509.OIDFromInts (opaque r0) (shared r1): r0<-oid
+crypto/x509.ParseCertificate (opaque r0 r1) (shared r0): r0<-der r1<-der
+crypto/x509.ParseCertificateRequest (opaque r0) (shared r0): r0<-asn1Data
+crypto/x509.ParseCertificates (opaque r0 r1) (shared r0): r0<-der r1<-der
+crypto/x509.ParseECPrivateKey (opaque r0) (shared r0): r0<-der
+crypto/x509.ParseOID (opaque r0) (shared r1): 
+crypto/x509.ParsePKCS1PrivateKey (opaque r0): r0<-der
+crypto/x509.ParsePKCS8PrivateKey (opaque r0) (shared r0): r0<-der
+crypto/x509.ParsePKIXPublicKey (opaque r0) (shared r0): r0<-derBytes
+crypto/x509.ParseRevocationList (opaque r0): r0<-der
+crypto/x509.RevocationList.CheckSignatureFrom (shared r0): r0<-[parent]
+crypto/x509.SystemCertPool (opaque r0) (shared r0 r1): 
+crypto/x509.SystemRootsError.Unwrap: r0<-recv
+crypto/x509/pkix.Name.ToRDNSequence (shared r0): r0<-[recv]
+database/sql.ColumnType.ScanType: r0<-recv
+database/sql.Conn.BeginTx (opaque r0) (shared r0 r1): r0<-ctx r0<-recv
+database/sql.Conn.Close (shared r0): 
+database/sql.Conn.ExecContext (opaque r0) (shared r1): r0<-args r0<-ctx r0<-recv
+database/sql.Conn.PingContext (shared r0): 
+database/sql.Conn.PrepareContext (opaque r0) (shared r1): r0<-ctx r0<-recv
+database/sql.Conn.QueryContext (opaque r0) (shared r1): r0<-args r0<-ctx r0<-recv
+database/sql.Conn.QueryRowContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Conn.Raw (shared r0): 
+database/sql.DB.Begin (opaque r0 r1) (shared r0 r1): r0<-recv r1<-recv
+database/sql.DB.BeginTx (opaque r0 r1) (shared r0 r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+database/sql.DB.Conn (opaque r0 r1) (shared r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+database/sql.DB.Exec (opaque r0 r1) (shared r1): r0<-args r0<-recv r1<-args r1<-recv
+database/sql.DB.ExecContext (opaque r0 r1) (shared r1): r0<-args r0<-ctx r0<-recv r1<-args r1<-ctx r1<-recv
+database/sql.DB.Ping (opaque r0) (shared r0): r0<-recv
+database/sql.DB.PingContext (opaque r0) (shared r0): r0<-ctx r0<-recv
+database/sql.DB.Prepare (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+database/sql.DB.PrepareContext (opaque r0 r1) (shared r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+database/sql.DB.Query (opaque r0 r1) (shared r1): r0<-args r0<-recv r1<-args r1<-recv
+database/sql.DB.QueryContext (opaque r0 r1) (shared r1): r0<-args r0<-ctx r0<-recv r1<-args r1<-ctx r1<-recv
+database/sql.DB.QueryRow (opaque r0) (shared r0): r0<-args r0<-recv
+database/sql.DB.QueryRowContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Named: r0<-[value]
+database/sql.Null.Scan (shared r0): r0<-[recv] r0<-[value]
+database/sql.Null.Value (opaque r0): r0<-recv r1<-[recv]
+database/sql.NullBool.Scan (shared r0): r0<-[value]
+database/sql.NullByte.Scan (shared r0): r0<-[value]
+database/sql.NullFloat64.Scan (shared r0): r0<-[value]
+database/sql.NullInt16.Scan (shared r0): r0<-[value]
+database/sql.NullInt32.Scan (shared r0): r0<-[value]
+database/sql.NullInt64.Scan (shared r0): r0<-[value]
+database/sql.NullString.Scan (shared r0): r0<-[value]
+database/sql.NullTime.Scan (shared r0): r0<-[recv] r0<-[value]
+database/sql.NullTime.Value: r0<-[recv]
+database/sql.Open (opaque r0) (shared r0): 
+database/sql.OpenDB (opaque r0) (shared r0): r0<-c
+database/sql.Row.Err: r0<-recv
+database/sql.Row.Scan (opaque r0) (shared r0): r0<-dest r0<-recv
+database/sql.Rows.Close (opaque r0): r0<-recv
+database/sql.Rows.ColumnTypes (shared r1): r1<-recv
+database/sql.Rows.Columns (shared r1): r1<-recv
+database/sql.Rows.Err: r0<-recv
+database/sql.Rows.Scan (shared r0): r0<-[dest] r0<-recv
+database/sql.Stmt.Close: r0<-recv
+database/sql.Stmt.Exec (opaque r0) (shared r0): r0<-args r0<-recv
+database/sql.Stmt.ExecContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Stmt.Query (opaque r0) (shared r0): r0<-args r0<-recv
+database/sql.Stmt.QueryContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Stmt.QueryRow (opaque r0) (shared r0): r0<-args r0<-recv
+database/sql.Stmt.QueryRowContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Tx.Commit (shared r0): 
+database/sql.Tx.Exec (opaque r0) (shared r1): r0<-args r0<-recv
+database/sql.Tx.ExecContext (opaque r0) (shared r1): r0<-args r0<-ctx r0<-recv
+database/sql.Tx.Prepare (opaque r0) (shared r1): r0<-recv
+database/sql.Tx.PrepareContext (opaque r0) (shared r1): r0<-ctx r0<-recv
+database/sql.Tx.Query (opaque r0) (shared r1): r0<-args r0<-recv
+database/sql.Tx.QueryContext (opaque r0) (shared r1): r0<-args r0<-ctx r0<-recv
+database/sql.Tx.QueryRow (opaque r0) (shared r0): r0<-args r0<-recv
+database/sql.Tx.QueryRowContext (opaque r0) (shared r0): r0<-args r0<-ctx r0<-recv
+database/sql.Tx.Rollback (shared r0): 
+database/sql.Tx.Stmt (opaque r0) (shared r0): r0<-recv r0<-stmt
+database/sql.Tx.StmtContext (opaque r0) (shared r0): r0<-ctx r0<-recv r0<-stmt
+debug/buildinfo.Read (shared r1): 
+debug/buildinfo.ReadFile (shared r1): 
+debug/dwarf.Data.AddTypes (opaque r0): r0<-recv r0<-types
+debug/dwarf.Data.LineReader (opaque r0 r1): r0<-cu r0<-recv r1<-cu r1<-recv
+debug/dwarf.Data.Ranges (opaque r1): r1<-e r1<-recv
+debug/dwarf.Data.Reader (opaque r0): r0<-recv
+debug/dwarf.Data.Type (opaque r0 r1): r0<-recv r1<-recv
+debug/dwarf.Entry.AttrField: r0<-recv
+debug/dwarf.Entry.Val: r0<-recv
+debug/dwarf.LineReader.Files: r0<-recv
+debug/dwarf.LineReader.Next (shared r0): r0<-recv
+debug/dwarf.LineReader.SeekPC (shared r0): r0<-recv
+debug/dwarf.New (opaque r0 r1): r0<-abbrev r0<-aranges r0<-frame r0<-info r0<-line r0<-pubnames r0<-ranges r0<-str r1<-abbrev r1<-aranges r1<-frame r1<-info r1<-line r1<-pubnames r1<-ranges r1<-str
+debug/dwarf.Reader.ByteOrder: r0<-recv
+debug/dwarf.Reader.Next (opaque r0): r0<-recv r1<-recv
+debug/dwarf.Reader.SeekPC (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+debug/elf.File.DWARF (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+debug/elf.File.DynString (shared r1): 
+debug/elf.File.DynValue (shared r1): 
+debug/elf.File.DynamicSymbols (shared r1): 
+debug/elf.File.DynamicVersionNeeds (shared r1): r0<-recv
+debug/elf.File.DynamicVersions (shared r1): r0<-recv
+debug/elf.File.ImportedLibraries (shared r1): 
+debug/elf.File.ImportedSymbols (shared r1): 
+debug/elf.File.Section: r0<-recv
+debug/elf.File.SectionByType: r0<-recv
+debug/elf.File.Symbols (shared r1): 
+debug/elf.NewFile (opaque r0) (shared r1): r0<-r
+debug/elf.Open (opaque r0) (shared r1): 
+debug/elf.Prog.Open: r0<-[recv]
+debug/elf.Section.Data (shared r1): 
+debug/elf.Section.Open (opaque r0): r0<-recv
+debug/gosym.NewLineTable: r0<-[data]
+debug/gosym.NewTable (opaque r0): r0<-pcln r0<-symtab
+debug/gosym.Table.LineToPC (opaque r1): r1<-recv
+debug/gosym.Table.LookupFunc: r0<-recv
+debug/gosym.Table.LookupSym: r0<-recv
+debug/gosym.Table.PCToFunc: r0<-recv
+debug/gosym.Table.PCToLine: r2<-recv
+debug/gosym.Table.SymByAddr: r0<-recv
+debug/macho.File.DWARF (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+debug/macho.File.Section: r0<-recv
+debug/macho.File.Segment: r0<-recv
+debug/macho.LoadBytes.Raw: r0<-recv
+debug/macho.NewFatFile (opaque r0) (shared r1): r0<-r
+debug/macho.NewFile (opaque r0) (shared r1): r0<-r
+debug/macho.Open (opaque r0) (shared r1): 
+debug/macho.OpenFat (opaque r0) (shared r1): 
+debug/macho.Section.Data (shared r1): 
+debug/macho.Section.Open: r0<-[recv]
+debug/macho.Segment.Data (shared r1): 
+debug/macho.Segment.Open: r0<-[recv]
+debug/pe.File.DWARF (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+debug/pe.File.ImportedSymbols (shared r1): 
+debug/pe.File.Section: r0<-recv
+debug/pe.NewFile (opaque r0) (shared r1): r0<-r
+debug/pe.Open (opaque r0) (shared r1): 
+debug/pe.Section.Data (shared r1): 
+debug/pe.Section.Open: r0<-[recv]
+debug/plan9obj.File.Section: r0<-recv
+debug/plan9obj.File.Symbols (opaque r0) (shared r1): r0<-recv
+debug/plan9obj.NewFile (opaque r0) (shared r1): r0<-r
+debug/plan9obj.Open (opaque r0) (shared r1): 
+debug/plan9obj.Section.Data (shared r1): 
+debug/plan9obj.Section.Open: r0<-[recv]
+embed.FS.Open (shared r1): r0<-[recv]
+embed.FS.ReadDir (shared r1): 
+embed.FS.ReadFile (shared r1): 
+encoding/ascii85.NewDecoder: r0<-[r]
+encoding/ascii85.NewEncoder: r0<-[w]
+encoding/asn1.BitString.RightAlign: r0<-recv
+encoding/asn1.Unmarshal: r0<-b
+encoding/asn1.UnmarshalWithParams: r0<-b
+encoding/base32.Encoding.AppendDecode: r0<-dst
+encoding/base32.Encoding.AppendEncode: r0<-dst
+encoding/base32.NewDecoder: r0<-[r]
+encoding/base32.NewEncoder: r0<-[w]
+encoding/base64.Encoding.AppendDecode: r0<-dst
+encoding/base64.Encoding.AppendEncode: r0<-dst
+encoding/base64.Encoding.DecodeString (opaque r0): 
+encoding/base64.NewDecoder: r0<-[r]
+encoding/base64.NewEncoder: r0<-[w]
+encoding/binary.Append: r0<-buf
+encoding/binary.AppendUvarint: r0<-buf
+encoding/binary.AppendVarint: r0<-buf
+encoding/binary.Decode (shared r1): 
+encoding/binary.Encode (shared r1): 
+encoding/binary.Read (shared r0): 
+encoding/binary.ReadUvarint (shared r1): 
+encoding/binary.ReadVarint (shared r1): 
+encoding/csv.NewReader (opaque r0): r0<-r
+encoding/csv.NewWriter: r0<-[w]
+encoding/csv.ParseError.Unwrap: r0<-recv
+encoding/csv.Reader.Read (shared r1): r0<-recv r1<-recv
+encoding/csv.Reader.ReadAll (shared r1): r1<-recv
+encoding/csv.Writer.Error: r0<-recv
+encoding/csv.Writer.Write (shared r0): r0<-recv
+encoding/csv.Writer.WriteAll (shared r0): r0<-recv
+encoding/gob.Decoder.Decode: r0<-recv
+encoding/gob.Decoder.DecodeValue: r0<-recv
+encoding/gob.Encoder.Encode: r0<-recv
+encoding/gob.Encoder.EncodeValue: r0<-recv
+encoding/gob.NewDecoder (opaque r0): r0<-r
+encoding/gob.NewEncoder (opaque r0): r0<-w
+encoding/hex.AppendDecode (shared r1): r0<-dst
+encoding/hex.AppendEncode: r0<-dst
+encoding/hex.Decode (shared r1): 
+encoding/hex.DecodeString (opaque r0) (shared r1): 
+encoding/hex.Dumper: r0<-[w]
+encoding/hex.NewDecoder: r0<-[r]
+encoding/hex.NewEncoder: r0<-[w]
+encoding/json.Compact (opaque r0): r0<-dst r0<-src
+encoding/json.Decoder.Buffered: r0<-[recv]
+encoding/json.Decoder.Decode (shared r0): r0<-recv
+encoding/json.Decoder.Token (shared r1): r1<-recv
+encoding/json.Encoder.Encode (opaque r0): r0<-recv r0<-v
+encoding/json.Indent (opaque r0): r0<-dst r0<-src
+encoding/json.Marshal (opaque r1): r1<-v
+encoding/json.MarshalIndent (opaque r0 r1): r0<-v r1<-v
+encoding/json.MarshalerError.Unwrap: r0<-recv
+encoding/json.NewDecoder: r0<-[r]
+encoding/json.NewEncoder: r0<-[w]
+encoding/json.Number.Float64 (shared r1): 
+encoding/json.Number.Int64 (shared r1): 
+encoding/json.RawMessage.MarshalJSON: r0<-recv
+encoding/json.Unmarshal (opaque r0) (shared r0): r0<-data r0<-v
+encoding/pem.Decode: r1<-data
+encoding/xml.CopyToken: r0<-t
+encoding/xml.Decoder.Decode (shared r0): r0<-recv
+encoding/xml.Decoder.DecodeElement (shared r0): r0<-recv
+encoding/xml.Decoder.RawToken (shared r1): r0<-recv r1<-recv
+encoding/xml.Decoder.Skip (shared r0): r0<-recv
+encoding/xml.Decoder.Token (opaque r0) (shared r1): r0<-recv r1<-recv
+encoding/xml.Encoder.Close (shared r0): r0<-recv
+encoding/xml.Encoder.Encode (shared r0): r0<-recv
+encoding/xml.Encoder.EncodeElement (shared r0): r0<-recv
+encoding/xml.Encoder.EncodeToken: r0<-recv
+encoding/xml.Encoder.Flush (shared r0): r0<-recv
+encoding/xml.Marshal (shared r1): 
+encoding/xml.MarshalIndent (shared r1): 
+encoding/xml.NewDecoder (opaque r0): r0<-r
+encoding/xml.NewEncoder: r0<-[w]
+encoding/xml.NewTokenDecoder: r0<-t
+encoding/xml.ProcInst.Copy: r0<-[recv]
+encoding/xml.StartElement.Copy: r0<-[recv]
+encoding/xml.Unmarshal (opaque r0) (shared r0): r0<-data r0<-v
+errors.Join: r0<-[errs]
+expvar.Handler (opaque r0): 
+expvar.Map.Init: r0<-recv
+expvar.NewMap (opaque r0): 
+flag.Args (shared r0): 
+flag.FlagSet.Args: r0<-recv
+flag.FlagSet.Lookup: r0<-recv
+flag.FlagSet.Output (shared r0): r0<-recv
+flag.FlagSet.Parse (shared r0): 
+flag.Lookup (opaque r0): 
+flag.NewFlagSet (opaque r0): 
+fmt.Append: r0<-b
+fmt.Appendf: r0<-b
+fmt.Appendln: r0<-b
+fmt.Errorf: r0<-[a]
+fmt.Fscan (opaque r1): r1<-a r1<-r
+fmt.Fscanf (opaque r1): r1<-a r1<-r
+fmt.Fscanln (opaque r1): r1<-a r1<-r
+fmt.Scan (opaque r1): r1<-a
+fmt.Scanf (opaque r1): r1<-a
+fmt.Scanln (opaque r1): r1<-a
+fmt.Sscan (opaque r1): r1<-a
+fmt.Sscanf (opaque r1): r1<-a
+fmt.Sscanln (opaque r1): r1<-a
+go/ast.CommentMap.Comments (opaque r0): r0<-recv
+go/ast.CommentMap.Filter: r0<-[recv]
+go/ast.CommentMap.Update: r0<-new
+go/ast.Fprint (opaque r0): r0<-fset r0<-w r0<-x
+go/ast.MergePackageFiles (opaque r0): r0<-pkg
+go/ast.NewCommentMap (opaque r0): r0<-comments r0<-fset r0<-node
+go/ast.NewPackage (opaque r1): r0<-[files] r0<-[universe] r1<-files r1<-fset r1<-universe
+go/ast.NewScope: r0<-[outer]
+go/ast.Preorder (opaque r0): r0<-root
+go/ast.Print (opaque r0): r0<-fset r0<-x
+go/ast.Scope.Insert: r0<-recv
+go/ast.Scope.Lookup: r0<-recv
+go/ast.Unparen (opaque r0): r0<-e
+go/build.Context.Import (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+go/build.Context.ImportDir (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+go/build.Context.MatchFile (opaque r1) (shared r1): r1<-recv
+go/build.Import (opaque r0 r1) (shared r1): 
+go/build.ImportDir (opaque r0 r1) (shared r1): 
+go/build/constraint.Parse (shared r1): 
+go/build/constraint.PlusBuildLines (shared r1): 
+go/constant.BinaryOp (opaque r0) (shared r0): r0<-x_ r0<-y_
+go/constant.Denom (opaque r0): r0<-x
+go/constant.Imag: r0<-x
+go/constant.Make (opaque r0) (shared r0): r0<-x
+go/constant.MakeFloat64 (opaque r0): 
+go/constant.MakeFromLiteral (opaque r0) (shared r0): 
+go/constant.MakeImag: r0<-x
+go/constant.Num (opaque r0): r0<-x
+go/constant.Real: r0<-x
+go/constant.Shift: r0<-[x]
+go/constant.ToComplex: r0<-[x]
+go/constant.ToFloat (opaque r0): r0<-x
+go/constant.ToInt (opaque r0): r0<-x
+go/constant.UnaryOp (opaque r0) (shared r0): r0<-y
+go/constant.Val: r0<-x
+go/doc.Examples (opaque r0): r0<-testFiles
+go/doc.New (opaque r0): r0<-pkg
+go/doc.NewFromFiles (opaque r0): r0<-files r0<-fset r0<-opts
+go/doc.Package.HTML (opaque r0): r0<-recv
+go/doc.Package.Markdown (opaque r0): r0<-recv
+go/doc.Package.Parser: r0<-[recv]
+go/doc.Package.Text (opaque r0): r0<-recv
+go/doc/comment.Parser.Parse (opaque r0): r0<-recv
+go/doc/comment.Printer.Comment (opaque r0): r0<-d
+go/doc/comment.Printer.HTML (opaque r0): r0<-d
+go/doc/comment.Printer.Markdown (opaque r0): r0<-d
+go/doc/comment.Printer.Text (opaque r0): r0<-d
+go/format.Node (opaque r0) (shared r0): r0<-dst r0<-fset r0<-node
+go/format.Source (opaque r1) (shared r1): r0<-src r1<-src
+go/importer.Default (opaque r0) (shared r0): 
+go/importer.For (opaque r0) (shared r0): 
+go/importer.ForCompiler (opaque r0) (shared r0): r0<-fset
+go/parser.ParseDir (opaque r0) (shared r1): r0<-fset
+go/parser.ParseExpr (opaque r0) (shared r1): 
+go/parser.ParseExprFrom (opaque r0) (shared r1): r0<-fset r0<-src
+go/parser.ParseFile (opaque r0) (shared r1): r0<-fset r0<-src
+go/printer.Config.Fprint (opaque r0): r0<-fset r0<-node r0<-output
+go/printer.Fprint (opaque r0): r0<-fset r0<-node r0<-output
+go/scanner.ErrorList.Err: r0<-recv
+go/token.File.Lines: r0<-recv
+go/token.FileSet.File (opaque r0): r0<-recv
+go/types.Alias.Obj: r0<-recv
+go/types.Alias.Origin: r0<-recv
+go/types.Alias.Rhs: r0<-recv
+go/types.Alias.TypeArgs: r0<-recv
+go/types.Alias.TypeParams: r0<-recv
+go/types.ArgumentError.Unwrap: r0<-recv
+go/types.Array.Elem: r0<-recv
+go/types.Array.Underlying: r0<-recv
+go/types.Chan.Elem: r0<-recv
+go/types.Chan.Underlying: r0<-recv
+go/types.CheckExpr (opaque r0): r0<-expr r0<-fset r0<-info r0<-pkg
+go/types.Checker.Files (opaque r0): r0<-files r0<-recv
+go/types.Config.Check (opaque r1) (shared r0): r1<-files r1<-fset r1<-info r1<-recv
+go/types.Const.Val: r0<-recv
+go/types.Default (shared r0): r0<-t
+go/types.Eval (opaque r1) (shared r1): r1<-fset r1<-pkg
+go/types.Func.Origin: r0<-recv
+go/types.Func.Pkg: r0<-recv
+go/types.Func.Scope: r0<-recv
+go/types.Func.Signature: r0<-recv
+go/types.Info.ObjectOf: r0<-recv
+go/types.Info.PkgNameOf: r0<-recv
+go/types.Info.TypeOf: r0<-recv
+go/types.Instantiate (opaque r0): r0<-ctxt r0<-orig r0<-targs r1<-[orig]
+go/types.Interface.Complete: r0<-recv
+go/types.Interface.Embedded (opaque r0): r0<-recv
+go/types.Interface.EmbeddedType: r0<-recv
+go/types.Interface.EmbeddedTypes: r0<-[recv]
+go/types.Interface.ExplicitMethod: r0<-recv
+go/types.Interface.ExplicitMethods: r0<-[recv]
+go/types.Interface.Method (opaque r0) (shared r0): r0<-recv
+go/types.Interface.Methods (opaque r0) (shared r0): r0<-recv
+go/types.Interface.Underlying: r0<-recv
+go/types.LookupFieldOrMethod (opaque r0) (shared r0): r0<-T r0<-pkg
+go/types.LookupSelection (opaque r0) (shared r0): r0<-T r0<-pkg
+go/types.Map.Elem: r0<-recv
+go/types.Map.Key: r0<-recv
+go/types.Map.Underlying: r0<-recv
+go/types.MethodSet.At: r0<-recv
+go/types.MethodSet.Lookup: r0<-recv
+go/types.MethodSet.Methods: r0<-[recv]
+go/types.MissingMethod (opaque r0) (shared r0): r0<-T r0<-V
+go/types.Named.Method: r0<-recv
+go/types.Named.Methods (opaque r0) (shared r0): r0<-recv
+go/types.Named.Obj (opaque r0): r0<-recv
+go/types.Named.Origin: r0<-recv
+go/types.Named.TypeArgs: r0<-recv
+go/types.Named.TypeParams: r0<-recv
+go/types.Named.Underlying (opaque r0): r0<-recv
+go/types.NewAlias (opaque r0): r0<-obj r0<-rhs
+go/types.NewArray: r0<-[elem]
+go/types.NewChan: r0<-[elem]
+go/types.NewChecker: r0<-[conf] r0<-[fset] r0<-[info] r0<-[pkg]
+go/types.NewConst: r0<-[pkg] r0<-[typ] r0<-[val]
+go/types.NewField: r0<-[pkg] r0<-[typ]
+go/types.NewFunc: r0<-[pkg] r0<-[sig]
+go/types.NewInterface (shared r0): 
+go/types.NewInterfaceType (shared r0): 
+go/types.NewLabel: r0<-[pkg]
+go/types.NewMap: r0<-[elem] r0<-[key]
+go/types.NewMethodSet (opaque r0) (shared r0): r0<-T
+go/types.NewNamed (opaque r0): r0<-methods r0<-obj r0<-underlying
+go/types.NewPackage (shared r0): 
+go/types.NewParam: r0<-[pkg] r0<-[typ]
+go/types.NewPkgName: r0<-[imported] r0<-[pkg]
+go/types.NewPointer: r0<-[elem]
+go/types.NewScope: r0<-[parent]
+go/types.NewSignature: r0<-[params] r0<-[recv] r0<-[results]
+go/types.NewSignatureType: r0<-[params] r0<-[recvTypeParams] r0<-[recv] r0<-[results] r0<-[typeParams]
+go/types.NewSlice: r0<-[elem]
+go/types.NewStruct (opaque r0): r0<-fields r0<-tags
+go/types.NewTerm: r0<-[typ]
+go/types.NewTuple: r0<-[x]
+go/types.NewTypeName: r0<-[pkg] r0<-[typ]
+go/types.NewTypeParam (opaque r0): r0<-constraint r0<-obj
+go/types.NewUnion: r0<-[terms]
+go/types.NewVar: r0<-[pkg] r0<-[typ]
+go/types.Package.Imports: r0<-recv
+go/types.Package.Scope (shared r0): r0<-recv
+go/types.PkgName.Imported: r0<-recv
+go/types.Pointer.Elem: r0<-recv
+go/types.Pointer.Underlying: r0<-recv
+go/types.RelativeTo: r0<-[pkg]
+go/types.Scope.Child: r0<-recv
+go/types.Scope.Children: r0<-[recv]
+go/types.Scope.Innermost: r0<-recv
+go/types.Scope.Insert (opaque r0) (shared r0): r0<-obj r0<-recv
+go/types.Scope.Lookup (opaque r0) (shared r0): r0<-recv
+go/types.Scope.LookupParent (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+go/types.Scope.Names (opaque r0): r0<-recv
+go/types.Scope.Parent: r0<-recv
+go/types.Selection.Index: r0<-recv
+go/types.Selection.Obj: r0<-recv
+go/types.Selection.Recv: r0<-recv
+go/types.Selection.Type (opaque r0): r0<-recv
+go/types.Signature.Params: r0<-recv
+go/types.Signature.Recv: r0<-recv
+go/types.Signature.RecvTypeParams: r0<-recv
+go/types.Signature.Results: r0<-recv
+go/types.Signature.TypeParams: r0<-recv
+go/types.Signature.Underlying: r0<-recv
+go/types.Slice.Elem: r0<-recv
+go/types.Slice.Underlying: r0<-recv
+go/types.Struct.Field: r0<-recv
+go/types.Struct.Fields: r0<-[recv]
+go/types.Struct.Underlying: r0<-recv
+go/types.Term.Type: r0<-recv
+go/types.Tuple.At: r0<-recv
+go/types.Tuple.Underlying: r0<-recv
+go/types.Tuple.Variables: r0<-[recv]
+go/types.TypeList.At: r0<-recv
+go/types.TypeList.Types: r0<-[recv]
+go/types.TypeParam.Constraint: r0<-recv
+go/types.TypeParam.Obj: r0<-recv
+go/types.TypeParam.Underlying (opaque r0) (shared r0): r0<-recv
+go/types.TypeParamList.At: r0<-recv
+go/types.TypeParamList.TypeParams: r0<-[recv]
+go/types.Unalias (opaque r0): r0<-t
+go/types.Union.Term: r0<-recv
+go/types.Union.Terms: r0<-[recv]
+go/types.Union.Underlying: r0<-recv
+go/types.Var.Origin: r0<-recv
+go/types.object.Parent: r0<-recv
+go/types.object.Pkg: r0<-recv
+go/types.object.Type: r0<-recv
+hash/maphash.Hash.Sum: r0<-b
+html/template.Must: r0<-t
+html/template.New (opaque r0): 
+html/template.ParseFS (opaque r0 r1) (shared r1): r0<-fs r0<-patterns r1<-fs r1<-patterns
+html/template.ParseFiles (opaque r0 r1): r0<-filenames r1<-filenames
+html/template.ParseGlob (opaque r0 r1) (shared r1): 
+html/template.Template.AddParseTree (opaque r0): r0<-recv r0<-tree
+html/template.Template.Clone (opaque r0): r0<-recv
+html/template.Template.Delims: r0<-recv
+html/template.Template.Execute (opaque r0): r0<-data r0<-recv r0<-wr
+html/template.Template.ExecuteTemplate (opaque r0): r0<-data r0<-recv r0<-wr
+html/template.Template.Funcs: r0<-recv
+html/template.Template.Lookup (opaque r0): r0<-recv
+html/template.Template.New (opaque r0): r0<-recv
+html/template.Template.Option: r0<-recv
+html/template.Template.Parse (opaque r1): r0<-recv r1<-recv
+html/template.Template.ParseFS (opaque r0 r1) (shared r1): r0<-fs r0<-patterns r0<-recv r1<-fs r1<-patterns r1<-recv
+html/template.Template.ParseFiles (opaque r0 r1): r0<-filenames r0<-recv r1<-filenames r1<-recv
+html/template.Template.ParseGlob (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+html/template.Template.Templates (opaque r0): r0<-recv
+image.Alpha.ColorModel (shared r0): 
+image.Alpha.SubImage: r0<-[recv]
+image.Alpha16.ColorModel (shared r0): 
+image.Alpha16.SubImage: r0<-[recv]
+image.CMYK.ColorModel (shared r0): 
+image.CMYK.SubImage: r0<-[recv]
+image.Decode (shared r2): 
+image.DecodeConfig (shared r2): 
+image.Gray.ColorModel (shared r0): 
+image.Gray.SubImage: r0<-[recv]
+image.Gray16.ColorModel (shared r0): 
+image.Gray16.SubImage: r0<-[recv]
+image.NRGBA.ColorModel (shared r0): 
+image.NRGBA.SubImage: r0<-[recv]
+image.NRGBA64.ColorModel (shared r0): 
+image.NRGBA64.SubImage: r0<-[recv]
+image.NYCbCrA.ColorModel (shared r0): 
+image.NYCbCrA.SubImage: r0<-[recv]
+image.NewPaletted: r0<-[p]
+image.NewUniform: r0<-[c]
+image.Paletted.At: r0<-recv
+image.Paletted.ColorModel: r0<-recv
+image.Paletted.SubImage: r0<-[recv]
+image.RGBA.ColorModel (shared r0): 
+image.RGBA.SubImage: r0<-[recv]
+image.RGBA64.ColorModel (shared r0): 
+image.RGBA64.SubImage: r0<-[recv]
+image.Rectangle.ColorModel (shared r0): 
+image.Uniform.At: r0<-recv
+image.Uniform.ColorModel: r0<-recv
+image.Uniform.Convert: r0<-recv
+image.YCbCr.ColorModel (shared r0): 
+image.YCbCr.SubImage: r0<-[recv]
+image/color.Palette.Convert: r0<-recv
+image/gif.Decode (opaque r0 r1) (shared r1): r0<-r r1<-r
+image/gif.DecodeAll (opaque r0 r1) (shared r1): r0<-r r1<-r
+image/gif.DecodeConfig (opaque r0 r1) (shared r1): r0<-r r1<-r
+image/gif.Encode (opaque r0): r0<-m r0<-o r0<-w
+image/gif.EncodeAll (opaque r0): r0<-g r0<-w
+image/jpeg.Decode (opaque r0) (shared r1): r0<-r
+image/jpeg.DecodeConfig (shared r0 r1): 
+image/jpeg.Encode (opaque r0): r0<-m r0<-w
+image/png.Decode (opaque r0 r1) (shared r1): r0<-r r1<-r
+image/png.DecodeConfig (opaque r0 r1) (shared r0 r1): r0<-r r1<-r
+image/png.Encode (opaque r0): r0<-m r0<-w
+image/png.Encoder.Encode (opaque r0): r0<-m r0<-recv r0<-w
+index/suffixarray.Index.Bytes: r0<-recv
+index/suffixarray.Index.Read (shared r0): 
+index/suffixarray.New: r0<-[data]
+io.Copy (shared r1): 
+io.CopyBuffer (shared r1): 
+io.CopyN (shared r1): 
+io.LimitReader: r0<-[r]
+io.LimitedReader.Read (shared r1): 
+io.MultiReader: r0<-[readers]
+io.MultiWriter: r0<-[writers]
+io.NewOffsetWriter: r0<-[w]
+io.NewSectionReader: r0<-[r]
+io.NopCloser: r0<-[r]
+io.OffsetWriter.Seek (shared r1): 
+io.OffsetWriter.WriteAt (shared r1): 
+io.PipeReader.Read (shared r1): r1<-recv
+io.PipeWriter.Write (shared r1): r1<-recv
+io.ReadAtLeast (shared r1): 
+io.ReadFull (shared r1): 
+io.SectionReader.Outer: r0<-recv
+io.SectionReader.Read (shared r1): 
+io.SectionReader.ReadAt (shared r1): 
+io.SectionReader.Seek (shared r1): 
+io.TeeReader: r0<-[r] r0<-[w]
+io/fs.FileInfoToDirEntry: r0<-[info]
+io/fs.Glob (shared r1): 
+io/fs.PathError.Unwrap: r0<-recv
+io/fs.ReadLink (shared r1): 
+io/fs.Sub (shared r1): r0<-fsys
+io/ioutil.NopCloser: r0<-[r]
+io/ioutil.ReadDir (opaque r0) (shared r1): 
+io/ioutil.ReadFile (shared r1): 
+io/ioutil.TempDir (shared r1): 
+io/ioutil.TempFile (opaque r0) (shared r1): 
+io/ioutil.WriteFile (shared r0): 
+iter.Pull (opaque r0 r1): 
+iter.Pull2 (opaque r0 r1): 
+log.Default (shared r0): 
+log.Logger.Writer: r0<-recv
+log.New (opaque r0): r0<-out
+log.Writer (shared r0): 
+log/slog.Any (opaque r0) (shared r0): r0<-value
+log/slog.AnyValue (opaque r0) (shared r0): r0<-v
+log/slog.Group (opaque r0): r0<-args
+log/slog.GroupAttrs (opaque r0): r0<-attrs
+log/slog.GroupValue (opaque r0): r0<-as
+log/slog.JSONHandler.WithAttrs: r0<-[recv]
+log/slog.JSONHandler.WithGroup: r0<-[recv]
+log/slog.Level.AppendText: r0<-b
+log/slog.Level.UnmarshalJSON (shared r0): 
+log/slog.Level.UnmarshalText (shared r0): 
+log/slog.LevelVar.AppendText: r0<-b
+log/slog.LevelVar.UnmarshalText (shared r0): 
+log/slog.Logger.Handler: r0<-recv
+log/slog.Logger.With: r0<-recv
+log/slog.Logger.WithGroup: r0<-recv
+log/slog.New: r0<-[h]
+log/slog.NewJSONHandler: r0<-[opts] r0<-[w]
+log/slog.NewLogLogger (opaque r0): r0<-h
+log/slog.NewRecord: r0<-[t]
+log/slog.NewTextHandler: r0<-[opts] r0<-[w]
+log/slog.Record.Clone: r0<-[recv]
+log/slog.TextHandler.WithAttrs: r0<-[recv]
+log/slog.TextHandler.WithGroup: r0<-[recv]
+log/slog.Time (opaque r0) (shared r0): r0<-v
+log/slog.TimeValue (opaque r0) (shared r0): r0<-v
+log/slog.Value.Any (opaque r0) (shared r0): r0<-recv
+log/slog.Value.Group (opaque r0): r0<-recv
+log/slog.Value.LogValuer: r0<-recv
+log/slog.Value.Resolve (opaque r0) (shared r0): r0<-recv
+log/slog.Value.Time (opaque r0) (shared r0): r0<-recv
+log/syslog.Dial (opaque r0 r1) (shared r1): 
+log/syslog.New (opaque r0 r1) (shared r1): 
+log/syslog.NewLogger (opaque r0 r1) (shared r1): 
+log/syslog.Writer.Alert (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Crit (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Debug (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Emerg (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Err (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Info (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Notice (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Warning (opaque r0) (shared r0): r0<-recv
+log/syslog.Writer.Write (opaque r1) (shared r1): r1<-b r1<-recv
+maps.All (opaque r0): r0<-m
+maps.Clone (opaque r0): r0<-m
+maps.Collect (opaque r0): 
+maps.Keys (opaque r0): r0<-m
+maps.Values: r0<-[m]
+math/big.Float.Abs: r0<-recv
+math/big.Float.Add: r0<-recv
+math/big.Float.Append: r0<-buf
+math/big.Float.AppendText: r0<-b
+math/big.Float.Copy: r0<-recv
+math/big.Float.GobEncode (opaque r0): r0<-recv
+math/big.Float.Int (opaque r0): r0<-recv r0<-z
+math/big.Float.Mul: r0<-recv
+math/big.Float.Neg: r0<-recv
+math/big.Float.Parse (shared r2): r0<-recv
+math/big.Float.Quo: r0<-recv
+math/big.Float.Rat (opaque r0): r0<-recv r0<-z
+math/big.Float.Scan (shared r0): 
+math/big.Float.Set: r0<-recv
+math/big.Float.SetFloat64: r0<-recv
+math/big.Float.SetInf: r0<-recv
+math/big.Float.SetInt64: r0<-recv
+math/big.Float.SetInt: r0<-recv
+math/big.Float.SetMantExp: r0<-recv
+math/big.Float.SetMode: r0<-recv
+math/big.Float.SetPrec: r0<-recv
+math/big.Float.SetRat: r0<-recv
+math/big.Float.SetString: r0<-recv
+math/big.Float.SetUint64: r0<-recv
+math/big.Float.Sqrt: r0<-recv
+math/big.Float.Sub: r0<-recv
+math/big.Float.UnmarshalText (shared r0): r0<-[text]
+math/big.Int.Abs: r0<-recv
+math/big.Int.Add: r0<-recv
+math/big.Int.And: r0<-recv
+math/big.Int.AndNot: r0<-recv
+math/big.Int.Append: r0<-buf
+math/big.Int.AppendText: r0<-b
+math/big.Int.Binomial: r0<-recv
+math/big.Int.Bits: r0<-recv
+math/big.Int.Bytes (opaque r0): r0<-recv
+math/big.Int.Div: r0<-recv
+math/big.Int.DivMod: r0<-recv r1<-m
+math/big.Int.Exp: r0<-recv
+math/big.Int.FillBytes: r0<-buf
+math/big.Int.GCD: r0<-recv
+math/big.Int.GobEncode (opaque r0): r0<-recv
+math/big.Int.Lsh: r0<-recv
+math/big.Int.MarshalJSON (opaque r0): r0<-recv
+math/big.Int.Mod: r0<-recv
+math/big.Int.ModInverse: r0<-recv
+math/big.Int.ModSqrt: r0<-recv
+math/big.Int.Mul: r0<-recv
+math/big.Int.MulRange: r0<-recv
+math/big.Int.Neg: r0<-recv
+math/big.Int.Not: r0<-recv
+math/big.Int.Or: r0<-recv
+math/big.Int.Quo: r0<-recv
+math/big.Int.QuoRem: r0<-recv r1<-r
+math/big.Int.Rand: r0<-recv
+math/big.Int.Rem: r0<-recv
+math/big.Int.Rsh: r0<-recv
+math/big.Int.Scan (shared r0): 
+math/big.Int.Set: r0<-recv
+math/big.Int.SetBit: r0<-recv
+math/big.Int.SetBits: r0<-recv
+math/big.Int.SetBytes: r0<-recv
+math/big.Int.SetInt64: r0<-recv
+math/big.Int.SetString: r0<-recv
+math/big.Int.SetUint64: r0<-recv
+math/big.Int.Sqrt: r0<-recv
+math/big.Int.Sub: r0<-recv
+math/big.Int.UnmarshalJSON: r0<-[text]
+math/big.Int.UnmarshalText: r0<-[text]
+math/big.Int.Xor: r0<-recv
+math/big.NewFloat (opaque r0): 
+math/big.NewRat (opaque r0): 
+math/big.ParseFloat (opaque r0) (shared r2): 
+math/big.Rat.Abs: r0<-recv
+math/big.Rat.Add: r0<-recv
+math/big.Rat.AppendText: r0<-b
+math/big.Rat.Denom: r0<-recv
+math/big.Rat.GobEncode (opaque r0): r0<-recv
+math/big.Rat.Inv: r0<-recv
+math/big.Rat.Mul: r0<-recv
+math/big.Rat.Neg: r0<-recv
+math/big.Rat.Num: r0<-recv
+math/big.Rat.Quo: r0<-recv
+math/big.Rat.Set: r0<-recv
+math/big.Rat.SetFloat64: r0<-recv
+math/big.Rat.SetFrac64: r0<-recv
+math/big.Rat.SetFrac: r0<-recv
+math/big.Rat.SetInt64: r0<-recv
+math/big.Rat.SetInt: r0<-recv
+math/big.Rat.SetString: r0<-recv
+math/big.Rat.SetUint64: r0<-recv
+math/big.Rat.Sub: r0<-recv
+math/big.Rat.UnmarshalText: r0<-[text]
+math/rand.New: r0<-[src]
+math/rand.NewZipf: r0<-[r]
+math/rand/v2.ChaCha8.AppendBinary: r0<-b
+math/rand/v2.New: r0<-[src]
+math/rand/v2.NewZipf: r0<-[r]
+math/rand/v2.PCG.AppendBinary: r0<-b
+math/rand/v2.PCG.UnmarshalBinary (shared r0): 
+mime.AddExtensionType (shared r0): 
+mime.ExtensionsByType (shared r1): 
+mime.ParseMediaType (shared r2): 
+mime.WordDecoder.Decode (shared r1): 
+mime.WordDecoder.DecodeHeader (shared r1): 
+mime/multipart.FileHeader.Open (opaque r0) (shared r1): r0<-recv
+mime/multipart.NewReader (opaque r0): r0<-r
+mime/multipart.NewWriter: r0<-[w]
+mime/multipart.Reader.NextPart (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+mime/multipart.Reader.NextRawPart (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+mime/multipart.Reader.ReadForm (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+mime/multipart.Writer.Close: r0<-recv
+mime/multipart.Writer.CreateFormField (opaque r0) (shared r1): r0<-recv r1<-recv
+mime/multipart.Writer.CreateFormFile (opaque r0) (shared r1): r0<-recv r1<-recv
+mime/multipart.Writer.CreatePart (opaque r0) (shared r1): r0<-header r0<-recv r1<-recv
+mime/multipart.Writer.WriteField (shared r0): r0<-recv
+mime/quotedprintable.NewReader (opaque r0): r0<-r
+mime/quotedprintable.NewWriter: r0<-[w]
+mime/quotedprintable.Reader.Read (shared r1): r1<-recv
+net.Buffers.Read (shared r1): 
+net.DNSConfigError.Unwrap: r0<-recv
+net.DNSError.Unwrap: r0<-recv
+net.Dial (opaque r0 r1) (shared r1): 
+net.DialIP (opaque r1) (shared r1): r1<-laddr r1<-raddr
+net.DialTCP (opaque r1) (shared r1): r1<-laddr r1<-raddr
+net.DialTimeout (opaque r0 r1) (shared r1): 
+net.DialUDP (opaque r1) (shared r1): r1<-laddr r1<-raddr
+net.DialUnix (opaque r1) (shared r1): 
+net.Dialer.Dial (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+net.Dialer.DialContext (opaque r0 r1) (shared r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+net.FileConn (shared r1): 
+net.FileListener (shared r1): 
+net.FilePacketConn (shared r1): 
+net.IP.AppendText: r0<-b
+net.IP.DefaultMask (shared r0): 
+net.IP.To16: r0<-recv
+net.IP.To4: r0<-recv
+net.IPConn.ReadFrom (shared r2): r2<-[recv]
+net.IPConn.ReadFromIP (shared r2): r2<-[recv]
+net.IPConn.ReadMsgIP (shared r4): r4<-[recv]
+net.IPConn.SyscallConn: r0<-[recv]
+net.IPConn.WriteMsgIP (shared r2): r2<-[addr] r2<-[recv]
+net.IPConn.WriteTo (shared r1): r1<-[addr] r1<-[recv]
+net.IPConn.WriteToIP (shared r1): r1<-[addr] r1<-[recv]
+net.Interface.Addrs (shared r1): 
+net.Interface.MulticastAddrs (shared r1): 
+net.InterfaceAddrs (shared r1): 
+net.InterfaceByIndex (opaque r0) (shared r1): 
+net.InterfaceByName (opaque r0) (shared r1): 
+net.Interfaces (opaque r0) (shared r1): 
+net.Listen (opaque r1) (shared r1): 
+net.ListenConfig.Listen (opaque r1) (shared r1): r1<-ctx
+net.ListenConfig.ListenPacket (opaque r1) (shared r1): r1<-ctx
+net.ListenIP (opaque r1) (shared r1): r1<-laddr
+net.ListenMulticastUDP (opaque r1) (shared r1): r1<-gaddr r1<-ifi
+net.ListenPacket (opaque r1) (shared r1): 
+net.ListenTCP (opaque r1) (shared r1): r1<-laddr
+net.ListenUDP (opaque r1) (shared r1): r1<-laddr
+net.ListenUnix (opaque r1) (shared r1): 
+net.ListenUnixgram (opaque r1) (shared r1): 
+net.LookupAddr (opaque r1) (shared r1): 
+net.LookupCNAME (opaque r1) (shared r1): 
+net.LookupHost (opaque r1) (shared r1): 
+net.LookupIP (opaque r0 r1) (shared r1): 
+net.LookupMX (opaque r1) (shared r1): 
+net.LookupNS (opaque r1) (shared r1): 
+net.LookupSRV (opaque r2) (shared r2): 
+net.LookupTXT (opaque r1) (shared r1): 
+net.OpError.Unwrap: r0<-recv
+net.ResolveIPAddr (opaque r1) (shared r1): 
+net.ResolveTCPAddr (opaque r1) (shared r1): 
+net.ResolveUDPAddr (opaque r1) (shared r1): 
+net.Resolver.LookupAddr (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupCNAME (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupHost (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupIP (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupIPAddr (opaque r0 r1) (shared r1): r0<-ctx r0<-recv r1<-ctx r1<-recv
+net.Resolver.LookupMX (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupNS (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupNetIP (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.Resolver.LookupSRV (opaque r2) (shared r2): r2<-ctx r2<-recv
+net.Resolver.LookupTXT (opaque r1) (shared r1): r1<-ctx r1<-recv
+net.TCPConn.CloseRead (shared r0): r0<-[recv]
+net.TCPConn.CloseWrite (shared r0): r0<-[recv]
+net.TCPConn.ReadFrom (shared r1): r1<-[recv]
+net.TCPConn.SetKeepAlive (shared r0): r0<-[recv]
+net.TCPConn.SetKeepAliveConfig (shared r0): r0<-[recv]
+net.TCPConn.SetKeepAlivePeriod (shared r0): r0<-[recv]
+net.TCPConn.SetLinger (shared r0): r0<-[recv]
+net.TCPConn.SetNoDelay (shared r0): r0<-[recv]
+net.TCPConn.SyscallConn: r0<-[recv]
+net.TCPConn.WriteTo (shared r1): r1<-[recv]
+net.TCPListener.Accept (shared r1): r1<-[recv]
+net.TCPListener.AcceptTCP (shared r1): r1<-[recv]
+net.TCPListener.Addr: r0<-recv
+net.TCPListener.Close (shared r0): r0<-[recv]
+net.TCPListener.File (opaque r0) (shared r1): r0<-recv r1<-[recv]
+net.TCPListener.SetDeadline (shared r0): 
+net.TCPListener.SyscallConn: r0<-[recv]
+net.UDPConn.ReadFrom (opaque r1 r2) (shared r2): r1<-b r1<-recv r2<-b r2<-recv
+net.UDPConn.ReadFromUDP (opaque r1 r2) (shared r2): r1<-b r1<-recv r2<-b r2<-recv
+net.UDPConn.ReadFromUDPAddrPort (opaque r2) (shared r2): r2<-b r2<-recv
+net.UDPConn.ReadMsgUDP (opaque r4) (shared r4): r4<-b r4<-oob r4<-recv
+net.UDPConn.ReadMsgUDPAddrPort (opaque r4) (shared r4): r4<-b r4<-oob r4<-recv
+net.UDPConn.SyscallConn: r0<-[recv]
+net.UDPConn.WriteMsgUDP (shared r2): r2<-[addr] r2<-[recv]
+net.UDPConn.WriteMsgUDPAddrPort (opaque r2) (shared r2): r2<-b r2<-oob r2<-recv
+net.UDPConn.WriteTo (opaque r1) (shared r1): r1<-addr r1<-b r1<-recv
+net.UDPConn.WriteToUDP (opaque r1) (shared r1): r1<-addr r1<-b r1<-recv
+net.UDPConn.WriteToUDPAddrPort (opaque r1) (shared r1): r1<-b r1<-recv
+net.UnixConn.CloseRead (shared r0): r0<-[recv]
+net.UnixConn.CloseWrite (shared r0): r0<-[recv]
+net.UnixConn.ReadFrom (shared r2): r2<-[recv]
+net.UnixConn.ReadFromUnix (shared r2): r2<-[recv]
+net.UnixConn.ReadMsgUnix (shared r4): r4<-[recv]
+net.UnixConn.SyscallConn: r0<-[recv]
+net.UnixConn.WriteMsgUnix (shared r2): r2<-[recv]
+net.UnixConn.WriteTo (shared r1): r1<-[addr] r1<-[recv]
+net.UnixConn.WriteToUnix (shared r1): r1<-[recv]
+net.UnixListener.Accept (shared r1): r1<-[recv]
+net.UnixListener.AcceptUnix (shared r1): r1<-[recv]
+net.UnixListener.Addr: r0<-recv
+net.UnixListener.Close (shared r0): r0<-[recv]
+net.UnixListener.File (opaque r0) (shared r1): r0<-recv r1<-[recv]
+net.UnixListener.SetDeadline (shared r0): 
+net.UnixListener.SyscallConn: r0<-[recv]
+net.conn.Close (shared r0): r0<-[recv]
+net.conn.File (opaque r0) (shared r1): r0<-recv r1<-[recv]
+net.conn.LocalAddr: r0<-recv
+net.conn.Read (shared r1): r1<-[recv]
+net.conn.RemoteAddr: r0<-recv
+net.conn.SetDeadline (shared r0): r0<-[recv]
+net.conn.SetReadBuffer (shared r0): r0<-[recv]
+net.conn.SetReadDeadline (shared r0): r0<-[recv]
+net.conn.SetWriteBuffer (shared r0): r0<-[recv]
+net.conn.SetWriteDeadline (shared r0): r0<-[recv]
+net.conn.Write (shared r1): r1<-[recv]
+net/http.AllowQuerySemicolons: r0<-[h]
+net/http.Client.Do (shared r1): r1<-[recv]
+net/http.Client.Get (shared r1): r1<-[recv]
+net/http.Client.Head (shared r1): r1<-[recv]
+net/http.Client.Post (shared r1): r1<-[recv]
+net/http.Client.PostForm (shared r1): r1<-[recv]
+net/http.CrossOriginProtection.Check (shared r0): 
+net/http.CrossOriginProtection.Handler (opaque r0): r0<-h r0<-recv
+net/http.Dir.Open (opaque r0) (shared r1): 
+net/http.FS: r0<-[fsys]
+net/http.FileServer: r0<-[root]
+net/http.FileServerFS: r0<-[root]
+net/http.Get (shared r1): 
+net/http.Head (shared r1): 
+net/http.Header.Values: r0<-recv
+net/http.ListenAndServe (opaque r0) (shared r0): r0<-handler
+net/http.ListenAndServeTLS (opaque r0) (shared r0): r0<-handler
+net/http.MaxBytesHandler: r0<-[h]
+net/http.MaxBytesReader: r0<-[r] r0<-[w]
+net/http.NewFileTransport: r0<-[fs]
+net/http.NewFileTransportFS: r0<-[fsys]
+net/http.NewRequest: r0<-[body]
+net/http.NewRequestWithContext: r0<-[body] r0<-[ctx]
+net/http.NewResponseController: r0<-[rw]
+net/http.NotFoundHandler (opaque r0): 
+net/http.ParseCookie (shared r1): 
+net/http.ParseSetCookie (opaque r0) (shared r0 r1): 
+net/http.ParseTime (opaque r0) (shared r0): 
+net/http.Post (shared r1): 
+net/http.PostForm (shared r1): 
+net/http.ReadRequest (opaque r0 r1) (shared r1): r0<-b r1<-b
+net/http.ReadResponse (opaque r0 r1) (shared r1): r0<-r r0<-req r1<-r r1<-req
+net/http.Request.Clone (opaque r0): r0<-ctx r0<-recv
+net/http.Request.Context: r0<-recv
+net/http.Request.Cookie (shared r1): 
+net/http.Request.FormFile (opaque r0 r1 r2) (shared r2): r0<-recv r1<-recv r2<-recv
+net/http.Request.MultipartReader (opaque r0): r0<-recv
+net/http.Request.ParseForm (shared r0): 
+net/http.Request.ParseMultipartForm (opaque r0) (shared r0): r0<-recv
+net/http.Request.WithContext: r0<-[ctx] r0<-[recv]
+net/http.Request.Write (opaque r0) (shared r0): r0<-recv r0<-w
+net/http.Request.WriteProxy (opaque r0) (shared r0): r0<-recv r0<-w
+net/http.Response.Cookies (opaque r0) (shared r0): r0<-recv
+net/http.Response.Location (shared r1): 
+net/http.Response.Write (opaque r0) (shared r0): r0<-recv r0<-w
+net/http.Serve (opaque r0) (shared r0): r0<-handler r0<-l
+net/http.ServeMux.Handler (opaque r0): r0<-r r0<-recv
+net/http.ServeTLS (opaque r0) (shared r0): r0<-handler r0<-l
+net/http.Server.ListenAndServe (opaque r0) (shared r0): r0<-recv
+net/http.Server.ListenAndServeTLS (opaque r0) (shared r0): r0<-recv
+net/http.Server.Serve (shared r0): r0<-recv
+net/http.Server.ServeTLS (opaque r0) (shared r0): r0<-l r0<-recv
+net/http.StripPrefix (opaque r0): r0<-h
+net/http.TimeoutHandler: r0<-[h]
+net/http.Transport.Clone (opaque r0): r0<-recv
+net/http.Transport.RoundTrip (opaque r0 r1) (shared r1): r0<-recv r0<-req r1<-recv r1<-req
+net/http/cgi.Request (opaque r0): 
+net/http/cgi.RequestFromMap (opaque r0): r0<-params
+net/http/cgi.Serve (opaque r0) (shared r0): r0<-handler
+net/http/cookiejar.New: r0<-[o]
+net/http/fcgi.Serve (shared r0): 
+net/http/httptest.NewRequest (opaque r0): r0<-body
+net/http/httptest.NewRequestWithContext (opaque r0): r0<-body r0<-ctx
+net/http/httptest.NewServer: r0<-[handler]
+net/http/httptest.NewTLSServer: r0<-[handler]
+net/http/httptest.NewUnstartedServer: r0<-[handler]
+net/http/httptest.ResponseRecorder.Header (opaque r0): r0<-recv
+net/http/httptest.ResponseRecorder.Result (opaque r0): r0<-recv
+net/http/httptest.Server.Certificate: r0<-recv
+net/http/httptest.Server.Client: r0<-recv
+net/http/httptrace.WithClientTrace: r0<-[ctx]
+net/http/httputil.ClientConn.Do (opaque r0 r1) (shared r1): r0<-recv r0<-req r1<-recv r1<-req
+net/http/httputil.ClientConn.Hijack: r0<-recv r1<-recv
+net/http/httputil.ClientConn.Read (opaque r0 r1) (shared r1): r0<-recv r0<-req r1<-recv r1<-req
+net/http/httputil.ClientConn.Write (opaque r0) (shared r0): r0<-recv r0<-req
+net/http/httputil.DumpRequest (shared r1): 
+net/http/httputil.DumpRequestOut (opaque r1) (shared r1): r1<-req
+net/http/httputil.DumpResponse (opaque r1) (shared r1): r1<-resp
+net/http/httputil.NewChunkedReader (opaque r0): r0<-r
+net/http/httputil.NewChunkedWriter: r0<-[w]
+net/http/httputil.NewClientConn (opaque r0) (shared r0): r0<-c r0<-r
+net/http/httputil.NewProxyClientConn (opaque r0) (shared r0): r0<-c r0<-r
+net/http/httputil.NewServerConn (opaque r0): r0<-c r0<-r
+net/http/httputil.ServerConn.Hijack: r0<-recv r1<-recv
+net/http/httputil.ServerConn.Read (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+net/http/httputil.ServerConn.Write (opaque r0) (shared r0): r0<-recv r0<-req r0<-resp
+net/mail.AddressParser.Parse (shared r1): 
+net/mail.AddressParser.ParseList (shared r1): 
+net/mail.Header.AddressList (shared r1): 
+net/mail.Header.Date (opaque r0) (shared r0 r1): r0<-recv
+net/mail.ParseAddress (shared r1): 
+net/mail.ParseAddressList (shared r1): 
+net/mail.ParseDate (opaque r0) (shared r0): 
+net/mail.ReadMessage (opaque r0 r1) (shared r1): r0<-r r1<-r
+net/netip.Addr.AppendBinary: r0<-b
+net/netip.Addr.AppendText: r0<-b
+net/netip.Addr.AppendTo: r0<-b
+net/netip.Addr.MarshalBinary (opaque r0): 
+net/netip.AddrPort.AppendBinary: r0<-b
+net/netip.AddrPort.AppendText: r0<-b
+net/netip.AddrPort.AppendTo: r0<-b
+net/netip.AddrPort.MarshalBinary (opaque r0): 
+net/netip.Prefix.AppendBinary: r0<-b
+net/netip.Prefix.AppendText: r0<-b
+net/netip.Prefix.AppendTo: r0<-b
+net/netip.Prefix.MarshalBinary (opaque r0): 
+net/rpc.Client.Call (opaque r0): r0<-args r0<-recv r0<-reply
+net/rpc.Client.Close (shared r0): 
+net/rpc.Client.Go (opaque r0): r0<-args r0<-recv r0<-reply
+net/rpc.Dial (opaque r0 r1) (shared r1): 
+net/rpc.DialHTTP (opaque r0 r1) (shared r1): 
+net/rpc.DialHTTPPath (opaque r0 r1) (shared r1): 
+net/rpc.NewClient (opaque r0): r0<-conn
+net/rpc.NewClientWithCodec (opaque r0): r0<-codec
+net/rpc/jsonrpc.Dial (opaque r0 r1) (shared r1): 
+net/rpc/jsonrpc.NewClient (opaque r0): r0<-conn
+net/rpc/jsonrpc.NewClientCodec: r0<-[conn]
+net/rpc/jsonrpc.NewServerCodec: r0<-[conn]
+net/smtp.Client.Auth (shared r0): r0<-recv
+net/smtp.Client.Data (shared r1): r0<-[recv] r1<-recv
+net/smtp.Client.Hello: r0<-recv
+net/smtp.Client.Mail (shared r0): r0<-recv
+net/smtp.Client.Noop (shared r0): r0<-recv
+net/smtp.Client.Quit (shared r0): r0<-recv
+net/smtp.Client.Rcpt (shared r0): r0<-recv
+net/smtp.Client.Reset (shared r0): r0<-recv
+net/smtp.Client.StartTLS (shared r0): r0<-recv
+net/smtp.Client.TLSConnectionState (opaque r0): r0<-recv
+net/smtp.Client.Verify (shared r0): r0<-recv
+net/smtp.Dial (opaque r0 r1) (shared r1): 
+net/smtp.NewClient (opaque r0 r1) (shared r1): r0<-conn r1<-conn
+net/smtp.SendMail (opaque r0) (shared r0): r0<-a r0<-msg r0<-to
+net/textproto.Conn.Cmd (shared r1): r1<-recv
+net/textproto.Dial (opaque r0 r1) (shared r1): 
+net/textproto.MIMEHeader.Values: r0<-recv
+net/textproto.NewConn (opaque r0): r0<-conn
+net/textproto.NewReader: r0<-[r]
+net/textproto.NewWriter: r0<-[w]
+net/textproto.Reader.DotReader: r0<-recv
+net/textproto.Reader.ReadCodeLine (shared r2): r2<-recv
+net/textproto.Reader.ReadContinuedLine (shared r1): r1<-recv
+net/textproto.Reader.ReadContinuedLineBytes (shared r1): r0<-recv r1<-recv
+net/textproto.Reader.ReadDotLines (shared r1): r1<-recv
+net/textproto.Reader.ReadLine (shared r1): r1<-recv
+net/textproto.Reader.ReadLineBytes (shared r1): r0<-recv r1<-recv
+net/textproto.Reader.ReadMIMEHeader (shared r1): r1<-recv
+net/textproto.Reader.ReadResponse (shared r2): r2<-recv
+net/textproto.TrimBytes: r0<-b
+net/textproto.Writer.DotWriter: r0<-recv
+net/textproto.Writer.PrintfLine (shared r0): r0<-recv
+net/url.Error.Unwrap: r0<-recv
+net/url.ParseQuery (opaque r0): 
+net/url.URL.AppendBinary: r0<-b
+net/url.URL.Query (opaque r0): 
+os.Chdir (shared r0): 
+os.Chtimes (shared r0): 
+os.Create (opaque r0) (shared r1): 
+os.CreateTemp (opaque r0) (shared r1): 
+os.File.Chdir (shared r0): 
+os.File.Chmod (shared r0): 
+os.File.Chown (shared r0): 
+os.File.Close (shared r0): 
+os.File.Read (shared r1): 
+os.File.ReadAt (shared r1): 
+os.File.ReadDir (opaque r0) (shared r1): r0<-recv
+os.File.ReadFrom (shared r1): 
+os.File.Readdir (opaque r0) (shared r1): r0<-recv
+os.File.Readdirnames (shared r1): 
+os.File.Seek (shared r1): 
+os.File.SetDeadline (shared r0): 
+os.File.SetReadDeadline (shared r0): 
+os.File.SetWriteDeadline (shared r0): 
+os.File.Stat (opaque r0) (shared r1): r0<-recv
+os.File.Sync (shared r0): 
+os.File.SyscallConn (shared r1): r0<-[recv]
+os.File.Truncate (shared r0): 
+os.File.Write (shared r1): 
+os.File.WriteAt (shared r1): 
+os.File.WriteString (shared r1): 
+os.File.WriteTo (shared r1): 
+os.Getgroups (shared r1): 
+os.Getwd (shared r1): 
+os.Hostname (shared r1): 
+os.LinkError.Unwrap: r0<-recv
+os.Lstat (opaque r0): 
+os.MkdirTemp (shared r1): 
+os.NewFile (opaque r0): 
+os.NewSyscallError: r0<-[err]
+os.Open (opaque r0) (shared r1): 
+os.OpenFile (opaque r0) (shared r1): 
+os.OpenInRoot (opaque r0) (shared r1): 
+os.Pipe (opaque r0 r1) (shared r2): 
+os.Process.Kill (shared r0): 
+os.Process.Signal (shared r0): 
+os.ReadDir (opaque r0) (shared r1): 
+os.ReadFile (shared r1): 
+os.RemoveAll (shared r0): 
+os.Root.Chmod (shared r0): 
+os.Root.Chown (shared r0): 
+os.Root.Chtimes (shared r0): 
+os.Root.Create (opaque r0) (shared r1): 
+os.Root.Lchown (shared r0): 
+os.Root.Link (shared r0): 
+os.Root.Lstat (shared r1): 
+os.Root.Mkdir (shared r0): 
+os.Root.MkdirAll (shared r0): 
+os.Root.Open (opaque r0) (shared r1): 
+os.Root.OpenFile (opaque r0) (shared r1): 
+os.Root.OpenRoot (shared r1): 
+os.Root.ReadFile (shared r1): 
+os.Root.Readlink (shared r1): 
+os.Root.Remove (shared r0): 
+os.Root.RemoveAll (shared r0): 
+os.Root.Rename (shared r0): 
+os.Root.Stat (shared r1): 
+os.Root.Symlink (shared r0): 
+os.Root.WriteFile (shared r0): 
+os.StartProcess (shared r1): 
+os.Stat (opaque r0): 
+os.SyscallError.Unwrap: r0<-recv
+os.WriteFile (shared r0): 
+os/exec.Cmd.CombinedOutput (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+os/exec.Cmd.Output (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+os/exec.Cmd.Run (opaque r0) (shared r0): r0<-recv
+os/exec.Cmd.Start (opaque r0) (shared r0): r0<-recv
+os/exec.Cmd.StderrPipe (opaque r0) (shared r1): r0<-recv
+os/exec.Cmd.StdinPipe (opaque r0) (shared r1): r0<-recv
+os/exec.Cmd.StdoutPipe (opaque r0) (shared r1): r0<-recv
+os/exec.Cmd.Wait (opaque r0) (shared r0): r0<-recv
+os/exec.Command (shared r0): 
+os/exec.CommandContext (shared r0): r0<-[ctx]
+os/exec.Error.Unwrap: r0<-recv
+os/exec.LookPath (shared r1): 
+os/signal.NotifyContext (opaque r0 r1) (shared r0 r1): r0<-parent r0<-signals r1<-parent r1<-signals
+os/user.Current (shared r1): 
+os/user.Lookup (opaque r1) (shared r1): 
+os/user.LookupGroup (opaque r1) (shared r1): 
+os/user.LookupGroupId (opaque r1) (shared r1): 
+os/user.LookupId (opaque r1) (shared r1): 
+os/user.User.GroupIds (opaque r1) (shared r1): 
+path.Match (shared r1): 
+path/filepath.Abs (shared r1): 
+path/filepath.Glob (shared r1): 
+path/filepath.Localize (shared r1): 
+path/filepath.Match (shared r1): 
+reflect.MakeSlice: r0<-[typ]
+reflect.Swapper (opaque r0): r0<-slice
+reflect.Value.Bytes (opaque r0): 
+reflect.Value.Index (shared r0): 
+reflect.Value.Recv (opaque r0): 
+reflect.Value.Seq (opaque r0): 
+reflect.Value.Seq2 (opaque r0) (shared r0): 
+reflect.Value.TryRecv (opaque r0): 
+reflect.VisibleFields (opaque r0): r0<-t
+reflect.Zero: r0<-[typ]
+regexp.Compile (opaque r0) (shared r0): 
+regexp.CompilePOSIX (opaque r0) (shared r0): 
+regexp.MustCompile (opaque r0) (shared r0): 
+regexp.MustCompilePOSIX (opaque r0) (shared r0): 
+regexp.Regexp.AppendText: r0<-b
+regexp.Regexp.Copy: r0<-[recv]
+regexp.Regexp.Expand: r0<-dst
+regexp.Regexp.ExpandString: r0<-dst
+regexp.Regexp.Find: r0<-b
+regexp.Regexp.FindAll: r0<-[b]
+regexp.Regexp.FindAllSubmatch: r0<-[b]
+regexp.Regexp.FindSubmatch: r0<-[b]
+regexp.Regexp.SubexpNames: r0<-recv
+regexp/syntax.Compile (opaque r0): r0<-re
+regexp/syntax.Parse (opaque r0): 
+regexp/syntax.Regexp.CapNames (opaque r0): r0<-recv
+regexp/syntax.Regexp.Simplify (opaque r0): r0<-recv
+runtime.CallersFrames: r0<-[callers]
+runtime.Frames.Next: r0<-[recv]
+runtime/coverage.WriteCounters (opaque r0) (shared r0): r0<-w
+runtime/coverage.WriteCountersDir (opaque r0) (shared r0): 
+runtime/coverage.WriteMeta (opaque r0) (shared r0): r0<-w
+runtime/coverage.WriteMetaDir (opaque r0) (shared r0): 
+runtime/debug.SetCrashOutput (shared r0): 
+runtime/metrics.All (shared r0): 
+runtime/pprof.Lookup (shared r0): 
+runtime/pprof.NewProfile (opaque r0): 
+runtime/pprof.Profile.WriteTo (opaque r0) (shared r0): r0<-recv r0<-w
+runtime/pprof.Profiles (opaque r0) (shared r0): 
+runtime/pprof.WithLabels: r0<-[ctx] r0<-[labels]
+runtime/pprof.WriteHeapProfile (opaque r0) (shared r0): r0<-w
+runtime/trace.NewTask: r0<-[pctx]
+slices.All: r0<-[s]
+slices.AppendSeq: r0<-s
+slices.Backward: r0<-[s]
+slices.Chunk: r0<-[s]
+slices.Clip: r0<-s
+slices.Clone: r0<-[s]
+slices.Compact: r0<-s
+slices.CompactFunc: r0<-s
+slices.Concat: r0<-[slices]
+slices.Delete: r0<-s
+slices.DeleteFunc: r0<-s
+slices.Grow: r0<-s
+slices.Insert: r0<-[v] r0<-s
+slices.Max (opaque r0): r0<-x
+slices.MaxFunc: r0<-x
+slices.Min (opaque r0): r0<-x
+slices.MinFunc: r0<-x
+slices.Repeat: r0<-[x]
+slices.Replace: r0<-[v] r0<-s
+slices.Values: r0<-[s]
+sort.Reverse: r0<-[data]
+strconv.AppendBool: r0<-dst
+strconv.AppendFloat: r0<-dst
+strconv.AppendInt: r0<-dst
+strconv.AppendQuote: r0<-dst
+strconv.AppendQuoteRune: r0<-dst
+strconv.AppendQuoteRuneToASCII: r0<-dst
+strconv.AppendQuoteRuneToGraphic: r0<-dst
+strconv.AppendQuoteToASCII: r0<-dst
+strconv.AppendQuoteToGraphic: r0<-dst
+strconv.AppendUint: r0<-dst
+strconv.Atoi (shared r1): 
+strconv.NumError.Unwrap: r0<-recv
+strconv.ParseBool (shared r1): 
+strconv.ParseComplex (shared r1): 
+strconv.ParseFloat (shared r1): 
+strconv.ParseInt (shared r1): 
+strconv.ParseUint (shared r1): 
+strconv.QuotedPrefix (shared r1): 
+strconv.Unquote (shared r1): 
+strconv.UnquoteChar (shared r3): 
+strings.Reader.Read (shared r1): 
+strings.Reader.ReadAt (shared r1): 
+strings.Reader.ReadByte (shared r1): 
+strings.Reader.ReadRune (shared r2): 
+strings.Reader.WriteTo (shared r1): 
+sync.Map.LoadOrStore: r0<-value
+sync.NewCond: r0<-[l]
+sync.OnceFunc (opaque r0): 
+sync.OnceValue (opaque r0): 
+sync.OnceValues (opaque r0): 
+sync.Pool.Get (opaque r0): 
+sync/atomic.Value.Load (opaque r0): r0<-recv
+sync/atomic.Value.Swap (opaque r0): r0<-new r0<-recv
+syscall.Accept (shared r2): 
+syscall.Accept4 (shared r2): 
+syscall.Access (shared r0): 
+syscall.Acct (shared r0): 
+syscall.Adjtimex (shared r1): 
+syscall.AttachLsf (shared r0): 
+syscall.Bind (shared r0): 
+syscall.BindToDevice (shared r0): 
+syscall.Chdir (shared r0): 
+syscall.Chmod (shared r0): 
+syscall.Chown (shared r0): 
+syscall.Chroot (shared r0): 
+syscall.Close (shared r0): 
+syscall.Connect (shared r0): 
+syscall.Creat (shared r1): 
+syscall.DetachLsf (shared r0): 
+syscall.Dup (shared r1): 
+syscall.Dup2 (shared r0): 
+syscall.Dup3 (shared r0): 
+syscall.EpollCreate (shared r1): 
+syscall.EpollCreate1 (shared r1): 
+syscall.EpollCtl (shared r0): 
+syscall.EpollWait (shared r1): 
+syscall.Faccessat (shared r0): 
+syscall.Fallocate (shared r0): 
+syscall.Fchdir (shared r0): 
+syscall.Fchmod (shared r0): 
+syscall.Fchmodat (shared r0): 
+syscall.Fchown (shared r0): 
+syscall.Fchownat (shared r0): 
+syscall.Fdatasync (shared r0): 
+syscall.Flock (shared r0): 
+syscall.ForkExec (shared r1): 
+syscall.Fstat (shared r0): 
+syscall.Fstatfs (shared r0): 
+syscall.Fsync (shared r0): 
+syscall.Ftruncate (shared r0): 
+syscall.Futimes (shared r0): 
+syscall.Futimesat (shared r0): 
+syscall.Getcwd (shared r1): 
+syscall.Getdents (shared r1): 
+syscall.Getgroups (shared r1): 
+syscall.Getpeername (shared r1): 
+syscall.Getpgid (shared r1): 
+syscall.Getpriority (shared r1): 
+syscall.Getrlimit (shared r0): 
+syscall.Getrusage (shared r0): 
+syscall.Getsockname (shared r1): 
+syscall.GetsockoptICMPv6Filter (shared r1): 
+syscall.GetsockoptIPMreq (shared r1): 
+syscall.GetsockoptIPMreqn (shared r1): 
+syscall.GetsockoptIPv6MTUInfo (shared r1): 
+syscall.GetsockoptIPv6Mreq (shared r1): 
+syscall.GetsockoptInet4Addr (shared r1): 
+syscall.GetsockoptInt (shared r1): 
+syscall.GetsockoptUcred (shared r1): 
+syscall.Getwd (shared r1): 
+syscall.Getxattr (shared r1): 
+syscall.InotifyAddWatch (shared r1): 
+syscall.InotifyInit (shared r1): 
+syscall.InotifyInit1 (shared r1): 
+syscall.InotifyRmWatch (shared r1): 
+syscall.Ioperm (shared r0): 
+syscall.Iopl (shared r0): 
+syscall.Kill (shared r0): 
+syscall.Klogctl (shared r1): 
+syscall.Lchown (shared r0): 
+syscall.Link (shared r0): 
+syscall.Listen (shared r0): 
+syscall.Listxattr (shared r1): 
+syscall.LsfSocket (shared r1): 
+syscall.Lstat (shared r0): 
+syscall.Madvise (shared r0): 
+syscall.Mkdir (shared r0): 
+syscall.Mkdirat (shared r0): 
+syscall.Mkfifo (shared r0): 
+syscall.Mknod (shared r0): 
+syscall.Mknodat (shared r0): 
+syscall.Mlock (shared r0): 
+syscall.Mlockall (shared r0): 
+syscall.Mmap (opaque r0): 
+syscall.Mount (shared r0): 
+syscall.Mprotect (shared r0): 
+syscall.Munlock (shared r0): 
+syscall.Munlockall (shared r0): 
+syscall.Nanosleep (shared r0): 
+syscall.NetlinkRIB (shared r1): 
+syscall.Open (shared r1): 
+syscall.Openat (shared r1): 
+syscall.ParseDirent: r2<-names
+syscall.ParseNetlinkMessage: r0<-[b]
+syscall.ParseNetlinkRouteAttr: r0<-[m]
+syscall.ParseSocketControlMessage: r0<-[b]
+syscall.Pause (shared r0): 
+syscall.Pipe (shared r0): 
+syscall.Pipe2 (shared r0): 
+syscall.PivotRoot (shared r0): 
+syscall.Pread (shared r1): 
+syscall.PtraceAttach (shared r0): 
+syscall.PtraceCont (shared r0): 
+syscall.PtraceDetach (shared r0): 
+syscall.PtraceGetEventMsg (shared r1): 
+syscall.PtraceGetRegs (shared r0): 
+syscall.PtracePeekData (shared r1): 
+syscall.PtracePeekText (shared r1): 
+syscall.PtracePokeData (shared r1): 
+syscall.PtracePokeText (shared r1): 
+syscall.PtraceSetOptions (shared r0): 
+syscall.PtraceSetRegs (shared r0): 
+syscall.PtraceSingleStep (shared r0): 
+syscall.PtraceSyscall (shared r0): 
+syscall.Pwrite (shared r1): 
+syscall.Read (shared r1): 
+syscall.ReadDirent (shared r1): 
+syscall.Readlink (shared r1): 
+syscall.Reboot (shared r0): 
+syscall.Recvfrom (shared r2): 
+syscall.Recvmsg (shared r4): 
+syscall.Removexattr (shared r0): 
+syscall.Rename (shared r0): 
+syscall.Renameat (shared r0): 
+syscall.Rmdir (shared r0): 
+syscall.Seek (shared r1): 
+syscall.Select (shared r1): 
+syscall.Sendfile (shared r1): 
+syscall.Sendmsg (shared r0): 
+syscall.SendmsgN (shared r1): 
+syscall.Sendto (shared r0): 
+syscall.SetLsfPromisc (shared r0): 
+syscall.SetNonblock (shared r0): 
+syscall.Setdomainname (shared r0): 
+syscall.Setegid (shared r0): 
+syscall.Seteuid (shared r0): 
+syscall.Setfsgid (shared r0): 
+syscall.Setfsuid (shared r0): 
+syscall.Setgid (shared r0): 
+syscall.Setgroups (shared r0): 
+syscall.Sethostname (shared r0): 
+syscall.Setpgid (shared r0): 
+syscall.Setpriority (shared r0): 
+syscall.Setregid (shared r0): 
+syscall.Setresgid (shared r0): 
+syscall.Setresuid (shared r0): 
+syscall.Setreuid (shared r0): 
+syscall.Setrlimit (shared r0): 
+syscall.Setsid (shared r1): 
+syscall.SetsockoptByte (shared r0): 
+syscall.SetsockoptICMPv6Filter (shared r0): 
+syscall.SetsockoptIPMreq (shared r0): 
+syscall.SetsockoptIPMreqn (shared r0): 
+syscall.SetsockoptIPv6Mreq (shared r0): 
+syscall.SetsockoptInet4Addr (shared r0): 
+syscall.SetsockoptInt (shared r0): 
+syscall.SetsockoptLinger (shared r0): 
+syscall.SetsockoptString (shared r0): 
+syscall.SetsockoptTimeval (shared r0): 
+syscall.Settimeofday (shared r0): 
+syscall.Setuid (shared r0): 
+syscall.Setxattr (shared r0): 
+syscall.Shutdown (shared r0): 
+syscall.Socket (shared r1): 
+syscall.Socketpair (shared r1): 
+syscall.Splice (shared r1): 
+syscall.StartProcess (shared r2): 
+syscall.Stat (shared r0): 
+syscall.Statfs (shared r0): 
+syscall.Symlink (shared r0): 
+syscall.SyncFileRange (shared r0): 
+syscall.Sysinfo (shared r0): 
+syscall.Tee (shared r1): 
+syscall.Tgkill (shared r0): 
+syscall.Times (shared r1): 
+syscall.Truncate (shared r0): 
+syscall.Uname (shared r0): 
+syscall.UnixCredentials (opaque r0): 
+syscall.UnixRights (opaque r0): r0<-fds
+syscall.Unlink (shared r0): 
+syscall.Unlinkat (shared r0): 
+syscall.Unmount (shared r0): 
+syscall.Unshare (shared r0): 
+syscall.Ustat (shared r0): 
+syscall.Utime (shared r0): 
+syscall.Utimes (shared r0): 
+syscall.UtimesNano (shared r0): 
+syscall.Wait4 (shared r1): 
+syscall.Write (shared r1): 
+testing.Benchmark (opaque r0): 
+testing.MainStart: r0<-[benchmarks] r0<-[deps] r0<-[examples] r0<-[fuzzTargets] r0<-[tests]
+testing.T.Deadline: r0<-[recv]
+testing.common.Context: r0<-recv
+testing.common.Output (opaque r0): r0<-recv
+testing/fstest.MapFS.Glob (shared r1): 
+testing/fstest.MapFS.Lstat (shared r1): r0<-[recv]
+testing/fstest.MapFS.Open (shared r1): r0<-[recv]
+testing/fstest.MapFS.ReadLink (shared r1): 
+testing/fstest.MapFS.Sub (shared r1): r0<-[recv]
+testing/fstest.TestFS (opaque r0) (shared r0): r0<-expected r0<-fsys
+testing/iotest.DataErrReader: r0<-[r]
+testing/iotest.ErrReader: r0<-[err]
+testing/iotest.HalfReader: r0<-[r]
+testing/iotest.NewReadLogger: r0<-[r]
+testing/iotest.NewWriteLogger: r0<-[w]
+testing/iotest.OneByteReader: r0<-[r]
+testing/iotest.TestReader: r0<-[content]
+testing/iotest.TimeoutReader: r0<-[r]
+testing/iotest.TruncateWriter: r0<-[w]
+text/scanner.Scanner.Init: r0<-recv
+text/tabwriter.NewWriter (opaque r0): r0<-output
+text/tabwriter.Writer.Flush (opaque r0): r0<-recv
+text/tabwriter.Writer.Init: r0<-recv
+text/tabwriter.Writer.Write (opaque r1): r1<-buf r1<-recv
+text/template.ExecError.Unwrap: r0<-recv
+text/template.Must: r0<-t
+text/template.New (opaque r0): 
+text/template.ParseFS (opaque r0 r1) (shared r1): r0<-fsys r0<-patterns r1<-fsys r1<-patterns
+text/template.ParseFiles (opaque r0 r1): r0<-filenames r1<-filenames
+text/template.ParseGlob (opaque r0 r1) (shared r1): 
+text/template.Template.AddParseTree: r0<-recv
+text/template.Template.Clone: r0<-[recv]
+text/template.Template.Delims: r0<-recv
+text/template.Template.Execute (opaque r0): r0<-data r0<-recv r0<-wr
+text/template.Template.ExecuteTemplate (opaque r0): r0<-data r0<-recv r0<-wr
+text/template.Template.Funcs: r0<-recv
+text/template.Template.Lookup (opaque r0): r0<-recv
+text/template.Template.New: r0<-[recv]
+text/template.Template.Option: r0<-recv
+text/template.Template.Parse (opaque r1): r0<-recv r1<-recv
+text/template.Template.ParseFS (opaque r0 r1) (shared r1): r0<-fsys r0<-patterns r0<-recv r1<-fsys r1<-patterns r1<-recv
+text/template.Template.ParseFiles (opaque r0 r1): r0<-filenames r0<-recv r1<-filenames r1<-recv
+text/template.Template.ParseGlob (opaque r0 r1) (shared r1): r0<-recv r1<-recv
+text/template.Template.Templates (opaque r0): r0<-recv
+text/template/parse.ActionNode.Copy: r0<-[recv]
+text/template/parse.BoolNode.Copy: r0<-[recv]
+text/template/parse.BranchNode.Copy: r0<-[recv]
+text/template/parse.BreakNode.Copy: r0<-[recv]
+text/template/parse.ChainNode.Copy: r0<-[recv]
+text/template/parse.CommandNode.Copy: r0<-recv
+text/template/parse.CommentNode.Copy: r0<-[recv]
+text/template/parse.ContinueNode.Copy: r0<-[recv]
+text/template/parse.DotNode.Copy: r0<-[recv]
+text/template/parse.FieldNode.Copy: r0<-[recv]
+text/template/parse.IdentifierNode.SetPos: r0<-recv
+text/template/parse.IdentifierNode.SetTree: r0<-recv
+text/template/parse.IfNode.Copy: r0<-[recv]
+text/template/parse.ListNode.Copy: r0<-recv
+text/template/parse.ListNode.CopyList: r0<-recv
+text/template/parse.New: r0<-[funcs]
+text/template/parse.NilNode.Copy: r0<-[recv]
+text/template/parse.NumberNode.Copy: r0<-[recv]
+text/template/parse.Parse (opaque r1): r1<-funcs
+text/template/parse.PipeNode.Copy: r0<-recv
+text/template/parse.PipeNode.CopyPipe: r0<-recv
+text/template/parse.RangeNode.Copy: r0<-[recv]
+text/template/parse.StringNode.Copy: r0<-[recv]
+text/template/parse.TemplateNode.Copy: r0<-[recv]
+text/template/parse.TextNode.Copy: r0<-[recv]
+text/template/parse.Tree.Copy: r0<-[recv]
+text/template/parse.Tree.Parse (opaque r1): r0<-recv r1<-funcs r1<-recv r1<-treeSet
+text/template/parse.VariableNode.Copy: r0<-[recv]
+text/template/parse.WithNode.Copy: r0<-[recv]
+time.Date (opaque r0) (shared r0): r0<-loc
+time.FixedZone (shared r0): 
+time.LoadLocation (shared r0 r1): 
+time.LoadLocationFromTZData (shared r1): 
+time.Now (shared r0): 
+time.Parse (opaque r0) (shared r0): 
+time.ParseInLocation (opaque r0) (shared r0): r0<-loc
+time.Time.Add (opaque r0): r0<-recv
+time.Time.AddDate (opaque r0) (shared r0): r0<-recv
+time.Time.AppendBinary: r0<-b
+time.Time.AppendFormat: r0<-b
+time.Time.AppendText: r0<-b
+time.Time.In (opaque r0): r0<-loc r0<-recv
+time.Time.Local (opaque r0): r0<-recv
+time.Time.Location (shared r0): r0<-recv
+time.Time.Round (opaque r0): r0<-recv
+time.Time.Truncate (opaque r0): r0<-recv
+time.Time.UTC (opaque r0): r0<-recv
+time.Time.ZoneBounds (opaque r0 r1) (shared r0 r1): r0<-recv r1<-recv
+time.Unix (shared r0): 
+time.UnixMicro (shared r0): 
+time.UnixMilli (shared r0): 
+unicode/utf16.AppendRune: r0<-a
+unicode/utf8.AppendRune: r0<-p
+unique.Handle.Value: r0<-recv
+unique.Make (opaque r0): r0<-value


### PR DESCRIPTION
Adds SSA analysis to bindgen so we can derive, for every Go fn, whether a container-typed result is fresh storage or a view of its args, and at what depth. Lis right now assumes every call result is fresh, which can result in corruption:

```rs
let b = "  data  ".to_bytes()
let mut t = bytes.TrimSpace(b)
t[0] = 88 // writes into b
```

For each result the analysis derives one or more of: 
- fresh, or a view of specific params or the receiver
- shared package-global storage 
- opaque, treated as a view of every arg unless an override refines it

The derived answers are checked against a list of known view-returning stdlib functions. The full stdlib output is committed as a golden file so a Go upgrade that changes what a fn returns shows up as a diff.

Nothing is emitted into typedefs yet.
