### PR TITLE
feat: integer constant in `Array` size

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -4021,7 +4021,57 @@ pub fn array_size_not_literal(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Array size must be an integer literal")
         .with_infer_code("array_size_not_literal")
         .with_span_label(&span, "expected an integer literal here")
-        .with_help("Array sizes are part of the type and must be constant, e.g. `Array<int, 3>`")
+        .with_help(
+            "Array sizes are part of the type and must be constant, \
+             e.g. `Array<int, 3>` or `Array<int, SIZE>`",
+        )
+}
+
+pub fn array_size_unknown_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("Cannot find constant `{name}`"))
+        .with_infer_code("array_size_unknown_constant")
+        .with_span_label(&span, "not found in this scope")
+        .with_help("An array size is an integer literal or the name of an integer constant")
+}
+
+pub fn array_size_not_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is not a constant"))
+        .with_infer_code("array_size_not_constant")
+        .with_span_label(&span, "expected a constant here")
+        .with_help("An array size is part of the type, so it cannot come from a runtime value")
+}
+
+pub fn array_size_local_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is not a package-level constant"))
+        .with_infer_code("array_size_local_constant")
+        .with_span_label(&span, "declared inside a function")
+        .with_help(format!(
+            "Move `{name}` out of the function body to use it as an array size"
+        ))
+}
+
+pub fn array_size_not_integer_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is not an integer constant"))
+        .with_infer_code("array_size_not_integer_constant")
+        .with_span_label(&span, "expected an integer constant here")
+        .with_help("An array size must be a whole number, e.g. `const SIZE = 3`")
+}
+
+pub fn array_size_computed_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is not a literal constant"))
+        .with_infer_code("array_size_computed_constant")
+        .with_span_label(&span, "its initializer is computed, not a literal")
+        .with_help(format!(
+            "An array size reads the constant's literal value, so `{name}` must be \
+             written as a single integer literal"
+        ))
+}
+
+pub fn array_size_negative_constant(name: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{name}` is negative"))
+        .with_infer_code("array_size_negative_constant")
+        .with_span_label(&span, "an array size cannot be negative")
+        .with_help("Array sizes count elements, so they start at zero")
 }
 
 pub fn array_size_too_large(size: u64, span: Span) -> LisetteDiagnostic {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -375,7 +375,12 @@ impl Backend {
                     let qualified = format!("{}.{}", file.package_id, name);
                     find_struct_field_span(&qualified, &f.name, &snapshot)
                 })
-                .or_else(|| offset_in_span(offset, name_span).then_some(*name_span)),
+                .or_else(|| offset_in_span(offset, name_span).then_some(*name_span))
+                .or_else(|| {
+                    fields.iter().find_map(|f| {
+                        resolve_annotation_definition(&f.annotation, offset, file, &snapshot)
+                    })
+                }),
 
             syntax::ast::Expression::Enum {
                 name,

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -13578,3 +13578,78 @@ fn a_closed_document_gets_no_diagnostics_from_a_surviving_sibling_key() {
     );
     client.shutdown();
 }
+
+#[test]
+fn goto_definition_array_size_constant_declared_later() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "fn take(xs: Array<int, SIZE>) -> int { xs.length() }\nconst SIZE = 3",
+    );
+
+    let response = client.goto_definition(TEST_URI, 0, 23);
+    assert!(response.is_some(), "forward-declared size should resolve");
+
+    let loc = definition_location(&response.unwrap());
+    assert!(loc.is_some());
+    assert_eq!(loc.unwrap().range.start.line, 1);
+
+    client.shutdown();
+}
+
+#[test]
+fn goto_definition_array_size_constant_in_struct_field() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "struct Holder {\n  pub data: Array<int, SIZE>\n}\nconst SIZE = 3",
+    );
+
+    let response = client.goto_definition(TEST_URI, 1, 23);
+    assert!(response.is_some(), "struct field size should resolve");
+
+    let loc = definition_location(&response.unwrap());
+    assert!(loc.is_some());
+    assert_eq!(loc.unwrap().range.start.line, 3);
+
+    client.shutdown();
+}
+
+#[test]
+fn hover_on_array_size_constant_shows_its_type() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "const SIZE = 3\nfn take(xs: Array<int, SIZE>) -> int { xs.length() }",
+    );
+
+    let hover = client.hover(TEST_URI, 1, 23);
+    assert!(hover.is_some(), "array size constant should hover");
+
+    let content = hover_content(&hover.unwrap());
+    assert!(content.contains("int"), "got: {content}");
+
+    client.shutdown();
+}
+
+#[test]
+fn goto_definition_array_size_constant() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "const SIZE = 3\nfn take(xs: Array<int, SIZE>) -> int { xs.length() }",
+    );
+
+    let response = client.goto_definition(TEST_URI, 1, 23);
+    assert!(response.is_some(), "array size constant should resolve");
+
+    let loc = definition_location(&response.unwrap());
+    assert!(loc.is_some());
+    assert_eq!(loc.unwrap().range.start.line, 0);
+
+    client.shutdown();
+}

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -508,20 +508,8 @@ impl InferCtx<'_> {
             }
         } else if type_args.len() == 2 {
             let elem = self.convert_to_type(store, &type_args[0], &span);
-            match &type_args[1] {
-                Annotation::Constant {
-                    value,
-                    span: size_span,
-                    ..
-                } => self
-                    .check_array_size_in_bounds(*value, *size_span)
-                    .then_some((elem, *value)),
-                other => {
-                    self.sink
-                        .push(diagnostics::infer::array_size_not_literal(other.get_span()));
-                    None
-                }
-            }
+            self.resolve_array_size(store, &type_args[1])
+                .map(|length| (elem, length))
         } else {
             self.sink
                 .push(diagnostics::infer::array_type_arity(type_args.len(), span));

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -7,14 +7,47 @@ use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span};
 use syntax::program::DefinitionBody;
 use syntax::types::{
-    FunctionParameter, Symbol, Type, build_named_substitution_map, substitute, unqualified_name,
+    FunctionParameter, SimpleKind, Symbol, Type, build_named_substitution_map, substitute,
+    unqualified_name,
 };
 
 use crate::checker::TaskState;
 use crate::checker::scopes::DeferredMapKeyCheck;
+use crate::checker::state::PendingArraySizeCheck;
 use crate::generics::apply_bounds;
 use crate::prelude::PRELUDE_PACKAGE_ID;
 use crate::store::Store;
+
+enum ArraySizeError {
+    NotInteger,
+    Negative,
+    TooLarge,
+}
+
+impl ArraySizeError {
+    fn into_diagnostic(self, name: &str, value: u64, span: Span) -> diagnostics::LisetteDiagnostic {
+        match self {
+            Self::NotInteger => diagnostics::infer::array_size_not_integer_constant(name, span),
+            Self::Negative => diagnostics::infer::array_size_negative_constant(name, span),
+            Self::TooLarge => diagnostics::infer::array_size_too_large(value, span),
+        }
+    }
+}
+
+fn constant_size_of(kind: SimpleKind, value: u64) -> Result<u64, ArraySizeError> {
+    if kind.integer_range().is_none() {
+        return Err(ArraySizeError::NotInteger);
+    }
+    // Past `i64::MAX` a signed constant is a wrapped negative, not a huge size.
+    if value > i64::MAX as u64 {
+        return Err(if kind.is_signed_int() {
+            ArraySizeError::Negative
+        } else {
+            ArraySizeError::TooLarge
+        });
+    }
+    Ok(value)
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TypePosition {
@@ -414,25 +447,126 @@ impl TaskState {
             return Type::Error;
         }
 
-        if let Annotation::Constant {
-            value,
-            span: size_span,
-            ..
-        } = &params[1]
-        {
-            if !self.check_array_size_in_bounds(*value, *size_span) {
-                return Type::Error;
-            }
-            return Type::Array {
-                length: *value,
+        match self.resolve_array_size(store, &params[1]) {
+            Some(length) => Type::Array {
+                length,
                 element: Box::new(element),
-            };
+            },
+            None => Type::Error,
+        }
+    }
+
+    pub(crate) fn resolve_array_size(
+        &mut self,
+        store: &Store,
+        annotation: &Annotation,
+    ) -> Option<u64> {
+        let span = annotation.get_span();
+        match annotation {
+            Annotation::Constant { value, .. } => self
+                .check_array_size_in_bounds(*value, span)
+                .then_some(*value),
+            Annotation::Constructor { name, params, .. }
+                if params.is_empty() && self.lookup_generic_index(name).is_none() =>
+            {
+                self.resolve_named_array_size(store, name, span)
+            }
+            _ => {
+                self.sink
+                    .push(diagnostics::infer::array_size_not_literal(span));
+                None
+            }
+        }
+    }
+
+    fn resolve_named_array_size(&mut self, store: &Store, name: &str, span: Span) -> Option<u64> {
+        if self.scopes.lookup_value(name).is_some() {
+            self.sink.push(if self.scopes.lookup_const(name) {
+                diagnostics::infer::array_size_local_constant(name, span)
+            } else {
+                diagnostics::infer::array_size_not_constant(name, span)
+            });
+            return None;
         }
 
-        self.sink.push(diagnostics::infer::array_size_not_literal(
-            params[1].get_span(),
-        ));
-        Type::Error
+        let Some(qualified_name) = self.lookup_qualified_name(store, name) else {
+            self.sink
+                .push(diagnostics::infer::array_size_unknown_constant(name, span));
+            return None;
+        };
+        let Some(definition) = store.get_definition(&qualified_name) else {
+            self.sink
+                .push(diagnostics::infer::array_size_unknown_constant(name, span));
+            return None;
+        };
+        if !definition.is_const() {
+            self.sink.push(if definition.is_value(&qualified_name) {
+                diagnostics::infer::array_size_not_constant(name, span)
+            } else {
+                // A type in size position, as in `Array<int, int>`.
+                diagnostics::infer::array_size_not_literal(span)
+            });
+            return None;
+        }
+        self.track_name_usage(store, &qualified_name, &span, name.len() as u32);
+
+        let Some(literal) = definition.const_value() else {
+            self.sink
+                .push(diagnostics::infer::array_size_computed_constant(name, span));
+            return None;
+        };
+        let syntax::ast::Literal::Integer { value, .. } = literal else {
+            self.sink
+                .push(diagnostics::infer::array_size_not_integer_constant(
+                    name, span,
+                ));
+            return None;
+        };
+        let value = *value;
+
+        // A type alias holding an array can read a constant before that constant's
+        // own type name resolves, so settle those after registration instead.
+        let Some(kind) = store.underlying_simple_kind(&definition.ty.resolve_in(&self.env)) else {
+            self.pending.array_size_checks.push(PendingArraySizeCheck {
+                qualified_name: qualified_name.to_string(),
+                name: name.into(),
+                span,
+            });
+            return (value <= i64::MAX as u64).then_some(value);
+        };
+
+        match constant_size_of(kind, value) {
+            Ok(length) => Some(length),
+            Err(error) => {
+                self.sink.push(error.into_diagnostic(name, value, span));
+                None
+            }
+        }
+    }
+
+    /// Settles the size constants whose type had not resolved at conversion time.
+    pub(super) fn check_pending_array_size_checks(&mut self, store: &Store) {
+        let mut seen = rustc_hash::FxHashSet::default();
+        for pending in std::mem::take(&mut self.pending.array_size_checks) {
+            if !seen.insert((pending.span, pending.qualified_name.clone())) {
+                continue;
+            }
+            let Some(definition) = store.get_definition(&pending.qualified_name) else {
+                continue;
+            };
+            let Some(syntax::ast::Literal::Integer { value, .. }) = definition.const_value() else {
+                continue;
+            };
+            let outcome = store
+                .underlying_simple_kind(&definition.ty.resolve_in(&self.env))
+                .map_or(Err(ArraySizeError::NotInteger), |kind| {
+                    constant_size_of(kind, *value)
+                });
+            if let Err(error) = outcome {
+                self.sink
+                    .push(error.into_diagnostic(&pending.name, *value, pending.span));
+            }
+        }
     }
 
     pub(crate) fn check_array_size_in_bounds(&mut self, value: u64, span: Span) -> bool {

--- a/crates/semantics/src/checker/registration/declarations.rs
+++ b/crates/semantics/src/checker/registration/declarations.rs
@@ -52,13 +52,14 @@ impl TaskState {
         items: &mut [Expression],
         visibility: &Visibility,
     ) {
+        let package_id = self.cursor.package_id().to_string();
         self.register_type_names(store, items, visibility);
+        self.register_constants(store, items, visibility);
         self.register_type_definitions(store, items);
         self.check_type_generic_bounds(store, items);
         self.register_impl_blocks(store, items);
-        self.register_values(store, items, visibility);
+        self.register_non_const_values(store, items, visibility);
         self.register_item_derived_attributes(store, items);
-        let package_id = self.cursor.package_id().to_string();
         self.validate_package_embeds(store, &package_id);
         self.check_package_recursive_types(store, &package_id);
     }

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -61,6 +61,7 @@ impl TaskState {
     pub fn finalize_registration(&mut self, store: &mut Store) {
         self.finalize_equality(store);
         self.check_pending_generic_bounds(store);
+        self.check_pending_array_size_checks(store);
         self.finalize_tests(store);
     }
 
@@ -129,6 +130,18 @@ impl TaskState {
                     file_id: file.id,
                     imports: &file.imports,
                 },
+                |this, store| this.register_constants(store, &file.items, &Visibility::Private),
+            );
+        }
+
+        for file in &mut files {
+            self.with_file_context_mut(
+                store,
+                FileContext::Standard {
+                    package_id: &id,
+                    file_id: file.id,
+                    imports: &file.imports,
+                },
                 |this, store| this.register_type_aliases(store, &mut file.items),
             );
         }
@@ -156,7 +169,7 @@ impl TaskState {
                 |this, store| {
                     this.check_type_generic_bounds(store, &file.items);
                     this.register_impl_blocks(store, &mut file.items);
-                    this.register_values(store, &mut file.items, &Visibility::Private);
+                    this.register_non_const_values(store, &mut file.items, &Visibility::Private);
                 },
             );
         }

--- a/crates/semantics/src/checker/registration/values.rs
+++ b/crates/semantics/src/checker/registration/values.rs
@@ -55,7 +55,21 @@ impl TaskState {
         }
     }
 
-    pub(crate) fn register_values(
+    /// Runs before every other declaration, so `Array<int, N>` can resolve `N`.
+    pub(crate) fn register_constants(
+        &mut self,
+        store: &mut Store,
+        items: &[Expression],
+        visibility: &Visibility,
+    ) {
+        for item in items {
+            if matches!(item, Expression::Const { .. }) {
+                self.register_const_value(store, item, visibility);
+            }
+        }
+    }
+
+    pub(crate) fn register_non_const_values(
         &mut self,
         store: &mut Store,
         items: &mut [Expression],
@@ -66,7 +80,6 @@ impl TaskState {
                 Expression::Function { .. } => {
                     self.register_function_value(store, item, visibility)
                 }
-                Expression::Const { .. } => self.register_const_value(store, item, visibility),
                 Expression::VariableDeclaration { .. } => {
                     self.register_variable_declaration(store, item, visibility)
                 }

--- a/crates/semantics/src/checker/state.rs
+++ b/crates/semantics/src/checker/state.rs
@@ -67,6 +67,14 @@ pub(crate) struct PendingWork {
     pub(crate) pre_inference_bound_checks: Vec<(Type, Type, Span)>,
     pub(crate) post_inference_bound_checks: Vec<(Type, Type, Span)>,
     pub(crate) test_functions: Vec<TestFunction>,
+    pub(crate) array_size_checks: Vec<PendingArraySizeCheck>,
+}
+
+/// An array size whose constant was typed by a name that had not resolved yet.
+pub(crate) struct PendingArraySizeCheck {
+    pub(crate) qualified_name: String,
+    pub(crate) name: EcoString,
+    pub(crate) span: Span,
 }
 
 impl PendingWork {
@@ -77,6 +85,7 @@ impl PendingWork {
         self.post_inference_bound_checks
             .extend(other.post_inference_bound_checks);
         self.test_functions.extend(other.test_functions);
+        self.array_size_checks.extend(other.array_size_checks);
     }
 }
 

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -40,9 +40,10 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         }
 
         for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
+            checker.register_constants(store, &file.items, &Visibility::Public);
             checker.register_type_definitions(store, &mut file.items);
             checker.register_impl_blocks(store, &mut file.items);
-            checker.register_values(store, &mut file.items, &Visibility::Public);
+            checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
         }
         checker.finalize_registration(store);
     });
@@ -84,9 +85,10 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
             }
 
             for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
+                checker.register_constants(store, &file.items, &Visibility::Public);
                 checker.register_type_definitions(store, &mut file.items);
                 checker.register_impl_blocks(store, &mut file.items);
-                checker.register_values(store, &mut file.items, &Visibility::Public);
+                checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
             }
             checker.finalize_registration(store);
         },

--- a/docs/reference/02-types.md
+++ b/docs/reference/02-types.md
@@ -187,7 +187,7 @@ Run `lis doc Slice` for the full method list.
 
 ### `Array<T, N>`
 
-A fixed-size, indexable sequence of elements. The size is part of the type, so `Array<byte, 2>` and `Array<byte, 3>` are distinct types. The size must be an integer literal.
+A fixed-size, indexable sequence of elements. The size is part of the type, so `Array<byte, 2>` and `Array<byte, 3>` are distinct types.
 
 A literal creates an array from its elements and must list exactly `N` of them:
 

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -106,6 +106,20 @@ fn string_range_slicing() {
 // Fixed-size arrays, exercised at runtime (the emit-only paths otherwise).
 type Vec3 = Array<int, 3>
 
+const LANE_COUNT = 3
+
+struct Mixer {
+  pub lanes: Array<int, LANE_COUNT>
+}
+
+#[test]
+fn array_size_from_constant() {
+  let mixer = Mixer { lanes: Array.new<int, LANE_COUNT>() }
+  assert mixer.lanes.length() == 3
+  let filled: Array<int, LANE_COUNT> = [7, 8, 9]
+  assert filled[1] == 8
+}
+
 #[test]
 fn array_index_length_get() {
   let a: Array<int, 3> = [10, 20, 30]

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -552,3 +552,23 @@ fn bump(a: Ref<Array<int, 3>>) {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn array_size_from_constant() {
+    let input = r#"
+const SIZE = 3
+
+struct Holder {
+  pub data: Array<int, SIZE>
+}
+
+fn take(xs: Array<int, SIZE>) -> int {
+  xs.length()
+}
+
+fn build() -> Holder {
+  Holder { data: Array.new<int, SIZE>() }
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/array_size_from_constant.snap
+++ b/tests/spec/emit/snapshots/array_size_from_constant.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  const SIZE = 3
+  
+  struct Holder {
+    pub data: Array<int, SIZE>
+  }
+  
+  fn take(xs: Array<int, SIZE>) -> int {
+    xs.length()
+  }
+  
+  fn build() -> Holder {
+    Holder { data: Array.new<int, SIZE>() }
+  }
+---
+package main
+
+const Size int = 3
+
+type Holder struct {
+	Data [3]int
+}
+
+func take(xs [3]int) int {
+	return len(xs)
+}
+
+func build() Holder {
+	return Holder{Data: [3]int{}}
+}

--- a/tests/spec/infer/arrays.rs
+++ b/tests/spec/infer/arrays.rs
@@ -424,3 +424,328 @@ fn large_array_literal_arm_is_not_exhaustive() {
     infer("fn f(arr: Array<int, 1000>) -> int { match arr { [0, ..] => 1 } }")
         .assert_infer_code("non_exhaustive");
 }
+
+#[test]
+fn array_size_from_constant() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_from_constant_declared_later() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "fn f(xs: Array<int, SIZE>) -> int { xs.length() }\nconst SIZE = 3\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_reaches_struct_field_and_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = 3\nstruct Holder { pub data: Array<int, SIZE> }\ntype Buf = Array<int, SIZE>\nfn f(b: Buf) -> Holder { Holder { data: b } }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_from_constant_in_another_package() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("sizes", "sizes.lis", "pub const WIDTH = 4\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        "import \"sizes\"\nfn f(xs: Array<int, sizes.WIDTH>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_rejects_wrong_literal_length() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = 3\nfn f() -> Array<int, SIZE> { [1, 2] }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_literal_length_mismatch");
+}
+
+#[test]
+fn array_new_turbofish_takes_a_constant() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = 3\nfn f() -> Array<int, 3> { Array.new<int, SIZE>() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_not_found() {
+    infer("let xs: Array<int, NOPE> = [1]; xs").assert_infer_code("array_size_unknown_constant");
+}
+
+#[test]
+fn array_size_constant_from_computed_initializer() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = 2 + 1\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_computed_constant");
+}
+
+#[test]
+fn array_size_constant_must_be_an_integer() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = \"three\"\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_not_integer_constant");
+}
+
+#[test]
+fn array_size_constant_must_not_be_negative() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE = -2\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_negative_constant");
+}
+
+#[test]
+fn array_size_constant_must_not_be_function_local() {
+    infer("fn f() -> int { const SIZE = 3; let xs: Array<int, SIZE> = [1, 2, 3]; xs.length() }")
+        .assert_infer_code("array_size_local_constant");
+}
+
+#[test]
+fn array_size_rejects_a_runtime_value() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "fn size() -> int { 3 }\nfn f(xs: Array<int, size>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_not_constant");
+}
+
+#[test]
+fn array_size_constant_above_int_max_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE: uint = 18000000000000000000\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_too_large");
+}
+
+#[test]
+fn array_size_constant_with_a_float_type_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE: float64 = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_not_integer_constant");
+}
+
+#[test]
+fn array_size_constant_typed_by_a_numeric_newtype() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "struct Width(int)\nconst SIZE: Width = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_newtype_declared_later() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Buf = Array<int, SIZE>\nstruct Width(int)\nconst SIZE: Width = 3\nfn f(b: Buf) -> int { b.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_nested_numeric_newtype() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "struct Inner(int)\nstruct Outer(Inner)\nconst SIZE: Outer = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_uintptr_newtype() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "struct Handle(uintptr)\nconst SIZE: Handle = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_uintptr_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Slot = uintptr\nconst SIZE: Slot = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_rune() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE: rune = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_rejects_a_function_parameter() {
+    infer("fn f(n: int) -> int { let xs: Array<int, n> = [1]; xs.length() }")
+        .assert_infer_code("array_size_not_constant");
+}
+
+#[test]
+fn array_size_rejects_a_local_binding() {
+    infer("fn f() -> int { let m = 2; let xs: Array<int, m> = [1]; xs.length() }")
+        .assert_infer_code("array_size_not_constant");
+}
+
+#[test]
+fn array_size_constant_typed_by_a_float_newtype_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "struct Weird(float64)\nconst SIZE: Weird = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_not_integer_constant");
+}
+
+#[test]
+fn array_size_constant_typed_by_an_alias_declared_later() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Buf = Array<int, SIZE>\ntype Width = int\nconst SIZE: Width = 3\nfn f(b: Buf) -> int { b.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_an_alias_declared_first() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Width = int\ntype Buf = Array<int, SIZE>\nconst SIZE: Width = 3\nfn f(b: Buf) -> int { b.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_typed_by_a_later_float_alias_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Buf = Array<int, SIZE>\ntype Weird = float64\nconst SIZE: Weird = 3\nfn f(b: Buf) -> int { b.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_not_integer_constant");
+}
+
+#[test]
+fn array_size_constant_typed_by_an_alias_in_another_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "width.lis", "pub type Width = int\n");
+    fs.add_file("main", "size.lis", "pub const SIZE: Width = 3\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Buf = Array<int, SIZE>\nfn f(b: Buf) -> int { b.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_through_an_integer_alias() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "type Width = int\nconst SIZE: Width = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_constant_with_a_narrow_integer_type() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "main",
+        "main.lis",
+        "const SIZE: int8 = 3\nfn f(xs: Array<int, SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_no_errors();
+}
+
+#[test]
+fn array_size_rejects_a_private_constant_from_another_package() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("sizes", "sizes.lis", "const WIDTH = 4\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        "import \"sizes\"\nfn f(xs: Array<int, sizes.WIDTH>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_unknown_constant");
+}
+
+#[test]
+fn array_size_rejects_a_test_only_constant_from_a_production_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("main", "main.test.lis", "const TEST_SIZE = 4\n");
+    fs.add_file(
+        "main",
+        "main.lis",
+        "fn f(xs: Array<int, TEST_SIZE>) -> int { xs.length() }\n",
+    );
+    infer_package("main", fs).assert_infer_code("array_size_unknown_constant");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -6750,6 +6750,62 @@ fn f(x: Array<int, 18000000000000000000>) {}
 }
 
 #[test]
+fn infer_array_size_unknown_constant() {
+    let input = r#"
+fn f(x: Array<int, NOPE>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_size_not_constant() {
+    let input = r#"
+fn size() -> int { 3 }
+fn f(x: Array<int, size>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_size_local_constant() {
+    let input = r#"
+fn f() -> int {
+  const N = 3
+  let xs: Array<int, N> = [1, 2, 3]
+  xs.length()
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_size_not_integer_constant() {
+    let input = r#"
+const N = "three"
+fn f(x: Array<int, N>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_size_computed_constant() {
+    let input = r#"
+const N = 2 + 2
+fn f(x: Array<int, N>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_array_size_negative_constant() {
+    let input = r#"
+const N = -2
+fn f(x: Array<int, N>) {}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_array_to_slice_type_mismatch_hint() {
     let input = r#"
 fn consume(items: Slice<int>) {}

--- a/tests/ui/errors/snapshots/infer_array_size_computed_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_computed_constant.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `N` is not a literal constant
+   ╭─[test.lis:3:20]
+ 2 │ const N = 2 + 2
+ 3 │ fn f(x: Array<int, N>) {}
+   ·                    ┬
+   ·                    ╰── its initializer is computed, not a literal
+   ╰────
+  help: An array size reads the constant's literal value, so `N` must be written as a single integer literal · code: [infer.array_size_computed_constant]

--- a/tests/ui/errors/snapshots/infer_array_size_local_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_local_constant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `N` is not a package-level constant
+   ╭─[test.lis:4:22]
+ 3 │   const N = 3
+ 4 │   let xs: Array<int, N> = [1, 2, 3]
+   ·                      ┬
+   ·                      ╰── declared inside a function
+ 5 │   xs.length()
+   ╰────
+  help: Move `N` out of the function body to use it as an array size · code: [infer.array_size_local_constant]

--- a/tests/ui/errors/snapshots/infer_array_size_negative_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_negative_constant.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `N` is negative
+   ╭─[test.lis:3:20]
+ 2 │ const N = -2
+ 3 │ fn f(x: Array<int, N>) {}
+   ·                    ┬
+   ·                    ╰── an array size cannot be negative
+   ╰────
+  help: Array sizes count elements, so they start at zero · code: [infer.array_size_negative_constant]

--- a/tests/ui/errors/snapshots/infer_array_size_not_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_not_constant.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `size` is not a constant
+   ╭─[test.lis:3:20]
+ 2 │ fn size() -> int { 3 }
+ 3 │ fn f(x: Array<int, size>) {}
+   ·                    ──┬─
+   ·                      ╰── expected a constant here
+   ╰────
+  help: An array size is part of the type, so it cannot come from a runtime value · code: [infer.array_size_not_constant]

--- a/tests/ui/errors/snapshots/infer_array_size_not_integer_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_not_integer_constant.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `N` is not an integer constant
+   ╭─[test.lis:3:20]
+ 2 │ const N = "three"
+ 3 │ fn f(x: Array<int, N>) {}
+   ·                    ┬
+   ·                    ╰── expected an integer constant here
+   ╰────
+  help: An array size must be a whole number, e.g. `const SIZE = 3` · code: [infer.array_size_not_integer_constant]

--- a/tests/ui/errors/snapshots/infer_array_size_unknown_constant.snap
+++ b/tests/ui/errors/snapshots/infer_array_size_unknown_constant.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot find constant `NOPE`
+   ╭─[test.lis:2:20]
+ 1 │ 
+ 2 │ fn f(x: Array<int, NOPE>) {}
+   ·                    ──┬─
+   ·                      ╰── not found in this scope
+   ╰────
+  help: An array size is an integer literal or the name of an integer constant · code: [infer.array_size_unknown_constant]


### PR DESCRIPTION
An `Array` size can now be a package-level integer constant, not only an integer literal.

```rs
const BUCKETS = 256

fn histogram(data: Slice<byte>) -> Array<int, BUCKETS> {
  let mut counts = Array.new<int, BUCKETS>()
  for b in data {
    counts[b as int] += 1
  }
  counts
}
```

Close #1266
