### PR TITLE
refactor: parse and represent `mut` in type position

### DIFF
--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -443,6 +443,7 @@ impl Planner<'_> {
             Type::Compound {
                 kind: CompoundKind::Ref,
                 args,
+                ..
             } => {
                 let Some(pointee) = args.first() else {
                     return ValueLayout::Plain(ty);
@@ -459,6 +460,7 @@ impl Planner<'_> {
             Type::Compound {
                 kind: kind @ (CompoundKind::Slice | CompoundKind::EnumeratedSlice),
                 args,
+                ..
             } => {
                 let Some(element) = args.first() else {
                     return ValueLayout::Plain(ty);
@@ -475,6 +477,7 @@ impl Planner<'_> {
             Type::Compound {
                 kind: CompoundKind::Map,
                 args,
+                ..
             } => {
                 let [key, value] = args.as_slice() else {
                     return ValueLayout::Plain(ty);
@@ -597,7 +600,7 @@ fn compound_hint(
     expected_kind: CompoundKind,
     index: usize,
 ) -> Option<&Type> {
-    let Type::Compound { kind, args } = declaration? else {
+    let Type::Compound { kind, args, .. } = declaration? else {
         return None;
     };
     (*kind == expected_kind).then(|| args.get(index)).flatten()

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -188,6 +188,7 @@ impl Planner<'_> {
         let nominal = Type::Nominal {
             id: id.into(),
             params: Vec::new(),
+            writable: false,
         };
         self.facts
             .peel_alias(&nominal)

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -11,6 +11,7 @@ impl Planner<'_> {
             Type::Compound {
                 kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
                 args,
+                ..
             } => match args.first().and_then(|elem| self.element_clone(elem)) {
                 Some(clone) => {
                     self.require_stdlib();
@@ -27,6 +28,7 @@ impl Planner<'_> {
             Type::Compound {
                 kind: CompoundKind::Map,
                 args,
+                ..
             } => match args.get(1).and_then(|v| self.element_clone(v)) {
                 Some(clone) => {
                     self.require_stdlib();

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -246,6 +246,7 @@ impl Planner<'_> {
 
         let return_type = Type::Nominal {
             id: Symbol::from_raw(enum_name.clone()),
+            writable: false,
             params: generics
                 .iter()
                 .map(|g| Type::Parameter(g.name.clone()))

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -161,6 +161,7 @@ impl Planner<'_> {
         let interface_ty = Type::Nominal {
             id: id.into(),
             params: vec![],
+            writable: false,
         };
         interface_requirements(&interface_ty, |id| self.facts.definition(id))
             .iter()

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -27,7 +27,7 @@ impl Planner<'_> {
         let declared_target = self
             .facts
             .definition(&self.facts.qualified_current(name))
-            .and_then(|definition| definition.instantiate_alias_target(&params));
+            .and_then(|definition| definition.instantiate_alias_target(&params, false));
         let function_target = declared_target
             .as_ref()
             .and_then(|target| self.facts.resolve_to_function_type(target));

--- a/crates/emit/src/expressions/top_items.rs
+++ b/crates/emit/src/expressions/top_items.rs
@@ -170,6 +170,7 @@ impl Planner<'_> {
             ty: Type::Nominal {
                 id: Symbol::from_parts(go_name::TEST_PRELUDE_PACKAGE, "TestContext"),
                 params: vec![],
+                writable: false,
             },
             mut_span: None,
         }])

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -69,7 +69,7 @@ impl Planner<'_> {
                     GoType::new(kind.leaf_name().to_string())
                 }
             }
-            Type::Compound { kind, args } => self.emit_compound(*kind, args, ty),
+            Type::Compound { kind, args, .. } => self.emit_compound(*kind, args, ty),
             Type::Function(f) => self.emit_function_type(&f.params, &f.return_type),
             Type::Var { .. } | Type::Uninferred | Type::Ignored => GoType::new("any"),
             Type::Forall { .. } => GoType::new("any"),

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -508,8 +508,13 @@ impl<'a> Formatter<'a> {
 
     pub(super) fn annotation(annotation: &'a Annotation) -> Document<'a> {
         match annotation {
-            Annotation::Constructor { name, params, .. } => {
-                if params.is_empty() {
+            Annotation::Constructor {
+                name,
+                params,
+                writable,
+                ..
+            } => {
+                let base = if params.is_empty() {
                     if name == "Unit" {
                         Document::str("()")
                     } else {
@@ -521,6 +526,11 @@ impl<'a> Formatter<'a> {
                         .append("<")
                         .append(join(param_docs, Document::str(", ")))
                         .append(">")
+                };
+                if *writable {
+                    Document::str("mut ").append(base)
+                } else {
+                    base
                 }
             }
             Annotation::Function {

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -76,6 +76,7 @@ pub(crate) fn type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String
         Type::Compound {
             kind: CompoundKind::Ref,
             args,
+            ..
         } => args.first().and_then(|ty| type_name(ty, snapshot)),
         Type::Compound { kind, .. } => Some(format!("prelude.{}", kind.leaf_name())),
         Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -220,6 +220,7 @@ pub(crate) fn get_instance_completions(
     let ty = Type::Nominal {
         id: type_id.into(),
         params: vec![],
+        writable: false,
     };
     for method in syntax::program::methods_for_type(&ty, &Default::default(), |id| {
         snapshot.definitions().get(id)

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -221,7 +221,9 @@ pub(crate) fn resolve_annotation_definition(
     let recurse = |child| resolve_annotation_definition(child, offset, file, snapshot);
 
     match annotation {
-        Annotation::Constructor { name, span, params } => params
+        Annotation::Constructor {
+            name, span, params, ..
+        } => params
             .iter()
             .find_map(recurse)
             .or_else(|| resolve_constructor_name(name, *span, offset, file, snapshot)),

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -26,7 +26,7 @@ pub(crate) fn resolve_declaration_hover(
         let qualified = format!("{}.{}", file.package_id, name);
         let definition = snapshot.definitions().get(qualified.as_str())?;
         let ty = definition
-            .instantiate_alias_target(&[])
+            .instantiate_alias_target(&[], false)
             .unwrap_or_else(|| definition.ty.clone());
         Some((ty, name_span))
     };
@@ -75,7 +75,9 @@ fn resolve_annotation_hover(
     }
     let recurse = |child| resolve_annotation_hover(child, offset, file, snapshot);
     match annotation {
-        Annotation::Constructor { name, params, span } => params
+        Annotation::Constructor {
+            name, params, span, ..
+        } => params
             .iter()
             .find_map(recurse)
             .or_else(|| resolve_constructor_name_hover(name, *span, offset, file, snapshot)),

--- a/crates/passes/src/passes/checks/instantiation_cycle.rs
+++ b/crates/passes/src/passes/checks/instantiation_cycle.rs
@@ -204,6 +204,7 @@ fn receiver_type_id(ty: &Type) -> Option<EcoString> {
         Type::Compound {
             kind: CompoundKind::Ref,
             args,
+            ..
         } => args.first().and_then(receiver_type_id),
         Type::Nominal { id, .. } => Some(id.as_eco().clone()),
         _ => None,

--- a/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
@@ -48,7 +48,7 @@ fn type_key(ty: &Type) -> String {
         Type::ImportNamespace(m) => format!("<import:{}>", m),
         Type::ReceiverPlaceholder => "<receiver>".to_string(),
         Type::Simple(kind) => kind.leaf_name().to_string(),
-        Type::Compound { kind, args } => {
+        Type::Compound { kind, args, .. } => {
             if args.is_empty() {
                 kind.leaf_name().to_string()
             } else {

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -114,6 +114,7 @@ mod tests {
     fn unbound_slice(id: u32) -> Type {
         Type::Compound {
             kind: CompoundKind::Slice,
+            writable: false,
             args: vec![Type::Var {
                 id: TypeVarId::new(id),
                 hint: Some("T".into()),

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -903,6 +903,7 @@ pub(super) fn equals_targets(
         Type::Compound {
             kind: CompoundKind::Slice,
             args,
+            ..
         } => {
             if let Some(element) = args.first() {
                 equals_targets(element, package, store, index, out);
@@ -911,6 +912,7 @@ pub(super) fn equals_targets(
         Type::Compound {
             kind: CompoundKind::Map,
             args,
+            ..
         } => {
             if let Some(value) = args.get(1) {
                 equals_targets(value, package, store, index, out);

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -440,6 +440,7 @@ mod tests {
             ty: Type::Nominal {
                 id: Symbol::from_raw("package.Box"),
                 params: vec![Type::Parameter("T".into())],
+                writable: false,
             },
             name_span: Some(Span::new(file_id, 0, 3)),
             doc: None,
@@ -450,11 +451,13 @@ mod tests {
                         Annotation::Constructor {
                             name: "Comparable".into(),
                             params: Vec::new(),
+                            writable: false,
                             span: bound_span,
                         },
                         Type::Nominal {
                             id: Symbol::from_raw("prelude.Comparable"),
                             params: Vec::new(),
+                            writable: false,
                         },
                     )],
                     Span::new(file_id, 4, 13),
@@ -598,6 +601,7 @@ mod tests {
             ty: Type::Nominal {
                 id: Symbol::from_raw("int"),
                 params: vec![],
+                writable: false,
             },
             name_span: None,
             doc: None,
@@ -693,6 +697,7 @@ mod tests {
             ty: Type::Nominal {
                 id: Symbol::from_raw("dep.Inner"),
                 params: vec![],
+                writable: false,
             },
             name_span: None,
             doc: None,
@@ -740,6 +745,7 @@ mod tests {
                 Some(Type::Nominal {
                     id: Symbol::from_raw("prelude.Comparable"),
                     params: Vec::new(),
+                    writable: false,
                 }),
             )
         );
@@ -775,6 +781,7 @@ mod tests {
                 Type::Nominal {
                     id: Symbol::from_raw("int"),
                     params: vec![],
+                    writable: false,
                 },
                 false,
             )],
@@ -782,6 +789,7 @@ mod tests {
             Box::new(Type::Nominal {
                 id: Symbol::from_raw("main.MyType"),
                 params: vec![Type::Tuple(vec![Type::Never])],
+                writable: false,
             }),
         );
 

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -58,6 +58,7 @@ enum CachedAnnotation {
     Constructor {
         name: EcoString,
         params: Vec<Self>,
+        writable: bool,
         span: CachedSpan,
     },
     Function {
@@ -89,7 +90,13 @@ struct CachedFunctionAnnotationParameter {
 impl CachedAnnotation {
     fn from_annotation(annotation: &Annotation, file_id_to_index: &HashMap<u32, u32>) -> Self {
         match annotation {
-            Annotation::Constructor { name, params, span } => Self::Constructor {
+            Annotation::Constructor {
+                name,
+                params,
+                writable,
+                span,
+            } => Self::Constructor {
+                writable: *writable,
                 name: name.clone(),
                 params: params
                     .iter()
@@ -133,7 +140,13 @@ impl CachedAnnotation {
 
     fn to_annotation(&self, file_ids: &[u32]) -> Annotation {
         match self {
-            Self::Constructor { name, params, span } => Annotation::Constructor {
+            Self::Constructor {
+                name,
+                params,
+                writable,
+                span,
+            } => Annotation::Constructor {
+                writable: *writable,
                 name: name.clone(),
                 params: params
                     .iter()

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -27,7 +27,11 @@ impl<'a> FreezeFolder<'a> {
 
     fn normalize_ref_aliases(&self, ty: &Type) -> Type {
         match ty {
-            Type::Nominal { id, params } => {
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => {
                 let peeled = self.store.peel_alias(ty);
                 if peeled.is_ref() {
                     return self.normalize_ref_aliases(&peeled);
@@ -38,12 +42,18 @@ impl<'a> FreezeFolder<'a> {
                         .iter()
                         .map(|p| self.normalize_ref_aliases(p))
                         .collect(),
+                    writable: *writable,
                 }
             }
-            Type::Compound { kind, args } => Type::Compound {
-                kind: *kind,
-                args: args.iter().map(|a| self.normalize_ref_aliases(a)).collect(),
-            },
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => Type::qualified_compound(
+                *kind,
+                args.iter().map(|a| self.normalize_ref_aliases(a)).collect(),
+                *writable,
+            ),
             Type::Tuple(elements) => Type::Tuple(
                 elements
                     .iter()

--- a/crates/semantics/src/checker/infer/carry_mut.rs
+++ b/crates/semantics/src/checker/infer/carry_mut.rs
@@ -30,12 +30,14 @@ pub(super) fn clone_severs_alias(ty: &Type, env: &TypeEnv, store: &Store) -> boo
         Type::Compound {
             kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
             args,
+            ..
         } => args
             .first()
             .is_some_and(|elem| element_severed(elem, env, store)),
         Type::Compound {
             kind: CompoundKind::Map,
             args,
+            ..
         } => args
             .get(1)
             .is_some_and(|value| element_severed(value, env, store)),
@@ -54,12 +56,14 @@ fn element_severed(ty: &Type, env: &TypeEnv, store: &Store) -> bool {
         Type::Compound {
             kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
             args,
+            ..
         } => args
             .first()
             .is_some_and(|elem| element_severed(elem, env, store)),
         Type::Compound {
             kind: CompoundKind::Map,
             args,
+            ..
         } => args
             .get(1)
             .is_some_and(|value| element_severed(value, env, store)),
@@ -91,7 +95,7 @@ fn can_carry_mutation(
 ) -> bool {
     let resolved = ty.resolve_in(env);
     match &resolved {
-        Type::Compound { kind, args } => match kind {
+        Type::Compound { kind, args, .. } => match kind {
             CompoundKind::Slice | CompoundKind::Map | CompoundKind::EnumeratedSlice => true,
             CompoundKind::Ref
             | CompoundKind::Channel

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -861,11 +861,16 @@ impl InferCtx<'_> {
 
     fn try_as_type_conversion(&self, callee: &Expression, callee_ty: &Type) -> Option<Type> {
         let store = self.store;
-        let Type::Nominal { id, params } = callee_ty else {
+        let Type::Nominal {
+            id,
+            params,
+            writable,
+        } = callee_ty
+        else {
             return None;
         };
         let definition = store.get_definition(id)?;
-        let underlying = definition.instantiate_alias_target(params)?;
+        let underlying = definition.instantiate_alias_target(params, *writable)?;
         if !matches!(underlying, Type::Function(_)) {
             return None;
         }

--- a/crates/semantics/src/checker/infer/expressions/qualified_path.rs
+++ b/crates/semantics/src/checker/infer/expressions/qualified_path.rs
@@ -136,11 +136,13 @@ impl InferCtx<'_> {
             return None;
         }
         match store.peel_alias(&definition.ty) {
-            Type::Nominal { id, params } if params.is_empty() && id.as_str() != qualified_root => {
+            Type::Nominal { id, params, .. }
+                if params.is_empty() && id.as_str() != qualified_root =>
+            {
                 Some(id.to_string())
             }
             Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),
-            Type::Compound { kind, args } if args.is_empty() => {
+            Type::Compound { kind, args, .. } if args.is_empty() => {
                 Some(format!("prelude.{}", kind.leaf_name()))
             }
             _ => None,

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -422,6 +422,7 @@ impl InferCtx<'_> {
         let interface_ty = Type::Nominal {
             id: interface_qualified_id.into(),
             params: vec![],
+            writable: false,
         };
         interface_requirements(&interface_ty, |id| store.get_definition(id))
             .into_iter()
@@ -769,6 +770,7 @@ pub(crate) fn interface_requires_methods(store: &Store, id: &str) -> bool {
     let interface_ty = Type::Nominal {
         id: id.into(),
         params: vec![],
+        writable: false,
     };
     !interface_requirements(&interface_ty, |id| store.get_definition(id)).is_empty()
 }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -222,9 +222,14 @@ impl InferCtx<'_> {
                 }
             }
 
-            (Type::Compound { kind: k1, args: a1 }, Type::Compound { kind: k2, args: a2 })
-                if k1 == k2 && a1.len() == a2.len() =>
-            {
+            (
+                Type::Compound {
+                    kind: k1, args: a1, ..
+                },
+                Type::Compound {
+                    kind: k2, args: a2, ..
+                },
+            ) if k1 == k2 && a1.len() == a2.len() => {
                 // Compound type arguments are invariant (same rule as generic
                 // user types). Track depth so that interface coercion is
                 // rejected inside generic positions.

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -353,10 +353,7 @@ fn method_has_pointer_receiver(method_ty: &Type) -> bool {
 }
 
 fn ref_of(ty: &Type) -> Type {
-    Type::Compound {
-        kind: CompoundKind::Ref,
-        args: vec![ty.clone()],
-    }
+    Type::compound(CompoundKind::Ref, vec![ty.clone()])
 }
 
 fn declaring_generics<'a>(store: &'a Store, id: &str) -> &'a [Generic] {
@@ -415,6 +412,7 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_parts(PACKAGE, name),
             params: vec![],
+            writable: false,
         }
     }
 
@@ -597,6 +595,7 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_parts(PACKAGE, name),
             params: args,
+            writable: false,
         }
     }
 
@@ -967,6 +966,7 @@ mod tests {
                         vec![Type::Compound {
                             kind: CompoundKind::Slice,
                             args: vec![param("V")],
+                            writable: false,
                         }],
                     ),
                     false,

--- a/crates/semantics/src/checker/registration/builtins.rs
+++ b/crates/semantics/src/checker/registration/builtins.rs
@@ -44,10 +44,7 @@ impl TaskState {
     }
 
     pub(crate) fn type_slice(&mut self, element_type: Type) -> Type {
-        Type::Compound {
-            kind: CompoundKind::Slice,
-            args: vec![element_type],
-        }
+        Type::compound(CompoundKind::Slice, vec![element_type])
     }
 
     pub(crate) fn type_array(&mut self, length: u64, element_type: Type) -> Type {
@@ -58,23 +55,18 @@ impl TaskState {
     }
 
     pub(crate) fn type_reference(&mut self, inner_type: Type) -> Type {
-        Type::Compound {
-            kind: CompoundKind::Ref,
-            args: vec![inner_type],
-        }
+        Type::compound(CompoundKind::Ref, vec![inner_type])
     }
 
     pub(crate) fn type_map(&mut self, key_type: Type, value_type: Type) -> Type {
-        Type::Compound {
-            kind: CompoundKind::Map,
-            args: vec![key_type, value_type],
-        }
+        Type::compound(CompoundKind::Map, vec![key_type, value_type])
     }
 
     pub(crate) fn type_result(&mut self, store: &Store, ok_type: Type, error_type: Type) -> Type {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Result"),
             params: vec![ok_type, error_type],
+            writable: false,
         }
     }
 
@@ -82,6 +74,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Option"),
             params: vec![some_type],
+            writable: false,
         }
     }
 
@@ -89,6 +82,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "PanicValue"),
             params: vec![],
+            writable: false,
         }
     }
 
@@ -96,6 +90,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "Range"),
             params: vec![element_type],
+            writable: false,
         }
     }
 
@@ -103,6 +98,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeInclusive"),
             params: vec![element_type],
+            writable: false,
         }
     }
 
@@ -110,6 +106,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeFrom"),
             params: vec![element_type],
+            writable: false,
         }
     }
 
@@ -117,6 +114,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeTo"),
             params: vec![element_type],
+            writable: false,
         }
     }
 
@@ -124,6 +122,7 @@ impl TaskState {
         Type::Nominal {
             id: self.builtin_qualified_name(store, "RangeToInclusive"),
             params: vec![element_type],
+            writable: false,
         }
     }
 

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -221,11 +221,13 @@ impl TaskState {
         let Annotation::Constructor {
             name: type_name,
             params,
+            writable,
             span: annotation_span,
         } = annotation
         else {
             unreachable!("convert_constructor_annotation called with non-Constructor annotation");
         };
+        let writable = *writable;
         let annotation_span = *annotation_span;
         let ConvertMode {
             variadic_allowed,
@@ -317,6 +319,9 @@ impl TaskState {
             Type::Forall { vars, body } => (vars, *body),
             other => (vec![], other),
         };
+        // Applied before substitution, so a read-only template does not
+        // demote writable type arguments.
+        let body = if writable { body.make_writable() } else { body };
 
         let concrete_args: Vec<Type> = params
             .iter()
@@ -389,6 +394,7 @@ impl TaskState {
             return Type::Nominal {
                 id: Symbol::from_parts("prelude", "Array"),
                 params: vec![element],
+                writable: false,
             };
         }
 
@@ -577,6 +583,7 @@ impl TaskState {
                     name,
                     params: sub_params,
                     span: param_span,
+                    ..
                 } = param
                 else {
                     return None;

--- a/crates/semantics/src/checker/registration/declarations.rs
+++ b/crates/semantics/src/checker/registration/declarations.rs
@@ -140,17 +140,20 @@ impl TaskState {
                     Type::Compound {
                         kind: compound,
                         args,
+                        writable: false,
                     }
                 } else {
                     Type::Nominal {
                         id: qualified_name.clone(),
                         params: args,
+                        writable: false,
                     }
                 }
             } else {
                 Type::Nominal {
                     id: qualified_name.clone(),
                     params: args,
+                    writable: false,
                 }
             };
 

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -76,6 +76,7 @@ impl TaskState {
             && let Type::Compound {
                 kind: CompoundKind::Map,
                 args,
+                ..
             } = ty
             && let Some(key) = args.first()
         {

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -75,10 +75,7 @@ impl TaskState {
             return;
         };
 
-        let slice_ty = Type::Compound {
-            kind: CompoundKind::Slice,
-            args: vec![enum_ty],
-        };
+        let slice_ty = Type::compound(CompoundKind::Slice, vec![enum_ty]);
         let fn_ty = Type::function(vec![], Default::default(), Box::new(slice_ty));
 
         let package = store

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -11,6 +11,7 @@ fn test_context_type() -> Type {
     Type::Nominal {
         id: Symbol::from_parts(crate::prelude::TEST_PRELUDE_PACKAGE_ID, "TestContext"),
         params: vec![],
+        writable: false,
     }
 }
 

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -518,17 +518,20 @@ impl TaskState {
                         Type::Compound {
                             kind: compound,
                             args: params,
+                            writable: false,
                         }
                     } else {
                         Type::Nominal {
                             id: qualified_name.clone(),
                             params,
+                            writable: false,
                         }
                     }
                 } else {
                     Type::Nominal {
                         id: qualified_name.clone(),
                         params,
+                        writable: false,
                     }
                 };
 
@@ -589,6 +592,7 @@ impl TaskState {
         let alias_reference = Type::Nominal {
             id: qualified_name.clone(),
             params,
+            writable: false,
         };
         let alias_ty = if generics.is_empty() {
             alias_reference

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -121,15 +121,22 @@ impl TypeEnv {
                     }
                 }
             },
-            Type::Nominal { id, params } => {
-                self.resolve_slice(params).map(|params| Type::Nominal {
-                    id: id.clone(),
-                    params,
-                })
-            }
-            Type::Compound { kind, args } => self
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => self.resolve_slice(params).map(|params| Type::Nominal {
+                id: id.clone(),
+                params,
+                writable: *writable,
+            }),
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => self
                 .resolve_slice(args)
-                .map(|args| Type::Compound { kind: *kind, args }),
+                .map(|args| Type::qualified_compound(*kind, args, *writable)),
             Type::Function(f) => {
                 let new_params = self.resolve_function_params(&f.params);
                 let new_return = self.resolve_changed(&f.return_type).map(Box::new);

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -252,6 +252,7 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_raw(id),
             params,
+            writable: false,
         }
     }
 

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -473,10 +473,15 @@ impl Store {
 
     pub(crate) fn peel_alias_deep(&self, ty: &Type) -> Type {
         match self.peel_alias(ty) {
-            Type::Compound { kind, args } => Type::Compound {
+            Type::Compound {
                 kind,
-                args: args.iter().map(|a| self.peel_alias_deep(a)).collect(),
-            },
+                args,
+                writable,
+            } => Type::qualified_compound(
+                kind,
+                args.iter().map(|a| self.peel_alias_deep(a)).collect(),
+                writable,
+            ),
             Type::Tuple(elements) => {
                 Type::Tuple(elements.iter().map(|e| self.peel_alias_deep(e)).collect())
             }
@@ -484,9 +489,14 @@ impl Store {
                 length,
                 element: Box::new(self.peel_alias_deep(&element)),
             },
-            Type::Nominal { id, params } => Type::Nominal {
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => Type::Nominal {
                 id,
                 params: params.iter().map(|p| self.peel_alias_deep(p)).collect(),
+                writable,
             },
             Type::Function(f) => {
                 let new_params = f
@@ -666,6 +676,7 @@ mod closed_domain_tests {
         Type::Nominal {
             id: Symbol::from_raw(id),
             params: vec![],
+            writable: false,
         }
     }
 
@@ -823,6 +834,7 @@ mod closed_domain_tests {
         let alias_ref = Type::Nominal {
             id: Symbol::from_raw("m.Items"),
             params: vec![Type::Parameter("T".into())],
+            writable: false,
         };
         insert(
             &mut store,
@@ -843,6 +855,7 @@ mod closed_domain_tests {
                         target: Type::Compound {
                             kind: CompoundKind::Slice,
                             args: vec![Type::Parameter("T".into())],
+                            writable: false,
                         },
                     },
                     methods: Default::default(),
@@ -854,13 +867,171 @@ mod closed_domain_tests {
         let occurrence = Type::Nominal {
             id: Symbol::from_raw("m.Items"),
             params: vec![Type::int()],
+            writable: false,
         };
         let expected = Type::Compound {
             kind: CompoundKind::Slice,
             args: vec![Type::int()],
+            writable: false,
         };
 
         assert_eq!(store.underlying_type(&occurrence), Some(expected.clone()));
+        assert_eq!(store.peel_alias(&occurrence), expected);
+    }
+
+    #[test]
+    fn alias_peeling_transfers_the_occurrence_qualifier() {
+        let mut store = Store::new();
+        insert(
+            &mut store,
+            "m",
+            "m.Bytes",
+            Definition {
+                visibility: Visibility::Public,
+                ty: Type::Nominal {
+                    id: Symbol::from_raw("m.Bytes"),
+                    params: vec![],
+                    writable: false,
+                },
+                name_span: None,
+                doc: None,
+                body: DefinitionBody::TypeAlias {
+                    generics: vec![],
+                    alias: AliasKind::Transparent {
+                        annotation: Annotation::Unknown,
+                        target: Type::compound(CompoundKind::Slice, vec![Type::int()]),
+                    },
+                    methods: Default::default(),
+                    attributes: Default::default(),
+                },
+            },
+        );
+
+        let writable_occurrence = Type::Nominal {
+            id: Symbol::from_raw("m.Bytes"),
+            params: vec![],
+            writable: true,
+        };
+        let expected = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+        assert_eq!(store.peel_alias(&writable_occurrence), expected);
+        assert_eq!(store.underlying_type(&writable_occurrence), Some(expected));
+
+        let plain_occurrence = Type::Nominal {
+            id: Symbol::from_raw("m.Bytes"),
+            params: vec![],
+            writable: false,
+        };
+        assert!(!store.peel_alias(&plain_occurrence).is_writable());
+    }
+
+    #[test]
+    fn newtype_underlying_applies_the_projection_meet() {
+        fn newtype_wrapping(name: &str, field_ty: Type) -> Definition {
+            Definition {
+                visibility: Visibility::Public,
+                ty: nominal_int(name),
+                name_span: None,
+                doc: None,
+                body: DefinitionBody::Struct {
+                    generics: vec![],
+                    fields: StructFields::Tuple(vec![StructFieldDefinition {
+                        doc: None,
+                        name: "0".into(),
+                        name_span: syntax::ast::Span::dummy(),
+                        annotation: syntax::ast::Annotation::Unknown,
+                        visibility: syntax::ast::Visibility::Private,
+                        ty: field_ty,
+                        kind: StructFieldKind::Named { attributes: vec![] },
+                    }]),
+                    methods: Default::default(),
+                    attributes: Default::default(),
+                },
+            }
+        }
+
+        let writable_slice = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+        let plain_slice = Type::compound(CompoundKind::Slice, vec![Type::int()]);
+
+        let mut store = Store::new();
+        insert(
+            &mut store,
+            "m",
+            "m.Writable",
+            newtype_wrapping("m.Writable", writable_slice.clone()),
+        );
+        insert(
+            &mut store,
+            "m",
+            "m.Plain",
+            newtype_wrapping("m.Plain", plain_slice.clone()),
+        );
+
+        let occurrence = |id: &str, writable: bool| Type::Nominal {
+            id: Symbol::from_raw(id),
+            params: vec![],
+            writable,
+        };
+
+        // Writable owner exposes the field as declared.
+        assert_eq!(
+            store.peel_underlying(&occurrence("m.Writable", true)),
+            writable_slice,
+        );
+        // Read-only owner demotes a writable field.
+        assert_eq!(
+            store.peel_underlying(&occurrence("m.Writable", false)),
+            plain_slice,
+        );
+        // Writable owner never promotes a read-only field.
+        assert_eq!(
+            store.peel_underlying(&occurrence("m.Plain", true)),
+            plain_slice,
+        );
+    }
+
+    #[test]
+    fn generic_alias_peeling_keeps_writable_type_arguments() {
+        let mut store = Store::new();
+        let generic = Generic::new("T", Vec::new(), Span::dummy());
+        let alias_ref = Type::Nominal {
+            id: Symbol::from_raw("m.Rows"),
+            params: vec![Type::Parameter("T".into())],
+            writable: false,
+        };
+        insert(
+            &mut store,
+            "m",
+            "m.Rows",
+            Definition {
+                visibility: Visibility::Public,
+                ty: Type::Forall {
+                    vars: vec!["T".into()],
+                    body: Box::new(alias_ref),
+                },
+                name_span: None,
+                doc: None,
+                body: DefinitionBody::TypeAlias {
+                    generics: vec![generic],
+                    alias: AliasKind::Transparent {
+                        annotation: Annotation::Unknown,
+                        target: Type::compound(
+                            CompoundKind::Slice,
+                            vec![Type::Parameter("T".into())],
+                        ),
+                    },
+                    methods: Default::default(),
+                    attributes: Default::default(),
+                },
+            },
+        );
+
+        let writable_arg = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+        let occurrence = Type::Nominal {
+            id: Symbol::from_raw("m.Rows"),
+            params: vec![writable_arg.clone()],
+            writable: true,
+        };
+        let expected = Type::qualified_compound(CompoundKind::Slice, vec![writable_arg], true);
         assert_eq!(store.peel_alias(&occurrence), expected);
     }
 
@@ -893,6 +1064,7 @@ mod closed_domain_tests {
                         target: Type::Compound {
                             kind: CompoundKind::Ref,
                             args: vec![nominal_int(target)],
+                            writable: false,
                         },
                     },
                     methods: Default::default(),

--- a/crates/semantics/src/zero.rs
+++ b/crates/semantics/src/zero.rs
@@ -16,7 +16,7 @@ use crate::store::Store;
 pub struct NoZero {
     pub(crate) chain: Vec<EcoString>,
     pub(crate) reason: NoZeroReason,
-    pub leaf_ty: Type,
+    pub leaf_ty: Box<Type>,
 }
 
 impl NoZero {
@@ -91,7 +91,7 @@ fn has_zero_seen(
             | CompoundKind::VarArgs => Err(NoZero {
                 chain: vec![],
                 reason: NoZeroReason::NoZeroForType,
-                leaf_ty: ty.clone(),
+                leaf_ty: Box::new(ty.clone()),
             }),
         },
         Type::Tuple(elements) => {
@@ -115,7 +115,7 @@ fn has_zero_seen(
         Type::Function(_) => Err(NoZero {
             chain: vec![],
             reason: NoZeroReason::NoZeroForType,
-            leaf_ty: ty.clone(),
+            leaf_ty: Box::new(ty.clone()),
         }),
         Type::Nominal { id, params, .. } => {
             if id.as_str() == "prelude.Option" {
@@ -134,13 +134,13 @@ fn has_zero_seen(
             Err(NoZero {
                 chain: vec![],
                 reason: NoZeroReason::NoZeroForType,
-                leaf_ty: ty.clone(),
+                leaf_ty: Box::new(ty.clone()),
             })
         }
         Type::Never | Type::Error | Type::ImportNamespace(_) => Err(NoZero {
             chain: vec![],
             reason: NoZeroReason::NoZeroForType,
-            leaf_ty: ty.clone(),
+            leaf_ty: Box::new(ty.clone()),
         }),
     }
 }
@@ -169,7 +169,7 @@ fn has_zero_nominal(
         return Err(NoZero {
             chain: vec![],
             reason: NoZeroReason::NoZeroForType,
-            leaf_ty: original_ty.clone(),
+            leaf_ty: Box::new(original_ty.clone()),
         });
     }
     visited.push(original_ty.clone());
@@ -199,7 +199,7 @@ fn has_zero_nominal_fields(
         return Err(NoZero {
             chain: vec![],
             reason: NoZeroReason::NoZeroForType,
-            leaf_ty: original_ty.clone(),
+            leaf_ty: Box::new(original_ty.clone()),
         });
     };
 
@@ -212,7 +212,7 @@ fn has_zero_nominal_fields(
                     reason: NoZeroReason::HiddenGoState {
                         go_type: go_display_name(id),
                     },
-                    leaf_ty: original_ty.clone(),
+                    leaf_ty: Box::new(original_ty.clone()),
                 });
             }
             let def_ty = &def.ty;
@@ -235,7 +235,7 @@ fn has_zero_nominal_fields(
                             field: f.name.clone(),
                             owning_package: EcoString::from(struct_package),
                         },
-                        leaf_ty: f.ty.clone(),
+                        leaf_ty: Box::new(f.ty.clone()),
                     });
                 }
                 let resolved = if map.is_empty() {
@@ -260,11 +260,11 @@ fn has_zero_nominal_fields(
                 return Err(NoZero {
                     chain: vec![],
                     reason: NoZeroReason::NoZeroForType,
-                    leaf_ty: original_ty.clone(),
+                    leaf_ty: Box::new(original_ty.clone()),
                 });
             }
             let resolved = def
-                .instantiate_alias_target(params)
+                .instantiate_alias_target(params, false)
                 .expect("transparent alias has a target");
             has_zero_seen(store, &resolved, from_package, visited)
         }
@@ -273,7 +273,7 @@ fn has_zero_nominal_fields(
         _ => Err(NoZero {
             chain: vec![],
             reason: NoZeroReason::NoZeroForType,
-            leaf_ty: original_ty.clone(),
+            leaf_ty: Box::new(original_ty.clone()),
         }),
     }
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -895,12 +895,13 @@ impl Default for CallTypeArguments {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Annotation {
     Constructor {
         name: EcoString,
         params: Vec<Self>,
+        writable: bool,
         span: Span,
     },
     Function {
@@ -925,11 +926,55 @@ pub enum Annotation {
     },
 }
 
+impl std::fmt::Debug for Annotation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Constructor {
+                name,
+                params,
+                writable,
+                span,
+            } => {
+                let mut s = f.debug_struct("Constructor");
+                s.field("name", name).field("params", params);
+                if *writable {
+                    s.field("writable", writable);
+                }
+                s.field("span", span).finish()
+            }
+            Self::Function {
+                params,
+                return_type,
+                span,
+            } => f
+                .debug_struct("Function")
+                .field("params", params)
+                .field("return_type", return_type)
+                .field("span", span)
+                .finish(),
+            Self::Tuple { elements, span } => f
+                .debug_struct("Tuple")
+                .field("elements", elements)
+                .field("span", span)
+                .finish(),
+            Self::Unknown => write!(f, "Unknown"),
+            Self::Opaque { span } => f.debug_struct("Opaque").field("span", span).finish(),
+            Self::Constant { value, text, span } => f
+                .debug_struct("Constant")
+                .field("value", value)
+                .field("text", text)
+                .field("span", span)
+                .finish(),
+        }
+    }
+}
+
 impl Annotation {
     pub(crate) fn unit() -> Self {
         Self::Constructor {
             name: "Unit".into(),
             params: vec![],
+            writable: false,
             span: Span::dummy(),
         }
     }

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -33,6 +33,15 @@ impl Type {
     }
 
     fn stringify_as(&self, qualifier: Qualifier) -> String {
+        let body = self.stringify_body(qualifier);
+        if self.is_writable() {
+            format!("mut {}", body)
+        } else {
+            body
+        }
+    }
+
+    fn stringify_body(&self, qualifier: Qualifier) -> String {
         match self {
             Type::Nominal {
                 id, params: args, ..
@@ -139,7 +148,7 @@ impl Type {
                 _ => kind.leaf_name().to_string(),
             },
 
-            Type::Compound { kind, args } => {
+            Type::Compound { kind, args, .. } => {
                 let args_formatted = args
                     .iter()
                     .map(|a| a.stringify_as(qualifier))

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -21,9 +21,9 @@ pub type AstBuildResult = parse::ParseResult;
 #[cfg(target_pointer_width = "64")]
 mod size_assertions {
     use std::mem::size_of;
-    const _: () = assert!(size_of::<super::ast::Expression>() == 288);
-    const _: () = assert!(size_of::<super::ast::Pattern>() == 152);
-    const _: () = assert!(size_of::<super::types::Type>() == 40);
+    const _: () = assert!(size_of::<super::ast::Expression>() == 304);
+    const _: () = assert!(size_of::<super::ast::Pattern>() == 160);
+    const _: () = assert!(size_of::<super::types::Type>() == 48);
     const _: () = assert!(size_of::<super::ast::Span>() == 12);
 }
 

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -22,6 +22,10 @@ impl<'source> Parser<'source> {
             return Annotation::Unknown;
         }
 
+        if self.is(Mut) {
+            return self.parse_writable_annotation();
+        }
+
         match self.current_token().kind {
             Function if self.stream.peek_ahead(1).kind == LeftParen => {
                 self.parse_function_annotation()
@@ -72,6 +76,7 @@ impl<'source> Parser<'source> {
                     return Annotation::Constructor {
                         name: "Slice".into(),
                         params: vec![],
+                        writable: false,
                         span: error_span,
                     };
                 }
@@ -80,6 +85,7 @@ impl<'source> Parser<'source> {
                 Annotation::Constructor {
                     name: "".into(),
                     params: vec![],
+                    writable: false,
                     span,
                 }
             }
@@ -97,6 +103,38 @@ impl<'source> Parser<'source> {
         };
         self.next();
         Annotation::Constant { value, text, span }
+    }
+
+    fn parse_writable_annotation(&mut self) -> Annotation {
+        let mut_token = self.current_token();
+        self.next();
+        while self.is(Mut) {
+            self.track_error("duplicate `mut` qualifier", "Write `mut` once.");
+            self.next();
+        }
+        let inner = self.parse_annotation_inner();
+        match inner {
+            Annotation::Constructor {
+                name,
+                params,
+                writable: _,
+                span,
+            } => Annotation::Constructor {
+                name,
+                params,
+                writable: true,
+                span,
+            },
+            other => {
+                self.track_error_at(
+                    Span::new(self.file_id, mut_token.byte_offset, mut_token.byte_length),
+                    "`mut` does not apply to this type",
+                    "Write `mut` on the reference type it protects, as in `mut Slice<int>`. \
+                     A tuple or function type cannot carry it.",
+                );
+                other
+            }
+        }
     }
 
     fn parse_named_annotation(&mut self) -> Annotation {
@@ -130,6 +168,7 @@ impl<'source> Parser<'source> {
             return Annotation::Constructor {
                 name,
                 params: type_params,
+                writable: false,
                 span: self.span_from_offset(start.byte_offset),
             };
         }
@@ -141,6 +180,7 @@ impl<'source> Parser<'source> {
         Annotation::Constructor {
             name,
             params: vec![],
+            writable: false,
             span: self.span_from_offset(start.byte_offset),
         }
     }
@@ -200,6 +240,7 @@ impl<'source> Parser<'source> {
         Annotation::Constructor {
             name,
             params: type_params,
+            writable: false,
             span: self.span_from_offset(start.byte_offset),
         }
     }

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -523,8 +523,8 @@ impl<'source> Parser<'source> {
 
         if self.is(Mut) {
             self.track_error(
-                "fields cannot be marked `mut`",
-                "Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`).",
+                "`mut` goes on the field's type",
+                "Write the permission in the type, as in `items: mut Slice<int>`.",
             );
             self.next();
         }

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -780,7 +780,7 @@ impl<'source> Parser<'source> {
     fn can_start_annotation(&self) -> bool {
         matches!(
             self.current_token().kind,
-            Identifier | Function | LeftParen | Integer
+            Identifier | Function | LeftParen | Integer | Mut
         )
     }
 

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -147,7 +147,7 @@ impl Definition {
             )
     }
 
-    pub fn instantiate_alias_target(&self, params: &[Type]) -> Option<Type> {
+    pub fn instantiate_alias_target(&self, params: &[Type], writable: bool) -> Option<Type> {
         let DefinitionBody::TypeAlias {
             generics,
             alias: AliasKind::Transparent { target, .. },
@@ -156,21 +156,27 @@ impl Definition {
         else {
             return None;
         };
-        Some(substitute(
-            target,
-            &build_substitution_map(generics, params),
-        ))
+        let map = build_substitution_map(generics, params);
+        if writable {
+            Some(substitute(&target.clone().make_writable(), &map))
+        } else {
+            Some(substitute(target, &map))
+        }
     }
 
-    pub fn instantiate_underlying(&self, params: &[Type]) -> Option<Type> {
-        if let Some(target) = self.instantiate_alias_target(params) {
+    pub fn instantiate_underlying(&self, params: &[Type], writable: bool) -> Option<Type> {
+        if let Some(target) = self.instantiate_alias_target(params, writable) {
             return Some(target);
         }
         match &self.body {
             DefinitionBody::Struct {
                 fields: StructFields::Tuple(fields),
                 ..
-            } if self.is_newtype() => Some(fields[0].ty.clone()),
+            } if self.is_newtype() => Some(if writable {
+                fields[0].ty.clone()
+            } else {
+                fields[0].ty.demoted()
+            }),
             _ => None,
         }
     }
@@ -478,7 +484,7 @@ where
         F: Copy + Fn(&str) -> Option<&'d Definition>,
     {
         let resolved = crate::types::peel_alias(interface_ty, lookup);
-        let Type::Nominal { id, params } = &resolved else {
+        let Type::Nominal { id, params, .. } = &resolved else {
             return;
         };
         // `Display` intentionally omits package qualification, so it cannot
@@ -546,7 +552,7 @@ where
 {
     let mut requirements = Vec::new();
     for instance in interface_instances(interface_ty, lookup) {
-        let Type::Nominal { id, params } = instance.ty else {
+        let Type::Nominal { id, params, .. } = instance.ty else {
             continue;
         };
         let Some(Definition {
@@ -688,6 +694,7 @@ mod tests {
         Type::Nominal {
             id: Symbol::from_raw("m.Box"),
             params,
+            writable: false,
         }
     }
 

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -230,9 +230,14 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
     }
     match ty {
         Type::Parameter(name) => map.get(name).cloned().unwrap_or_else(|| ty.clone()),
-        Type::Nominal { id, params } => Type::Nominal {
+        Type::Nominal {
+            id,
+            params,
+            writable,
+        } => Type::Nominal {
             id: id.clone(),
             params: params.iter().map(|p| substitute(p, map)).collect(),
+            writable: *writable,
         },
         Type::Function(f) => f.rebuild(
             f.params
@@ -272,10 +277,15 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
             length: *length,
             element: Box::new(substitute(element, map)),
         },
-        Type::Compound { kind, args } => Type::Compound {
-            kind: *kind,
-            args: args.iter().map(|a| substitute(a, map)).collect(),
-        },
+        Type::Compound {
+            kind,
+            args,
+            writable,
+        } => Type::qualified_compound(
+            *kind,
+            args.iter().map(|a| substitute(a, map)).collect(),
+            *writable,
+        ),
         Type::Simple(_) | Type::Never | Type::ImportNamespace(_) | Type::ReceiverPlaceholder => {
             ty.clone()
         }
@@ -393,11 +403,15 @@ pub enum Type {
     Compound {
         kind: CompoundKind,
         args: Vec<Type>,
+        /// Write permission through this reference hop. Only `Slice`, `Map`,
+        /// and `Ref` can carry it.
+        writable: bool,
     },
 
     Nominal {
         id: Symbol,
         params: Vec<Type>,
+        writable: bool,
     },
 
     /// Package namespace handle. Produced by imports (e.g. `import http "net/http"`
@@ -461,11 +475,18 @@ impl std::fmt::Debug for TypePlaceholder {
 impl std::fmt::Debug for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Type::Nominal { id, params, .. } => f
-                .debug_struct("Nominal")
-                .field("id", id)
-                .field("params", params)
-                .finish(),
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => {
+                let mut s = f.debug_struct("Nominal");
+                s.field("id", id).field("params", params);
+                if *writable {
+                    s.field("writable", writable);
+                }
+                s.finish()
+            }
             Type::Function(f_ty) => {
                 let mut s = f.debug_struct("Function");
                 s.field("params", &f_ty.params)
@@ -508,11 +529,18 @@ impl std::fmt::Debug for Type {
             }
             Type::ReceiverPlaceholder => write!(f, "ReceiverPlaceholder"),
             Type::Simple(kind) => f.debug_tuple("Simple").field(kind).finish(),
-            Type::Compound { kind, args } => f
-                .debug_struct("Compound")
-                .field("kind", kind)
-                .field("args", args)
-                .finish(),
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => {
+                let mut s = f.debug_struct("Compound");
+                s.field("kind", kind).field("args", args);
+                if *writable {
+                    s.field("writable", writable);
+                }
+                s.finish()
+            }
         }
     }
 }
@@ -524,14 +552,14 @@ impl PartialEq for Type {
                 Type::Nominal {
                     id: id1,
                     params: params1,
-                    ..
+                    writable: w1,
                 },
                 Type::Nominal {
                     id: id2,
                     params: params2,
-                    ..
+                    writable: w2,
                 },
-            ) => id1 == id2 && params1 == params2,
+            ) => id1 == id2 && params1 == params2 && w1 == w2,
             (Type::Function(f1), Type::Function(f2)) => f1 == f2,
             (Type::Var { id: id1, .. }, Type::Var { id: id2, .. }) => id1 == id2,
             (Type::Uninferred, Type::Uninferred) | (Type::Ignored, Type::Ignored) => true,
@@ -561,9 +589,18 @@ impl PartialEq for Type {
             (Type::ImportNamespace(m1), Type::ImportNamespace(m2)) => m1 == m2,
             (Type::ReceiverPlaceholder, Type::ReceiverPlaceholder) => true,
             (Type::Simple(k1), Type::Simple(k2)) => k1 == k2,
-            (Type::Compound { kind: k1, args: a1 }, Type::Compound { kind: k2, args: a2 }) => {
-                k1 == k2 && a1 == a2
-            }
+            (
+                Type::Compound {
+                    kind: k1,
+                    args: a1,
+                    writable: w1,
+                },
+                Type::Compound {
+                    kind: k2,
+                    args: a2,
+                    writable: w2,
+                },
+            ) => k1 == k2 && a1 == a2 && w1 == w2,
             _ => false,
         }
     }
@@ -575,7 +612,92 @@ impl Type {
     }
 
     pub fn compound(kind: CompoundKind, args: Vec<Type>) -> Type {
-        Self::Compound { kind, args }
+        Self::qualified_compound(kind, args, false)
+    }
+
+    pub fn qualified_compound(kind: CompoundKind, args: Vec<Type>, writable: bool) -> Type {
+        debug_assert!(
+            !writable || kind.carries_write_permission(),
+            "writable flag is restricted to Slice, Map, and Ref"
+        );
+        let args = if kind.carries_write_permission()
+            && !writable
+            && args.iter().any(Type::contains_write_permission)
+        {
+            args.iter().map(Type::demoted).collect()
+        } else {
+            args
+        };
+        Self::Compound {
+            kind,
+            args,
+            writable,
+        }
+    }
+
+    /// Whether a write permission appears anywhere in this type.
+    fn contains_write_permission(&self) -> bool {
+        match self {
+            Type::Compound { args, writable, .. } => {
+                *writable || args.iter().any(Type::contains_write_permission)
+            }
+            Type::Nominal {
+                params, writable, ..
+            } => *writable || params.iter().any(Type::contains_write_permission),
+            Type::Tuple(elements) => elements.iter().any(Type::contains_write_permission),
+            Type::Array { element, .. } => element.contains_write_permission(),
+            _ => false,
+        }
+    }
+
+    pub fn is_writable(&self) -> bool {
+        matches!(
+            self,
+            Type::Compound { writable: true, .. } | Type::Nominal { writable: true, .. }
+        )
+    }
+
+    pub fn make_writable(self) -> Type {
+        match self {
+            Type::Compound { kind, args, .. } if kind.carries_write_permission() => {
+                Type::qualified_compound(kind, args, true)
+            }
+            Type::Nominal { id, params, .. } => Type::Nominal {
+                id,
+                params,
+                writable: true,
+            },
+            other => other,
+        }
+    }
+
+    pub fn demoted(&self) -> Type {
+        match self {
+            Type::Compound {
+                kind,
+                args,
+                writable: _,
+            } => Type::Compound {
+                kind: *kind,
+                args: args.iter().map(Type::demoted).collect(),
+                writable: false,
+            },
+            Type::Nominal {
+                id,
+                params,
+                writable: _,
+            } => Type::Nominal {
+                id: id.clone(),
+                params: params.iter().map(Type::demoted).collect(),
+                writable: false,
+            },
+            Type::Tuple(elements) => Type::Tuple(elements.iter().map(Type::demoted).collect()),
+            Type::Array { length, element } => Type::Array {
+                length: *length,
+                element: Box::new(element.demoted()),
+            },
+            _ => self.clone(),
+        }
     }
 
     pub fn function(
@@ -667,6 +789,13 @@ pub enum CompoundKind {
 }
 
 impl CompoundKind {
+    pub fn carries_write_permission(self) -> bool {
+        matches!(
+            self,
+            CompoundKind::Slice | CompoundKind::Map | CompoundKind::Ref
+        )
+    }
+
     pub fn leaf_name(self) -> &'static str {
         match self {
             CompoundKind::Ref => "Ref",
@@ -992,7 +1121,7 @@ impl Type {
 
     pub fn as_compound(&self) -> Option<(CompoundKind, &[Type])> {
         match self {
-            Type::Compound { kind, args } => Some((*kind, args.as_slice())),
+            Type::Compound { kind, args, .. } => Some((*kind, args.as_slice())),
             _ => None,
         }
     }
@@ -1238,7 +1367,7 @@ impl Type {
                     element.remove_found_type_names(names);
                 }
             }
-            Type::Compound { kind, args } => {
+            Type::Compound { kind, args, .. } => {
                 names.remove(kind.leaf_name());
                 for arg in args {
                     arg.remove_found_type_names(names);
@@ -1265,7 +1394,7 @@ impl Type {
     pub fn get_name(&self) -> Option<&str> {
         match self {
             Type::Simple(kind) => Some(kind.leaf_name()),
-            Type::Compound { kind, args } => match kind {
+            Type::Compound { kind, args, .. } => match kind {
                 CompoundKind::Ref => args.first().and_then(|inner| inner.get_name()),
                 _ => Some(kind.leaf_name()),
             },
@@ -1373,12 +1502,18 @@ where
 {
     let mut current = ty.unwrap_forall().clone();
     let mut seen: HashSet<Symbol> = HashSet::default();
-    while let Type::Nominal { id, params } = &current {
+    while let Type::Nominal {
+        id,
+        params,
+        writable,
+    } = &current
+    {
+        let writable = *writable;
         if !seen.insert(id.clone()) {
             break;
         }
-        let Some(target) =
-            lookup(id.as_str()).and_then(|definition| definition.instantiate_alias_target(params))
+        let Some(target) = lookup(id.as_str())
+            .and_then(|definition| definition.instantiate_alias_target(params, writable))
         else {
             break;
         };
@@ -1393,10 +1528,15 @@ pub fn underlying_type<'d, F>(ty: &Type, lookup: F) -> Option<Type>
 where
     F: Fn(&str) -> Option<&'d Definition>,
 {
-    let Type::Nominal { id, params } = ty.unwrap_forall() else {
+    let Type::Nominal {
+        id,
+        params,
+        writable,
+    } = ty.unwrap_forall()
+    else {
         return None;
     };
-    lookup(id.as_str())?.instantiate_underlying(params)
+    lookup(id.as_str())?.instantiate_underlying(params, *writable)
 }
 
 /// Follow transparent aliases and newtype fields to their canonical
@@ -1408,12 +1548,18 @@ where
 {
     let mut current = ty.unwrap_forall().clone();
     let mut seen: HashSet<Symbol> = HashSet::default();
-    while let Type::Nominal { id, params } = &current {
+    while let Type::Nominal {
+        id,
+        params,
+        writable,
+    } = &current
+    {
+        let writable = *writable;
         if !seen.insert(id.clone()) {
             break;
         }
-        let Some(underlying) =
-            lookup(id.as_str()).and_then(|definition| definition.instantiate_underlying(params))
+        let Some(underlying) = lookup(id.as_str())
+            .and_then(|definition| definition.instantiate_underlying(params, writable))
         else {
             break;
         };
@@ -1632,12 +1778,14 @@ impl Type {
             Type::Nominal {
                 id: name,
                 params: args,
+                writable,
             } => Type::Nominal {
                 id: name.clone(),
                 params: args
                     .iter()
                     .map(|a| Self::remove_vars_impl(a, vars))
                     .collect(),
+                writable: *writable,
             },
 
             Type::Function(f) => Type::function(
@@ -1675,8 +1823,13 @@ impl Type {
                     .map(|e| Self::remove_vars_impl(e, vars))
                     .collect(),
             ),
-            Type::Compound { kind, args } => Type::Compound {
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => Type::Compound {
                 kind: *kind,
+                writable: *writable,
                 args: args
                     .iter()
                     .map(|a| Self::remove_vars_impl(a, vars))

--- a/tests/_harness/builders.rs
+++ b/tests/_harness/builders.rs
@@ -41,17 +41,11 @@ pub fn unit_type() -> Type {
 }
 
 pub fn slice_type(inner: Type) -> Type {
-    Type::Compound {
-        kind: CompoundKind::Slice,
-        args: vec![inner],
-    }
+    Type::compound(CompoundKind::Slice, vec![inner])
 }
 
 pub fn ref_type(inner: Type) -> Type {
-    Type::Compound {
-        kind: CompoundKind::Ref,
-        args: vec![inner],
-    }
+    Type::compound(CompoundKind::Ref, vec![inner])
 }
 
 pub fn tuple_type(types: Vec<Type>) -> Type {
@@ -69,6 +63,7 @@ pub fn con_type(name: &str, args: Vec<Type>) -> Type {
     Type::Nominal {
         id: format!("_entry_.{}", name).into(),
         params: args,
+        writable: false,
     }
 }
 

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -435,6 +435,7 @@ fn is_slice_with_type_var(ty: &Type) -> bool {
         Type::Compound {
             kind: syntax::types::CompoundKind::Slice,
             args,
+            ..
         } => args.len() == 1 && matches!(args[0], Type::Var { .. }),
         _ => false,
     }
@@ -492,8 +493,8 @@ fn types_equal_with(
     }
 
     match (t1, t2) {
-        (Type::Compound { kind, args }, Type::Nominal { id, params, .. })
-        | (Type::Nominal { id, params, .. }, Type::Compound { kind, args }) => {
+        (Type::Compound { kind, args, .. }, Type::Nominal { id, params, .. })
+        | (Type::Nominal { id, params, .. }, Type::Compound { kind, args, .. }) => {
             let leaf = id.rsplit('.').next().unwrap_or("");
             if kind.leaf_name() == leaf && args.len() == params.len() {
                 return args
@@ -519,6 +520,7 @@ fn types_equal_with(
             Type::Nominal {
                 id: id1,
                 params: args1,
+                ..
             },
             Type::Nominal {
                 id: id2,
@@ -558,7 +560,14 @@ fn types_equal_with(
 
         (Type::Simple(k1), Type::Simple(k2)) => k1 == k2,
 
-        (Type::Compound { kind: k1, args: a1 }, Type::Compound { kind: k2, args: a2 }) => {
+        (
+            Type::Compound {
+                kind: k1, args: a1, ..
+            },
+            Type::Compound {
+                kind: k2, args: a2, ..
+            },
+        ) => {
             k1 == k2
                 && a1.len() == a2.len()
                 && a1

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -74,11 +74,9 @@ fn register_test_builtins(store: &mut Store) {
     let unknown = Type::Nominal {
         id: "prelude.Unknown".into(),
         params: vec![],
+        writable: false,
     };
-    let unknown_map = Type::Compound {
-        kind: CompoundKind::Map,
-        args: vec![string_type(), unknown.clone()],
-    };
+    let unknown_map = Type::compound(CompoundKind::Map, vec![string_type(), unknown.clone()]);
     let unknown_slice = slice_type(unknown.clone());
 
     define("get_unknown", vec![], unknown.clone());

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -2091,3 +2091,15 @@ fn shebang_above_a_file_comment() {
 fn shebang_only() {
     assert_format_snapshot!("#!/usr/bin/env -S lis run");
 }
+
+#[test]
+fn writable_qualifier_types() {
+    assert_format_snapshot!(
+        "struct Batch { items: mut Slice<int>, tags: Slice<string> }\nfn fill(data: mut Slice<int>) -> mut Slice<int> { data }"
+    );
+}
+
+#[test]
+fn writable_qualifier_nested_type_argument() {
+    assert_format_snapshot!("fn rows(data: mut Slice<mut Slice<int>>) -> int { 0 }");
+}

--- a/tests/spec/format/snapshots/writable_qualifier_nested_type_argument.snap
+++ b/tests/spec/format/snapshots/writable_qualifier_nested_type_argument.snap
@@ -1,0 +1,7 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn rows(data: mut Slice<mut Slice<int>>) -> int { 0 }"
+---
+fn rows(data: mut Slice<mut Slice<int>>) -> int {
+  0
+}

--- a/tests/spec/format/snapshots/writable_qualifier_types.snap
+++ b/tests/spec/format/snapshots/writable_qualifier_types.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  struct Batch { items: mut Slice<int>, tags: Slice<string> }
+  fn fill(data: mut Slice<int>) -> mut Slice<int> { data }
+---
+struct Batch { items: mut Slice<int>, tags: Slice<string> }
+
+fn fill(data: mut Slice<int>) -> mut Slice<int> {
+  data
+}

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -837,6 +837,7 @@ fn store_get_definition_domain_style_go_package() {
             ty: syntax::types::Type::Nominal {
                 id: "go:github.com/gorilla/mux.Router".into(),
                 params: vec![],
+                writable: false,
             },
             name_span: Some(syntax::ast::Span::dummy()),
             doc: None,

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -1,4 +1,4 @@
-use crate::assert_parse_snapshot;
+use crate::{assert_parse_error_snapshot, assert_parse_snapshot};
 
 #[test]
 fn array_literal_operand() {
@@ -3728,4 +3728,44 @@ fn parse_raw_string_crlf_normalised() {
 fn parse_pattern_string_multiline() {
     let input = "fn test() { match s { \"a\nb\" => 1, _ => 0 } }";
     assert_parse_snapshot!(input);
+}
+
+#[test]
+fn writable_qualifier_positions() {
+    let input = r#"
+struct Batch { items: mut Slice<int>, tags: Slice<string> }
+fn fill(data: mut Slice<int>) -> mut Slice<int> { data }
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn writable_qualifier_nested_type_argument() {
+    let input = r#"
+fn rows(data: mut Slice<mut Slice<int>>) -> int { 0 }
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn writable_qualifier_enum_payload() {
+    let input = r#"
+enum Holder { Tags(mut Slice<string>), None }
+"#;
+    assert_parse_snapshot!(input);
+}
+
+#[test]
+fn writable_qualifier_duplicate_mut_error() {
+    assert_parse_error_snapshot!("fn f(x: mut mut Slice<int>) -> int { 0 }");
+}
+
+#[test]
+fn writable_qualifier_on_tuple_error() {
+    assert_parse_error_snapshot!("fn f(x: mut (int, string)) -> int { 0 }");
+}
+
+#[test]
+fn struct_field_name_position_mut_error() {
+    assert_parse_error_snapshot!("struct S { mut items: Slice<int> }");
 }

--- a/tests/spec/parse/snapshots/struct_field_name_position_mut_error.snap
+++ b/tests/spec/parse/snapshots/struct_field_name_position_mut_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/parse/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:1:12]
+ 1 │ struct S { mut items: Slice<int> }
+   ·            ─┬─
+   ·             ╰── `mut` goes on the field's type
+   ╰────
+  help: Write the permission in the type, as in `items: mut Slice<int>` · code: [parse.syntax_error]

--- a/tests/spec/parse/snapshots/writable_qualifier_duplicate_mut_error.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_duplicate_mut_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/parse/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:1:13]
+ 1 │ fn f(x: mut mut Slice<int>) -> int { 0 }
+   ·             ─┬─
+   ·              ╰── duplicate `mut` qualifier
+   ╰────
+  help: Write `mut` once · code: [parse.syntax_error]

--- a/tests/spec/parse/snapshots/writable_qualifier_enum_payload.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_enum_payload.snap
@@ -1,0 +1,81 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  enum Holder { Tags(mut Slice<string>), None }
+---
+[
+    Enum {
+        doc: None,
+        attributes: [],
+        name: "Holder",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 6,
+            byte_length: 6,
+        },
+        generics: [],
+        variants: [
+            EnumVariant {
+                doc: None,
+                name: "Tags",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 15,
+                    byte_length: 4,
+                },
+                fields: Tuple(
+                    [
+                        EnumFieldDefinition {
+                            name: "field0",
+                            name_span: Span {
+                                file_id: 4294967295,
+                                byte_offset: 0,
+                                byte_length: 0,
+                            },
+                            annotation: Constructor {
+                                name: "Slice",
+                                params: [
+                                    Constructor {
+                                        name: "string",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 30,
+                                            byte_length: 6,
+                                        },
+                                    },
+                                ],
+                                writable: true,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 13,
+                                },
+                            },
+                            ty: Var {
+                                id: uninferred,
+                            },
+                        },
+                    ],
+                ),
+            },
+            EnumVariant {
+                doc: None,
+                name: "None",
+                name_span: Span {
+                    file_id: 0,
+                    byte_offset: 40,
+                    byte_length: 4,
+                },
+                fields: Unit,
+            },
+        ],
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 45,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/writable_qualifier_nested_type_argument.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_nested_type_argument.snap
@@ -1,0 +1,116 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  fn rows(data: mut Slice<mut Slice<int>>) -> int { 0 }
+---
+[
+    Function {
+        doc: None,
+        attributes: [],
+        name: "rows",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 4,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "data",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 9,
+                        byte_length: 4,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "Slice",
+                        params: [
+                            Constructor {
+                                name: "Slice",
+                                params: [
+                                    Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 35,
+                                            byte_length: 3,
+                                        },
+                                    },
+                                ],
+                                writable: true,
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 29,
+                                    byte_length: 10,
+                                },
+                            },
+                        ],
+                        writable: true,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 19,
+                            byte_length: 21,
+                        },
+                    },
+                ),
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+        ],
+        return_annotation: Constructor {
+            name: "int",
+            params: [],
+            span: Span {
+                file_id: 0,
+                byte_offset: 45,
+                byte_length: 3,
+            },
+        },
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Definition(
+            Block {
+                items: [
+                    Literal {
+                        literal: Integer {
+                            value: 0,
+                            text: None,
+                        },
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 51,
+                            byte_length: 1,
+                        },
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 49,
+                    byte_length: 5,
+                },
+            },
+        ),
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 53,
+        },
+    },
+]

--- a/tests/spec/parse/snapshots/writable_qualifier_on_tuple_error.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_on_tuple_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/spec/parse/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:1:9]
+ 1 │ fn f(x: mut (int, string)) -> int { 0 }
+   ·         ─┬─
+   ·          ╰── `mut` does not apply to this type
+   ╰────
+  help: Write `mut` on the reference type it protects, as in `mut Slice<int>`. A tuple or function type cannot carry it · code: [parse.syntax_error]

--- a/tests/spec/parse/snapshots/writable_qualifier_positions.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_positions.snap
@@ -1,0 +1,207 @@
+---
+source: tests/spec/parse/mod.rs
+description: |
+  
+  struct Batch { items: mut Slice<int>, tags: Slice<string> }
+  fn fill(data: mut Slice<int>) -> mut Slice<int> { data }
+---
+[
+    Struct {
+        doc: None,
+        attributes: [],
+        name: "Batch",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 8,
+            byte_length: 5,
+        },
+        generics: [],
+        fields: Record(
+            [
+                StructFieldDefinition {
+                    doc: None,
+                    name: "items",
+                    name_span: Span {
+                        file_id: 0,
+                        byte_offset: 16,
+                        byte_length: 5,
+                    },
+                    annotation: Constructor {
+                        name: "Slice",
+                        params: [
+                            Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 33,
+                                    byte_length: 3,
+                                },
+                            },
+                        ],
+                        writable: true,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 27,
+                            byte_length: 10,
+                        },
+                    },
+                    visibility: Private,
+                    ty: Var {
+                        id: uninferred,
+                    },
+                    kind: Named {
+                        attributes: [],
+                    },
+                },
+                StructFieldDefinition {
+                    doc: None,
+                    name: "tags",
+                    name_span: Span {
+                        file_id: 0,
+                        byte_offset: 39,
+                        byte_length: 4,
+                    },
+                    annotation: Constructor {
+                        name: "Slice",
+                        params: [
+                            Constructor {
+                                name: "string",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 51,
+                                    byte_length: 6,
+                                },
+                            },
+                        ],
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 45,
+                            byte_length: 13,
+                        },
+                    },
+                    visibility: Private,
+                    ty: Var {
+                        id: uninferred,
+                    },
+                    kind: Named {
+                        attributes: [],
+                    },
+                },
+            ],
+        ),
+        visibility: Private,
+        span: Span {
+            file_id: 0,
+            byte_offset: 1,
+            byte_length: 59,
+        },
+    },
+    Function {
+        doc: None,
+        attributes: [],
+        name: "fill",
+        name_span: Span {
+            file_id: 0,
+            byte_offset: 64,
+            byte_length: 4,
+        },
+        generics: [],
+        params: [
+            Binding {
+                pattern: Identifier {
+                    identifier: "data",
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 69,
+                        byte_length: 4,
+                    },
+                },
+                annotation: Some(
+                    Constructor {
+                        name: "Slice",
+                        params: [
+                            Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 85,
+                                    byte_length: 3,
+                                },
+                            },
+                        ],
+                        writable: true,
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 79,
+                            byte_length: 10,
+                        },
+                    },
+                ),
+                ty: Var {
+                    id: uninferred,
+                },
+            },
+        ],
+        return_annotation: Constructor {
+            name: "Slice",
+            params: [
+                Constructor {
+                    name: "int",
+                    params: [],
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 104,
+                        byte_length: 3,
+                    },
+                },
+            ],
+            writable: true,
+            span: Span {
+                file_id: 0,
+                byte_offset: 98,
+                byte_length: 10,
+            },
+        },
+        return_type: Var {
+            id: uninferred,
+        },
+        visibility: Private,
+        body: Definition(
+            Block {
+                items: [
+                    Identifier {
+                        value: "data",
+                        ty: Var {
+                            id: uninferred,
+                        },
+                        span: Span {
+                            file_id: 0,
+                            byte_offset: 111,
+                            byte_length: 4,
+                        },
+                        resolution: Unresolved,
+                    },
+                ],
+                ty: Var {
+                    id: uninferred,
+                },
+                span: Span {
+                    file_id: 0,
+                    byte_offset: 109,
+                    byte_length: 8,
+                },
+            },
+        ),
+        ty: Var {
+            id: uninferred,
+        },
+        span: Span {
+            file_id: 0,
+            byte_offset: 61,
+            byte_length: 56,
+        },
+    },
+]

--- a/tests/spec/representation.rs
+++ b/tests/spec/representation.rs
@@ -303,14 +303,17 @@ fn native_type_classification_uses_the_canonical_type_variant() {
     let merely_named_like_native = Type::Nominal {
         id: Symbol::from_parts("example", "Slice"),
         params: vec![Type::int()],
+        writable: false,
     };
     let noncanonical_prelude_name = Type::Nominal {
         id: Symbol::from_parts("prelude", "Slice"),
         params: vec![Type::int()],
+        writable: false,
     };
     let merely_named_like_simple = Type::Nominal {
         id: Symbol::from_parts("example", "int"),
         params: vec![],
+        writable: false,
     };
 
     assert_eq!(
@@ -486,7 +489,7 @@ fn identity(value: UserId) -> UserId { value }
 
     for ty in [&parameter.ty, function_ty.return_type.as_ref()] {
         assert!(
-            matches!(ty, Type::Nominal { id, params } if id.last_segment() == "UserId" && params.is_empty()),
+            matches!(ty, Type::Nominal { id, params, .. } if id.last_segment() == "UserId" && params.is_empty()),
             "transparent alias identity was lost: {ty:?}"
         );
     }
@@ -542,4 +545,106 @@ fn recursion_depth_is_scoped_to_each_top_level_item() {
 
     assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
     assert_eq!(parsed.ast.len(), 80);
+}
+
+#[test]
+fn writable_flag_participates_in_type_identity() {
+    let plain = Type::compound(CompoundKind::Slice, vec![Type::int()]);
+    let writable = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+    assert_ne!(plain, writable);
+    assert_eq!(plain, writable.demoted());
+    assert!(writable.is_writable());
+    assert!(!plain.is_writable());
+}
+
+#[test]
+fn qualified_compound_demotes_beneath_a_read_only_hop() {
+    let inner = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+    let outer = Type::qualified_compound(CompoundKind::Slice, vec![inner.clone()], false);
+    let Type::Compound { args, writable, .. } = &outer else {
+        panic!("expected a compound type");
+    };
+    assert!(!writable);
+    assert_eq!(args[0], inner.demoted());
+
+    let kept = Type::qualified_compound(CompoundKind::Slice, vec![inner.clone()], true);
+    let Type::Compound { args, .. } = &kept else {
+        panic!("expected a compound type");
+    };
+    assert_eq!(args[0], inner);
+}
+
+#[test]
+fn writable_type_renders_with_the_qualifier() {
+    let writable = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+    assert_eq!(writable.to_string(), "mut Slice<int>");
+    assert_eq!(writable.demoted().to_string(), "Slice<int>");
+}
+
+#[test]
+fn substitution_restores_canonical_form() {
+    let writable_slice = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+    let map: SubstitutionMap = [("T".into(), writable_slice.clone())].into_iter().collect();
+
+    let through_plain = substitute(
+        &Type::compound(CompoundKind::Slice, vec![Type::Parameter("T".into())]),
+        &map,
+    );
+    assert_eq!(
+        through_plain,
+        Type::compound(CompoundKind::Slice, vec![writable_slice.demoted()]),
+    );
+
+    let through_writable = substitute(
+        &Type::qualified_compound(CompoundKind::Slice, vec![Type::Parameter("T".into())], true),
+        &map,
+    );
+    assert_eq!(
+        through_writable,
+        Type::qualified_compound(CompoundKind::Slice, vec![writable_slice], true),
+    );
+}
+
+#[test]
+fn nested_writable_annotation_survives_template_substitution() {
+    let result = infer(
+        r#"
+fn rows(data: mut Slice<mut Slice<int>>) -> int { 0 }
+"#,
+    )
+    .assert_no_errors();
+
+    let function_ty = result
+        .ast
+        .iter()
+        .find_map(|expression| match expression {
+            Expression::Function { name, ty, .. } if name == "rows" => ty.as_function_type(),
+            _ => None,
+        })
+        .expect("expected rows's function type");
+    let [parameter] = function_ty.params.as_slice() else {
+        panic!("expected one parameter");
+    };
+
+    let inner = Type::qualified_compound(CompoundKind::Slice, vec![Type::int()], true);
+    let expected = Type::qualified_compound(CompoundKind::Slice, vec![inner], true);
+    assert_eq!(parameter.ty, expected);
+}
+
+#[test]
+fn writable_constructor_span_starts_at_the_type_name() {
+    let source = "fn f(x: mut Slice<int>) -> int { 0 }";
+    let lexed = Lexer::new(source, 0).lex();
+    let parsed = Parser::new(lexed.tokens, source).parse();
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+
+    let Expression::Function { params, .. } = &parsed.ast[0] else {
+        panic!("expected a function");
+    };
+    let annotation = params[0].annotation.as_ref().expect("expected annotation");
+    let Annotation::Constructor { span, .. } = annotation else {
+        panic!("expected a constructor annotation");
+    };
+    let name_offset = source.find("Slice").unwrap() as u32;
+    assert_eq!(span.byte_offset, name_offset);
 }

--- a/tests/ui/errors/snapshots/parse_struct_field_mut.snap
+++ b/tests/ui/errors/snapshots/parse_struct_field_mut.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ struct Foo {
  3 │   mut diffs: Slice<string>,
    ·   ─┬─
-   ·    ╰── fields cannot be marked `mut`
+   ·    ╰── `mut` goes on the field's type
  4 │ }
    ╰────
-  help: Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`) · code: [parse.syntax_error]
+  help: Write the permission in the type, as in `items: mut Slice<int>` · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_struct_field_pub_mut.snap
+++ b/tests/ui/errors/snapshots/parse_struct_field_pub_mut.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  2 │ struct Foo {
  3 │   pub mut diffs: Slice<string>,
    ·       ─┬─
-   ·        ╰── fields cannot be marked `mut`
+   ·        ╰── `mut` goes on the field's type
  4 │ }
    ╰────
-  help: Fields cannot be marked `mut`; mutability applies to bindings (`let mut x = ...`) · code: [parse.syntax_error]
+  help: Write the permission in the type, as in `items: mut Slice<int>` · code: [parse.syntax_error]


### PR DESCRIPTION
Adds `mut` as a type qualifier, so write permission can be attached to a type.

```rs
struct Index {
  counts: mut Map<string, int>,
  tags: Slice<string>,
}

fn fill(data: mut Slice<byte>) -> mut Slice<byte> { ... }
```

Nothing checks the qualifier yet. This is groundwork for upcoming semantics changes.
