### PR TITLE
refactor: drop the underscore prefix on live emit temps

### DIFF
--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -647,7 +647,7 @@ fn emit_lowered_tuple_tail(
             })
             .collect();
         let (mut statements, parts) = planner
-            .sequence_values(stages, CaptureBoundary::SiblingSequence, "_ret")
+            .sequence_values(stages, CaptureBoundary::SiblingSequence, "ret")
             .into_rendered();
         let parts = planner.coerce_elements_to_slots(&mut statements, elements, parts, &slot_tys);
         statements.push(multi_value_return(parts));

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -322,7 +322,7 @@ impl Planner<'_> {
             .flat_map(|(key, value)| [*key, *value])
             .map(|e| self.stage_composite(e, ExpressionContext::value()))
             .collect();
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_entry");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "entry");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
@@ -625,7 +625,7 @@ impl Planner<'_> {
             .iter()
             .map(|a| self.stage_composite(a, arg_ctx))
             .collect();
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_arg");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "arg");
         let effect = EvaluationEffect::PureCall.combine(sequenced.effect);
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (mut setup, values) = sequenced.into_rendered();

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -703,7 +703,7 @@ impl Planner<'_> {
 
         let combine =
             plan_variadic_spread(&self.facts, ctx.function, ctx.spread).map(|p| p.combine(1));
-        let mut sequenced = self.sequence_values(all_stages, ctx.capture_boundary, "_arg");
+        let mut sequenced = self.sequence_values(all_stages, ctx.capture_boundary, "arg");
         if let Some(spread_index) = spread_index {
             self.finalize_spread_stage(&mut sequenced.values, spread_index, false, combine);
         }
@@ -904,7 +904,7 @@ impl Planner<'_> {
         });
         let combine =
             plan_variadic_spread(&self.facts, ctx.function, ctx.spread).map(|p| p.combine(0));
-        let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "_arg");
+        let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "arg");
         if let Some(spread_index) = spread_index {
             self.finalize_spread_stage(&mut sequenced.values, spread_index, false, combine);
         }
@@ -945,7 +945,7 @@ impl Planner<'_> {
             if let Some(e) = end.as_deref() {
                 stages.push(self.stage_operand(e, ExpressionContext::value()));
             }
-            let sequenced = self.sequence_values(stages, capture_boundary, "_arg");
+            let sequenced = self.sequence_values(stages, capture_boundary, "arg");
             let effect = sequenced.effect;
             let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
             let (setup, values) = sequenced.into_rendered();
@@ -977,11 +977,8 @@ impl Planner<'_> {
             .expect("substring arg should resolve to a known range type");
         let receiver_staged = self.stage_operand(receiver_expr, ExpressionContext::value());
         let range_staged = self.stage_or_capture(arg, "range");
-        let sequenced = self.sequence_values(
-            vec![receiver_staged, range_staged],
-            capture_boundary,
-            "_arg",
-        );
+        let sequenced =
+            self.sequence_values(vec![receiver_staged, range_staged], capture_boundary, "arg");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (setup, values) = sequenced.into_rendered();

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -312,7 +312,7 @@ impl<'a> Planner<'a> {
         }
         let staged = self.stage_operand(argument, ExpressionContext::value());
         let mut sequenced =
-            self.sequence_values(vec![staged], expression_ctx.capture_boundary(), "_arg");
+            self.sequence_values(vec![staged], expression_ctx.capture_boundary(), "arg");
         let effect = self.regular_call_effect(function, sequenced.effect);
         let value = sequenced
             .values
