### PR TITLE
refactor: emit `map`, `filter`, `fold` and `find` as Go loops

### DIFF
--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod dispatch;
 pub(crate) mod go_interop;
 pub(crate) mod native;
 mod regular;
+mod slice_loop;
 mod ufcs;
 
 use crate::plan::values::CaptureBoundary;

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -22,7 +22,7 @@ pub(super) struct NativeCallResult {
 }
 
 impl NativeCallResult {
-    fn new(
+    pub(super) fn new(
         setup: Vec<LoweredStatement>,
         value: String,
         argument_effect: EvaluationEffect,
@@ -457,6 +457,12 @@ impl Planner<'_> {
             return result;
         }
 
+        if matches!(ctx.native_type, NativeGoType::Slice)
+            && let Some(result) = self.try_lower_slice_loop(ctx, expression, ctx.args)
+        {
+            return result;
+        }
+
         if ctx.method == "clone" {
             let receiver_ty = self.facts.strip_and_peel(&expression.get_type());
             if is_cloneable_container(&receiver_ty) {
@@ -786,6 +792,13 @@ impl Planner<'_> {
                     );
                 }
             }
+        }
+
+        if matches!(ctx.native_type, NativeGoType::Slice)
+            && let Some((receiver, args)) = ctx.args.split_first()
+            && let Some(result) = self.try_lower_slice_loop(ctx, receiver, args)
+        {
+            return result;
         }
 
         if ctx.method == "clone"

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -1,0 +1,354 @@
+use syntax::ast::{Binding, Expression, Pattern};
+use syntax::types::Type;
+
+use super::NativeCallContext;
+use super::native::NativeCallResult;
+use crate::Planner;
+use crate::context::expression::ExpressionContext;
+use crate::names::go_name;
+use crate::plan::bodies::{
+    ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan,
+};
+use crate::plan::values::EvaluationEffect;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SliceLoop {
+    Map,
+    Filter,
+    Fold,
+    Find,
+}
+
+impl SliceLoop {
+    fn from_method(method: &str) -> Option<Self> {
+        match method {
+            "map" => Some(Self::Map),
+            "filter" => Some(Self::Filter),
+            "fold" => Some(Self::Fold),
+            "find" => Some(Self::Find),
+            _ => None,
+        }
+    }
+
+    fn argument_count(self) -> usize {
+        match self {
+            Self::Fold => 2,
+            _ => 1,
+        }
+    }
+}
+
+/// An escape belongs to the lambda, and inlining would hand it to the
+/// enclosing function.
+fn body_moves_into_a_loop(body: &Expression) -> bool {
+    if matches!(
+        body,
+        Expression::Return { .. }
+            | Expression::Propagate { .. }
+            | Expression::Break { .. }
+            | Expression::Continue { .. }
+            | Expression::TryBlock { .. }
+            | Expression::RecoverBlock { .. }
+            | Expression::Defer { .. }
+    ) {
+        return false;
+    }
+    // A nested lambda keeps its own escapes.
+    matches!(body, Expression::Lambda { .. })
+        || body
+            .children()
+            .iter()
+            .all(|child| body_moves_into_a_loop(child))
+}
+
+/// Fold names the accumulator after the result the loop rewrites, so anything
+/// holding it past its iteration would read a later one.
+fn body_captures_by_reference(body: &Expression) -> bool {
+    matches!(
+        body,
+        Expression::Lambda { .. } | Expression::Task { .. } | Expression::Reference { .. }
+    ) || body
+        .children()
+        .iter()
+        .any(|child| body_captures_by_reference(child))
+}
+
+fn identifier_of(param: &Binding) -> Option<&Pattern> {
+    matches!(param.pattern, Pattern::Identifier { .. }).then_some(&param.pattern)
+}
+
+#[derive(Clone, Copy)]
+struct SliceLoopBody<'a> {
+    kind: SliceLoop,
+    body: &'a Expression,
+    result_ty: &'a Type,
+    element_ty: &'a Type,
+    result: &'a str,
+    element_name: &'a str,
+    index: Option<&'a str>,
+}
+
+fn peel_single_expression_block(body: &Expression) -> &Expression {
+    match body {
+        Expression::Block { items, .. } if items.len() == 1 => {
+            peel_single_expression_block(&items[0])
+        }
+        _ => body,
+    }
+}
+
+impl Planner<'_> {
+    /// Lower `xs.map(|x| ...)` and its siblings to the loop the prelude helper
+    /// runs. `None` keeps the helper call.
+    pub(super) fn try_lower_slice_loop(
+        &mut self,
+        ctx: &NativeCallContext,
+        receiver: &Expression,
+        args: &[Expression],
+    ) -> Option<NativeCallResult> {
+        let kind = SliceLoop::from_method(ctx.method)?;
+        if args.len() != kind.argument_count() || ctx.spread.is_some() {
+            return None;
+        }
+        let Expression::Lambda { params, body, .. } = args.last()?.unwrap_parens() else {
+            return None;
+        };
+        let body = peel_single_expression_block(body);
+        let patterns: Vec<&Pattern> = params.iter().filter_map(identifier_of).collect();
+        if patterns.len() != params.len() || !body_moves_into_a_loop(body) {
+            return None;
+        }
+        let expects_accumulator = kind == SliceLoop::Fold;
+        if patterns.len() != 1 + expects_accumulator as usize {
+            return None;
+        }
+        if expects_accumulator && body_captures_by_reference(body) {
+            return None;
+        }
+
+        let result_ty = ctx.call_ty?.clone();
+        let element_ty = self
+            .facts
+            .strip_and_peel(&receiver.get_type())
+            .get_type_params()?
+            .first()?
+            .clone();
+
+        let mut source_staged = self.stage_operand(receiver, ExpressionContext::value());
+        // `map` reads the source twice, for its length and for the range.
+        if kind == SliceLoop::Map && !self.plan_rests_in_stable_name(&source_staged) {
+            self.pin_staged(&mut source_staged, "src");
+        }
+        let mut stages = vec![source_staged];
+        if expects_accumulator {
+            stages.push(self.stage_operand(&args[0], ExpressionContext::value()));
+        }
+        let sequenced = self.sequence_values(stages, ctx.capture_boundary, "arg");
+        let effect = sequenced.effect;
+        let (mut setup, values) = sequenced.into_rendered();
+        let source = values[0].clone();
+
+        let result = self.fresh_var(Some("result"));
+        self.declare(&result);
+        setup.push(self.slice_loop_declaration(kind, &result, &result_ty, &source, values.get(1)));
+
+        let index = (kind == SliceLoop::Map).then(|| {
+            let index = self.fresh_var(Some("i"));
+            self.declare(&index);
+            index
+        });
+
+        let (element_name, body_statements) = self.with_scope(|this| {
+            if expects_accumulator {
+                this.bind_loop_callback_param(patterns[0], Some(result.clone()));
+            }
+            let element_name = this.element_loop_name(kind, patterns[patterns.len() - 1]);
+            let statements = this.lower_slice_loop_body(&SliceLoopBody {
+                kind,
+                body,
+                result_ty: &result_ty,
+                element_ty: &element_ty,
+                result: &result,
+                element_name: &element_name,
+                index: index.as_deref(),
+            });
+            (element_name, statements)
+        });
+
+        // Go rejects a range variable nothing reads.
+        let header = match (&index, element_name.as_str()) {
+            (Some(index), "_") => index.clone(),
+            (Some(index), element) => format!("{}, {}", index, element),
+            (None, "_") => String::new(),
+            (None, element) => format!("_, {}", element),
+        };
+        let header = if header.is_empty() {
+            format!("for range {} {{\n", source)
+        } else {
+            format!("for {} := range {} {{\n", header, source)
+        };
+        setup.push(LoweredStatement::Loop(LoopPlan {
+            prologue: Vec::new(),
+            kind: LoopKind::Generated { label: None },
+            header,
+            body: LoweredBlock {
+                statements: body_statements,
+            },
+        }));
+
+        Some(NativeCallResult::new(
+            setup,
+            result,
+            effect.combine(EvaluationEffect::EffectfulCall),
+            false,
+        ))
+    }
+
+    /// `filter` and `find` read the element back whatever the body does.
+    fn element_loop_name(&mut self, kind: SliceLoop, pattern: &Pattern) -> String {
+        let name = self.bind_loop_callback_param(pattern, None);
+        if name != "_" || matches!(kind, SliceLoop::Map | SliceLoop::Fold) {
+            return name;
+        }
+        let name = self.fresh_var(Some("v"));
+        self.declare(&name);
+        name
+    }
+
+    fn bind_loop_callback_param(&mut self, pattern: &Pattern, existing: Option<String>) -> String {
+        let Pattern::Identifier { identifier, .. } = pattern else {
+            unreachable!("callback parameters are checked for identifier patterns");
+        };
+        let go_name = match existing {
+            Some(name) => name,
+            None => match self.go_name_for_binding(pattern) {
+                Some(name) => {
+                    let escaped = go_name::escape_reserved(&name).into_owned();
+                    if self.is_declared(&escaped) {
+                        self.fresh_var(Some(&name))
+                    } else {
+                        escaped
+                    }
+                }
+                None => "_".to_string(),
+            },
+        };
+        if go_name != "_" {
+            self.declare(&go_name);
+            self.scope.bind(identifier.as_str(), go_name.clone());
+        }
+        go_name
+    }
+
+    fn slice_loop_declaration(
+        &mut self,
+        kind: SliceLoop,
+        result: &str,
+        result_ty: &Type,
+        source: &str,
+        init: Option<&String>,
+    ) -> LoweredStatement {
+        match kind {
+            SliceLoop::Map => {
+                let element = self.first_type_argument_go_string(result_ty);
+                LoweredStatement::TempBind {
+                    name: result.to_string(),
+                    value: format!("make([]{}, len({}))", element, source),
+                }
+            }
+            SliceLoop::Filter => LoweredStatement::RawGo(format!(
+                "var {} []{}\n",
+                result,
+                self.first_type_argument_go_string(result_ty)
+            )),
+            SliceLoop::Fold => LoweredStatement::TempBind {
+                name: result.to_string(),
+                value: init.expect("fold stages its initial value").clone(),
+            },
+            SliceLoop::Find => {
+                self.require_stdlib();
+                let payload = self.first_type_argument_go_string(result_ty);
+                LoweredStatement::TempBind {
+                    name: result.to_string(),
+                    value: format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, payload),
+                }
+            }
+        }
+    }
+
+    fn lower_slice_loop_body(&mut self, loop_body: &SliceLoopBody<'_>) -> Vec<LoweredStatement> {
+        let SliceLoopBody {
+            kind,
+            body,
+            result_ty,
+            element_ty,
+            result,
+            element_name,
+            index,
+        } = *loop_body;
+
+        // Map and fold store their body's value, so it lowers into the slot.
+        if let SliceLoop::Map | SliceLoop::Fold = kind {
+            let (slot, target_ty) = match kind {
+                SliceLoop::Map => (
+                    format!("{}[{}]", result, index.expect("map binds a loop index")),
+                    self.first_type_argument(result_ty)
+                        .expect("map returns a slice carrying its element type"),
+                ),
+                _ => (result.to_string(), result_ty.clone()),
+            };
+            let place = PlacePlan::Assign {
+                local: &slot,
+                target_ty: Some(&target_ty),
+            };
+            return self.lower_block_to_place(body, &place).statements;
+        }
+
+        let plan = self.lower_value(body, ExpressionContext::value());
+        let (mut statements, condition) = plan.into_parts();
+        let then_body = match kind {
+            SliceLoop::Filter => LoweredBlock {
+                statements: vec![LoweredStatement::RawGo(format!(
+                    "{} = append({}, {})\n",
+                    result, result, element_name
+                ))],
+            },
+            SliceLoop::Find => {
+                self.require_stdlib();
+                let payload = self.go_type_string(element_ty);
+                LoweredBlock {
+                    statements: vec![
+                        LoweredStatement::RawGo(format!(
+                            "{} = {}.MakeOptionSome[{}]({})\n",
+                            result,
+                            go_name::GO_STDLIB_PKG,
+                            payload,
+                            element_name
+                        )),
+                        LoweredStatement::RawGo("break\n".to_string()),
+                    ],
+                }
+            }
+            SliceLoop::Map | SliceLoop::Fold => unreachable!("assign-place kinds returned above"),
+        };
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition,
+            then_body,
+            else_arm: ElseArm::None,
+        }));
+        statements
+    }
+
+    fn first_type_argument(&self, ty: &Type) -> Option<Type> {
+        ty.get_type_params()
+            .and_then(|params| params.first().cloned())
+    }
+
+    fn first_type_argument_go_string(&mut self, ty: &Type) -> String {
+        let argument = self
+            .first_type_argument(ty)
+            .expect("slice and option results carry a type argument");
+        self.go_type_string(&argument)
+    }
+}

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1082,6 +1082,87 @@ fn main() {
 }
 
 #[test]
