### PR TITLE
refactor: elide redundant element types in Go composite literals

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -1,4 +1,5 @@
 use crate::expressions::access::struct_call::emit_struct_literal;
+use crate::expressions::literals::elide_element_type;
 use crate::names::generics::extract_type_mapping;
 use rustc_hash::FxHashMap as HashMap;
 use std::borrow::Cow;
@@ -262,7 +263,7 @@ impl Planner<'_> {
                 if let Some(Type::Array { length, element }) = &peeled {
                     Some(ValuePlan::computed(
                         Vec::new(),
-                        GoExpression::composite_literal(self.array_zero(*length, element), false),
+                        self.array_zero(*length, element),
                         self.native_constructor_effect(ctx, EvaluationEffect::Pure),
                     ))
                 } else {
@@ -304,11 +305,9 @@ impl Planner<'_> {
 
         let (key_ty, value_ty) =
             self.resolve_map_lisette_types(ctx.function, ctx.resolved_type_args, ctx.call_ty);
-        let map_ty = format!(
-            "map[{}]{}",
-            self.go_type_string(&key_ty),
-            self.go_type_string(&value_ty)
-        );
+        let key_go_ty = self.go_type_string(&key_ty);
+        let value_go_ty = self.go_type_string(&value_ty);
+        let map_ty = format!("map[{}]{}", key_go_ty, value_go_ty);
 
         if pairs.is_empty() {
             return Some(ValuePlan::computed(
@@ -326,24 +325,33 @@ impl Planner<'_> {
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_entry");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (mut setup, rendered) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
+        let values = sequenced.values;
 
         let mut lowered = Vec::with_capacity(pairs.len());
-        for ((key, value), staged) in pairs.iter().zip(rendered.chunks_exact(2)) {
+        let mut widest = 0;
+        for ((key, value), staged) in pairs.iter().zip(values.chunks_exact(2)) {
             let [staged_key, staged_value] = staged else {
                 unreachable!("each pair stages exactly two values")
             };
             let (key_setup, coerced_key) = CoercionPlan::internal(self, &key.get_type(), &key_ty)
-                .lower(self, staged_key.clone());
+                .lower(self, staged_key.rendered());
             setup.extend(key_setup);
-            let (value_setup, coerced_value) =
-                CoercionPlan::internal(self, &value.get_type(), &value_ty)
-                    .lower(self, staged_value.clone());
+            let value_coercion = CoercionPlan::internal(self, &value.get_type(), &value_ty);
+            let is_whole_literal =
+                value_coercion.is_identity() && staged_value.is_composite_literal();
+            let (value_setup, coerced_value) = value_coercion.lower(self, staged_value.rendered());
             setup.extend(value_setup);
+            widest = widest.max(coerced_key.len() + coerced_value.len() + ": ".len());
+            let coerced_value = if is_whole_literal {
+                elide_element_type(&value_go_ty, coerced_value)
+            } else {
+                coerced_value
+            };
             lowered.push(format!("{coerced_key}: {coerced_value}"));
         }
 
-        let value = if lowered.len() > 1 && lowered.iter().any(|entry| entry.len() > 30) {
+        let value = if lowered.len() > 1 && widest > 30 {
             let indented = lowered
                 .iter()
                 .map(|entry| format!("\t{}", entry))

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -19,6 +19,7 @@ struct SpreadInput<'a> {
     base: &'a Expression,
     base_staged: ValuePlan,
     field_pairs: Vec<(String, String)>,
+    fields_contain_deferred_evaluation: bool,
 }
 
 struct StructCallContext<'a> {
@@ -102,7 +103,6 @@ impl Planner<'_> {
             field_pairs.insert(0, tag);
         }
 
-        let mut base_contains_deferred_evaluation = false;
         let value = match spread {
             StructSpread::From(base) => {
                 // Never-typed spread base diverges, emit as statement and
@@ -112,47 +112,48 @@ impl Planner<'_> {
                         effect = effect.combine(EvaluationEffect::EffectfulCall);
                     }
                     setup.push(self.lower_statement(base));
-                    format!("{}{{}}", ctx.go_type)
+                    GoExpression::composite_literal(
+                        format!("{}{{}}", ctx.go_type),
+                        fields_contain_deferred_evaluation,
+                    )
                 } else {
                     let base_staged = self.stage_operand(base, ExpressionContext::value());
                     effect = effect.combine(base_staged.evaluation.effect);
                     let field_pairs =
                         self.hoist_observable_fields(&mut setup, field_pairs, &field_side_effects);
-                    let (spread_setup, value, contains_deferred_evaluation) =
-                        if ctx.enum_ctx.is_some() {
-                            self.lower_enum_variant_spread(
-                                SpreadInput {
-                                    base,
-                                    base_staged,
-                                    field_pairs,
-                                },
-                                &ctx,
-                                field_assignments,
-                                expression_ctx,
-                            )
-                        } else {
-                            self.lower_struct_update(base_staged, &field_pairs)
-                        };
+                    let (spread_setup, value) = if ctx.enum_ctx.is_some() {
+                        self.lower_enum_variant_spread(
+                            SpreadInput {
+                                base,
+                                base_staged,
+                                field_pairs,
+                                fields_contain_deferred_evaluation,
+                            },
+                            &ctx,
+                            field_assignments,
+                            expression_ctx,
+                        )
+                    } else {
+                        self.lower_struct_update(base_staged, &field_pairs)
+                    };
                     setup.extend(spread_setup);
-                    base_contains_deferred_evaluation = contains_deferred_evaluation;
                     value
                 }
             }
             StructSpread::Autofill { .. } => {
                 self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
-                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx)
+                GoExpression::composite_literal(
+                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                    fields_contain_deferred_evaluation,
+                )
             }
-            StructSpread::None => emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+            StructSpread::None => GoExpression::composite_literal(
+                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                fields_contain_deferred_evaluation,
+            ),
         };
 
-        ValuePlan::computed(
-            setup,
-            GoExpression::composite_literal(
-                value,
-                fields_contain_deferred_evaluation || base_contains_deferred_evaluation,
-            ),
-            effect,
-        )
+        ValuePlan::computed(setup, value, effect)
     }
 
     /// Apply Go-boundary coercion followed by internal coercion. The Go-boundary
@@ -371,7 +372,7 @@ impl Planner<'_> {
                 ValueLayout::Array {
                     length, element, ..
                 },
-            ) => self.array_zero(*length, element.logical_type()),
+            ) => self.array_zero(*length, element.logical_type()).rendered(),
             _ => format!("{}{{}}", self.go_type_string(ty)),
         }
     }
