### PR TITLE
refactor: emit guarded matches as a `switch` without a jump target

### DIFF
--- a/crates/emit/src/analyze/inline_uses.rs
+++ b/crates/emit/src/analyze/inline_uses.rs
@@ -1,4 +1,4 @@
-use syntax::ast::{Expression, SelectArm};
+use syntax::ast::{Expression, FormatStringPart, Literal, SelectArm};
 
 use crate::patterns::binding_decls::pattern_binds_name;
 
@@ -141,8 +141,17 @@ impl<'a> Walker<'a> {
                     self.record_use(ctx);
                 }
             }
-            Expression::Literal { .. }
-            | Expression::Unit { .. }
+            Expression::Literal { literal, .. } => {
+                if let Literal::FormatString(parts) = literal {
+                    for part in parts {
+                        if let FormatStringPart::Expression(expression) = part {
+                            self.walk(expression, ctx);
+                        }
+                    }
+                    self.barriers_seen += 1;
+                }
+            }
+            Expression::Unit { .. }
             | Expression::Break { value: None, .. }
             | Expression::Continue { .. } => {}
 

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1,7 +1,8 @@
-use syntax::ast::{Expression, MatchArm};
+use syntax::ast::{BinaryOperator, Expression, Literal, MatchArm, UnaryOperator};
 use syntax::types::Type;
 
 use crate::Planner;
+use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::{is_catchall_pattern, is_unconditional_catchall};
 use crate::patterns::binding_emit::{drop_inline_overlays, tree_binding_statements};
@@ -15,7 +16,70 @@ use crate::plan::bodies::{
     SwitchCasePlan, SwitchKind, SwitchStatementPlan,
 };
 use crate::plan::placement::unreachable_panic_if_needed;
+use crate::state::bindings::{BindingValue, InlineExpr};
 use crate::utils::wrap_if_struct_literal;
+
+struct FlatCase<'d> {
+    conditions: Vec<String>,
+    bindings: &'d [PatternBinding],
+    decision: &'d Decision,
+}
+
+fn decision_arm_index(decision: &Decision) -> usize {
+    match decision {
+        Decision::Success { arm_index, .. } | Decision::Guard { arm_index, .. } => *arm_index,
+        _ => unreachable!("a flattened case body lowers from an arm leaf"),
+    }
+}
+
+fn binds_looser_than_conjunction(guard: &Expression) -> bool {
+    matches!(
+        guard,
+        Expression::Binary {
+            operator: BinaryOperator::Or,
+            ..
+        }
+    )
+}
+
+fn guard_renders_inline(guard: &Expression) -> bool {
+    match guard {
+        Expression::Literal { literal, ty, .. } => {
+            matches!(
+                literal,
+                Literal::Integer { .. }
+                    | Literal::Float { .. }
+                    | Literal::Imaginary(_)
+                    | Literal::Boolean(_)
+                    | Literal::String { .. }
+                    | Literal::Char(_)
+            ) && ty.as_simple().is_some()
+        }
+        Expression::Identifier { ty, .. } => ty.as_simple().is_some(),
+        Expression::Paren { expression, .. } => guard_renders_inline(expression),
+        Expression::Unary {
+            operator,
+            expression,
+            ..
+        } => {
+            matches!(
+                operator,
+                UnaryOperator::Not | UnaryOperator::Negative | UnaryOperator::BitwiseNot
+            ) && guard_renders_inline(expression)
+        }
+        Expression::Binary {
+            left,
+            operator,
+            right,
+            ..
+        } => {
+            !matches!(operator, BinaryOperator::Pipeline)
+                && guard_renders_inline(left)
+                && guard_renders_inline(right)
+        }
+        _ => false,
+    }
+}
 
 #[derive(Clone, Copy)]
 struct ChainGroup<'a> {
@@ -320,6 +384,12 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             return;
         }
 
+        if self.guarded_tree_flattens(tree)
+            && self.render_conditional_switch(statements, tree, place)
+        {
+            return;
+        }
+
         // Wrap the tree in a labeled `for { ... }` retry loop.
         let label = self.planner.fresh_var(Some("match"));
         let ctx = WalkCtx::retry_loop(place, Some(label.as_str()));
