### PR TITLE
refactor: emit counted loops as `for i := range n`

### DIFF
--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -481,20 +481,32 @@ impl Planner<'_> {
             start_expression = var;
         }
 
+        let counts_from_zero = !*inclusive && start_expression == "0";
         let (header, lowered_body) = self.with_scope(|this| {
-            let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
             let header = match end_expression {
+                Some(end_expression) if counts_from_zero => {
+                    let loop_var = this.bind_loop_pattern(&binding.pattern, None);
+                    if loop_var == "_" {
+                        format!("for range {} {{\n", end_expression)
+                    } else {
+                        format!("for {} := range {} {{\n", loop_var, end_expression)
+                    }
+                }
                 Some(end_expression) => {
+                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
                     let operator = if *inclusive { "<=" } else { "<" };
                     format!(
                         "for {} := {}; {} {} {}; {}++ {{\n",
                         loop_var, start_expression, loop_var, operator, end_expression, loop_var
                     )
                 }
-                None => format!(
-                    "for {} := {}; ; {}++ {{\n",
-                    loop_var, start_expression, loop_var
-                ),
+                None => {
+                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+                    format!(
+                        "for {} := {}; ; {}++ {{\n",
+                        loop_var, start_expression, loop_var
+                    )
+                }
             };
             (header, this.lower_block_as_body(body))
         });

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1014,6 +1014,81 @@ fn main() {
 }
 
 #[test]