@@ -423,16 +424,16 @@ impl Planner<'_> {
 
     /// Array zero value, filling per index with `lisette_zero` when Go's own
     /// `[N]E{}` zero differs from Lisette's (e.g. `Option<T>`).
-    pub(crate) fn array_zero(&mut self, len: u64, elem: &Type) -> String {
+    pub(crate) fn array_zero(&mut self, len: u64, elem: &Type) -> GoExpression {
         let elem_go = self.go_type_string(elem);
         if len == 0 || self.element_go_zero_ok(elem) {
-            return format!("[{}]{}{{}}", len, elem_go);
+            return GoExpression::composite_literal(format!("[{}]{}{{}}", len, elem_go), false);
         }
         let zero = self.lisette_zero(elem);
         // Go has no syntax to repeat a value across all N slots, so fill each index.
-        format!(
+        GoExpression::opaque(format!(
             "func() [{len}]{elem_go} {{ var arr [{len}]{elem_go}; for i := range arr {{ arr[i] = {zero} }}; return arr }}()"
-        )
+        ))
     }
 
     /// True when Go's zero for the element already matches Lisette's.
@@ -631,12 +632,10 @@ impl Planner<'_> {
         &mut self,
         base_staged: ValuePlan,
         fields: &[(String, String)],
-    ) -> (Vec<LoweredStatement>, String, bool) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
+        // A spread that assigns nothing is its base, whatever shape that has.
         if fields.is_empty() {
-            let contains_deferred_evaluation =
-                base_staged.expression.contains_deferred_evaluation();
-            let (setup, value) = base_staged.into_parts();
-            return (setup, value, contains_deferred_evaluation);
+            return (base_staged.setup, base_staged.expression);
         }
 
         let (mut statements, base_value) = base_staged.into_parts();
@@ -649,7 +648,7 @@ impl Planner<'_> {
             )));
         }
 
-        (statements, tmp, false)
+        (statements, GoExpression::name(tmp))
     }
 
     fn lower_enum_variant_spread(
@@ -658,11 +657,12 @@ impl Planner<'_> {
         ctx: &StructCallContext<'_>,
         field_assignments: &[StructFieldAssignment],
         expression_ctx: ExpressionContext<'_>,
-    ) -> (Vec<LoweredStatement>, String, bool) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let SpreadInput {
             base,
             base_staged,
             mut field_pairs,
+            fields_contain_deferred_evaluation,
         } = input;
         let assigned: HashSet<&str> = field_assignments.iter().map(|f| f.name.as_str()).collect();
         let carried = self