@@ -336,6 +406,258 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             header: "for {\n".to_string(),
             body: LoweredBlock { statements: body },
         }));
+    }
+
+    fn guarded_tree_flattens(&self, tree: &Decision) -> bool {
+        match tree {
+            Decision::Success { .. } | Decision::Unreachable => true,
+            Decision::Guard {
+                arm_index,
+                bindings,
+                success,
+                failure,
+            } => {
+                self.arms[*arm_index]
+                    .guard
+                    .as_deref()
+                    .is_some_and(guard_renders_inline)
+                    && bindings
+                        .iter()
+                        .all(|binding| !binding.path.contains_deferred_evaluation())
+                    && self.guarded_tree_flattens(success)
+                    && self.guarded_tree_flattens(failure)
+            }
+            Decision::Chain { tests, fallback } => {
+                tests
+                    .iter()
+                    .all(|test| self.guarded_tree_flattens(&test.decision))
+                    && self.guarded_tree_flattens(fallback)
+            }
+            Decision::Switch {
+                shape: SwitchShape::TypeSwitch,
+                ..
+            } => false,
+            Decision::Switch {
+                branches, fallback, ..
+            } => {
+                branches
+                    .iter()
+                    .all(|branch| self.guarded_tree_flattens(&branch.decision))
+                    && fallback
+                        .as_deref()
+                        .is_none_or(|fallback| self.guarded_tree_flattens(fallback))
+            }
+        }
+    }
+
+    fn render_conditional_switch(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        tree: &Decision,
+        place: &PlacePlan,
+    ) -> bool {
+        let mut collected: Vec<FlatCase> = Vec::new();
+        if !self.collect_flat_cases(tree, &mut Vec::new(), &mut collected, true) {
+            return false;
+        }
+        let default_at = collected.iter().position(|case| case.conditions.is_empty());
+        let default_case = default_at.map(|at| collected.split_off(at).remove(0));
+        let has_default = default_case.is_some();
+
+        let cases = collected
+            .into_iter()
+            .map(|case| SwitchCasePlan {
+                labels: case.conditions.join(" && "),
+                body: self.lower_flat_case_body(&case, place),
+            })
+            .collect::<Vec<_>>();
+        let default = default_case
+            .map(|case| self.lower_flat_case_body(&case, place))
+            .filter(|body| !body.renders_empty());
+
+        if cases.is_empty() {
+            if let Some(body) = default {
+                statements.extend(body.statements);
+            }
+            return true;
+        }
+
+        let postlude = switch_postlude(place, has_default);
+        statements.push(LoweredStatement::Switch(SwitchStatementPlan {
+            kind: SwitchKind::Conditional,
+            cases,
+            default,
+            postlude,
+        }));
+        true
+    }
+
+    fn collect_flat_cases<'d>(
+        &mut self,
+        decision: &'d Decision,
+        conditions: &mut Vec<String>,
+        out: &mut Vec<FlatCase<'d>>,
+        tail: bool,
+    ) -> bool {
+        match decision {
+            Decision::Unreachable => true,
+            Decision::Success { .. } => {
+                out.push(FlatCase {
+                    conditions: conditions.clone(),
+                    bindings: &[],
+                    decision,
+                });
+                true
+            }
+            Decision::Guard {
+                arm_index,
+                bindings,
+                success,
+                failure,
+            } => {
+                let Some(condition) = self.guard_condition_over_paths(*arm_index, bindings) else {
+                    return false;
+                };
+                conditions.push(condition);
+                out.push(FlatCase {
+                    conditions: conditions.clone(),
+                    bindings,
+                    decision: success,
+                });
+                conditions.pop();
+                if !tail {
+                    return true;
+                }
+                self.collect_flat_cases(failure, conditions, out, tail)
+            }
+            Decision::Chain { tests, fallback } => {
+                let (cased, lifted) = split_chain_with_catchall_lift(tests, fallback);
+                for test in cased {
+                    if test.checks.is_empty() {
+                        if !self.collect_flat_cases(&test.decision, conditions, out, false) {
+                            return false;
+                        }
+                        continue;
+                    }
+                    self.planner.scope.record_go_use(&self.subject);
+                    conditions.push(render_condition(&test.checks, &self.subject));
+                    let flattened = self.collect_flat_cases(&test.decision, conditions, out, false);
+                    conditions.pop();
+                    if !flattened {
+                        return false;
+                    }
+                }
+                match lifted {
+                    Some(lifted) => self.collect_flat_cases(lifted, conditions, out, tail),
+                    None => self.collect_flat_cases(fallback, conditions, out, tail),
+                }
+            }
+            Decision::Switch {
+                path,
+                kind,
+                shape,
+                branches,
+                fallback,
+            } => {
+                let rendered_path = path.render(&self.subject);
+                let (cased, lifted) = split_with_default_lift(branches, fallback.as_deref());
+                for branch in cased {
+                    self.planner.scope.record_go_use(&self.subject);
+                    conditions.push(switch_branch_condition(
+                        &rendered_path,
+                        kind,
+                        shape,
+                        &branch.case_label,
+                    ));
+                    let flattened =
+                        self.collect_flat_cases(&branch.decision, conditions, out, false);
+                    conditions.pop();
+                    if !flattened {
+                        return false;
+                    }
+                }
+                match lifted {
+                    Some(lifted) => self.collect_flat_cases(lifted, conditions, out, tail),
+                    None => true,
+                }
+            }
+        }
+    }
+
+    fn guard_condition_over_paths(
+        &mut self,
+        arm_index: usize,
+        bindings: &[PatternBinding],
+    ) -> Option<String> {
+        let overlays = self.install_path_overlays(bindings);
+        let lowered = self.lower_guard_condition(arm_index);
+        drop_inline_overlays(self.planner, &overlays);
+        let (setup, condition) = lowered?;
+        if !setup.is_empty() {
+            return None;
+        }
+        let guard = self.arms[arm_index]
+            .guard
+            .as_deref()
+            .expect("a Guard decision has a guard expression");
+        Some(if binds_looser_than_conjunction(guard) {
+            format!("({condition})")
+        } else {
+            condition
+        })
+    }
+
+    fn install_path_overlays(
+        &mut self,
+        bindings: &[PatternBinding],
+    ) -> Vec<(String, Option<BindingValue>)> {
+        let mut overlays = Vec::with_capacity(bindings.len());
+        for binding in bindings {
+            if binding.go_name.is_none() {
+                continue;
+            }
+            let previous = self
+                .planner
+                .scope
+                .resolve_identifier_binding(&binding.lisette_name)
+                .cloned();
+            let text = binding.path.render_composable(&self.subject);
+            self.planner.scope.bind_inline_expr(
+                &binding.lisette_name,
+                InlineExpr::new(
+                    text,
+                    vec![self.subject.clone()],
+                    binding.path.contains_deferred_evaluation(),
+                ),
+            );
+            overlays.push((binding.lisette_name.clone(), previous));
+        }
+        overlays
+    }
+
+    fn lower_flat_case_body(&mut self, case: &FlatCase, place: &PlacePlan) -> LoweredBlock {
+        let ctx = WalkCtx::switch_case(place);
+        self.with_scope(|this| {
+            let mut body: Vec<LoweredStatement> = Vec::new();
+            if case.bindings.is_empty() {
+                this.walk(&mut body, case.decision, &ctx);
+                return LoweredBlock { statements: body };
+            }
+            let arm_body = &*this.arms[decision_arm_index(case.decision)].expression;
+            let bindings: Vec<PatternBinding> = case
+                .bindings
+                .iter()
+                .filter(|binding| {
+                    analyze_inline_candidate(&binding.lisette_name, &[arm_body])
+                        != InlineDecision::Unused
+                })
+                .cloned()
+                .collect();
+            this.with_bindings(&mut body, &bindings, &[arm_body], None, |this, body| {
+                this.walk(body, case.decision, &ctx);
+            });
+            LoweredBlock { statements: body }
+        })
     }
 
     fn walk(&mut self, statements: &mut Vec<LoweredStatement>, decision: &Decision, ctx: &WalkCtx) {
@@ -964,6 +1286,21 @@ fn chain_last_is_catchall(tests: &[ChainTest], fallback: &Decision) -> bool {
     matches!(fallback, Decision::Unreachable) && tests.len() > 1
 }
 
+fn split_chain_with_catchall_lift<'t>(
+    tests: &'t [ChainTest],
+    fallback: &Decision,
+) -> (&'t [ChainTest], Option<&'t Decision>) {
+    if !chain_last_is_catchall(tests, fallback) {
+        return (tests, None);
+    }
+    match tests.split_last() {
+        Some((last, rest)) if !matches!(last.decision, Decision::Guard { .. }) => {
+            (rest, Some(&last.decision))
+        }
+        _ => (tests, None),
+    }
+}
+
 fn split_with_default_lift<'t>(
     branches: &'t [SwitchBranch],
     fallback: Option<&'t Decision>,
