### PR TITLE
refactor: emit `errors.New` instead of verb-free `fmt.Errorf`

### DIFF
--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -140,27 +140,29 @@ impl EnumLayout {
         let mut output = Vec::new();
 
         output.push(format!("type {} int", self.tag_type));
-        output.push("const (".to_string());
+        if !self.variants.is_empty() {
+            output.push("const (".to_string());
 
-        for (i, variant) in self.variants.iter().enumerate() {
-            if let Some(doc) = &variant.doc {
-                for line in doc.lines() {
-                    if line.is_empty() {
-                        output.push("//".to_string());
-                    } else {
-                        output.push(format!("// {}", line));
+            for (i, variant) in self.variants.iter().enumerate() {
+                if let Some(doc) = &variant.doc {
+                    for line in doc.lines() {
+                        if line.is_empty() {
+                            output.push("//".to_string());
+                        } else {
+                            output.push(format!("// {}", line));
+                        }
                     }
+                }
+
+                if i == 0 {
+                    output.push(format!("{} {} = iota", variant.tag_constant, self.tag_type));
+                } else {
+                    output.push(variant.tag_constant.clone());
                 }
             }
 
-            if i == 0 {
-                output.push(format!("{} {} = iota", variant.tag_constant, self.tag_type));
-            } else {
-                output.push(variant.tag_constant.clone());
-            }
+            output.push(")".to_string());
         }
-
-        output.push(")".to_string());
 
         let go_type_name = go_name::escape_type_name(&self.enum_name);
         output.push(format!(
@@ -453,6 +455,14 @@ impl EnumLayout {
             self.emit_unmarshal_with_payload_block(&mut lines, &with_payload, receiver, names);
         }
 
+        // No variant means no shape can decode, and Go needs a return anyway.
+        if self.variants.is_empty() {
+            lines.push(format!(
+                "return errors.New(\"invalid {} JSON\")",
+                self.enum_name
+            ));
+        }
+
         lines.push("}".to_string());
 
         lines.join("\n")
@@ -480,7 +490,7 @@ impl EnumLayout {
                 "if err := json.Unmarshal({data}, &{name}); err != nil {{"
             ));
             lines.push(format!(
-                "return fmt.Errorf(\"invalid {} JSON: expected string\")",
+                "return errors.New(\"invalid {} JSON: expected string\")",
                 self.enum_name
             ));
             lines.push("}".to_string());
@@ -516,7 +526,7 @@ impl EnumLayout {
             "if err := json.Unmarshal({data}, &{obj}); err != nil {{"
         ));
         lines.push(format!(
-            "return fmt.Errorf(\"invalid {} JSON\")",
+            "return errors.New(\"invalid {} JSON\")",
             self.enum_name
         ));
         lines.push("}".to_string());
@@ -537,7 +547,7 @@ impl EnumLayout {
         lines.push("}".to_string());
         lines.push("}".to_string());
         lines.push(format!(
-            "return fmt.Errorf(\"empty {} JSON object\")",
+            "return errors.New(\"empty {} JSON object\")",
             self.enum_name
         ));
     }

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -85,7 +85,10 @@ impl Planner<'_> {
             self.require_fmt();
         }
         if has_json {
-            self.require_json();
+            self.require_errors();
+            if !layout.variants.is_empty() {
+                self.require_json();
+            }
         }
 
         Some(result)

--- a/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
+++ b/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -35,7 +36,7 @@ func (s Status) MarshalJSON() ([]byte, error) {
 func (s *Status) UnmarshalJSON(data []byte) error {
 	var name string
 	if err := json.Unmarshal(data, &name); err != nil {
-		return fmt.Errorf("invalid Status JSON: expected string")
+		return errors.New("invalid Status JSON: expected string")
 	}
 	switch name {
 	case "Ready":

--- a/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/json"
 	js "encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -36,7 +37,7 @@ func (s Status) MarshalJSON() ([]byte, error) {
 func (s *Status) UnmarshalJSON(data []byte) error {
 	var name string
 	if err := json.Unmarshal(data, &name); err != nil {
-		return fmt.Errorf("invalid Status JSON: expected string")
+		return errors.New("invalid Status JSON: expected string")
 	}
 	switch name {
 	case "Ready":

--- a/tests/spec/emit/snapshots/enum_contested_field_json_keys_stay_source_spelled.snap
+++ b/tests/spec/emit/snapshots/enum_contested_field_json_keys_stay_source_spelled.snap
@@ -17,6 +17,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -55,7 +56,7 @@ func (s Shape) MarshalJSON() ([]byte, error) {
 func (s *Shape) UnmarshalJSON(data []byte) error {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Shape JSON")
+		return errors.New("invalid Shape JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -87,7 +88,7 @@ func (s *Shape) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Shape variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Shape JSON object")
+	return errors.New("empty Shape JSON object")
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
@@ -9,6 +9,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -52,7 +53,7 @@ func (s Status) MarshalJSON() ([]byte, error) {
 func (s *Status) UnmarshalJSON(data []byte) error {
 	var name string
 	if err := json.Unmarshal(data, &name); err != nil {
-		return fmt.Errorf("invalid Status JSON: expected string")
+		return errors.New("invalid Status JSON: expected string")
 	}
 	switch name {
 	case "Active":

--- a/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
@@ -12,6 +12,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -60,7 +61,7 @@ func (s *Shape) UnmarshalJSON(data []byte) error {
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Shape JSON")
+		return errors.New("invalid Shape JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -81,5 +82,5 @@ func (s *Shape) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Shape variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Shape JSON object")
+	return errors.New("empty Shape JSON object")
 }

--- a/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
@@ -13,6 +13,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -68,7 +69,7 @@ func (s *Shape) UnmarshalJSON(data []byte) error {
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Shape JSON")
+		return errors.New("invalid Shape JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -82,5 +83,5 @@ func (s *Shape) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Shape variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Shape JSON object")
+	return errors.New("empty Shape JSON object")
 }

--- a/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
@@ -12,6 +12,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -60,7 +61,7 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Message JSON")
+		return errors.New("invalid Message JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -85,5 +86,5 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Message variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Message JSON object")
+	return errors.New("empty Message JSON object")
 }

--- a/tests/spec/emit/snapshots/json_enum_without_variants.snap
+++ b/tests/spec/emit/snapshots/json_enum_without_variants.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[json]
+  enum Nothing {}
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+type NothingTag int
+type Nothing struct {
+	Tag NothingTag
+}
+
+func (n Nothing) MarshalJSON() ([]byte, error) {
+	switch n.Tag {
+	default:
+		return nil, fmt.Errorf("unknown Nothing tag: %d", n.Tag)
+	}
+}
+
+func (n *Nothing) UnmarshalJSON(data []byte) error {
+	return errors.New("invalid Nothing JSON")
+}

--- a/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -87,7 +88,7 @@ func (bb *Box[b]) UnmarshalJSON(data []byte) error {
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Box JSON")
+		return errors.New("invalid Box JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -98,7 +99,7 @@ func (bb *Box[b]) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Box variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Box JSON object")
+	return errors.New("empty Box JSON object")
 }
 
 func (bb Box[b]) toString() string {

--- a/tests/spec/emit/snapshots/synthesized_json_freshens_local_against_receiver.snap
+++ b/tests/spec/emit/snapshots/synthesized_json_freshens_local_against_receiver.snap
@@ -17,6 +17,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -48,7 +49,7 @@ func (v Vault) MarshalJSON() ([]byte, error) {
 func (v *Vault) UnmarshalJSON(data []byte) error {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid Vault JSON")
+		return errors.New("invalid Vault JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -73,7 +74,7 @@ func (v *Vault) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown Vault variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Vault JSON object")
+	return errors.New("empty Vault JSON object")
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/synthesized_json_freshens_param_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_json_freshens_param_against_type_param.snap
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -66,7 +67,7 @@ func (b *Box[data]) UnmarshalJSON(data_2 []byte) error {
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(data_2, &obj); err != nil {
-		return fmt.Errorf("invalid Box JSON")
+		return errors.New("invalid Box JSON")
 	}
 	for key, val := range obj {
 		switch key {
@@ -77,7 +78,7 @@ func (b *Box[data]) UnmarshalJSON(data_2 []byte) error {
 			return fmt.Errorf("unknown Box variant: %s", key)
 		}
 	}
-	return fmt.Errorf("empty Box JSON object")
+	return errors.New("empty Box JSON object")
 }
 
 func test() int {

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -3640,6 +3640,15 @@ enum Status { Active, Inactive, Suspended }
 }
 
 #[test]
+fn json_enum_without_variants() {
+    let input = r#"
+#[json]
+enum Nothing {}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn json_enum_with_single_payload() {
     let input = r#"
 #[json]


### PR DESCRIPTION
The synthetic JSON decoder now returns `errors.New` for its verb-free failures instead of `fmt.Errorf`.

Before:

```go
	if err := json.Unmarshal(data, &obj); err != nil {
		return fmt.Errorf("invalid Shape JSON")
	}
```

After:

```go
	if err := json.Unmarshal(data, &obj); err != nil {
		return errors.New("invalid Shape JSON")
	}
```