@@ -675,8 +675,10 @@ impl Planner<'_> {
             statements.push(LoweredStatement::RawGo(format!("_ = {}\n", base_value)));
             return (
                 statements,
-                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
-                false,
+                GoExpression::composite_literal(
+                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                    fields_contain_deferred_evaluation,
+                ),
             );
         }
 
@@ -691,8 +693,10 @@ impl Planner<'_> {
         }
         (
             statements,
-            emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
-            false,
+            GoExpression::composite_literal(
+                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                fields_contain_deferred_evaluation,
+            ),
         )
     }
 }

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -79,18 +79,26 @@ impl Planner<'_> {
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_v");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (mut setup, rendered) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
+        let values = sequenced.values;
 
-        let mut wrapped: Vec<String> = Vec::with_capacity(rendered.len());
-        for (expr, emitted) in elements.iter().zip(rendered) {
+        let mut wrapped: Vec<String> = Vec::with_capacity(values.len());
+        let mut widest = 0;
+        for (expr, value) in elements.iter().zip(&values) {
             let coercion = CoercionPlan::internal(self, &expr.get_type(), &element_lisette_ty);
-            let (coercion_setup, coerced) = coercion.lower(self, emitted);
+            let is_whole_literal = coercion.is_identity() && value.is_composite_literal();
+            let (coercion_setup, coerced) = coercion.lower(self, value.rendered());
             setup.extend(coercion_setup);
-            wrapped.push(coerced);
+            widest = widest.max(coerced.len());
+            wrapped.push(if is_whole_literal {
+                elide_element_type(&element_ty, coerced)
+            } else {
+                coerced
+            });
         }
         let elements = wrapped;
 
-        let value = if elements.len() > 1 && elements.iter().any(|e| e.len() > 30) {
+        let value = if elements.len() > 1 && widest > 30 {
             let indented = elements
                 .iter()
                 .map(|e| format!("\t{}", e))
@@ -207,6 +215,13 @@ fn format_verb_for(ty: &Type) -> &'static str {
         Some(k) if k.is_signed_int() || k.is_unsigned_int() => "%d",
         Some(k) if k.is_float() => "%g",
         _ => "%v",
+    }
+}
+
+pub(crate) fn elide_element_type(element_ty: &str, rendered: String) -> String {
+    match rendered.strip_prefix(element_ty) {
+        Some(literal) if literal.starts_with('{') => literal.to_string(),
+        _ => rendered,
     }
 }
 

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -258,7 +258,11 @@ impl Planner<'_> {
             }
             Expression::Call { ty, .. } => self.lower_call_value(expression, ty, ctx),
             Expression::RawGo { text } => ValuePlan::opaque(text.clone()),
-            Expression::Unit { .. } => ValuePlan::opaque("struct{}{}".to_string()),
+            Expression::Unit { .. } => ValuePlan::computed(
+                Vec::new(),
+                GoExpression::composite_literal("struct{}{}".to_string(), false),
+                EvaluationEffect::Pure,
+            ),
             Expression::Lambda {
                 params, body, ty, ..
             } => ValuePlan::opaque(self.emit_lambda(params, body, ty, ctx)),

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -160,6 +160,10 @@ impl GoExpression {
     pub(crate) fn rendered(&self) -> String {
         self.to_string()
     }
+
+    pub(crate) fn is_composite_literal(&self) -> bool {
+        matches!(self, Self::CompositeLiteral { .. })
+    }
 }
 
 impl Display for GoExpression {

--- a/tests/e2e_suite.rs
+++ b/tests/e2e_suite.rs
@@ -10,8 +10,8 @@ use rayon::prelude::*;
 
 use harness::{
     EmittedTest, HarvestedTest, compile_e2e_suite_test, harvest_snapshots, prelude_dir,
-    read_go_version, read_skip_list, run_go_test, run_go_vet, skip_reason_for_imports,
-    snapshots_dir, target_dir, write_go_mod, write_subpackage,
+    read_go_version, read_skip_list, run_go_test, run_go_vet, run_gofmt_simplify,
+    skip_reason_for_imports, snapshots_dir, target_dir, write_go_mod, write_subpackage,
 };
 
 #[test]
@@ -131,5 +131,11 @@ fn e2e_suite() {
     if let Err(out) = run_go_vet(&target) {
         eprintln!("{out}");
         panic!("go vet failed");
+    }
+
+    eprintln!("running `gofmt -s -l .` in {}", target.display());
+    if let Err(out) = run_gofmt_simplify(&target) {
+        eprintln!("{out}");
+        panic!("gofmt -s would rewrite the files listed above");
     }
 }

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -321,6 +321,25 @@ pub fn run_go_vet(target_dir: &Path) -> Result<String, String> {
     }
 }
 
