### PR TITLE
refactor: emit assertions as a direct failure test without temps

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -1001,18 +1001,41 @@ impl Planner<'_> {
         ty: &Type,
         generics: &[Generic],
     ) -> String {
+        self.render_equality_test(lhs, rhs, ty, generics, false)
+    }
+
+    /// `!=` where equality is an operator, a `!` prefix where it is a call.
+    pub(crate) fn render_inequality(
+        &mut self,
+        lhs: &str,
+        rhs: &str,
+        ty: &Type,
+        generics: &[Generic],
+    ) -> String {
+        self.render_equality_test(lhs, rhs, ty, generics, true)
+    }
+
+    fn render_equality_test(
+        &mut self,
+        lhs: &str,
+        rhs: &str,
+        ty: &Type,
+        generics: &[Generic],
+        negated: bool,
+    ) -> String {
+        let (operator, prefix) = if negated { ("!=", "!") } else { ("==", "") };
         let peeled = self.facts.peel_alias(ty);
         if peeled.is_ref() {
-            return format!("{lhs} == {rhs}");
+            return format!("{lhs} {operator} {rhs}");
         }
         if peeled.is_slice() {
             self.require_slices();
             return match peeled.inner() {
                 Some(elem) if self.needs_custom_equality(&elem, generics) => {
                     let eq = self.equality_closure(&elem, generics);
-                    format!("slices.EqualFunc({lhs}, {rhs}, {eq})")
+                    format!("{prefix}slices.EqualFunc({lhs}, {rhs}, {eq})")
                 }
-                _ => format!("slices.Equal({lhs}, {rhs})"),
+                _ => format!("{prefix}slices.Equal({lhs}, {rhs})"),
             };
         }
         if peeled.is_map() {
@@ -1023,15 +1046,15 @@ impl Planner<'_> {
             return match value {
                 Some(value) if self.needs_custom_equality(&value, generics) => {
                     let eq = self.equality_closure(&value, generics);
-                    format!("maps.EqualFunc({lhs}, {rhs}, {eq})")
+                    format!("{prefix}maps.EqualFunc({lhs}, {rhs}, {eq})")
                 }
-                _ => format!("maps.Equal({lhs}, {rhs})"),
+                _ => format!("{prefix}maps.Equal({lhs}, {rhs})"),
             };
         }
         if self.type_has_equals(&peeled, generics) {
-            return format!("{lhs}.{}({rhs})", self.equals_method_go_name());
+            return format!("{prefix}{lhs}.{}({rhs})", self.equals_method_go_name());
         }
-        format!("{lhs} == {rhs}")
+        format!("{lhs} {operator} {rhs}")
     }
 
     fn equality_closure(&mut self, ty: &Type, generics: &[Generic]) -> String {

--- a/crates/emit/src/expressions/mod.rs
+++ b/crates/emit/src/expressions/mod.rs
@@ -6,3 +6,5 @@ mod operators;
 pub(crate) mod staging;
 pub(crate) mod top_items;
 pub(crate) mod values;
+
+pub(crate) use operators::{flip_comparison, flip_preserves_nan};

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -217,7 +217,11 @@ impl Planner<'_> {
 
     /// Plan `!` (logical-not). Comparisons flip operator because `!` binds
     /// tighter than `==` in Go (`!(a == b)` must not emit as `!a == b`).
-    fn plan_unary_not(&mut self, expression: &Expression, ctx: ExpressionContext<'_>) -> ValuePlan {
+    pub(crate) fn plan_unary_not(
+        &mut self,
+        expression: &Expression,
+        ctx: ExpressionContext<'_>,
+    ) -> ValuePlan {
         let target = expression.unwrap_parens();
         let preserve_parens = matches!(expression, Expression::Paren { .. });
         let wrap = |s: String| {
@@ -300,7 +304,9 @@ impl Planner<'_> {
     }
 }
 
-fn flip_preserves_nan(
+/// `!(a < b)` holds for a NaN operand where `a >= b` does not, so only `==`
+/// and `!=` flip unconditionally.
+pub(crate) fn flip_preserves_nan(
     facts: &EmitFacts<'_>,
     operator: &BinaryOperator,
     left: &Expression,
@@ -316,7 +322,7 @@ fn is_non_float(facts: &EmitFacts<'_>, expression: &Expression) -> bool {
         .is_some_and(|kind| !kind.is_float())
 }
 
-fn flip_comparison(operator: &BinaryOperator) -> Option<BinaryOperator> {
+pub(crate) fn flip_comparison(operator: &BinaryOperator) -> Option<BinaryOperator> {
     match operator {
         BinaryOperator::Equal => Some(BinaryOperator::NotEqual),
         BinaryOperator::NotEqual => Some(BinaryOperator::Equal),

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -5,6 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::control_flow::targets::legalize_source_loop;
 use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
+use crate::expressions::{flip_comparison, flip_preserves_nan};
 use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
 use crate::plan::bodies::{
     ElseArm, ExpressionStatementForm, ExpressionStatementPlan, IfPlan, LoopKind, LoopPlan,
@@ -14,11 +15,11 @@ use crate::plan::bodies::{
 use crate::plan::placement::{
     collapse_boolean_branch_assign, collapse_declare_assign, requires_temp_var, try_elide_tail_let,
 };
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{OperandForm, ValuePlan};
 use crate::utils::wrap_if_struct_literal;
 use syntax::ast::{
     BinaryOperator, Expression, IdentifierResolution, IfLetAlternative, Literal, MatchArm, Pattern,
-    Span,
+    Span, UnaryOperator,
 };
 use syntax::types::Type;
 
@@ -415,8 +416,6 @@ impl Planner<'_> {
         let operand = operand.unwrap_parens();
         self.require_testkit();
 
-        // Each shape stages its operands into `statements` and returns the
-        // condition, the record kind, and any operand arguments for the call.
         let mut statements = Vec::new();
         let shape = if let Expression::Binary {
             operator,
@@ -434,7 +433,7 @@ impl Planner<'_> {
         };
 
         let AssertShape {
-            condition,
+            failure_condition,
             kind,
             message,
             operands,
@@ -443,12 +442,17 @@ impl Planner<'_> {
             .current_test_handle()
             .expect("assert without a test handle should be rejected by semantics");
         let span = operand.get_span();
-        statements.push(LoweredStatement::RawGo(format!(
-            "if !({condition}) {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"{message}\"{operands})\n}}\n",
+        let test = LoweredStatement::RawGo(format!(
+            "if {failure_condition} {{\n{handle}.FailAssert({}, {}, {}, \"{kind}\", \"{message}\"{operands})\n}}\n",
             span.file_id,
             span.byte_offset,
             span.byte_offset + span.byte_length,
-        )));
+        ));
+        // The block exists only to scope the temps.
+        if statements.is_empty() {
+            return test;
+        }
+        statements.push(test);
         LoweredStatement::Block(LoweredBlock { statements })
     }
 
@@ -524,8 +528,8 @@ impl Planner<'_> {
         (statements, call)
     }
 
-    /// `assert a <op> b`: compare the captured temps via the normal binary
-    /// lowering, reporting both as `left`/`right`.
+    /// `assert a <op> b`: compare the operands via the normal binary lowering,
+    /// reporting both as `left`/`right`.
     fn lower_relation_assert(
         &mut self,
         operator: &BinaryOperator,
@@ -534,19 +538,27 @@ impl Planner<'_> {
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertShape {
         self.require_stdlib();
-        let lhs = self.stage_assert_operand(left, "assertLeft", statements);
-        let rhs = self.stage_assert_operand(right, "assertRight", statements);
-        let left_ref = temp_identifier(&lhs, left);
-        let right_ref = temp_identifier(&rhs, right);
+        let (lhs, rhs) =
+            self.stage_assert_operands(left, right, LiteralInlining::Allowed, statements);
+        let flipped = flip_comparison(operator)
+            .filter(|_| flip_preserves_nan(&self.facts, operator, left, right));
         let (cond_setup, condition) = self
-            .plan_binary(operator, &left_ref, &right_ref, ExpressionContext::value())
+            .plan_binary(
+                flipped.as_ref().unwrap_or(operator),
+                &lhs.expression,
+                &rhs.expression,
+                ExpressionContext::value(),
+            )
             .into_parts();
         statements.extend(cond_setup);
         AssertShape {
-            condition,
+            failure_condition: match flipped {
+                Some(_) => condition,
+                None => format!("!({condition})"),
+            },
             kind: "relation",
             message: format!("expected {operator}"),
-            operands: paired_operands(&lhs, &rhs),
+            operands: paired_operands(&lhs.rendered, &rhs.rendered),
         }
     }
 
@@ -559,56 +571,132 @@ impl Planner<'_> {
     ) -> AssertShape {
         self.require_stdlib();
         let recv_ty = recv.get_type();
-        let lhs = self.stage_assert_operand(recv, "assertLeft", statements);
-        let rhs = self.stage_assert_operand(arg, "assertRight", statements);
-        let condition = self.render_equality(&lhs, &rhs, &recv_ty, &[]);
+        let (lhs, rhs) = self.stage_assert_operands(recv, arg, LiteralInlining::Denied, statements);
+        let failure_condition = self.render_inequality(&lhs.rendered, &rhs.rendered, &recv_ty, &[]);
         AssertShape {
-            condition,
+            failure_condition,
             kind: "labeled",
             message: "expected ==".to_string(),
-            operands: paired_operands(&lhs, &rhs),
+            operands: paired_operands(&lhs.rendered, &rhs.rendered),
         }
     }
 
-    /// `assert <expr>`: any other boolean, lowered as-is (no decomposition).
+    /// `assert <expr>`: any other boolean, tested through its negation.
     fn lower_bare_assert(
         &mut self,
         operand: &Expression,
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertShape {
-        let (setup, condition) = self.lower_condition(operand);
-        statements.extend(setup);
+        let ctx = ExpressionContext::value().condition();
+        let failure_condition = if let Expression::Unary {
+            operator: UnaryOperator::Not,
+            expression: negated,
+            ..
+        } = operand
+        {
+            let (setup, condition) = self.plan_operand(negated, ctx).into_parts();
+            statements.extend(setup);
+            wrap_if_struct_literal(condition)
+        } else if matches!(operand, Expression::Binary { .. }) {
+            // `!` binds tighter than `&&` and `||`, so a binary predicate keeps
+            // its parentheses.
+            let (setup, condition) = self.lower_condition(operand);
+            statements.extend(setup);
+            format!("!({condition})")
+        } else {
+            let (setup, condition) = self.plan_unary_not(operand, ctx).into_parts();
+            statements.extend(setup);
+            wrap_if_struct_literal(condition)
+        };
         AssertShape {
-            condition,
+            failure_condition,
             kind: "bare",
             message: "assertion failed".to_string(),
             operands: String::new(),
         }
     }
 
-    /// Capture an `assert` operand into a fresh temp, declared with its inferred
-    /// type so an untyped constant (e.g. a large `uint64` literal) keeps its type.
-    fn stage_assert_operand(
+    /// A name reads the same twice unless the other operand calls something.
+    fn stage_assert_operands(
+        &mut self,
+        left: &Expression,
+        right: &Expression,
+        literals: LiteralInlining,
+        statements: &mut Vec<LoweredStatement>,
+    ) -> (AssertOperand, AssertOperand) {
+        let left_plan = self.lower_value(left, ExpressionContext::value());
+        let right_plan = self.lower_value(right, ExpressionContext::value());
+        let names_inline = left_plan.setup.is_empty()
+            && right_plan.setup.is_empty()
+            && !left_plan.evaluation.effect.has_call()
+            && !right_plan.evaluation.effect.has_call();
+        let left_temp = self.assert_operand_temp_type(left, &left_plan, literals, names_inline);
+        let right_temp = self.assert_operand_temp_type(right, &right_plan, literals, names_inline);
+        let lhs = self.bind_assert_operand(left, left_plan, "assertLeft", left_temp, statements);
+        let rhs =
+            self.bind_assert_operand(right, right_plan, "assertRight", right_temp, statements);
+        (lhs, rhs)
+    }
+
+    /// The Go type to declare an operand's temp with, or `None` to render the
+    /// operand twice instead.
+    fn assert_operand_temp_type(
         &mut self,
         expression: &Expression,
+        plan: &ValuePlan,
+        literals: LiteralInlining,
+        names_inline: bool,
+    ) -> Option<String> {
+        let go_type = self.go_type_string(&expression.get_type());
+        let inlines = plan.setup.is_empty()
+            && match plan.evaluation.form {
+                OperandForm::Name => names_inline,
+                _ => {
+                    matches!(literals, LiteralInlining::Allowed)
+                        && constant_default_go_type(expression) == Some(go_type.as_str())
+                }
+            };
+        (!inlines).then_some(go_type)
+    }
+
+    fn bind_assert_operand(
+        &mut self,
+        expression: &Expression,
+        plan: ValuePlan,
         hint: &str,
+        temp_type: Option<String>,
         statements: &mut Vec<LoweredStatement>,
-    ) -> String {
-        let (setup, value) = self
-            .lower_value(expression, ExpressionContext::value())
-            .into_parts();
+    ) -> AssertOperand {
+        let (setup, value) = plan.into_parts();
         statements.extend(setup);
+        let Some(go_type) = temp_type else {
+            return AssertOperand {
+                expression: expression.clone(),
+                rendered: value,
+            };
+        };
         let name = self.fresh_var(Some(hint));
         self.declare(&name);
         // Bind the temp to itself so the relation shape's synthetic identifier resolves.
         self.scope.bind(name.clone(), name.clone());
-        let go_type = self.go_type_string(&expression.get_type());
-        statements.push(LoweredStatement::VarDecl {
-            name: name.clone(),
-            go_type,
-            value: Some(value),
+        // Under `:=` a Go constant may take its own default type, so a large
+        // `uint64` literal would come back as an overflowing `int`.
+        statements.push(if self.is_go_constant_expression(expression) {
+            LoweredStatement::VarDecl {
+                name: name.clone(),
+                go_type,
+                value: Some(value),
+            }
+        } else {
+            LoweredStatement::TempBind {
+                name: name.clone(),
+                value,
+            }
         });
-        name
+        AssertOperand {
+            expression: temp_identifier(&name, expression),
+            rendered: name,
+        }
     }
 
     /// A `recv.equals(arg)` whose receiver has an `equals` the compiler can lower
@@ -1038,13 +1126,49 @@ impl Planner<'_> {
     }
 }
 
-/// The lowered pieces of an `assert`: the boolean condition, the record kind,
-/// and any `, Operand{...}` arguments appended to the failure call.
+/// The lowered pieces of an `assert`: the condition under which it fails, the
+/// record kind, and any `, Operand{...}` arguments appended to the failure call.
 struct AssertShape {
-    condition: String,
+    failure_condition: String,
     kind: &'static str,
     message: String,
     operands: String,
+}
+
+/// An `assert` operand: the expression the test reads, and the Go text the
+/// failure call reports.
+struct AssertOperand {
+    expression: Expression,
+    rendered: String,
+}
+
+/// The equals lowering can read its left operand as a method receiver, where a
+/// bare literal is not valid Go.
+#[derive(Clone, Copy)]
+enum LiteralInlining {
+    Allowed,
+    Denied,
+}
+
+/// The Go type an operand takes on its own when it emits as an untyped
+/// constant. `None` for anything typed, or whose default is not knowable here.
+fn constant_default_go_type(expression: &Expression) -> Option<&'static str> {
+    match expression {
+        Expression::Paren { expression, .. }
+        | Expression::Unary {
+            operator: UnaryOperator::Negative,
+            expression,
+            ..
+        } => constant_default_go_type(expression),
+        Expression::Literal { literal, .. } => match literal {
+            Literal::Integer { .. } => Some("int"),
+            Literal::Float { .. } => Some("float64"),
+            Literal::String { .. } => Some("string"),
+            Literal::Boolean(_) => Some("bool"),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn paired_operands(lhs: &str, rhs: &str) -> String {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -8597,6 +8597,123 @@ fn assert_lowers_to_decomposed_failure_call() {
     );
 }
 
+fn compile_test_source(source: &str) -> String {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        "import \"math\"\n\nfn main() {\n  let _ = math.add(1, 2)\n}",
+    );
+    fs.add_file(
+        "math",
+        "core.lis",
+        "pub fn add(a: int, b: int) -> int { a + b }",
+    );
+    fs.add_file("math", "core.test.lis", source);
+
+    compile_project_files_with_tests(fs, "github.com/user/p", false, true)
+        .iter()
+        .find(|f| f.name.ends_with("core_test.go"))
+        .expect("expected a core_test.go output")
+        .to_go()
+}
+
+#[test]
+fn assert_relation_reads_local_and_literal_operands_directly() {
+    let go = compile_test_source(
+        "#[test]\nfn totals() {\n  let result = add(40, 60)\n  assert result == 100\n}",
+    );
+
+    assert!(
+        go.contains("if result != 100 {"),
+        "operands safe to read twice must be compared in place, got:\n{go}"
+    );
+    assert!(
+        !go.contains("assertLeft"),
+        "an `assert` over such operands must bind no temps, got:\n{go}"
+    );
+    assert!(
+        go.contains("lisette.Debug(result)") && go.contains("lisette.Debug(100)"),
+        "the failure call must report the operands themselves, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_relation_binds_a_call_operand_with_short_declaration() {
+    let go = compile_test_source("#[test]\nfn smallest() {\n  assert min(3, 1, 2) == 1\n}");
+
+    assert!(
+        go.contains("assertLeft_1 := min(3, 1, 2)"),
+        "a called operand must bind through `:=`, got:\n{go}"
+    );
+    assert!(
+        go.contains("if assertLeft_1 != 1 {"),
+        "the failure test must negate the relation directly, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_relation_declares_an_imported_constant_operand() {
+    let go = compile_test_source(
+        "import \"go:time\"\n\n#[test]\nfn waits() {\n  let d: time.Duration = time.Second\n  assert d == time.Second\n}",
+    );
+
+    assert!(
+        go.contains("var assertRight_1 time.Duration = time.Second"),
+        "emit does not tell a typed Go constant from an untyped one, so every Go constant keeps its declaration, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_relation_binds_a_local_beside_a_called_operand() {
+    let go = compile_test_source("#[test]\nfn totals() {\n  let n = 3\n  assert n == add(1, 2)\n}");
+
+    assert!(
+        go.contains("assertLeft_1 := n"),
+        "a local read before a call must keep its temp, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_ordering_flips_only_where_a_nan_cannot_differ() {
+    let go = compile_test_source(
+        "#[test]\nfn ints() {\n  let a = 1\n  let b = 2\n  assert a < b\n}\n\n#[test]\nfn floats() {\n  let x: float64 = 1.0\n  let y: float64 = 2.0\n  assert x < y\n}",
+    );
+
+    assert!(
+        go.contains("if a >= b {"),
+        "an integer ordering must test the flipped operator, got:\n{go}"
+    );
+    assert!(
+        go.contains("if !(x < y) {"),
+        "a float ordering must keep the negation, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_bare_predicate_tests_its_negation() {
+    let go = compile_test_source(
+        "#[test]\nfn filled() {\n  let xs = [1, 2]\n  assert !xs.is_empty()\n}",
+    );
+
+    assert!(
+        go.contains("if len(xs) == 0 {"),
+        "a negated predicate must test the predicate itself, got:\n{go}"
+    );
+}
+
+#[test]
+fn assert_bare_predicate_parenthesizes_a_struct_literal() {
+    let go = compile_test_source(
+        "struct Point {\n  x: int,\n}\n\nimpl Point {\n  fn is_origin(self) -> bool { self.x == 0 }\n}\n\n#[test]\nfn origin() {\n  assert Point { x: 0 }.is_origin()\n}",
+    );
+
+    assert!(
+        go.contains("if (!Point{"),
+        "a condition opening with a composite literal must be parenthesized, got:\n{go}"
+    );
+}
+
 #[test]
 fn test_log_in_value_position_keeps_span_arguments() {
     let mut fs = MockFileSystem::new();
@@ -8801,8 +8918,8 @@ fn assert_equals_lowers_to_labeled_failure() {
         .to_go();
 
     assert!(
-        go.contains("\"labeled\"") && go.contains("slices.Equal("),
-        "a `.equals()` assert must lower to a labeled record via `slices.Equal`, got:\n{go}"
+        go.contains("\"labeled\"") && go.contains("if !slices.Equal(xs, ys) {"),
+        "a `.equals()` assert must lower to a labeled record via a negated `slices.Equal`, got:\n{go}"
     );
     assert!(
         go.contains("Label: \"left\"") && go.contains("Label: \"right\""),


### PR DESCRIPTION
An `assert` in a test now emits a direct failure test, instead of binding both operands to typed temps inside a block and negating the success condition.

Before:

```go
{
	var assertLeft_2 int = result
	var assertRight_3 int = 100
	if !(assertLeft_2 == assertRight_3) {
		_lisTest_ctx.FailAssert(8, 636, 649, "relation", "expected ==",
			testkit.Operand{Label: "left", Value: lisette.Debug(assertLeft_2)},
			testkit.Operand{Label: "right", Value: lisette.Debug(assertRight_3)})
	}
}
```

After:

```go
if result != 100 {
	_lisTest_ctx.FailAssert(8, 636, 649, "relation", "expected ==",
		testkit.Operand{Label: "left", Value: lisette.Debug(result)},
		testkit.Operand{Label: "right", Value: lisette.Debug(100)})
}
```