+fn run_counted_loops_iterate_from_zero_up_to_the_bound() {
+    if !go_available() {
+        eprintln!("skipping run_counted_loops_iterate_from_zero_up_to_the_bound: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"counted\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+fn counted(n: int) -> int {
+  let mut sum = 0
+  for i in 0..n {
+    sum += i
+  }
+  sum
+}
+
+fn repeats(n: int) -> int {
+  let mut count = 0
+  for _ in 0..n {
+    count += 1
+  }
+  count
+}
+
+fn inclusive() -> int {
+  let mut sum = 0
+  for i in 0..=3 {
+    sum += i
+  }
+  sum
+}
+
+fn breaks() -> int {
+  let mut last = -1
+  for i in 0..10 {
+    if i == 4 { break }
+    last = i
+  }
+  last
+}
+
+fn main() {
+  fmt.Println(counted(4), counted(0), counted(-3))
+  fmt.Println(repeats(3), repeats(-1))
+  fmt.Println(inclusive(), breaks())
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "6 0 0\n3 0\n6 3", "stderr: {stderr}");
+}
+
+#[test]
 fn run_equality_matching_parametrized_interface_bound_builds() {
     if !go_available() {
         eprintln!(

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -841,6 +841,37 @@ fn test() {
 }
 
 #[test]
+fn for_loop_range_with_unread_binding_drops_the_clause() {
+    let input = r#"
+fn do_work() {}
+
+fn test() {
+  for i in 0..3 {
+    do_work();
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn for_loop_nonzero_start_keeps_the_counted_form() {
+    let input = r#"
+fn test(from: int) -> int {
+  let mut sum = 0
+  for i in 1..5 {
+    sum = sum + i
+  }
+  for j in from..5 {
+    sum = sum + j
+  }
+  sum
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn for_loop_stored_range_mutation_captured() {
     let input = r#"
 fn main() {

--- a/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
@@ -19,7 +19,7 @@ import "fmt"
 func main() {
 	_bound_0 := 10
 	_bound_1 := (1 + 2)
-	for i := 0; i < _bound_1; i++ {
+	for i := range _bound_1 {
 		fmt.Println(i)
 	}
 	fmt.Println(_bound_0)

--- a/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_range_loop_bound_temp_no_collision.snap
@@ -23,7 +23,7 @@ func makeBound() int {
 func main() {
 	sum := 0
 	_bound_1 := makeBound()
-	for i := 0; i < _bound_1; i++ {
+	for i := range _bound_1 {
 		sum += i
 	}
 	_bound_1_2 := 7

--- a/tests/spec/emit/snapshots/for_loop_inline_range_end_mutation_captured.snap
+++ b/tests/spec/emit/snapshots/for_loop_inline_range_end_mutation_captured.snap
@@ -19,7 +19,7 @@ func main() {
 	n := 3
 	iters := 0
 	_bound_1 := n
-	for i := 0; i < _bound_1; i++ {
+	for i := range _bound_1 {
 		iters++
 		n = 0
 		_ = i

--- a/tests/spec/emit/snapshots/for_loop_let_shadowing_does_not_leak.snap
+++ b/tests/spec/emit/snapshots/for_loop_let_shadowing_does_not_leak.snap
@@ -15,7 +15,7 @@ package main
 
 func test() string {
 	x := "outside"
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		x := i
 		_ = x
 	}

--- a/tests/spec/emit/snapshots/for_loop_nonzero_start_keeps_the_counted_form.snap
+++ b/tests/spec/emit/snapshots/for_loop_nonzero_start_keeps_the_counted_form.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(from: int) -> int {
+    let mut sum = 0
+    for i in 1..5 {
+      sum = sum + i
+    }
+    for j in from..5 {
+      sum = sum + j
+    }
+    sum
+  }
+---
+package main
+
+func test(from int) int {
+	sum := 0
+	for i := 1; i < 5; i++ {
+		sum += i
+	}
+	for j := from; j < 5; j++ {
+		sum += j
+	}
+	return sum
+}

--- a/tests/spec/emit/snapshots/for_loop_range_exclusive.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_exclusive.snap
@@ -14,7 +14,7 @@ package main
 
 func test() int {
 	sum := 0
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/for_loop_range_with_call.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_with_call.snap
@@ -21,7 +21,7 @@ func getEnd() int {
 func test() int {
 	sum := 0
 	_bound_1 := getEnd()
-	for i := 0; i < _bound_1; i++ {
+	for i := range _bound_1 {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/for_loop_range_with_unread_binding_drops_the_clause.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_with_unread_binding_drops_the_clause.snap
@@ -5,7 +5,7 @@ description: |
   fn do_work() {}
   
   fn test() {
-    for _ in 0..3 {
+    for i in 0..3 {
       do_work();
     }
   }

--- a/tests/spec/emit/snapshots/for_loop_variable_does_not_shadow_outer_binding.snap
+++ b/tests/spec/emit/snapshots/for_loop_variable_does_not_shadow_outer_binding.snap
@@ -14,7 +14,7 @@ package main
 
 func test() int {
 	i := 100
-	for i_1 := 0; i_1 < 3; i_1++ {
+	for i_1 := range 3 {
 		_ = i_1
 	}
 	return i

--- a/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_integer_literal_and_catchall.snap
@@ -19,7 +19,7 @@ package main
 import "fmt"
 
 func main() {
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		switch {
 		case i < 5:
 			fmt.Println("low")

--- a/tests/spec/emit/snapshots/propagate_in_range_end.snap
+++ b/tests/spec/emit/snapshots/propagate_in_range_end.snap
@@ -25,7 +25,7 @@ func f() lisette.Result[int, string] {
 		return lisette.MakeResultErr[int, string](check_2.ErrVal)
 	}
 	_bound_1 := check_2.OkVal
-	for i := 0; i < _bound_1; i++ {
+	for i := range _bound_1 {
 		s += i
 	}
 	return lisette.MakeResultOk[int, string](s)

--- a/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
+++ b/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
@@ -38,7 +38,7 @@ type IntList struct {
 func (i IntList) display() string {
 	s := "["
 	_bound_1 := len(i.items)
-	for i_2 := 0; i_2 < _bound_1; i_2++ {
+	for i_2 := range _bound_1 {
 		if i_2 > 0 {
 			s += ", "
 		}

--- a/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_default_arm_needs_label.snap
@@ -33,7 +33,7 @@ func main() {
 	ch := make(chan int, 1)
 	skipped := 0
 loop_1:
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if i == 1 {
 			_ = lisette.ChannelSend(ch, 7)
 		}

--- a/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
@@ -42,18 +42,18 @@ func main() {
 	lisette.ChannelClose(ch)
 	processed := ""
 loop_1:
-	for _i_1 := 0; _i_1 < 2; _i_1++ {
-		ch_2 := ch
+	for range 2 {
+		ch_1 := ch
 		for {
 			select {
-			case x, ok := <-ch_2:
+			case x, ok := <-ch_1:
 				if ok {
 					if x < 0 {
 						continue loop_1
 					}
 					processed += fmt.Sprintf("%d,", x)
 				} else {
-					ch_2 = nil
+					ch_1 = nil
 					continue
 				}
 			default:

--- a/tests/spec/emit/snapshots/select_continue_without_retry_loop_unlabeled.snap
+++ b/tests/spec/emit/snapshots/select_continue_without_retry_loop_unlabeled.snap
@@ -40,7 +40,7 @@ func main() {
 	_ = lisette.ChannelSend(ch, 1)
 	_ = lisette.ChannelSend(ch, 2)
 	total := 0
-	for _i_1 := 0; _i_1 < 2; _i_1++ {
+	for range 2 {
 		select {
 		case x, ok := <-ch:
 			if ok {

--- a/tests/spec/emit/snapshots/select_retry_region_preserves_nested_loop_target.snap
+++ b/tests/spec/emit/snapshots/select_retry_region_preserves_nested_loop_target.snap
@@ -43,7 +43,7 @@ loop_1:
 			select {
 			case _, ok := <-ch_1:
 				if ok {
-					for i := 0; i < 2; i++ {
+					for i := range 2 {
 						if i == 0 {
 							continue
 						}

--- a/tests/spec/emit/snapshots/task_defer_in_loop.snap
+++ b/tests/spec/emit/snapshots/task_defer_in_loop.snap
@@ -21,7 +21,7 @@ import "sync"
 
 func test() {
 	wg := sync.WaitGroup{}
-	for _i_1 := 0; _i_1 < 5; _i_1++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
A counted `for` loop over an exclusive range starting at zero now emits Go's `range` form.

Before:

```go
	for i := 0; i < 5; i++ {
	for _i_1 := 0; _i_1 < 3; _i_1++ {
```

After:

```go
	for i := range 5 {
	for range 3 {
```