+pub fn run_gofmt_simplify(target_dir: &Path) -> Result<String, String> {
+    let output = Command::new("gofmt")
+        .args(["-s", "-l", "."])
+        .current_dir(target_dir)
+        .env("NO_COLOR", "1")
+        .output()
+        .map_err(|e| format!("failed to spawn gofmt: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !output.status.success() {
+        return Err(format!("{stdout}{stderr}"));
+    }
+    if stdout.trim().is_empty() {
+        Ok(stdout)
+    } else {
+        Err(stdout)
+    }
+}
+
 pub fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/tests/spec/build/snapshots/cross_package_interface_impl_in_main.snap
+++ b/tests/spec/build/snapshots/cross_package_interface_impl_in_main.snap
@@ -30,6 +30,6 @@ func (n Name) Display() string {
 }
 
 func main() {
-	names := []Name{Name{value: "alice"}}
+	names := []Name{{value: "alice"}}
 	fmt.Println(lib.PrintAll(names))
 }

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -110,6 +110,96 @@ fn grid() -> Array<Array<int, 3>, 2> {
 }
 
 #[test]
+fn literal_elements_of_a_wider_type_keep_their_own_type() {
+    let input = r#"
+interface Shape {
+  fn area() -> int
+}
+
+struct Circle {
+  r: int
+}
+
+impl Circle {
+  fn area(self) -> int { self.r }
+}
+
+fn test() -> int {
+  let shapes: Slice<Shape> = [Circle { r: 1 }, Circle { r: 2 }]
+  shapes[0].area() + shapes[1].area()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn element_calling_a_method_on_a_literal_keeps_its_type() {
+    let input = r#"
+struct Point {
+  x: int,
+  y: int
+}
+
+impl Point {
+  fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+}
+
+fn test() -> int {
+  let pts: Slice<Point> = [Point { x: 1, y: 2 }.scaled(), Point { x: 3, y: 4 }]
+  pts[0].x + pts[1].y
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn element_slicing_a_literal_keeps_its_type() {
+    let input = r#"
+fn test() -> int {
+  let rows: Slice<Slice<int>> = [[1, 2, 3][..2], [4, 5]]
+  rows[0][0] + rows[1][1]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn element_spreading_a_call_result_keeps_its_type() {
+    let input = r#"
+struct Point {
+  x: int,
+  y: int
+}
+
+impl Point {
+  fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+}
+
+fn test() -> int {
+  let pts: Slice<Point> = [Point { ..Point { x: 1, y: 2 }.scaled() }]
+  pts[0].x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn element_spreading_a_literal_elides_its_type() {
+    let input = r#"
+struct Point {
+  x: int,
+  y: int
+}
+
+fn test() -> int {
+  let pts: Slice<Point> = [Point { ..Point { x: 5, y: 6 } }]
+  pts[0].x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn array_zero_value() {
     let input = r#"
 struct Buf {

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -892,6 +892,40 @@ fn test() {
 }
 
 #[test]
+fn map_from_struct_values_elides_the_value_type() {
+    let input = r#"
+struct Point {
+  x: int,
+  y: int
+}
+
+fn test() -> Map<string, Point> {
+  Map.from([("a", Point { x: 1, y: 2 }), ("b", Point { x: 3, y: 4 })])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_value_calling_a_method_on_a_literal_keeps_its_type() {
+    let input = r#"
+struct Point {
+  x: int,
+  y: int
+}
+
+impl Point {
+  fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+}
+
+fn test() -> Map<string, Point> {
+  Map.from([("a", Point { x: 1, y: 2 }.scaled())])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_from_non_literal_keys_keeps_prelude_call() {
     let input = r#"
 const KEY = "a"

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_argument_position.snap
@@ -34,7 +34,7 @@ func first(errs [2]error) string {
 }
 
 func test() {
-	concrete := [2]Boom{Boom{}, Boom{}}
+	concrete := [2]Boom{{}, {}}
 	var boxed_1 [2]error
 	for i_2 := range concrete {
 		boxed_1[i_2] = concrete[i_2]

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_assignment.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_assignment.snap
@@ -43,7 +43,7 @@ func (q Quiet) Error() string {
 
 func test() {
 	errs := [2]error{Quiet{}, Quiet{}}
-	concrete := [2]Boom{Boom{}, Boom{}}
+	concrete := [2]Boom{{}, {}}
 	var boxed_1 [2]error
 	for i_2 := range concrete {
 		boxed_1[i_2] = concrete[i_2]

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_let_annotation.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_let_annotation.snap
@@ -35,7 +35,7 @@ func first(errs [2]error) string {
 }
 
 func test() {
-	concrete := [2]Boom{Boom{}, Boom{}}
+	concrete := [2]Boom{{}, {}}
 	var boxed_1 [2]error
 	for i_2 := range concrete {
 		boxed_1[i_2] = concrete[i_2]

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
@@ -30,7 +30,7 @@ func (b Boom) Error() string {
 }
 
 func widen() [2]error {
-	concrete := [2]Boom{Boom{}, Boom{}}
+	concrete := [2]Boom{{}, {}}
 	var boxed_1 [2]error
 	for i_2 := range concrete {
 		boxed_1[i_2] = concrete[i_2]

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_struct_field.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_struct_field.snap
@@ -35,7 +35,7 @@ type Holder struct {
 }
 
 func test() {
-	concrete := [2]Boom{Boom{}, Boom{}}
+	concrete := [2]Boom{{}, {}}
 	var boxed_1 [2]error
 	for i_2 := range concrete {
 		boxed_1[i_2] = concrete[i_2]

--- a/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
@@ -37,7 +37,7 @@ func bump(i *int) int {
 }
 
 func run() {
-	items := []Cell{Cell{v: 0}, Cell{v: 0}}
+	items := []Cell{{v: 0}, {v: 0}}
 	i := 0
 	_arg_1 := &items[i]
 	Cell_add[int](_arg_1, bump(&i))

--- a/tests/spec/emit/snapshots/block_tail_append_reads_receiver_before_argument_effects.snap
+++ b/tests/spec/emit/snapshots/block_tail_append_reads_receiver_before_argument_effects.snap
@@ -29,7 +29,7 @@ type Holder struct {
 func main() {
 	h := Holder{slc: []struct{}{}}
 	bump := func() {
-		h.slc = []struct{}{struct{}{}, struct{}{}, struct{}{}}
+		h.slc = []struct{}{{}, {}, {}}
 	}
 	var ys []struct{}
 	recv_1 := h.slc

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -54,7 +54,7 @@ func first(a, _ int) int {
 
 func main() {
 	i := 0
-	m := [][]int{[]int{10}, []int{20}}
+	m := [][]int{{10}, {20}}
 	c := Carrier{
 		Tag: CarrierC,
 		P:   &i,

--- a/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
@@ -36,7 +36,7 @@ func first(a, _ int) int {
 
 func main() {
 	i := 0
-	m := [][]int{[]int{10}, []int{20}}
+	m := [][]int{{10}, {20}}
 	c := Carrier{p: &i}
 	_arg_2 := m[i][0]
 	_base_1 := []int{bump(c)}

--- a/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
@@ -30,7 +30,7 @@ func first(a, _ int) int {
 
 func main() {
 	i := 0
-	m := [][]int{[]int{10}, []int{20}}
+	m := [][]int{{10}, {20}}
 	ip := &i
 	_arg_2 := m[i][0]
 	_base_1 := []int{bump(ip)}

--- a/tests/spec/emit/snapshots/clone_container_of_user_clone_stays_shallow.snap
+++ b/tests/spec/emit/snapshots/clone_container_of_user_clone_stays_shallow.snap
@@ -30,7 +30,7 @@ func (d Doc) clone() Doc {
 }
 
 func main() {
-	docs := []Doc{Doc{tags: []string{"x"}}}
+	docs := []Doc{{tags: []string{"x"}}}
 	copy_ := slices.Clone(docs)
 	_ = docs
 	_ = copy_

--- a/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
+++ b/tests/spec/emit/snapshots/clone_map_slice_values_deep.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	m := map[string][]int{"k": []int{1, 2}}
+	m := map[string][]int{"k": {1, 2}}
 	m2 := lisette.MapCloneFunc(m, func(e_1 []int) []int { return slices.Clone(e_1) })
 	m2["k"] = []int{9}
 	_ = m

--- a/tests/spec/emit/snapshots/clone_nested_slice_deep.snap
+++ b/tests/spec/emit/snapshots/clone_nested_slice_deep.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	a := [][]int{[]int{1, 2}, []int{3, 4}}
+	a := [][]int{{1, 2}, {3, 4}}
 	b := lisette.SliceCloneFunc(a, func(e_1 []int) []int { return slices.Clone(e_1) })
 	b[0][0] = 9
 	_ = a

--- a/tests/spec/emit/snapshots/element_calling_a_method_on_a_literal_keeps_its_type.snap
+++ b/tests/spec/emit/snapshots/element_calling_a_method_on_a_literal_keeps_its_type.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  struct Point {
+    x: int,
+    y: int
+  }
+  
+  impl Point {
+    fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+  }
+  
+  fn test() -> int {
+    let pts: Slice<Point> = [Point { x: 1, y: 2 }.scaled(), Point { x: 3, y: 4 }]
+    pts[0].x + pts[1].y
+  }
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) scaled() Point {
+	return Point{
+		x: p.x * 2,
+		y: p.y * 2,
+	}
+}
+
+func test() int {
+	pts := []Point{Point{
+		x: 1,
+		y: 2,
+	}.scaled(), {
+		x: 3,
+		y: 4,
+	}}
+	return pts[0].x + pts[1].y
+}

--- a/tests/spec/emit/snapshots/element_slicing_a_literal_keeps_its_type.snap
+++ b/tests/spec/emit/snapshots/element_slicing_a_literal_keeps_its_type.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn test() -> int {
+    let rows: Slice<Slice<int>> = [[1, 2, 3][..2], [4, 5]]
+    rows[0][0] + rows[1][1]
+  }
+---
+package main
+
+func test() int {
+	rows := [][]int{[]int{1, 2, 3}[:2:2], {4, 5}}
+	return rows[0][0] + rows[1][1]
+}

--- a/tests/spec/emit/snapshots/element_spreading_a_call_result_keeps_its_type.snap
+++ b/tests/spec/emit/snapshots/element_spreading_a_call_result_keeps_its_type.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  struct Point {
+    x: int,
+    y: int
+  }
+  
+  impl Point {
+    fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+  }
+  
+  fn test() -> int {
+    let pts: Slice<Point> = [Point { ..Point { x: 1, y: 2 }.scaled() }]
+    pts[0].x
+  }
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) scaled() Point {
+	return Point{
+		x: p.x * 2,
+		y: p.y * 2,
+	}
+}
+
+func test() int {
+	pts := []Point{Point{
+		x: 1,
+		y: 2,
+	}.scaled()}
+	return pts[0].x
+}

--- a/tests/spec/emit/snapshots/element_spreading_a_literal_elides_its_type.snap
+++ b/tests/spec/emit/snapshots/element_spreading_a_literal_elides_its_type.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  struct Point {
+    x: int,
+    y: int
+  }
+  
+  fn test() -> int {
+    let pts: Slice<Point> = [Point { ..Point { x: 5, y: 6 } }]
+    pts[0].x
+  }
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func test() int {
+	pts := []Point{{
+		x: 5,
+		y: 6,
+	}}
+	return pts[0].x
+}

--- a/tests/spec/emit/snapshots/expr_position_indexed_assign_pins_base_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/expr_position_indexed_assign_pins_base_before_call_rhs.snap
@@ -13,7 +13,7 @@ description: |
 package main
 
 func main() {
-	xss := [][]int{[]int{10, 11}, []int{20, 21}}
+	xss := [][]int{{10, 11}, {20, 21}}
 	i := 0
 	bump := func() int {
 		i++

--- a/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
+++ b/tests/spec/emit/snapshots/for_complex_pattern_binding_nothing.snap
@@ -18,7 +18,7 @@ type Foo struct {
 }
 
 func main() {
-	items := []Foo{Foo{x: 1}, Foo{x: 2}}
+	items := []Foo{{x: 1}, {x: 2}}
 	for range items {
 	}
 }

--- a/tests/spec/emit/snapshots/for_complex_pattern_unused_item.snap
+++ b/tests/spec/emit/snapshots/for_complex_pattern_unused_item.snap
@@ -16,7 +16,7 @@ type P struct {
 }
 
 func test() {
-	for _, item_1 := range []P{P{v: 1}} {
+	for _, item_1 := range []P{{v: 1}} {
 		_ = item_1
 	}
 }

--- a/tests/spec/emit/snapshots/for_loop_iter_seq_compound_pattern.snap
+++ b/tests/spec/emit/snapshots/for_loop_iter_seq_compound_pattern.snap
@@ -30,7 +30,7 @@ type Point struct {
 }
 
 func main() {
-	points := []Point{Point{
+	points := []Point{{
 		x: 1,
 		y: 2,
 	}}

--- a/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/identifier_native_receiver_arg_mutates_index.snap
@@ -19,7 +19,7 @@ func bump(i *int) int {
 }
 
 func run() int {
-	xss := [][]int{[]int{10}, []int{20}}
+	xss := [][]int{{10}, {20}}
 	i := 0
 	recv_1 := xss[i]
 	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))

--- a/tests/spec/emit/snapshots/indexed_lvalue_pins_base_before_call_index.snap
+++ b/tests/spec/emit/snapshots/indexed_lvalue_pins_base_before_call_index.snap
@@ -13,7 +13,7 @@ description: |
 package main
 
 func main() {
-	xss := [][]int{[]int{10, 11}, []int{20, 21}}
+	xss := [][]int{{10, 11}, {20, 21}}
 	i := 0
 	bump := func() int {
 		i++

--- a/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_arg_mutates_index.snap
@@ -22,7 +22,7 @@ func bump(i *int) int {
 }
 
 func test() int {
-	xss := [][]int{[]int{10}, []int{20}}
+	xss := [][]int{{10}, {20}}
 	i := 0
 	recv_1 := xss[i]
 	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))

--- a/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/indexed_receiver_append_spread_arg_mutates_index.snap
@@ -22,7 +22,7 @@ func bumpAndMake(i *int) []int {
 }
 
 func test() int {
-	xss := [][]int{[]int{10}, []int{20}}
+	xss := [][]int{{10}, {20}}
 	i := 0
 	recv_1 := xss[i]
 	ys := append(recv_1[:len(recv_1):len(recv_1)], bumpAndMake(&i)...)

--- a/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
+++ b/tests/spec/emit/snapshots/interop_nested_slice_of_option_unwrapped_at_go_field.snap
@@ -24,7 +24,7 @@ import (
 func main() {
 	f1 := &cli.Flag{Name: "a"}
 	f2 := &cli.Flag{Name: "b"}
-	src_1 := [][]lisette.Option[*cli.Flag]{[]lisette.Option[*cli.Flag]{lisette.MakeOptionSome(f1), lisette.MakeOptionSome(f2)}}
+	src_1 := [][]lisette.Option[*cli.Flag]{{lisette.MakeOptionSome(f1), lisette.MakeOptionSome(f2)}}
 	unwrapped_2 := make([][]*cli.Flag, len(src_1))
 	for i_3, v_4 := range src_1 {
 		unwrapped_5 := make([]*cli.Flag, len(v_4))

--- a/tests/spec/emit/snapshots/literal_elements_of_a_wider_type_keep_their_own_type.snap
+++ b/tests/spec/emit/snapshots/literal_elements_of_a_wider_type_keep_their_own_type.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  interface Shape {
+    fn area() -> int
+  }
+  
+  struct Circle {
+    r: int
+  }
+  
+  impl Circle {
+    fn area(self) -> int { self.r }
+  }
+  
+  fn test() -> int {
+    let shapes: Slice<Shape> = [Circle { r: 1 }, Circle { r: 2 }]
+    shapes[0].area() + shapes[1].area()
+  }
+---
+package main
+
+type Shape interface {
+	area() int
+}
+
+type Circle struct {
+	r int
+}
+
+func (c Circle) area() int {
+	return c.r
+}
+
+func test() int {
+	shapes := []Shape{Circle{r: 1}, Circle{r: 2}}
+	return shapes[0].area() + shapes[1].area()
+}

--- a/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_dot_access_key_evaluated_once.snap
@@ -41,7 +41,7 @@ func makeKey(counter *int) Key {
 
 func main() {
 	counter := 0
-	m := map[string]Box{"a": Box{x: 1}}
+	m := map[string]Box{"a": {x: 1}}
 	key := makeKey(&counter).k
 	entry := m[key]
 	entry.x = 2

--- a/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_on_deref_map.snap
@@ -19,7 +19,7 @@ type Box struct {
 }
 
 func main() {
-	m := map[string]Box{"k": Box{x: 0}}
+	m := map[string]Box{"k": {x: 0}}
 	r := &m
 	entry := (*r)["k"]
 	entry.x = 1

--- a/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_parenthesized.snap
@@ -18,7 +18,7 @@ type Box struct {
 }
 
 func main() {
-	m := map[string]Box{"a": Box{x: 1}}
+	m := map[string]Box{"a": {x: 1}}
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_temp_var_no_collision.snap
@@ -24,7 +24,7 @@ type Box struct {
 }
 
 func main() {
-	m := map[string]Box{"a": Box{x: 1}}
+	m := map[string]Box{"a": {x: 1}}
 	entry := m["a"]
 	entry.x = 2
 	m["a"] = entry

--- a/tests/spec/emit/snapshots/map_from_struct_values_elides_the_value_type.snap
+++ b/tests/spec/emit/snapshots/map_from_struct_values_elides_the_value_type.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  struct Point {
+    x: int,
+    y: int
+  }
+  
+  fn test() -> Map<string, Point> {
+    Map.from([("a", Point { x: 1, y: 2 }), ("b", Point { x: 3, y: 4 })])
+  }
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func test() map[string]Point {
+	return map[string]Point{"a": {
+		x: 1,
+		y: 2,
+	}, "b": {
+		x: 3,
+		y: 4,
+	}}
+}

--- a/tests/spec/emit/snapshots/map_value_calling_a_method_on_a_literal_keeps_its_type.snap
+++ b/tests/spec/emit/snapshots/map_value_calling_a_method_on_a_literal_keeps_its_type.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  struct Point {
+    x: int,
+    y: int
+  }
+  
+  impl Point {
+    fn scaled(self) -> Point { Point { x: self.x * 2, y: self.y * 2 } }
+  }
+  
+  fn test() -> Map<string, Point> {
+    Map.from([("a", Point { x: 1, y: 2 }.scaled())])
+  }
+---
+package main
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) scaled() Point {
+	return Point{
+		x: p.x * 2,
+		y: p.y * 2,
+	}
+}
+
+func test() map[string]Point {
+	return map[string]Point{"a": Point{
+		x: 1,
+		y: 2,
+	}.scaled()}
+}

--- a/tests/spec/emit/snapshots/nested_array_type.snap
+++ b/tests/spec/emit/snapshots/nested_array_type.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func grid() [2][3]int {
-	return [2][3]int{[3]int{1, 2, 3}, [3]int{4, 5, 6}}
+	return [2][3]int{{1, 2, 3}, {4, 5, 6}}
 }

--- a/tests/spec/emit/snapshots/range_rhs_index_target_frozen.snap
+++ b/tests/spec/emit/snapshots/range_rhs_index_target_frozen.snap
@@ -22,11 +22,11 @@ func lo() int {
 
 func run() int {
 	rs := []lisette.Range[int]{
-		lisette.Range[int]{
+		{
 			Start: 0,
 			End:   0,
 		},
-		lisette.Range[int]{
+		{
 			Start: 0,
 			End:   0,
 		},

--- a/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/selector_callee_eval_order_captured.snap
@@ -31,7 +31,7 @@ type Handler struct {
 }
 
 func run() lisette.Result[int, string] {
-	hs := []Handler{Handler{f: f0}, Handler{f: f1}}
+	hs := []Handler{{f: f0}, {f: f1}}
 	i := 0
 	get := func() lisette.Result[int, string] {
 		i = 1

--- a/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
+++ b/tests/spec/emit/snapshots/selector_receiver_append_arg_mutates_index.snap
@@ -24,7 +24,7 @@ func bump(i *int) int {
 }
 
 func run() int {
-	hs := []Holder{Holder{slc: []int{10}}, Holder{slc: []int{20}}}
+	hs := []Holder{{slc: []int{10}}, {slc: []int{20}}}
 	i := 0
 	recv_1 := hs[i].slc
 	ys := append(recv_1[:len(recv_1):len(recv_1)], bump(&i))

--- a/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
+++ b/tests/spec/emit/snapshots/slice_append_side_effecting_receiver.snap
@@ -16,7 +16,7 @@ func makeI() int {
 }
 
 func main() {
-	outer := [][]int{[]int{1}, []int{2}, []int{3}}
+	outer := [][]int{{1}, {2}, {3}}
 	base_2 := outer
 	idx_3 := makeI()
 	recv_1 := outer[makeI()]

--- a/tests/spec/emit/snapshots/slice_literal_rhs_index_target_frozen.snap
+++ b/tests/spec/emit/snapshots/slice_literal_rhs_index_target_frozen.snap
@@ -13,7 +13,7 @@ description: |
 package main
 
 func run() int {
-	xs := [][]int{[]int{0}, []int{0}}
+	xs := [][]int{{0}, {0}}
 	i := 0
 	bump := func() int {
 		i = 1


### PR DESCRIPTION
An array, slice, or map literal where its elements repeat the container's element type now emits them without it. This is the same simplification `gofmt -s` applies.

Before:

```go
	a := [][]int{[]int{1, 2}, []int{3, 4}}
	names := []Name{Name{value: "alice"}}
	return [2][3]int{[3]int{1, 2, 3}, [3]int{4, 5, 6}}
```

After:

```go
	a := [][]int{{1, 2}, {3, 4}}
	names := []Name{{value: "alice"}}
	return [2][3]int{{1, 2, 3}, {4, 5, 6}}
```
