### PR TITLE
refactor: match tuple subjects without building tuple

### DIFF
--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -1,6 +1,8 @@
 use crate::Planner;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
-use crate::patterns::decision_tree::{Check, PatternBinding, PatternInfo, render_condition};
+use crate::patterns::decision_tree::{
+    Check, PatternBinding, PatternInfo, SubjectRoot, render_condition,
+};
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::placement::simple_assign;
 use crate::plan::values::ValuePlan;
@@ -94,7 +96,7 @@ pub(crate) fn compose_refutable_condition(
     checks: &[Check],
     effective_subject: &str,
 ) -> String {
-    let condition = render_condition(checks, effective_subject);
+    let condition = render_condition(checks, SubjectRoot::Var(effective_subject));
     match ok_var {
         None => condition,
         Some(ok) if condition == "true" => ok.to_string(),
@@ -119,7 +121,7 @@ pub(crate) fn tree_binding_statements(
             continue;
         };
 
-        let access_expression = binding.path.render(subject_var);
+        let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
 
         if !consumers.is_empty()
             && analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline
@@ -129,7 +131,9 @@ pub(crate) fn tree_binding_statements(
                 .scope
                 .resolve_identifier_binding(&binding.lisette_name)
                 .cloned();
-            let safe_text = binding.path.render_composable(subject_var);
+            let safe_text = binding
+                .path
+                .render_composable(SubjectRoot::Var(subject_var));
             planner.scope.bind_inline_expr(
                 &binding.lisette_name,
                 InlineExpr::new(
@@ -220,7 +224,7 @@ pub(crate) fn tree_assignment_statements(
         };
         let name = registered_name.to_string();
         planner.scope.record_go_use(subject_var);
-        let access_expression = binding.path.render(subject_var);
+        let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
         statements.push(simple_assign(&name, ValuePlan::opaque(access_expression)));
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -34,6 +34,39 @@ pub(crate) enum PathSegment {
     AssertedAs(String),
 }
 
+fn element_index(segments: &[PathSegment]) -> usize {
+    let [PathSegment::Field(field), ..] = segments else {
+        unreachable!("a tuple-element subject only resolves field paths")
+    };
+    TUPLE_FIELDS
+        .iter()
+        .position(|tuple_field| tuple_field == field)
+        .expect("a tuple-element subject only resolves tuple fields")
+}
+
+/// One subject, or one name per element when the match never builds its tuple.
+#[derive(Clone, Copy)]
+pub(crate) enum SubjectRoot<'a> {
+    Var(&'a str),
+    Elements(&'a [String]),
+}
+
+impl<'a> SubjectRoot<'a> {
+    fn resolve<'p>(&self, segments: &'p [PathSegment]) -> (String, &'p [PathSegment]) {
+        match self {
+            Self::Var(var) => ((*var).to_string(), segments),
+            Self::Elements(names) => (names[element_index(segments)].clone(), &segments[1..]),
+        }
+    }
+
+    pub(crate) fn names(&self) -> Vec<&'a str> {
+        match self {
+            Self::Var(var) => vec![var],
+            Self::Elements(names) => names.iter().map(String::as_str).collect(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AccessPath {
     pub segments: Vec<PathSegment>,
@@ -54,10 +87,10 @@ impl AccessPath {
         new
     }
 
-    pub(crate) fn render(&self, subject: &str) -> String {
-        let mut result = subject.to_string();
-        let last = self.segments.len().saturating_sub(1);
-        for (i, seg) in self.segments.iter().enumerate() {
+    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> String {
+        let (mut result, segments) = subject.resolve(&self.segments);
+        let last = segments.len().saturating_sub(1);
+        for (i, seg) in segments.iter().enumerate() {
             match seg {
                 PathSegment::Field(name) => result = format!("{}.{}", result, name),
                 PathSegment::Index(index) => result = format!("{}[{}]", result, index),
@@ -89,7 +122,7 @@ impl AccessPath {
 
     /// Like `render`, but a tail-`Deref` is parenthesized so the result is
     /// safe as a selector receiver, index target, or call callee.
-    pub(crate) fn render_composable(&self, subject: &str) -> String {
+    pub(crate) fn render_composable(&self, subject: SubjectRoot<'_>) -> String {
         let rendered = self.render(subject);
         if matches!(self.segments.last(), Some(PathSegment::Deref)) {
             format!("({})", rendered)
@@ -142,7 +175,7 @@ pub(crate) enum Check {
 }
 
 impl Check {
-    pub(crate) fn render(&self, subject: &str) -> String {
+    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> String {
         match self {
             Check::EnumTag {
                 path, tag_constant, ..
@@ -203,7 +236,7 @@ impl Check {
 
     /// Comparison-shaped checks flip their operator; `Or`/`TypeAssert` wrap
     /// in `!(...)`.
-    pub(crate) fn render_negated(&self, subject: &str) -> String {
+    pub(crate) fn render_negated(&self, subject: SubjectRoot<'_>) -> String {
         match self {
             Check::EnumTag {
                 path, tag_constant, ..
@@ -1673,7 +1706,7 @@ fn extract_root_assertion(checks: &mut Vec<Check>) -> Option<TypeAssertion> {
     }
 }
 
-pub(super) fn render_condition(checks: &[Check], subject_var: &str) -> String {
+pub(super) fn render_condition(checks: &[Check], subject_var: SubjectRoot<'_>) -> String {
     if checks.is_empty() {
         return "true".to_string();
     }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -5,11 +5,13 @@ use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
-use crate::patterns::tree_emitter::TreePlanner;
+use crate::patterns::tree_emitter::{MatchSubject, TreePlanner};
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::plan::calls::{CallPlan, CallableOrigin};
+use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::bindings::BindingValue;
-use syntax::ast::{Expression, MatchArm, Pattern};
+use syntax::ast::{ConstructorPatternResolution, Expression, MatchArm, Pattern};
+use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
 struct FusedShape {
@@ -60,12 +62,22 @@ impl Planner<'_> {
             return LoweredBlock { statements };
         }
 
+        if let Some(elementwise) = self.lower_tuple_subject_match(subject, arms, place) {
+            statements.extend(elementwise);
+            return LoweredBlock { statements };
+        }
+
         let subject_ty = subject.get_type();
         let (subject_var, declaration) =
             self.lower_match_subject_var(&mut statements, subject, arms);
 
         let (block, used_set) = self.capture_go_uses(|this| {
-            this.lower_match_tree(arms, subject_var.clone(), subject_ty, place)
+            this.lower_match_tree(
+                arms,
+                MatchSubject::Var(subject_var.clone()),
+                subject_ty,
+                place,
+            )
         });
         let used = used_set.contains(&subject_var);
 
@@ -92,10 +104,63 @@ impl Planner<'_> {
         LoweredBlock { statements }
     }
 
+    /// `match (a, b)` reads the operands where they sit, building no tuple.
+    fn lower_tuple_subject_match(
+        &mut self,
+        subject: &Expression,
+        arms: &[MatchArm],
+        place: &PlacePlan,
+    ) -> Option<Vec<LoweredStatement>> {
+        let Expression::Tuple { elements, .. } = subject.unwrap_parens() else {
+            return None;
+        };
+        if elements.len() > TUPLE_FIELDS.len() || arms.iter().any(MatchArm::has_guard) {
+            return None;
+        }
+        let mut tested = vec![false; elements.len()];
+        for arm in arms {
+            let arm_tested = arm_tested_elements(self, &arm.pattern, elements.len())?;
+            for (element, arm_element) in tested.iter_mut().zip(arm_tested) {
+                *element |= arm_element;
+            }
+        }
+
+        let subject_ty = subject.get_type();
+        let mut statements: Vec<LoweredStatement> = Vec::new();
+        let mut stages: Vec<ValuePlan> = elements
+            .iter()
+            .map(|element| self.stage_composite(element, ExpressionContext::value()))
+            .collect();
+        for ((stage, tested), element) in stages.iter_mut().zip(&tested).zip(elements) {
+            let rereadable = is_inert_value(element, &stage.expression)
+                || stage.evaluation.stability.is_fixed()
+                || self.plan_rests_in_stable_name(stage);
+            if *tested && !rereadable {
+                self.pin_staged(stage, "arg");
+            }
+        }
+        let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "arg");
+        statements.extend(sequenced.setup);
+
+        let mut names = Vec::with_capacity(elements.len());
+        for ((value, tested), element) in sequenced.values.iter().zip(&tested).zip(elements) {
+            let rendered = value.rendered();
+            // An untested element still runs, but nothing may name it.
+            if !tested && !is_inert_value(element, value) {
+                statements.push(LoweredStatement::RawGo(format!("_ = {}\n", rendered)));
+            }
+            names.push(rendered);
+        }
+
+        let block = self.lower_match_tree(arms, MatchSubject::Elements(names), subject_ty, place);
+        statements.extend(block.statements);
+        Some(statements)
+    }
+
     fn lower_match_tree(
         &mut self,
         arms: &[MatchArm],
-        subject_var: String,
+        subject_var: MatchSubject,
         subject_ty: syntax::types::Type,
         place: &PlacePlan,
     ) -> LoweredBlock {
@@ -464,6 +529,78 @@ impl Planner<'_> {
             expression: value,
         };
         (var, declaration)
+    }
+}
+
+/// Whether reading the value again costs nothing and skipping it loses nothing.
+fn is_inert_value(element: &Expression, value: &GoExpression) -> bool {
+    match value {
+        GoExpression::Literal(_) => true,
+        GoExpression::CompositeLiteral { .. } => element.get_type().is_unit(),
+        _ => false,
+    }
+}
+
+/// Whether an element pattern tests its element, or `None` for a shape whose
+/// checks this lowering does not predict.
+fn element_pattern_tests(planner: &Planner, pattern: &Pattern) -> Option<bool> {
+    match pattern {
+        Pattern::WildCard { .. } | Pattern::Unit { .. } => Some(false),
+        Pattern::Literal { .. } => Some(true),
+        // A tuple struct or a newtype carries no tag, so its checks come from
+        // fields this grammar does not read.
+        Pattern::EnumVariant {
+            resolution,
+            ty,
+            fields,
+            ..
+        } => {
+            for field in fields {
+                element_pattern_tests(planner, field)?;
+            }
+            match resolution {
+                ConstructorPatternResolution::Const { .. }
+                | ConstructorPatternResolution::ConstValue { .. } => Some(true),
+                ConstructorPatternResolution::EnumVariant { .. }
+                    if !planner.is_tuple_struct_type(ty) =>
+                {
+                    Some(true)
+                }
+                _ => None,
+            }
+        }
+        Pattern::Tuple { elements, .. } => elements.iter().try_fold(false, |tests, element| {
+            element_pattern_tests(planner, element).map(|element| tests || element)
+        }),
+        // A catchall alternative leaves the whole pattern untested.
+        Pattern::Or { patterns, .. } => patterns.iter().try_fold(true, |tests, alternative| {
+            element_pattern_tests(planner, alternative).map(|alternative| tests && alternative)
+        }),
+        _ => None,
+    }
+}
+
+/// Which elements an arm tests, or `None` when its shape leaves that open.
+/// Or-pattern alternatives have to agree, since each becomes its own arm.
+fn arm_tested_elements(planner: &Planner, pattern: &Pattern, arity: usize) -> Option<Vec<bool>> {
+    match pattern {
+        Pattern::WildCard { .. } => Some(vec![false; arity]),
+        Pattern::Tuple { elements, .. } if elements.len() == arity => elements
+            .iter()
+            .map(|element| element_pattern_tests(planner, element))
+            .collect(),
+        Pattern::Or { patterns, .. } => {
+            let mut alternatives = Vec::with_capacity(patterns.len());
+            for alternative in patterns {
+                alternatives.push(arm_tested_elements(planner, alternative, arity)?);
+            }
+            let first = alternatives.first()?.clone();
+            alternatives
+                .iter()
+                .all(|alternative| *alternative == first)
+                .then_some(first)
+        }
+        _ => None,
     }
 }
 

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -13,7 +13,7 @@ use crate::patterns::binding_emit::{
     apply_refutable_root_assertion, apply_root_assertion, compose_refutable_condition,
     tree_assignment_statements, tree_binding_statements, with_tree_bindings,
 };
-use crate::patterns::decision_tree::{self, PatternInfo, render_condition};
+use crate::patterns::decision_tree::{self, PatternInfo, SubjectRoot, render_condition};
 use crate::patterns::matching::{field_binding, some_pattern_field};
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
@@ -503,8 +503,9 @@ impl Planner<'_> {
             apply_refutable_root_assertion(self, &mut statements, &info, subject_var);
 
         if subject_is_fixed {
-            info.checks
-                .retain(|check| !self.is_condition_established(&check.render(&effective_subject)));
+            info.checks.retain(|check| {
+                !self.is_condition_established(&check.render(SubjectRoot::Var(&effective_subject)))
+            });
         }
 
         if info.checks.is_empty() && assert_ok_var.is_none() {
@@ -526,8 +527,11 @@ impl Planner<'_> {
         if !info.checks.is_empty() {
             self.scope.record_go_use(effective_subject.as_ref());
             let negated = match info.checks.as_slice() {
-                [check] => check.render_negated(&effective_subject),
-                _ => format!("!({})", render_condition(&info.checks, &effective_subject)),
+                [check] => check.render_negated(SubjectRoot::Var(&effective_subject)),
+                _ => format!(
+                    "!({})",
+                    render_condition(&info.checks, SubjectRoot::Var(&effective_subject))
+                ),
             };
             guard_parts.push(wrap_if_struct_literal(negated));
         }

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -7,9 +7,9 @@ use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::{is_catchall_pattern, is_unconditional_catchall};
 use crate::patterns::binding_emit::{drop_inline_overlays, tree_binding_statements};
 use crate::patterns::decision_tree::{
-    ChainTest, Decision, PatternBinding, SwitchBranch, SwitchKind as PatternSwitchKind,
-    SwitchShape, compile_expanded_arms, decision_is_exhaustive, expand_or_patterns,
-    render_condition, tree_has_unguarded_terminal,
+    ChainTest, Decision, PatternBinding, SubjectRoot, SwitchBranch,
+    SwitchKind as PatternSwitchKind, SwitchShape, compile_expanded_arms, decision_is_exhaustive,
+    expand_or_patterns, render_condition, tree_has_unguarded_terminal,
 };
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopKind, LoopPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
@@ -150,10 +150,36 @@ impl<'a> WalkCtx<'a> {
     }
 }
 
+pub(crate) enum MatchSubject {
+    Var(String),
+    Elements(Vec<String>),
+}
+
+impl MatchSubject {
+    /// The one name a binding resolves against.
+    fn var(&self) -> &str {
+        match self {
+            Self::Var(var) => var,
+            Self::Elements(_) => unreachable!("tuple elements carry no bindings"),
+        }
+    }
+
+    pub(crate) fn root(&self) -> SubjectRoot<'_> {
+        match self {
+            Self::Var(var) => SubjectRoot::Var(var),
+            Self::Elements(names) => SubjectRoot::Elements(names),
+        }
+    }
+
+    fn names(&self) -> Vec<&str> {
+        self.root().names()
+    }
+}
+
 pub(crate) struct TreePlanner<'a, 'e> {
     planner: &'a mut Planner<'e>,
     arms: &'a [MatchArm],
-    subject: String,
+    subject: MatchSubject,
     subject_ty: Type,
 }
 
@@ -161,7 +187,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
     pub(crate) fn new(
         planner: &'a mut Planner<'e>,
         arms: &'a [MatchArm],
-        subject_var: String,
+        subject_var: MatchSubject,
         subject_ty: Type,
     ) -> Self {
         Self {
@@ -198,6 +224,12 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             }
         }
         LoweredBlock { statements }
+    }
+
+    fn record_subject_use(&mut self) {
+        for name in self.subject.names().to_vec() {
+            self.planner.scope.record_go_use(name);
+        }
     }
 
     fn with_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
@@ -314,7 +346,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let mut last_diverges = false;
         for (test, condition) in tests[..regular_len].iter().zip(&conditions) {
             if condition.is_some() {
-                self.planner.scope.record_go_use(&self.subject);
+                self.record_subject_use();
             }
             let condition = condition.as_deref().unwrap_or("true").to_string();
             let walk_ctx = if matches!(test.decision, Decision::Guard { .. }) {
@@ -539,8 +571,8 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                         }
                         continue;
                     }
-                    self.planner.scope.record_go_use(&self.subject);
-                    conditions.push(render_condition(&test.checks, &self.subject));
+                    self.record_subject_use();
+                    conditions.push(render_condition(&test.checks, self.subject.root()));
                     let flattened = self.collect_flat_cases(&test.decision, conditions, out, false);
                     conditions.pop();
                     if !flattened {
@@ -559,10 +591,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 branches,
                 fallback,
             } => {
-                let rendered_path = path.render(&self.subject);
+                let rendered_path = path.render(self.subject.root());
                 let (cased, lifted) = split_with_default_lift(branches, fallback.as_deref());
                 for branch in cased {
-                    self.planner.scope.record_go_use(&self.subject);
+                    self.record_subject_use();
                     conditions.push(switch_branch_condition(
                         &rendered_path,
                         kind,
@@ -621,12 +653,12 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 .scope
                 .resolve_identifier_binding(&binding.lisette_name)
                 .cloned();
-            let text = binding.path.render_composable(&self.subject);
+            let text = binding.path.render_composable(self.subject.root());
             self.planner.scope.bind_inline_expr(
                 &binding.lisette_name,
                 InlineExpr::new(
                     text,
-                    vec![self.subject.clone()],
+                    vec![self.subject.var().to_string()],
                     binding.path.contains_deferred_evaluation(),
                 ),
             );
@@ -714,10 +746,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             unreachable!("walk_switch requires a Switch decision");
         };
         let fallback = fallback.as_deref();
-        let rendered_path = path.render(&self.subject);
+        let rendered_path = path.render(self.subject.root());
         match shape {
             SwitchShape::TypeSwitch => {
-                self.planner.scope.record_go_use(&self.subject);
+                self.record_subject_use();
                 let plan = self.lower_type_switch(rendered_path, branches, fallback, ctx.arm_place);
                 let body_diverges =
                     capture_diverge(vec![LoweredStatement::Switch(plan)], statements);
@@ -772,7 +804,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 self.walk_condition_branch(statements, condition, &branch.decision, fallback, ctx);
             }
             SwitchShape::Multi => {
-                self.planner.scope.record_go_use(&self.subject);
+                self.record_subject_use();
                 let expr = render_switch_expression(&rendered_path, kind);
                 let plan = self.lower_value_switch(expr, branches, fallback, ctx.arm_place);
                 let body_diverges =
@@ -790,7 +822,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         else_branch: &Decision,
         ctx: &WalkCtx,
     ) {
-        self.planner.scope.record_go_use(&self.subject);
+        self.record_subject_use();
         let inner = WalkCtx::switch_case(ctx.arm_place);
         let then_statements = self.with_scope(|this| {
             this.planner.scope.establish_condition(condition.clone());
@@ -952,7 +984,8 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let arms = self.arms;
         let subject_ty = self.subject_ty.clone();
         let ((case_plans, default_block), used) = self.planner.capture_go_uses(|planner| {
-            let mut nested = TreePlanner::new(planner, arms, base.clone(), subject_ty);
+            let mut nested =
+                TreePlanner::new(planner, arms, MatchSubject::Var(base.clone()), subject_ty);
             let case_plans = nested.lower_switch_cases(regular, place, None);
             let default_block = nested.lower_switch_default(default, place);
             (case_plans, default_block)
@@ -1083,7 +1116,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         let body = LoweredBlock { statements: body };
         let first_condition = &conditions[indices[0]];
         if first_condition.is_some() {
-            self.planner.scope.record_go_use(&self.subject);
+            self.record_subject_use();
         }
         match first_condition {
             Some(condition) => statements.push(LoweredStatement::If(IfPlan {
@@ -1232,11 +1265,14 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             None => Vec::new(),
         };
 
+        if bindings.is_empty() {
+            return Vec::new();
+        }
         tree_binding_statements(
             self.planner,
             statements,
             bindings,
-            &self.subject,
+            self.subject.var(),
             consumers,
             &failure_trees,
         )
@@ -1285,7 +1321,8 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         tests
             .iter()
             .map(|test| {
-                (!test.checks.is_empty()).then(|| render_condition(&test.checks, &self.subject))
+                (!test.checks.is_empty())
+                    .then(|| render_condition(&test.checks, self.subject.root()))
             })
             .collect()
     }

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -1493,6 +1493,238 @@ pub struct Rect { pub W: int, pub H: int }
 }
 
 #[test]
+fn tuple_subject_of_calls_reads_each_once() {
+    let input = r#"
+fn left() -> int { 1 }
+
+fn right() -> int { 2 }
+
+fn test() -> string {
+  match (left(), right()) {
+    (1, 2) => "one two",
+    _ => "other",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_element_no_arm_reads_still_runs() {
+    let input = r#"
+fn left() -> int { 1 }
+
+fn test(b: bool) -> string {
+  match (left(), b) {
+    (_, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_unit_element_runs_as_a_statement() {
+    let input = r#"
+import "go:fmt"
+
+fn ping() {
+  fmt.Println("ping")
+}
+
+fn test(b: bool) -> string {
+  match (ping(), b) {
+    (_, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_untested_literal_keeps_its_call() {
+    let input = r#"
+struct Box { value: int }
+
+fn source() -> int { 1 }
+
+fn test(b: bool) -> string {
+  match (Box { value: source() }, b) {
+    (_, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_with_a_tuple_struct_pattern_keeps_its_tuple() {
+    let input = r#"
+struct Pair(int, int)
+
+fn make_pair() -> Pair { Pair(1, 2) }
+
+fn test(b: bool) -> string {
+  match (make_pair(), b) {
+    (Pair(_, _), true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_or_arm_reading_different_elements_keeps_its_tuple() {
+    let input = r#"
+fn left() -> int { 2 }
+
+fn right() -> int { 1 }
+
+fn test() -> string {
+  match (left(), right()) {
+    (_, 1) | (2, _) => "hit",
+    _ => "miss",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_with_a_variant_binding_keeps_its_tuple() {
+    let input = r#"
+enum Event {
+  Click(int, int),
+  Close,
+}
+
+fn test(e: Event, b: bool) -> int {
+  match (e, b) {
+    (Event.Click(x, y), true) => x + y,
+    _ => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_single_variant_enum_reads_its_tag() {
+    let input = r#"
+enum Only { Single }
+
+fn test(o: Only, b: bool) -> string {
+  match (o, b) {
+    (Only.Single, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_with_a_struct_pattern_keeps_its_tuple() {
+    let input = r#"
+struct Box {}
+
+fn make_box() -> Box { Box {} }
+
+fn test(b: bool) -> string {
+  match (make_box(), b) {
+    (Box {}, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_untested_literal_keeps_its_division() {
+    let input = r#"
+struct Box { value: int }
+
+fn test(n: int, b: bool) -> string {
+  match (Box { value: 1 / n }, b) {
+    (_, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_unit_access_keeps_its_bounds_check() {
+    let input = r#"
+fn units() -> Slice<()> {
+  []
+}
+
+fn test(b: bool) -> string {
+  match (units()[0], b) {
+    (_, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_with_a_binding_keeps_its_tuple() {
+    let input = r#"
+fn source() -> int { 1 }
+
+fn test(b: bool) -> string {
+  match (source(), b) {
+    (x, true) => "yes",
+    _ => "no",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_bound_whole_keeps_its_tuple() {
+    let input = r#"
+fn test(a: int, b: int) -> int {
+  match (a, b) {
+    pair => pair.0 + pair.1,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tuple_subject_with_a_guard_keeps_its_tuple() {
+    let input = r#"
+fn bump(mut n: int) -> bool {
+  n = n + 1
+  true
+}
+
+fn test(start: int, b: int) -> string {
+  let mut a = start
+  a = a + 1
+  match (a, b) {
+    (1, _) if bump(a) => "first",
+    (2, _) => "second",
+    _ => "none",
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_enum_match_checks_every_element() {
     let input = r#"
 pub enum Hand {

--- a/tests/spec/emit/snapshots/or_pattern_booleans.snap
+++ b/tests/spec/emit/snapshots/or_pattern_booleans.snap
@@ -11,11 +11,8 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func test(a, b bool) string {
-	subject_1 := lisette.MakeTuple2[bool, bool](a, b)
-	if (subject_1.First && subject_1.Second) || (!subject_1.First && !subject_1.Second) {
+	if (a && b) || (!a && !b) {
 		return "same"
 	}
 	return "different"

--- a/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
+++ b/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
@@ -33,8 +33,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func MakeHandLeft() Hand {
 	return Hand{Tag: HandLeft}
 }
@@ -55,9 +53,8 @@ type Hand struct {
 }
 
 func (h Hand) LeftRight(other Hand) bool {
-	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
-	if subject_1.First.Tag == HandLeft {
-		if subject_1.Second.Tag == HandRight {
+	if h.Tag == HandLeft {
+		if other.Tag == HandRight {
 			return true
 		}
 		return false
@@ -66,9 +63,8 @@ func (h Hand) LeftRight(other Hand) bool {
 }
 
 func (h Hand) LeftLeft(other Hand) bool {
-	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
-	if subject_1.First.Tag == HandLeft {
-		if subject_1.Second.Tag == HandLeft {
+	if h.Tag == HandLeft {
+		if other.Tag == HandLeft {
 			return true
 		}
 		return false
@@ -77,15 +73,14 @@ func (h Hand) LeftLeft(other Hand) bool {
 }
 
 func (h Hand) Eq(other Hand) bool {
-	subject_1 := lisette.MakeTuple2[Hand, Hand](h, other)
-	switch subject_1.First.Tag {
+	switch h.Tag {
 	case HandLeft:
-		if subject_1.Second.Tag == HandLeft {
+		if other.Tag == HandLeft {
 			return true
 		}
 		return false
 	case HandRight:
-		if subject_1.Second.Tag == HandRight {
+		if other.Tag == HandRight {
 			return true
 		}
 		return false

--- a/tests/spec/emit/snapshots/tuple_subject_bound_whole_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_bound_whole_keeps_its_tuple.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn test(a: int, b: int) -> int {
+    match (a, b) {
+      pair => pair.0 + pair.1,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(a, b int) int {
+	subject_1 := lisette.MakeTuple2[int, int](a, b)
+	{
+		pair := subject_1
+		return pair.First + pair.Second
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_subject_element_no_arm_reads_still_runs.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_element_no_arm_reads_still_runs.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn left() -> int { 1 }
+  
+  fn test(b: bool) -> string {
+    match (left(), b) {
+      (_, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+func left() int {
+	return 1
+}
+
+func test(b bool) string {
+	_ = left()
+	if b == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_of_calls_reads_each_once.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_of_calls_reads_each_once.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn left() -> int { 1 }
+  
+  fn right() -> int { 2 }
+  
+  fn test() -> string {
+    match (left(), right()) {
+      (1, 2) => "one two",
+      _ => "other",
+    }
+  }
+---
+package main
+
+func left() int {
+	return 1
+}
+
+func right() int {
+	return 2
+}
+
+func test() string {
+	arg_1 := left()
+	arg_2 := right()
+	if arg_1 == 1 && arg_2 == 2 {
+		return "one two"
+	}
+	return "other"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_or_arm_reading_different_elements_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_or_arm_reading_different_elements_keeps_its_tuple.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn left() -> int { 2 }
+  
+  fn right() -> int { 1 }
+  
+  fn test() -> string {
+    match (left(), right()) {
+      (_, 1) | (2, _) => "hit",
+      _ => "miss",
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func left() int {
+	return 2
+}
+
+func right() int {
+	return 1
+}
+
+func test() string {
+	subject_1 := lisette.MakeTuple2[int, int](left(), right())
+	if subject_1.Second == 1 || subject_1.First == 2 {
+		return "hit"
+	}
+	return "miss"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_single_variant_enum_reads_its_tag.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_single_variant_enum_reads_its_tag.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Only { Single }
+  
+  fn test(o: Only, b: bool) -> string {
+    match (o, b) {
+      (Only.Single, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+func MakeOnlySingle() Only {
+	return Only{Tag: OnlySingle}
+}
+
+type OnlyTag int
+
+const (
+	OnlySingle OnlyTag = iota
+)
+
+type Only struct {
+	Tag OnlyTag
+}
+
+func test(o Only, b bool) string {
+	if o.Tag == OnlySingle {
+		if b == true {
+			return "yes"
+		}
+		return "no"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_unit_access_keeps_its_bounds_check.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_unit_access_keeps_its_bounds_check.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn units() -> Slice<()> {
+    []
+  }
+  
+  fn test(b: bool) -> string {
+    match (units()[0], b) {
+      (_, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+func units() []struct{} {
+	return []struct{}{}
+}
+
+func test(b bool) string {
+	base_1 := units()
+	_ = base_1[0]
+	if b == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_unit_element_runs_as_a_statement.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_unit_element_runs_as_a_statement.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn ping() {
+    fmt.Println("ping")
+  }
+  
+  fn test(b: bool) -> string {
+    match (ping(), b) {
+      (_, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+import "fmt"
+
+func ping() {
+	fmt.Println("ping")
+}
+
+func test(b bool) string {
+	ping()
+	if b == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_untested_literal_keeps_its_call.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_untested_literal_keeps_its_call.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Box { value: int }
+  
+  fn source() -> int { 1 }
+  
+  fn test(b: bool) -> string {
+    match (Box { value: source() }, b) {
+      (_, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+type Box struct {
+	value int
+}
+
+func source() int {
+	return 1
+}
+
+func test(b bool) string {
+	_ = Box{value: source()}
+	if b == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_untested_literal_keeps_its_division.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_untested_literal_keeps_its_division.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Box { value: int }
+  
+  fn test(n: int, b: bool) -> string {
+    match (Box { value: 1 / n }, b) {
+      (_, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+type Box struct {
+	value int
+}
+
+func test(n int, b bool) string {
+	_ = Box{value: 1 / n}
+	if b == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_binding_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_binding_keeps_its_tuple.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn source() -> int { 1 }
+  
+  fn test(b: bool) -> string {
+    match (source(), b) {
+      (x, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func source() int {
+	return 1
+}
+
+func test(b bool) string {
+	subject_1 := lisette.MakeTuple2[int, bool](source(), b)
+	if subject_1.Second == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_guard_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_guard_keeps_its_tuple.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn bump(mut n: int) -> bool {
+    n = n + 1
+    true
+  }
+  
+  fn test(start: int, b: int) -> string {
+    let mut a = start
+    a = a + 1
+    match (a, b) {
+      (1, _) if bump(a) => "first",
+      (2, _) => "second",
+      _ => "none",
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func bump(n int) bool {
+	n++
+	return true
+}
+
+func test(start, b int) string {
+	a := start
+	a++
+	subject_1 := lisette.MakeTuple2[int, int](a, b)
+	if subject_1.First == 1 {
+		if bump(a) {
+			return "first"
+		}
+	}
+	if subject_1.First == 2 {
+		return "second"
+	}
+	{
+		return "none"
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_struct_pattern_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_struct_pattern_keeps_its_tuple.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Box {}
+  
+  fn make_box() -> Box { Box {} }
+  
+  fn test(b: bool) -> string {
+    match (make_box(), b) {
+      (Box {}, true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Box struct{}
+
+func makeBox() Box {
+	return Box{}
+}
+
+func test(b bool) string {
+	subject_1 := lisette.MakeTuple2[Box, bool](makeBox(), b)
+	if subject_1.Second == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_tuple_struct_pattern_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_tuple_struct_pattern_keeps_its_tuple.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Pair(int, int)
+  
+  fn make_pair() -> Pair { Pair(1, 2) }
+  
+  fn test(b: bool) -> string {
+    match (make_pair(), b) {
+      (Pair(_, _), true) => "yes",
+      _ => "no",
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Pair struct {
+	F0 int
+	F1 int
+}
+
+func makePair() Pair {
+	return Pair{
+		F0: 1,
+		F1: 2,
+	}
+}
+
+func test(b bool) string {
+	subject_1 := lisette.MakeTuple2[Pair, bool](makePair(), b)
+	if subject_1.Second == true {
+		return "yes"
+	}
+	return "no"
+}

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_variant_binding_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_variant_binding_keeps_its_tuple.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum Event {
+    Click(int, int),
+    Close,
+  }
+  
+  fn test(e: Event, b: bool) -> int {
+    match (e, b) {
+      (Event.Click(x, y), true) => x + y,
+      _ => 0,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func MakeEventClick(arg0 int, arg1 int) Event {
+	return Event{Tag: EventClick, Click0: arg0, Click1: arg1}
+}
+
+func MakeEventClose() Event {
+	return Event{Tag: EventClose}
+}
+
+type EventTag int
+
+const (
+	EventClick EventTag = iota
+	EventClose
+)
+
+type Event struct {
+	Tag    EventTag
+	Click0 int
+	Click1 int
+}
+
+func test(e Event, b bool) int {
+	subject_1 := lisette.MakeTuple2[Event, bool](e, b)
+	if subject_1.First.Tag == EventClick {
+		if subject_1.Second == true {
+			return subject_1.First.Click0 + subject_1.First.Click1
+		}
+		return 0
+	}
+	return 0
+}


### PR DESCRIPTION
A `match` on a tuple of expressions now tests the operands where they appear, instead of building a `Tuple2` to read the fields back.

```rs
fn test(a: bool, b: bool) -> string {
  match (a, b) {
    (true, true) | (false, false) => "same",
    (true, false) | (false, true) => "different",
  }
}
```

Before:

```go
import lisette "github.com/ivov/lisette/prelude"

func test(a, b bool) string {
	subject_1 := lisette.MakeTuple2[bool, bool](a, b)
	if (subject_1.First && subject_1.Second) || (!subject_1.First && !subject_1.Second) {
		return "same"
	}
	return "different"
}
```

After:

```go
func test(a, b bool) string {
	if (a && b) || (!a && !b) {
		return "same"
	}
	return "different"
}
```