+fn run_inlined_slice_helpers_match_the_prelude_bodies() {
+    if !go_available() {
+        eprintln!("skipping run_inlined_slice_helpers_match_the_prelude_bodies: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    let invocation = scratch.path().join("invocation");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(&invocation).unwrap();
+
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"slicehelpers\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+import "go:encoding/json"
+
+fn mapped(xs: Slice<int>) -> Slice<int> {
+  xs.map(|x| x * 2)
+}
+
+fn kept(xs: Slice<int>) -> Slice<int> {
+  xs.filter(|x| x > 2)
+}
+
+fn total(xs: Slice<int>) -> int {
+  xs.fold(100, |acc, x| acc + x)
+}
+
+fn first_big(xs: Slice<int>) -> int {
+  match xs.find(|x| x > 2) {
+    Some(found) => found,
+    None => -1,
+  }
+}
+
+fn encoded(xs: Slice<int>) -> string {
+  match json.Marshal(xs) {
+    Ok(bytes) => bytes as string,
+    Err(_) => "err",
+  }
+}
+
+fn source() -> Slice<int> {
+  fmt.Println("src")
+  [1, 2, 3]
+}
+
+fn main() {
+  let xs: Slice<int> = [1, 2, 3, 4]
+  let empty: Slice<int> = []
+  fmt.Println(mapped(xs), kept(xs), total(xs), first_big(xs))
+  fmt.Println(mapped(empty), kept(empty), total(empty), first_big(empty))
+  fmt.Println(encoded(mapped(empty)), encoded(kept(empty)))
+  fmt.Println(source().map(|x| x * 10))
+}
+"#,
+    )
+    .unwrap();
+
+    let output = lis_run(&project, &invocation, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "lis run failed:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "[2 4 6 8] [3 4] 110 3\n[] [] 100 -1\n[] null\nsrc\n[10 20 30]",
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn run_counted_loops_iterate_from_zero_up_to_the_bound() {
     if !go_available() {
         eprintln!("skipping run_counted_loops_iterate_from_zero_up_to_the_bound: `go` not found");

--- a/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
+++ b/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
@@ -4,16 +4,15 @@ source: tests/spec/build/mod.rs
 // === main.go ===
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 func main() {
 	nums := []int{1, 2, 3}
-	strs := lisette.SliceMap[int, string](nums, func(x int) string {
-		return fmt.Sprintf("n=%d", x)
-	})
+	result_1 := make([]string, len(nums))
+	for i_2, x := range nums {
+		result_1[i_2] = fmt.Sprintf("n=%d", x)
+	}
+	strs := result_1
 	for _, s := range strs {
 		fmt.Println(s)
 	}

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -612,6 +612,122 @@ fn test(s: Slice<int>, f: fn(int) -> string) -> Slice<string> {
 }
 
 #[test]
+fn slice_map_lambda_becomes_a_loop() {
+    let input = r#"
+fn test(s: Slice<int>) -> Slice<int> {
+  s.map(|x| x * 2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_map_capturing_lambda_becomes_a_loop() {
+    let input = r#"
+fn test(s: Slice<int>, factor: int) -> Slice<int> {
+  let mut seen = 0
+  let doubled = s.map(|x| {
+    seen += 1
+    x * factor
+  })
+  doubled.append(seen)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_map_on_a_call_receiver_reads_it_once() {
+    let input = r#"
+fn source() -> Slice<int> { [1, 2] }
+
+fn test() -> Slice<int> {
+  source().map(|x| x * 2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_filter_with_an_unused_parameter_names_the_element() {
+    let input = r#"
+fn test(s: Slice<int>) -> Slice<int> {
+  s.filter(|_x| true)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_map_with_an_unused_parameter_drops_the_element() {
+    let input = r#"
+fn test(s: Slice<int>) -> Slice<int> {
+  s.map(|_x| 7)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_map_deferring_lambda_keeps_the_helper() {
+    let input = r#"
+import "go:fmt"
+
+fn test(s: Slice<int>) -> Slice<int> {
+  s.map(|x| {
+    defer fmt.Println(x)
+    x * 2
+  })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_fold_capturing_lambda_keeps_the_helper() {
+    let input = r#"
+fn test(s: Slice<int>) -> fn(int) -> int {
+  s.fold(|y| y, |acc, x| {
+    |y| acc(y) + x
+  })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_fold_spawning_lambda_keeps_the_helper() {
+    let input = r#"
+import "go:fmt"
+
+fn test(s: Slice<int>) -> int {
+  s.fold(0, |acc, x| {
+    task {
+      fmt.Println(acc)
+    }
+    acc + x
+  })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_map_returning_lambda_keeps_the_helper() {
+    let input = r#"
+fn test(s: Slice<int>) -> Slice<int> {
+  s.map(|x| {
+    if x > 0 {
+      return x
+    }
+    0
+  })
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn slice_contains() {
     let input = r#"
 fn test(s: Slice<int>, v: int) -> bool {

--- a/tests/spec/emit/snapshots/slice_filter_with_an_unused_parameter_names_the_element.snap
+++ b/tests/spec/emit/snapshots/slice_filter_with_an_unused_parameter_names_the_element.snap
@@ -3,16 +3,16 @@ source: tests/spec/emit/prelude.rs
 description: |
   
   fn test(s: Slice<int>) -> Slice<int> {
-    s.filter(|x| x > 0)
+    s.filter(|_x| true)
   }
 ---
 package main
 
 func test(s []int) []int {
 	var result_1 []int
-	for _, x := range s {
-		if x > 0 {
-			result_1 = append(result_1, x)
+	for _, v_2 := range s {
+		if true {
+			result_1 = append(result_1, v_2)
 		}
 	}
 	return result_1

--- a/tests/spec/emit/snapshots/slice_find.snap
+++ b/tests/spec/emit/snapshots/slice_find.snap
@@ -11,11 +11,16 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func test(s []int) (int, bool) {
-	v_1 := lisette.SliceFind(s, func(x int) bool {
-		return x > 0
-	})
-	if v_1.Tag == lisette.OptionSome {
-		return v_1.SomeVal, true
+	result_1 := lisette.MakeOptionNone[int]()
+	for _, x := range s {
+		if x > 0 {
+			result_1 = lisette.MakeOptionSome[int](x)
+			break
+		}
+	}
+	v_2 := result_1
+	if v_2.Tag == lisette.OptionSome {
+		return v_2.SomeVal, true
 	}
 	return 0, false
 }

--- a/tests/spec/emit/snapshots/slice_fold.snap
+++ b/tests/spec/emit/snapshots/slice_fold.snap
@@ -8,10 +8,10 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func test(s []int) int {
-	return lisette.SliceFold(s, 0, func(acc, x int) int {
-		return acc + x
-	})
+	result_1 := 0
+	for _, x := range s {
+		result_1 = result_1 + x
+	}
+	return result_1
 }

--- a/tests/spec/emit/snapshots/slice_fold_capturing_lambda_keeps_the_helper.snap
+++ b/tests/spec/emit/snapshots/slice_fold_capturing_lambda_keeps_the_helper.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(s: Slice<int>) -> fn(int) -> int {
+    s.fold(|y| y, |acc, x| {
+      |y| acc(y) + x
+    })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s []int) func(int) int {
+	return lisette.SliceFold(s, func(y int) int {
+		return y
+	}, func(acc func(int) int, x int) func(int) int {
+		return func(y int) int {
+			return acc(y) + x
+		}
+	})
+}

--- a/tests/spec/emit/snapshots/slice_fold_spawning_lambda_keeps_the_helper.snap
+++ b/tests/spec/emit/snapshots/slice_fold_spawning_lambda_keeps_the_helper.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(s: Slice<int>) -> int {
+    s.fold(0, |acc, x| {
+      task {
+        fmt.Println(acc)
+      }
+      acc + x
+    })
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func test(s []int) int {
+	return lisette.SliceFold(s, 0, func(acc, x int) int {
+		go func() {
+			fmt.Println(acc)
+		}()
+		return acc + x
+	})
+}

--- a/tests/spec/emit/snapshots/slice_map_capturing_lambda_becomes_a_loop.snap
+++ b/tests/spec/emit/snapshots/slice_map_capturing_lambda_becomes_a_loop.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(s: Slice<int>, factor: int) -> Slice<int> {
+    let mut seen = 0
+    let doubled = s.map(|x| {
+      seen += 1
+      x * factor
+    })
+    doubled.append(seen)
+  }
+---
+package main
+
+func test(s []int, factor int) []int {
+	seen := 0
+	result_1 := make([]int, len(s))
+	for i_2, x := range s {
+		seen++
+		result_1[i_2] = x * factor
+	}
+	doubled := result_1
+	return append(doubled[:len(doubled):len(doubled)], seen)
+}

--- a/tests/spec/emit/snapshots/slice_map_deferring_lambda_keeps_the_helper.snap
+++ b/tests/spec/emit/snapshots/slice_map_deferring_lambda_keeps_the_helper.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn test(s: Slice<int>) -> Slice<int> {
+    s.map(|x| {
+      defer fmt.Println(x)
+      x * 2
+    })
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func test(s []int) []int {
+	return lisette.SliceMap(s, func(x int) int {
+		defer fmt.Println(x)
+		return x * 2
+	})
+}

--- a/tests/spec/emit/snapshots/slice_map_lambda_becomes_a_loop.snap
+++ b/tests/spec/emit/snapshots/slice_map_lambda_becomes_a_loop.snap
@@ -3,17 +3,15 @@ source: tests/spec/emit/prelude.rs
 description: |
   
   fn test(s: Slice<int>) -> Slice<int> {
-    s.filter(|x| x > 0)
+    s.map(|x| x * 2)
   }
 ---
 package main
 
 func test(s []int) []int {
-	var result_1 []int
-	for _, x := range s {
-		if x > 0 {
-			result_1 = append(result_1, x)
-		}
+	result_1 := make([]int, len(s))
+	for i_2, x := range s {
+		result_1[i_2] = x * 2
 	}
 	return result_1
 }

--- a/tests/spec/emit/snapshots/slice_map_on_a_call_receiver_reads_it_once.snap
+++ b/tests/spec/emit/snapshots/slice_map_on_a_call_receiver_reads_it_once.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn source() -> Slice<int> { [1, 2] }
+  
+  fn test() -> Slice<int> {
+    source().map(|x| x * 2)
+  }
+---
+package main
+
+func source() []int {
+	return []int{1, 2}
+}
+
+func test() []int {
+	src_1 := source()
+	result_2 := make([]int, len(src_1))
+	for i_3, x := range src_1 {
+		result_2[i_3] = x * 2
+	}
+	return result_2
+}

--- a/tests/spec/emit/snapshots/slice_map_returning_lambda_keeps_the_helper.snap
+++ b/tests/spec/emit/snapshots/slice_map_returning_lambda_keeps_the_helper.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(s: Slice<int>) -> Slice<int> {
+    s.map(|x| {
+      if x > 0 {
+        return x
+      }
+      0
+    })
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(s []int) []int {
+	return lisette.SliceMap(s, func(x int) int {
+		if x > 0 {
+			return x
+		}
+		return 0
+	})
+}

--- a/tests/spec/emit/snapshots/slice_map_with_an_unused_parameter_drops_the_element.snap
+++ b/tests/spec/emit/snapshots/slice_map_with_an_unused_parameter_drops_the_element.snap
@@ -3,17 +3,15 @@ source: tests/spec/emit/prelude.rs
 description: |
   
   fn test(s: Slice<int>) -> Slice<int> {
-    s.filter(|x| x > 0)
+    s.map(|_x| 7)
   }
 ---
 package main
 
 func test(s []int) []int {
-	var result_1 []int
-	for _, x := range s {
-		if x > 0 {
-			result_1 = append(result_1, x)
-		}
+	result_1 := make([]int, len(s))
+	for i_2 := range s {
+		result_1[i_2] = 7
 	}
 	return result_1
 }

--- a/tests/spec/emit/snapshots/slice_string_map_filter_join.snap
+++ b/tests/spec/emit/snapshots/slice_string_map_filter_join.snap
@@ -11,15 +11,18 @@ description: |
 ---
 package main
 
-import (
-	lisette "github.com/ivov/lisette/prelude"
-	"strings"
-)
+import "strings"
 
 func test(items []string) string {
-	return strings.Join(lisette.SliceFilter(lisette.SliceMap(items, func(s string) string {
-		return s + "!"
-	}), func(s string) bool {
-		return len(s) > 2
-	}), ", ")
+	result_1 := make([]string, len(items))
+	for i_2, s := range items {
+		result_1[i_2] = s + "!"
+	}
+	var result_3 []string
+	for _, s := range result_1 {
+		if len(s) > 2 {
+			result_3 = append(result_3, s)
+		}
+	}
+	return strings.Join(result_3, ", ")
 }


### PR DESCRIPTION
A `map`, `filter`, `fold`, or `find` call whose callback is a lambda now emits the loop directly, without a prelude helper.

```rs
fn keep_positive(s: Slice<int>) -> Slice<int> {
  s.filter(|x| x > 0)
}
```

Before:

```go
func keepPositive(s []int) []int {
	return lisette.SliceFilter(s, func(x int) bool {
		return x > 0
	})
}
```

After:

```go
func keepPositive(s []int) []int {
	var result_1 []int
	for _, x := range s {
		if x > 0 {
			result_1 = append(result_1, x)
		}
	}
	return result_1
}
```
