### PR TITLE
refactor: drop unreachable `if` in `let ... else`

### DIFF
--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -483,6 +483,11 @@ impl<'a> Planner<'a> {
         self.scope.is_go_name_declared(go_name)
     }
 
+    /// Whether an enclosing branch already tested this exact condition.
+    fn is_condition_established(&self, condition: &str) -> bool {
+        self.scope.is_condition_established(condition)
+    }
+
     /// Unconditionally marks `go_name` as declared in the current block.
     fn declare(&mut self, go_name: &str) {
         self.scope.declare_go_name(go_name);

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -142,7 +142,7 @@ pub(crate) enum Check {
 }
 
 impl Check {
-    fn render(&self, subject: &str) -> String {
+    pub(crate) fn render(&self, subject: &str) -> String {
         match self {
             Check::EnumTag {
                 path, tag_constant, ..

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -224,11 +224,12 @@ impl Planner<'_> {
             ty: &value_ty,
         };
 
+        let subject_is_fixed = self.is_unmutated_identifier(scrutinee);
         let (body, used) = self.capture_go_uses(|this| {
             if matches!(ap.pattern, Pattern::Or { .. }) {
                 this.lower_let_else_or_pattern(ap, binding_ty, subject, fail)
             } else {
-                this.lower_let_else_single_pattern(ap, subject, fail)
+                this.lower_let_else_single_pattern(ap, subject, fail, subject_is_fixed)
             }
         });
         let body_block = LoweredBlock { statements: body };
@@ -487,18 +488,24 @@ impl Planner<'_> {
         ap: AnnotatedPattern,
         subject: TypedSubject,
         fail: RefutableFail,
+        subject_is_fixed: bool,
     ) -> Vec<LoweredStatement> {
         let AnnotatedPattern { pattern } = ap;
         let TypedSubject {
             var: subject_var,
             ty: subject_ty,
         } = subject;
-        let info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
+        let mut info = decision_tree::collect_pattern_info(self, pattern, subject_ty);
         self.require_packages(&info.packages);
 
         let mut statements = Vec::new();
         let (effective_subject, assert_ok_var) =
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
+
+        if subject_is_fixed {
+            info.checks
+                .retain(|check| !self.is_condition_established(&check.render(&effective_subject)));
+        }
 
         if info.checks.is_empty() && assert_ok_var.is_none() {
             tree_binding_statements(

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -793,6 +793,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         self.planner.scope.record_go_use(&self.subject);
         let inner = WalkCtx::switch_case(ctx.arm_place);
         let then_statements = self.with_scope(|this| {
+            this.planner.scope.establish_condition(condition.clone());
             let mut then_statements: Vec<LoweredStatement> = Vec::new();
             this.walk(&mut then_statements, then_branch, &inner);
             then_statements
@@ -930,7 +931,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         place: &PlacePlan,
     ) -> SwitchStatementPlan {
         let (regular, default) = split_with_default_lift(branches, fallback);
-        let case_plans = self.lower_switch_cases(regular, place);
+        let case_plans = self.lower_switch_cases(regular, place, Some(&expr));
         let default_block = self.lower_switch_default(default, place);
         SwitchStatementPlan {
             kind: SwitchKind::Value { subject: expr },
@@ -952,7 +953,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let subject_ty = self.subject_ty.clone();
         let ((case_plans, default_block), used) = self.planner.capture_go_uses(|planner| {
             let mut nested = TreePlanner::new(planner, arms, base.clone(), subject_ty);
-            let case_plans = nested.lower_switch_cases(regular, place);
+            let case_plans = nested.lower_switch_cases(regular, place, None);
             let default_block = nested.lower_switch_default(default, place);
             (case_plans, default_block)
         });
@@ -977,11 +978,19 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         &mut self,
         branches: &[SwitchBranch],
         place: &PlacePlan,
+        subject: Option<&str>,
     ) -> Vec<SwitchCasePlan> {
         let ctx = WalkCtx::switch_case(place);
         let mut case_plans = Vec::with_capacity(branches.len());
         for branch in branches {
+            // A case listing several labels establishes none of them on its own.
+            let established = subject
+                .filter(|_| !branch.case_label.contains(','))
+                .map(|subject| format!("{} == {}", subject, branch.case_label));
             let body = self.with_scope(|this| {
+                if let Some(condition) = established {
+                    this.planner.scope.establish_condition(condition);
+                }
                 let mut body: Vec<LoweredStatement> = Vec::new();
                 this.walk(&mut body, &branch.decision, &ctx);
                 body

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -18,10 +18,13 @@ pub(crate) struct ScopeState {
     assign_targets: HashSet<String>,
     /// Go identifiers referenced during lowering, for structural liveness.
     use_frames: Vec<HashSet<String>>,
+    /// Conditions the branch being lowered has already tested, per block.
+    established: Vec<Vec<String>>,
 }
 
 pub(crate) struct IsolatedFunctionFrame {
     declared: Vec<HashSet<String>>,
+    established: Vec<Vec<String>>,
 }
 
 impl ScopeState {
@@ -37,6 +40,7 @@ impl ScopeState {
             test_handle_stack: Vec::new(),
             assign_targets: HashSet::default(),
             use_frames: Vec::new(),
+            established: vec![Vec::new()],
         }
     }
 
@@ -68,6 +72,8 @@ impl ScopeState {
         self.bindings.reset();
         self.declared.clear();
         self.declared.push(HashSet::default());
+        self.established.clear();
+        self.established.push(Vec::new());
         self.type_param_go_names.clear();
     }
 
@@ -164,18 +170,37 @@ impl ScopeState {
     pub(crate) fn enter_block(&mut self) {
         self.bindings.save();
         self.declared.push(HashSet::default());
+        self.established.push(Vec::new());
     }
 
     pub(crate) fn exit_block(&mut self) {
         self.bindings.restore();
         pop_keep_base(&mut self.declared);
+        pop_keep_base(&mut self.established);
+    }
+
+    /// Record that the block being lowered runs only when `condition` holds.
+    pub(crate) fn establish_condition(&mut self, condition: String) {
+        self.established
+            .last_mut()
+            .expect("scope state always retains an established frame")
+            .push(condition);
+    }
+
+    pub(crate) fn is_condition_established(&self, condition: &str) -> bool {
+        self.established
+            .iter()
+            .flatten()
+            .any(|established| established == condition)
     }
 
     pub(crate) fn enter_isolated_function(&mut self) -> IsolatedFunctionFrame {
         let saved = IsolatedFunctionFrame {
             declared: std::mem::take(&mut self.declared),
+            established: std::mem::take(&mut self.established),
         };
         self.declared = vec![self.type_param_go_names.clone()];
+        self.established = vec![Vec::new()];
         self.bindings.save();
         saved
     }
@@ -183,6 +208,7 @@ impl ScopeState {
     pub(crate) fn exit_isolated_function(&mut self, frame: IsolatedFunctionFrame) {
         self.bindings.restore();
         self.declared = frame.declared;
+        self.established = frame.established;
     }
 
     pub(crate) fn fresh_go_name(&mut self, hint: Option<&str>) -> String {

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1014,6 +1014,74 @@ fn main() {
 }
 
 #[test]
+fn run_let_else_in_arm_still_tests_a_reassigned_subject() {
+    if !go_available() {
+        eprintln!("skipping run_let_else_in_arm_still_tests_a_reassigned_subject: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"letelse\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+
+enum Event {
+  Click { x: int, y: int },
+  Close,
+}
+
+fn reassigned(start: Event) -> int {
+  let mut e = start
+  match e {
+    Event.Click { x, y } => {
+      e = Event.Close
+      let Event.Click { x: a, y: b } = e else { return 7 }
+      a + b + x + y
+    },
+    _ => 0,
+  }
+}
+
+fn kept(e: Event) -> int {
+  match e {
+    Event.Click { x, y } => {
+      let Event.Click { x: a, y: b } = e else { return 0 }
+      a + b + x + y
+    },
+    _ => 0,
+  }
+}
+
+fn main() {
+  let click = Event.Click { x: 30, y: 12 }
+  fmt.Println(reassigned(click), kept(click), kept(Event.Close))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "7 84 0", "stderr: {stderr}");
+}
+
+#[test]
 fn run_counted_loops_iterate_from_zero_up_to_the_bound() {
     if !go_available() {
         eprintln!("skipping run_counted_loops_iterate_from_zero_up_to_the_bound: `go` not found");

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -566,6 +566,115 @@ fn test(s: string) -> int {
 }
 
 #[test]
+fn let_else_in_arm_drops_the_test_the_arm_made() {
+    let input = r#"
+enum Event {
+  Click { x: int, y: int },
+  Close,
+}
+
+fn test(e: Event) -> int {
+  match e {
+    Event.Click { x, y } => {
+      let Event.Click { x: a, y: b } = e else { return 0 }
+      a + b + x + y
+    },
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_in_switch_case_drops_the_test_the_case_made() {
+    let input = r#"
+enum Event {
+  Click { x: int, y: int },
+  Move { dx: int },
+  Close,
+}
+
+fn test(e: Event) -> int {
+  match e {
+    Event.Click { x, y } => {
+      let Event.Click { x: a, y: b } = e else { return 0 }
+      a + b + x + y
+    },
+    Event.Move { dx } => dx,
+    Event.Close => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_on_reassigned_subject_keeps_its_test() {
+    let input = r#"
+enum Event {
+  Click { x: int, y: int },
+  Close,
+}
+
+fn test(start: Event) -> int {
+  let mut e = start
+  match e {
+    Event.Click { x, y } => {
+      e = Event.Close
+      let Event.Click { x: a, y: b } = e else { return 7 }
+      a + b + x + y
+    },
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_in_the_else_arm_keeps_its_test() {
+    let input = r#"
+enum Event {
+  Click { x: int, y: int },
+  Close,
+}
+
+fn test(e: Event) -> int {
+  match e {
+    Event.Click { x, y } => x + y,
+    _ => {
+      let Event.Click { x: a, y: b } = e else { return 5 }
+      a + b
+    },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_on_another_variant_keeps_its_test() {
+    let input = r#"
+enum Event {
+  Click { x: int, y: int },
+  Close,
+}
+
+fn test(e: Event) -> int {
+  match e {
+    Event.Click { x, y } => {
+      let Event.Close = e else { return x + y }
+      1
+    },
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn or_pattern_let_else_shadow() {
     let input = r#"
 enum E { A(int), B(int), C }

--- a/tests/spec/emit/snapshots/let_else_in_arm_drops_the_test_the_arm_made.snap
+++ b/tests/spec/emit/snapshots/let_else_in_arm_drops_the_test_the_arm_made.snap
@@ -1,0 +1,50 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click { x: int, y: int },
+    Close,
+  }
+  
+  fn test(e: Event) -> int {
+    match e {
+      Event.Click { x, y } => {
+        let Event.Click { x: a, y: b } = e else { return 0 }
+        a + b + x + y
+      },
+      _ => 0,
+    }
+  }
+---
+package main
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, X: arg0, Y: arg1}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventClose
+)
+
+type Event struct {
+	Tag EventTag
+	X   int
+	Y   int
+}
+
+func test(e Event) int {
+	if e.Tag == EventClick {
+		a := e.X
+		b := e.Y
+		return a + b + e.X + e.Y
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/let_else_in_switch_case_drops_the_test_the_case_made.snap
+++ b/tests/spec/emit/snapshots/let_else_in_switch_case_drops_the_test_the_case_made.snap
@@ -1,0 +1,62 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click { x: int, y: int },
+    Move { dx: int },
+    Close,
+  }
+  
+  fn test(e: Event) -> int {
+    match e {
+      Event.Click { x, y } => {
+        let Event.Click { x: a, y: b } = e else { return 0 }
+        a + b + x + y
+      },
+      Event.Move { dx } => dx,
+      Event.Close => 0,
+    }
+  }
+---
+package main
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, X: arg0, Y: arg1}
+}
+
+func MakeEventMove(arg0 int) Event {
+	return Event{Tag: EventMove, Dx: arg0}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventMove
+	EventClose
+)
+
+type Event struct {
+	Tag EventTag
+	X   int
+	Y   int
+	Dx  int
+}
+
+func test(e Event) int {
+	switch e.Tag {
+	case EventClick:
+		a := e.X
+		b := e.Y
+		return a + b + e.X + e.Y
+	case EventMove:
+		return e.Dx
+	default:
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/let_else_in_the_else_arm_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_in_the_else_arm_keeps_its_test.snap
@@ -1,0 +1,53 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click { x: int, y: int },
+    Close,
+  }
+  
+  fn test(e: Event) -> int {
+    match e {
+      Event.Click { x, y } => x + y,
+      _ => {
+        let Event.Click { x: a, y: b } = e else { return 5 }
+        a + b
+      },
+    }
+  }
+---
+package main
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, X: arg0, Y: arg1}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventClose
+)
+
+type Event struct {
+	Tag EventTag
+	X   int
+	Y   int
+}
+
+func test(e Event) int {
+	if e.Tag == EventClick {
+		return e.X + e.Y
+	}
+	if e.Tag != EventClick {
+		return 5
+	}
+	a := e.X
+	b := e.Y
+	return a + b
+}

--- a/tests/spec/emit/snapshots/let_else_on_another_variant_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_on_another_variant_keeps_its_test.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click { x: int, y: int },
+    Close,
+  }
+  
+  fn test(e: Event) -> int {
+    match e {
+      Event.Click { x, y } => {
+        let Event.Close = e else { return x + y }
+        1
+      },
+      _ => 0,
+    }
+  }
+---
+package main
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, X: arg0, Y: arg1}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventClose
+)
+
+type Event struct {
+	Tag EventTag
+	X   int
+	Y   int
+}
+
+func test(e Event) int {
+	if e.Tag == EventClick {
+		if e.Tag != EventClose {
+			return e.X + e.Y
+		}
+		return 1
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/let_else_on_reassigned_subject_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_on_reassigned_subject_keeps_its_test.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click { x: int, y: int },
+    Close,
+  }
+  
+  fn test(start: Event) -> int {
+    let mut e = start
+    match e {
+      Event.Click { x, y } => {
+        e = Event.Close
+        let Event.Click { x: a, y: b } = e else { return 7 }
+        a + b + x + y
+      },
+      _ => 0,
+    }
+  }
+---
+package main
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, X: arg0, Y: arg1}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventClose
+)
+
+type Event struct {
+	Tag EventTag
+	X   int
+	Y   int
+}
+
+func test(start Event) int {
+	e := start
+	if e.Tag == EventClick {
+		x := e.X
+		y := e.Y
+		e = MakeEventClose()
+		if e.Tag != EventClick {
+			return 7
+		}
+		a := e.X
+		b := e.Y
+		return a + b + x + y
+	}
+	return 0
+}


### PR DESCRIPTION
In a `let ... else` where the enclosing arm already its matched subject, we no longer emit a check that cannot fail.

```rs
match e {
  Event.Click { x, y } => {
    let Event.Click { x: a, y: b } = e else { return 0 }
    a + b
  },
  _ => 0,
}
```

Before:

```go
	if e.Tag == EventClick {
		if e.Tag != EventClick {
			return 0
		}
		a := e.X
		b := e.Y
```

After:

```go
	if e.Tag == EventClick {
		a := e.X
		b := e.Y
```
