### PR TITLE
refactor: reuse stable names instead of copying them into temps

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -172,19 +172,6 @@ impl Planner<'_> {
         value
     }
 
-    /// Bind `value` to a name that can be read more than once.
-    fn stable_source(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        hint: &str,
-        value: &str,
-    ) -> String {
-        if go_name::is_plain_identifier(value) {
-            return value.to_string();
-        }
-        self.hoist_tmp_value_statement(statements, hint, value)
-    }
-
     fn plan_array_rebuild(
         &mut self,
         statements: &mut Vec<LoweredStatement>,

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -168,7 +168,7 @@ impl Planner<'_> {
         slot_ty: &str,
         address: bool,
     ) -> String {
-        let opt_var = self.hoist_tmp_value_statement(statements, "opt", option_value);
+        let opt_var = self.stable_source(statements, "opt", option_value);
         let slot_var = self.fresh_var(Some(slot_hint));
         self.declare(&slot_var);
         statements.push(LoweredStatement::VarDecl {
@@ -294,7 +294,7 @@ impl Planner<'_> {
                 }
             }
             LayoutBridge::Reference { pointee } => {
-                let source = self.hoist_tmp_value_statement(statements, "src", value);
+                let source = self.stable_source(statements, "src", value);
                 let pointee = self.plan_layout_bridge(statements, &format!("*{source}"), pointee);
                 self.hoist_tmp_value_statement(statements, "ref", &format!("&{pointee}"))
             }
@@ -315,7 +315,7 @@ impl Planner<'_> {
         payload_bridge: &LayoutBridge,
         address: bool,
     ) -> String {
-        let option = self.hoist_tmp_value_statement(statements, "opt", option_value);
+        let option = self.stable_source(statements, "opt", option_value);
         let target_type = target_payload.go_type(self);
         let slot_type = if address {
             format!("*{target_type}")
@@ -363,7 +363,7 @@ impl Planner<'_> {
         pointer: bool,
     ) -> String {
         self.require_stdlib();
-        let source = self.hoist_tmp_value_statement(statements, "raw", raw_value);
+        let source = self.stable_source(statements, "raw", raw_value);
         let fallible = Fallible::from_type(option_type).expect("Option type expected");
         let option_type_string = {
             let mut planner = FalliblePlanner::new(self, &fallible);
@@ -434,7 +434,7 @@ impl Planner<'_> {
         let element_bridge: &LayoutBridge = element;
         let key_bridge = key.as_deref();
         self.require_stdlib();
-        let source = self.hoist_tmp_value_statement(statements, "src", value);
+        let source = self.stable_source(statements, "src", value);
         let direction = key_bridge
             .and_then(LayoutBridge::direction)
             .or_else(|| element_bridge.direction())

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -40,7 +40,7 @@ impl Planner<'_> {
             body,
             closure_close: "}()\n".to_string(),
         }];
-        ValuePlan::name(setup, result_var, false)
+        ValuePlan::captured(setup, result_var)
     }
 
     fn lower_try_body(&mut self, items: &[Expression], fallible: &Fallible) -> LoweredBlock {
@@ -196,7 +196,7 @@ impl Planner<'_> {
             body,
             closure_close: "})\n".to_string(),
         }];
-        ValuePlan::name(setup, result_var, false)
+        ValuePlan::captured(setup, result_var)
     }
 
     fn lower_recover_body_block(

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -52,7 +52,7 @@ impl Planner<'_> {
         let expression_ty = expression.get_type();
 
         let base_plan = if let Some(package) = expression_ty.as_import_namespace() {
-            ValuePlan::name(Vec::new(), self.require_package_import(package), true)
+            ValuePlan::captured(Vec::new(), self.require_package_import(package))
         } else {
             self.plan_coerced_expression(expression, receiver_coercion, ctx)
         };

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -145,6 +145,26 @@ impl Planner<'_> {
         }
     }
 
+    /// Whether readers can name the value where it sits instead of pinning it.
+    pub(crate) fn plan_rests_in_stable_name(&self, plan: &ValuePlan) -> bool {
+        if plan.rests_in_fixed_name() {
+            return true;
+        }
+        let rendered = plan.rendered();
+        plan.rests_in_own_temp(&rendered) && !self.scope.has_binding_for_go_name(&rendered)
+    }
+
+    /// How much of a read's surroundings can change the value it observes.
+    pub(crate) fn identifier_read_stability(&self, expression: &Expression) -> Stability {
+        if self.is_unmutated_identifier(expression) {
+            Stability::Fixed
+        } else if self.identifier_immune_to_calls(expression) {
+            Stability::StableAcrossCalls
+        } else {
+            Stability::Observable
+        }
+    }
+
     /// Only a binding mutated through an alias can be rebound by a call, so
     /// reads of alias-free bindings commute with sibling calls.
     pub(crate) fn identifier_immune_to_calls(&self, expression: &Expression) -> bool {
@@ -349,7 +369,7 @@ impl Planner<'_> {
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let mut results = Vec::with_capacity(stages.len());
         for i in 0..stages.len() {
-            let s_non_literal = !stages[i].evaluation.stability.is_literal();
+            let s_non_literal = !stages[i].evaluation.stability.is_fixed();
             let s_expression = std::mem::replace(
                 &mut stages[i].expression,
                 GoExpression::opaque(String::new()),

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -234,9 +234,8 @@ impl Planner<'_> {
                 ..
             } => {
                 let go_expression = self.emit_identifier(value, resolution.definition(), ty, ctx);
-                let stable_across_calls = self.identifier_immune_to_calls(expression);
-                let plan =
-                    ValuePlan::from_identifier_expression(go_expression, stable_across_calls);
+                let stability = self.identifier_read_stability(expression);
+                let plan = ValuePlan::from_identifier_expression(go_expression, stability);
                 let mut adapter_setup = Vec::new();
                 let value = self.maybe_lower_tagged_fn_ref(
                     &mut adapter_setup,

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -497,6 +497,19 @@ impl<'a> Planner<'a> {
         tmp
     }
 
+    /// Bind `value` to a name that can be read more than once.
+    fn stable_source(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        hint: &str,
+        value: &str,
+    ) -> String {
+        if go_name::is_plain_identifier(value) {
+            return value.to_string();
+        }
+        self.hoist_tmp_value_statement(statements, hint, value)
+    }
+
     /// Structured counterpart of `hoist_tmp_value`: push a `TempBind` leaf.
     fn hoist_tmp_value_statement(
         &mut self,

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -444,14 +444,21 @@ impl Planner<'_> {
             setup.extend(subject_setup);
             return (value, SubjectDeclaration::None);
         }
-        let var = self.fresh_var(Some("subject"));
-        self.declare(&var);
         let staged = self.stage_composite(subject, ExpressionContext::value());
+        let rests_in_stable_name = self.plan_rests_in_stable_name(&staged);
         let (subject_setup, value) = staged.into_parts();
         setup.extend(subject_setup);
         if !any_guard && is_plain_identifier(&value) {
             return (value, SubjectDeclaration::None);
         }
+        if any_guard && rests_in_stable_name {
+            return (
+                value.clone(),
+                SubjectDeclaration::PlainDiscard { var: value },
+            );
+        }
+        let var = self.fresh_var(Some("subject"));
+        self.declare(&var);
         let declaration = SubjectDeclaration::Deferred {
             var: var.clone(),
             expression: value,

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -124,12 +124,15 @@ impl Planner<'_> {
                     let var = self.reference_go_name(value);
                     return ResolvedSubject::Existing { var };
                 }
+                let plan = self.lower_value(scrutinee, ExpressionContext::value());
+                let rests_in_stable_name = self.plan_rests_in_stable_name(&plan);
+                let (op_setup, expression) = plan.into_parts();
+                setup.extend(op_setup);
+                if rests_in_stable_name {
+                    return ResolvedSubject::Existing { var: expression };
+                }
                 let var = self.fresh_var(temp_hint);
                 self.declare(&var);
-                let (op_setup, expression) = self
-                    .lower_value(scrutinee, ExpressionContext::value())
-                    .into_parts();
-                setup.extend(op_setup);
                 ResolvedSubject::Composite { var, expression }
             }
         }

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -459,6 +459,42 @@ impl LoweredBlock {
 }
 
 impl LoweredStatement {
+    /// The Go name this statement binds, seeing through a sourcemap directive.
+    pub(crate) fn bound_name(&self) -> Option<&str> {
+        match self {
+            LoweredStatement::Directed { inner, .. } => inner.bound_name(),
+            LoweredStatement::TempBind { name, .. }
+            | LoweredStatement::ClosureBind { name, .. }
+            | LoweredStatement::VarDecl {
+                name,
+                value: Some(_),
+                ..
+            } => Some(name),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn binds_name(&self, go_name: &str) -> bool {
+        self.bound_name() == Some(go_name)
+    }
+
+    /// `false` when the statement binds nothing.
+    pub(crate) fn rename_bound_name(&mut self, go_name: &str) -> bool {
+        let bound = match self {
+            LoweredStatement::Directed { inner, .. } => return inner.rename_bound_name(go_name),
+            LoweredStatement::TempBind { name, .. }
+            | LoweredStatement::ClosureBind { name, .. }
+            | LoweredStatement::VarDecl {
+                name,
+                value: Some(_),
+                ..
+            } => name,
+            _ => return false,
+        };
+        *bound = go_name.to_string();
+        true
+    }
+
     fn emits_output(&self) -> bool {
         match self {
             LoweredStatement::If(_)

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -96,7 +96,7 @@ impl Planner<'_> {
         );
         let mut setup = vec![declaration, LoweredStatement::If(plan)];
         collapse_boolean_branch_assign(&mut setup, &result_var);
-        ValuePlan::name(setup, result_var, false)
+        ValuePlan::captured(setup, result_var)
     }
 
     /// Lower a value-position `if let`/`match`/`select` to a fresh operand-temp
@@ -119,7 +119,7 @@ impl Planner<'_> {
         setup.extend(block.statements);
         collapse_declare_assign(&mut setup, &result_var);
         collapse_boolean_branch_assign(&mut setup, &result_var);
-        ValuePlan::name(setup, result_var, false)
+        ValuePlan::captured(setup, result_var)
     }
 
     /// Lower a value-position `loop` to a fresh operand-temp variable.
@@ -137,11 +137,7 @@ impl Planner<'_> {
         let plan = self.with_loop(result_var.clone(), |this| {
             this.lower_loop_with_header("for {\n".to_string(), body)
         });
-        ValuePlan::name(
-            vec![declaration, LoweredStatement::Loop(plan)],
-            result_var,
-            false,
-        )
+        ValuePlan::captured(vec![declaration, LoweredStatement::Loop(plan)], result_var)
     }
 
     fn lower_body_until_diverge(

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -60,6 +60,17 @@ pub(crate) fn simple_assign(target_var: &str, value: ValuePlan) -> LoweredStatem
     })
 }
 
+/// Bind the setup's trailing temp under `name` instead of copying it.
+pub(crate) fn rebind_trailing_temp(
+    statements: &mut [LoweredStatement],
+    name: &str,
+    temp: &str,
+) -> bool {
+    statements
+        .last_mut()
+        .is_some_and(|statement| statement.binds_name(temp) && statement.rename_bound_name(name))
+}
+
 /// Collapse `var x T` + one unconditional `x = v` into `x := v`, when `:=`
 /// infers T identically (a `float64` context can hold an untyped int literal).
 pub(crate) fn collapse_declare_assign(statements: &mut Vec<LoweredStatement>, name: &str) {
@@ -782,7 +793,7 @@ impl Planner<'_> {
             } else {
                 statements.extend(body);
             }
-            return ValuePlan::name(statements, result_var, false);
+            return ValuePlan::captured(statements, result_var);
         }
         if let Expression::Loop { .. } = expression {
             return self.plan_loop_as_operand_temp(expression, ty);
@@ -790,7 +801,7 @@ impl Planner<'_> {
         let (result_var, declaration) = self.operand_temp_declaration(ty);
         let mut statements = vec![declaration];
         statements.extend(self.lower_assign(expression, &result_var, Some(ty)));
-        ValuePlan::name(statements, result_var, false)
+        ValuePlan::captured(statements, result_var)
     }
 
     /// Build a `BreakValuePlan` for a `break value` statement.

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use std::fmt::{self, Display, Formatter};
 use syntax::ast::Expression;