@@ -451,7 +451,7 @@ impl<'a> Planner<'a> {
         {
             stages.push(stage);
             let spread_index = stages.len() - 1;
-            let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "_arg");
+            let mut sequenced = self.sequence_values(stages, ctx.capture_boundary, "arg");
             self.finalize_spread_stage(
                 &mut sequenced.values,
                 spread_index,

--- a/crates/emit/src/control_flow/loops.rs
+++ b/crates/emit/src/control_flow/loops.rs
@@ -92,11 +92,11 @@ impl Planner<'_> {
                 this.capture_value_at_boundary(
                     &mut prologue,
                     iterable,
-                    "_range",
+                    "range",
                     CaptureBoundary::LoopLifetime,
                 )
             };
-            let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+            let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
             let header = match range_shape {
                 RangeShape::Range => format!(
                     "for {} := {}.Start; {} < {}.End; {}++ {{\n",
@@ -155,11 +155,11 @@ impl Planner<'_> {
                 this.capture_value_at_boundary(
                     &mut prologue,
                     receiver,
-                    "_s",
+                    "s",
                     CaptureBoundary::LoopLifetime,
                 )
             };
-            let index_var = this.fresh_var(Some("_i"));
+            let index_var = this.fresh_var(Some("i"));
             let loop_var = this.bind_loop_pattern(&binding.pattern, None);
             let mut header = format!(
                 "for {} := 0; {} < len({}); {}++ {{\n",
@@ -458,7 +458,7 @@ impl Planner<'_> {
             self.capture_value_at_boundary(
                 &mut prologue,
                 end,
-                "_bound",
+                "bound",
                 CaptureBoundary::LoopLifetime,
             )
         });
@@ -493,7 +493,7 @@ impl Planner<'_> {
                     }
                 }
                 Some(end_expression) => {
-                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
                     let operator = if *inclusive { "<=" } else { "<" };
                     format!(
                         "for {} := {}; {} {} {}; {}++ {{\n",
@@ -501,7 +501,7 @@ impl Planner<'_> {
                     )
                 }
                 None => {
-                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("_i"));
+                    let loop_var = this.bind_loop_pattern(&binding.pattern, Some("i"));
                     format!(
                         "for {} := {}; ; {}++ {{\n",
                         loop_var, start_expression, loop_var
@@ -556,7 +556,9 @@ impl Planner<'_> {
         if let Pattern::Identifier { identifier, .. } = pattern
             && let Some(mut go_name) = self.go_name_for_binding(pattern)
         {
-            if self.scope.has_binding_for_go_name(&go_name) {
+            if self.scope.has_binding_for_go_name(&go_name)
+                || self.scope.is_go_name_declared(&go_name)
+            {
                 go_name = self.fresh_var(Some(&go_name));
             }
             return self.scope.bind(identifier, go_name);

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -35,13 +35,13 @@ impl Planner<'_> {
         {
             let needs_cap = self.is_native_shape(&expression.get_type(), NativeGoType::Slice);
             if base_staged.evaluation.effect.has_call() {
-                self.pin_staged(&mut base_staged, "_base");
+                self.pin_staged(&mut base_staged, "base");
             }
             let index_staged = self.stage_or_capture(index, "range");
             let sequenced = self.sequence_values(
                 vec![base_staged, index_staged],
                 CaptureBoundary::SiblingSequence,
-                "_base",
+                "base",
             );
             let effect = sequenced.effect;
             let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
@@ -54,7 +54,7 @@ impl Planner<'_> {
             );
         }
 
-        self.sequence_indexed_access(expression, base_staged, index, "_base")
+        self.sequence_indexed_access(expression, base_staged, index, "base")
     }
 
     pub(crate) fn sequence_indexed_access(
@@ -117,7 +117,7 @@ impl Planner<'_> {
         if let Some(e) = end {
             all_stages.push(self.stage_operand(e, ExpressionContext::value()));
         }
-        let sequenced = self.sequence_values(all_stages, CaptureBoundary::SiblingSequence, "_base");
+        let sequenced = self.sequence_values(all_stages, CaptureBoundary::SiblingSequence, "base");
         let effect = sequenced.effect;
         let mut setup = sequenced.setup;
         let mut values = sequenced.values.into_iter();

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -70,7 +70,7 @@ impl Planner<'_> {
         if ctx.enum_ctx.is_some() {
             field_side_effects.insert(0, false);
         }
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_field");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "field");
         let mut effect = sequenced.effect;
         let fields_contain_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (mut setup, emitted_values) = sequenced.into_rendered();

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -76,7 +76,7 @@ impl Planner<'_> {
             .iter()
             .map(|e| self.stage_composite(e, ExpressionContext::value()))
             .collect();
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_v");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "v");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
@@ -130,7 +130,7 @@ impl Planner<'_> {
                 }
             })
             .collect();
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_fmtarg");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "fmtarg");
         let effect = sequenced.effect;
         let (setup, emitted) = sequenced.into_rendered();
 

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -115,7 +115,7 @@ impl Planner<'_> {
             self.stage_composite(left_expression, ctx),
             self.stage_composite(right_expression, ctx),
         ];
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_left");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "left");
         let effect = sequenced.effect;
         let setup = sequenced.setup;
         let mut values = sequenced.values.into_iter();
@@ -274,7 +274,7 @@ impl Planner<'_> {
             self.stage_operand(left_expression, ctx),
             self.stage_operand(right_expression, ctx),
         ];
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_left");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "left");
         let effect = sequenced.effect;
         let setup = sequenced.setup;
         let mut values = sequenced.values.into_iter();

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -407,7 +407,7 @@ impl Planner<'_> {
             stages.push(self.stage_operand(s, ExpressionContext::value()));
             stages.len() - 1
         });
-        let mut sequenced = self.sequence_values(stages, options.boundary, "_arg");
+        let mut sequenced = self.sequence_values(stages, options.boundary, "arg");
         if let Some(i) = spread_index {
             self.finalize_spread_stage(
                 &mut sequenced.values,
@@ -432,7 +432,7 @@ impl Planner<'_> {
         {
             stages.push(adapter_stage);
             let spread_index = stages.len() - 1;
-            let mut sequenced = self.sequence_values(stages, options.boundary, "_arg");
+            let mut sequenced = self.sequence_values(stages, options.boundary, "arg");
             self.finalize_spread_stage(
                 &mut sequenced.values,
                 spread_index,

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -364,7 +364,7 @@ impl Planner<'_> {
                 self.stage_composite(e, element_ctx)
             })
             .collect();
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_v");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "v");
         let effect = sequenced.effect;
         let (mut setup, element_expressions) = sequenced.into_rendered();
 
@@ -561,7 +561,7 @@ impl Planner<'_> {
             );
         }
 