@@ -972,6 +1309,22 @@ fn split_with_default_lift<'t>(
         (None, Some((last, rest))) => (rest, Some(&last.decision)),
         _ => (branches, fallback),
     }
+}
+
+fn switch_branch_condition(
+    rendered_path: &str,
+    kind: &PatternSwitchKind,
+    shape: &SwitchShape,
+    case_label: &str,
+) -> String {
+    if matches!(shape, SwitchShape::Bool) && case_label == "true" {
+        return wrap_if_struct_literal(rendered_path.to_string());
+    }
+    format!(
+        "{} == {}",
+        render_switch_expression(rendered_path, kind),
+        case_label
+    )
 }
 
 fn render_switch_expression(rendered_path: &str, kind: &PatternSwitchKind) -> String {

--- a/crates/emit/src/plan/bodies.rs
+++ b/crates/emit/src/plan/bodies.rs
@@ -293,8 +293,11 @@ pub(crate) struct SwitchStatementPlan {
 }
 
 pub(crate) enum SwitchKind {
+    Conditional,
     /// `switch <subject> {`
-    Value { subject: String },
+    Value {
+        subject: String,
+    },
     /// `switch <binding> := <subject>.(type) {` when `binding` is set,
     /// otherwise `switch <subject>.(type) {`.
     Type {

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -65,6 +65,7 @@ impl Renderer {
     /// `case`/`default:` plus body, the closing brace, and any postlude.
     fn render_switch(&self, output: &mut String, plan: &SwitchStatementPlan) {
         match &plan.kind {
+            SwitchKind::Conditional => output.push_str("switch {\n"),
             SwitchKind::Value { subject } => write_line!(output, "switch {} {{", subject),
             SwitchKind::Type {
                 subject,

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -917,6 +917,103 @@ fn main() {
 }
 
 #[test]
+fn run_guarded_match_picks_the_first_arm_whose_guard_holds() {
+    if !go_available() {
+        eprintln!(
+            "skipping run_guarded_match_picks_the_first_arm_whose_guard_holds: `go` not found"
+        );
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"guardarms\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+fn classify(r: Result<int, string>) -> string {
+  let mut out = ""
+  match r {
+    Ok(n) if n > 10 => { out = f"big {n}" },
+    Ok(n) if n > 0 => { out = f"small {n}" },
+    Ok(n) => { out = f"zero {n}" },
+    Err(e) => { out = f"err {e}" },
+  }
+  out
+}
+
+fn first_negative(items: Slice<int>) -> int {
+  let mut found = 0
+  for item in items {
+    match item {
+      n if n < 0 => { found = n; break },
+      _ => (),
+    }
+  }
+  found
+}
+
+fn either(opt: Option<int>, flag: bool) -> int {
+  let mut out = 0
+  match opt {
+    Some(n) if n > 10 || flag => { out = 1 },
+    Some(_) => { out = 2 },
+    None => { out = 3 },
+  }
+  out
+}
+
+fn skip_negatives(items: Slice<int>) -> int {
+  let mut sum = 0
+  for item in items {
+    match item {
+      n if n > 0 => { sum = sum + n },
+      _ => { continue },
+    }
+  }
+  sum
+}
+
+fn main() {
+  fmt.Println(classify(Ok(42)))
+  fmt.Println(classify(Ok(5)))
+  fmt.Println(classify(Ok(0)))
+  fmt.Println(classify(Err("bad")))
+  fmt.Println(first_negative([3, 1, -7, -2]))
+  fmt.Println(skip_negatives([3, -1, 4]))
+  fmt.Println(either(None, true))
+  fmt.Println(either(Some(20), false))
+  fmt.Println(either(Some(1), false))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "big 42\nsmall 5\nzero 0\nerr bad\n-7\n7\n3\n1\n2",
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn run_equality_matching_parametrized_interface_bound_builds() {
     if !go_available() {
         eprintln!(

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -1510,6 +1510,90 @@ fn test(opt: Option<int>) -> int {
 }
 
 #[test]
+fn format_string_guard_keeps_the_jump_target() {
+    let input = r#"
+fn label(n: int) -> Result<string, string> { Ok("x") }
+
+fn test(opt: Option<int>) -> Result<int, string> {
+  let mut out = 0
+  match opt {
+    Some(x) if f"v{label(x)?}" == "vx" => { out = 1 },
+    Some(_) => { out = 2 },
+    None => { out = 3 },
+  }
+  Ok(out)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn flattened_disjunctive_guard_groups_against_the_pattern_test() {
+    let input = r#"
+fn test(opt: Option<int>, flag: bool) -> int {
+  let mut out = 0
+  match opt {
+    Some(x) if x > 10 || flag => { out = 1 },
+    Some(_) => { out = 2 },
+    None => { out = 3 },
+  }
+  out
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn flattened_guard_binding_shadowed_by_the_arm_body_is_dropped() {
+    let input = r#"
+import "go:fmt"
+
+fn test(opt: Option<int>) {
+  match opt {
+    Some(x) if x > 0 => { let x = 5; fmt.Println(x) },
+    _ => (),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn flattened_guard_binds_only_what_the_arm_body_reads() {
+    let input = r#"
+import "go:fmt"
+
+fn test(opt: Option<int>) {
+  match opt {
+    Some(a) if a > 10 => fmt.Println("big"),
+    Some(b) if b > 0 => fmt.Print(f"small: {b}\n"),
+    Some(c) => fmt.Println(c),
+    None => fmt.Println("none"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn guard_needing_statement_lowering_keeps_the_jump_target() {
+    let input = r#"
+fn check(n: int) -> Result<bool, string> { Ok(n > 0) }
+
+fn test(opt: Option<int>) -> Result<int, string> {
+  let mut out = 0
+  match opt {
+    Some(x) if check(x)? => { out = 1 },
+    Some(_) => { out = 2 },
+    None => { out = 0 },
+  }
+  Ok(out)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn match_guard_with_binding() {
     let input = r#"
 fn test(opt: Option<int>) -> int {

--- a/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/break_in_guarded_match_in_loop.snap
@@ -19,18 +19,10 @@ func findFirstNegative(items []int) int {
 	result := 0
 loop_1:
 	for _, item := range items {
-	match_1:
-		for {
-			{
-				n := item
-				if n < 0 {
-					result = n
-					break loop_1
-				}
-			}
-			{
-				break match_1
-			}
+		switch {
+		case item < 0:
+			result = item
+			break loop_1
 		}
 	}
 	return result

--- a/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
+++ b/tests/spec/emit/snapshots/continue_in_guarded_match_in_loop.snap
@@ -17,20 +17,12 @@ package main
 
 func sumPositives(items []int) int {
 	sum := 0
-loop_1:
 	for _, item := range items {
-	match_1:
-		for {
-			{
-				n := item
-				if n > 0 {
-					sum += n
-					break match_1
-				}
-			}
-			{
-				continue loop_1
-			}
+		switch {
+		case item > 0:
+			sum += item
+		default:
+			continue
 		}
 	}
 	return sum

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -49,11 +49,9 @@ type ASTNode struct {
 func visit(node ASTNode) string {
 	switch node.Tag {
 	case ASTNodeNumber:
-		n := node.Number
-		return fmt.Sprintf("number:%d", n)
+		return fmt.Sprintf("number:%d", node.Number)
 	case ASTNodeString:
-		s := node.ASTNodeString_
-		return fmt.Sprintf("string:%s", s)
+		return fmt.Sprintf("string:%s", node.ASTNodeString_)
 	default:
 		return "null"
 	}

--- a/tests/spec/emit/snapshots/flattened_disjunctive_guard_groups_against_the_pattern_test.snap
+++ b/tests/spec/emit/snapshots/flattened_disjunctive_guard_groups_against_the_pattern_test.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(opt: Option<int>, flag: bool) -> int {
+    let mut out = 0
+    match opt {
+      Some(x) if x > 10 || flag => { out = 1 },
+      Some(_) => { out = 2 },
+      None => { out = 3 },
+    }
+    out
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(opt lisette.Option[int], flag bool) int {
+	out := 0
+	switch {
+	case opt.Tag == lisette.OptionSome && (opt.SomeVal > 10 || flag):
+		out = 1
+	case opt.Tag == lisette.OptionSome:
+		out = 2
+	default:
+		out = 3
+	}
+	return out
+}

--- a/tests/spec/emit/snapshots/flattened_guard_binding_shadowed_by_the_arm_body_is_dropped.snap
+++ b/tests/spec/emit/snapshots/flattened_guard_binding_shadowed_by_the_arm_body_is_dropped.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(opt: Option<int>) {
+    match opt {
+      Some(x) if x > 0 => { let x = 5; fmt.Println(x) },
+      _ => (),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func test(opt lisette.Option[int]) {
+	switch {
+	case opt.Tag == lisette.OptionSome && opt.SomeVal > 0:
+		x := 5
+		fmt.Println(x)
+	}
+}

--- a/tests/spec/emit/snapshots/flattened_guard_binds_only_what_the_arm_body_reads.snap
+++ b/tests/spec/emit/snapshots/flattened_guard_binds_only_what_the_arm_body_reads.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(opt: Option<int>) {
+    match opt {
+      Some(a) if a > 10 => fmt.Println("big"),
+      Some(b) if b > 0 => fmt.Print(f"small: {b}\n"),
+      Some(c) => fmt.Println(c),
+      None => fmt.Println("none"),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func test(opt lisette.Option[int]) {
+	switch {
+	case opt.Tag == lisette.OptionSome && opt.SomeVal > 10:
+		fmt.Println("big")
+	case opt.Tag == lisette.OptionSome && opt.SomeVal > 0:
+		fmt.Printf("small: %d\n", opt.SomeVal)
+	case opt.Tag == lisette.OptionSome:
+		fmt.Println(opt.SomeVal)
+	default:
+		fmt.Println("none")
+	}
+}

--- a/tests/spec/emit/snapshots/format_string_guard_keeps_the_jump_target.snap
+++ b/tests/spec/emit/snapshots/format_string_guard_keeps_the_jump_target.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn label(n: int) -> Result<string, string> { Ok("x") }
+  
+  fn test(opt: Option<int>) -> Result<int, string> {
+    let mut out = 0
+    match opt {
+      Some(x) if f"v{label(x)?}" == "vx" => { out = 1 },
+      Some(_) => { out = 2 },
+      None => { out = 3 },
+    }
+    Ok(out)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func label(_ int) lisette.Result[string, string] {
+	return lisette.MakeResultOk[string, string]("x")
+}
+
+func test(opt lisette.Option[int]) lisette.Result[int, string] {
+	out := 0
+match_1:
+	for {
+		if opt.Tag == lisette.OptionSome {
+			check_2 := label(opt.SomeVal)
+			if check_2.Tag != lisette.ResultOk {
+				return lisette.MakeResultErr[int, string](check_2.ErrVal)
+			}
+			if fmt.Sprintf("v%s", check_2.OkVal) == "vx" {
+				out = 1
+				break match_1
+			}
+			out = 2
+			break match_1
+		}
+		out = 3
+		break match_1
+	}
+	return lisette.MakeResultOk[int, string](out)
+}

--- a/tests/spec/emit/snapshots/guard_needing_statement_lowering_keeps_the_jump_target.snap
+++ b/tests/spec/emit/snapshots/guard_needing_statement_lowering_keeps_the_jump_target.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn check(n: int) -> Result<bool, string> { Ok(n > 0) }
+  
+  fn test(opt: Option<int>) -> Result<int, string> {
+    let mut out = 0
+    match opt {
+      Some(x) if check(x)? => { out = 1 },
+      Some(_) => { out = 2 },
+      None => { out = 0 },
+    }
+    Ok(out)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func check(n int) lisette.Result[bool, string] {
+	return lisette.MakeResultOk[bool, string](n > 0)
+}
+
+func test(opt lisette.Option[int]) lisette.Result[int, string] {
+	out := 0
+match_1:
+	for {
+		if opt.Tag == lisette.OptionSome {
+			check_2 := check(opt.SomeVal)
+			if check_2.Tag != lisette.ResultOk {
+				return lisette.MakeResultErr[int, string](check_2.ErrVal)
+			}
+			if check_2.OkVal {
+				out = 1
+				break match_1
+			}
+			out = 2
+			break match_1
+		}
+		out = 0
+		break match_1
+	}
+	return lisette.MakeResultOk[int, string](out)
+}

--- a/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_result_without_else_branch.snap
@@ -31,7 +31,6 @@ func tryParse(s string) lisette.Result[int, string] {
 func test() {
 	subject_1 := tryParse("42")
 	if subject_1.Tag == lisette.ResultOk {
-		x := subject_1.OkVal
-		fmt.Printf("Parsed: %d\n", x)
+		fmt.Printf("Parsed: %d\n", subject_1.OkVal)
 	}
 }

--- a/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
+++ b/tests/spec/emit/snapshots/match_arm_shadow_does_not_clobber_result_var.snap
@@ -19,20 +19,13 @@ import "fmt"
 
 func test(x int) string {
 	var result string
-match_1:
-	for {
-		{
-			n := x
-			if n < 10 {
-				result_2 := n * n
-				result = fmt.Sprintf("small(%d)", result_2)
-				break match_1
-			}
-		}
-		{
-			result = "other"
-			break match_1
-		}
+	switch {
+	case x < 10:
+		n := x
+		result_1 := n * n
+		result = fmt.Sprintf("small(%d)", result_1)
+	default:
+		result = "other"
 	}
 	return result
 }

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -20,20 +20,13 @@ import "fmt"
 
 func main() {
 	for i := 0; i < 10; i++ {
-	match_1:
-		for {
-			{
-				if i < 5 {
-					fmt.Println("low")
-					break match_1
-				}
-			}
-			if i == 5 {
-				fmt.Println("five")
-			} else {
-				fmt.Println("high")
-			}
-			break match_1
+		switch {
+		case i < 5:
+			fmt.Println("low")
+		case i == 5:
+			fmt.Println("five")
+		default:
+			fmt.Println("high")
 		}
 	}
 }

--- a/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
+++ b/tests/spec/emit/snapshots/match_guarded_catchall_unused_subject.snap
@@ -24,13 +24,7 @@ func mk() P {
 
 func test() {
 	_ = mk()
-match_2:
-	for {
-		if false {
-			break match_2
-		}
-		{
-			break match_2
-		}
+	switch {
+	case false:
 	}
 }

--- a/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
+++ b/tests/spec/emit/snapshots/match_guarded_ident_subject_unused.snap
@@ -20,15 +20,7 @@ type P struct {
 func test() {
 	p := P{v: 1}
 	_ = p
-match_1:
-	for {
-		{
-			if false {
-				break match_1
-			}
-		}
-		{
-			break match_1
-		}
+	switch {
+	case false:
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
@@ -23,11 +23,9 @@ import (
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		fmt.Printf("success: %d\n", n)
+		fmt.Printf("success: %d\n", result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Printf("error: %s\n", e)
+		fmt.Printf("error: %s\n", result.ErrVal)
 	}
 	fmt.Print("done\n")
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -22,18 +22,12 @@ import (
 
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
-match_1:
-	for {
-		if result.Tag == lisette.ResultOk {
-			if result.OkVal > 0 {
-				fmt.Printf("positive: %d\n", result.OkVal)
-				break match_1
-			}
-			fmt.Printf("non-positive: %d\n", result.OkVal)
-			break match_1
-		}
-		e := result.ErrVal
-		fmt.Printf("error: %s\n", e)
-		break match_1
+	switch {
+	case result.Tag == lisette.ResultOk && result.OkVal > 0:
+		fmt.Printf("positive: %d\n", result.OkVal)
+	case result.Tag == lisette.ResultOk:
+		fmt.Printf("non-positive: %d\n", result.OkVal)
+	default:
+		fmt.Printf("error: %s\n", result.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
@@ -22,10 +22,8 @@ import (
 func test() {
 	result := lisette.MakeResultOk[int, string](42)
 	if result.Tag == lisette.ResultOk {
-		n := result.OkVal
-		fmt.Printf("success: %d\n", n)
+		fmt.Printf("success: %d\n", result.OkVal)
 	} else {
-		e := result.ErrVal
-		fmt.Printf("error: %s\n", e)
+		fmt.Printf("error: %s\n", result.ErrVal)
 	}
 }

--- a/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
+++ b/tests/spec/emit/snapshots/match_one_arm_tuple_no_outer_leak.snap
@@ -24,10 +24,6 @@ func test() string {
 	s := "original"
 	pair := lisette.MakeTuple2[int, string](100, "replaced")
 	var r string
-	{
-		n_1 := pair.First
-		s_2 := pair.Second
-		r = fmt.Sprintf("%d-%s", n_1, s_2)
-	}
+	r = fmt.Sprintf("%d-%s", pair.First, pair.Second)
 	return fmt.Sprintf("%d %s %s", n, s, r)
 }

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
@@ -41,20 +41,8 @@ type E struct {
 
 func test() {
 	e := MakeEC()
-match_1:
-	for {
-		if e.Tag == EA {
-			if false {
-				break match_1
-			}
-		}
-		if e.Tag == EB {
-			if false {
-				break match_1
-			}
-		}
-		{
-			break match_1
-		}
+	switch {
+	case e.Tag == EA && false:
+	case e.Tag == EB && false:
 	}
 }

--- a/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
+++ b/tests/spec/emit/snapshots/result_constructor_as_argument_no_binding.snap
@@ -19,8 +19,7 @@ import (
 
 func describe(r lisette.Result[int, string]) string {
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		return fmt.Sprint(v)
+		return fmt.Sprint(r.OkVal)
 	}
 	return r.ErrVal
 }

--- a/tests/spec/emit/snapshots/result_direct_as_argument.snap
+++ b/tests/spec/emit/snapshots/result_direct_as_argument.snap
@@ -30,8 +30,7 @@ func divide(a, b int) lisette.Result[int, string] {
 
 func describe(r lisette.Result[int, string]) string {
 	if r.Tag == lisette.ResultOk {
-		v := r.OkVal
-		return fmt.Sprint(v)
+		return fmt.Sprint(r.OkVal)
 	}
 	return r.ErrVal
 }

--- a/tests/spec/emit/snapshots/while_let_result_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_result_function_call.snap
@@ -35,8 +35,7 @@ func test() {
 	for {
 		subject_1 := nextResult(i)
 		if subject_1.Tag == lisette.ResultOk {
-			x := subject_1.OkVal
-			fmt.Printf("Got: %d\n", x)
+			fmt.Printf("Got: %d\n", subject_1.OkVal)
 			i++
 		} else {
 			break


### PR DESCRIPTION
A `match` with guards now lowers to a Go `switch`, one case per arm, instead of a labelled `for` loop that could never iterate and existed only as a target for `break`.

Before:

```go
match_1:
	for {
		if result.Tag == lisette.ResultOk {
			if result.OkVal > 0 {
				fmt.Printf("positive: %d\n", result.OkVal)
				break match_1
			}
			fmt.Printf("non-positive: %d\n", result.OkVal)
			break match_1
		}
		e := result.ErrVal
		fmt.Printf("error: %s\n", e)
		break match_1
	}
```

After:

```go
	switch {
	case result.Tag == lisette.ResultOk && result.OkVal > 0:
		fmt.Printf("positive: %d\n", result.OkVal)
	case result.Tag == lisette.ResultOk:
		fmt.Printf("non-positive: %d\n", result.OkVal)
	default:
		fmt.Printf("error: %s\n", result.ErrVal)
	}
```