@@ -242,17 +243,19 @@ pub(crate) enum OperandForm {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Stability {
     Literal,
+    /// A name nothing can rebind before its readers run.
+    Fixed,
     Observable,
     StableAcrossCalls,
 }
 
 impl Stability {
-    pub(crate) fn is_literal(self) -> bool {
-        matches!(self, Stability::Literal)
+    pub(crate) fn is_fixed(self) -> bool {
+        matches!(self, Stability::Literal | Stability::Fixed)
     }
 
     pub(crate) fn is_observable(self) -> bool {
-        !self.is_literal()
+        !self.is_fixed()
     }
 
     pub(crate) fn is_stable_across_calls(self) -> bool {
@@ -317,18 +320,6 @@ impl EvaluationFacts {
         Self::new(
             OperandForm::Literal,
             Stability::Literal,
-            EvaluationEffect::Pure,
-        )
-    }
-
-    const fn name(stable_across_calls: bool) -> Self {
-        Self::new(
-            OperandForm::Name,
-            if stable_across_calls {
-                Stability::StableAcrossCalls
-            } else {
-                Stability::Observable
-            },
             EvaluationEffect::Pure,
         )
     }
@@ -417,27 +408,12 @@ impl ValuePlan {
         )
     }
 
-    pub(crate) fn name(
-        setup: Vec<LoweredStatement>,
-        name: String,
-        stable_across_calls: bool,
-    ) -> Self {
-        Self::from_facts(
-            setup,
-            GoExpression::name(name),
-            EvaluationFacts::name(stable_across_calls),
-        )
-    }
-
+    /// A name the setup just bound, or which nothing can rebind.
     pub(crate) fn captured(setup: Vec<LoweredStatement>, name: String) -> Self {
         Self::from_facts(
             setup,
             GoExpression::name(name),
-            EvaluationFacts::new(
-                OperandForm::Name,
-                Stability::Literal,
-                EvaluationEffect::Pure,
-            ),
+            EvaluationFacts::new(OperandForm::Name, Stability::Fixed, EvaluationEffect::Pure),
         )
     }
 
@@ -449,21 +425,25 @@ impl ValuePlan {
         Self::from_facts(setup, expression, EvaluationFacts::value(effect))
     }
 
+    /// `stability` describes the binding, so only a bare name inherits it
+    /// whole: a composite form re-reads whatever it is built from.
     pub(crate) fn from_identifier_expression(
         expression: GoExpression,
-        stable_across_calls: bool,
+        stability: Stability,
     ) -> Self {
         let evaluation = match &expression {
             GoExpression::Literal(_) | GoExpression::CompositeLiteral { .. } => {
                 EvaluationFacts::literal()
             }
             GoExpression::Call { .. } => EvaluationFacts::call(EvaluationEffect::PureCall),
-            GoExpression::Name(_) => EvaluationFacts::name(stable_across_calls),
+            GoExpression::Name(_) => {
+                EvaluationFacts::new(OperandForm::Name, stability, EvaluationEffect::Pure)
+            }
             _ => EvaluationFacts::value(EvaluationEffect::Pure).with_stability(
-                if stable_across_calls {
-                    Stability::StableAcrossCalls
-                } else {
+                if stability.is_observable() {
                     Stability::Observable
+                } else {
+                    Stability::StableAcrossCalls
                 },
             ),
         };
@@ -583,6 +563,20 @@ impl ValuePlan {
 
     pub(crate) fn rendered(&self) -> String {
         self.expression.rendered()
+    }
+
+    /// `rendered` is a name this plan's own setup bound. Callers must also
+    /// check that no source binding answers to it.
+    pub(crate) fn rests_in_own_temp(&self, rendered: &str) -> bool {
+        go_name::is_plain_identifier(rendered)
+            && self
+                .setup
+                .last()
+                .is_some_and(|statement| statement.binds_name(rendered))
+    }
+
+    pub(crate) fn rests_in_fixed_name(&self) -> bool {
+        matches!(self.expression, GoExpression::Name(_)) && self.evaluation.stability.is_fixed()
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,5 +1,5 @@
 use crate::Planner;
-use crate::abi::callable::CallableReturnAbi;
+use crate::abi::callable::{AbiTransition, CallableReturnAbi};
 use crate::abi::coercion::CoercionPlan;
 use crate::calls::go_interop::WrapperTarget;
 use crate::context::expression::ExpressionContext;
@@ -10,7 +10,7 @@ use crate::plan::bodies::{LetForm, LetPlan, LoweredBlock, LoweredStatement};
 use crate::plan::calls::CallableOrigin;
 use crate::plan::placement::{
     collapse_boolean_branch_assign, collapse_declare_assign, expression_contains_binding,
-    is_unit_call, requires_temp_var,
+    is_unit_call, rebind_trailing_temp, requires_temp_var,
 };
 use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
 use syntax::types::Type;
@@ -243,26 +243,30 @@ impl Planner<'_> {
             bound
         };
 
-        statements.push(
-            if needs_explicit_type_declaration(self, value, binding_ty) {
-                let var_ty = self.go_type_string(binding_ty);
-                LoweredStatement::VarDecl {
-                    name: go_identifier,
-                    go_type: var_ty,
-                    value: Some(value_expression),
-                }
-            } else {
-                LoweredStatement::TempBind {
-                    name: go_identifier,
-                    value: value_expression,
-                }
-            },
-        );
+        if needs_explicit_type_declaration(self, value, binding_ty) {
+            let var_ty = self.go_type_string(binding_ty);
+            statements.push(LoweredStatement::VarDecl {
+                name: go_identifier,
+                go_type: var_ty,
+                value: Some(value_expression),
+            });
+            return statements;
+        }
+        // A temp no source binding answers to has no other reader to break.
+        if !self.scope.has_binding_for_go_name(&value_expression)
+            && rebind_trailing_temp(&mut statements, &go_identifier, &value_expression)
+        {
+            return statements;
+        }
+        statements.push(LoweredStatement::TempBind {
+            name: go_identifier,
+            value: value_expression,
+        });
         statements
     }
 
-    /// Route a slot-style Go-interop wrapper into the let's Go name, removing
-    /// the `name := result_N` alias.
+    /// Route a slot-style ABI wrapper into the let's Go name, removing the
+    /// `name := result_N` alias.
     fn try_lower_let_into_wrapper_slot(
         &mut self,
         identifier: &str,
@@ -281,7 +285,7 @@ impl Planner<'_> {
             return None;
         }
         let plan = self.plan_call(value)?;
-        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop) {
+        if !matches!(plan.result_transition, AbiTransition::WrapToTagged) {
             return None;
         }
         if matches!(plan.resolved.abi.result, CallableReturnAbi::Tuple { .. }) {

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -851,6 +851,72 @@ fn main() {
 }
 
 #[test]
+fn run_match_arm_after_a_failing_guard_sees_the_original_subject() {
+    if !go_available() {
+        eprintln!(
+            "skipping run_match_arm_after_a_failing_guard_sees_the_original_subject: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"guardsubject\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+fn shadowed(opt: Option<int>) -> int {
+  let current = opt
+  let mut current = current
+  let clear = || -> bool { current = None; false }
+  match current {
+    Some(x) if clear() => x,
+    Some(y) => y,
+    None => 0,
+  }
+}
+
+fn plain(opt: Option<int>) -> int {
+  let mut current = opt
+  let clear = || -> bool { current = None; false }
+  match current {
+    Some(x) if clear() => x,
+    Some(y) => y,
+    None => 0,
+  }
+}
+
+fn main() {
+  fmt.Println(shadowed(Some(7)), plain(Some(9)))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.lines().any(|line| line == "7 9"),
+        "a guard that clears the subject must not change what later arms read:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
 fn run_equality_matching_parametrized_interface_bound_builds() {
     if !go_available() {
         eprintln!(

--- a/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_option_from_generic_callee_keeps_tagged_return.snap
@@ -27,12 +27,11 @@ func main() {
 		}
 		return nil, false
 	})
-	var option_6 lisette.Option[Face]
+	var rez lisette.Option[Face]
 	if ret_5 && !lisette.IsNilInterface(ret_4) {
-		option_6 = lisette.MakeOptionSome[Face](ret_4)
+		rez = lisette.MakeOptionSome[Face](ret_4)
 	} else {
-		option_6 = lisette.MakeOptionNone[Face]()
+		rez = lisette.MakeOptionNone[Face]()
 	}
-	rez := option_6
 	_ = rez
 }

--- a/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
+++ b/tests/spec/build/snapshots/comma_ok_fn_arg_emits_lowered_for_generic_method_param.snap
@@ -15,9 +15,8 @@ func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {
 }
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[int](Holder_Resolve(Holder{N: 5}, func(x int) (int, bool) {
+	rez := lisette.OptionFromCommaOk[int](Holder_Resolve(Holder{N: 5}, func(x int) (int, bool) {
 		return x, true
 	}))
-	rez := option_1
 	_ = rez
 }

--- a/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
+++ b/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
@@ -26,28 +26,26 @@ func main() {
 	if opt_1.Tag == lisette.OptionSome {
 		unwrap_2 = opt_1.SomeVal
 	}
-	src_3 := objects
-	unwrapped_4 := make(map[string]*ast.Object, len(src_3))
-	for i_5, v_6 := range src_3 {
-		if v_6.Tag == lisette.OptionSome {
-			unwrapped_4[i_5] = v_6.SomeVal
+	unwrapped_3 := make(map[string]*ast.Object, len(objects))
+	for i_4, v_5 := range objects {
+		if v_5.Tag == lisette.OptionSome {
+			unwrapped_3[i_4] = v_5.SomeVal
 		} else {
-			unwrapped_4[i_5] = nil
+			unwrapped_3[i_4] = nil
 		}
 	}
 	scope := ast.Scope{
 		Outer:   unwrap_2,
-		Objects: unwrapped_4,
+		Objects: unwrapped_3,
 	}
-	raw_7 := scope.Objects
-	src_8 := raw_7
-	wrapped_9 := make(map[string]lisette.Option[*ast.Object], len(src_8))
-	for i_10, v_11 := range src_8 {
-		if v_11 != nil {
-			wrapped_9[i_10] = lisette.MakeOptionSome[*ast.Object](v_11)
+	raw_6 := scope.Objects
+	wrapped_7 := make(map[string]lisette.Option[*ast.Object], len(raw_6))
+	for i_8, v_9 := range raw_6 {
+		if v_9 != nil {
+			wrapped_7[i_8] = lisette.MakeOptionSome[*ast.Object](v_9)
 		} else {
-			wrapped_9[i_10] = lisette.MakeOptionNone[*ast.Object]()
+			wrapped_7[i_8] = lisette.MakeOptionNone[*ast.Object]()
 		}
 	}
-	fmt.Print(wrapped_9)
+	fmt.Print(wrapped_7)
 }

--- a/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
+++ b/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
@@ -23,8 +23,7 @@ func main() {
 		Replace: unwrap_2,
 	}
 	raw_3 := mod_.Replace
-	option_4 := lisette.OptionFromNilable[*debug.Module](raw_3, raw_3 == nil)
-	r := option_4
+	r := lisette.OptionFromNilable[*debug.Module](raw_3, raw_3 == nil)
 	raw_1 := 3
 	fmt.Println(r)
 	fmt.Println(raw_1)

--- a/tests/spec/build/snapshots/go_three_value_return_tuple.snap
+++ b/tests/spec/build/snapshots/go_three_value_return_tuple.snap
@@ -12,7 +12,6 @@ import (
 
 func main() {
 	ret_1, ret_2, ret_3 := strings.Cut("hello-world", "-")
-	tup_4 := lisette.MakeTuple3(ret_1, ret_2, ret_3)
-	result := tup_4
+	result := lisette.MakeTuple3(ret_1, ret_2, ret_3)
 	fmt.Println(result)
 }

--- a/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
+++ b/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
@@ -32,12 +32,11 @@ func main() {
 		}
 		return nil, false
 	})
-	var option_7 lisette.Option[Face]
+	var rez lisette.Option[Face]
 	if ret_6 && !lisette.IsNilInterface(ret_5) {
-		option_7 = lisette.MakeOptionSome[Face](ret_5)
+		rez = lisette.MakeOptionSome[Face](ret_5)
 	} else {
-		option_7 = lisette.MakeOptionNone[Face]()
+		rez = lisette.MakeOptionNone[Face]()
 	}
-	rez := option_7
 	_ = rez
 }

--- a/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
+++ b/tests/spec/build/snapshots/strings_index_lowers_sentinel_to_option.snap
@@ -10,10 +10,10 @@ import (
 )
 
 func find(haystack, needle string) int {
-	ret_2 := strings.Index(haystack, needle)
-	option_3 := lisette.OptionFromCommaOk[int](ret_2, ret_2 != -1)
-	if option_3.Tag == lisette.OptionSome {
-		return option_3.SomeVal
+	ret_1 := strings.Index(haystack, needle)
+	option_2 := lisette.OptionFromCommaOk[int](ret_1, ret_1 != -1)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal
 	}
 	return -2
 }

--- a/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
+++ b/tests/spec/build/snapshots/tuple_with_nilable_option_slot_lowers_recursively.snap
@@ -15,12 +15,11 @@ func produce() (int, Cmd) {
 }
 
 func consume() int {
-	ret_2, ret_3 := produce()
-	option_4 := lisette.OptionFromNilable[Cmd](ret_3, ret_3 == nil)
-	tup_5 := lisette.MakeTuple2(ret_2, option_4)
-	tmp_1 := tup_5
-	n := tmp_1.First
-	c := tmp_1.Second
+	ret_1, ret_2 := produce()
+	option_3 := lisette.OptionFromNilable[Cmd](ret_2, ret_2 == nil)
+	tup_4 := lisette.MakeTuple2(ret_1, option_3)
+	n := tup_4.First
+	c := tup_4.Second
 	if c.Tag == lisette.OptionSome {
 		return n + c.SomeVal()
 	}

--- a/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
+++ b/tests/spec/build/snapshots/user_alias_to_function_is_nilable_in_option_return.snap
@@ -26,7 +26,6 @@ func run(cb lisette.Option[Callback]) int {
 
 func main() {
 	raw_1 := maybeGet()
-	option_2 := lisette.OptionFromNilable[Callback](raw_1, raw_1 == nil)
-	cb := option_2
+	cb := lisette.OptionFromNilable[Callback](raw_1, raw_1 == nil)
 	fmt.Println(run(cb))
 }

--- a/tests/spec/emit/concurrency.rs
+++ b/tests/spec/emit/concurrency.rs
@@ -1236,6 +1236,18 @@ fn test() {
 }
 
 #[test]
+fn task_captures_reassigned_local_before_the_goroutine_runs() {
+    let input = r#"
+fn test() {
+  let mut xs = [1]
+  task xs.length()
+  xs = [1, 2]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn defer_native_method_inlined_to_builtin_wraps_in_iife() {
     let input = r#"
 fn test() {

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -1477,6 +1477,39 @@ fn test(opt: Option<int>) -> string {
 }
 
 #[test]
+fn match_guard_pins_mutated_subject() {
+    let input = r#"
+fn test(opt: Option<int>) -> int {
+  let mut current = opt
+  let clear = || -> bool { current = None; true }
+  match current {
+    Some(x) if clear() => x,
+    Some(_) => 1,
+    None => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_pins_shadowed_mutated_subject() {
+    let input = r#"
+fn test(opt: Option<int>) -> int {
+  let current = opt
+  let mut current = current
+  let clear = || -> bool { current = None; false }
+  match current {
+    Some(x) if clear() => x,
+    Some(y) => y,
+    None => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn match_guard_with_binding() {
     let input = r#"
 fn test(opt: Option<int>) -> int {

--- a/tests/spec/emit/snapshots/abi_transition_lowered_tail_return_tuple_with_nullable_slot.snap
+++ b/tests/spec/emit/snapshots/abi_transition_lowered_tail_return_tuple_with_nullable_slot.snap
@@ -11,11 +11,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func run(x int, y lisette.Option[*int]) (int, *int) {
-	_ret_3 := x
-	opt_1 := y
-	var unwrap_2 *int
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
+	var unwrap_1 *int
+	if y.Tag == lisette.OptionSome {
+		unwrap_1 = y.SomeVal
 	}
-	return _ret_3, unwrap_2
+	return x, unwrap_1
 }

--- a/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
@@ -19,18 +19,17 @@ func findFirstNegative(items []int) int {
 	result := 0
 loop_1:
 	for _, item := range items {
-		subject_1 := item
-	match_2:
+	match_1:
 		for {
 			{
-				n := subject_1
+				n := item
 				if n < 0 {
 					result = n
 					break loop_1
 				}
 			}
 			{
-				break match_2
+				break match_1
 			}
 		}
 	}

--- a/tests/spec/emit/snapshots/chained_option_construction.snap
+++ b/tests/spec/emit/snapshots/chained_option_construction.snap
@@ -20,11 +20,10 @@ func getValue() (int, bool) {
 }
 
 func test() (int, bool) {
-	option_1 := lisette.OptionFromCommaOk[int](getValue())
-	x := option_1
-	v_2 := x
-	if v_2.Tag == lisette.OptionSome {
-		return v_2.SomeVal, true
+	x := lisette.OptionFromCommaOk[int](getValue())
+	v_1 := x
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
 	}
 	return 0, false
 }

--- a/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
@@ -19,14 +19,13 @@ func sumPositives(items []int) int {
 	sum := 0
 loop_1:
 	for _, item := range items {
-		subject_1 := item
-	match_2:
+	match_1:
 		for {
 			{
-				n := subject_1
+				n := item
 				if n > 0 {
 					sum += n
-					break match_2
+					break match_1
 				}
 			}
 			{

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
@@ -19,9 +19,8 @@ func mark() int {
 
 func test() {
 	xs := []int{1}
-	_arg_1 := xs
-	_arg_2 := mark()
+	_arg_1 := mark()
 	defer func() {
-		_ = append(_arg_1[:len(_arg_1):len(_arg_1)], _arg_2)
+		_ = append(xs[:len(xs):len(xs)], _arg_1)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_inlined_to_builtin_wraps_in_iife.snap
@@ -11,8 +11,7 @@ package main
 
 func test() {
 	xs := []int{1}
-	_arg_1 := xs
 	defer func() {
-		_ = len(_arg_1)
+		_ = len(xs)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_static_native_method_iife_captures_value_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_static_native_method_iife_captures_value_receiver.snap
@@ -11,8 +11,7 @@ package main
 
 func test() {
 	items := []int{1, 2, 3}
-	_arg_1 := items
 	defer func() {
-		_ = len(_arg_1)
+		_ = len(items)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_static_native_method_iife_on_alias_captures_value_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_static_native_method_iife_on_alias_captures_value_receiver.snap
@@ -15,8 +15,7 @@ type MyString = string
 
 func test() {
 	s := "hi"
-	_arg_1 := s
 	defer func() {
-		_ = len(_arg_1)
+		_ = len(s)
 	}()
 }

--- a/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_temp_var_no_collision.snap
@@ -25,10 +25,9 @@ func makeRange() lisette.Range[int] {
 
 func main() {
 	s := []int{1, 2, 3}
-	_base_2 := s
 	range_1 := makeRange()
-	sub := _base_2[range_1.Start:range_1.End:range_1.End]
-	range_1_3 := 7
+	sub := s[range_1.Start:range_1.End:range_1.End]
+	range_1_2 := 7
 	_ = sub
-	_ = range_1_3
+	_ = range_1_2
 }

--- a/tests/spec/emit/snapshots/empty_varargs_call_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_call_forwards_inferred_type_arg.snap
@@ -20,8 +20,7 @@ func first[T any](_ ...T) (T, bool) {
 }
 
 func test() {
-	option_1 := lisette.OptionFromCommaOk[int](first[int]())
-	r := option_1
+	r := lisette.OptionFromCommaOk[int](first[int]())
 	if r.UnwrapOr(7) != 7 {
 		panic("expected 7")
 	}

--- a/tests/spec/emit/snapshots/empty_varargs_method_call_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_method_call_forwards_inferred_type_arg.snap
@@ -28,8 +28,7 @@ func Box_first[T any](_ Box, _ ...T) (T, bool) {
 
 func test() {
 	b := Box{}
-	option_1 := lisette.OptionFromCommaOk[int](Box_first[int](b))
-	r := option_1
+	r := lisette.OptionFromCommaOk[int](Box_first[int](b))
 	if r.UnwrapOr(7) != 7 {
 		panic("expected 7")
 	}

--- a/tests/spec/emit/snapshots/empty_varargs_with_fixed_arg_forwards_inferred_type_arg.snap
+++ b/tests/spec/emit/snapshots/empty_varargs_with_fixed_arg_forwards_inferred_type_arg.snap
@@ -20,8 +20,7 @@ func g[T any](_ int, _ ...T) (T, bool) {
 }
 
 func test() {
-	option_1 := lisette.OptionFromCommaOk[int](g[int](5))
-	r := option_1
+	r := lisette.OptionFromCommaOk[int](g[int](5))
 	if r.UnwrapOr(9) != 9 {
 		panic("expected 9")
 	}

--- a/tests/spec/emit/snapshots/for_loop_range_with_expressions.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_with_expressions.snap
@@ -14,8 +14,7 @@ package main
 
 func test(start, end int) int {
 	sum := 0
-	_bound_1 := end
-	for i := start; i < _bound_1; i++ {
+	for i := start; i < end; i++ {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/go_fn_value_if_binding_wrapping.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_if_binding_wrapping.snap
@@ -29,12 +29,11 @@ func main() {
 		f = strconv.Atoi
 	}
 	ret_1, ret_2 := f("99")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	fmt.Println(r)
 }

--- a/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_parenthesized_binding.snap
@@ -23,13 +23,12 @@ import (
 func main() {
 	f := (strconv.Atoi)
 	ret_1, ret_2 := f("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/go_fn_value_shadowed_wrapping.snap
+++ b/tests/spec/emit/snapshots/go_fn_value_shadowed_wrapping.snap
@@ -24,12 +24,11 @@ func main() {
 	_ = strconv.Atoi
 	f := strconv.Atoi
 	ret_1, ret_2 := f("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	fmt.Println(r)
 }

--- a/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
+++ b/tests/spec/emit/snapshots/go_function_returning_tuple_and_error_generates_three_variables.snap
@@ -26,18 +26,18 @@ import (
 )
 
 func main() {
-	ret_2, ret_3, ret_4 := net.SplitHostPort("localhost:8080")
-	tup_5 := lisette.MakeTuple2(ret_2, ret_3)
-	var result_6 lisette.Result[lisette.Tuple2[string, string], error]
-	if ret_4 != nil {
-		result_6 = lisette.MakeResultErr[lisette.Tuple2[string, string], error](ret_4)
+	ret_1, ret_2, ret_3 := net.SplitHostPort("localhost:8080")
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[string, string], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[string, string], error](ret_3)
 	} else {
-		result_6 = lisette.MakeResultOk[lisette.Tuple2[string, string], error](tup_5)
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[string, string], error](tup_4)
 	}
-	if result_6.Tag == lisette.ResultOk {
-		_ = result_6.OkVal.First
-		_ = result_6.OkVal.Second
+	if result_5.Tag == lisette.ResultOk {
+		_ = result_5.OkVal.First
+		_ = result_5.OkVal.Second
 	} else {
-		_ = result_6.ErrVal
+		_ = result_5.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_array_of_pointer_options_bridges_go_field_round_trip.snap
@@ -20,26 +20,24 @@ import (
 
 func main() {
 	values := [2]lisette.Option[int]{lisette.MakeOptionSome(1), lisette.MakeOptionNone[int]()}
-	src_1 := values
-	var unwrapped_2 [2]*int
-	for i_3, v_4 := range src_1 {
-		if v_4.Tag == lisette.OptionSome {
-			unwrapped_2[i_3] = &v_4.SomeVal
+	var unwrapped_1 [2]*int
+	for i_2, v_3 := range values {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = &v_3.SomeVal
 		} else {
-			unwrapped_2[i_3] = nil
+			unwrapped_1[i_2] = nil
 		}
 	}
-	container := arrays.Container{Values: unwrapped_2}
-	raw_5 := container.Values
-	src_6 := raw_5
-	var wrapped_7 [2]lisette.Option[int]
-	for i_8, v_9 := range src_6 {
-		if v_9 != nil {
-			wrapped_7[i_8] = lisette.MakeOptionSome[int](*v_9)
+	container := arrays.Container{Values: unwrapped_1}
+	raw_4 := container.Values
+	var wrapped_5 [2]lisette.Option[int]
+	for i_6, v_7 := range raw_4 {
+		if v_7 != nil {
+			wrapped_5[i_6] = lisette.MakeOptionSome[int](*v_7)
 		} else {
-			wrapped_7[i_8] = lisette.MakeOptionNone[int]()
+			wrapped_5[i_6] = lisette.MakeOptionNone[int]()
 		}
 	}
-	roundtrip := wrapped_7
+	roundtrip := wrapped_5
 	_ = roundtrip
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_let_call.snap
@@ -22,8 +22,7 @@ import (
 
 func main() {
 	f := os.LookupEnv
-	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
-	r := option_1
+	r := lisette.OptionFromCommaOk[string](f("HOME"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_return_pos.snap
@@ -30,8 +30,7 @@ func makeLookup() func(string) (string, bool) {
 
 func main() {
 	f := makeLookup()
-	option_1 := lisette.OptionFromCommaOk[string](f("HOME"))
-	r := option_1
+	r := lisette.OptionFromCommaOk[string](f("HOME"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_comma_ok_slice_option_prelude_map_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_slice_option_prelude_map_arg.snap
@@ -22,16 +22,15 @@ func main() {
 	out := lisette.SliceMap(keys, func(arg0 string) lisette.Option[[]lisette.Option[string]] {
 		ret_1, ret_2 := aws.Fetch(arg0)
 		if ret_2 {
-			src_3 := ret_1
-			wrapped_4 := make([]lisette.Option[string], len(src_3))
-			for i_5, v_6 := range src_3 {
-				if v_6 != nil {
-					wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+			wrapped_3 := make([]lisette.Option[string], len(ret_1))
+			for i_4, v_5 := range ret_1 {
+				if v_5 != nil {
+					wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
 				} else {
-					wrapped_4[i_5] = lisette.MakeOptionNone[string]()
+					wrapped_3[i_4] = lisette.MakeOptionNone[string]()
 				}
 			}
-			return lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_4)
+			return lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_3)
 		} else {
 			return lisette.MakeOptionNone[[]lisette.Option[string]]()
 		}

--- a/tests/spec/emit/snapshots/interop_comma_ok_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_slice_option_return.snap
@@ -28,24 +28,23 @@ import (
 )
 
 func main() {
-	ret_2, ret_3 := aws.Fetch()
-	var option_8 lisette.Option[[]lisette.Option[string]]
-	if ret_3 {
-		src_4 := ret_2
-		wrapped_5 := make([]lisette.Option[string], len(src_4))
-		for i_6, v_7 := range src_4 {
-			if v_7 != nil {
-				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+	ret_1, ret_2 := aws.Fetch()
+	var option_6 lisette.Option[[]lisette.Option[string]]
+	if ret_2 {
+		wrapped_3 := make([]lisette.Option[string], len(ret_1))
+		for i_4, v_5 := range ret_1 {
+			if v_5 != nil {
+				wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
 			} else {
-				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+				wrapped_3[i_4] = lisette.MakeOptionNone[string]()
 			}
 		}
-		option_8 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_5)
+		option_6 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_3)
 	} else {
-		option_8 = lisette.MakeOptionNone[[]lisette.Option[string]]()
+		option_6 = lisette.MakeOptionNone[[]lisette.Option[string]]()
 	}
-	if option_8.Tag == lisette.OptionSome {
-		for _, x := range option_8.SomeVal {
+	if option_6.Tag == lisette.OptionSome {
+		for _, x := range option_6.SomeVal {
 			if x.Tag == lisette.OptionSome {
 				fmt.Println(x.SomeVal)
 			} else {

--- a/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
+++ b/tests/spec/emit/snapshots/interop_err_sentinel_pattern.snap
@@ -33,18 +33,18 @@ func main() {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		var r_1 rune
-		ret_3, ret_4, ret_5 := reader.ReadRune()
-		tup_6 := lisette.MakeTuple2(ret_3, ret_4)
-		var result_7 lisette.Result[lisette.Tuple2[rune, int], error]
-		if ret_5 != nil {
-			result_7 = lisette.MakeResultErr[lisette.Tuple2[rune, int], error](ret_5)
+		ret_2, ret_3, ret_4 := reader.ReadRune()
+		tup_5 := lisette.MakeTuple2(ret_2, ret_3)
+		var result_6 lisette.Result[lisette.Tuple2[rune, int], error]
+		if ret_4 != nil {
+			result_6 = lisette.MakeResultErr[lisette.Tuple2[rune, int], error](ret_4)
 		} else {
-			result_7 = lisette.MakeResultOk[lisette.Tuple2[rune, int], error](tup_6)
+			result_6 = lisette.MakeResultOk[lisette.Tuple2[rune, int], error](tup_5)
 		}
-		if result_7.Tag == lisette.ResultOk {
-			r_1 = result_7.OkVal.First
+		if result_6.Tag == lisette.ResultOk {
+			r_1 = result_6.OkVal.First
 		} else {
-			if result_7.ErrVal == io.EOF {
+			if result_6.ErrVal == io.EOF {
 				break
 			}
 			panic("error")

--- a/tests/spec/emit/snapshots/interop_fn_arg_map_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_map_option_string.snap
@@ -22,14 +22,13 @@ func main() {
 	xs := make(map[string]lisette.Option[string])
 	xs["k"] = lisette.MakeOptionSome("hi")
 	xs["gone"] = lisette.MakeOptionNone[string]()
-	src_1 := xs
-	unwrapped_2 := make(map[string]*string, len(src_1))
-	for i_3, v_4 := range src_1 {
-		if v_4.Tag == lisette.OptionSome {
-			unwrapped_2[i_3] = &v_4.SomeVal
+	unwrapped_1 := make(map[string]*string, len(xs))
+	for i_2, v_3 := range xs {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = &v_3.SomeVal
 		} else {
-			unwrapped_2[i_3] = nil
+			unwrapped_1[i_2] = nil
 		}
 	}
-	aws.Use(unwrapped_2)
+	aws.Use(unwrapped_1)
 }

--- a/tests/spec/emit/snapshots/interop_fn_arg_spread_variadic_option_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_spread_variadic_option_pointer.snap
@@ -23,12 +23,11 @@ func main() {
 		lisette.MakeOptionSome(&n),
 		lisette.MakeOptionNone[*aws.Node](),
 	}
-	src_1 := xs
-	unwrapped_2 := make([]*aws.Node, len(src_1))
-	for i_3, v_4 := range src_1 {
-		if v_4.Tag == lisette.OptionSome {
-			unwrapped_2[i_3] = v_4.SomeVal
+	unwrapped_1 := make([]*aws.Node, len(xs))
+	for i_2, v_3 := range xs {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = v_3.SomeVal
 		}
 	}
-	aws.Use(unwrapped_2...)
+	aws.Use(unwrapped_1...)
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
@@ -29,27 +29,26 @@ func main() {
 		if ret_2 == nil {
 			return nil, ret_3
 		}
-		src_4 := ret_2
-		wrapped_5 := make([]lisette.Option[string], len(src_4))
-		for i_6, v_7 := range src_4 {
-			if v_7 != nil {
-				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+		wrapped_4 := make([]lisette.Option[string], len(ret_2))
+		for i_5, v_6 := range ret_2 {
+			if v_6 != nil {
+				wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
 			} else {
-				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+				wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 			}
 		}
-		return wrapped_5, ret_3
+		return wrapped_4, ret_3
 	}
-	ret_8, ret_9 := f()
-	if ret_9 == nil {
-		xs := ret_8
+	ret_7, ret_8 := f()
+	if ret_8 == nil {
+		xs := ret_7
 		fmt.Println("ok", len(xs))
-	} else if ret_8 == nil {
-		e := ret_9
+	} else if ret_7 == nil {
+		e := ret_8
 		fmt.Println("err", e)
 	} else {
-		xs := ret_8
-		e := ret_9
+		xs := ret_7
+		e := ret_8
 		fmt.Println("both", len(xs), e)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_let_call.snap
@@ -33,25 +33,23 @@ func main() {
 	cb_1 := aws.Make
 	f := func() ([]lisette.Option[string], error) {
 		ret_2, ret_3 := cb_1()
-		src_4 := ret_2
-		wrapped_5 := make([]lisette.Option[string], len(src_4))
-		for i_6, v_7 := range src_4 {
-			if v_7 != nil {
-				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+		wrapped_4 := make([]lisette.Option[string], len(ret_2))
+		for i_5, v_6 := range ret_2 {
+			if v_6 != nil {
+				wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
 			} else {
-				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+				wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 			}
 		}
-		return wrapped_5, ret_3
+		return wrapped_4, ret_3
 	}
-	ret_8, ret_9 := f()
-	var result_10 lisette.Result[[]lisette.Option[string], error]
-	if ret_9 != nil {
-		result_10 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_9)
+	ret_7, ret_8 := f()
+	var r lisette.Result[[]lisette.Option[string], error]
+	if ret_8 != nil {
+		r = lisette.MakeResultErr[[]lisette.Option[string], error](ret_8)
 	} else {
-		result_10 = lisette.MakeResultOk[[]lisette.Option[string], error](ret_8)
+		r = lisette.MakeResultOk[[]lisette.Option[string], error](ret_7)
 	}
-	r := result_10
 	if r.Tag == lisette.ResultOk {
 		for _, x := range r.OkVal {
 			if x.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
@@ -32,20 +32,19 @@ func main() {
 	cb_1 := aws.Make
 	f := func() ([]lisette.Option[string], error) {
 		ret_2, ret_3 := cb_1()
-		src_4 := ret_2
-		wrapped_5 := make([]lisette.Option[string], len(src_4))
-		for i_6, v_7 := range src_4 {
-			if v_7 != nil {
-				wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+		wrapped_4 := make([]lisette.Option[string], len(ret_2))
+		for i_5, v_6 := range ret_2 {
+			if v_6 != nil {
+				wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
 			} else {
-				wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+				wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 			}
 		}
-		return wrapped_5, ret_3
+		return wrapped_4, ret_3
 	}
-	ret_8, ret_9 := f()
-	if ret_9 == nil {
-		xs := ret_8
+	ret_7, ret_8 := f()
+	if ret_8 == nil {
+		xs := ret_7
 		for _, x := range xs {
 			if x.Tag == lisette.OptionSome {
 				fmt.Println(x.SomeVal)
@@ -54,7 +53,7 @@ func main() {
 			}
 		}
 	} else {
-		e := ret_9
+		e := ret_8
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_tuple_nested_option_slot.snap
@@ -32,31 +32,29 @@ func apply(f func() (lisette.Option[[]lisette.Option[string]], int)) (lisette.Op
 }
 
 func main() {
-	cb_2 := aws.Make
-	ret_11, ret_12 := apply(func() (lisette.Option[[]lisette.Option[string]], int) {
-		ret_3, ret_4 := cb_2()
-		raw_5 := ret_3
-		var option_6 lisette.Option[[]lisette.Option[string]]
-		if raw_5 != nil {
-			src_7 := *raw_5
-			wrapped_8 := make([]lisette.Option[string], len(src_7))
-			for i_9, v_10 := range src_7 {
-				if v_10 != nil {
-					wrapped_8[i_9] = lisette.MakeOptionSome[string](*v_10)
+	cb_1 := aws.Make
+	ret_9, ret_10 := apply(func() (lisette.Option[[]lisette.Option[string]], int) {
+		ret_2, ret_3 := cb_1()
+		var option_4 lisette.Option[[]lisette.Option[string]]
+		if ret_2 != nil {
+			src_5 := *ret_2
+			wrapped_6 := make([]lisette.Option[string], len(src_5))
+			for i_7, v_8 := range src_5 {
+				if v_8 != nil {
+					wrapped_6[i_7] = lisette.MakeOptionSome[string](*v_8)
 				} else {
-					wrapped_8[i_9] = lisette.MakeOptionNone[string]()
+					wrapped_6[i_7] = lisette.MakeOptionNone[string]()
 				}
 			}
-			option_6 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_8)
+			option_4 = lisette.MakeOptionSome[[]lisette.Option[string]](wrapped_6)
 		} else {
-			option_6 = lisette.MakeOptionNone[[]lisette.Option[string]]()
+			option_4 = lisette.MakeOptionNone[[]lisette.Option[string]]()
 		}
-		return option_6, ret_4
+		return option_4, ret_3
 	})
-	tup_13 := lisette.MakeTuple2(ret_11, ret_12)
-	tmp_1 := tup_13
-	xs := tmp_1.First
-	n := tmp_1.Second
+	tup_11 := lisette.MakeTuple2(ret_9, ret_10)
+	xs := tup_11.First
+	n := tup_11.Second
 	_ = n
 	if xs.Tag == lisette.OptionSome {
 		for _, x := range xs.SomeVal {

--- a/tests/spec/emit/snapshots/interop_lisette_result_slice_option_let.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_result_slice_option_let.snap
@@ -39,13 +39,12 @@ func make_() ([]lisette.Option[string], error) {
 
 func main() {
 	ret_1, ret_2 := make_()
-	var result_3 lisette.Result[[]lisette.Option[string], error]
+	var r lisette.Result[[]lisette.Option[string], error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
+		r = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[[]lisette.Option[string], error](ret_1)
+		r = lisette.MakeResultOk[[]lisette.Option[string], error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		for _, x := range r.OkVal {
 			if x.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_tuple_nested_option_slot.snap
@@ -29,8 +29,7 @@ func make_() (lisette.Option[[]lisette.Option[string]], int) {
 
 func main() {
 	ret_1, ret_2 := make_()
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	t := tup_3
+	t := lisette.MakeTuple2(ret_1, ret_2)
 	xs := t.First
 	n := t.Second
 	_ = n

--- a/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
@@ -49,18 +49,17 @@ func main() {
 	if opt_1.Tag == lisette.OptionSome {
 		unwrap_2 = opt_1.SomeVal
 	}
-	src_3 := objects
-	unwrapped_4 := make(map[string]*ast.Object, len(src_3))
-	for i_5, v_6 := range src_3 {
-		if v_6.Tag == lisette.OptionSome {
-			unwrapped_4[i_5] = v_6.SomeVal
+	unwrapped_3 := make(map[string]*ast.Object, len(objects))
+	for i_4, v_5 := range objects {
+		if v_5.Tag == lisette.OptionSome {
+			unwrapped_3[i_4] = v_5.SomeVal
 		} else {
-			unwrapped_4[i_5] = nil
+			unwrapped_3[i_4] = nil
 		}
 	}
 	scope := ast.Scope{
 		Outer:   unwrap_2,
-		Objects: unwrapped_4,
+		Objects: unwrapped_3,
 	}
 	_ = scope
 }

--- a/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_map_with_pointer_option_keys_bridges_go_field_round_trip.snap
@@ -24,24 +24,21 @@ func main() {
 	values := make(map[lisette.Option[int]]string)
 	values[lisette.MakeOptionSome(1)] = "one"
 	values[lisette.MakeOptionNone[int]()] = "none"
-	src_1 := values
-	unwrapped_2 := make(map[*int]string, len(src_1))
-	for i_3, v_4 := range src_1 {
-		opt_5 := i_3
-		var ptr_6 *int
-		if opt_5.Tag == lisette.OptionSome {
-			ptr_6 = &opt_5.SomeVal
+	unwrapped_1 := make(map[*int]string, len(values))
+	for i_2, v_3 := range values {
+		var ptr_4 *int
+		if i_2.Tag == lisette.OptionSome {
+			ptr_4 = &i_2.SomeVal
 		}
-		unwrapped_2[ptr_6] = v_4
+		unwrapped_1[ptr_4] = v_3
 	}
-	container := maps.Container{Values: unwrapped_2}
-	raw_7 := container.Values
-	src_8 := raw_7
-	wrapped_9 := make(map[lisette.Option[int]]string, len(src_8))
-	for i_10, v_11 := range src_8 {
-		option_12 := lisette.OptionFromPointer[int](i_10)
-		wrapped_9[option_12] = v_11
+	container := maps.Container{Values: unwrapped_1}
+	raw_5 := container.Values
+	wrapped_6 := make(map[lisette.Option[int]]string, len(raw_5))
+	for i_7, v_8 := range raw_5 {
+		option_9 := lisette.OptionFromPointer[int](i_7)
+		wrapped_6[option_9] = v_8
 	}
-	roundtrip := wrapped_9
+	roundtrip := wrapped_6
 	_ = roundtrip
 }

--- a/tests/spec/emit/snapshots/interop_nested_option_collection_bridges_go_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_nested_option_collection_bridges_go_field_round_trip.snap
@@ -20,38 +20,36 @@ import (
 
 func main() {
 	values := lisette.MakeOptionSome([]lisette.Option[int]{lisette.MakeOptionSome(1), lisette.MakeOptionNone[int]()})
-	opt_1 := values
-	var ptr_2 *[]*int
-	if opt_1.Tag == lisette.OptionSome {
-		src_3 := opt_1.SomeVal
-		unwrapped_4 := make([]*int, len(src_3))
-		for i_5, v_6 := range src_3 {
-			if v_6.Tag == lisette.OptionSome {
-				unwrapped_4[i_5] = &v_6.SomeVal
+	var ptr_1 *[]*int
+	if values.Tag == lisette.OptionSome {
+		src_2 := values.SomeVal
+		unwrapped_3 := make([]*int, len(src_2))
+		for i_4, v_5 := range src_2 {
+			if v_5.Tag == lisette.OptionSome {
+				unwrapped_3[i_4] = &v_5.SomeVal
 			} else {
-				unwrapped_4[i_5] = nil
+				unwrapped_3[i_4] = nil
 			}
 		}
-		ptr_2 = &unwrapped_4
+		ptr_1 = &unwrapped_3
 	}
-	container := nested.Container{Values: ptr_2}
-	raw_7 := container.Values
-	raw_8 := raw_7
-	var option_9 lisette.Option[[]lisette.Option[int]]
-	if raw_8 != nil {
-		src_10 := *raw_8
-		wrapped_11 := make([]lisette.Option[int], len(src_10))
-		for i_12, v_13 := range src_10 {
-			if v_13 != nil {
-				wrapped_11[i_12] = lisette.MakeOptionSome[int](*v_13)
+	container := nested.Container{Values: ptr_1}
+	raw_6 := container.Values
+	var option_7 lisette.Option[[]lisette.Option[int]]
+	if raw_6 != nil {
+		src_8 := *raw_6
+		wrapped_9 := make([]lisette.Option[int], len(src_8))
+		for i_10, v_11 := range src_8 {
+			if v_11 != nil {
+				wrapped_9[i_10] = lisette.MakeOptionSome[int](*v_11)
 			} else {
-				wrapped_11[i_12] = lisette.MakeOptionNone[int]()
+				wrapped_9[i_10] = lisette.MakeOptionNone[int]()
 			}
 		}
-		option_9 = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_11)
+		option_7 = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_9)
 	} else {
-		option_9 = lisette.MakeOptionNone[[]lisette.Option[int]]()
+		option_7 = lisette.MakeOptionNone[[]lisette.Option[int]]()
 	}
-	roundtrip := option_9
+	roundtrip := option_7
 	_ = roundtrip
 }

--- a/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
+++ b/tests/spec/emit/snapshots/interop_nested_option_collections_bridge_go_returns.snap
@@ -32,16 +32,15 @@ func main() {
 	ret_5, ret_6 := nested.MaybeValues()
 	var maybe_values lisette.Option[[]lisette.Option[int]]
 	if ret_6 {
-		src_7 := ret_5
-		wrapped_8 := make([]lisette.Option[int], len(src_7))
-		for i_9, v_10 := range src_7 {
-			if v_10 != nil {
-				wrapped_8[i_9] = lisette.MakeOptionSome[int](*v_10)
+		wrapped_7 := make([]lisette.Option[int], len(ret_5))
+		for i_8, v_9 := range ret_5 {
+			if v_9 != nil {
+				wrapped_7[i_8] = lisette.MakeOptionSome[int](*v_9)
 			} else {
-				wrapped_8[i_9] = lisette.MakeOptionNone[int]()
+				wrapped_7[i_8] = lisette.MakeOptionNone[int]()
 			}
 		}
-		maybe_values = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_8)
+		maybe_values = lisette.MakeOptionSome[[]lisette.Option[int]](wrapped_7)
 	} else {
 		maybe_values = lisette.MakeOptionNone[[]lisette.Option[int]]()
 	}

--- a/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
+++ b/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
@@ -27,14 +27,13 @@ func main() {
 	src_1 := [][]lisette.Option[*cli.Flag]{[]lisette.Option[*cli.Flag]{lisette.MakeOptionSome(f1), lisette.MakeOptionSome(f2)}}
 	unwrapped_2 := make([][]*cli.Flag, len(src_1))
 	for i_3, v_4 := range src_1 {
-		src_5 := v_4
-		unwrapped_6 := make([]*cli.Flag, len(src_5))
-		for i_7, v_8 := range src_5 {
-			if v_8.Tag == lisette.OptionSome {
-				unwrapped_6[i_7] = v_8.SomeVal
+		unwrapped_5 := make([]*cli.Flag, len(v_4))
+		for i_6, v_7 := range v_4 {
+			if v_7.Tag == lisette.OptionSome {
+				unwrapped_5[i_6] = v_7.SomeVal
 			}
 		}
-		unwrapped_2[i_3] = unwrapped_6
+		unwrapped_2[i_3] = unwrapped_5
 	}
 	g := cli.Group{Flags: unwrapped_2}
 	_ = g

--- a/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
@@ -19,9 +19,9 @@ import (
 )
 
 func main() {
-	raw_2 := reg.Events()
-	option_3 := lisette.OptionFromNilable[chan int](raw_2, raw_2 == nil)
-	if option_3.Tag == lisette.OptionSome {
-		_ = lisette.ChannelReceive(option_3.SomeVal)
+	raw_1 := reg.Events()
+	option_2 := lisette.OptionFromNilable[chan int](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		_ = lisette.ChannelReceive(option_2.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_map_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_map_return.snap
@@ -19,9 +19,9 @@ import (
 )
 
 func main() {
-	raw_2 := reg.Registry(true)
-	option_3 := lisette.OptionFromNilable[map[string]int](raw_2, raw_2 == nil)
-	if option_3.Tag == lisette.OptionSome {
-		_ = len(option_3.SomeVal)
+	raw_1 := reg.Registry(true)
+	option_2 := lisette.OptionFromNilable[map[string]int](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		_ = len(option_2.SomeVal)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
@@ -19,9 +19,9 @@ import (
 )
 
 func main() {
-	raw_2 := reg.Lookup()
-	option_3 := lisette.OptionFromNilable[reg.Index](raw_2, raw_2 == nil)
-	if option_3.Tag == lisette.OptionSome {
-		_ = option_3.SomeVal
+	raw_1 := reg.Lookup()
+	option_2 := lisette.OptionFromNilable[reg.Index](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		_ = option_2.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
@@ -24,9 +24,9 @@ import (
 )
 
 func apply(f func(string) *flag.Flag, name string) bool {
-	raw_2 := f(name)
-	option_3 := lisette.OptionFromNilable[*flag.Flag](raw_2, raw_2 == nil)
-	if option_3.Tag == lisette.OptionSome {
+	raw_1 := f(name)
+	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
 		return true
 	}
 	return false

--- a/tests/spec/emit/snapshots/interop_nullable_collection_field_assign_through_go_struct_alias_unwraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_collection_field_assign_through_go_struct_alias_unwraps.snap
@@ -39,13 +39,12 @@ func main() {
 	}
 	cert := x509.Certificate{PublicKey: 0}
 	urls := []lisette.Option[*url.URL]{lisette.MakeOptionSome(&u)}
-	src_1 := urls
-	unwrapped_2 := make([]*url.URL, len(src_1))
-	for i_3, v_4 := range src_1 {
-		if v_4.Tag == lisette.OptionSome {
-			unwrapped_2[i_3] = v_4.SomeVal
+	unwrapped_1 := make([]*url.URL, len(urls))
+	for i_2, v_3 := range urls {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = v_3.SomeVal
 		}
 	}
-	cert.URIs = unwrapped_2
+	cert.URIs = unwrapped_1
 	_ = cert
 }

--- a/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_collection_field_read_through_go_struct_alias_wraps.snap
@@ -53,16 +53,15 @@ func main() {
 		PublicKey: 0,
 	}
 	raw_5 := cert.URIs
-	src_6 := raw_5
-	wrapped_7 := make([]lisette.Option[*url.URL], len(src_6))
-	for i_8, v_9 := range src_6 {
-		if v_9 != nil {
-			wrapped_7[i_8] = lisette.MakeOptionSome[*url.URL](v_9)
+	wrapped_6 := make([]lisette.Option[*url.URL], len(raw_5))
+	for i_7, v_8 := range raw_5 {
+		if v_8 != nil {
+			wrapped_6[i_7] = lisette.MakeOptionSome[*url.URL](v_8)
 		} else {
-			wrapped_7[i_8] = lisette.MakeOptionNone[*url.URL]()
+			wrapped_6[i_7] = lisette.MakeOptionNone[*url.URL]()
 		}
 	}
-	urls := wrapped_7
+	urls := wrapped_6
 	first := urls[0]
 	if first.Tag == lisette.OptionSome {
 		_ = first.SomeVal

--- a/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_field_read_through_go_struct_alias_wraps.snap
@@ -27,8 +27,7 @@ type MyFlag = flag.Flag
 func main() {
 	f := flag.Flag{}
 	raw_1 := f.Value
-	option_2 := lisette.OptionFromNilable[flag.Value](raw_1, lisette.IsNilInterface(raw_1))
-	v := option_2
+	v := lisette.OptionFromNilable[flag.Value](raw_1, lisette.IsNilInterface(raw_1))
 	if v.Tag == lisette.OptionSome {
 		_ = v.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_nullable_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_let_call.snap
@@ -23,8 +23,7 @@ import (
 func main() {
 	f := flag.Lookup
 	raw_1 := f("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	r := option_2
+	r := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_return_pos.snap
@@ -31,8 +31,7 @@ func makeLookup() func(string) *flag.Flag {
 func main() {
 	f := makeLookup()
 	raw_1 := f("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	r := option_2
+	r := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_nullable_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_slice_element.snap
@@ -23,8 +23,7 @@ import (
 func main() {
 	arr := []func(string) *flag.Flag{flag.Lookup}
 	raw_1 := arr[0]("verbose")
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	r := option_2
+	r := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	}

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -21,10 +21,10 @@ import (
 )
 
 func main() {
-	raw_2 := evts.Peek()
-	option_3 := lisette.OptionFromNilable[evts.Msg](raw_2, lisette.IsNilInterface(raw_2))
-	if option_3.Tag == lisette.OptionSome {
-		fmt.Println(option_3.SomeVal)
+	raw_1 := evts.Peek()
+	option_2 := lisette.OptionFromNilable[evts.Msg](raw_1, lisette.IsNilInterface(raw_1))
+	if option_2.Tag == lisette.OptionSome {
+		fmt.Println(option_2.SomeVal)
 	} else {
 		fmt.Println("none")
 	}

--- a/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
@@ -19,42 +19,41 @@ import (
 )
 
 func main() {
-	raw_2 := aws.Make()
-	var option_3 lisette.Option[*[]lisette.Option[string]]
-	if raw_2 != nil {
-		src_4 := raw_2
-		src_5 := *src_4
-		wrapped_6 := make([]lisette.Option[string], len(src_5))
-		for i_7, v_8 := range src_5 {
-			if v_8 != nil {
-				wrapped_6[i_7] = lisette.MakeOptionSome[string](*v_8)
+	raw_1 := aws.Make()
+	var option_2 lisette.Option[*[]lisette.Option[string]]
+	if raw_1 != nil {
+		src_3 := *raw_1
+		wrapped_4 := make([]lisette.Option[string], len(src_3))
+		for i_5, v_6 := range src_3 {
+			if v_6 != nil {
+				wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
 			} else {
-				wrapped_6[i_7] = lisette.MakeOptionNone[string]()
+				wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 			}
 		}
-		ref_9 := &wrapped_6
-		option_3 = lisette.MakeOptionSome[*[]lisette.Option[string]](ref_9)
+		ref_7 := &wrapped_4
+		option_2 = lisette.MakeOptionSome[*[]lisette.Option[string]](ref_7)
 	} else {
-		option_3 = lisette.MakeOptionNone[*[]lisette.Option[string]]()
+		option_2 = lisette.MakeOptionNone[*[]lisette.Option[string]]()
 	}
-	if option_3.Tag == lisette.OptionSome {
-		opt_10 := lisette.MakeOptionSome(option_3.SomeVal)
-		var unwrap_11 *[]*string
-		if opt_10.Tag == lisette.OptionSome {
-			src_12 := opt_10.SomeVal
-			src_13 := *src_12
-			unwrapped_14 := make([]*string, len(src_13))
-			for i_15, v_16 := range src_13 {
-				if v_16.Tag == lisette.OptionSome {
-					unwrapped_14[i_15] = &v_16.SomeVal
+	if option_2.Tag == lisette.OptionSome {
+		opt_8 := lisette.MakeOptionSome(option_2.SomeVal)
+		var unwrap_9 *[]*string
+		if opt_8.Tag == lisette.OptionSome {
+			src_10 := opt_8.SomeVal
+			src_11 := *src_10
+			unwrapped_12 := make([]*string, len(src_11))
+			for i_13, v_14 := range src_11 {
+				if v_14.Tag == lisette.OptionSome {
+					unwrapped_12[i_13] = &v_14.SomeVal
 				} else {
-					unwrapped_14[i_15] = nil
+					unwrapped_12[i_13] = nil
 				}
 			}
-			ref_17 := &unwrapped_14
-			unwrap_11 = ref_17
+			ref_15 := &unwrapped_12
+			unwrap_9 = ref_15
 		}
-		aws.Use(unwrap_11)
+		aws.Use(unwrap_9)
 	} else {
 		aws.Use(nil)
 	}

--- a/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
+++ b/tests/spec/emit/snapshots/interop_parallel_error_tuple_return.snap
@@ -26,13 +26,12 @@ import (
 )
 
 func main() {
-	ret_2, ret_3 := migrate.Close()
+	ret_1, ret_2 := migrate.Close()
+	option_3 := lisette.OptionFromNilable[error](ret_1, lisette.IsNilInterface(ret_1))
 	option_4 := lisette.OptionFromNilable[error](ret_2, lisette.IsNilInterface(ret_2))
-	option_5 := lisette.OptionFromNilable[error](ret_3, lisette.IsNilInterface(ret_3))
-	tup_6 := lisette.MakeTuple2(option_4, option_5)
-	tmp_1 := tup_6
-	src := tmp_1.First
-	db := tmp_1.Second
+	tup_5 := lisette.MakeTuple2(option_3, option_4)
+	src := tup_5.First
+	db := tup_5.Second
 	if src.Tag == lisette.OptionSome {
 		fmt.Println("source:", src.SomeVal)
 	}

--- a/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
@@ -33,16 +33,15 @@ func run() error {
 	if ret_2 != nil {
 		return ret_2
 	}
-	src_3 := ret_1
-	wrapped_4 := make([]lisette.Option[string], len(src_3))
-	for i_5, v_6 := range src_3 {
-		if v_6 != nil {
-			wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+	wrapped_3 := make([]lisette.Option[string], len(ret_1))
+	for i_4, v_5 := range ret_1 {
+		if v_5 != nil {
+			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
 		} else {
-			wrapped_4[i_5] = lisette.MakeOptionNone[string]()
+			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
 		}
 	}
-	xs := wrapped_4
+	xs := wrapped_3
 	for _, x := range xs {
 		if x.Tag == lisette.OptionSome {
 			fmt.Println(x.SomeVal)

--- a/tests/spec/emit/snapshots/interop_ref_slice_option_return_and_arg.snap
+++ b/tests/spec/emit/snapshots/interop_ref_slice_option_return_and_arg.snap
@@ -27,18 +27,16 @@ func main() {
 			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
 		}
 	}
-	ref_6 := &wrapped_3
-	xs := ref_6
-	src_7 := xs
-	src_8 := *src_7
-	unwrapped_9 := make([]*string, len(src_8))
-	for i_10, v_11 := range src_8 {
-		if v_11.Tag == lisette.OptionSome {
-			unwrapped_9[i_10] = &v_11.SomeVal
+	xs := &wrapped_3
+	src_7 := *xs
+	unwrapped_8 := make([]*string, len(src_7))
+	for i_9, v_10 := range src_7 {
+		if v_10.Tag == lisette.OptionSome {
+			unwrapped_8[i_9] = &v_10.SomeVal
 		} else {
-			unwrapped_9[i_10] = nil
+			unwrapped_8[i_9] = nil
 		}
 	}
-	ref_12 := &unwrapped_9
-	aws.Use(ref_12)
+	ref_11 := &unwrapped_8
+	aws.Use(ref_11)
 }

--- a/tests/spec/emit/snapshots/interop_result_alias_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_alias_call.snap
@@ -25,13 +25,12 @@ func main() {
 	f := strconv.Atoi
 	g := f
 	ret_1, ret_2 := g("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_assignment.snap
@@ -31,13 +31,12 @@ func main() {
 	f := fallback
 	f = strconv.Atoi
 	ret_1, ret_2 := f("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_break_value.snap
+++ b/tests/spec/emit/snapshots/interop_result_break_value.snap
@@ -38,13 +38,12 @@ func make_() func(string) (int, error) {
 func main() {
 	f := make_()
 	ret_1, ret_2 := f("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_call_arg.snap
@@ -29,13 +29,12 @@ func apply(f func(string) (int, error), s string) (int, error) {
 
 func main() {
 	ret_1, ret_2 := apply(strconv.Atoi, "42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_if_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_if_assignment.snap
@@ -32,13 +32,12 @@ func main() {
 		f = strconv.Atoi
 	}
 	ret_1, ret_2 := f("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_result_let_call.snap
@@ -23,13 +23,12 @@ import (
 func main() {
 	f := strconv.Atoi
 	ret_1, ret_2 := f("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_let_mut.snap
+++ b/tests/spec/emit/snapshots/interop_result_let_mut.snap
@@ -23,22 +23,20 @@ import (
 func main() {
 	f := strconv.Atoi
 	ret_1, ret_2 := f("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	_ = r
 	f = strconv.Atoi
-	ret_4, ret_5 := f("99")
-	var result_6 lisette.Result[int, error]
-	if ret_5 != nil {
-		result_6 = lisette.MakeResultErr[int, error](ret_5)
+	ret_3, ret_4 := f("99")
+	var r2 lisette.Result[int, error]
+	if ret_4 != nil {
+		r2 = lisette.MakeResultErr[int, error](ret_4)
 	} else {
-		result_6 = lisette.MakeResultOk[int, error](ret_4)
+		r2 = lisette.MakeResultOk[int, error](ret_3)
 	}
-	r2 := result_6
 	_ = r2
 }

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -47,13 +47,12 @@ func main() {
 		return
 	}
 	ret_3, ret_4 := h.f("1")
-	var result_5 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_4 != nil {
-		result_5 = lisette.MakeResultErr[int, error](ret_4)
+		r = lisette.MakeResultErr[int, error](ret_4)
 	} else {
-		result_5 = lisette.MakeResultOk[int, error](ret_3)
+		r = lisette.MakeResultOk[int, error](ret_3)
 	}
-	r := result_5
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_ok_constructor.snap
@@ -35,22 +35,20 @@ func make_() (func(string) (int, error), error) {
 
 func main() {
 	ret_1, ret_2 := make_()
-	var result_3 lisette.Result[func(string) (int, error), error]
+	var r lisette.Result[func(string) (int, error), error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[func(string) (int, error), error](ret_2)
+		r = lisette.MakeResultErr[func(string) (int, error), error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
+		r = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
-		ret_4, ret_5 := r.OkVal("1")
-		var result_6 lisette.Result[int, error]
-		if ret_5 != nil {
-			result_6 = lisette.MakeResultErr[int, error](ret_5)
+		ret_3, ret_4 := r.OkVal("1")
+		var r2 lisette.Result[int, error]
+		if ret_4 != nil {
+			r2 = lisette.MakeResultErr[int, error](ret_4)
 		} else {
-			result_6 = lisette.MakeResultOk[int, error](ret_4)
+			r2 = lisette.MakeResultOk[int, error](ret_3)
 		}
-		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
 		}

--- a/tests/spec/emit/snapshots/interop_result_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_result_return_pos.snap
@@ -31,13 +31,12 @@ func makeParser() func(string) (int, error) {
 func main() {
 	f := makeParser()
 	ret_1, ret_2 := f("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_slice_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_element.snap
@@ -23,13 +23,12 @@ import (
 func main() {
 	arr := []func(string) (int, error){strconv.Atoi}
 	ret_1, ret_2 := arr[0]("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_result_slice_option_return.snap
@@ -28,24 +28,23 @@ import (
 )
 
 func main() {
-	ret_2, ret_3 := aws.Make()
-	var result_4 lisette.Result[[]lisette.Option[string], error]
-	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_3)
+	ret_1, ret_2 := aws.Make()
+	var result_3 lisette.Result[[]lisette.Option[string], error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]lisette.Option[string], error](ret_2)
 	} else {
-		src_5 := ret_2
-		wrapped_6 := make([]lisette.Option[string], len(src_5))
-		for i_7, v_8 := range src_5 {
-			if v_8 != nil {
-				wrapped_6[i_7] = lisette.MakeOptionSome[string](*v_8)
+		wrapped_4 := make([]lisette.Option[string], len(ret_1))
+		for i_5, v_6 := range ret_1 {
+			if v_6 != nil {
+				wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
 			} else {
-				wrapped_6[i_7] = lisette.MakeOptionNone[string]()
+				wrapped_4[i_5] = lisette.MakeOptionNone[string]()
 			}
 		}
-		result_4 = lisette.MakeResultOk[[]lisette.Option[string], error](wrapped_6)
+		result_3 = lisette.MakeResultOk[[]lisette.Option[string], error](wrapped_4)
 	}
-	if result_4.Tag == lisette.ResultOk {
-		for _, x := range result_4.OkVal {
+	if result_3.Tag == lisette.ResultOk {
+		for _, x := range result_3.OkVal {
 			if x.Tag == lisette.OptionSome {
 				fmt.Println(x.SomeVal)
 			} else {
@@ -53,6 +52,6 @@ func main() {
 			}
 		}
 	} else {
-		_ = result_4.ErrVal
+		_ = result_3.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_struct_field.snap
+++ b/tests/spec/emit/snapshots/interop_result_struct_field.snap
@@ -29,13 +29,12 @@ type Parser struct {
 func main() {
 	p := Parser{parse: strconv.Atoi}
 	ret_1, ret_2 := p.parse("42")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_task_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_task_block.snap
@@ -23,13 +23,12 @@ func main() {
 	f := strconv.Atoi
 	go func() {
 		ret_1, ret_2 := f("42")
-		var result_3 lisette.Result[int, error]
+		var r lisette.Result[int, error]
 		if ret_2 != nil {
-			result_3 = lisette.MakeResultErr[int, error](ret_2)
+			r = lisette.MakeResultErr[int, error](ret_2)
 		} else {
-			result_3 = lisette.MakeResultOk[int, error](ret_1)
+			r = lisette.MakeResultOk[int, error](ret_1)
 		}
-		r := result_3
 		_ = r
 	}()
 }

--- a/tests/spec/emit/snapshots/interop_result_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_try_block.snap
@@ -49,22 +49,20 @@ func make_() (func(string) (int, error), error) {
 
 func main() {
 	ret_1, ret_2 := make_()
-	var result_3 lisette.Result[func(string) (int, error), error]
+	var r lisette.Result[func(string) (int, error), error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[func(string) (int, error), error](ret_2)
+		r = lisette.MakeResultErr[func(string) (int, error), error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
+		r = lisette.MakeResultOk[func(string) (int, error), error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
-		ret_4, ret_5 := r.OkVal("1")
-		var result_6 lisette.Result[int, error]
-		if ret_5 != nil {
-			result_6 = lisette.MakeResultErr[int, error](ret_5)
+		ret_3, ret_4 := r.OkVal("1")
+		var r2 lisette.Result[int, error]
+		if ret_4 != nil {
+			r2 = lisette.MakeResultErr[int, error](ret_4)
 		} else {
-			result_6 = lisette.MakeResultOk[int, error](ret_4)
+			r2 = lisette.MakeResultOk[int, error](ret_3)
 		}
-		r2 := result_6
 		if r2.Tag == lisette.ResultOk {
 			_ = r2.OkVal
 		}

--- a/tests/spec/emit/snapshots/interop_result_tuple_element.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_element.snap
@@ -23,13 +23,12 @@ import (
 func main() {
 	t := lisette.MakeTuple2[func(string) (int, error), int](strconv.Atoi, 1)
 	ret_1, ret_2 := t.First("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
+++ b/tests/spec/emit/snapshots/interop_result_tuple_struct_constructor.snap
@@ -36,13 +36,12 @@ func main() {
 		F1: 1,
 	}
 	ret_1, ret_2 := p.F0("1")
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_result_ufcs_call_arg.snap
@@ -37,13 +37,12 @@ func (b Box) apply(f func(string) (int, error)) (int, error) {
 func main() {
 	b := Box{}
 	ret_1, ret_2 := b.apply(strconv.Atoi)
-	var result_3 lisette.Result[int, error]
+	var r lisette.Result[int, error]
 	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
+		r = lisette.MakeResultErr[int, error](ret_2)
 	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+		r = lisette.MakeResultOk[int, error](ret_1)
 	}
-	r := result_3
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal
 	}

--- a/tests/spec/emit/snapshots/interop_sentinel_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_let_call.snap
@@ -25,8 +25,7 @@ func main() {
 		ret_1 := idx.Find(arg0, arg1)
 		return ret_1, ret_1 != -1
 	}
-	option_2 := lisette.OptionFromCommaOk[int](f("hello", "ll"))
-	r := option_2
+	r := lisette.OptionFromCommaOk[int](f("hello", "ll"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {

--- a/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_return_pos.snap
@@ -33,8 +33,7 @@ func makeFinder() func(string, string) (int, bool) {
 
 func main() {
 	f := makeFinder()
-	option_1 := lisette.OptionFromCommaOk[int](f("hello", "ll"))
-	r := option_1
+	r := lisette.OptionFromCommaOk[int](f("hello", "ll"))
 	if r.Tag == lisette.OptionSome {
 		_ = r.SomeVal
 	} else {

--- a/tests/spec/emit/snapshots/interop_slice_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_slice_alias_value_unwrapped_at_go_struct_literal.snap
@@ -41,15 +41,14 @@ func main() {
 		lisette.MakeOptionSome(&u),
 		lisette.MakeOptionNone[*url.URL](),
 	}
-	src_1 := urls
-	unwrapped_2 := make([]*url.URL, len(src_1))
-	for i_3, v_4 := range src_1 {
-		if v_4.Tag == lisette.OptionSome {
-			unwrapped_2[i_3] = v_4.SomeVal
+	unwrapped_1 := make([]*url.URL, len(urls))
+	for i_2, v_3 := range urls {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = v_3.SomeVal
 		}
 	}
 	cert := x509.Certificate{
-		URIs:      unwrapped_2,
+		URIs:      unwrapped_1,
 		PublicKey: 0,
 	}
 	_ = cert

--- a/tests/spec/emit/snapshots/interop_struct_field_read_array_option_pointer_index.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_array_option_pointer_index.snap
@@ -23,18 +23,17 @@ import (
 func main() {
 	b := aws.Bucket{}
 	raw_1 := b.Slots
-	src_2 := raw_1
-	var wrapped_3 [2]lisette.Option[*aws.Node]
-	for i_4, v_5 := range src_2 {
-		if v_5 != nil {
-			wrapped_3[i_4] = lisette.MakeOptionSome[*aws.Node](v_5)
+	var wrapped_2 [2]lisette.Option[*aws.Node]
+	for i_3, v_4 := range raw_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[*aws.Node](v_4)
 		} else {
-			wrapped_3[i_4] = lisette.MakeOptionNone[*aws.Node]()
+			wrapped_2[i_3] = lisette.MakeOptionNone[*aws.Node]()
 		}
 	}
-	slots := wrapped_3
-	subject_6 := slots[0]
-	if subject_6.Tag == lisette.OptionSome {
-		_ = subject_6.SomeVal
+	slots := wrapped_2
+	subject_5 := slots[0]
+	if subject_5.Tag == lisette.OptionSome {
+		_ = subject_5.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_map_option_string_index.snap
@@ -21,18 +21,17 @@ import (
 
 func main() {
 	b := aws.Bucket{Annotations: map[string]*string{}}
-	raw_2 := b.Annotations
-	src_3 := raw_2
-	wrapped_4 := make(map[string]lisette.Option[string], len(src_3))
-	for i_5, v_6 := range src_3 {
-		if v_6 != nil {
-			wrapped_4[i_5] = lisette.MakeOptionSome[string](*v_6)
+	raw_1 := b.Annotations
+	wrapped_2 := make(map[string]lisette.Option[string], len(raw_1))
+	for i_3, v_4 := range raw_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[string](*v_4)
 		} else {
-			wrapped_4[i_5] = lisette.MakeOptionNone[string]()
+			wrapped_2[i_3] = lisette.MakeOptionNone[string]()
 		}
 	}
-	subject_1 := wrapped_4["k"]
-	if subject_1.Tag == lisette.OptionSome {
-		_ = subject_1.SomeVal
+	subject_5 := wrapped_2["k"]
+	if subject_5.Tag == lisette.OptionSome {
+		_ = subject_5.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_int32_let_binding.snap
@@ -20,7 +20,6 @@ import (
 func main() {
 	input := aws.ListInput{}
 	raw_1 := input.MaxItems
-	option_2 := lisette.OptionFromPointer[int32](raw_1)
-	n := option_2
+	n := lisette.OptionFromPointer[int32](raw_1)
 	_ = n
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_in_loop.snap
@@ -26,10 +26,10 @@ import (
 func main() {
 	buckets := []aws.Bucket{}
 	for _, bucket := range buckets {
-		raw_2 := bucket.Name
-		option_3 := lisette.OptionFromPointer[string](raw_2)
-		if option_3.Tag == lisette.OptionSome {
-			fmt.Println(option_3.SomeVal)
+		raw_1 := bucket.Name
+		option_2 := lisette.OptionFromPointer[string](raw_1)
+		if option_2.Tag == lisette.OptionSome {
+			fmt.Println(option_2.SomeVal)
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_option_string_match.snap
@@ -21,9 +21,9 @@ import (
 
 func main() {
 	bucket := aws.Bucket{}
-	raw_2 := bucket.Name
-	option_3 := lisette.OptionFromPointer[string](raw_2)
-	if option_3.Tag == lisette.OptionSome {
-		_ = option_3.SomeVal
+	raw_1 := bucket.Name
+	option_2 := lisette.OptionFromPointer[string](raw_1)
+	if option_2.Tag == lisette.OptionSome {
+		_ = option_2.SomeVal
 	}
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_read_slice_option_string_iter.snap
@@ -24,16 +24,15 @@ import (
 func main() {
 	b := aws.Bucket{}
 	raw_1 := b.Tags
-	src_2 := raw_1
-	wrapped_3 := make([]lisette.Option[string], len(src_2))
-	for i_4, v_5 := range src_2 {
-		if v_5 != nil {
-			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+	wrapped_2 := make([]lisette.Option[string], len(raw_1))
+	for i_3, v_4 := range raw_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[string](*v_4)
 		} else {
-			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+			wrapped_2[i_3] = lisette.MakeOptionNone[string]()
 		}
 	}
-	for _, tag := range wrapped_3 {
+	for _, tag := range wrapped_2 {
 		if tag.Tag == lisette.OptionSome {
 			_ = tag.SomeVal
 		}

--- a/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
@@ -23,11 +23,10 @@ import (
 )
 
 func useSplit(f func(string) (string, string), p string) string {
-	ret_2, ret_3 := f(p)
-	tup_4 := lisette.MakeTuple2(ret_2, ret_3)
-	tmp_1 := tup_4
-	dir := tmp_1.First
-	file := tmp_1.Second
+	ret_1, ret_2 := f(p)
+	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
+	dir := tup_3.First
+	file := tup_3.Second
 	return fmt.Sprintf("%s/%s", dir, file)
 }
 

--- a/tests/spec/emit/snapshots/interop_tuple_direct_call.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_direct_call.snap
@@ -18,7 +18,6 @@ import (
 
 func main() {
 	ret_1, ret_2 := path.Split("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	r := tup_3
+	r := lisette.MakeTuple2(ret_1, ret_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/interop_tuple_let_call.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_let_call.snap
@@ -20,7 +20,6 @@ import (
 func main() {
 	f := path.Split
 	ret_1, ret_2 := f("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	r := tup_3
+	r := lisette.MakeTuple2(ret_1, ret_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_return_pos.snap
@@ -28,7 +28,6 @@ func makeSplitter() func(string) (string, string) {
 func main() {
 	f := makeSplitter()
 	ret_1, ret_2 := f("/foo/bar.txt")
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	r := tup_3
+	r := lisette.MakeTuple2(ret_1, ret_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/interop_tuple_slice_option_slot.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_slice_option_slot.snap
@@ -25,20 +25,18 @@ import (
 )
 
 func main() {
-	ret_2, ret_3 := aws.Make()
-	src_4 := ret_2
-	wrapped_5 := make([]lisette.Option[string], len(src_4))
-	for i_6, v_7 := range src_4 {
-		if v_7 != nil {
-			wrapped_5[i_6] = lisette.MakeOptionSome[string](*v_7)
+	ret_1, ret_2 := aws.Make()
+	wrapped_3 := make([]lisette.Option[string], len(ret_1))
+	for i_4, v_5 := range ret_1 {
+		if v_5 != nil {
+			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
 		} else {
-			wrapped_5[i_6] = lisette.MakeOptionNone[string]()
+			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
 		}
 	}
-	tup_8 := lisette.MakeTuple2(wrapped_5, ret_3)
-	tmp_1 := tup_8
-	xs := tmp_1.First
-	n := tmp_1.Second
+	tup_6 := lisette.MakeTuple2(wrapped_3, ret_2)
+	xs := tup_6.First
+	n := tup_6.Second
 	fmt.Println(n)
 	for _, x := range xs {
 		if x.Tag == lisette.OptionSome {

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -53,16 +53,15 @@ func main() {
 		Incomplete: false,
 	}
 	raw_7 := lit.Elts
-	src_8 := raw_7
-	wrapped_9 := make([]lisette.Option[ast.Expr], len(src_8))
-	for i_10, v_11 := range src_8 {
-		if !lisette.IsNilInterface(v_11) {
-			wrapped_9[i_10] = lisette.MakeOptionSome[ast.Expr](v_11)
+	wrapped_8 := make([]lisette.Option[ast.Expr], len(raw_7))
+	for i_9, v_10 := range raw_7 {
+		if !lisette.IsNilInterface(v_10) {
+			wrapped_8[i_9] = lisette.MakeOptionSome[ast.Expr](v_10)
 		} else {
-			wrapped_9[i_10] = lisette.MakeOptionNone[ast.Expr]()
+			wrapped_8[i_9] = lisette.MakeOptionNone[ast.Expr]()
 		}
 	}
-	elts := wrapped_9
+	elts := wrapped_8
 	for _, elt := range elts {
 		if elt.Tag == lisette.OptionSome {
 			fmt.Println(elt.SomeVal.Pos())

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
@@ -23,10 +23,10 @@ import (
 
 func main() {
 	ctx := context.Background()
-	raw_2 := ctx.Err()
-	option_3 := lisette.OptionFromNilable[error](raw_2, lisette.IsNilInterface(raw_2))
-	if option_3.Tag == lisette.OptionSome {
-		fmt.Println(option_3.SomeVal.Error())
+	raw_1 := ctx.Err()
+	option_2 := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
+	if option_2.Tag == lisette.OptionSome {
+		fmt.Println(option_2.SomeVal.Error())
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/let_else_shadow_variable.snap
+++ b/tests/spec/emit/snapshots/let_else_shadow_variable.snap
@@ -14,10 +14,9 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test() int {
 	opt := lisette.MakeOptionSome(99)
-	subject_1 := opt
-	if subject_1.Tag != lisette.OptionSome {
+	if opt.Tag != lisette.OptionSome {
 		return 0
 	}
-	opt_2 := subject_1.SomeVal
-	return opt_2
+	opt_1 := opt.SomeVal
+	return opt_1
 }

--- a/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_partial_tuple_uses_packed_abi.snap
@@ -32,22 +32,22 @@ func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
 }
 
 func test() {
-	ret_2, ret_3 := pair[int, string](1, "x")
-	var result_4 lisette.Partial[lisette.Tuple2[int, string], error]
-	if ret_3 != nil {
-		result_4 = lisette.MakePartialBoth[lisette.Tuple2[int, string], error](ret_2, ret_3)
+	ret_1, ret_2 := pair[int, string](1, "x")
+	var result_3 lisette.Partial[lisette.Tuple2[int, string], error]
+	if ret_2 != nil {
+		result_3 = lisette.MakePartialBoth[lisette.Tuple2[int, string], error](ret_1, ret_2)
 	} else {
-		result_4 = lisette.MakePartialOk[lisette.Tuple2[int, string], error](ret_2)
+		result_3 = lisette.MakePartialOk[lisette.Tuple2[int, string], error](ret_1)
 	}
-	switch result_4.Tag {
+	switch result_3.Tag {
 	case lisette.PartialOk:
-		_ = result_4.OkVal.First
-		_ = result_4.OkVal.Second
+		_ = result_3.OkVal.First
+		_ = result_3.OkVal.Second
 	case lisette.PartialErr:
-		_ = result_4.ErrVal
+		_ = result_3.ErrVal
 	default:
-		_ = result_4.OkVal.First
-		_ = result_4.OkVal.Second
-		_ = result_4.ErrVal
+		_ = result_3.OkVal.First
+		_ = result_3.OkVal.Second
+		_ = result_3.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
+++ b/tests/spec/emit/snapshots/lisette_function_returning_result_tuple_uses_packed_abi.snap
@@ -27,17 +27,17 @@ func pair[A any, B any](a A, b B) (lisette.Tuple2[A, B], error) {
 }
 
 func test() {
-	ret_2, ret_3 := pair[int, string](1, "x")
-	var result_4 lisette.Result[lisette.Tuple2[int, string], error]
-	if ret_3 != nil {
-		result_4 = lisette.MakeResultErr[lisette.Tuple2[int, string], error](ret_3)
+	ret_1, ret_2 := pair[int, string](1, "x")
+	var result_3 lisette.Result[lisette.Tuple2[int, string], error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[lisette.Tuple2[int, string], error](ret_2)
 	} else {
-		result_4 = lisette.MakeResultOk[lisette.Tuple2[int, string], error](ret_2)
+		result_3 = lisette.MakeResultOk[lisette.Tuple2[int, string], error](ret_1)
 	}
-	if result_4.Tag == lisette.ResultOk {
-		_ = result_4.OkVal.First
-		_ = result_4.OkVal.Second
+	if result_3.Tag == lisette.ResultOk {
+		_ = result_3.OkVal.First
+		_ = result_3.OkVal.Second
 	} else {
-		_ = result_4.ErrVal
+		_ = result_3.ErrVal
 	}
 }

--- a/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
+++ b/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
@@ -19,20 +19,19 @@ import "fmt"
 
 func test(x int) string {
 	var result string
-	subject_1 := x
-match_2:
+match_1:
 	for {
 		{
-			n := subject_1
+			n := x
 			if n < 10 {
-				result_3 := n * n
-				result = fmt.Sprintf("small(%d)", result_3)
-				break match_2
+				result_2 := n * n
+				result = fmt.Sprintf("small(%d)", result_2)
+				break match_1
 			}
 		}
 		{
 			result = "other"
-			break match_2
+			break match_1
 		}
 	}
 	return result

--- a/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
@@ -16,15 +16,14 @@ package main
 
 func categorize(items []int) string {
 	len_ := len(items)
-	subject_1 := len_
-	if subject_1 == 0 {
+	if len_ == 0 {
 		return "empty"
 	}
-	n := subject_1
+	n := len_
 	if n == 1 {
 		return "single"
 	}
-	if subject_1 <= 3 {
+	if len_ <= 3 {
 		return "few"
 	}
 	return "many"

--- a/tests/spec/emit/snapshots/match_guard_basic.snap
+++ b/tests/spec/emit/snapshots/match_guard_basic.snap
@@ -16,9 +16,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) string {
-	subject_1 := opt
-	if subject_1.Tag == lisette.OptionSome {
-		x := subject_1.SomeVal
+	if opt.Tag == lisette.OptionSome {
+		x := opt.SomeVal
 		if x > 0 {
 			return "positive"
 		}

--- a/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
+++ b/tests/spec/emit/snapshots/match_guard_generic_tuple_comparison.snap
@@ -20,9 +20,8 @@ type W[T any] struct {
 
 func test() int {
 	w := W[int]{F0: 1}
-	subject_1 := w
 	{
-		if subject_1 == (W[int]{F0: 2}) {
+		if w == (W[int]{F0: 2}) {
 			return 0
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_mixed.snap
+++ b/tests/spec/emit/snapshots/match_guard_mixed.snap
@@ -15,9 +15,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) string {
-	subject_1 := opt
-	if subject_1.Tag == lisette.OptionSome {
-		if subject_1.SomeVal > 0 {
+	if opt.Tag == lisette.OptionSome {
+		if opt.SomeVal > 0 {
 			return "positive"
 		}
 		return "non-positive"

--- a/tests/spec/emit/snapshots/match_guard_on_option_call.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_option_call.snap
@@ -21,10 +21,9 @@ func getOption() (int, bool) {
 }
 
 func test() int {
-	option_2 := lisette.OptionFromCommaOk[int](getOption())
-	subject_1 := option_2
-	if subject_1.Tag == lisette.OptionSome {
-		x := subject_1.SomeVal
+	option_1 := lisette.OptionFromCommaOk[int](getOption())
+	if option_1.Tag == lisette.OptionSome {
+		x := option_1.SomeVal
 		if x > 0 {
 			return x
 		}

--- a/tests/spec/emit/snapshots/match_guard_on_struct.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_struct.snap
@@ -20,16 +20,15 @@ type Point struct {
 }
 
 func test(p Point) string {
-	subject_1 := p
 	{
-		x := subject_1.x
-		y := subject_1.y
+		x := p.x
+		y := p.y
 		if x == y {
 			return "diagonal"
 		}
 	}
 	{
-		if subject_1.x > subject_1.y {
+		if p.x > p.y {
 			return "above"
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_pins_mutated_subject.snap
+++ b/tests/spec/emit/snapshots/match_guard_pins_mutated_subject.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(opt: Option<int>) -> int {
+    let mut current = opt
+    let clear = || -> bool { current = None; true }
+    match current {
+      Some(x) if clear() => x,
+      Some(_) => 1,
+      None => 0,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(opt lisette.Option[int]) int {
+	current := opt
+	clear_ := func() bool {
+		current = lisette.MakeOptionNone[int]()
+		return true
+	}
+	subject_1 := current
+	if subject_1.Tag == lisette.OptionSome {
+		x := subject_1.SomeVal
+		if clear_() {
+			return x
+		}
+		return 1
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/match_guard_pins_shadowed_mutated_subject.snap
+++ b/tests/spec/emit/snapshots/match_guard_pins_shadowed_mutated_subject.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(opt: Option<int>) -> int {
+    let current = opt
+    let mut current = current
+    let clear = || -> bool { current = None; false }
+    match current {
+      Some(x) if clear() => x,
+      Some(y) => y,
+      None => 0,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(opt lisette.Option[int]) int {
+	current := opt
+	current_1 := current
+	clear_ := func() bool {
+		current_1 = lisette.MakeOptionNone[int]()
+		return false
+	}
+	subject_2 := current_1
+	if subject_2.Tag == lisette.OptionSome {
+		{
+			x := subject_2.SomeVal
+			if clear_() {
+				return x
+			}
+		}
+		return subject_2.SomeVal
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/match_guard_struct_literal.snap
+++ b/tests/spec/emit/snapshots/match_guard_struct_literal.snap
@@ -24,17 +24,16 @@ func main() {
 		x: 1,
 		y: 2,
 	}
-	_ = p
-match_2:
+match_1:
 	for {
 		if (p == Point{
 			x: 1,
 			y: 2,
 		}) {
-			break match_2
+			break match_1
 		}
 		{
-			break match_2
+			break match_1
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
+++ b/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
@@ -34,8 +34,7 @@ type Dir struct {
 }
 
 func check(d Dir, urgent bool) string {
-	subject_1 := d
-	if subject_1.Tag == DirNorth {
+	if d.Tag == DirNorth {
 		if urgent {
 			return "NORTH!"
 		}

--- a/tests/spec/emit/snapshots/match_guard_tuple.snap
+++ b/tests/spec/emit/snapshots/match_guard_tuple.snap
@@ -15,16 +15,15 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(pair lisette.Tuple2[int, int]) string {
-	subject_1 := pair
 	{
-		x := subject_1.First
-		y := subject_1.Second
+		x := pair.First
+		y := pair.Second
 		if x == y {
 			return "equal"
 		}
 	}
 	{
-		if subject_1.First > subject_1.Second {
+		if pair.First > pair.Second {
 			return "greater"
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_binding.snap
@@ -16,9 +16,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(opt lisette.Option[int]) int {
-	subject_1 := opt
-	if subject_1.Tag == lisette.OptionSome {
-		n := subject_1.SomeVal
+	if opt.Tag == lisette.OptionSome {
+		n := opt.SomeVal
 		if n > 100 {
 			return n * 2
 		}

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -20,21 +20,20 @@ import "fmt"
 
 func main() {
 	for i := 0; i < 10; i++ {
-		subject_1 := i
-	match_2:
+	match_1:
 		for {
 			{
-				if subject_1 < 5 {
+				if i < 5 {
 					fmt.Println("low")
-					break match_2
+					break match_1
 				}
 			}
-			if subject_1 == 5 {
+			if i == 5 {
 				fmt.Println("five")
 			} else {
 				fmt.Println("high")
 			}
-			break match_2
+			break match_1
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
@@ -41,18 +41,17 @@ type E struct {
 }
 
 func test(e E) int {
-	subject_1 := e
-	if subject_1.Tag == EC {
-		x := subject_1.C
+	if e.Tag == EC {
+		x := e.C
 		if x > 0 {
 			return x * 100
 		}
 	}
-	if subject_1.Tag == EA {
-		return subject_1.A
+	if e.Tag == EA {
+		return e.A
 	}
-	if subject_1.Tag == EB {
-		return subject_1.B
+	if e.Tag == EB {
+		return e.B
 	}
-	return subject_1.C
+	return e.C
 }

--- a/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
@@ -20,15 +20,15 @@ type P struct {
 func test() {
 	p := P{v: 1}
 	_ = p
-match_2:
+match_1:
 	for {
 		{
 			if false {
-				break match_2
+				break match_1
 			}
 		}
 		{
-			break match_2
+			break match_1
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_recover_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_in_recover_unused_subject.snap
@@ -20,11 +20,10 @@ type P struct {
 }
 
 func test() {
-	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
+	out := lisette.RecoverBlock(func() struct{} {
 		p := P{v: 1}
 		_ = p
 		return struct{}{}
 	})
-	out := recoverResult_1
 	_ = out
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -22,19 +22,18 @@ import (
 
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
-	subject_1 := result
-match_2:
+match_1:
 	for {
-		if subject_1.Tag == lisette.ResultOk {
-			if subject_1.OkVal > 0 {
-				fmt.Printf("positive: %d\n", subject_1.OkVal)
-				break match_2
+		if result.Tag == lisette.ResultOk {
+			if result.OkVal > 0 {
+				fmt.Printf("positive: %d\n", result.OkVal)
+				break match_1
 			}
-			fmt.Printf("non-positive: %d\n", subject_1.OkVal)
-			break match_2
+			fmt.Printf("non-positive: %d\n", result.OkVal)
+			break match_1
 		}
-		e := subject_1.ErrVal
+		e := result.ErrVal
 		fmt.Printf("error: %s\n", e)
-		break match_2
+		break match_1
 	}
 }

--- a/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_go_interface_guarded_arm.snap
@@ -17,10 +17,9 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, active bool) int {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		return subject_1.X + subject_1.Y
+		return e.X + e.Y
 	case events.KeyPress:
 		if active {
 			return -1

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
@@ -44,15 +44,14 @@ type E struct {
 }
 
 func eval(e E) int {
-	subject_1 := e
-	if subject_1.Tag == EA {
-		x := subject_1.A.First
+	if e.Tag == EA {
+		x := e.A.First
 		if x > 0 {
 			return x
 		}
 	}
-	if subject_1.Tag == EB {
-		x := subject_1.B.First
+	if e.Tag == EB {
+		x := e.B.First
 		if x > 0 {
 			return x
 		}

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
@@ -41,21 +41,20 @@ type E struct {
 
 func test() {
 	e := MakeEC()
-	subject_1 := e
-match_2:
+match_1:
 	for {
-		if subject_1.Tag == EA {
+		if e.Tag == EA {
 			if false {
-				break match_2
+				break match_1
 			}
 		}
-		if subject_1.Tag == EB {
+		if e.Tag == EB {
 			if false {
-				break match_2
+				break match_1
 			}
 		}
 		{
-			break match_2
+			break match_1
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
+++ b/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
@@ -56,10 +56,10 @@ func (b Bar[T]) find() (T, bool) {
 }
 
 func useOpt(o Opt) {
-	raw_2 := o.find()
-	option_3 := lisette.OptionFromNilable[*Thing](raw_2, raw_2 == nil)
-	if option_3.Tag == lisette.OptionSome {
-		_ = option_3.SomeVal
+	raw_1 := o.find()
+	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		_ = option_2.SomeVal
 	}
 }
 

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -35,15 +35,14 @@ type Res struct {
 }
 
 func test(r Res, threshold int) int {
-	subject_1 := r
-	if subject_1.Tag == ResOk {
-		x := subject_1.Ok
+	if r.Tag == ResOk {
+		x := r.Ok
 		if x > threshold {
 			return 100
 		}
 	}
-	if subject_1.Tag == ResErr {
-		if subject_1.Err > threshold {
+	if r.Tag == ResErr {
+		if r.Err > threshold {
 			return 100
 		}
 	}

--- a/tests/spec/emit/snapshots/or_pattern_let_else_binding_shadowing.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_binding_shadowing.snap
@@ -20,17 +20,16 @@ func maybe() (int, bool) {
 }
 
 func main() {
-	option_2 := lisette.OptionFromCommaOk[int](maybe())
-	subject_1 := option_2
+	option_1 := lisette.OptionFromCommaOk[int](maybe())
 	var x int
-	if subject_1.Tag == lisette.OptionSome {
-		x = subject_1.SomeVal
-	} else if subject_1.Tag == lisette.OptionSome {
-		x = subject_1.SomeVal
+	if option_1.Tag == lisette.OptionSome {
+		x = option_1.SomeVal
+	} else if option_1.Tag == lisette.OptionSome {
+		x = option_1.SomeVal
 	} else {
 		return
 	}
 	_ = x
-	x_3 := 2
-	_ = x_3
+	x_2 := 2
+	_ = x_2
 }

--- a/tests/spec/emit/snapshots/or_pattern_on_interface_field_check_with_guard.snap
+++ b/tests/spec/emit/snapshots/or_pattern_on_interface_field_check_with_guard.snap
@@ -16,10 +16,9 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, active bool) int {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		if subject_1.X == 5 {
+		if e.X == 5 {
 			if active {
 				return 1
 			}

--- a/tests/spec/emit/snapshots/or_pattern_on_interface_with_guard.snap
+++ b/tests/spec/emit/snapshots/or_pattern_on_interface_with_guard.snap
@@ -16,8 +16,7 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, active bool) int {
-	subject_1 := e
-	switch subject_1.(type) {
+	switch e.(type) {
 	case events.Click, events.Scroll:
 		if active {
 			return 1

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_prelude_constructor.snap
@@ -23,11 +23,10 @@ func main() {
 		return 0, false
 	}
 	opt := lisette.MakeOptionSome(1)
-	_arg_5 := opt
 	cb_3 := g
 	tagged_4 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_3(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_5, tagged_4)
+	r := lisette.OptionAndThen(opt, tagged_4)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_captured_user_fn_local.snap
@@ -21,11 +21,10 @@ func doubler(x int) (int, bool) {
 func main() {
 	g := doubler
 	opt := lisette.MakeOptionSome(1)
-	_arg_3 := opt
 	cb_1 := g
 	tagged_2 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_3, tagged_2)
+	r := lisette.OptionAndThen(opt, tagged_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
+++ b/tests/spec/emit/snapshots/prelude_dispatch_with_user_fn_arg.snap
@@ -19,11 +19,10 @@ func doubler(x int) (int, bool) {
 
 func main() {
 	opt := lisette.MakeOptionSome(1)
-	_arg_3 := opt
 	cb_1 := doubler
 	tagged_2 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	r := lisette.OptionAndThen(_arg_3, tagged_2)
+	r := lisette.OptionAndThen(opt, tagged_2)
 	_ = r
 }

--- a/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
+++ b/tests/spec/emit/snapshots/prelude_method_value_capture_with_option_returning_callback.snap
@@ -24,9 +24,8 @@ func main() {
 		}
 		return 0, false
 	}
-	option_4 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) (int, bool) {
+	x := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) (int, bool) {
 		return v * 2, true
 	}))
-	x := option_4
 	_ = x
 }

--- a/tests/spec/emit/snapshots/prelude_method_value_type_instantiation.snap
+++ b/tests/spec/emit/snapshots/prelude_method_value_type_instantiation.snap
@@ -21,9 +21,8 @@ func main() {
 		}
 		return 0, false
 	}
-	option_3 := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) int {
+	x := lisette.OptionFromCommaOk[int](f(lisette.MakeOptionSome(1), func(v int) int {
 		return v + 1
 	}))
-	x := option_3
 	_ = x
 }

--- a/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
+++ b/tests/spec/emit/snapshots/prelude_some_ok_constructor_value.snap
@@ -21,7 +21,6 @@ func main() {
 		}
 		return 0, false
 	}
-	option_3 := lisette.OptionFromCommaOk[int](f(42))
-	x := option_3
+	x := lisette.OptionFromCommaOk[int](f(42))
 	_ = x
 }

--- a/tests/spec/emit/snapshots/propagate_in_if_let_subject.snap
+++ b/tests/spec/emit/snapshots/propagate_in_if_let_subject.snap
@@ -17,13 +17,13 @@ func g() lisette.Result[lisette.Option[int], string] {
 }
 
 func f() lisette.Result[int, string] {
-	check_2 := g()
-	if check_2.Tag != lisette.ResultOk {
-		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	check_1 := g()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	subject_1 := check_2.OkVal
-	if subject_1.Tag == lisette.OptionSome {
-		return lisette.MakeResultOk[int, string](subject_1.SomeVal)
+	subject_2 := check_1.OkVal
+	if subject_2.Tag == lisette.OptionSome {
+		return lisette.MakeResultOk[int, string](subject_2.SomeVal)
 	}
 	return lisette.MakeResultOk[int, string](0)
 }

--- a/tests/spec/emit/snapshots/propagate_in_match_subject.snap
+++ b/tests/spec/emit/snapshots/propagate_in_match_subject.snap
@@ -20,13 +20,13 @@ func g() lisette.Result[int, string] {
 }
 
 func f() lisette.Result[int, string] {
-	check_2 := g()
-	if check_2.Tag != lisette.ResultOk {
-		return lisette.MakeResultErr[int, string](check_2.ErrVal)
+	check_1 := g()
+	if check_1.Tag != lisette.ResultOk {
+		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	subject_1 := check_2.OkVal
-	if subject_1 == 0 {
+	subject_2 := check_1.OkVal
+	if subject_2 == 0 {
 		return lisette.MakeResultOk[int, string](10)
 	}
-	return lisette.MakeResultOk[int, string](subject_1)
+	return lisette.MakeResultOk[int, string](subject_2)
 }

--- a/tests/spec/emit/snapshots/range_index_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/range_index_evaluated_once.snap
@@ -32,8 +32,7 @@ func makeRange() lisette.Range[int] {
 
 func main() {
 	items := []int{0, 1, 2, 3, 4}
-	_base_2 := items
 	range_1 := makeRange()
-	sub := _base_2[range_1.Start:range_1.End:range_1.End]
+	sub := items[range_1.Start:range_1.End:range_1.End]
 	fmt.Println(len(sub))
 }

--- a/tests/spec/emit/snapshots/recover_block_never_returning_user_function.snap
+++ b/tests/spec/emit/snapshots/recover_block_never_returning_user_function.snap
@@ -21,11 +21,10 @@ func fail(msg string) struct{} {
 }
 
 func test() string {
-	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
+	result := lisette.RecoverBlock(func() struct{} {
 		fail("intentional")
 		panic("unreachable")
 	})
-	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {
 		return "ok"
 	}

--- a/tests/spec/emit/snapshots/recover_block_panic_pattern_match.snap
+++ b/tests/spec/emit/snapshots/recover_block_panic_pattern_match.snap
@@ -15,10 +15,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() string {
-	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
+	result := lisette.RecoverBlock(func() struct{} {
 		panic("oh no!")
 	})
-	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {
 		return "ok"
 	}

--- a/tests/spec/emit/snapshots/recover_block_result_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recover_block_result_temp_var_no_collision.snap
@@ -14,10 +14,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func main() {
-	recoverResult_1 := lisette.RecoverBlock(func() int {
+	result := lisette.RecoverBlock(func() int {
 		return 1
 	})
-	result := recoverResult_1
 	recoverResult_1_2 := 7
 	_ = recoverResult_1_2
 	_ = result

--- a/tests/spec/emit/snapshots/recover_block_unit_ok_binding.snap
+++ b/tests/spec/emit/snapshots/recover_block_unit_ok_binding.snap
@@ -15,10 +15,9 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test() {
-	recoverResult_1 := lisette.RecoverBlock(func() struct{} {
+	result := lisette.RecoverBlock(func() struct{} {
 		panic("boom")
 	})
-	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {
 	}
 }

--- a/tests/spec/emit/snapshots/recover_block_with_match.snap
+++ b/tests/spec/emit/snapshots/recover_block_with_match.snap
@@ -21,10 +21,9 @@ func mayPanic() int {
 }
 
 func test() int {
-	recoverResult_1 := lisette.RecoverBlock(func() int {
+	result := lisette.RecoverBlock(func() int {
 		return mayPanic()
 	})
-	result := recoverResult_1
 	if result.Tag == lisette.ResultOk {
 		return result.OkVal
 	}

--- a/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
+++ b/tests/spec/emit/snapshots/select_receive_propagate_channel_operand.snap
@@ -28,19 +28,18 @@ func f() lisette.Result[int, string] {
 	chans := []chan int{make(chan int, 1)}
 	_ = lisette.ChannelSend(chans[0], 7)
 	var x int
-	_base_2 := chans
 	check_1 := g()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_1.ErrVal)
 	}
-	ch_3 := _base_2[check_1.OkVal]
+	ch_2 := chans[check_1.OkVal]
 	for {
 		select {
-		case v, ok := <-ch_3:
+		case v, ok := <-ch_2:
 			if ok {
 				x = v
 			} else {
-				ch_3 = nil
+				ch_2 = nil
 				continue
 			}
 		default:

--- a/tests/spec/emit/snapshots/task_captures_reassigned_local_before_the_goroutine_runs.snap
+++ b/tests/spec/emit/snapshots/task_captures_reassigned_local_before_the_goroutine_runs.snap
@@ -3,15 +3,18 @@ source: tests/spec/emit/concurrency.rs
 description: |
   
   fn test() {
-    let xs = [1]
+    let mut xs = [1]
     task xs.length()
+    xs = [1, 2]
   }
 ---
 package main
 
 func test() {
 	xs := []int{1}
+	_arg_1 := xs
 	go func() {
-		_ = len(xs)
+		_ = len(_arg_1)
 	}()
+	xs = []int{1, 2}
 }

--- a/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
+++ b/tests/spec/emit/snapshots/task_native_method_inlined_to_non_call_wraps_in_iife.snap
@@ -11,8 +11,7 @@ package main
 
 func test() {
 	xs := []int{1}
-	_arg_1 := xs
 	go func() {
-		_ = len(_arg_1) == 0
+		_ = len(xs) == 0
 	}()
 }

--- a/tests/spec/emit/snapshots/try_block_nested.snap
+++ b/tests/spec/emit/snapshots/try_block_nested.snap
@@ -52,12 +52,11 @@ func test() int {
 		} else {
 			inner_val = 0
 		}
-		_left_5 := inner_val
 		check_4 := riskyB()
 		if check_4.Tag != lisette.ResultOk {
 			return lisette.MakeResultErr[int, string](check_4.ErrVal)
 		}
-		return lisette.MakeResultOk[int, string](_left_5 + check_4.OkVal)
+		return lisette.MakeResultOk[int, string](inner_val + check_4.OkVal)
 	}()
 	outer = tryResult_1
 	if outer.Tag == lisette.ResultOk {

--- a/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
@@ -19,15 +19,14 @@ type Point struct {
 }
 
 func test(p Point) int {
-	subject_1 := p
 	{
-		x := subject_1.F0
-		y := subject_1.F1
+		x := p.F0
+		y := p.F1
 		if x > 0 {
 			return x + y
 		}
 	}
 	{
-		return subject_1.F1
+		return p.F1
 	}
 }

--- a/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
+++ b/tests/spec/emit/snapshots/tuple_tail_return_wraps_adapter_for_interface_slot.snap
@@ -54,8 +54,7 @@ func make_() (Box[lisette.Option[*Thing]], int) {
 
 func test() {
 	ret_1, ret_2 := make_()
-	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
-	pair := tup_3
+	pair := lisette.MakeTuple2(ret_1, ret_2)
 	subject_4 := pair.First.get()
 	if subject_4.Tag == lisette.OptionSome {
 		panic("expected None")

--- a/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
+++ b/tests/spec/emit/snapshots/type_switch_arm_with_binding_and_guard.snap
@@ -17,14 +17,13 @@ package main
 import "example.com/events"
 
 func handle(e events.Event, threshold int) int {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		x := subject_1.X
+		x := e.X
 		if x > threshold {
 			return x
 		}
-		return subject_1.X + 1
+		return e.X + 1
 	default:
 		return 0
 	}

--- a/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
@@ -19,22 +19,21 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) int {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		x := subject_1.X
+		x := e.X
 		if x > 1000 {
 			return 4
 		}
-		x_2 := subject_1.X
-		if x_2 > 100 {
+		x_1 := e.X
+		if x_1 > 100 {
 			return 3
 		}
-		x_3 := subject_1.X
-		if x_3 > 50 {
+		x_2 := e.X
+		if x_2 > 50 {
 			return 2
 		}
-		if subject_1.X > 0 {
+		if e.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
+++ b/tests/spec/emit/snapshots/type_switch_guards_then_unguarded_arm_returning_complex_value.snap
@@ -18,18 +18,17 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) (int, bool) {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		x := subject_1.X
+		x := e.X
 		if x > 100 {
 			return x * 10, true
 		}
-		x_2 := subject_1.X
-		if x_2 > 0 {
-			return x_2, true
+		x_1 := e.X
+		if x_1 > 0 {
+			return x_1, true
 		}
-		return -subject_1.X, true
+		return -e.X, true
 	default:
 		return 0, false
 	}

--- a/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
@@ -18,18 +18,17 @@ package main
 import "example.com/events"
 
 func handle(e events.Event) int {
-	subject_1 := e
-	switch subject_1 := subject_1.(type) {
+	switch e := e.(type) {
 	case events.Click:
-		x := subject_1.X
+		x := e.X
 		if x > 100 {
 			return 3
 		}
-		x_2 := subject_1.X
-		if x_2 > 50 {
+		x_1 := e.X
+		if x_1 > 50 {
 			return 2
 		}
-		if subject_1.X > 0 {
+		if e.X > 0 {
 			return 1
 		}
 		return 0

--- a/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_channel_send.snap
@@ -17,7 +17,6 @@ func noop() {}
 
 func test() {
 	ch := make(chan struct{}, 1)
-	_arg_1 := ch
 	noop()
-	_ = lisette.ChannelSend(_arg_1, struct{}{})
+	_ = lisette.ChannelSend(ch, struct{}{})
 }

--- a/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_identifier_native_append.snap
@@ -16,8 +16,7 @@ func noop() {}
 
 func main() {
 	xs := []struct{}{}
-	_arg_1 := xs
 	noop()
-	y := append(_arg_1[:len(_arg_1):len(_arg_1)], struct{}{})
+	y := append(xs[:len(xs):len(xs)], struct{}{})
 	_ = y
 }

--- a/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_slice_append.snap
@@ -15,7 +15,6 @@ func noop() {}
 
 func test() {
 	xs := []struct{}{}
-	_arg_1 := xs
 	noop()
-	_ = append(_arg_1[:len(_arg_1):len(_arg_1)], struct{}{})
+	_ = append(xs[:len(xs):len(xs)], struct{}{})
 }

--- a/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
+++ b/tests/spec/emit/snapshots/unit_call_in_ufcs_method_arg.snap
@@ -25,7 +25,6 @@ func (b Box) ping(_ struct{}) {}
 
 func test() {
 	b := Box{}
-	_arg_1 := b
 	noop()
-	_arg_1.ping(struct{}{})
+	b.ping(struct{}{})
 }

--- a/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
+++ b/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
@@ -22,7 +22,6 @@ func maybePair(n int) (lisette.Tuple2[int, int], bool) {
 }
 
 func main() {
-	option_1 := lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybePair(5))
-	r := option_1
+	r := lisette.OptionFromCommaOk[lisette.Tuple2[int, int]](maybePair(5))
 	_ = r
 }


### PR DESCRIPTION
A value that already has a Go name is now read under that name, instead of being copied into a fresh temp first.

Before:

```go
func test(opt lisette.Option[int]) string {
	subject_1 := opt
	if subject_1.Tag == lisette.OptionSome {
		x := subject_1.SomeVal
```

After:

```go
func test(opt lisette.Option[int]) string {
	if opt.Tag == lisette.OptionSome {
		x := opt.SomeVal
```