-        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "_range");
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "range");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (setup, values) = sequenced.into_rendered();

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -124,7 +124,7 @@ impl Planner<'_> {
             || (right_hand_side_has_effectful_call
                 && !self.identifier_immune_to_calls(target.unwrap_parens()));
         let pinned_left = needs_left_pin.then(|| {
-            let tmp = self.fresh_var(Some("_left"));
+            let tmp = self.fresh_var(Some("left"));
             self.declare(&tmp);
             target_capture.push(LoweredStatement::TempBind {
                 name: tmp.clone(),

--- a/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_partial_from_generic_method_keeps_tagged_return.snap
@@ -22,9 +22,9 @@ func Holder_Resolve[T any, R any, E any](self Holder[T], f func(T) lisette.Parti
 }
 
 func main() {
-	_arg_4 := Holder[int]{Val: 4}
+	arg_4 := Holder[int]{Val: 4}
 	cb_1 := Fallible
-	rez := Holder_Resolve(_arg_4, func(arg0 int) lisette.Partial[int, Face] {
+	rez := Holder_Resolve(arg_4, func(arg0 int) lisette.Partial[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		if ret_3 != nil {
 			return lisette.MakePartialBoth[int, Face](ret_2, ret_3)

--- a/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
+++ b/tests/spec/build/snapshots/bound_result_from_generic_method_keeps_tagged_return.snap
@@ -22,9 +22,9 @@ func Holder_Resolve[R any, E any](self Holder, f func(int) lisette.Result[R, E])
 }
 
 func main() {
-	_arg_4 := Holder{N: 4}
+	arg_4 := Holder{N: 4}
 	cb_1 := Resultant
-	rez := Holder_Resolve(_arg_4, func(arg0 int) lisette.Result[int, Face] {
+	rez := Holder_Resolve(arg_4, func(arg0 int) lisette.Result[int, Face] {
 		ret_2, ret_3 := cb_1(arg0)
 		if ret_3 != nil {
 			return lisette.MakeResultErr[int, Face](ret_3)

--- a/tests/spec/build/snapshots/fixed_size_array_lowers.snap
+++ b/tests/spec/build/snapshots/fixed_size_array_lowers.snap
@@ -22,7 +22,7 @@ func main() {
 	xs := [3]int{1, 2, 3}
 	g := Grid{cells: [3]int{4, 5, 6}}
 	same := xs == makeArr()
-	_arg_1 := len(xs)
-	_arg_2 := xs[0]
-	fmt.Println(_arg_1, _arg_2, same, first(g.cells))
+	arg_1 := len(xs)
+	arg_2 := xs[0]
+	fmt.Println(arg_1, arg_2, same, first(g.cells))
 }

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
@@ -23,8 +23,8 @@ type Container[T interface {
 }
 
 func (c Container[T]) display() string {
-	_fmtarg_1 := c.label
-	return fmt.Sprintf("[%s] %s", _fmtarg_1, c.value.PrintVal())
+	fmtarg_1 := c.label
+	return fmt.Sprintf("[%s] %s", fmtarg_1, c.value.PrintVal())
 }
 
 func (c Container[T]) total() int {

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -82,8 +82,8 @@ type Tagged[T traits.Showable] struct {
 }
 
 func (t Tagged[T]) Show() string {
-	_fmtarg_1 := t.Label
-	return fmt.Sprintf("[%s] %s", _fmtarg_1, t.Value.Show())
+	fmtarg_1 := t.Label
+	return fmt.Sprintf("[%s] %s", fmtarg_1, t.Value.Show())
 }
 
 func (t Tagged[T]) Display() string {

--- a/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
+++ b/tests/spec/build/snapshots/option_fn_arg_adapts_to_comma_ok_generic_method_param.snap
@@ -22,9 +22,9 @@ func Holder_Resolve[R any](self Holder, f func(int) (R, bool)) (R, bool) {
 }
 
 func main() {
-	_arg_4 := Holder{N: 4}
+	arg_4 := Holder{N: 4}
 	cb_1 := Lookup
-	ret_5, ret_6 := Holder_Resolve(_arg_4, func(arg0 int) (Face, bool) {
+	ret_5, ret_6 := Holder_Resolve(arg_4, func(arg0 int) (Face, bool) {
 		raw_2 := cb_1(arg0)
 		option_3 := lisette.OptionFromNilable[Face](raw_2, lisette.IsNilInterface(raw_2))
 		if option_3.Tag == lisette.OptionSome {

--- a/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
+++ b/tests/spec/build/snapshots/spread_slice_into_variadic_generic_method_param_adapts_each_element.snap
@@ -21,7 +21,7 @@ func Holder_Resolve[R any, E any](_ Holder, default_ R, _ ...func(int) lisette.R
 
 func main() {
 	fns := []func(int) (int, Face){Resultant}
-	_arg_7 := Holder{}
+	arg_7 := Holder{}
 	src_1 := fns
 	adapted_2 := make([]func(int) lisette.Result[int, Face], len(src_1))
 	for i, cb_3 := range src_1 {
@@ -35,6 +35,6 @@ func main() {
 			}
 		}
 	}
-	rez := Holder_Resolve[int, Face](_arg_7, 0, adapted_2...)
+	rez := Holder_Resolve[int, Face](arg_7, 0, adapted_2...)
 	_ = rez
 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2265,11 +2265,11 @@ fn emit_or_capture_no_collision_with_user_vars() {
 import "go:fmt"
 
 fn main() {
-  let _bound_0 = 10
+  let bound_0 = 10
   for i in 0..(1 + 2) {
     fmt.Println(i)
   }
-  fmt.Println(_bound_0)
+  fmt.Println(bound_0)
 }
 "#;
     assert_emit_snapshot!(input);
@@ -2919,9 +2919,41 @@ fn main() {
   for i in 0..make_bound() {
     sum = sum + i;
   }
-  let _bound_1 = 7;
+  let bound_1 = 7;
   let _ = sum;
-  let _ = _bound_1;
+  let _ = bound_1;
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn loop_variable_named_like_bound_temp_no_collision() {
+    let input = r#"
+fn make_bound() -> int { 3 }
+
+fn main() {
+  let mut sum = 0;
+  for bound_1 in 0..=make_bound() {
+    sum = sum + bound_1;
+  }
+  let _ = sum;
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn loop_variable_named_like_range_temp_no_collision() {
+    let input = r#"
+fn make_range() -> Range<int> { 0..3 }
+
+fn main() {
+  let mut sum = 0;
+  for range_1 in make_range() {
+    sum = sum + range_1;
+  }
+  let _ = sum;
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
+++ b/tests/spec/emit/snapshots/abi_transition_callback_adapter_lowered_to_tagged.snap
@@ -17,12 +17,12 @@ func double(x int) (int, bool) {
 }
 
 func run() (int, bool) {
-	_arg_3 := lisette.MakeOptionSome(2)
+	arg_3 := lisette.MakeOptionSome(2)
 	cb_1 := double
 	tagged_2 := func(arg0 int) lisette.Option[int] {
 		return lisette.OptionFromCommaOk[int](cb_1(arg0))
 	}
-	v_4 := lisette.OptionAndThen(_arg_3, tagged_2)
+	v_4 := lisette.OptionAndThen(arg_3, tagged_2)
 	if v_4.Tag == lisette.OptionSome {
 		return v_4.SomeVal, true
 	}

--- a/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/alias_free_operand_not_pinned_before_call.snap
@@ -25,7 +25,7 @@ func run() int {
 		i = 1
 		return 10
 	}
-	_arg_1 := i
-	items = append(items, _arg_1, ibump())
+	arg_1 := i
+	items = append(items, arg_1, ibump())
 	return items[0] + items[1]
 }

--- a/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/append_args_eval_order_captured.snap
@@ -24,7 +24,7 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	items := []int{}
-	_arg_1 := i
-	items = append(items, _arg_1, bump(&i))
+	arg_1 := i
+	items = append(items, arg_1, bump(&i))
 	_ = items
 }

--- a/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
+++ b/tests/spec/emit/snapshots/array_of_concrete_widens_to_interface_elements_in_return_position.snap
@@ -39,8 +39,8 @@ func widen() [2]error {
 }
 
 func test() {
-	_base_1 := widen()
-	if _base_1[1].Error() != "boom" {
+	base_1 := widen()
+	if base_1[1].Error() != "boom" {
 		panic("returned array lost its interface elements")
 	}
 }

--- a/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_index_receiver_pinned_before_effectful_arg.snap
@@ -39,6 +39,6 @@ func bump(i *int) int {
 func run() {
 	items := []Cell{{v: 0}, {v: 0}}
 	i := 0
-	_arg_1 := &items[i]
-	Cell_add[int](_arg_1, bump(&i))
+	arg_1 := &items[i]
+	Cell_add[int](arg_1, bump(&i))
 }

--- a/tests/spec/emit/snapshots/auto_addressed_struct_literal_receiver_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_struct_literal_receiver_pinned_before_effectful_arg.snap
@@ -37,6 +37,6 @@ func bump(i *int) int {
 
 func run() {
 	i := 0
-	_arg_1 := &Cell{v: i}
-	Cell_add[int](_arg_1, bump(&i))
+	arg_1 := &Cell{v: i}
+	Cell_add[int](arg_1, bump(&i))
 }

--- a/tests/spec/emit/snapshots/binary_left_hoisted_when_right_is_call.snap
+++ b/tests/spec/emit/snapshots/binary_left_hoisted_when_right_is_call.snap
@@ -22,7 +22,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_left_1 := i
-	z := _left_1 + bump(&i)
+	left_1 := i
+	z := left_1 + bump(&i)
 	_ = z
 }

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -59,8 +59,8 @@ func main() {
 		Tag: CarrierC,
 		P:   &i,
 	}
-	_arg_2 := m[i][0]
-	_base_1 := []int{bump(c)}
-	x := first(_arg_2, _base_1[0])
+	arg_2 := m[i][0]
+	base_1 := []int{bump(c)}
+	x := first(arg_2, base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_struct_ref_eval_order.snap
@@ -38,8 +38,8 @@ func main() {
 	i := 0
 	m := [][]int{{10}, {20}}
 	c := Carrier{p: &i}
-	_arg_2 := m[i][0]
-	_base_1 := []int{bump(c)}
-	x := first(_arg_2, _base_1[0])
+	arg_2 := m[i][0]
+	base_1 := []int{bump(c)}
+	x := first(arg_2, base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/call_args_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/call_args_eval_order_captured.snap
@@ -28,7 +28,7 @@ func sum(a, b int) int {
 
 func main() {
 	i := 0
-	_arg_1 := i
-	z := sum(_arg_1, bump(&i))
+	arg_1 := i
+	z := sum(arg_1, bump(&i))
 	_ = z
 }

--- a/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_prebound_ref_eval_order.snap
@@ -32,8 +32,8 @@ func main() {
 	i := 0
 	m := [][]int{{10}, {20}}
 	ip := &i
-	_arg_2 := m[i][0]
-	_base_1 := []int{bump(ip)}
-	x := first(_arg_2, _base_1[0])
+	arg_2 := m[i][0]
+	base_1 := []int{bump(ip)}
+	x := first(arg_2, base_1[0])
 	_ = x
 }

--- a/tests/spec/emit/snapshots/compound_binary_rhs_keeps_grouping_when_left_pinned.snap
+++ b/tests/spec/emit/snapshots/compound_binary_rhs_keeps_grouping_when_left_pinned.snap
@@ -19,8 +19,8 @@ func run() int {
 		y = 10
 		return 4
 	}
-	_left_2 := x
-	_left_1 := y
-	x = _left_2 * (_left_1 + bump())
+	left_2 := x
+	left_1 := y
+	x = left_2 * (left_1 + bump())
 	return x
 }

--- a/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
+++ b/tests/spec/emit/snapshots/compound_deref_assignment_target_captured.snap
@@ -36,8 +36,8 @@ func main() {
 	b := 2
 	h := H{ptr: &a}
 	ref_1 := h.ptr
-	_left_2 := *ref_1
-	*ref_1 = _left_2 + h.repoint(&b)
+	left_2 := *ref_1
+	*ref_1 = left_2 + h.repoint(&b)
 	_ = a
 	_ = b
 }

--- a/tests/spec/emit/snapshots/compound_identifier_target_reads_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_identifier_target_reads_before_call_rhs.snap
@@ -17,7 +17,7 @@ func run() int {
 		x = 100
 		return 5
 	}
-	_left_1 := x
-	x = _left_1 + bump()
+	left_1 := x
+	x = left_1 + bump()
 	return x
 }

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_call_rhs.snap
@@ -20,7 +20,7 @@ func run() int {
 		return 5
 	}
 	idx_1 := i
-	_left_2 := xs[idx_1]
-	xs[idx_1] = _left_2 + bump()
+	left_2 := xs[idx_1]
+	xs[idx_1] = left_2 + bump()
 	return xs[0]
 }

--- a/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
+++ b/tests/spec/emit/snapshots/compound_index_target_frozen_before_rhs.snap
@@ -26,11 +26,11 @@ func run() lisette.Result[struct{}, string] {
 	}
 	base_2 := xs
 	idx_3 := i
-	_left_4 := base_2[idx_3]
+	left_4 := base_2[idx_3]
 	check_1 := bump()
 	if check_1.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[struct{}, string](check_1.ErrVal)
 	}
-	base_2[idx_3] = _left_4 + check_1.OkVal
+	base_2[idx_3] = left_4 + check_1.OkVal
 	return lisette.MakeResultOk[struct{}, string](struct{}{})
 }

--- a/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
+++ b/tests/spec/emit/snapshots/constructor_lowered_to_conversion_pins_before_call.snap
@@ -23,7 +23,7 @@ func run() int {
 		x = 50
 		return v
 	}
-	_v_1 := Box(x)
-	r := lisette.MakeTuple2[Box, int](_v_1, bump(5))
+	v_1 := Box(x)
+	r := lisette.MakeTuple2[Box, int](v_1, bump(5))
 	return int(r.First) + r.Second
 }

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_argument_eagerly.snap
@@ -19,8 +19,8 @@ func mark() int {
 
 func test() {
 	xs := []int{1}
-	_arg_1 := mark()
+	arg_1 := mark()
 	defer func() {
-		_ = append(xs[:len(xs):len(xs)], _arg_1)
+		_ = append(xs[:len(xs):len(xs)], arg_1)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_evaluates_receiver_eagerly.snap
@@ -17,8 +17,8 @@ func getItems() []int {
 }
 
 func test() {
-	_arg_1 := getItems()
+	arg_1 := getItems()
 	defer func() {
-		_ = len(_arg_1)
+		_ = len(arg_1)
 	}()
 }

--- a/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_deref_receiver.snap
@@ -10,10 +10,10 @@ description: |
 package main
 
 func run(out *[]int) {
-	_arg_1 := *out
-	_arg_2 := []int{1, 2, 3}
+	arg_1 := *out
+	arg_2 := []int{1, 2, 3}
 	defer func() {
-		_ = copy(_arg_1, _arg_2)
+		_ = copy(arg_1, arg_2)
 	}()
 	*out = []int{7, 7, 7, 7, 7}
 }

--- a/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_mutable_identifier_argument.snap
+++ b/tests/spec/emit/snapshots/defer_native_method_iife_snapshots_mutable_identifier_argument.snap
@@ -14,10 +14,10 @@ package main
 func run() {
 	dst := []int{0, 0, 0}
 	src := []int{1, 2, 3}
-	_arg_1 := dst
-	_arg_2 := src
+	arg_1 := dst
+	arg_2 := src
 	defer func() {
-		_ = copy(_arg_1, _arg_2)
+		_ = copy(arg_1, arg_2)
 	}()
 	src = []int{9, 9, 9}
 }

--- a/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
+++ b/tests/spec/emit/snapshots/emit_or_capture_no_collision_with_user_vars.snap
@@ -5,11 +5,11 @@ description: |
   import "go:fmt"
   
   fn main() {
-    let _bound_0 = 10
+    let bound_0 = 10
     for i in 0..(1 + 2) {
       fmt.Println(i)
     }
-    fmt.Println(_bound_0)
+    fmt.Println(bound_0)
   }
 ---
 package main
@@ -17,10 +17,10 @@ package main
 import "fmt"
 
 func main() {
-	_bound_0 := 10
-	_bound_1 := (1 + 2)
-	for i := range _bound_1 {
+	bound_0 := 10
+	bound_1 := (1 + 2)
+	for i := range bound_1 {
 		fmt.Println(i)
 	}
-	fmt.Println(_bound_0)
+	fmt.Println(bound_0)
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -27,10 +27,10 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	_arg_3 := side()
+	arg_3 := side()
 	ret_1, ret_2 := getY()
 	if ret_2 != nil {
 		return 0, ret_2
 	}
-	return add(_arg_3, ret_1), nil
+	return add(arg_3, ret_1), nil
 }

--- a/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
+++ b/tests/spec/emit/snapshots/eval_order_assignment_call_target_if_value.snap
@@ -18,8 +18,8 @@ func getItems() []int {
 func main() {
 	items := []int{0, 0, 0}
 	base_2 := items
-	_base_3 := getItems()
-	idx_4 := _base_3[0]
+	base_3 := getItems()
+	idx_4 := base_3[0]
 	var tmp_1 int
 	if true {
 		tmp_1 = 42

--- a/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
+++ b/tests/spec/emit/snapshots/for_bytes_loop_captures_mutated_receiver.snap
@@ -20,9 +20,9 @@ package main
 func main() {
 	s := "ab"
 	count := 0
-	_s_1 := s
-	for _i_2 := 0; _i_2 < len(_s_1); _i_2++ {
-		b := _s_1[_i_2]
+	s_1 := s
+	for i_2 := 0; i_2 < len(s_1); i_2++ {
+		b := s_1[i_2]
 		count++
 		s = ""
 		_ = b

--- a/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
+++ b/tests/spec/emit/snapshots/for_bytes_zero_alloc.snap
@@ -14,8 +14,8 @@ package main
 import "fmt"
 
 func test(s string) {
-	for _i_1 := 0; _i_1 < len(s); _i_1++ {
-		b := s[_i_1]
+	for i_1 := 0; i_1 < len(s); i_1++ {
+		b := s[i_1]
 		fmt.Println(b)
 	}
 }

--- a/tests/spec/emit/snapshots/for_loop_inline_range_end_mutation_captured.snap
+++ b/tests/spec/emit/snapshots/for_loop_inline_range_end_mutation_captured.snap
@@ -18,8 +18,8 @@ package main
 func main() {
 	n := 3
 	iters := 0
-	_bound_1 := n
-	for i := range _bound_1 {
+	bound_1 := n
+	for i := range bound_1 {
 		iters++
 		n = 0
 		_ = i

--- a/tests/spec/emit/snapshots/for_loop_range_from_call.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_from_call.snap
@@ -25,8 +25,8 @@ func getRange() lisette.Range[int] {
 
 func test() int {
 	sum := 0
-	_range_1 := getRange()
-	for i := _range_1.Start; i < _range_1.End; i++ {
+	range_1 := getRange()
+	for i := range_1.Start; i < range_1.End; i++ {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/for_loop_range_start_frozen_before_call_bound.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_start_frozen_before_call_bound.snap
@@ -22,8 +22,8 @@ func test() int {
 	}
 	sum := 0
 	start_2 := n
-	_bound_1 := consume()
-	for i := start_2; i < _bound_1; i++ {
+	bound_1 := consume()
+	for i := start_2; i < bound_1; i++ {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/for_loop_range_with_call.snap
+++ b/tests/spec/emit/snapshots/for_loop_range_with_call.snap
@@ -20,8 +20,8 @@ func getEnd() int {
 
 func test() int {
 	sum := 0
-	_bound_1 := getEnd()
-	for i := range _bound_1 {
+	bound_1 := getEnd()
+	for i := range bound_1 {
 		sum += i
 	}
 	return sum

--- a/tests/spec/emit/snapshots/for_loop_stored_range_mutation_captured.snap
+++ b/tests/spec/emit/snapshots/for_loop_stored_range_mutation_captured.snap
@@ -23,8 +23,8 @@ func main() {
 		End:   3,
 	}
 	n := 0
-	_range_1 := r
-	for i := _range_1.Start; i < _range_1.End; i++ {
+	range_1 := r
+	for i := range_1.Start; i < range_1.End; i++ {
 		n++
 		r = lisette.Range[int]{
 			Start: 0,

--- a/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/format_string_eval_order_captured.snap
@@ -24,7 +24,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_fmtarg_1 := i
-	s := fmt.Sprintf("%d,%d", _fmtarg_1, bump(&i))
+	fmtarg_1 := i
+	s := fmt.Sprintf("%d,%d", fmtarg_1, bump(&i))
 	_ = s
 }

--- a/tests/spec/emit/snapshots/inline_call_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/inline_call_pins_when_later_operand_pins.snap
@@ -22,8 +22,8 @@ func run() int {
 		x += 7
 		return v
 	}
-	_v_1 := setx()
-	_v_2 := x
-	r := []int{_v_1, _v_2, bump(5)}
+	v_1 := setx()
+	v_2 := x
+	r := []int{v_1, v_2, bump(5)}
 	return r[0] + r[1] + r[2]
 }

--- a/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
+++ b/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
@@ -31,6 +31,6 @@ func main() {
 	empty := slices.Concat[[]byte, byte]()
 	value := slices.Clone[[]byte, byte]
 	out := apply(slices.Clone[[]byte, byte], empty)
-	_arg_1 := len(empty)
-	fmt.Println(_arg_1, len(value(empty)), len(out))
+	arg_1 := len(empty)
+	fmt.Println(arg_1, len(value(empty)), len(out))
 }

--- a/tests/spec/emit/snapshots/loop_variable_named_like_bound_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/loop_variable_named_like_bound_temp_no_collision.snap
@@ -6,12 +6,10 @@ description: |
   
   fn main() {
     let mut sum = 0;
-    for i in 0..make_bound() {
-      sum = sum + i;
+    for bound_1 in 0..=make_bound() {
+      sum = sum + bound_1;
     }
-    let bound_1 = 7;
     let _ = sum;
-    let _ = bound_1;
   }
 ---
 package main
@@ -23,10 +21,8 @@ func makeBound() int {
 func main() {
 	sum := 0
 	bound_1 := makeBound()
-	for i := range bound_1 {
-		sum += i
+	for bound_1_2 := 0; bound_1_2 <= bound_1; bound_1_2++ {
+		sum += bound_1_2
 	}
-	bound_1_2 := 7
 	_ = sum
-	_ = bound_1_2
 }

--- a/tests/spec/emit/snapshots/loop_variable_named_like_range_temp_no_collision.snap
+++ b/tests/spec/emit/snapshots/loop_variable_named_like_range_temp_no_collision.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn make_range() -> Range<int> { 0..3 }
+  
+  fn main() {
+    let mut sum = 0;
+    for range_1 in make_range() {
+      sum = sum + range_1;
+    }
+    let _ = sum;
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func makeRange() lisette.Range[int] {
+	return lisette.Range[int]{
+		Start: 0,
+		End:   3,
+	}
+}
+
+func main() {
+	sum := 0
+	range_1 := makeRange()
+	for range_1_2 := range_1.Start; range_1_2 < range_1.End; range_1_2++ {
+		sum += range_1_2
+	}
+	_ = sum
+}

--- a/tests/spec/emit/snapshots/propagate_in_range_end.snap
+++ b/tests/spec/emit/snapshots/propagate_in_range_end.snap
@@ -24,8 +24,8 @@ func f() lisette.Result[int, string] {
 	if check_2.Tag != lisette.ResultOk {
 		return lisette.MakeResultErr[int, string](check_2.ErrVal)
 	}
-	_bound_1 := check_2.OkVal
-	for i := range _bound_1 {
+	bound_1 := check_2.OkVal
+	for i := range bound_1 {
 		s += i
 	}
 	return lisette.MakeResultOk[int, string](s)

--- a/tests/spec/emit/snapshots/pure_constructor_with_mutable_read_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/pure_constructor_with_mutable_read_pins_when_later_operand_pins.snap
@@ -19,13 +19,13 @@ func run() int {
 		x = 20
 		return 2
 	}
-	_v_2 := lisette.MakeOptionSome(x)
-	_left_1 := x
+	v_2 := lisette.MakeOptionSome(x)
+	left_1 := x
 	elems := []lisette.Option[int]{
-		_v_2,
-		lisette.MakeOptionSome(_left_1 + bump()),
+		v_2,
+		lisette.MakeOptionSome(left_1 + bump()),
 		lisette.MakeOptionSome(x),
 	}
-	_left_3 := elems[0].UnwrapOr(-1) + elems[1].UnwrapOr(-1)
-	return _left_3 + elems[2].UnwrapOr(-1)
+	left_3 := elems[0].UnwrapOr(-1) + elems[1].UnwrapOr(-1)
+	return left_3 + elems[2].UnwrapOr(-1)
 }

--- a/tests/spec/emit/snapshots/range_for_loop_end_before_start.snap
+++ b/tests/spec/emit/snapshots/range_for_loop_end_before_start.snap
@@ -23,8 +23,8 @@ func bound() int {
 
 func main() {
 	start_2 := start()
-	_bound_1 := bound()
-	for i := start_2; i < _bound_1; i++ {
+	bound_1 := bound()
+	for i := start_2; i < bound_1; i++ {
 		_ = i
 	}
 }

--- a/tests/spec/emit/snapshots/range_value_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/range_value_eval_order_captured.snap
@@ -24,9 +24,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_range_1 := i
+	range_1 := i
 	r := lisette.Range[int]{
-		Start: _range_1,
+		Start: range_1,
 		End:   bump(&i),
 	}
 	_ = r

--- a/tests/spec/emit/snapshots/range_variable_slice_base_call_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/range_variable_slice_base_call_evaluated_once.snap
@@ -20,7 +20,7 @@ func make_() []int {
 
 func run() int {
 	r := lisette.RangeFrom[int]{Start: 1}
-	_base_1 := make_()
-	s := _base_1[r.Start:len(_base_1):len(_base_1)]
+	base_1 := make_()
+	s := base_1[r.Start:len(base_1):len(base_1)]
 	return len(s)
 }

--- a/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
+++ b/tests/spec/emit/snapshots/receiver_collision_with_range_loop_variable.snap
@@ -37,8 +37,8 @@ type IntList struct {
 
 func (i IntList) display() string {
 	s := "["
-	_bound_1 := len(i.items)
-	for i_2 := range _bound_1 {
+	bound_1 := len(i.items)
+	for i_2 := range bound_1 {
 		if i_2 > 0 {
 			s += ", "
 		}

--- a/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
@@ -55,8 +55,8 @@ func total(c Cycle[int]) int {
 		return 0
 	}
 	l := *c.Next
-	_left_1 := l.Value
-	return _left_1 + total(l.Next)
+	left_1 := l.Value
+	return left_1 + total(l.Next)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/ref_of_call_in_call_args.snap
+++ b/tests/spec/emit/snapshots/ref_of_call_in_call_args.snap
@@ -25,7 +25,7 @@ func sideEffect() int {
 }
 
 func test() int {
-	_left_2 := sideEffect()
+	left_2 := sideEffect()
 	ref_1 := makeInt()
-	return _left_2 + readRef(&ref_1)
+	return left_2 + readRef(&ref_1)
 }

--- a/tests/spec/emit/snapshots/setup_bearing_call_pins_when_later_operand_pins.snap
+++ b/tests/spec/emit/snapshots/setup_bearing_call_pins_when_later_operand_pins.snap
@@ -28,9 +28,9 @@ func run() int {
 		x += 7
 		return v
 	}
-	_arg_1 := x
-	_v_2 := foo(_arg_1, setx())
-	_v_3 := x
-	r := []int{_v_2, _v_3, bump(5)}
+	arg_1 := x
+	v_2 := foo(arg_1, setx())
+	v_3 := x
+	r := []int{v_2, v_3, bump(5)}
 	return r[0] + r[1] + r[2]
 }

--- a/tests/spec/emit/snapshots/slice_literal_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/slice_literal_eval_order_captured.snap
@@ -22,7 +22,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_v_1 := i
-	s := []int{_v_1, bump(&i)}
+	v_1 := i
+	s := []int{v_1, bump(&i)}
 	_ = s
 }

--- a/tests/spec/emit/snapshots/slice_range_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/slice_range_eval_order_captured.snap
@@ -24,8 +24,8 @@ func bump(i *int) int {
 func main() {
 	items := []int{10, 20, 30, 40, 50}
 	i := 1
-	_base_1 := i
+	base_1 := i
 	end_2 := bump(&i)
-	s := items[_base_1:end_2:end_2]
+	s := items[base_1:end_2:end_2]
 	_ = s
 }

--- a/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/slice_range_value_eval_order.snap
@@ -40,8 +40,8 @@ func makeRange() lisette.Range[int] {
 }
 
 func main() {
-	_base_1 := makeItems()
+	base_1 := makeItems()
 	range_2 := makeRange()
-	xs := _base_1[range_2.Start:range_2.End:range_2.End]
+	xs := base_1[range_2.Start:range_2.End:range_2.End]
 	fmt.Println(len(xs))
 }

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -27,10 +27,10 @@ func variadic(_ int, _ ...int) int {
 }
 
 func run() (int, error) {
-	_arg_3 := sideA()
+	arg_3 := sideA()
 	ret_1, ret_2 := getXs()
 	if ret_2 != nil {
 		return 0, ret_2
 	}
-	return variadic(_arg_3, ret_1...), nil
+	return variadic(arg_3, ret_1...), nil
 }

--- a/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
+++ b/tests/spec/emit/snapshots/string_substring_range_value_eval_order.snap
@@ -39,7 +39,7 @@ func makeRange() lisette.Range[int] {
 }
 
 func main() {
-	_arg_2 := makeS()
+	arg_2 := makeS()
 	range_1 := makeRange()
-	fmt.Println(lisette.Substring(_arg_2, range_1.Start, range_1.End))
+	fmt.Println(lisette.Substring(arg_2, range_1.Start, range_1.End))
 }

--- a/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_eval_order_captured.snap
@@ -29,9 +29,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_field_1 := i
+	field_1 := i
 	p := Pair{
-		a: _field_1,
+		a: field_1,
 		b: bump(&i),
 	}
 	_ = p

--- a/tests/spec/emit/snapshots/task_captures_reassigned_local_before_the_goroutine_runs.snap
+++ b/tests/spec/emit/snapshots/task_captures_reassigned_local_before_the_goroutine_runs.snap
@@ -12,9 +12,9 @@ package main
 
 func test() {
 	xs := []int{1}
-	_arg_1 := xs
+	arg_1 := xs
 	go func() {
-		_ = len(_arg_1)
+		_ = len(arg_1)
 	}()
 	xs = []int{1, 2}
 }

--- a/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_eval_order_captured.snap
@@ -24,7 +24,7 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_v_1 := i
-	t := lisette.MakeTuple2[int, int](_v_1, bump(&i))
+	v_1 := i
+	t := lisette.MakeTuple2[int, int](v_1, bump(&i))
 	_ = t
 }

--- a/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_call_eval_order_captured.snap
@@ -29,9 +29,9 @@ func bump(i *int) int {
 
 func main() {
 	i := 0
-	_arg_1 := i
+	arg_1 := i
 	p := Pair{
-		F0: _arg_1,
+		F0: arg_1,
 		F1: bump(&i),
 	}
 	_ = p

--- a/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
+++ b/tests/spec/emit/snapshots/ufcs_receiver_method_eval_order_captured.snap
@@ -40,7 +40,7 @@ func bump(i *int) int {
 func main() {
 	i := 0
 	adder := Adder{base: 5}
-	_arg_1 := i
-	v := adder.add(_arg_1, bump(&i))
+	arg_1 := i
+	v := adder.add(arg_1, bump(&i))
 	_ = v
 }

--- a/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
+++ b/tests/spec/emit/snapshots/unit_call_as_map_index_key.snap
@@ -18,8 +18,8 @@ func noop() {}
 func main() {
 	m := make(map[struct{}]int)
 	m[struct{}{}] = 7
-	_base_1 := m
+	base_1 := m
 	noop()
-	x := _base_1[struct{}{}]
+	x := base_1[struct{}{}]
 	_ = x
 }

--- a/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
+++ b/tests/spec/emit/snapshots/while_condition_with_setup_statements_inside_loop.snap
@@ -25,8 +25,8 @@ func bump(i *int) int {
 func test() {
 	i := 0
 	for {
-		_v_1 := i < 3
-		if !(lisette.MakeTuple2[bool, int](_v_1, bump(&i)).First) {
+		v_1 := i < 3
+		if !(lisette.MakeTuple2[bool, int](v_1, bump(&i)).First) {
 			break
 		}
 		_ = i


### PR DESCRIPTION
Temps that the emitted Go reads back no longer carry a leading underscore. In Go this typically means a variable nothing uses, which is not the case here.

Before:

```go
	for _i_1 := 0; _i_1 < len(s); _i_1++ {
		b := s[_i_1]
	}
```

After:

```go
	for i_1 := 0; i_1 < len(s); i_1++ {
		b := s[i_1]
	}
```
