### PR TITLE
chore: enforce short paths at callsites

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ large_enum_variant = "forbid"
 absolute_paths = "deny"
 
 [workspace.lints.rust]
-unused_qualifications = "warn"
+unused_qualifications = "deny"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ description = "Little language inspired by Rust that compiles to Go"
 too_many_arguments = "forbid"
 result_large_err = "forbid"
 large_enum_variant = "forbid"
-absolute_paths = "warn"
+absolute_paths = "deny"
+
+[workspace.lints.rust]
+unused_qualifications = "warn"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ description = "Little language inspired by Rust that compiles to Go"
 too_many_arguments = "forbid"
 result_large_err = "forbid"
 large_enum_variant = "forbid"
+absolute_paths = "warn"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,2 @@
 too-many-arguments-threshold = 6
 absolute-paths-max-segments = 3
-absolute-paths-allowed-crates = ["std"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,3 @@
 too-many-arguments-threshold = 6
+absolute-paths-max-segments = 3
+absolute-paths-allowed-crates = ["std"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
 too-many-arguments-threshold = 6
-absolute-paths-max-segments = 3
+absolute-paths-max-segments = 2
+absolute-paths-allowed-crates = ["diagnostics"]

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,16 +1,19 @@
+use std::env;
+use std::fs;
+use std::path::Path;
 fn main() {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let go_version_path = std::path::Path::new(&manifest_dir).join("go-version");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let go_version_path = Path::new(&manifest_dir).join("go-version");
 
-    let go_version = std::fs::read_to_string(&go_version_path).expect("failed to read go-version");
+    let go_version = fs::read_to_string(&go_version_path).expect("failed to read go-version");
     let go_version = go_version.trim();
     assert!(
         go_version.chars().all(|c| c.is_ascii_digit() || c == '.'),
         "go-version contains invalid characters: {go_version}"
     );
 
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    std::fs::write(
+    let out_dir = env::var("OUT_DIR").unwrap();
+    fs::write(
         format!("{out_dir}/go_version.rs"),
         format!("pub const GO_VERSION: &str = \"{go_version}\";"),
     )

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -1,3 +1,6 @@
+use crate::go_cli;
+use crate::shell_words;
+use crate::shell_words::SplitError;
 use diagnostics::render::{Filter, OutputFormat};
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -213,18 +216,16 @@ fn flag_value(
 }
 
 fn extend_go_flags(go_flags: &mut Vec<String>, raw: &str) -> Result<(), ParseError> {
-    match crate::shell_words::split(raw) {
+    match shell_words::split(raw) {
         Ok(tokens) => {
             go_flags.extend(tokens);
             Ok(())
         }
-        Err(crate::shell_words::SplitError::UnterminatedQuote(quote)) => {
-            Err(ParseError::UnexpectedArgument {
-                message: format!("unterminated {} quote in `--go-flags`", quote),
-                reason: "the value passed to `--go-flags` has an unbalanced quote".to_string(),
-                hint: "Balance the quotes, e.g. `--go-flags \"-ldflags='-s -w'\"`".to_string(),
-            })
-        }
+        Err(SplitError::UnterminatedQuote(quote)) => Err(ParseError::UnexpectedArgument {
+            message: format!("unterminated {} quote in `--go-flags`", quote),
+            reason: "the value passed to `--go-flags` has an unbalanced quote".to_string(),
+            hint: "Balance the quotes, e.g. `--go-flags \"-ldflags='-s -w'\"`".to_string(),
+        }),
     }
 }
 
@@ -421,10 +422,7 @@ fn parse_run(
         }
     }
 
-    if let Some(flag) = go_flags
-        .iter()
-        .find(|f| crate::go_cli::is_go_output_flag(f))
-    {
+    if let Some(flag) = go_flags.iter().find(|f| go_cli::is_go_output_flag(f)) {
         return Err(ParseError::UnexpectedArgument {
             message: format!("`{}` cannot be passed to `lis run` via `--go-flags`", flag),
             reason: "`run` executes the binary it links at an internal path, so it owns `-o`"
@@ -576,7 +574,7 @@ fn parse_test(mut arguments: impl Iterator<Item = String>) -> Result<Command, Pa
         }
     }
 
-    if let Some(flag) = go_flags.iter().find(|f| crate::go_cli::is_go_json_flag(f)) {
+    if let Some(flag) = go_flags.iter().find(|f| go_cli::is_go_json_flag(f)) {
         return Err(ParseError::UnexpectedArgument {
             message: format!("`{}` cannot be passed to `lis test` via `--go-flags`", flag),
             reason: "`lis test` runs `go test -json` and parses that stream to render the report"
@@ -585,10 +583,7 @@ fn parse_test(mut arguments: impl Iterator<Item = String>) -> Result<Command, Pa
         });
     }
 
-    if let Some(flag) = go_flags
-        .iter()
-        .find(|f| crate::go_cli::is_go_selection_flag(f))
-    {
+    if let Some(flag) = go_flags.iter().find(|f| go_cli::is_go_selection_flag(f)) {
         return Err(ParseError::UnexpectedArgument {
             message: format!("`{}` cannot be passed to `lis test` via `--go-flags`", flag),
             reason: "`lis test` selects which tests run and reconciles the report against them"

--- a/crates/cli/src/fs.rs
+++ b/crates/cli/src/fs.rs
@@ -1,3 +1,6 @@
+use semantics::loader;
+use std::fs;
+use std::fs::DirEntry;
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,
@@ -64,7 +67,7 @@ impl LocalFileSystem {
         let Some((project_root, _)) = &self.project_root else {
             return Vec::new();
         };
-        let tests_root = project_root.join(semantics::loader::EXTERNAL_TESTS_DIR);
+        let tests_root = project_root.join(loader::EXTERNAL_TESTS_DIR);
         let walked;
         let test_sources = match &self.scanned_test_sources {
             Some(test_sources) => test_sources.as_slice(),
@@ -283,7 +286,7 @@ fn remove_direct_go_files(dir: &Path) -> io::Result<()> {
 
 /// `remove_dir_all` that treats an already-absent directory as success.
 fn remove_dir_all_if_present(dir: &Path) -> io::Result<()> {
-    match std::fs::remove_dir_all(dir) {
+    match fs::remove_dir_all(dir) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
@@ -394,7 +397,7 @@ pub fn collect_lis_filepaths_recursive(dir: &Path) -> Vec<PathBuf> {
     files
 }
 
-fn entry_is_dir(entry: &std::fs::DirEntry, path: &Path) -> bool {
+fn entry_is_dir(entry: &DirEntry, path: &Path) -> bool {
     match entry.file_type() {
         Ok(file_type) if file_type.is_symlink() => false,
         Ok(file_type) => file_type.is_dir(),
@@ -404,7 +407,7 @@ fn entry_is_dir(entry: &std::fs::DirEntry, path: &Path) -> bool {
 
 impl Loader for LocalFileSystem {
     fn scan_folder(&self, folder_name: &str) -> Files {
-        if semantics::loader::is_external_test_package(folder_name)
+        if loader::is_external_test_package(folder_name)
             && let Some((project_root, display_base)) = &self.project_root
         {
             return self.collect_files(&project_root.join(folder_name), folder_name, display_base);
@@ -459,7 +462,7 @@ impl Loader for LocalFileSystem {
                 contents.has_test = true;
             } else {
                 contents.has_test_root_file = true;
-                if semantics::loader::is_production_package_file(name) {
+                if loader::is_production_package_file(name) {
                     contents.has_production = true;
                 }
             }

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -475,8 +475,8 @@ pub fn prewarm_module_cache(target: Target) {
             "download",
             &format!("{}@v{}", PRELUDE_IMPORT_PATH, prelude_version),
         ])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn();
 }
 
@@ -739,12 +739,12 @@ mod tests {
         assert_eq!(binary_name("github.com/u/myproj", linux()), "myproj");
     }
 
-    fn locator_with(deps: Vec<(&str, deps::GoDependency)>) -> deps::TypedefLocator {
+    fn locator_with(deps: Vec<(&str, deps::GoDependency)>) -> TypedefLocator {
         let map = deps
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
             .collect::<std::collections::BTreeMap<_, _>>();
-        deps::TypedefLocator::new(map, None, Target::host())
+        TypedefLocator::new(map, None, Target::host())
     }
 
     #[test]
@@ -762,7 +762,7 @@ mod tests {
         )]);
 
         write_go_mod(dir.path(), "example.com/app", &locator).unwrap();
-        let content = std::fs::read_to_string(dir.path().join("go.mod")).unwrap();
+        let content = fs::read_to_string(dir.path().join("go.mod")).unwrap();
 
         assert!(
             content.contains("github.com/df-mc/dragonfly v0.0.0\n"),
@@ -793,7 +793,7 @@ mod tests {
         )]);
 
         write_go_mod(dir.path(), "example.com/app", &locator).unwrap();
-        let content = std::fs::read_to_string(dir.path().join("go.mod")).unwrap();
+        let content = fs::read_to_string(dir.path().join("go.mod")).unwrap();
 
         assert!(
             content.contains("example.com/lib/v2 v2.0.0\n"),
@@ -820,18 +820,18 @@ mod tests {
     fn write_go_mod_local_emits_synthetic_require_and_quoted_directory_replace() {
         let project = tempfile::tempdir().unwrap();
         let module_dir = project.path().join("foo");
-        std::fs::create_dir_all(&module_dir).unwrap();
-        std::fs::write(module_dir.join("go.mod"), "module example.com/me/foo\n").unwrap();
+        fs::create_dir_all(&module_dir).unwrap();
+        fs::write(module_dir.join("go.mod"), "module example.com/me/foo\n").unwrap();
         let target_dir = project.path().join("target");
-        std::fs::create_dir_all(&target_dir).unwrap();
+        fs::create_dir_all(&target_dir).unwrap();
 
         let mut go_deps = std::collections::BTreeMap::new();
         go_deps.insert("example.com/me/foo".to_string(), local_dep("foo"));
         let locator =
-            deps::TypedefLocator::new(go_deps, Some(project.path().to_path_buf()), Target::host());
+            TypedefLocator::new(go_deps, Some(project.path().to_path_buf()), Target::host());
 
         write_go_mod(&target_dir, "example.com/app", &locator).unwrap();
-        let content = std::fs::read_to_string(target_dir.join("go.mod")).unwrap();
+        let content = fs::read_to_string(target_dir.join("go.mod")).unwrap();
 
         assert!(
             content.contains("example.com/me/foo v0.0.0\n"),
@@ -847,11 +847,11 @@ mod tests {
     fn write_go_mod_local_errors_on_missing_directory_or_missing_go_mod() {
         let project = tempfile::tempdir().unwrap();
         let target_dir = project.path().join("target");
-        std::fs::create_dir_all(&target_dir).unwrap();
+        fs::create_dir_all(&target_dir).unwrap();
 
         let mut go_deps = std::collections::BTreeMap::new();
         go_deps.insert("example.com/me/foo".to_string(), local_dep("foo"));
-        let locator = deps::TypedefLocator::new(
+        let locator = TypedefLocator::new(
             go_deps.clone(),
             Some(project.path().to_path_buf()),
             Target::host(),
@@ -860,9 +860,9 @@ mod tests {
         assert!(error.contains("example.com/me/foo"), "{}", error);
         assert!(error.contains("does not exist"), "{}", error);
 
-        std::fs::create_dir_all(project.path().join("foo")).unwrap();
+        fs::create_dir_all(project.path().join("foo")).unwrap();
         let locator =
-            deps::TypedefLocator::new(go_deps, Some(project.path().to_path_buf()), Target::host());
+            TypedefLocator::new(go_deps, Some(project.path().to_path_buf()), Target::host());
         let error = write_go_mod(&target_dir, "example.com/app", &locator).unwrap_err();
         assert!(error.contains("no `go.mod`"), "{}", error);
     }

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
 
 include!(concat!(env!("OUT_DIR"), "/go_version.rs"));
 
@@ -324,7 +326,7 @@ pub fn write_go_outputs(dir: &Path, files: &[OutputFile]) -> Result<EmitWriteRes
 
 /// Hash of the sorted union of external (non-stdlib, non-local) Go imports.
 pub fn compute_import_set_hash(manifest: &[ManifestEntry], go_module_name: &str) -> u64 {
-    let mut paths: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    let mut paths: BTreeSet<&str> = BTreeSet::new();
     for entry in manifest {
         for path in &entry.imports {
             if is_external_import(path, go_module_name) {
@@ -370,7 +372,7 @@ fn hash_go_code(content: &str) -> u64 {
     h
 }
 
-fn read_emit_manifest(dir: &Path) -> std::collections::HashMap<String, ManifestEntry> {
+fn read_emit_manifest(dir: &Path) -> HashMap<String, ManifestEntry> {
     let Ok(content) = fs::read_to_string(emit_manifest_path(dir)) else {
         return Default::default();
     };
@@ -724,6 +726,7 @@ fn run_go_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     fn linux() -> Target {
         Target::new("linux", "amd64")
@@ -743,7 +746,7 @@ mod tests {
         let map = deps
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
-            .collect::<std::collections::BTreeMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         TypedefLocator::new(map, None, Target::host())
     }
 
@@ -825,7 +828,7 @@ mod tests {
         let target_dir = project.path().join("target");
         fs::create_dir_all(&target_dir).unwrap();
 
-        let mut go_deps = std::collections::BTreeMap::new();
+        let mut go_deps = BTreeMap::new();
         go_deps.insert("example.com/me/foo".to_string(), local_dep("foo"));
         let locator =
             TypedefLocator::new(go_deps, Some(project.path().to_path_buf()), Target::host());
@@ -849,7 +852,7 @@ mod tests {
         let target_dir = project.path().join("target");
         fs::create_dir_all(&target_dir).unwrap();
 
-        let mut go_deps = std::collections::BTreeMap::new();
+        let mut go_deps = BTreeMap::new();
         go_deps.insert("example.com/me/foo".to_string(), local_dep("foo"));
         let locator = TypedefLocator::new(
             go_deps.clone(),

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -11,6 +11,8 @@ use crate::output::{print_add_success, print_preview_notice, print_progress, pri
 use crate::workspace::GoWorkspace;
 use crate::{cli_error, error};
 use deps::GoModule;
+use std::collections::BTreeMap;
+use std::env;
 use stdlib::Target;
 
 /// CLI-input dependency: the path the user typed, which may be a subpackage.
@@ -171,7 +173,7 @@ fn setup_project_local(path_arg: &str) -> Result<AddPlan, i32> {
     let setup = MutationProject::open()?;
     print_preview_notice("Local Go modules", true);
 
-    let invocation_dir = std::env::current_dir().map_err(|error| {
+    let invocation_dir = env::current_dir().map_err(|error| {
         error!(
             "failed to resolve directory",
             format!("could not read the current directory: {}", error)
@@ -631,7 +633,7 @@ fn write_target_go_mod(setup: &MutationProject, extra: Option<(&str, deps::GoDep
 /// Write `target/go.mod` from an explicit dependency set.
 fn write_target_go_mod_from(
     setup: &MutationProject,
-    go_deps: std::collections::BTreeMap<String, deps::GoDependency>,
+    go_deps: BTreeMap<String, deps::GoDependency>,
 ) -> bool {
     let locator = deps::TypedefLocator::new(go_deps, Some(setup.root.clone()), Target::host());
     if let Err(msg) =
@@ -644,10 +646,7 @@ fn write_target_go_mod_from(
 }
 
 /// Remove any declared replacement for the module that owns `package`.
-fn strip_replacement_for(
-    go_deps: &mut std::collections::BTreeMap<String, deps::GoDependency>,
-    package: &str,
-) {
+fn strip_replacement_for(go_deps: &mut BTreeMap<String, deps::GoDependency>, package: &str) {
     let owner = go_deps
         .keys()
         .filter(|module| package == module.as_str() || package.starts_with(&format!("{module}/")))
@@ -799,6 +798,7 @@ fn setup_project_replace(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn normalize_module_path_applies_github_shorthand() {
@@ -861,7 +861,7 @@ mod tests {
 
     #[test]
     fn strip_replacement_leaves_parent_when_child_remote_owns_package() {
-        let mut go_deps = std::collections::BTreeMap::new();
+        let mut go_deps = BTreeMap::new();
         go_deps.insert(
             "go.opentelemetry.io/otel".to_string(),
             deps::GoDependency::Replaced {
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn strip_replacement_removes_longest_prefix_replaced_owner() {
-        let mut go_deps = std::collections::BTreeMap::new();
+        let mut go_deps = BTreeMap::new();
         go_deps.insert(
             "go.opentelemetry.io/otel".to_string(),
             deps::GoDependency::Remote {

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -46,7 +46,7 @@ pub fn add(
             );
             return 1;
         };
-        return super::script_add::run(std::path::Path::new(script), dep_string);
+        return super::script_add::run(Path::new(script), dep_string);
     }
     if let Some(path) = path {
         return add_local(path);

--- a/crates/cli/src/handlers/bindgen.rs
+++ b/crates/cli/src/handlers/bindgen.rs
@@ -5,6 +5,9 @@ use stdlib::Target;
 
 use crate::cli_error;
 use crate::command::BindgenTarget;
+use crate::go_cli;
+use std::env;
+use std::fs;
 
 pub fn bindgen(target: BindgenTarget, verbose: bool) -> i32 {
     match target {
@@ -43,7 +46,7 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
 
     match workspace.run_bindgen(target_pkg) {
         Ok(content) => {
-            if let Err(e) = std::fs::write(&output_path, &content) {
+            if let Err(e) = fs::write(&output_path, &content) {
                 cli_error!(
                     "Failed to write bindings",
                     format!("Could not write to {}: {}", output_path, e),
@@ -56,7 +59,7 @@ fn bindgen_pkg(target_pkg: &str, output: Option<String>, verbose: bool) -> i32 {
             0
         }
         Err(msg) => {
-            let (detail, hint) = match crate::go_cli::toolchain_failure() {
+            let (detail, hint) = match go_cli::toolchain_failure() {
                 Some(failure) => (failure.message, failure.hint),
                 None => (msg, "Check Go installation with `go version`"),
             };
@@ -73,7 +76,7 @@ fn bindgen_std(source_dir: &Path, version: Option<String>, verbose: bool) -> i32
         eprintln!("Generating stdlib bindings to {}", out_dir);
     }
 
-    let cwd = match std::env::current_dir() {
+    let cwd = match env::current_dir() {
         Ok(cwd) => cwd,
         Err(e) => {
             cli_error!(
@@ -125,7 +128,7 @@ fn bindgen_std(source_dir: &Path, version: Option<String>, verbose: bool) -> i32
             1
         }
         Err(e) => {
-            let (detail, hint) = match crate::go_cli::toolchain_failure() {
+            let (detail, hint) = match go_cli::toolchain_failure() {
                 Some(failure) => (failure.message, failure.hint),
                 None => (
                     format!("Failed to run bindgen: {}", e),

--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -7,19 +7,27 @@ use crate::cli_error;
 use crate::go_cli;
 use crate::handlers::project::FileTarget;
 use crate::lock::acquire_target_lock;
+use crate::output;
 use crate::output::{format_elapsed, print_warning, use_color};
 use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 use diagnostics::render::{self, Filter};
+use lisette::fs::collect_lis_filepaths_recursive;
 use lisette::fs::{LocalFileSystem, prune_orphan_go_files, prune_stale_root_go, relative_to_cwd};
+use lisette::pipeline::CompileResult;
 use lisette::pipeline::{
     CompileConfig, CompileEntry, CompileInput, CompileMode, CompileScope, ProjectKind, Sources,
     TestIndex, compile,
 };
+use semantics::cache;
+use semantics::loader;
 use semantics::loader::{
     EXTERNAL_TESTS_DIR, ExternalTestFileIssue, ROOT_IMPORT, external_test_file_issue,
     is_production_package_file,
 };
 use semantics::store::ENTRY_PACKAGE_ID;
+use std::io;
+use std::io::ErrorKind;
+use std::ops::Deref;
 
 pub fn emit(path: Option<String>, sourcemap: bool, output: Option<String>) -> i32 {
     let target = path.unwrap_or_else(|| ".".to_string());
@@ -86,7 +94,7 @@ pub fn build(
                 );
                 return 1;
             }
-            crate::output::print_preview_notice("Library projects", true);
+            output::print_preview_notice("Library projects", true);
         }
 
         if let Err(code) = build_locked(prep, BuildPurpose::Emit { sourcemap }) {
@@ -307,7 +315,7 @@ impl LockedProject {
     }
 }
 
-impl std::ops::Deref for LockedProject {
+impl Deref for LockedProject {
     type Target = BuildPrep;
 
     fn deref(&self) -> &Self::Target {
@@ -348,12 +356,12 @@ pub(super) struct BuildArtifacts {
 fn remove_stale_test_outputs(
     target_dir: &Path,
     manifest: &mut Vec<go_cli::ManifestEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     for entry in manifest.iter() {
         if entry.name.ends_with("_test.go") {
             match fs::remove_file(target_dir.join(&entry.name)) {
                 Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if e.kind() == ErrorKind::NotFound => {}
                 Err(e) => return Err(e),
             }
         }
@@ -503,7 +511,7 @@ fn compile_project(
     mode: CompileMode,
     entry: &EntryPoint,
     locator: &deps::TypedefLocator,
-) -> lisette::pipeline::CompileResult {
+) -> CompileResult {
     let go_module_name = &prep.manifest.project.name;
     let library_package_name = match prep.kind {
         ProjectKind::Binary => None,
@@ -527,7 +535,7 @@ fn compile_project(
     compile(entry.compile_input(), compile_config, &local_fs)
 }
 
-fn render_diagnostics(result: &lisette::pipeline::CompileResult) -> render::Counts {
+fn render_diagnostics(result: &CompileResult) -> render::Counts {
     render::render_all(
         &result.diagnostics,
         render::SourceCache::new(|file_id| {
@@ -543,7 +551,7 @@ fn render_diagnostics(result: &lisette::pipeline::CompileResult) -> render::Coun
 
 fn write_and_prune_outputs(
     prep: &BuildPrep,
-    result: &lisette::pipeline::CompileResult,
+    result: &CompileResult,
     sourcemap: bool,
     emit_tests: bool,
 ) -> Result<go_cli::EmitWriteResult, i32> {
@@ -551,7 +559,7 @@ fn write_and_prune_outputs(
     let produced: Vec<&str> = result.output.iter().map(|f| f.name.as_str()).collect();
 
     if sourcemap
-        && let Err(e) = semantics::cache::apply_emit_stamps(
+        && let Err(e) = cache::apply_emit_stamps(
             &prep.project_path,
             &result
                 .emit_stamps
@@ -666,8 +674,8 @@ fn reconcile_target_manifest(
     Ok(())
 }
 
-fn commit_emit_stamps(prep: &BuildPrep, result: &lisette::pipeline::CompileResult) {
-    if let Err(e) = semantics::cache::apply_emit_stamps(
+fn commit_emit_stamps(prep: &BuildPrep, result: &CompileResult) {
+    if let Err(e) = cache::apply_emit_stamps(
         &prep.project_path,
         &result
             .emit_stamps
@@ -723,7 +731,7 @@ pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayou
     }
 
     let src = project_path.join("src");
-    let sources = lisette::fs::collect_lis_filepaths_recursive(&src);
+    let sources = collect_lis_filepaths_recursive(&src);
 
     if let Some(rel) = sources.iter().find_map(|path| {
         path.strip_prefix(&src)
@@ -779,7 +787,7 @@ pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayou
     }
 
     let tests_dir = project_path.join(EXTERNAL_TESTS_DIR);
-    let test_sources = lisette::fs::collect_lis_filepaths_recursive(&tests_dir);
+    let test_sources = collect_lis_filepaths_recursive(&tests_dir);
 
     if let Some((rel, issue)) = test_sources.iter().find_map(|path| {
         let rel = path
@@ -932,7 +940,7 @@ fn rejected_source_shape(
         let Some(name) = rel.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
-        if semantics::loader::is_typedef_file(name) {
+        if loader::is_typedef_file(name) {
             continue;
         }
 

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -5,14 +5,19 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::go_cli;
+use crate::output;
 use deps::TypedefLocator;
 use diagnostics::render::{self, Filter, OutputFormat};
 use diagnostics::{Fix, apply_fixes};
 use lisette::fs::LocalFileSystem;
+use lisette::fs::collect_lis_filepaths_recursive;
+use lisette::fs::relative_to_cwd;
 use lisette::pipeline::{
     CompileConfig, CompileEntry, CompileInput, CompileMode, CompileResult, CompileScope,
     ProjectKind, compile,
 };
+use std::time::Duration;
 
 use semantics::loader::{Loader, MemoryLoader};
 
@@ -161,7 +166,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
         Err(code) => return code,
     };
 
-    if let Err(e) = crate::go_cli::write_go_mod(&target_dir, &manifest.project.name, &locator) {
+    if let Err(e) = go_cli::write_go_mod(&target_dir, &manifest.project.name, &locator) {
         cli_error!(
             "Failed to check project",
             e,
@@ -314,7 +319,7 @@ fn compile_single_file(
         .unwrap_or("main.lis")
         .to_string();
     let entry_display =
-        lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
+        relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
 
     let input = CompileInput::Binary(CompileEntry {
         source: &source,
@@ -385,7 +390,7 @@ fn compile_entry(
 }
 
 fn check_loose_dir(dir: &Path, options: &CheckOptions) -> i32 {
-    let mut files = lisette::fs::collect_lis_filepaths_recursive(dir);
+    let mut files = collect_lis_filepaths_recursive(dir);
     files.sort();
 
     if files.is_empty() {
@@ -565,8 +570,8 @@ fn apply_result_fixes(result: &CompileResult, summary: &mut FixSummary) {
     }
 }
 
-fn print_fix_summary(summary: &FixSummary, elapsed: std::time::Duration) {
-    let time_display = crate::output::format_elapsed(elapsed);
+fn print_fix_summary(summary: &FixSummary, elapsed: Duration) {
+    let time_display = output::format_elapsed(elapsed);
 
     if summary.files_changed == 0 {
         eprintln!("  ✓ No fixes applied {}", time_display);

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -93,7 +93,7 @@ struct Snapshot {
 
 impl Snapshot {
     fn read(file: &Path) -> Self {
-        let Ok(source) = std::fs::read_to_string(file) else {
+        let Ok(source) = fs::read_to_string(file) else {
             return Self {
                 source: None,
                 locator: TypedefLocator::default(),
@@ -138,7 +138,7 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
         None => return 1,
     };
 
-    let (manifest, locator) = match deps::TypedefLocator::from_project_with_manifest(project_path) {
+    let (manifest, locator) = match TypedefLocator::from_project_with_manifest(project_path) {
         Ok(pair) => pair,
         Err(msg) => {
             cli_error!("Failed to check project", msg, "Fix `lisette.toml`");

--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -3,10 +3,12 @@ use crate::output::{format_backticks, use_color};
 use diagnostics::infer::levenshtein_distance;
 use semantics::cache::go_stdlib::{GoPackageCache, try_load_go_stdlib_cache};
 use semantics::cache::types::CachedDefinitionBody;
+use std::mem;
 use stdlib::{
     Target, format_targets, get_go_stdlib_package_targets, get_go_stdlib_packages,
     get_go_stdlib_typedef,
 };
+use syntax::ast::EnumVariant;
 use syntax::ast::{Annotation, Binding, Expression, Generic, Pattern, StructFields, VariantFields};
 
 #[derive(Debug, Clone, Copy)]
@@ -237,7 +239,7 @@ fn struct_definition(name: &str, gen_str: &str, fields: &StructFields, show_pub:
     }
 }
 
-fn enum_definition(name: &str, gen_str: &str, variants: &[syntax::ast::EnumVariant]) -> String {
+fn enum_definition(name: &str, gen_str: &str, variants: &[EnumVariant]) -> String {
     let is_compact = variants.len() <= 3
         && variants.iter().all(|v| {
             matches!(&v.fields, VariantFields::Unit)
@@ -1044,7 +1046,7 @@ fn wrap_into_lines(items: &[String], area: usize) -> Vec<Vec<&String>> {
         let item_width = item.chars().count();
         let separator = if current.is_empty() { 0 } else { 3 };
         if !current.is_empty() && current_width + separator + item_width > area {
-            lines.push(std::mem::take(&mut current));
+            lines.push(mem::take(&mut current));
             current_width = 0;
         }
         current_width += if current.is_empty() {

--- a/crates/cli/src/handlers/format.rs
+++ b/crates/cli/src/handlers/format.rs
@@ -8,6 +8,8 @@ use lisette::fs::collect_lis_filepaths_recursive;
 use rayon::prelude::*;
 
 use crate::cli_error;
+use crate::output;
+use std::path::PathBuf;
 
 enum Outcome {
     Unchanged,
@@ -28,7 +30,7 @@ pub fn format(path: Option<String>, check: bool) -> i32 {
         return 1;
     }
 
-    let filepaths: Vec<std::path::PathBuf> = if target_path.is_dir() {
+    let filepaths: Vec<PathBuf> = if target_path.is_dir() {
         collect_lis_filepaths_recursive(target_path)
     } else {
         vec![target_path.to_path_buf()]
@@ -93,7 +95,7 @@ pub fn format(path: Option<String>, check: bool) -> i32 {
         })
         .collect();
 
-    let mut changed_files: Vec<std::path::PathBuf> = Vec::new();
+    let mut changed_files: Vec<PathBuf> = Vec::new();
     let mut error_count = 0;
 
     for (file, outcome) in filepaths.iter().zip(outcomes) {
@@ -113,10 +115,10 @@ pub fn format(path: Option<String>, check: bool) -> i32 {
 
     eprintln!();
 
-    let time_display = crate::output::format_elapsed(start.elapsed());
+    let time_display = output::format_elapsed(start.elapsed());
 
     if check {
-        let colored = crate::output::use_color();
+        let colored = output::use_color();
         let render_path = |file: &Path| -> String {
             let s = file.display().to_string();
             if colored {

--- a/crates/cli/src/handlers/format.rs
+++ b/crates/cli/src/handlers/format.rs
@@ -117,7 +117,7 @@ pub fn format(path: Option<String>, check: bool) -> i32 {
 
     if check {
         let colored = crate::output::use_color();
-        let render_path = |file: &std::path::Path| -> String {
+        let render_path = |file: &Path| -> String {
             let s = file.display().to_string();
             if colored {
                 use owo_colors::OwoColorize;

--- a/crates/cli/src/handlers/help.rs
+++ b/crates/cli/src/handlers/help.rs
@@ -1,4 +1,5 @@
 use crate::cli_error;
+use crate::command::Command;
 use crate::output::{print_dimmed, print_help};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -343,7 +344,7 @@ Print compiler version (Lisette and Go toolchain).",
         ),
 
         unknown => {
-            let hint = match crate::command::Command::suggest(unknown) {
+            let hint = match Command::suggest(unknown) {
                 Some(suggestion) => format!("Did you mean `{}`?", suggestion),
                 None => "Run `lis help` for available commands".to_string(),
             };

--- a/crates/cli/src/handlers/learn.rs
+++ b/crates/cli/src/handlers/learn.rs
@@ -1,7 +1,11 @@
 use std::fs;
 use std::path::Path;
 
+use crate::agents_md;
 use crate::cli_error;
+use crate::go_cli;
+use crate::output;
+use std::process::Command;
 
 const MAIN: &str = include_str!("learn/main.lis");
 const PROPS: &str = include_str!("learn/models/props.lis");
@@ -80,7 +84,7 @@ pub fn learn() -> i32 {
         }
     }
 
-    if let Err(e) = fs::write(project_dir.join("AGENTS.md"), crate::agents_md::AGENTS_MD) {
+    if let Err(e) = fs::write(project_dir.join("AGENTS.md"), agents_md::AGENTS_MD) {
         cli_error!(
             "Failed to create project",
             format!("Failed to write `AGENTS.md`: {}", e),
@@ -89,16 +93,16 @@ pub fn learn() -> i32 {
         return 1;
     }
 
-    let _ = std::process::Command::new("git")
+    let _ = Command::new("git")
         .arg("init")
         .arg("--quiet")
         .current_dir(project_dir)
         .status();
 
-    crate::go_cli::prewarm_module_cache(stdlib::Target::host());
+    go_cli::prewarm_module_cache(stdlib::Target::host());
 
     eprintln!();
-    if crate::output::use_color() {
+    if output::use_color() {
         use owo_colors::OwoColorize;
         eprintln!("  ✓ Created {} project", "learn-lisette".bright_magenta());
         eprintln!(

--- a/crates/cli/src/handlers/lsp.rs
+++ b/crates/cli/src/handlers/lsp.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use deps::BindgenSetup;
 
 use crate::workspace::WorkspaceBindgenSetup;
+use lsp::protocol;
+use std::io;
 
 pub fn lsp() -> i32 {
     let setup: Arc<dyn BindgenSetup> = Arc::new(WorkspaceBindgenSetup);
-    lsp::protocol::serve(std::io::stdin().lock(), std::io::stdout(), Some(setup))
+    protocol::serve(io::stdin().lock(), io::stdout(), Some(setup))
 }

--- a/crates/cli/src/handlers/new.rs
+++ b/crates/cli/src/handlers/new.rs
@@ -1,7 +1,11 @@
 use std::fs;
 use std::path::Path;
 
+use crate::agents_md;
 use crate::cli_error;
+use crate::go_cli;
+use crate::output;
+use std::process::Command;
 
 pub fn new_project(name: &str) -> i32 {
     let project_dir = Path::new(name);
@@ -109,7 +113,7 @@ lis run
         return 1;
     }
 
-    if let Err(e) = fs::write(project_dir.join("AGENTS.md"), crate::agents_md::AGENTS_MD) {
+    if let Err(e) = fs::write(project_dir.join("AGENTS.md"), agents_md::AGENTS_MD) {
         cli_error!(
             "Failed to create project",
             format!("Failed to write `AGENTS.md`: {}", e),
@@ -128,16 +132,16 @@ lis run
         return 1;
     }
 
-    let _ = std::process::Command::new("git")
+    let _ = Command::new("git")
         .arg("init")
         .arg("--quiet")
         .current_dir(project_dir)
         .status();
 
-    crate::go_cli::prewarm_module_cache(stdlib::Target::host());
+    go_cli::prewarm_module_cache(stdlib::Target::host());
 
     eprintln!();
-    if crate::output::use_color() {
+    if output::use_color() {
         use owo_colors::OwoColorize;
         eprintln!("  ✓ Created {} project", project_name.bright_magenta());
         eprintln!(

--- a/crates/cli/src/handlers/project.rs
+++ b/crates/cli/src/handlers/project.rs
@@ -4,6 +4,10 @@ use std::path::{Path, PathBuf};
 
 use crate::lock::{acquire_mutation_lock, acquire_target_lock};
 use crate::{cli_error, error};
+use lisette::fs;
+use semantics::loader;
+use std::env;
+use std::fs::create_dir_all;
 
 pub(crate) struct MutationProject {
     pub(crate) root: PathBuf,
@@ -41,7 +45,7 @@ impl MutationProject {
             );
             return Err(1);
         }
-        std::fs::create_dir_all(&target_dir).map_err(|error| {
+        create_dir_all(&target_dir).map_err(|error| {
             error!(
                 "failed to set up target directory",
                 format!("Failed to create target directory: {error}")
@@ -96,7 +100,7 @@ fn validate_manifest(manifest: &deps::Manifest) -> Result<(), i32> {
 }
 
 fn find_project_root() -> Option<PathBuf> {
-    deps::find_project_root(&std::env::current_dir().ok()?)
+    deps::find_project_root(&env::current_dir().ok()?)
 }
 
 /// The compilation unit a named `.lis` file belongs to.
@@ -136,7 +140,7 @@ pub(crate) fn resolve_file_target(file: &Path) -> FileTarget {
         return outside;
     };
     // The walk needs absolute paths to climb, but every message shows a root.
-    let root = lisette::fs::relative_to_cwd(&root)
+    let root = fs::relative_to_cwd(&root)
         .map(PathBuf::from)
         .unwrap_or(root);
     let mut components = relative.components();
@@ -148,7 +152,7 @@ pub(crate) fn resolve_file_target(file: &Path) -> FileTarget {
                 FileTarget::ProjectPackage { root }
             }
         }
-        Some(semantics::loader::EXTERNAL_TESTS_DIR) => FileTarget::ProjectPackage { root },
+        Some(loader::EXTERNAL_TESTS_DIR) => FileTarget::ProjectPackage { root },
         _ => outside,
     }
 }
@@ -156,7 +160,5 @@ pub(crate) fn resolve_file_target(file: &Path) -> FileTarget {
 pub(crate) fn project_label(root: &Path) -> String {
     deps::parse_manifest(root)
         .map(|manifest| manifest.project.name)
-        .unwrap_or_else(|_| {
-            lisette::fs::relative_to_cwd(root).unwrap_or_else(|| root.display().to_string())
-        })
+        .unwrap_or_else(|_| fs::relative_to_cwd(root).unwrap_or_else(|| root.display().to_string()))
 }

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -12,6 +12,7 @@ use crate::output::{print_progress, print_warning};
 use crate::workspace::{GoWorkspace, UnresolvedTransitive};
 use crate::{cli_error, error};
 use deps::GoModule;
+use std::fs;
 use stdlib::Target;
 
 /// The dependency to reconcile, after its containing module is resolved.
@@ -607,7 +608,7 @@ fn collect_nested_modules(
     declared: &HashSet<&str>,
     out: &mut Vec<LocalChildHint>,
 ) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -1366,6 +1367,7 @@ pub(crate) fn finalize_manifest_via(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn message_names_module_requires_path_boundaries() {
@@ -1402,10 +1404,10 @@ mod tests {
     fn nested_fixture() -> (tempfile::TempDir, Vec<(String, PathBuf)>) {
         let dir = tempfile::tempdir().unwrap();
         let parent = dir.path().join("parent");
-        std::fs::create_dir_all(parent.join("child/sub")).unwrap();
-        std::fs::create_dir_all(parent.join("plain")).unwrap();
-        std::fs::write(parent.join("go.mod"), "module example.com/x/parent\n").unwrap();
-        std::fs::write(
+        fs::create_dir_all(parent.join("child/sub")).unwrap();
+        fs::create_dir_all(parent.join("plain")).unwrap();
+        fs::write(parent.join("go.mod"), "module example.com/x/parent\n").unwrap();
+        fs::write(
             parent.join("child/go.mod"),
             "module example.com/x/parent/child\n",
         )

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use crate::cli_error;
 use crate::go_cli;
 use crate::handlers::project::FileTarget;
+use lisette::fs;
 use lisette::pipeline::ProjectKind;
 
 fn exec_binary(output_path: &Path, args: &[String], heading: &str) -> i32 {
@@ -52,8 +53,7 @@ pub fn run(
 }
 
 fn not_an_entrypoint(file_path: &Path, root: &Path) -> i32 {
-    let file =
-        lisette::fs::relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
+    let file = fs::relative_to_cwd(file_path).unwrap_or_else(|| file_path.display().to_string());
     let project = super::project::project_label(root);
     let project_path = root.display();
 

--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -296,7 +296,7 @@ fn compile_file(
 }
 
 fn ensure_build_dir(dir: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(dir).map_err(|e| format!("Failed to create `{}`: {}", dir.display(), e))
+    fs::create_dir_all(dir).map_err(|e| format!("Failed to create `{}`: {}", dir.display(), e))
 }
 
 const BUILD_DIR_PREFIX: &str = "lis-script-";

--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -5,12 +5,16 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::cli_error;
 use crate::go_cli;
+use crate::output;
 use diagnostics::render::{self, Filter};
 use emit::PRELUDE_IMPORT_PATH;
+use lisette::fs::relative_to_cwd;
 use lisette::pipeline::{
     CompileConfig, CompileEntry, CompileInput, CompileMode, CompileResult, CompileScope, compile,
 };
 use semantics::loader::MemoryLoader;
+use std::env;
+use std::path;
 
 pub(super) const GO_MODULE: &str = "lis-script";
 
@@ -257,8 +261,7 @@ fn compile_file(
         .and_then(|name| name.to_str())
         .unwrap_or("main.lis")
         .to_string();
-    let entry_display =
-        lisette::fs::relative_to_cwd(file).unwrap_or_else(|| file.display().to_string());
+    let entry_display = relative_to_cwd(file).unwrap_or_else(|| file.display().to_string());
 
     let result = compile(
         CompileInput::Binary(CompileEntry {
@@ -305,7 +308,7 @@ pub(crate) fn script_build_dir(file: &Path) -> PathBuf {
     let absolute = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
     let mut hasher = DefaultHasher::new();
     absolute.hash(&mut hasher);
-    std::env::temp_dir().join(format!("{}{:x}", BUILD_DIR_PREFIX, hasher.finish()))
+    env::temp_dir().join(format!("{}{:x}", BUILD_DIR_PREFIX, hasher.finish()))
 }
 
 fn build_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
@@ -340,7 +343,7 @@ fn absolute(path: &Path) -> Option<PathBuf> {
     if path.is_absolute() {
         return Some(path.to_path_buf());
     }
-    Some(std::env::current_dir().ok()?.join(path))
+    Some(env::current_dir().ok()?.join(path))
 }
 
 fn prune_stale_go(dir: &Path, emitted: &[&str]) {
@@ -428,12 +431,12 @@ fn check_destination(input: &Path, output: &Path, heading: &str) -> Result<PathB
 /// drops, so this reads the path as written.
 fn demands_a_directory(path: &Path) -> bool {
     let text = path.as_os_str().to_string_lossy();
-    if text.ends_with(std::path::is_separator) {
+    if text.ends_with(path::is_separator) {
         return true;
     }
 
     text.strip_suffix('.')
-        .is_some_and(|rest| rest.is_empty() || rest.ends_with(std::path::is_separator))
+        .is_some_and(|rest| rest.is_empty() || rest.ends_with(path::is_separator))
 }
 
 enum PathError {
@@ -534,7 +537,7 @@ fn file_identity(path: &Path) -> Option<(u32, u64)> {
 }
 
 fn shown(path: &Path) -> String {
-    lisette::fs::relative_to_cwd(path).unwrap_or_else(|| path.display().to_string())
+    relative_to_cwd(path).unwrap_or_else(|| path.display().to_string())
 }
 
 fn report_written(what: &str, path: &Path, diagnostics_shown: bool) {
@@ -542,7 +545,7 @@ fn report_written(what: &str, path: &Path, diagnostics_shown: bool) {
         eprintln!();
     }
     let path = shown(path);
-    if crate::output::use_color() {
+    if output::use_color() {
         use owo_colors::OwoColorize;
         eprintln!("  ✓ {} at {}", what, path.bright_magenta());
     } else {

--- a/crates/cli/src/handlers/script_add.rs
+++ b/crates/cli/src/handlers/script_add.rs
@@ -13,6 +13,7 @@ use super::script_edit::{
 };
 use super::script_table::ScriptTable;
 use crate::cli_error;
+use crate::lock;
 use crate::output::{print_add_success, print_preview_notice, print_progress};
 use crate::workspace::GoWorkspace;
 
@@ -53,11 +54,11 @@ pub(super) fn run(file: &Path, dep_string: &str) -> i32 {
         Ok(dir) => dir,
         Err(code) => return code,
     };
-    let _mutation = match crate::lock::acquire_mutation_lock(&dir, "script") {
+    let _mutation = match lock::acquire_mutation_lock(&dir, "script") {
         Ok(lock) => lock,
         Err(code) => return code,
     };
-    let _target = match crate::lock::acquire_target_lock(&dir) {
+    let _target = match lock::acquire_target_lock(&dir) {
         Ok(lock) => lock,
         Err(code) => return code,
     };

--- a/crates/cli/src/handlers/script_deps.rs
+++ b/crates/cli/src/handlers/script_deps.rs
@@ -3,8 +3,13 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use crate::workspace::WorkspaceBindgen;
 use deps::{GoDependency, TypedefLocator};
+use std::path::PathBuf;
+use std::sync::Arc;
 use stdlib::Target;
+use syntax::dependency_block;
+use syntax::dependency_block::DependencyBlock;
 
 /// Whether resolution may reach the network.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -29,8 +34,8 @@ pub(crate) fn script_deps(source: &str) -> BTreeMap<String, GoDependency> {
         .collect()
 }
 
-pub(crate) fn deps_block(source: &str) -> Option<syntax::dependency_block::DependencyBlock> {
-    syntax::dependency_block::scan_dependency_blocks(source, 0)
+pub(crate) fn deps_block(source: &str) -> Option<DependencyBlock> {
+    dependency_block::scan_dependency_blocks(source, 0)
         .into_iter()
         .next()
 }
@@ -46,12 +51,14 @@ pub(crate) fn locator(
         return locator;
     }
 
-    locator.with_bindgen(std::sync::Arc::new(
-        crate::workspace::WorkspaceBindgen::new(dir.to_path_buf(), typedef_dir(dir), target),
-    ))
+    locator.with_bindgen(Arc::new(WorkspaceBindgen::new(
+        dir.to_path_buf(),
+        typedef_dir(dir),
+        target,
+    )))
 }
 
-pub(crate) fn typedef_dir(dir: &Path) -> std::path::PathBuf {
+pub(crate) fn typedef_dir(dir: &Path) -> PathBuf {
     deps::typedef_cache_dir(dir)
 }
 

--- a/crates/cli/src/handlers/script_edit.rs
+++ b/crates/cli/src/handlers/script_edit.rs
@@ -2,6 +2,9 @@ use std::path::{Path, PathBuf};
 
 use super::script_table::ScriptTable;
 use crate::cli_error;
+use crate::go_cli;
+use std::fs;
+use syntax::imports;
 
 pub(super) fn refuse_project_file(file: &Path, heading: &str) -> Result<(), i32> {
     let root = match super::project::resolve_file_target(file) {
@@ -22,7 +25,7 @@ pub(super) fn refuse_project_file(file: &Path, heading: &str) -> Result<(), i32>
 }
 
 pub(super) fn save_unchanged(table: &ScriptTable, file: &Path, source: &str) -> Result<(), String> {
-    let current = std::fs::read_to_string(file)
+    let current = fs::read_to_string(file)
         .map_err(|e| format!("Failed to read `{}`: {}", file.display(), e))?;
     if current != source {
         return Err(format!(
@@ -34,7 +37,7 @@ pub(super) fn save_unchanged(table: &ScriptTable, file: &Path, source: &str) -> 
 }
 
 pub(super) fn read(file: &Path, heading: &str) -> Option<String> {
-    match std::fs::read_to_string(file) {
+    match fs::read_to_string(file) {
         Ok(source) => Some(source),
         Err(e) => {
             cli_error!(
@@ -49,7 +52,7 @@ pub(super) fn read(file: &Path, heading: &str) -> Option<String> {
 
 pub(super) fn script_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
     let dir = super::script::script_build_dir(file);
-    if let Err(e) = std::fs::create_dir_all(&dir) {
+    if let Err(e) = fs::create_dir_all(&dir) {
         cli_error!(heading, e.to_string(), "Check permissions on the temp dir");
         return Err(1);
     }
@@ -58,7 +61,7 @@ pub(super) fn script_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
 
 pub(super) fn write_go_mod(dir: &Path, table: &ScriptTable, heading: &str) -> Result<(), i32> {
     let locator = super::script_deps::locator(table.deps(), dir, super::script_deps::Mode::Offline);
-    if let Err(message) = crate::go_cli::write_go_mod(dir, super::script::GO_MODULE, &locator) {
+    if let Err(message) = go_cli::write_go_mod(dir, super::script::GO_MODULE, &locator) {
         cli_error!(heading, message, "Check permissions on the temp dir");
         return Err(1);
     }
@@ -66,7 +69,7 @@ pub(super) fn write_go_mod(dir: &Path, table: &ScriptTable, heading: &str) -> Re
 }
 
 pub(super) fn third_party_imports(source: &str) -> Vec<String> {
-    syntax::imports::scan_imports(source, 0)
+    imports::scan_imports(source, 0)
         .into_iter()
         .filter_map(|import| {
             let package = import.name.strip_prefix("go:")?;

--- a/crates/cli/src/handlers/script_sync.rs
+++ b/crates/cli/src/handlers/script_sync.rs
@@ -1,5 +1,6 @@
 //! `lis sync --script`.
 
+use crate::lock;
 use std::path::Path;
 
 use super::script_edit::{
@@ -31,7 +32,7 @@ pub(super) fn run(file: &Path) -> i32 {
         Ok(dir) => dir,
         Err(code) => return code,
     };
-    let _mutation = match crate::lock::acquire_mutation_lock(&dir, "script") {
+    let _mutation = match lock::acquire_mutation_lock(&dir, "script") {
         Ok(lock) => lock,
         Err(code) => return code,
     };

--- a/crates/cli/src/handlers/script_table.rs
+++ b/crates/cli/src/handlers/script_table.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
+use std::fs;
 use std::ops::Range;
 use std::path::Path;
+use syntax::dependency_block;
 
 pub(crate) struct ScriptTable {
     pub(crate) document: deps::DocumentMut,
@@ -10,7 +13,7 @@ pub(crate) struct ScriptTable {
 
 impl ScriptTable {
     pub(crate) fn read(source: &str) -> Result<Self, String> {
-        let mut blocks = syntax::dependency_block::scan_dependency_blocks(source, 0);
+        let mut blocks = dependency_block::scan_dependency_blocks(source, 0);
         if blocks.len() > 1 {
             return Err(format!(
                 "This script has {} `[dependencies.go]` blocks. Merge them into one",
@@ -28,7 +31,7 @@ impl ScriptTable {
             return Ok(Self {
                 document: deps::DocumentMut::new(),
                 range: {
-                    let at = syntax::dependency_block::insertion_point(source);
+                    let at = dependency_block::insertion_point(source);
                     at..at
                 },
                 existed: false,
@@ -51,7 +54,7 @@ impl ScriptTable {
         })
     }
 
-    pub(crate) fn deps(&self) -> std::collections::BTreeMap<String, deps::GoDependency> {
+    pub(crate) fn deps(&self) -> BTreeMap<String, deps::GoDependency> {
         deps::go_deps_of_document(&self.document).unwrap_or_default()
     }
 
@@ -103,7 +106,7 @@ impl ScriptTable {
     }
 
     pub(crate) fn save(&self, file: &Path, source: &str) -> Result<(), String> {
-        std::fs::write(file, self.write(source))
+        fs::write(file, self.write(source))
             .map_err(|e| format!("Failed to write `{}`: {}", file.display(), e))
     }
 }

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -10,10 +10,11 @@ use crate::typedef_regen::prewarm_typedef_cache;
 use crate::typedef_scan::{SourceScanError, scan_source_imports};
 use crate::workspace::WorkspaceBindgen;
 use crate::{cli_error, error};
+use std::path::Path;
 
 pub fn sync(script: Option<&str>) -> i32 {
     if let Some(script) = script {
-        return super::script_sync::run(std::path::Path::new(script));
+        return super::script_sync::run(Path::new(script));
     }
 
     let project = match MutationProject::open() {

--- a/crates/cli/src/handlers/test/failed.rs
+++ b/crates/cli/src/handlers/test/failed.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use super::report::{TestRow, failed_keys};
+use std::fs;
 
 #[derive(Serialize, Deserialize, Default)]
 struct LastFailures {
@@ -27,15 +28,15 @@ pub fn save(target_dir: &Path, rows: &[TestRow]) {
         .collect();
     let path = last_failures_path(target_dir);
     if let Some(dir) = path.parent() {
-        let _ = std::fs::create_dir_all(dir);
+        let _ = fs::create_dir_all(dir);
     }
     if let Ok(json) = serde_json::to_string(&LastFailures { failures }) {
-        let _ = std::fs::write(path, json);
+        let _ = fs::write(path, json);
     }
 }
 
 pub fn load(target_dir: &Path) -> HashSet<(String, String)> {
-    let Ok(json) = std::fs::read_to_string(last_failures_path(target_dir)) else {
+    let Ok(json) = fs::read_to_string(last_failures_path(target_dir)) else {
         return HashSet::new();
     };
     serde_json::from_str::<LastFailures>(&json)

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -10,14 +10,16 @@ use super::build::{BuildPurpose, build_locked, project_root_for, with_locked_pro
 
 mod failed;
 mod report;
+use crate::output;
 use report::{
     all_test_keys, build_report_filtered, exit_code, matching_tests, nothing_executed, render,
 };
+use std::path::Path;
 
 pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelection) -> i32 {
-    crate::output::print_preview_notice("Test runner", false);
+    output::print_preview_notice("Test runner", false);
     let target = path.unwrap_or_else(|| ".".to_string());
-    let root = project_root_for(std::path::Path::new(&target));
+    let root = project_root_for(Path::new(&target));
     with_locked_project(&root, |prep| {
         let outcome = match build_locked(prep, BuildPurpose::Test) {
             Ok(outcome) => outcome,
@@ -34,7 +36,7 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelectio
                     .filter(|key| live.contains(key))
                     .collect();
                 if set.is_empty() {
-                    let message = crate::output::format_backticks(
+                    let message = output::format_backticks(
                         "No failures to rerun. Run `lis test` first.",
                         use_color(),
                     );
@@ -46,7 +48,7 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelectio
             TestSelection::Filter(pattern) => {
                 let matched = matching_tests(&outcome.test_index, go_module, pattern);
                 if matched.is_empty() {
-                    let message = crate::output::format_backticks(
+                    let message = output::format_backticks(
                         &format!("No tests match `{pattern}`"),
                         use_color(),
                     );

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -11,6 +11,9 @@ use crate::go_cli::GoTestEvent;
 use crate::output::{format_backticks, format_elapsed};
 use diagnostics::LisetteDiagnostic;
 use lisette::pipeline::{Sources, TestIndex};
+use semantics::loader;
+use std::iter;
+use std::mem;
 
 type TestKey = (String, String);
 
@@ -558,7 +561,7 @@ fn collect_children(
             pkg == package && name.starts_with(&prefix) && state.execution.was_observed()
         })
         .map(|((_, name), _)| name.as_str())
-        .chain(std::iter::once(parent))
+        .chain(iter::once(parent))
         .collect();
 
     let mut children_of: HashMap<&str, Vec<&str>> = HashMap::new();
@@ -658,7 +661,7 @@ fn package_display(package: &str, go_module: &str) -> String {
         .strip_prefix(go_module)
         .and_then(|rest| rest.strip_prefix('/'))
     {
-        if semantics::loader::is_external_test_package(package_id) {
+        if loader::is_external_test_package(package_id) {
             package_id.to_string()
         } else {
             format!("src/{package_id}")
@@ -1321,7 +1324,7 @@ fn wrap_description(text: &str, width: usize, max_lines: usize) -> Vec<String> {
             continue;
         }
         if !current.is_empty() {
-            lines.push(std::mem::take(&mut current));
+            lines.push(mem::take(&mut current));
         }
         let mut rest = word;
         while rest.chars().count() > width {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,13 +11,16 @@ mod typedef_scan;
 mod workspace;
 
 use command::Command;
+use std::env;
+use std::path::Path;
+use std::process;
 
 fn main() {
     panic::add_handler();
 
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = env::args().collect();
 
-    let command = match Command::parse(args, |path| std::path::Path::new(path).is_file()) {
+    let command = match Command::parse(args, |path| Path::new(path).is_file()) {
         Ok(command) => command,
         Err(command::ParseError::MissingArgument { command, argument }) => {
             cli_error!(
@@ -25,7 +28,7 @@ fn main() {
                 format!("`lis {}` requires `<{}>` argument", command, argument),
                 format!("Run `lis help {}` for usage", command)
             );
-            std::process::exit(1);
+            process::exit(1);
         }
         Err(command::ParseError::UnknownCommand(cmd)) => {
             let hint = match Command::suggest(&cmd) {
@@ -37,7 +40,7 @@ fn main() {
                 format!("`{}` is not a lis command", cmd),
                 hint
             );
-            std::process::exit(1);
+            process::exit(1);
         }
         Err(command::ParseError::UnknownFlag(flag)) => {
             cli_error!(
@@ -45,7 +48,7 @@ fn main() {
                 format!("`{}` is not a valid flag", flag),
                 "Run `lis help` for available flags"
             );
-            std::process::exit(1);
+            process::exit(1);
         }
         Err(command::ParseError::UnexpectedArgument {
             message,
@@ -53,7 +56,7 @@ fn main() {
             hint,
         }) => {
             cli_error!(message, reason, hint);
-            std::process::exit(1);
+            process::exit(1);
         }
     };
 
@@ -123,5 +126,5 @@ fn main() {
         Command::Completions { shell } => handlers::completions(shell),
     };
 
-    std::process::exit(exit_code);
+    process::exit(exit_code);
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
             std::process::exit(1);
         }
         Err(command::ParseError::UnknownCommand(cmd)) => {
-            let hint = match command::Command::suggest(&cmd) {
+            let hint = match Command::suggest(&cmd) {
                 Some(suggestion) => format!("Did you mean `{}`?", suggestion),
                 None => "Run `lis help` for available commands".to_string(),
             };

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -2,9 +2,15 @@ use std::io::IsTerminal;
 use std::sync::LazyLock;
 
 use owo_colors::OwoColorize;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::env;
+use std::io;
+use std::str::Chars;
+use std::time::Duration;
 
 static USE_COLOR: LazyLock<bool> =
-    LazyLock::new(|| std::env::var("NO_COLOR").is_err() && std::io::stderr().is_terminal());
+    LazyLock::new(|| env::var("NO_COLOR").is_err() && io::stderr().is_terminal());
 
 pub fn use_color() -> bool {
     *USE_COLOR
@@ -47,7 +53,7 @@ fn platform_terminal_width() -> Option<u16> {
     const GET_WINDOW_SIZE: c_ulong = 0x4008_7468;
 
     let mut size = WindowSize::default();
-    let stderr = std::io::stderr();
+    let stderr = io::stderr();
     // SAFETY: stderr supplies a live file descriptor for the duration of the
     // call, and `size` is the C-compatible buffer required by TIOCGWINSZ.
     let result = unsafe { ioctl(stderr.as_raw_fd(), GET_WINDOW_SIZE, &mut size) };
@@ -94,7 +100,7 @@ fn platform_terminal_width() -> Option<u16> {
         ) -> i32;
     }
 
-    let stderr = std::io::stderr();
+    let stderr = io::stderr();
     let mut info = ConsoleScreenBufferInfo::default();
     // SAFETY: the borrowed stderr handle remains live for the call, and
     // `info` exactly matches the Windows CONSOLE_SCREEN_BUFFER_INFO layout.
@@ -114,7 +120,7 @@ fn platform_terminal_width() -> Option<u16> {
     None
 }
 
-pub fn format_elapsed(elapsed: std::time::Duration) -> String {
+pub fn format_elapsed(elapsed: Duration) -> String {
     let time_str = if elapsed.as_secs() >= 1 {
         format!("{:.2}s", elapsed.as_secs_f64())
     } else if elapsed.as_millis() > 0 {
@@ -234,7 +240,7 @@ fn format_help_text(text: &str, use_color: bool) -> String {
     out
 }
 
-fn take_until(chars: &mut std::str::Chars<'_>, close: char) -> (String, bool) {
+fn take_until(chars: &mut Chars<'_>, close: char) -> (String, bool) {
     let mut content = String::new();
     for c in chars.by_ref() {
         if c == close {
@@ -275,8 +281,8 @@ pub enum ReplacementLabel<'a> {
 pub fn print_add_success(
     module_path: &str,
     version: &str,
-    edges: &std::collections::HashMap<String, Vec<String>>,
-    versions: &std::collections::HashMap<String, String>,
+    edges: &HashMap<String, Vec<String>>,
+    versions: &HashMap<String, String>,
     upgraded_directs: &[(&str, &str, &str)],
     replacement: Option<ReplacementLabel<'_>>,
 ) {
@@ -332,17 +338,17 @@ pub fn print_add_success(
         edges,
         versions,
         colored,
-        visited: std::collections::HashSet::new(),
+        visited: HashSet::new(),
     };
     printer.visited.insert(module_path.to_string());
     printer.print_children(module_path, "    ");
 }
 
 struct TreePrinter<'a> {
-    edges: &'a std::collections::HashMap<String, Vec<String>>,
-    versions: &'a std::collections::HashMap<String, String>,
+    edges: &'a HashMap<String, Vec<String>>,
+    versions: &'a HashMap<String, String>,
     colored: bool,
-    visited: std::collections::HashSet<String>,
+    visited: HashSet<String>,
 }
 
 impl TreePrinter<'_> {
@@ -409,9 +415,8 @@ pub fn print_sync_summary(
 
     let colored = use_color();
 
-    let promoted_set: std::collections::HashSet<&str> =
-        promoted.iter().map(String::as_str).collect();
-    let removed_set: std::collections::HashSet<&str> = removed.iter().map(String::as_str).collect();
+    let promoted_set: HashSet<&str> = promoted.iter().map(String::as_str).collect();
+    let removed_set: HashSet<&str> = removed.iter().map(String::as_str).collect();
 
     for entry in trimmed {
         if promoted_set.contains(entry.module_path.as_str())

--- a/crates/cli/src/panic.rs
+++ b/crates/cli/src/panic.rs
@@ -1,4 +1,5 @@
 use std::backtrace::Backtrace;
+use std::env::consts;
 use std::io::{IsTerminal, Write};
 use std::panic::PanicHookInfo;
 
@@ -65,7 +66,7 @@ Lisette {version} · Go {go_version} · {os}/{arch}"#,
         backtrace = backtrace,
         version = env!("CARGO_PKG_VERSION"),
         go_version = GO_VERSION,
-        os = std::env::consts::OS,
-        arch = std::env::consts::ARCH,
+        os = consts::OS,
+        arch = consts::ARCH,
     );
 }

--- a/crates/cli/src/panic.rs
+++ b/crates/cli/src/panic.rs
@@ -1,12 +1,14 @@
 use std::backtrace::Backtrace;
 use std::env::consts;
+use std::io;
 use std::io::{IsTerminal, Write};
+use std::panic;
 use std::panic::PanicHookInfo;
 
 include!(concat!(env!("OUT_DIR"), "/go_version.rs"));
 
 pub fn add_handler() {
-    std::panic::set_hook(Box::new(|info: &PanicHookInfo<'_>| {
+    panic::set_hook(Box::new(|info: &PanicHookInfo<'_>| {
         print_compiler_bug_message(info);
     }));
 }
@@ -33,7 +35,7 @@ fn print_compiler_bug_message(info: &PanicHookInfo<'_>) {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let use_color = std::io::stderr().is_terminal();
+    let use_color = io::stderr().is_terminal();
 
     let (badge, reset) = if use_color {
         ("\x1b[41;30;1m", "\x1b[0m")
@@ -42,7 +44,7 @@ fn print_compiler_bug_message(info: &PanicHookInfo<'_>) {
     };
 
     let _ = writeln!(
-        std::io::stderr(),
+        io::stderr(),
         r#"
 {badge} INTERNAL COMPILER ERROR {reset}
 

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -218,9 +218,10 @@ mod tests {
     use crate::fs::LocalFileSystem;
     use semantics::PARALLEL_THRESHOLD;
     use std::fs as stdfs;
+    use std::path::Path;
     use tempfile::tempdir;
 
-    fn check_diagnostics(project_dir: &std::path::Path) -> Vec<(bool, Option<String>)> {
+    fn check_diagnostics(project_dir: &Path) -> Vec<(bool, Option<String>)> {
         let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();
@@ -496,9 +497,7 @@ mod tests {
         );
     }
 
-    fn analyze_cache_state(
-        project_dir: &std::path::Path,
-    ) -> (Vec<String>, Vec<(bool, Option<String>)>) {
+    fn analyze_cache_state(project_dir: &Path) -> (Vec<String>, Vec<(bool, Option<String>)>) {
         let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();
@@ -596,7 +595,7 @@ mod tests {
         );
     }
 
-    fn test_index_names(project_dir: &std::path::Path) -> Vec<String> {
+    fn test_index_names(project_dir: &Path) -> Vec<String> {
         let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();

--- a/crates/cli/src/shell_words.rs
+++ b/crates/cli/src/shell_words.rs
@@ -1,5 +1,6 @@
 //! POSIX-style word splitting for the `--go-flags` passthrough.
 
+use std::mem;
 #[derive(Debug, PartialEq, Eq)]
 pub enum SplitError {
     UnterminatedQuote(char),
@@ -15,7 +16,7 @@ pub fn split(input: &str) -> Result<Vec<String>, SplitError> {
         match c {
             ' ' | '\t' | '\n' | '\r' => {
                 if in_word {
-                    words.push(std::mem::take(&mut current));
+                    words.push(mem::take(&mut current));
                     in_word = false;
                 }
             }

--- a/crates/cli/src/typedef_scan.rs
+++ b/crates/cli/src/typedef_scan.rs
@@ -4,16 +4,12 @@ use syntax::ast::{Expression, ImportAlias};
 use syntax::parse::Parser;
 
 use lisette::fs::collect_lis_filepaths_recursive;
+use std::fs;
+use std::io::Error;
 
 pub(crate) enum SourceScanError {
-    Parse {
-        path: PathBuf,
-        message: String,
-    },
-    Read {
-        path: PathBuf,
-        error: std::io::Error,
-    },
+    Parse { path: PathBuf, message: String },
+    Read { path: PathBuf, error: Error },
 }
 
 pub(crate) struct ScannedImports {
@@ -70,7 +66,7 @@ pub(crate) fn scan_source_imports(src_dir: &Path) -> Result<ScannedImports, Sour
 }
 
 fn scan_file_imports(path: PathBuf) -> Result<Vec<ScannedImport>, SourceScanError> {
-    let source = match std::fs::read_to_string(&path) {
+    let source = match fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) => return Err(SourceScanError::Read { path, error: e }),
     };
@@ -104,13 +100,14 @@ fn scan_file_imports(path: PathBuf) -> Result<Vec<ScannedImport>, SourceScanErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn project_src(files: &[(&str, &str)]) -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
-        std::fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&src).unwrap();
         for (name, body) in files {
-            std::fs::write(src.join(name), body).unwrap();
+            fs::write(src.join(name), body).unwrap();
         }
         dir
     }

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -13,6 +13,8 @@ use serde::Deserialize;
 use syntax::ast::{Expression, ImportAlias};
 use syntax::parse::Parser;
 
+use crate::handlers::reconciliation;
+
 const BINDGEN_GO_MODULE: &str = "github.com/ivov/lisette/bindgen";
 const BINDGEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -1120,12 +1122,7 @@ impl WorkspaceBindgen {
     fn local_child_remedy(&self, stderr: &str) -> Option<String> {
         let project_root = self.target_dir.parent()?;
         let manifest = deps::parse_manifest(project_root).ok()?;
-        crate::handlers::reconciliation::local_child_remedy(
-            stderr,
-            project_root,
-            &self.target_dir,
-            &manifest,
-        )
+        reconciliation::local_child_remedy(stderr, project_root, &self.target_dir, &manifest)
     }
 }
 

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1,8 +1,16 @@
+use crate::go_cli;
+use crate::handlers;
+use crate::handlers::ScriptResolveMode;
+use crate::lock;
+use crate::output;
+use crate::typedef_scan;
 use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::PoisonError;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
@@ -79,18 +87,18 @@ impl<'a> GoWorkspace<'a> {
     /// Run a `go` subcommand and return its stdout on success.
     fn run_go(&self, args: &[&str]) -> Result<String, String> {
         let cmd_display = format!("go {}", args.join(" "));
-        let output = crate::go_cli::go_command(self.target)
+        let output = go_cli::go_command(self.target)
             .args(args)
             .current_dir(self.root)
             .output()
             .map_err(|e| {
-                crate::go_cli::toolchain_failure_message()
+                go_cli::toolchain_failure_message()
                     .unwrap_or_else(|| format!("Failed to run `{}`: {}", cmd_display, e))
             })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(crate::go_cli::toolchain_failure_message()
+            return Err(go_cli::toolchain_failure_message()
                 .unwrap_or_else(|| translate_go_error(args, stderr.trim())));
         }
 
@@ -247,7 +255,7 @@ impl<'a> GoWorkspace<'a> {
             c
         } else {
             let bindgen_at_version = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
-            let mut c = crate::go_cli::go_command(self.target);
+            let mut c = go_cli::go_command(self.target);
             c.args(["run", &bindgen_at_version, sub]);
             c
         };
@@ -881,7 +889,7 @@ pub(crate) fn warm_typedefs(
     }
 
     let src_dir = project_root.join("src");
-    let Ok(scanned) = crate::typedef_scan::scan_source_imports(&src_dir) else {
+    let Ok(scanned) = typedef_scan::scan_source_imports(&src_dir) else {
         return;
     };
 
@@ -910,7 +918,7 @@ pub(crate) fn warm_typedefs(
         return;
     }
 
-    crate::output::print_progress(&format!(
+    output::print_progress(&format!(
         "Generating typedefs for {} Go import(s)",
         roots.len()
     ));
@@ -1050,15 +1058,15 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         fs::create_dir_all(&target_dir)
             .map_err(|e| format!("Failed to create `{}`: {}", target_dir.display(), e))?;
 
-        let lock = crate::lock::acquire_target_lock_quiet(&target_dir)?;
+        let lock = lock::acquire_target_lock_quiet(&target_dir)?;
 
         let manifest_locator =
             TypedefLocator::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
-        crate::go_cli::write_go_mod(&target_dir, &manifest.project.name, &manifest_locator)?;
+        go_cli::write_go_mod(&target_dir, &manifest.project.name, &manifest_locator)?;
 
         let typedef_cache_dir = deps::typedef_cache_dir(project_root);
-        let bindgen: std::sync::Arc<dyn Bindgen> =
-            std::sync::Arc::new(WorkspaceBindgen::new(target_dir, typedef_cache_dir, target));
+        let bindgen: Arc<dyn Bindgen> =
+            Arc::new(WorkspaceBindgen::new(target_dir, typedef_cache_dir, target));
 
         Ok(BindgenSession::new(bindgen, Box::new(lock)))
     }
@@ -1068,13 +1076,9 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         source: &str,
         file: &Path,
     ) -> Result<(TypedefLocator, Option<deps::ScriptSession>), String> {
-        let (locator, dir) = crate::handlers::script_locator(
-            source,
-            file,
-            crate::handlers::ScriptResolveMode::Offline,
-        )?;
+        let (locator, dir) = handlers::script_locator(source, file, ScriptResolveMode::Offline)?;
         let session = dir
-            .map(|dir| crate::lock::acquire_target_lock_quiet(&dir))
+            .map(|dir| lock::acquire_target_lock_quiet(&dir))
             .transpose()?
             .map(|lock| deps::ScriptSession::new(Box::new(lock)));
         Ok((locator, session))
@@ -1083,21 +1087,18 @@ impl BindgenSetup for WorkspaceBindgenSetup {
 
 impl Bindgen for WorkspaceBindgen {
     fn run(&self, pkg: &GoPackage<'_>) -> Result<(), BindgenFailure> {
-        let _guard = self
-            .mutex
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = self.mutex.lock().unwrap_or_else(PoisonError::into_inner);
 
         let typedef_path = pkg.typedef_path(&self.typedef_cache_dir, self.target);
         if typedef_path.exists() {
             return Ok(());
         }
 
-        if !*self.go_present.get_or_init(crate::go_cli::is_go_present) {
+        if !*self.go_present.get_or_init(go_cli::is_go_present) {
             return Err(BindgenFailure::GoToolchainMissing);
         }
 
-        crate::output::print_progress(&format!("Generating typedef for {}", pkg.package));
+        output::print_progress(&format!("Generating typedef for {}", pkg.package));
         self.progress_emitted.store(true, Ordering::Relaxed);
 
         let workspace = GoWorkspace::new(&self.target_dir, &self.typedef_cache_dir, self.target);
@@ -1143,6 +1144,7 @@ fn dev_bindgen_path() -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handlers;
     use deps::GoModule;
     use std::fs as stdfs;
 
@@ -1168,7 +1170,7 @@ mod tests {
             .unwrap();
 
         assert!(dir.is_none());
-        assert!(!crate::handlers::script_build_dir(&file).exists());
+        assert!(!handlers::script_build_dir(&file).exists());
     }
 
     fn valid_typedef() -> String {

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -951,7 +951,7 @@ fn warm_stamp_for(roots: &[String], locator: &TypedefLocator) -> String {
 fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
     let mut tmp_os = path.as_os_str().to_owned();
     tmp_os.push(".tmp");
-    let tmp_path = std::path::PathBuf::from(tmp_os);
+    let tmp_path = PathBuf::from(tmp_os);
 
     fs::write(&tmp_path, content)
         .map_err(|e| format!("Failed to write `{}`: {}", tmp_path.display(), e))?;
@@ -1038,7 +1038,7 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         project_root: &Path,
         target: stdlib::Target,
     ) -> Result<BindgenSession, String> {
-        let (manifest, _) = deps::TypedefLocator::from_project_with_manifest(project_root)?;
+        let (manifest, _) = TypedefLocator::from_project_with_manifest(project_root)?;
 
         let target_dir = project_root.join("target");
         if target_dir.is_file() {
@@ -1053,7 +1053,7 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         let lock = crate::lock::acquire_target_lock_quiet(&target_dir)?;
 
         let manifest_locator =
-            deps::TypedefLocator::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
+            TypedefLocator::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
         crate::go_cli::write_go_mod(&target_dir, &manifest.project.name, &manifest_locator)?;
 
         let typedef_cache_dir = deps::typedef_cache_dir(project_root);
@@ -1067,7 +1067,7 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         &self,
         source: &str,
         file: &Path,
-    ) -> Result<(deps::TypedefLocator, Option<deps::ScriptSession>), String> {
+    ) -> Result<(TypedefLocator, Option<deps::ScriptSession>), String> {
         let (locator, dir) = crate::handlers::script_locator(
             source,
             file,
@@ -1127,8 +1127,8 @@ impl WorkspaceBindgen {
 }
 
 #[cfg(debug_assertions)]
-fn dev_bindgen_path() -> Option<std::path::PathBuf> {
-    let path = std::path::PathBuf::from(concat!(
+fn dev_bindgen_path() -> Option<PathBuf> {
+    let path = PathBuf::from(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../bindgen/bin/bindgen"
     ));
@@ -1203,7 +1203,7 @@ mod tests {
         GoWorkspace::new(cache_dir, cache_dir, test_target())
     }
 
-    fn cache_path_for(cache_dir: &Path, pkg: &str) -> std::path::PathBuf {
+    fn cache_path_for(cache_dir: &Path, pkg: &str) -> PathBuf {
         let go_pkg = GoPackage {
             module: module(),
             package: pkg,

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1137,7 +1137,7 @@ fn dev_bindgen_path() -> Option<PathBuf> {
 }
 
 #[cfg(not(debug_assertions))]
-fn dev_bindgen_path() -> Option<std::path::PathBuf> {
+fn dev_bindgen_path() -> Option<PathBuf> {
     None
 }
 

--- a/crates/deps/src/dependency_table.rs
+++ b/crates/deps/src/dependency_table.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 use std::ops::Range;
 
 use crate::GoDependency;
+use crate::module_path;
+use toml_edit::de;
 
 #[derive(Debug)]
 pub struct DependencyTable {
@@ -83,7 +85,7 @@ pub(crate) fn deserialize_go_table(
 ) -> Result<BTreeMap<String, GoDependency>, TableError> {
     let mut document = toml_edit::DocumentMut::new();
     document.insert(GO, go.clone());
-    Ok(toml_edit::de::from_document::<Wrapper>(document)
+    Ok(de::from_document::<Wrapper>(document)
         .map_err(|error| TableError {
             message: error.message().to_string(),
             range: error.span(),
@@ -111,7 +113,7 @@ struct Wrapper {
 }
 
 pub fn validate_script_entry(module_path: &str, dep: &GoDependency) -> Result<(), String> {
-    crate::module_path::check_module_path(module_path)
+    module_path::check_module_path(module_path)
         .map_err(|reason| format!("`{}` is not a Go module path: {}", module_path, reason))?;
 
     let version = match dep {

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -65,7 +65,7 @@ pub fn placeholder_require_version(module_path: &str) -> String {
 }
 
 pub fn check_version_matches_path(module_path: &str, version: &str) -> Result<(), String> {
-    let Some((_, path_major)) = crate::module_path::split_path_version(module_path) else {
+    let Some((_, path_major)) = module_path::split_path_version(module_path) else {
         return Ok(());
     };
     let path_major = path_major.strip_suffix("-unstable").unwrap_or(path_major);
@@ -116,7 +116,7 @@ fn version_major(version: &str) -> Option<u64> {
 
 /// The major a path's suffix demands: `/vN` (N >= 2), or gopkg.in `.vN` (any N).
 fn path_major(module_path: &str) -> Option<u64> {
-    let (_, path_major) = crate::module_path::split_path_version(module_path)?;
+    let (_, path_major) = module_path::split_path_version(module_path)?;
     let digits = path_major
         .strip_suffix("-unstable")
         .unwrap_or(path_major)

--- a/crates/deps/src/lib.rs
+++ b/crates/deps/src/lib.rs
@@ -9,6 +9,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
+use std::env;
+use std::fs;
+use std::fs::DirEntry;
+use std::process;
+use std::sync::PoisonError;
 pub use stdlib::Target;
 use stdlib::{
     GO_STD_CONTENT_HASH, LIS_PRELUDE_SOURCE, PRELUDE_CONTENT_HASH, get_go_stdlib_packages,
@@ -31,7 +36,7 @@ pub fn set_typedef_home(home: PathBuf) {
 fn typedef_home() -> Option<PathBuf> {
     match TYPEDEF_HOME.get() {
         Some(home) => Some(home.clone()),
-        None => Some(PathBuf::from(std::env::var_os("HOME")?)),
+        None => Some(PathBuf::from(env::var_os("HOME")?)),
     }
 }
 
@@ -242,12 +247,12 @@ pub fn ensure_stdlib_extracted(target: Target) {
 
     let _guard = STDLIB_EXTRACT_LOCK
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+        .unwrap_or_else(PoisonError::into_inner);
     if target_dir.exists() {
         return;
     }
 
-    if std::fs::create_dir_all(&version_dir).is_err() {
+    if fs::create_dir_all(&version_dir).is_err() {
         return;
     }
     clear_stale_temp_dirs(&version_dir, target, STALE_TEMP_AGE);
@@ -258,16 +263,16 @@ pub fn ensure_stdlib_extracted(target: Target) {
     let tmp = version_dir.join(format!(
         "{}.tmp.{}.{}",
         target.cache_segment(),
-        std::process::id(),
+        process::id(),
         counter
     ));
     if extract_all(&tmp, target).is_none() {
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(&tmp);
         return;
     }
-    if std::fs::rename(&tmp, &target_dir).is_err() {
+    if fs::rename(&tmp, &target_dir).is_err() {
         // Another extraction won the race, or the rename failed; drop our temp.
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(&tmp);
     }
     prune_stale_version_dirs(&version_dir);
 }
@@ -280,8 +285,8 @@ fn extract_all(target_tmp: &Path, target: Target) -> Option<()> {
             continue;
         };
         let path = target_tmp.join(format!("{pkg}.d.lis"));
-        std::fs::create_dir_all(path.parent()?).ok()?;
-        std::fs::write(&path, source).ok()?;
+        fs::create_dir_all(path.parent()?).ok()?;
+        fs::write(&path, source).ok()?;
     }
     Some(())
 }
@@ -290,7 +295,7 @@ const STALE_TEMP_AGE: Duration = Duration::from_secs(300);
 
 fn clear_stale_temp_dirs(version_dir: &Path, target: Target, min_age: Duration) {
     let prefix = format!("{}.tmp.", target.cache_segment());
-    let Ok(entries) = std::fs::read_dir(version_dir) else {
+    let Ok(entries) = fs::read_dir(version_dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -299,12 +304,12 @@ fn clear_stale_temp_dirs(version_dir: &Path, target: Target, min_age: Duration) 
             .to_str()
             .is_some_and(|name| name.starts_with(&prefix));
         if name_matches && temp_dir_is_stale(&entry, min_age) {
-            let _ = std::fs::remove_dir_all(entry.path());
+            let _ = fs::remove_dir_all(entry.path());
         }
     }
 }
 
-fn temp_dir_is_stale(entry: &std::fs::DirEntry, min_age: Duration) -> bool {
+fn temp_dir_is_stale(entry: &DirEntry, min_age: Duration) -> bool {
     entry
         .metadata()
         .and_then(|m| m.modified())
@@ -322,7 +327,7 @@ fn prune_stale_version_dirs(current: &Path) {
     let Some(parent) = current.parent() else {
         return;
     };
-    let Ok(entries) = std::fs::read_dir(parent) else {
+    let Ok(entries) = fs::read_dir(parent) else {
         return;
     };
     for entry in entries.flatten() {
@@ -335,7 +340,7 @@ fn prune_stale_version_dirs(current: &Path) {
             .and_then(|n| n.to_str())
             .is_some_and(|n| n.starts_with("lis@v"));
         if is_version_dir {
-            let _ = std::fs::remove_dir_all(&path);
+            let _ = fs::remove_dir_all(&path);
         }
     }
 }
@@ -373,18 +378,18 @@ pub fn ensure_prelude_extracted() {
     if path.exists() {
         return;
     }
-    if std::fs::create_dir_all(&version_dir).is_err() {
+    if fs::create_dir_all(&version_dir).is_err() {
         return;
     }
 
     let counter = TYPEDEF_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let tmp = version_dir.join(format!("prelude.tmp.{}.{}", std::process::id(), counter));
-    if std::fs::write(&tmp, LIS_PRELUDE_SOURCE).is_err() {
-        let _ = std::fs::remove_file(&tmp);
+    let tmp = version_dir.join(format!("prelude.tmp.{}.{}", process::id(), counter));
+    if fs::write(&tmp, LIS_PRELUDE_SOURCE).is_err() {
+        let _ = fs::remove_file(&tmp);
         return;
     }
-    if std::fs::rename(&tmp, &path).is_err() {
-        let _ = std::fs::remove_file(&tmp);
+    if fs::rename(&tmp, &path).is_err() {
+        let _ = fs::remove_file(&tmp);
     }
     prune_stale_version_dirs(&version_dir);
 }
@@ -468,6 +473,7 @@ impl GoPackage<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn clear_stale_temp_dirs_removes_old_temps_but_keeps_fresh_and_other_targets() {
@@ -476,12 +482,12 @@ mod tests {
         let target = Target::new("darwin", "arm64");
 
         let this_target = root.join("darwin_arm64.tmp.999.0");
-        std::fs::create_dir_all(&this_target).unwrap();
-        std::fs::write(this_target.join("fmt.d.lis"), "x").unwrap();
+        fs::create_dir_all(&this_target).unwrap();
+        fs::write(this_target.join("fmt.d.lis"), "x").unwrap();
         let completed = root.join("darwin_arm64");
-        std::fs::create_dir_all(&completed).unwrap();
+        fs::create_dir_all(&completed).unwrap();
         let other_target_tmp = root.join("linux_amd64.tmp.1.0");
-        std::fs::create_dir_all(&other_target_tmp).unwrap();
+        fs::create_dir_all(&other_target_tmp).unwrap();
 
         clear_stale_temp_dirs(root, target, STALE_TEMP_AGE);
         assert!(this_target.exists(), "a fresh in-flight temp is kept");

--- a/crates/deps/src/local_source.rs
+++ b/crates/deps/src/local_source.rs
@@ -5,6 +5,9 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::project_manifest::{GoDependency, ReplacementSource};
+use std::fs;
+use std::io::Error;
+use std::io::ErrorKind;
 
 /// Content, never mtime: a `git checkout` can move mtimes backwards.
 pub(crate) fn stamp_hash(
@@ -40,7 +43,7 @@ pub(crate) fn stamp_hash(
 /// Stops at nested `go.mod` boundaries: a nested module is a separate module,
 /// hashed by its own entry if declared.
 fn hash_local_module(hash: &mut Fnv, module_dir: &Path) {
-    match std::fs::read(module_dir.join("go.mod")) {
+    match fs::read(module_dir.join("go.mod")) {
         Ok(bytes) => {
             hash.write(b"go.mod");
             hash.write(&bytes);
@@ -55,14 +58,14 @@ fn hash_local_module(hash: &mut Fnv, module_dir: &Path) {
     files.sort();
     for relative in files {
         hash.write(relative.as_os_str().as_encoded_bytes());
-        if let Ok(bytes) = std::fs::read(module_dir.join(&relative)) {
+        if let Ok(bytes) = fs::read(module_dir.join(&relative)) {
             hash.write(&bytes);
         }
     }
 }
 
 fn collect_go_files(dir: &Path, relative: PathBuf, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -100,28 +103,27 @@ fn stamp_path_for_typedef(typedef_path: &Path) -> PathBuf {
 }
 
 pub(crate) fn local_typedef_is_fresh(typedef_path: &Path, stamp: &str) -> bool {
-    std::fs::read_to_string(stamp_path_for_typedef(typedef_path))
-        .is_ok_and(|existing| existing == stamp)
+    fs::read_to_string(stamp_path_for_typedef(typedef_path)).is_ok_and(|existing| existing == stamp)
 }
 
 /// On stamp mismatch, delete the typedef so resolution reroutes into the
 /// regenerate-on-miss path. A failed eviction (e.g. a file lock on Windows) is
 /// returned so the caller refuses the stale read, and keeps the old stamp so
 /// eviction retries next time.
-pub(crate) fn gate_local_typedef(typedef_path: &Path, stamp: &str) -> Result<(), std::io::Error> {
+pub(crate) fn gate_local_typedef(typedef_path: &Path, stamp: &str) -> Result<(), Error> {
     if local_typedef_is_fresh(typedef_path, stamp) {
         return Ok(());
     }
     let stamp_path = stamp_path_for_typedef(typedef_path);
-    match std::fs::remove_file(typedef_path) {
+    match fs::remove_file(typedef_path) {
         Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
         Err(error) => return Err(error),
     }
     if let Some(parent) = stamp_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        let _ = fs::create_dir_all(parent);
     }
-    let _ = std::fs::write(&stamp_path, stamp);
+    let _ = fs::write(&stamp_path, stamp);
     Ok(())
 }
 
@@ -150,6 +152,8 @@ impl Fnv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::fs::Permissions;
 
     fn local_dep(path: &str) -> GoDependency {
         GoDependency::Replaced {
@@ -169,8 +173,8 @@ mod tests {
 
     fn write(root: &Path, relative: &str, content: &str) {
         let path = root.join(relative);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, content).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
     }
 
     #[test]
@@ -245,16 +249,16 @@ mod tests {
     fn gate_deletes_typedef_on_mismatch_and_keeps_it_on_match() {
         let dir = tempfile::tempdir().unwrap();
         let typedef = dir.path().join("foo.d.lis");
-        std::fs::write(&typedef, "typedef").unwrap();
+        fs::write(&typedef, "typedef").unwrap();
 
         gate_local_typedef(&typedef, "aaaa").unwrap();
         assert!(!typedef.exists(), "no stamp -> typedef discarded");
         assert_eq!(
-            std::fs::read_to_string(stamp_path_for_typedef(&typedef)).unwrap(),
+            fs::read_to_string(stamp_path_for_typedef(&typedef)).unwrap(),
             "aaaa"
         );
 
-        std::fs::write(&typedef, "typedef").unwrap();
+        fs::write(&typedef, "typedef").unwrap();
         gate_local_typedef(&typedef, "aaaa").unwrap();
         assert!(typedef.exists(), "matching stamp -> typedef kept");
 
@@ -277,22 +281,22 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let locked = dir.path().join("locked");
-        std::fs::create_dir(&locked).unwrap();
+        fs::create_dir(&locked).unwrap();
         let typedef = locked.join("foo.d.lis");
-        std::fs::write(&typedef, "typedef").unwrap();
-        std::fs::write(stamp_path_for_typedef(&typedef), "old").unwrap();
-        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555)).unwrap();
+        fs::write(&typedef, "typedef").unwrap();
+        fs::write(stamp_path_for_typedef(&typedef), "old").unwrap();
+        fs::set_permissions(&locked, Permissions::from_mode(0o555)).unwrap();
 
         let outcome = gate_local_typedef(&typedef, "new");
 
-        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&locked, Permissions::from_mode(0o755)).unwrap();
         assert!(
             outcome.is_err(),
             "failed eviction is reported to the caller"
         );
         assert!(typedef.exists(), "typedef untouched when eviction fails");
         assert_eq!(
-            std::fs::read_to_string(stamp_path_for_typedef(&typedef)).unwrap(),
+            fs::read_to_string(stamp_path_for_typedef(&typedef)).unwrap(),
             "old",
             "stale content is not blessed with the new stamp"
         );

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -684,12 +684,12 @@ mod tests {
 
     fn project_with(manifest: &str) -> TempDir {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("lisette.toml"), manifest).unwrap();
+        fs::write(dir.path().join("lisette.toml"), manifest).unwrap();
         dir
     }
 
     fn manifest_text(dir: &TempDir) -> String {
-        std::fs::read_to_string(dir.path().join("lisette.toml")).unwrap()
+        fs::read_to_string(dir.path().join("lisette.toml")).unwrap()
     }
 
     fn finalize(dir: &TempDir, imported: &[&str]) -> ViaChanges {
@@ -707,9 +707,9 @@ mod tests {
         let dir = project_with("[project]\nname = \"demo\"\nversion = \"0.1.0\"\n");
         let root = dir.path().canonicalize().unwrap();
         let nested = root.join("src/util");
-        std::fs::create_dir_all(&nested).unwrap();
+        fs::create_dir_all(&nested).unwrap();
         let file = nested.join("util.lis");
-        std::fs::write(&file, "pub fn f() {}\n").unwrap();
+        fs::write(&file, "pub fn f() {}\n").unwrap();
 
         assert_eq!(find_project_root(&file).as_deref(), Some(root.as_path()));
         assert_eq!(find_project_root(&nested).as_deref(), Some(root.as_path()));
@@ -717,7 +717,7 @@ mod tests {
 
         let outside = tempfile::tempdir().unwrap();
         let orphan = outside.path().join("loose.lis");
-        std::fs::write(&orphan, "fn main() {}\n").unwrap();
+        fs::write(&orphan, "fn main() {}\n").unwrap();
         assert_eq!(find_project_root(&orphan), None);
     }
 
@@ -784,7 +784,7 @@ mod tests {
     #[test]
     fn a_directory_named_like_the_manifest_is_not_a_project_root() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("lisette.toml")).unwrap();
+        fs::create_dir_all(dir.path().join("lisette.toml")).unwrap();
 
         assert_eq!(find_project_root(dir.path()), None);
     }

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -2,8 +2,13 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::module_path;
 use serde::Deserialize;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
+use std::fmt;
+use std::str;
+use std::str::Utf8Error;
+use toml_edit::de as toml_de;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
@@ -85,7 +90,7 @@ impl<'de> Deserialize<'de> for GoDependency {
         impl<'de> Visitor<'de> for GoDependencyVisitor {
             type Value = GoDependency;
 
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str(
                     "a version string, or a table with exactly one of `version`, `replacement`, or `path` (and optional `via`)",
                 )
@@ -197,7 +202,7 @@ pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
     let content =
         strip_bom_to_str(&bytes).map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))?;
 
-    let manifest: Manifest = toml_edit::de::from_str(content)
+    let manifest: Manifest = toml_de::from_str(content)
         .map_err(|e| format!("Invalid `lisette.toml` manifest: {}", e))?;
     validate_go_dep_paths(&manifest)?;
     Ok(manifest)
@@ -230,7 +235,7 @@ fn validate_go_dep_paths(manifest: &Manifest) -> Result<(), String> {
             }
         }
 
-        crate::module_path::check_module_path(key).map_err(|reason| {
+        module_path::check_module_path(key).map_err(|reason| {
             format!(
                 "`{}` in `[dependencies.go]` is not a Go module path: {}",
                 key, reason
@@ -243,7 +248,7 @@ fn validate_go_dep_paths(manifest: &Manifest) -> Result<(), String> {
             ..
         } = dep
         {
-            crate::module_path::check_module_path(path).map_err(|reason| {
+            module_path::check_module_path(path).map_err(|reason| {
                 format!(
                     "the `replace` target `{}` for `{}` is not a Go module path: {}",
                     path, key, reason
@@ -332,9 +337,9 @@ pub fn check_no_subpackage_deps(manifest: &Manifest) -> Result<(), String> {
 
 const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
 
-fn strip_bom_to_str(bytes: &[u8]) -> Result<&str, std::str::Utf8Error> {
+fn strip_bom_to_str(bytes: &[u8]) -> Result<&str, Utf8Error> {
     let body = bytes.strip_prefix(UTF8_BOM).unwrap_or(bytes);
-    std::str::from_utf8(body)
+    str::from_utf8(body)
 }
 
 struct ManifestEncoding {
@@ -408,7 +413,7 @@ pub fn go_deps_of_document(
 
     let mut wrapped = toml_edit::DocumentMut::new();
     wrapped.insert("go", go.clone());
-    toml_edit::de::from_document::<GoTable>(wrapped)
+    toml_de::from_document::<GoTable>(wrapped)
         .map(|table| table.go)
         .map_err(|error| format!("Invalid `[dependencies.go]`: {}", error.message()))
 }

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -164,12 +164,12 @@ pub trait Bindgen: Send + Sync + std::fmt::Debug {
 
 /// Per-analysis bindgen runner; dropping the session releases the lock.
 pub struct BindgenSession {
-    pub bindgen: std::sync::Arc<dyn Bindgen>,
+    pub bindgen: Arc<dyn Bindgen>,
     _guard: Box<dyn BindgenGuard>,
 }
 
 impl BindgenSession {
-    pub fn new(bindgen: std::sync::Arc<dyn Bindgen>, guard: Box<dyn BindgenGuard>) -> Self {
+    pub fn new(bindgen: Arc<dyn Bindgen>, guard: Box<dyn BindgenGuard>) -> Self {
         Self {
             bindgen,
             _guard: guard,
@@ -328,7 +328,7 @@ impl TypedefLocator {
         let Some(root) = self.project_root.as_deref() else {
             return;
         };
-        if path.starts_with(crate::typedef_cache_dir(root)) {
+        if path.starts_with(typedef_cache_dir(root)) {
             let _ = std::fs::remove_file(path);
         }
     }
@@ -801,7 +801,7 @@ mod tests {
             module: GoModule {
                 path: module,
                 version: "v0.0.0",
-                replacement: Some(crate::ReplacementTarget::LocalDirectory),
+                replacement: Some(ReplacementTarget::LocalDirectory),
             },
             package: module,
         };
@@ -846,7 +846,7 @@ mod tests {
             module: GoModule {
                 path: module,
                 version: "v0.0.0",
-                replacement: Some(crate::ReplacementTarget::LocalDirectory),
+                replacement: Some(ReplacementTarget::LocalDirectory),
             },
             package: module,
         };
@@ -886,7 +886,7 @@ mod tests {
             module: GoModule {
                 path: module,
                 version: "v0.0.0",
-                replacement: Some(crate::ReplacementTarget::LocalDirectory),
+                replacement: Some(ReplacementTarget::LocalDirectory),
             },
             package: module,
         };

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -3,6 +3,13 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
+use crate::local_source;
+use std::fmt;
+use std::fs;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::ErrorKind;
 use stdlib::Target;
 
 use crate::project_manifest::{
@@ -116,7 +123,7 @@ impl ImportablePackage {
     pub fn typedef_source(&self) -> Option<Cow<'static, str>> {
         match &self.typedef {
             PackageTypedef::Embedded(source) => Some(Cow::Borrowed(source)),
-            PackageTypedef::Cached(path) => std::fs::read_to_string(path).ok().map(Cow::Owned),
+            PackageTypedef::Cached(path) => fs::read_to_string(path).ok().map(Cow::Owned),
         }
     }
 
@@ -126,10 +133,10 @@ impl ImportablePackage {
                 stdlib::declared_package_name(source).map(str::to_string)
             }
             PackageTypedef::Cached(path) => {
-                let mut reader = std::io::BufReader::new(std::fs::File::open(path).ok()?);
+                let mut reader = BufReader::new(File::open(path).ok()?);
                 let mut header = String::new();
                 for _ in 0..stdlib::HEADER_LINES {
-                    if std::io::BufRead::read_line(&mut reader, &mut header).ok()? == 0 {
+                    if BufRead::read_line(&mut reader, &mut header).ok()? == 0 {
                         break;
                     }
                 }
@@ -157,7 +164,7 @@ impl TypedefOrigin {
 }
 
 /// Cache-miss hook the locator invokes for declared third-party packages.
-pub trait Bindgen: Send + Sync + std::fmt::Debug {
+pub trait Bindgen: Send + Sync + fmt::Debug {
     /// Generate `pkg`'s typedef and write it to the cache (no transitives).
     fn run(&self, pkg: &GoPackage) -> Result<(), BindgenFailure>;
 }
@@ -193,8 +200,8 @@ mod sealed {
     pub trait Sealed {}
 }
 
-impl sealed::Sealed for std::fs::File {}
-impl BindgenGuard for std::fs::File {}
+impl sealed::Sealed for File {}
+impl BindgenGuard for File {}
 
 pub trait BindgenSetup: Send + Sync {
     fn for_project(&self, project_root: &Path, target: Target) -> Result<BindgenSession, String>;
@@ -232,7 +239,7 @@ impl TypedefLocator {
     }
 
     pub fn declared_stamp(&self) -> String {
-        crate::local_source::stamp_hash(&self.deps, None)
+        local_source::stamp_hash(&self.deps, None)
     }
 
     pub fn with_fresh_local_stamp(&self) -> Self {
@@ -256,7 +263,7 @@ impl TypedefLocator {
                         }
                     )
                 });
-                has_local.then(|| crate::local_source::stamp_hash(&self.deps, Some(project_root)))
+                has_local.then(|| local_source::stamp_hash(&self.deps, Some(project_root)))
             })
             .as_deref()
     }
@@ -329,7 +336,7 @@ impl TypedefLocator {
             return;
         };
         if path.starts_with(typedef_cache_dir(root)) {
-            let _ = std::fs::remove_file(path);
+            let _ = fs::remove_file(path);
         }
     }
 
@@ -508,7 +515,7 @@ impl TypedefLocator {
 
         if is_local
             && let Some(stamp) = self.local_stamp_value()
-            && let Err(error) = crate::local_source::gate_local_typedef(&typedef_path, stamp)
+            && let Err(error) = local_source::gate_local_typedef(&typedef_path, stamp)
         {
             return TypedefLocatorResult::UnreadableTypedef {
                 path: typedef_path,
@@ -563,8 +570,8 @@ fn collect_cached_packages(
 ) {
     let last_segment = package_path.rsplit('/').next().unwrap_or(package_path);
     let typedef = dir.join(format!("{last_segment}.d.lis"));
-    let fresh = local_stamp
-        .is_none_or(|stamp| crate::local_source::local_typedef_is_fresh(&typedef, stamp));
+    let fresh =
+        local_stamp.is_none_or(|stamp| local_source::local_typedef_is_fresh(&typedef, stamp));
     if fresh && typedef.is_file() {
         out.push(ImportablePackage {
             path: package_path.to_string(),
@@ -572,7 +579,7 @@ fn collect_cached_packages(
         });
     }
 
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
@@ -602,9 +609,9 @@ enum ReadOutcome {
 }
 
 fn read_typedef(path: &Path) -> ReadOutcome {
-    match std::fs::read_to_string(path) {
+    match fs::read_to_string(path) {
         Ok(s) => ReadOutcome::Found(s),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReadOutcome::Missing,
+        Err(e) if e.kind() == ErrorKind::NotFound => ReadOutcome::Missing,
         Err(e) => ReadOutcome::Unreadable(e.to_string()),
     }
 }
@@ -628,10 +635,11 @@ fn read_cached_typedef(path: &Path) -> Option<TypedefLocatorResult> {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use std::fs;
 
     fn write_typedef(path: &Path, content: &str) {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, content).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
     }
 
     #[test]
@@ -770,13 +778,13 @@ mod tests {
     fn local_project(module: &str, path: &str) -> (tempfile::TempDir, TypedefLocator) {
         let project = tempfile::tempdir().unwrap();
         let module_dir = project.path().join(path);
-        std::fs::create_dir_all(&module_dir).unwrap();
-        std::fs::write(
+        fs::create_dir_all(&module_dir).unwrap();
+        fs::write(
             module_dir.join("go.mod"),
             format!("module {}\n\ngo 1.25\n", module),
         )
         .unwrap();
-        std::fs::write(module_dir.join("lib.go"), "package lib\n").unwrap();
+        fs::write(module_dir.join("lib.go"), "package lib\n").unwrap();
 
         let mut deps = BTreeMap::new();
         deps.insert(
@@ -806,15 +814,15 @@ mod tests {
             package: module,
         };
         let typedef_path = pkg.typedef_path(&typedef_cache_dir(project.path()), Target::host());
-        std::fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
-        std::fs::write(&typedef_path, "// Generated\n").unwrap();
+        fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
+        fs::write(&typedef_path, "// Generated\n").unwrap();
 
         match locator.find_typedef_content(module) {
             TypedefLocatorResult::MissingTypedef { local, .. } => assert!(local),
             other => panic!("expected MissingTypedef after gate, got {:?}", other),
         }
 
-        std::fs::write(&typedef_path, "// Generated\n").unwrap();
+        fs::write(&typedef_path, "// Generated\n").unwrap();
         let same = TypedefLocator::new(
             locator.deps().clone(),
             Some(project.path().to_path_buf()),
@@ -825,7 +833,7 @@ mod tests {
             TypedefLocatorResult::Found { .. }
         ));
 
-        std::fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
+        fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
         let edited = TypedefLocator::new(
             locator.deps().clone(),
             Some(project.path().to_path_buf()),
@@ -855,7 +863,7 @@ mod tests {
         let stamp = locator
             .local_stamp_value()
             .expect("a local module is declared");
-        std::fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
+        fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
 
         let is_offered = |locator: &TypedefLocator| {
             locator
@@ -865,7 +873,7 @@ mod tests {
         };
         assert!(is_offered(&locator));
 
-        std::fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
+        fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
         assert!(
             is_offered(&locator),
             "this locator answered once already and holds that answer"
@@ -895,7 +903,7 @@ mod tests {
         let stamp = locator
             .local_stamp_value()
             .expect("a declared local module has a stamp");
-        std::fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
+        fs::write(typedef_path.with_file_name("foo.stamp"), stamp).unwrap();
 
         let is_offered = |locator: &TypedefLocator| {
             locator
@@ -905,7 +913,7 @@ mod tests {
         };
         assert!(is_offered(&locator), "a stamped typedef is current");
 
-        std::fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
+        fs::write(project.path().join("foo/lib.go"), "package lib // edited\n").unwrap();
         let edited = TypedefLocator::new(
             locator.deps().clone(),
             Some(project.path().to_path_buf()),

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::graphical::FrameLabel;
+use std::cmp::Ordering;
+use std::error::Error;
 use syntax::ParseError;
 use syntax::ast::Span;
 
@@ -165,7 +167,7 @@ impl fmt::Display for LisetteDiagnostic {
     }
 }
 
-impl std::error::Error for LisetteDiagnostic {}
+impl Error for LisetteDiagnostic {}
 
 fn style_help(text: &str, use_color: bool) -> String {
     if use_color {
@@ -501,7 +503,7 @@ impl LisetteDiagnostic {
         self.severity == Severity::Advice
     }
 
-    pub fn sort_key(a: &Self, b: &Self) -> std::cmp::Ordering {
+    pub fn sort_key(a: &Self, b: &Self) -> Ordering {
         a.file_id()
             .cmp(&b.file_id())
             .then_with(|| a.primary_offset().cmp(&b.primary_offset()))

--- a/crates/diagnostics/src/emit.rs
+++ b/crates/diagnostics/src/emit.rs
@@ -1,4 +1,5 @@
 use crate::LisetteDiagnostic;
+use crate::pattern;
 use syntax::ast::Span;
 
 pub fn go_name_collision(
@@ -73,7 +74,7 @@ pub fn go_import_collision(
              Add an alias to at least one of them in your source: \
              `import my_{} \"go:{}\"`. \
              One of these may have been pulled in transitively by a typedef.",
-            crate::pattern::join_and(&packages),
+            pattern::join_and(&packages),
             if packages.len() == 2 { "both" } else { "all" },
             alias,
             alias,

--- a/crates/diagnostics/src/fix.rs
+++ b/crates/diagnostics/src/fix.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use syntax::ast::Span;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,7 +67,7 @@ impl Fix {
     }
 
     pub fn edits(&self) -> impl Iterator<Item = &Edit> + Clone {
-        std::iter::once(&self.first).chain(self.rest.iter())
+        iter::once(&self.first).chain(self.rest.iter())
     }
 
     pub(crate) fn file_id(&self) -> u32 {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1,4 +1,7 @@
 use crate::LisetteDiagnostic;
+use crate::pattern;
+use std::fmt::Display;
+use std::mem;
 use syntax::ast::{Annotation, BinaryOperator, BindingKind, Span};
 use syntax::types::{SimpleKind, Type};
 
@@ -2932,7 +2935,7 @@ pub fn enum_spread_missing_fields(
         ("field", "it", format!("`{}`", missing[0]))
     } else {
         let formatted: Vec<String> = missing.iter().map(|f| format!("`{}`", f)).collect();
-        ("fields", "them", crate::pattern::join_and(&formatted))
+        ("fields", "them", pattern::join_and(&formatted))
     };
 
     let (label, help) = match counterexample {
@@ -3360,7 +3363,7 @@ pub fn levenshtein_distance(a: &str, b: &str) -> usize {
             let cost = if a_char == b_char { 0 } else { 1 };
             curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
         }
-        std::mem::swap(&mut prev, &mut curr);
+        mem::swap(&mut prev, &mut curr);
     }
 
     prev[b_len]
@@ -4132,7 +4135,7 @@ pub fn array_new_cannot_infer_size(span: Span) -> LisetteDiagnostic {
         .with_help("Write the type arguments, e.g. `Array.new<int, 3>()`, or annotate the binding")
 }
 
-pub fn array_new_no_zero(element: &dyn std::fmt::Display, span: Span) -> LisetteDiagnostic {
+pub fn array_new_no_zero(element: &dyn Display, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("`{element}` has no zero value"))
         .with_infer_code("array_new_no_zero")
         .with_span_label(
@@ -4168,7 +4171,7 @@ pub fn channel_no_make_constructor(span: Span) -> LisetteDiagnostic {
 }
 
 pub fn slice_make_no_zero(
-    element: &dyn std::fmt::Display,
+    element: &dyn Display,
     hidden_go_state: Option<&str>,
     span: Span,
 ) -> LisetteDiagnostic {
@@ -4190,7 +4193,7 @@ pub fn slice_make_no_zero(
         .with_help(help)
 }
 
-pub fn hidden_state_no_zero(type_name: &dyn std::fmt::Display, span: Span) -> LisetteDiagnostic {
+pub fn hidden_state_no_zero(type_name: &dyn Display, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("`{type_name}` has no zero value"))
         .with_infer_code("hidden_state_no_zero")
         .with_span_label(&span, "no zero available")

--- a/crates/diagnostics/src/package_graph.rs
+++ b/crates/diagnostics/src/package_graph.rs
@@ -1,4 +1,5 @@
 use crate::LisetteDiagnostic;
+use std::path::Path;
 use syntax::ast::Span;
 
 pub enum MissingPackageReason {
@@ -399,7 +400,7 @@ pub fn corrupt_go_typedef(go_pkg: &str, discarded: bool, script: bool) -> Lisett
         .with_help(help)
 }
 
-pub fn unreadable_go_typedef(path: &std::path::Path, error: &str, span: Span) -> LisetteDiagnostic {
+pub fn unreadable_go_typedef(path: &Path, error: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Failed to read Go typedef")
         .with_resolve_code("unreadable_go_typedef")
         .with_span_label(&span, "typedef exists but could not be read")

--- a/crates/diagnostics/src/render.rs
+++ b/crates/diagnostics/src/render.rs
@@ -7,6 +7,7 @@ use crate::LisetteDiagnostic;
 use crate::diagnostic::IndexedSource;
 use crate::graphical::{self, FrameReport, FrameSource, FrameTheme};
 use owo_colors::{OwoColorize, Style};
+use std::env;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OutputFormat {
@@ -55,7 +56,7 @@ pub fn print_summary(
     info: usize,
 ) {
     let time_string = format_time(elapsed);
-    let use_color = std::env::var("NO_COLOR").is_err();
+    let use_color = env::var("NO_COLOR").is_err();
     let time_display = if use_color {
         format!("({})", time_string).dimmed().to_string()
     } else {
@@ -302,7 +303,7 @@ pub fn render_all(
         eprintln!(); // Blank line before first diagnostic
     }
 
-    let use_color = std::env::var("NO_COLOR").is_err();
+    let use_color = env::var("NO_COLOR").is_err();
 
     render_group(&groups.errors, use_color, &mut sources);
     render_group(&groups.warnings, use_color, &mut sources);

--- a/crates/emit/src/abi/catalog.rs
+++ b/crates/emit/src/abi/catalog.rs
@@ -6,6 +6,7 @@ use crate::abi::callable::CallableReturnAbi;
 use crate::abi::layout::SlotOrigin;
 use crate::classify_go_return_type;
 use crate::names::go_name;
+use syntax::types;
 
 #[derive(Debug, Default)]
 pub(crate) struct GoAbiCatalog {
@@ -94,15 +95,14 @@ impl GoAbiCatalog {
             .params
             .iter()
             .map(|parameter| GoSlotDescriptor {
-                origin: SlotOrigin::go_parameter(syntax::types::resolves_to_unknown(
-                    &parameter.ty,
-                    |id| definitions.get(id),
-                )),
+                origin: SlotOrigin::go_parameter(types::resolves_to_unknown(&parameter.ty, |id| {
+                    definitions.get(id)
+                })),
                 declared_type: parameter.ty.clone(),
             })
             .collect();
         let return_slot = GoSlotDescriptor {
-            origin: SlotOrigin::go_return(syntax::types::resolves_to_unknown(
+            origin: SlotOrigin::go_return(types::resolves_to_unknown(
                 &function.return_type,
                 |id| definitions.get(id),
             )),
@@ -133,10 +133,9 @@ impl GoAbiCatalog {
             slots.insert(
                 field.name.to_string(),
                 GoSlotDescriptor {
-                    origin: SlotOrigin::go_field(syntax::types::resolves_to_unknown(
-                        &field.ty,
-                        |id| definitions.get(id),
-                    )),
+                    origin: SlotOrigin::go_field(types::resolves_to_unknown(&field.ty, |id| {
+                        definitions.get(id)
+                    })),
                     declared_type: field.ty.clone(),
                 },
             );

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -15,6 +15,7 @@ use crate::plan::bodies::{
 };
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::write_line;
+use syntax::ast::Expression;
 use syntax::parse::TUPLE_FIELDS;
 
 /// A bare `return v0, v1, ...` statement leaf.
@@ -593,7 +594,7 @@ pub(crate) fn lower_arg_to_tagged(
 /// path handled the emission.
 pub(crate) fn try_emit_lowered_tail_return(
     planner: &mut Planner,
-    expression: &syntax::ast::Expression,
+    expression: &Expression,
 ) -> Option<Vec<LoweredStatement>> {
     let shape = planner.return_ctx().lowered_shape()?;
     match shape {
@@ -607,7 +608,7 @@ pub(crate) fn try_emit_lowered_tail_return(
 
 fn lowered_tail_fallback(
     planner: &mut Planner,
-    expression: &syntax::ast::Expression,
+    expression: &Expression,
     return_ty: &Type,
     shape: &CallableReturnAbi,
     hoist_hint: Option<&str>,
@@ -627,10 +628,10 @@ fn lowered_tail_fallback(
 
 fn emit_lowered_tuple_tail(
     planner: &mut Planner,
-    expression: &syntax::ast::Expression,
+    expression: &Expression,
     arity: usize,
 ) -> Vec<LoweredStatement> {
-    use syntax::ast::Expression;
+    use Expression;
     if let Expression::Tuple { elements, .. } = expression
         && elements.len() == arity
     {
@@ -666,9 +667,9 @@ fn emit_lowered_tuple_tail(
 
 fn emit_lowered_partial_tail(
     planner: &mut Planner,
-    expression: &syntax::ast::Expression,
+    expression: &Expression,
 ) -> Vec<LoweredStatement> {
-    use syntax::ast::Expression;
+    use Expression;
     let return_ty = planner.return_ctx().expect_ty();
 
     if let Expression::Call {
@@ -727,10 +728,10 @@ fn emit_lowered_partial_tail(
 /// project at runtime.
 fn lower_nullable_slot_value(
     planner: &mut Planner,
-    expression: &syntax::ast::Expression,
+    expression: &Expression,
     slot_ty: &Type,
 ) -> ValuePlan {
-    use syntax::ast::Expression;
+    use Expression;
     if let Expression::Call {
         expression: callee,
         args,

--- a/crates/emit/src/analyze/collisions.rs
+++ b/crates/emit/src/analyze/collisions.rs
@@ -1,9 +1,12 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, emit as emit_diag};
+use syntax::ast::Generic;
 use syntax::ast::{
     EnumVariant, Expression, ImportAlias, Pattern, Span, StructFields, VariantFields, Visibility,
 };
+use syntax::attributes;
+use syntax::go_names;
 use syntax::program::File;
 
 use crate::Planner;
@@ -152,7 +155,7 @@ impl Planner<'_> {
         self.check_reserved_prefix(name, name_span, diagnostics);
         self.check_reserved_prefix(&go, name_span, diagnostics);
         package_block.entry(go).or_default().push(*name_span);
-        if syntax::attributes::has_test_attribute(attributes) {
+        if attributes::has_test_attribute(attributes) {
             let wrapper = go_name::go_test_function_name(name);
             package_block.entry(wrapper).or_default().push(*name_span);
         }
@@ -402,7 +405,7 @@ impl Planner<'_> {
         members: &mut SpanMap,
         diagnostics: &mut Vec<LisetteDiagnostic>,
     ) {
-        let slots = syntax::go_names::enum_field_slots(name, variants);
+        let slots = go_names::enum_field_slots(name, variants);
         let mut seen: HashSet<String> = HashSet::default();
         for (variant_index, variant) in variants.iter().enumerate() {
             let field_names = &slots[variant_index];
@@ -622,7 +625,7 @@ impl Planner<'_> {
 
     fn check_reserved_qualifier_generics(
         &self,
-        generics: &[syntax::ast::Generic],
+        generics: &[Generic],
         out: &mut Vec<LisetteDiagnostic>,
     ) {
         let mut emitted: SpanMap = HashMap::default();
@@ -638,8 +641,8 @@ impl Planner<'_> {
 
     fn check_free_function_generics(
         &self,
-        impl_generics: &[syntax::ast::Generic],
-        method_generics: &[syntax::ast::Generic],
+        impl_generics: &[Generic],
+        method_generics: &[Generic],
         out: &mut Vec<LisetteDiagnostic>,
     ) {
         let mut emitted: SpanMap = HashMap::default();

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -3,11 +3,14 @@ use std::sync::Arc;
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use std::sync::LazyLock;
 use syntax::ast::{BindingId, Pattern, RestPattern, Span};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, Method, MutationInfo, PackageId, TestIndex,
     UnusedInfo,
 };
+use syntax::types;
+use syntax::types::SimpleKind;
 use syntax::types::{Symbol, Type};
 
 use crate::abi::callable::CallableReturnAbi;
@@ -75,10 +78,7 @@ impl<'a> EmitFacts<'a> {
     where
         'a: 'b,
     {
-        syntax::types::package_for_qualified_name(
-            id,
-            self.go_package_ids.iter().map(String::as_str),
-        )
+        types::package_for_qualified_name(id, self.go_package_ids.iter().map(String::as_str))
     }
 
     pub(crate) fn definition(&self, id: &str) -> Option<&'a Definition> {
@@ -107,27 +107,27 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn underlying_type(&self, ty: &Type) -> Option<Type> {
-        syntax::types::underlying_type(ty, |id| self.definition(id))
+        types::underlying_type(ty, |id| self.definition(id))
     }
 
-    pub(crate) fn underlying_simple_kind(&self, ty: &Type) -> Option<syntax::types::SimpleKind> {
-        syntax::types::underlying_simple_kind(ty, |id| self.definition(id))
+    pub(crate) fn underlying_simple_kind(&self, ty: &Type) -> Option<SimpleKind> {
+        types::underlying_simple_kind(ty, |id| self.definition(id))
     }
 
     pub(crate) fn underlying_numeric_type(&self, ty: &Type) -> Option<Type> {
-        syntax::types::underlying_numeric_type(ty, |id| self.definition(id))
+        types::underlying_numeric_type(ty, |id| self.definition(id))
     }
 
     pub(crate) fn is_aliased_numeric_type(&self, ty: &Type) -> bool {
-        syntax::types::is_aliased_numeric_type(ty, |id| self.definition(id))
+        types::is_aliased_numeric_type(ty, |id| self.definition(id))
     }
 
     pub(crate) fn resolves_to_unknown(&self, ty: &Type) -> bool {
-        syntax::types::resolves_to_unknown(ty, |id| self.definition(id))
+        types::resolves_to_unknown(ty, |id| self.definition(id))
     }
 
     pub(crate) fn contains_unknown(&self, ty: &Type) -> bool {
-        syntax::types::contains_unknown(ty, |id| self.definition(id))
+        types::contains_unknown(ty, |id| self.definition(id))
     }
 
     pub(crate) fn strip_and_peel(&self, ty: &Type) -> Type {
@@ -182,8 +182,7 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn unused_imports_for_current_package(&self) -> &'a HashSet<EcoString> {
-        static EMPTY: std::sync::LazyLock<HashSet<EcoString>> =
-            std::sync::LazyLock::new(HashSet::default);
+        static EMPTY: LazyLock<HashSet<EcoString>> = LazyLock::new(HashSet::default);
         self.unused
             .imports_by_package
             .get(self.current_package.as_str())
@@ -282,7 +281,7 @@ impl<'a> EmitFacts<'a> {
             .iter()
             .any(|variant| variant.name == variant_name)
             .then(|| {
-                let enum_name = syntax::types::unqualified_name(enum_id);
+                let enum_name = types::unqualified_name(enum_id);
                 let make_function = go_name::enum_make_function(enum_name, variant_name);
                 if enum_id.starts_with(go_name::PRELUDE_PREFIX) {
                     format!("{}{}", go_name::PRELUDE_PREFIX, make_function)
@@ -343,7 +342,7 @@ pub(crate) fn is_nullable_option(definitions: &HashMap<Symbol, Definition>, ty: 
 }
 
 fn is_nilable_go_type(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> bool {
-    syntax::types::is_nilable_go_type(ty, |id| definitions.get(id))
+    types::is_nilable_go_type(ty, |id| definitions.get(id))
 }
 
 fn as_interface(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Option<String> {
@@ -362,10 +361,10 @@ fn resolve_to_function_type(definitions: &HashMap<Symbol, Definition>, ty: &Type
     if matches!(resolved, Type::Function(_)) {
         return Some(resolved);
     }
-    syntax::types::underlying_type(ty, |id| definitions.get(id))
+    types::underlying_type(ty, |id| definitions.get(id))
         .filter(|underlying| matches!(underlying, Type::Function(_)))
 }
 
 fn peel_alias(definitions: &HashMap<Symbol, Definition>, ty: &Type) -> Type {
-    syntax::types::peel_alias(ty, |id| definitions.get(id))
+    types::peel_alias(ty, |id| definitions.get(id))
 }

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -9,7 +9,9 @@ use crate::definitions::structs::is_raw_function_type;
 use crate::names::go_name;
 use syntax::ast::{Generic, Pattern, RestPattern, StructFields};
 use syntax::containment::enum_payload_pointer_wrapped;
+use syntax::go_names;
 use syntax::program::{Definition, DefinitionBody, interface_requirements};
+use syntax::types;
 use syntax::types::{Type, substitute};
 
 impl Planner<'_> {
@@ -60,7 +62,7 @@ impl Planner<'_> {
         match &resolved.definition.body {
             DefinitionBody::Struct { fields, .. } => {
                 if let Some(field) = fields.iter().find(|f| f.name == field_name) {
-                    return syntax::go_names::struct_field_is_exported(
+                    return go_names::struct_field_is_exported(
                         field,
                         resolved.definition.is_serialized(),
                     );
@@ -249,7 +251,7 @@ impl Planner<'_> {
             return None;
         };
 
-        let name = syntax::types::unqualified_name(enum_id);
+        let name = types::unqualified_name(enum_id);
         if name == "Option" || name == "Result" || name == "Partial" {
             return None;
         }

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -6,6 +6,7 @@ use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
+use std::iter;
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -75,7 +76,7 @@ impl Planner<'_> {
         let all_vars: Vec<&str> = val_vars
             .iter()
             .map(|s| s.as_str())
-            .chain(std::iter::once(ok_var.as_str()))
+            .chain(iter::once(ok_var.as_str()))
             .collect();
         statements.push(LoweredStatement::RawGo(format!(
             "{} := {}\n",

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -10,6 +10,7 @@ use crate::plan::values::{CaptureBoundary, EvaluationEffect, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
 use crate::utils::reads_mutable_operand;
+use std::iter;
 use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
 use syntax::program::{CallKind, DotAccessKind, NativeTypeKind};
 use syntax::types::{CompoundKind, Type, peel_to_range_type};
@@ -314,7 +315,7 @@ fn render_inline(template: &str, receiver: &str, args: &[String]) -> String {
         result = result.replace("{args}", &args.join(", "));
     }
     if result.contains("{r+args}") {
-        let all = std::iter::once(receiver.to_string())
+        let all = iter::once(receiver.to_string())
             .chain(args.iter().cloned())
             .collect::<Vec<_>>()
             .join(", ");

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -2,6 +2,7 @@ use crate::abi::is_tagged_shape_fn_value;
 use crate::calls::dispatch::{
     CallArgShape, all_type_params_inferrable, is_prelude_variant_constructor,
 };
+use syntax::types::FunctionParameter;
 
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableParamAbi, CallableReturnAbi};
@@ -681,7 +682,7 @@ impl<'a> Planner<'a> {
     pub(crate) fn try_emit_variadic_spread_adapter(
         &mut self,
         spread: &Expression,
-        generic_params: Option<&[syntax::types::FunctionParameter]>,
+        generic_params: Option<&[FunctionParameter]>,
     ) -> Option<ValuePlan> {
         let generic_params = generic_params?;
         let raw_variadic = generic_params.last()?;

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -24,7 +24,7 @@ struct SelectReceiveContext<'a> {
     body: &'a Expression,
     default_body: Option<&'a Expression>,
     retry_var: Option<&'a str>,
-    element_ty: syntax::types::Type,
+    element_ty: Type,
     place: &'a PlacePlan<'a>,
 }
 
@@ -495,7 +495,7 @@ impl Planner<'_> {
         &mut self,
         match_arms: &[MatchArm],
         channel: &str,
-        element_ty: &syntax::types::Type,
+        element_ty: &Type,
         place: &PlacePlan,
     ) -> SelectArmPlan {
         self.with_binding_frame(|this| {

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -5,6 +5,8 @@ use crate::names::go_name;
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use syntax::ast::{EnumVariant, Generic};
 
+use syntax::go_names;
+use syntax::go_names::EnumFieldShape;
 pub(crate) use syntax::go_names::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_METHOD, ENUM_TAG_FIELD};
 
 #[derive(Debug, Clone)]
@@ -52,7 +54,7 @@ impl EnumLayout {
         let enum_name = go_name::unqualified_name(enum_id).to_string();
         let tag_type = format!("{}Tag", enum_name);
 
-        let slots = syntax::go_names::enum_field_slots(&enum_name, variants);
+        let slots = go_names::enum_field_slots(&enum_name, variants);
         let variants = variants
             .iter()
             .enumerate()
@@ -76,15 +78,15 @@ impl EnumLayout {
     ) -> VariantLayout {
         let tag_constant = go_name::enum_tag_constant(enum_name, &variant.name);
 
-        let field_shape = syntax::go_names::enum_field_shape(&variant.fields)
-            .unwrap_or(syntax::go_names::EnumFieldShape::TupleMultiple);
+        let field_shape =
+            go_names::enum_field_shape(&variant.fields).unwrap_or(EnumFieldShape::TupleMultiple);
 
         let fields = variant
             .fields
             .iter()
             .enumerate()
             .map(|(fi, field)| {
-                let source_name = if field_shape == syntax::go_names::EnumFieldShape::Struct {
+                let source_name = if field_shape == EnumFieldShape::Struct {
                     field.name.to_string()
                 } else {
                     fi.to_string()
@@ -112,7 +114,7 @@ impl EnumLayout {
         VariantLayout {
             name: variant.name.to_string(),
             tag_constant,
-            is_struct_variant: field_shape == syntax::go_names::EnumFieldShape::Struct,
+            is_struct_variant: field_shape == EnumFieldShape::Struct,
             fields,
             doc: variant.doc.clone(),
         }

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -8,6 +8,7 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::patterns::sites::PatternSubject;
 use crate::plan::bodies::LoweredBlock;
+use crate::state::package_state::FunctionEmissionContext;
 use crate::types::native::NativeGoType;
 use crate::utils::{group_params, receiver_name};
 use syntax::EcoString;
@@ -543,10 +544,7 @@ impl Planner<'_> {
                     .then(|| name.to_string())
             })
             .collect();
-        let context = crate::state::package_state::FunctionEmissionContext::for_function(
-            generic_context,
-            absorbed_ref_generics,
-        );
+        let context = FunctionEmissionContext::for_function(generic_context, absorbed_ref_generics);
         self.function_contexts.push(context);
         let result = f(self);
         self.function_contexts

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -637,7 +637,7 @@ pub(crate) fn is_breakless_loop(expression: &Expression) -> bool {
 
 /// Renamed definition parts for methods on native Go receiver types; the
 /// caller rebinds its view to borrow these.
-type NativeMethodOverride = (ecow::EcoString, Vec<Binding>);
+type NativeMethodOverride = (EcoString, Vec<Binding>);
 
 fn change_go_builtin_methods(
     function_definition: FunctionDefinitionView<'_>,

--- a/crates/emit/src/definitions/interface_adapter.rs
+++ b/crates/emit/src/definitions/interface_adapter.rs
@@ -6,6 +6,8 @@ use crate::names::go_name::GO_IMPORT_PREFIX;
 use crate::write_line;
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
+use syntax::go_names;
+use syntax::go_names::ConformanceCandidate;
 use syntax::program::{Definition, DefinitionBody, interface_requirements};
 use syntax::types::{
     SubstitutionMap, Symbol, Type, build_substitution_map, substitute, unqualified_name,
@@ -108,7 +110,7 @@ impl Planner<'_> {
             _ => return None,
         };
 
-        let own_candidate = |name: &str| syntax::go_names::ConformanceCandidate::Resolved {
+        let own_candidate = |name: &str| ConformanceCandidate::Resolved {
             depth: 0,
             owner: source_id.as_eco().clone(),
             shadowed: self.facts.is_ufcs_method(source_id.as_str(), name),
@@ -127,7 +129,7 @@ impl Planner<'_> {
             if !seen.insert(selector) {
                 continue;
             }
-            let (_, impl_ty) = syntax::go_names::conformance_method(
+            let (_, impl_ty) = go_names::conformance_method(
                 impl_methods,
                 requirement.declaring_interface.as_str(),
                 self.facts

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -7,6 +7,8 @@ use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use rustc_hash::FxHashSet;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructFields};
 use syntax::attributes::struct_attribute_forces_field_export;
+use syntax::go_names;
+use syntax::program::MethodOrigin;
 use syntax::program::{Definition, DefinitionBody, Methods, interface_requirements};
 use syntax::types::Type;
 
@@ -400,8 +402,7 @@ impl Planner<'_> {
             .facts
             .method(&qualified, "to_string")
             .is_some_and(|method| {
-                matches!(method.origin, syntax::program::MethodOrigin::Declared)
-                    && method.ty.is_stringer_signature()
+                matches!(method.origin, MethodOrigin::Declared) && method.ty.is_stringer_signature()
             })
             && !self.facts.is_ufcs_method(&qualified, "to_string");
         !has_user_method
@@ -519,7 +520,7 @@ pub(crate) fn struct_field_go_name(
     let struct_forces_export = struct_attrs
         .iter()
         .any(struct_attribute_forces_field_export);
-    syntax::go_names::struct_field_go_name(field, struct_forces_export).into_owned()
+    go_names::struct_field_go_name(field, struct_forces_export).into_owned()
 }
 
 struct StringerField {
@@ -593,9 +594,9 @@ fn definition_emits_go_string_field(definition: &Definition) -> bool {
         return false;
     };
     let forces_export = definition.is_serialized();
-    fields.iter().any(|field| {
-        syntax::go_names::struct_field_go_name(field, forces_export) == ENUM_STRINGER_METHOD
-    })
+    fields
+        .iter()
+        .any(|field| go_names::struct_field_go_name(field, forces_export) == ENUM_STRINGER_METHOD)
 }
 
 fn type_methods(definition: &Definition) -> Option<&Methods> {

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -1,4 +1,5 @@
 use syntax::ast::{Expression, StructFields};
+use syntax::parse;
 use syntax::program::{
     Definition, DefinitionBody, DotAccessKind as SemanticDotKind, ReceiverCoercion,
 };
@@ -175,7 +176,7 @@ impl Planner<'_> {
         };
         match dot_access_kind {
             Some(SemanticDotKind::TupleElement) => {
-                let field = syntax::parse::TUPLE_FIELDS
+                let field = parse::TUPLE_FIELDS
                     .get(index)
                     .expect("oversize tuple arity");
                 Some(format!("{}.{}", expression_string, field))

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -14,6 +14,9 @@ use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::utils::is_order_sensitive;
+use syntax::program::AliasKind;
+use syntax::types;
+use syntax::types::SubstitutionMap;
 
 struct SpreadInput<'a> {
     base: &'a Expression,
@@ -298,7 +301,7 @@ impl Planner<'_> {
         let is_opaque = matches!(
             self.facts.definition(id).map(|d| &d.body),
             Some(DefinitionBody::TypeAlias {
-                alias: syntax::program::AliasKind::Opaque(_),
+                alias: AliasKind::Opaque(_),
                 ..
             })
         );
@@ -710,40 +713,40 @@ fn layout_is_map(layout: &ValueLayout) -> bool {
     }
 }
 
-fn forall_substitution(definition_ty: &Type, params: &[Type]) -> syntax::types::SubstitutionMap {
+fn forall_substitution(definition_ty: &Type, params: &[Type]) -> SubstitutionMap {
     if let Type::Forall { vars, .. } = definition_ty
         && !vars.is_empty()
         && vars.len() == params.len()
     {
         generics_substitution(vars.iter().cloned(), params)
     } else {
-        syntax::types::SubstitutionMap::default()
+        SubstitutionMap::default()
     }
 }
 
 fn generics_substitution(
     vars: impl Iterator<Item = ecow::EcoString>,
     params: &[Type],
-) -> syntax::types::SubstitutionMap {
-    let mut map = syntax::types::SubstitutionMap::default();
+) -> SubstitutionMap {
+    let mut map = SubstitutionMap::default();
     for (var, param) in vars.zip(params.iter()) {
         map.insert(var, param.clone());
     }
     map
 }
 
-fn apply_substitution(ty: &Type, map: &syntax::types::SubstitutionMap) -> Type {
+fn apply_substitution(ty: &Type, map: &SubstitutionMap) -> Type {
     if map.is_empty() {
         ty.clone()
     } else {
-        syntax::types::substitute(ty, map)
+        types::substitute(ty, map)
     }
 }
 
 fn unspecified_pairs<'a>(
     fields: impl Iterator<Item = (&'a ecow::EcoString, &'a Type)>,
     assigned: &HashSet<&str>,
-    map: &syntax::types::SubstitutionMap,
+    map: &SubstitutionMap,
 ) -> Vec<(ecow::EcoString, Type)> {
     fields
         .filter(|(name, _)| !assigned.contains(name.as_str()))

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -4,6 +4,7 @@ use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::plan::values::GoExpression;
 use crate::state::bindings::BindingValue;
+use syntax::types::FunctionParameter;
 use syntax::types::{Type, unqualified_name};
 
 enum IdentifierKind {
@@ -145,7 +146,7 @@ impl Planner<'_> {
     /// inferred from the parameter types.
     fn constructor_fn_type_args(
         &mut self,
-        fn_params: &[syntax::types::FunctionParameter],
+        fn_params: &[FunctionParameter],
         ret_params: &[Type],
         ctx: ExpressionContext<'_>,
     ) -> String {

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -181,11 +181,11 @@ impl Planner<'_> {
     pub(crate) fn stage_prelude_arg(
         &mut self,
         expression: &Expression,
-        declared_param: Option<&syntax::types::Type>,
-        param_ty: Option<&syntax::types::Type>,
+        declared_param: Option<&Type>,
+        param_ty: Option<&Type>,
     ) -> ValuePlan {
-        let suppress = declared_param
-            .is_some_and(|p| matches!(p.unwrap_forall(), syntax::types::Type::Function(_)));
+        let suppress =
+            declared_param.is_some_and(|p| matches!(p.unwrap_forall(), Type::Function(_)));
         let arg_ctx = ExpressionContext::value().with_forced_tagged_go_function(suppress);
         let staged = self.stage_composite(expression, arg_ctx);
 

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -8,6 +8,8 @@ use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, Stability, ValuePlan,
 };
+use std::iter;
+use std::mem;
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::types::{FunctionParameter, Type};
 
@@ -43,8 +45,8 @@ impl Planner<'_> {
     /// Pin a staged operand's value into a temp so it evaluates before any
     /// later sibling.
     pub(crate) fn pin_staged(&mut self, staged: &mut ValuePlan, prefix: &str) {
-        let value = std::mem::replace(&mut staged.expression, GoExpression::opaque(String::new()))
-            .rendered();
+        let value =
+            mem::replace(&mut staged.expression, GoExpression::opaque(String::new())).rendered();
         let tmp = self.hoist_tmp_value_statement(&mut staged.setup, prefix, &value);
         staged.replace_with_pinned_name(tmp);
     }
@@ -301,7 +303,7 @@ impl Planner<'_> {
                 let combined = format!("append([]{element_go}{{{leading}}}, {spread_value}...)...");
                 values.splice(
                     c.fixed_count..=spread_index,
-                    std::iter::once(GoExpression::opaque_with_deferred_evaluation(
+                    iter::once(GoExpression::opaque_with_deferred_evaluation(
                         combined, true,
                     )),
                 );
@@ -370,11 +372,11 @@ impl Planner<'_> {
         let mut results = Vec::with_capacity(stages.len());
         for i in 0..stages.len() {
             let s_non_literal = !stages[i].evaluation.stability.is_fixed();
-            let s_expression = std::mem::replace(
+            let s_expression = mem::replace(
                 &mut stages[i].expression,
                 GoExpression::opaque(String::new()),
             );
-            let s_setup = std::mem::take(&mut stages[i].setup);
+            let s_setup = mem::take(&mut stages[i].setup);
 
             setup.extend(s_setup);
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -50,6 +50,7 @@ use state::file_namespace::FileNamespace;
 use state::package_state::{FunctionEmissionContext, PackageState};
 use state::scope::ScopeState;
 use syntax::ast::{Expression, Span};
+use syntax::program;
 use syntax::program::{
     Definition, DefinitionBody, EmitInput, EqualityIndex, File, MutationInfo, TestIndex, UnusedInfo,
 };
@@ -64,7 +65,7 @@ pub struct EmitOptions {
 
 /// A library root's Go package name, from its package path (`example.com/lib/v2` -> `lib`).
 pub fn root_package_name(go_module: &str) -> String {
-    go_name::sanitize_package_name(syntax::program::go_import_default_name(go_module)).into_owned()
+    go_name::sanitize_package_name(program::go_import_default_name(go_module)).into_owned()
 }
 
 #[derive(Default)]

--- a/crates/emit/src/names/resolution.rs
+++ b/crates/emit/src/names/resolution.rs
@@ -3,6 +3,7 @@ use syntax::types::unqualified_name;
 use crate::Planner;
 use crate::names::go_name;
 use crate::names::packages::{PackageRequirements, PackageUse};
+use syntax::program;
 
 impl Planner<'_> {
     /// A `locally_bound` name must not be rewritten by a package-level remap
@@ -150,7 +151,7 @@ impl Planner<'_> {
             .map(str::to_string)
             .or_else(|| self.facts.go_package_name(package).map(str::to_string))
             .unwrap_or_else(|| match package.strip_prefix(go_name::GO_IMPORT_PREFIX) {
-                Some(go_path) => syntax::program::go_import_default_name(go_path).to_string(),
+                Some(go_path) => program::go_import_default_name(go_path).to_string(),
                 None => go_name::go_package_name(package).to_string(),
             });
         let qualifier = if qualifier == go_name::go_package_name(&path) {

--- a/crates/emit/src/output/imports.rs
+++ b/crates/emit/src/output/imports.rs
@@ -7,6 +7,7 @@ use syntax::ast::ImportAlias;
 use syntax::program::{File, FileImport, PackageId};
 
 use crate::names::packages::{PackageRequirements, PackageUse};
+use syntax::program;
 
 /// Source-derived imports resolved during the plan phase: path -> chosen
 /// alias, plus the aliases of imports dropped as unused (still needed so a
@@ -189,7 +190,7 @@ fn effective_qualifier(path: &str, alias: &str, go_package_ids: &HashSet<String>
     let package_name = if !alias.is_empty() {
         alias
     } else if go_package_ids.contains(&format!("{}{path}", go_name::GO_IMPORT_PREFIX)) {
-        syntax::program::go_import_default_name(path)
+        program::go_import_default_name(path)
     } else {
         path.rsplit('/').next().unwrap_or(path)
     };

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -7,6 +7,8 @@ use crate::plan::bodies::LoweredStatement;
 use crate::plan::placement::simple_assign;
 use crate::plan::values::ValuePlan;
 use crate::state::bindings::{BindingValue, InlineExpr};
+use std::borrow::Cow;
+use syntax::ast::Expression;
 
 /// Hoist a root type assertion as `asserted := subject.(T)` for irrefutable
 /// destructure paths (the pattern compiler has already verified the type).
@@ -15,12 +17,12 @@ pub(crate) fn apply_root_assertion<'s>(
     statements: &mut Vec<LoweredStatement>,
     info: &PatternInfo,
     subject: &'s str,
-) -> std::borrow::Cow<'s, str> {
+) -> Cow<'s, str> {
     let Some(assertion) = info.root_assertion.as_ref() else {
-        return std::borrow::Cow::Borrowed(subject);
+        return Cow::Borrowed(subject);
     };
     if !info.requires_asserted_subject() {
-        return std::borrow::Cow::Borrowed(subject);
+        return Cow::Borrowed(subject);
     }
     let [go_type] = assertion.go_types.as_slice() else {
         unreachable!("multi-type root assertions only reach match destructure paths")
@@ -28,7 +30,7 @@ pub(crate) fn apply_root_assertion<'s>(
     planner.scope.record_go_use(subject);
     let expression = format!("{}.({})", subject, go_type);
     let var = planner.hoist_tmp_value_statement(statements, "asserted", &expression);
-    std::borrow::Cow::Owned(var)
+    Cow::Owned(var)
 }
 
 /// Hoist a root type assertion as comma-ok for refutable contexts (while-let,
@@ -38,9 +40,9 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
     statements: &mut Vec<LoweredStatement>,
     info: &PatternInfo,
     subject: &'s str,
-) -> (std::borrow::Cow<'s, str>, Option<String>) {
+) -> (Cow<'s, str>, Option<String>) {
     let Some(assertion) = info.root_assertion.as_ref() else {
-        return (std::borrow::Cow::Borrowed(subject), None);
+        return (Cow::Borrowed(subject), None);
     };
     planner.scope.record_go_use(subject);
     let needs_asserted = info.requires_asserted_subject();
@@ -60,9 +62,9 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
                 asserted_lhs, ok, subject, go_type
             )));
             let effective = if needs_asserted {
-                std::borrow::Cow::Owned(asserted_lhs)
+                Cow::Owned(asserted_lhs)
             } else {
-                std::borrow::Cow::Borrowed(subject)
+                Cow::Borrowed(subject)
             };
             (effective, Some(ok))
         }
@@ -82,7 +84,7 @@ pub(crate) fn apply_refutable_root_assertion<'s>(
                 })
                 .collect();
             (
-                std::borrow::Cow::Borrowed(subject),
+                Cow::Borrowed(subject),
                 Some(format!("({})", oks.join(" || "))),
             )
         }
@@ -111,8 +113,8 @@ pub(crate) fn tree_binding_statements(
     statements: &mut Vec<LoweredStatement>,
     bindings: &[PatternBinding],
     subject_var: &str,
-    consumers: &[&syntax::ast::Expression],
-    inline_blockers: &[&syntax::ast::Expression],
+    consumers: &[&Expression],
+    inline_blockers: &[&Expression],
 ) -> Vec<(String, Option<BindingValue>)> {
     let mut installed_inlines = Vec::new();
     for binding in bindings {
@@ -195,7 +197,7 @@ pub(crate) fn with_tree_bindings<R>(
     statements: &mut Vec<LoweredStatement>,
     bindings: &[PatternBinding],
     subject_var: &str,
-    body: &syntax::ast::Expression,
+    body: &Expression,
     f: impl FnOnce(&mut Planner, &mut Vec<LoweredStatement>) -> R,
 ) -> R {
     let overlays =

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -1150,7 +1150,7 @@ fn collect_const_pattern_check(
     qualified_name: &str,
     collector: &mut PatternCollector,
 ) {
-    let const_name = go_name::unqualified_name(qualified_name);
+    let const_name = unqualified_name(qualified_name);
     let go_literal = match planner.facts.package_for_qualified_name(qualified_name) {
         Some(package) => {
             if planner.facts.is_current_package(package) {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -161,7 +161,7 @@ impl Planner<'_> {
         &mut self,
         arms: &[MatchArm],
         subject_var: MatchSubject,
-        subject_ty: syntax::types::Type,
+        subject_ty: Type,
         place: &PlacePlan,
     ) -> LoweredBlock {
         let tree_emitter = TreePlanner::new(self, arms, subject_var, subject_ty);

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1247,7 +1247,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         bindings: &[PatternBinding],
         consumers: &[&Expression],
         failure_blocker: Option<&Decision>,
-    ) -> Vec<(String, Option<crate::state::bindings::BindingValue>)> {
+    ) -> Vec<(String, Option<BindingValue>)> {
         let failure_trees: Vec<&Expression> = match failure_blocker {
             Some(failure) => {
                 let mut reached: Vec<usize> = Vec::new();

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -4,6 +4,7 @@ use crate::abi::transition::try_emit_lowered_tail_return;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::control_flow::targets::legalize_source_loop;
+use crate::definitions::ConstScope;
 use crate::definitions::functions::{is_breakless_loop, is_go_never, is_test_context_ty};
 use crate::expressions::{flip_comparison, flip_preserves_nan};
 use crate::names::go_name::{prelude_qualifier, testkit_qualifier};
@@ -17,6 +18,7 @@ use crate::plan::placement::{
 };
 use crate::plan::values::{OperandForm, ValuePlan};
 use crate::utils::wrap_if_struct_literal;
+use std::slice;
 use syntax::ast::{
     BinaryOperator, Expression, IdentifierResolution, IfLetAlternative, Literal, MatchArm, Pattern,
     Span, UnaryOperator,
@@ -170,7 +172,7 @@ impl Planner<'_> {
         let items: &[Expression] = if let Expression::Block { items, .. } = body {
             items
         } else {
-            std::slice::from_ref(body)
+            slice::from_ref(body)
         };
 
         let Some((last, rest)) = items.split_last() else {
@@ -270,12 +272,7 @@ impl Planner<'_> {
                 let Some(value) = value.value() else {
                     return LoweredStatement::Block(LoweredBlock { statements: vec![] });
                 };
-                let plan = self.build_const_plan(
-                    identifier,
-                    value,
-                    ty,
-                    crate::definitions::ConstScope::Local,
-                );
+                let plan = self.build_const_plan(identifier, value, ty, ConstScope::Local);
                 self.directed_at(expression, LoweredStatement::Const(plan))
             }
             Expression::Return {
@@ -805,7 +802,7 @@ impl Planner<'_> {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
             items
         } else {
-            std::slice::from_ref(expression)
+            slice::from_ref(expression)
         };
         let statements = items
             .iter()
@@ -896,7 +893,7 @@ impl Planner<'_> {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
             items
         } else {
-            std::slice::from_ref(expression)
+            slice::from_ref(expression)
         };
 
         let Some((last, rest)) = try_elide_tail_let(items).or_else(|| items.split_last()) else {

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -995,7 +995,7 @@ impl Planner<'_> {
     fn lower_never_return_tail(
         &mut self,
         last: &Expression,
-        return_span: &syntax::ast::Span,
+        return_span: &Span,
     ) -> Vec<LoweredStatement> {
         let directive = self.maybe_line_directive(return_span);
         let mut statements: Vec<LoweredStatement> = Vec::new();

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -14,6 +14,8 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::statements::assignments::is_lvalue_chain;
 use crate::types::native::NativeGoType;
+use std::slice;
+use syntax::ast::Pattern;
 use syntax::ast::{Expression, Literal};
 use syntax::types::Type;
 
@@ -246,7 +248,7 @@ pub(crate) fn try_elide_tail_let(items: &[Expression]) -> Option<(&Expression, &
     if mode.else_block().is_some() || binding.is_mutable() {
         return None;
     }
-    let syntax::ast::Pattern::Identifier { identifier, .. } = &binding.pattern else {
+    let Pattern::Identifier { identifier, .. } = &binding.pattern else {
         return None;
     };
     if identifier != tail_name {
@@ -547,7 +549,7 @@ impl Planner<'_> {
         let items: &[Expression] = if let Expression::Block { items, .. } = expression {
             items
         } else {
-            std::slice::from_ref(expression)
+            slice::from_ref(expression)
         };
 
         self.with_block_scope(is_block, has_go_braces, |this| {

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -5,6 +5,7 @@ use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::{is_breakless_loop, is_go_never};
 use crate::expressions::staging::SpreadSequenceOptions;
+use crate::names::go_name::is_plain_identifier;
 use crate::plan::bodies::{
     AssignForm, AssignPlan, BreakValueAction, BreakValuePlan, ElseArm, LoopTransfer, LoweredBlock,
     LoweredStatement, PlacePlan,
@@ -189,7 +190,7 @@ fn join_boolean_branches(condition: &str, then_value: &str, else_value: &str) ->
 }
 
 fn negate_condition(condition: &str) -> String {
-    if crate::names::go_name::is_plain_identifier(condition) {
+    if is_plain_identifier(condition) {
         format!("!{}", condition)
     } else {
         format!("!({})", condition)
@@ -198,7 +199,7 @@ fn negate_condition(condition: &str) -> String {
 
 /// Parenthesize a synthesized `&&` operand, keeping bare identifiers bare.
 fn and_operand(operand: &str) -> String {
-    if crate::names::go_name::is_plain_identifier(operand) {
+    if is_plain_identifier(operand) {
         operand.to_string()
     } else {
         format!("({})", operand)

--- a/crates/emit/src/state/adapter_registry.rs
+++ b/crates/emit/src/state/adapter_registry.rs
@@ -1,5 +1,6 @@
 use ecow::EcoString;
 use rustc_hash::FxHashMap as HashMap;
+use std::mem;
 
 #[derive(Default)]
 pub(crate) struct AdapterRegistry {
@@ -34,6 +35,6 @@ impl AdapterRegistry {
     }
 
     pub(crate) fn drain_declarations(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.pending_declarations)
+        mem::take(&mut self.pending_declarations)
     }
 }

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::escape_reserved;
+use std::mem;
 
 #[derive(Clone, Debug)]
 pub(crate) struct InlineExpr {
@@ -100,7 +101,7 @@ impl Bindings {
             return;
         };
         if let BindingValue::GoName(name) = value {
-            let name = std::mem::take(name);
+            let name = mem::take(name);
             *value = BindingValue::GoConst(name);
         }
     }
@@ -139,7 +140,7 @@ impl Bindings {
     }
 
     pub(crate) fn replace_snapshot(&mut self, snapshot: BindingSnapshot) -> BindingSnapshot {
-        BindingSnapshot(std::mem::replace(self.current_mut(), snapshot.0))
+        BindingSnapshot(mem::replace(self.current_mut(), snapshot.0))
     }
 
     pub(crate) fn remove(&mut self, key: &str) {

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -5,6 +5,7 @@ use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::plan::bodies::LoopId;
 use crate::state::bindings::{BindingSnapshot, BindingValue, InlineExpr};
+use std::mem;
 
 pub(crate) struct ScopeState {
     next_var: usize,
@@ -196,8 +197,8 @@ impl ScopeState {
 
     pub(crate) fn enter_isolated_function(&mut self) -> IsolatedFunctionFrame {
         let saved = IsolatedFunctionFrame {
-            declared: std::mem::take(&mut self.declared),
-            established: std::mem::take(&mut self.established),
+            declared: mem::take(&mut self.declared),
+            established: mem::take(&mut self.established),
         };
         self.declared = vec![self.type_param_go_names.clone()];
         self.established = vec![Vec::new()];

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -7,6 +7,7 @@ use crate::names::go_name;
 use crate::plan::bodies::{AssignForm, AssignPlan, CompoundKind, LoweredBlock, LoweredStatement};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::bindings::BindingValue;
+use syntax::ast::Literal;
 use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
@@ -456,7 +457,7 @@ fn is_literal_one(expression: &Expression) -> bool {
     matches!(
         expression.unwrap_parens(),
         Expression::Literal {
-            literal: syntax::ast::Literal::Integer { value: 1, .. },
+            literal: Literal::Integer { value: 1, .. },
             ..
         }
     )

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -63,7 +63,7 @@ impl Planner<'_> {
         match ty {
             Type::Nominal { id, params, .. } => self.emit_constructor(id, params, ty),
             Type::Simple(kind) => {
-                if matches!(kind, syntax::types::SimpleKind::Unit) {
+                if matches!(kind, SimpleKind::Unit) {
                     GoType::new("struct{}")
                 } else {
                     GoType::new(kind.leaf_name().to_string())
@@ -90,7 +90,7 @@ impl Planner<'_> {
         }
     }
 
-    fn emit_compound(&self, kind: syntax::types::CompoundKind, args: &[Type], ty: &Type) -> GoType {
+    fn emit_compound(&self, kind: CompoundKind, args: &[Type], ty: &Type) -> GoType {
         use syntax::types::CompoundKind;
 
         if kind == CompoundKind::Ref

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -5,6 +5,9 @@ use crate::names::go_name;
 use crate::names::packages::{PackageRequirements, PackageUse};
 use crate::types::native::NativeGoType;
 use crate::types::prelude::PreludeType;
+use fmt::Formatter;
+use std::fmt;
+use std::fmt::Display;
 use syntax::ast::ResolvedCallTypeArguments;
 use syntax::program::DefinitionBody;
 use syntax::types::{CompoundKind, FunctionParameter, SimpleKind, Type};
@@ -52,8 +55,8 @@ impl GoType {
     }
 }
 
-impl std::fmt::Display for GoType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for GoType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.code)
     }
 }

--- a/crates/emit/src/types/shape.rs
+++ b/crates/emit/src/types/shape.rs
@@ -2,6 +2,7 @@ use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
 use crate::types::native::NativeGoType;
+use syntax::types::SimpleKind;
 
 #[derive(Debug, Clone)]
 pub(crate) struct NativeShape {
@@ -51,7 +52,7 @@ impl Planner<'_> {
                 };
                 Some(NativeShape { kind: native })
             }
-            Type::Simple(syntax::types::SimpleKind::String) => Some(NativeShape {
+            Type::Simple(SimpleKind::String) => Some(NativeShape {
                 kind: NativeGoType::String,
             }),
             _ => None,

--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -1,4 +1,5 @@
 use crate::lindig::{Document, concat, join};
+use syntax::ast::Span;
 use syntax::lex::{Token, TokenKind};
 
 #[derive(Debug, Clone)]
@@ -352,7 +353,7 @@ impl<'a> Comments<'a> {
         None
     }
 
-    pub fn has_comments_in_range(&self, span: syntax::ast::Span) -> bool {
+    pub fn has_comments_in_range(&self, span: Span) -> bool {
         let start = span.byte_offset;
         let end = span.byte_offset + span.byte_length;
 

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -12,10 +12,17 @@ use syntax::types::{CompoundKind, Type};
 
 use crate::imports::PackageResolver;
 use crate::loader::ProjectAnalysis;
+use crate::paths;
 use crate::paths::uri_to_package_file;
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
 use crate::state::{AnalysisKey, SharedState, Workspace};
+use semantics::loader;
+use semantics::loader::ExternalTestFileIssue;
+use std::fs;
+use syntax::ast::Span;
+use syntax::program::File;
+use syntax::types;
 
 pub(crate) enum AnalysisError {
     Diagnostics(Vec<Diagnostic>),
@@ -29,7 +36,7 @@ struct BuildInput {
 }
 
 fn dotted_directory_reaches_package_graph(uri: &Url, filename: &str, root: &Path) -> bool {
-    if !semantics::loader::is_typedef_file(filename) {
+    if !loader::is_typedef_file(filename) {
         return true;
     }
 
@@ -54,7 +61,7 @@ fn dotted_directory_reaches_package_graph(uri: &Url, filename: &str, root: &Path
 }
 
 fn tree_has_compiled_source(dir: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(dir) else {
+    let Ok(entries) = fs::read_dir(dir) else {
         return true;
     };
     entries.flatten().any(|entry| {
@@ -64,13 +71,13 @@ fn tree_has_compiled_source(dir: &Path) -> bool {
         entry
             .file_name()
             .to_str()
-            .is_some_and(|name| name.ends_with(".lis") && !semantics::loader::is_typedef_file(name))
+            .is_some_and(|name| name.ends_with(".lis") && !loader::is_typedef_file(name))
     })
 }
 
 /// Extract the constructor type name, unwrapping `Ref<T>` and peeling aliases.
 pub(crate) fn type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String> {
-    let resolved = syntax::types::peel_alias(ty, |id| snapshot.definitions().get(id));
+    let resolved = types::peel_alias(ty, |id| snapshot.definitions().get(id));
     match &resolved {
         Type::Nominal { id, .. } => Some(id.to_string()),
         Type::Compound {
@@ -85,13 +92,13 @@ pub(crate) fn type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String
     }
 }
 
-pub(crate) fn offset_in_span(offset: u32, span: &syntax::ast::Span) -> bool {
+pub(crate) fn offset_in_span(offset: u32, span: &Span) -> bool {
     offset >= span.byte_offset && offset < span.byte_offset + span.byte_length
 }
 
 /// Look up the package name for an import alias in a file.
 pub(crate) fn find_package_by_alias(
-    file: &syntax::program::File,
+    file: &File,
     alias: &str,
     go_package_names: &FxHashMap<String, String>,
 ) -> Option<String> {
@@ -132,16 +139,14 @@ impl SharedState {
         }
 
         if external_test {
-            return semantics::loader::external_test_file_issue(&filename).map(
-                |issue| match issue {
-                    semantics::loader::ExternalTestFileIssue::WrongSuffix => {
-                        diagnostics::package_graph::wrong_test_file_suffix(&filename)
-                    }
-                    semantics::loader::ExternalTestFileIssue::NotATestFile => {
-                        diagnostics::package_graph::non_test_file_under_tests(&filename)
-                    }
-                },
-            );
+            return loader::external_test_file_issue(&filename).map(|issue| match issue {
+                ExternalTestFileIssue::WrongSuffix => {
+                    diagnostics::package_graph::wrong_test_file_suffix(&filename)
+                }
+                ExternalTestFileIssue::NotATestFile => {
+                    diagnostics::package_graph::non_test_file_under_tests(&filename)
+                }
+            });
         }
 
         None
@@ -437,7 +442,7 @@ fn recover_target(key: &AnalysisKey) -> RecoverTarget {
         AnalysisKey::Package {
             external_test: false,
             ..
-        } => RecoverTarget::Package(crate::paths::ENTRY_PACKAGE_ID.to_string()),
+        } => RecoverTarget::Package(paths::ENTRY_PACKAGE_ID.to_string()),
         AnalysisKey::Document { .. } => RecoverTarget::None,
     }
 }
@@ -520,6 +525,7 @@ pub(crate) fn convert_diagnostic_in(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use syntax::ast::Span;
 
     #[test]
     fn info_maps_to_lsp_information() {
@@ -537,7 +543,7 @@ mod tests {
 
     #[test]
     fn prose_label_is_capitalized() {
-        let span = syntax::ast::Span::new(0, 0, 1);
+        let span = Span::new(0, 0, 1);
         let diagnostic = convert_diagnostic(
             &LisetteDiagnostic::warn("Unused function")
                 .with_span_label(&span, "never called")
@@ -556,11 +562,8 @@ mod tests {
         let uri = Url::parse("file:///x.lis").unwrap();
         let diagnostic = convert_diagnostic_in(
             &LisetteDiagnostic::error("`File` does not implement `Writer`")
-                .with_span_label(&syntax::ast::Span::new(0, 17, 4), "`Writer` needed here")
-                .with_span_label(
-                    &syntax::ast::Span::new(0, 3, 5),
-                    "`Writer` requires `fn () -> int`",
-                ),
+                .with_span_label(&Span::new(0, 17, 4), "`Writer` needed here")
+                .with_span_label(&Span::new(0, 3, 5), "`Writer` requires `fn () -> int`"),
             &index,
             Some(&uri),
         );
@@ -576,7 +579,7 @@ mod tests {
 
     #[test]
     fn multi_line_help_leads_with_the_message() {
-        let span = syntax::ast::Span::new(0, 0, 1);
+        let span = Span::new(0, 0, 1);
         let diagnostic = convert_diagnostic(
             &LisetteDiagnostic::error("`File` does not implement `ReadWriter`")
                 .with_span_label(&span, "`ReadWriter` needed here")
@@ -594,7 +597,7 @@ mod tests {
 
     #[test]
     fn identifier_led_label_is_left_untouched() {
-        let span = syntax::ast::Span::new(0, 0, 1);
+        let span = Span::new(0, 0, 1);
         let diagnostic = convert_diagnostic(
             &LisetteDiagnostic::error("Name not found")
                 .with_span_label(&span, "`missing` not found in package `root`"),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -50,10 +50,7 @@ pub(crate) fn definition_to_completion_kind(
         DefinitionBody::Interface { .. } => CompletionItemKind::INTERFACE,
         DefinitionBody::TypeAlias { .. } => CompletionItemKind::TYPE_PARAMETER,
         DefinitionBody::Value { .. } => {
-            if matches!(
-                &definition.ty,
-                syntax::types::Type::Function(_) | syntax::types::Type::Forall { .. }
-            ) {
+            if matches!(&definition.ty, Type::Function(_) | Type::Forall { .. }) {
                 CompletionItemKind::FUNCTION
             } else {
                 CompletionItemKind::CONSTANT
@@ -136,7 +133,7 @@ pub(crate) fn resolve_variable_type(
         &owned_ty
     };
 
-    let (resolved, _) = syntax::types::Type::remove_vars(&[ty]);
+    let (resolved, _) = Type::remove_vars(&[ty]);
     let ty = &resolved[0];
 
     if indexed {
@@ -248,7 +245,7 @@ fn struct_field_completions(
     items: &mut Vec<CompletionItem>,
 ) {
     if let Some(syntax::program::Definition {
-        body: syntax::program::DefinitionBody::Struct { fields, .. },
+        body: DefinitionBody::Struct { fields, .. },
         ..
     }) = snapshot.definitions().get(type_id)
     {
@@ -333,7 +330,7 @@ fn enum_variant_field_completions(
     items: &mut Vec<CompletionItem>,
 ) {
     let Some(syntax::program::Definition {
-        body: syntax::program::DefinitionBody::Enum { variants, .. },
+        body: DefinitionBody::Enum { variants, .. },
         ..
     }) = snapshot.definitions().get(type_id)
     else {

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -6,9 +6,18 @@ use syntax::program::DefinitionBody;
 use syntax::types::Type;
 
 use crate::definition::get_root_expression;
+use crate::hover;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::{find_enclosing_impl_type, find_expression_at};
 use crate::type_name;
+use syntax::ast::Pattern;
+use syntax::ast::StructFieldAssignment;
+use syntax::attributes;
+use syntax::program;
+use syntax::program::AliasKind;
+use syntax::program::Definition;
+use syntax::program::File;
+use syntax::types;
 
 /// The identifier before the dot, with that dot's offset, whether the cursor
 /// sits right after it or partway through the member.
@@ -40,9 +49,7 @@ pub(crate) fn get_package_prefix(source: &str, offset: usize) -> Option<(&str, u
     Some((identifier, dot_offset))
 }
 
-pub(crate) fn definition_to_completion_kind(
-    definition: &syntax::program::Definition,
-) -> CompletionItemKind {
+pub(crate) fn definition_to_completion_kind(definition: &Definition) -> CompletionItemKind {
     use syntax::program::DefinitionBody;
     match &definition.body {
         DefinitionBody::Struct { .. } => CompletionItemKind::STRUCT,
@@ -80,7 +87,7 @@ fn element_type_name(ty: &Type, snapshot: &AnalysisSnapshot) -> Option<String> {
 /// When `indexed` is true, extracts the element type for collection types.
 pub(crate) fn resolve_variable_type(
     var_name: &str,
-    file: &syntax::program::File,
+    file: &File,
     offset: u32,
     snapshot: &AnalysisSnapshot,
     indexed: bool,
@@ -97,8 +104,8 @@ pub(crate) fn resolve_variable_type(
             ..
         } => {
             let matches_name = match &let_binding.pattern {
-                syntax::ast::Pattern::Identifier { identifier, .. } => identifier == var_name,
-                syntax::ast::Pattern::AsBinding { name, .. } => name == var_name,
+                Pattern::Identifier { identifier, .. } => identifier == var_name,
+                Pattern::AsBinding { name, .. } => name == var_name,
                 _ => false,
             };
             if matches_name {
@@ -114,8 +121,8 @@ pub(crate) fn resolve_variable_type(
         } => Some(&for_binding.ty),
         Expression::Function { params, .. } | Expression::Lambda { params, .. } => {
             let param = params.iter().find(|p| match &p.pattern {
-                syntax::ast::Pattern::Identifier { identifier, .. } => identifier == var_name,
-                syntax::ast::Pattern::AsBinding { name, .. } => name == var_name,
+                Pattern::Identifier { identifier, .. } => identifier == var_name,
+                Pattern::AsBinding { name, .. } => name == var_name,
                 _ => false,
             })?;
             Some(&param.ty)
@@ -127,8 +134,7 @@ pub(crate) fn resolve_variable_type(
     let ty = if let Some(t) = borrowed_ty {
         t
     } else {
-        let (t, _) =
-            crate::hover::get_hover_type_and_span(snapshot, expression, binding.span.byte_offset);
+        let (t, _) = hover::get_hover_type_and_span(snapshot, expression, binding.span.byte_offset);
         owned_ty = t;
         &owned_ty
     };
@@ -149,7 +155,7 @@ pub(crate) enum DotContext {
 }
 
 pub(crate) fn detect_dot_context(
-    file: &syntax::program::File,
+    file: &File,
     offset: u32,
     snapshot: &AnalysisSnapshot,
 ) -> Option<DotContext> {
@@ -219,7 +225,7 @@ pub(crate) fn get_instance_completions(
         params: vec![],
         writable: false,
     };
-    for method in syntax::program::methods_for_type(&ty, &Default::default(), |id| {
+    for method in program::methods_for_type(&ty, &Default::default(), |id| {
         snapshot.definitions().get(id)
     })
     .into_values()
@@ -244,7 +250,7 @@ fn struct_field_completions(
     same_package: bool,
     items: &mut Vec<CompletionItem>,
 ) {
-    if let Some(syntax::program::Definition {
+    if let Some(Definition {
         body: DefinitionBody::Struct { fields, .. },
         ..
     }) = snapshot.definitions().get(type_id)
@@ -264,9 +270,9 @@ fn struct_field_completions(
 
 /// The struct literal's name, type, and assignments when `offset` is at a field name.
 pub(crate) fn detect_struct_literal_field_context(
-    file: &syntax::program::File,
+    file: &File,
     offset: u32,
-) -> Option<(&str, &Type, &[syntax::ast::StructFieldAssignment])> {
+) -> Option<(&str, &Type, &[StructFieldAssignment])> {
     let tokens = Lexer::new(&file.source, 0).lex().tokens;
     let split = tokens.partition_point(|t| (t.byte_offset as usize) < offset as usize);
     if !in_field_name_position(&tokens[..split]) {
@@ -308,7 +314,7 @@ pub(crate) fn get_struct_literal_completions(
     call_name: &str,
     snapshot: &AnalysisSnapshot,
     same_package: bool,
-    assigned: &[syntax::ast::StructFieldAssignment],
+    assigned: &[StructFieldAssignment],
     offset: u32,
 ) -> Vec<CompletionItem> {
     let mut items = Vec::new();
@@ -329,7 +335,7 @@ fn enum_variant_field_completions(
     snapshot: &AnalysisSnapshot,
     items: &mut Vec<CompletionItem>,
 ) {
-    let Some(syntax::program::Definition {
+    let Some(Definition {
         body: DefinitionBody::Enum { variants, .. },
         ..
     }) = snapshot.definitions().get(type_id)
@@ -350,7 +356,7 @@ fn enum_variant_field_completions(
     }
 }
 
-fn cursor_on_name(fa: &syntax::ast::StructFieldAssignment, offset: u32) -> bool {
+fn cursor_on_name(fa: &StructFieldAssignment, offset: u32) -> bool {
     let start = fa.name_span.byte_offset;
     offset >= start && offset <= start + fa.name_span.byte_length
 }
@@ -419,7 +425,7 @@ fn alias_target(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<String> {
     let def = snapshot.definitions().get(type_id)?;
     let DefinitionBody::TypeAlias {
         generics,
-        alias: syntax::program::AliasKind::Transparent { .. },
+        alias: AliasKind::Transparent { .. },
         ..
     } = &def.body
     else {
@@ -428,7 +434,7 @@ fn alias_target(type_id: &str, snapshot: &AnalysisSnapshot) -> Option<String> {
     if !generics.is_empty() {
         return None;
     }
-    let target = syntax::types::peel_alias(&def.ty, |id| snapshot.definitions().get(id));
+    let target = types::peel_alias(&def.ty, |id| snapshot.definitions().get(id));
     let target = match target {
         Type::Nominal { id, .. } => id.to_string(),
         Type::Simple(kind) => format!("prelude.{}", kind.leaf_name()),
@@ -502,7 +508,7 @@ fn attribute_item(info: &AttributeInfo) -> CompletionItem {
 }
 
 fn top_level_attributes() -> impl Iterator<Item = &'static AttributeInfo> {
-    syntax::attributes::ATTRIBUTES.iter().filter(|a| {
+    attributes::ATTRIBUTES.iter().filter(|a| {
         a.applies_to(AttributeTarget::Struct)
             || a.applies_to(AttributeTarget::Enum)
             || a.applies_to(AttributeTarget::Function)

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -1,9 +1,12 @@
 use rustc_hash::FxHashMap;
+use syntax::ast::StructFieldAssignment;
 use syntax::ast::{
     Annotation, ConstructorPatternResolution, Expression, IdentifierResolution, MatchArm, Pattern,
     RecordPatternResolution, Span, StructFieldPattern,
 };
 use syntax::program::DefinitionBody;
+use syntax::program::File;
+use syntax::types::Type;
 use syntax::types::unqualified_name;
 
 use crate::analysis::find_package_by_alias;
@@ -42,11 +45,11 @@ pub(crate) fn find_struct_field_span(
 }
 
 pub(crate) fn resolve_struct_call_field(
-    field_assignments: &[syntax::ast::StructFieldAssignment],
+    field_assignments: &[StructFieldAssignment],
     name: &str,
-    ty: &syntax::types::Type,
+    ty: &Type,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     let type_id = type_name(ty, snapshot);
@@ -72,7 +75,7 @@ pub(crate) fn resolve_dot_access_definition(
     expression: &Expression,
     member: &str,
     dot_access_span: Span,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     let try_lookup = |name: &str| -> Option<Span> {
@@ -192,7 +195,7 @@ pub(crate) fn is_generated_typedef_span(snapshot: &AnalysisSnapshot, span: &Span
 /// Resolve an import alias to the import statement's span.
 pub(crate) fn resolve_import_span(
     name: &str,
-    file: &syntax::program::File,
+    file: &File,
     go_package_names: &FxHashMap<String, String>,
 ) -> Option<Span> {
     file.imports().into_iter().find_map(|import| {
@@ -208,7 +211,7 @@ pub(crate) fn resolve_import_span(
 pub(crate) fn resolve_annotation_definition(
     annotation: &Annotation,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     if !offset_in_span(offset, &annotation.get_span()) {
@@ -244,7 +247,7 @@ fn resolve_constructor_name(
     name: &str,
     span: Span,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     let cursor_in_name = (offset - span.byte_offset) as usize;
@@ -273,7 +276,7 @@ fn resolve_constructor_name(
 
 pub(crate) fn lookup_definition_span(
     name: &str,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     if let Some(definition) = snapshot.definitions().get(name)
@@ -345,7 +348,7 @@ pub(crate) fn word_at_offset(source: &str, offset: u32) -> Option<(&str, usize, 
 pub(crate) fn resolve_word_at_offset(
     source: &str,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     let (word, _, _) = word_at_offset(source, offset)?;
@@ -356,7 +359,7 @@ pub(crate) fn resolve_word_at_offset(
 pub(crate) fn resolve_match_pattern_definition(
     arms: &[MatchArm],
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     arms.iter()
@@ -367,7 +370,7 @@ pub(crate) fn resolve_match_pattern_definition(
 pub(crate) fn resolve_enum_in_pattern(
     pattern: &Pattern,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<Span> {
     if !offset_in_span(offset, &pattern.get_span()) {
@@ -521,7 +524,7 @@ fn record_pattern_field_span(
 /// Checks binding definitions first, then falls back to expression-based resolution.
 pub(crate) fn resolve_symbol_definition_span(
     snapshot: &AnalysisSnapshot,
-    file: &syntax::program::File,
+    file: &File,
     file_id: u32,
     offset: u32,
 ) -> Option<Span> {

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -24,7 +24,7 @@ pub(crate) fn find_struct_field_span(
     type_id: &str,
     field_name: &str,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     use syntax::program::{Definition, DefinitionBody};
 
     if let Some(Definition {
@@ -48,7 +48,7 @@ pub(crate) fn resolve_struct_call_field(
     offset: u32,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     let type_id = type_name(ty, snapshot);
 
     field_assignments
@@ -74,8 +74,8 @@ pub(crate) fn resolve_dot_access_definition(
     dot_access_span: Span,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
-    let try_lookup = |name: &str| -> Option<syntax::ast::Span> {
+) -> Option<Span> {
+    let try_lookup = |name: &str| -> Option<Span> {
         snapshot
             .definitions()
             .get(name)
@@ -182,10 +182,7 @@ pub(crate) fn resolve_dot_access_definition(
 }
 
 /// True when the span points into a generated typedef (`go:` or prelude), which rename must refuse.
-pub(crate) fn is_generated_typedef_span(
-    snapshot: &AnalysisSnapshot,
-    span: &syntax::ast::Span,
-) -> bool {
+pub(crate) fn is_generated_typedef_span(snapshot: &AnalysisSnapshot, span: &Span) -> bool {
     snapshot
         .files()
         .get(&span.file_id)
@@ -197,7 +194,7 @@ pub(crate) fn resolve_import_span(
     name: &str,
     file: &syntax::program::File,
     go_package_names: &FxHashMap<String, String>,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     file.imports().into_iter().find_map(|import| {
         if import.effective_alias(go_package_names).as_deref() == Some(name) {
             Some(import.span)
@@ -278,7 +275,7 @@ pub(crate) fn lookup_definition_span(
     name: &str,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     if let Some(definition) = snapshot.definitions().get(name)
         && let Some(span) = definition.name_span
     {
@@ -350,7 +347,7 @@ pub(crate) fn resolve_word_at_offset(
     offset: u32,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     let (word, _, _) = word_at_offset(source, offset)?;
     lookup_definition_span(word, file, snapshot)
 }
@@ -361,7 +358,7 @@ pub(crate) fn resolve_match_pattern_definition(
     offset: u32,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     arms.iter()
         .find_map(|arm| resolve_enum_in_pattern(&arm.pattern, offset, file, snapshot))
 }
@@ -372,7 +369,7 @@ pub(crate) fn resolve_enum_in_pattern(
     offset: u32,
     file: &syntax::program::File,
     snapshot: &AnalysisSnapshot,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     if !offset_in_span(offset, &pattern.get_span()) {
         return None;
     }
@@ -527,7 +524,7 @@ pub(crate) fn resolve_symbol_definition_span(
     file: &syntax::program::File,
     file_id: u32,
     offset: u32,
-) -> Option<syntax::ast::Span> {
+) -> Option<Span> {
     snapshot
         .bindings()
         .values()

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -11,15 +11,18 @@ use crate::patterns::get_pattern_element_type;
 use crate::snapshot::AnalysisSnapshot;
 use crate::traversal::find_expression_at;
 use crate::type_name;
+use syntax::ast::Binding;
+use syntax::program::File;
+use syntax::types::Type;
 
 /// Hover for top-level declarations and the annotation trees inside them.
 pub(crate) fn resolve_declaration_hover(
     expression: &Expression,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
-) -> Option<(syntax::types::Type, Span)> {
-    let name_hover = |name: &str, name_span: Span| -> Option<(syntax::types::Type, Span)> {
+) -> Option<(Type, Span)> {
+    let name_hover = |name: &str, name_span: Span| -> Option<(Type, Span)> {
         if !offset_in_span(offset, &name_span) {
             return None;
         }
@@ -67,9 +70,9 @@ pub(crate) fn resolve_declaration_hover(
 fn resolve_annotation_hover(
     annotation: &Annotation,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
-) -> Option<(syntax::types::Type, Span)> {
+) -> Option<(Type, Span)> {
     if !offset_in_span(offset, &annotation.get_span()) {
         return None;
     }
@@ -99,9 +102,9 @@ fn resolve_constructor_name_hover(
     name: &str,
     span: Span,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
-) -> Option<(syntax::types::Type, Span)> {
+) -> Option<(Type, Span)> {
     let cursor_in_name = (offset - span.byte_offset) as usize;
     let dot_pos = name.find('.').unwrap_or(name.len());
 
@@ -125,11 +128,7 @@ fn resolve_constructor_name_hover(
     Some((ty, first_span))
 }
 
-fn lookup_type_by_name(
-    name: &str,
-    file: &syntax::program::File,
-    snapshot: &AnalysisSnapshot,
-) -> Option<syntax::types::Type> {
+fn lookup_type_by_name(name: &str, file: &File, snapshot: &AnalysisSnapshot) -> Option<Type> {
     let candidates = [
         format!("{}.{}", file.package_id, name),
         name.to_string(),
@@ -157,12 +156,12 @@ pub(crate) fn get_hover_type_and_span(
     snapshot: &AnalysisSnapshot,
     expression: &Expression,
     offset: u32,
-) -> (syntax::types::Type, Span) {
+) -> (Type, Span) {
     fn get_binding_type(
         snapshot: &AnalysisSnapshot,
-        binding: &syntax::ast::Binding,
+        binding: &Binding,
         offset: u32,
-    ) -> Option<(syntax::types::Type, Span)> {
+    ) -> Option<(Type, Span)> {
         get_pattern_element_type(snapshot, &binding.pattern, &binding.ty, offset)
     }
 
@@ -288,7 +287,7 @@ fn find_doc_at_definition_span(
 fn resolve_dot_access_doc(
     expression: &Expression,
     member: &str,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<String> {
     if let Some(type_id) = type_name(&expression.get_type(), snapshot) {
@@ -333,7 +332,7 @@ fn resolve_dot_access_doc(
 pub(crate) fn get_hover_doc(
     expression: &Expression,
     offset: u32,
-    file: &syntax::program::File,
+    file: &File,
     snapshot: &AnalysisSnapshot,
 ) -> Option<String> {
     if let Some(doc) = extract_doc_from_expression(expression, offset) {

--- a/crates/lsp/src/imports.rs
+++ b/crates/lsp/src/imports.rs
@@ -11,6 +11,8 @@ use syntax::program::{File, FileImport, go_import_default_name};
 use crate::position::LineIndex;
 use crate::protocol::*;
 use crate::snapshot::AnalysisSnapshot;
+use std::path::Path;
+use syntax::dependency_block;
 
 const UNIMPORTED_SORT_PREFIX: &str = "~";
 
@@ -107,7 +109,7 @@ impl PackageResolver {
         );
 
         *discovered = Some(Discovered {
-            root: root.map(std::path::Path::to_path_buf),
+            root: root.map(Path::to_path_buf),
             stamp,
             walked: Instant::now(),
             packages: Arc::clone(&packages),
@@ -330,7 +332,7 @@ fn header_end(source: &str) -> u32 {
 }
 
 fn table_end(source: &str) -> u32 {
-    syntax::dependency_block::scan_dependency_blocks(source, 0)
+    dependency_block::scan_dependency_blocks(source, 0)
         .iter()
         .map(|block| block.span.byte_offset + block.span.byte_length)
         .max()
@@ -412,6 +414,8 @@ fn signature(item: &Expression, source: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
 
     fn applied(path: &str, source: &str) -> String {
         let mut file = File::new_cached("root", "main.lis", "main.lis", source, 0);
@@ -583,12 +587,12 @@ mod tests {
         );
     }
 
-    fn declare(root: &std::path::Path, modules: &[&str]) {
+    fn declare(root: &Path, modules: &[&str]) {
         let entries: String = modules
             .iter()
             .map(|module| format!("\"{module}\" = \"v1.0.0\"\n"))
             .collect();
-        std::fs::write(
+        fs::write(
             root.join("lisette.toml"),
             format!(
                 "[project]\nname = \"t\"\nversion = \"0.0.1\"\n\n[toolchain]\nlis = \"{}\"\n\n[dependencies.go]\n{entries}",
@@ -601,13 +605,13 @@ mod tests {
             let dir = deps::typedef_cache_dir(root)
                 .join(deps::Target::host().cache_segment())
                 .join(format!("{module}@v1.0.0"));
-            std::fs::create_dir_all(&dir).unwrap();
+            fs::create_dir_all(&dir).unwrap();
             let name = module.rsplit('/').next().unwrap();
-            std::fs::write(dir.join(format!("{name}.d.lis")), "pub fn Do() -> int\n").unwrap();
+            fs::write(dir.join(format!("{name}.d.lis")), "pub fn Do() -> int\n").unwrap();
         }
     }
 
-    fn resolver(root: &std::path::Path, index: &Arc<PackageIndex>) -> PackageResolver {
+    fn resolver(root: &Path, index: &Arc<PackageIndex>) -> PackageResolver {
         PackageResolver::new(
             TypedefLocator::from_project(root).expect("the manifest should parse"),
             Arc::clone(index),

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -17,6 +17,8 @@ mod state;
 mod traversal;
 mod validation;
 
+use std::sync::atomic::Ordering;
+
 use crate::protocol::RpcResult as Result;
 use crate::protocol::*;
 use syntax::ast::IdentifierResolution;
@@ -50,7 +52,7 @@ impl Backend {
                 .pointer("/textDocument/completion/completionItem/insertReplaceSupport")
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false),
-            std::sync::atomic::Ordering::Relaxed,
+            Ordering::Relaxed,
         );
 
         let workspace_root = params
@@ -1002,9 +1004,7 @@ impl Backend {
                 start,
                 end: line_index.offset_to_position(end as u32),
             },
-            insert_replace_support: self
-                .insert_replace_support
-                .load(std::sync::atomic::Ordering::Relaxed),
+            insert_replace_support: self.insert_replace_support.load(Ordering::Relaxed),
         })
     }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -40,7 +40,12 @@ use crate::position::LineIndex;
 use crate::project::find_project_root;
 use crate::snapshot::{AnalysisSnapshot, SnapshotDocument};
 use crate::traversal::find_expression_at;
+use std::collections::HashMap;
+use std::sync::Arc;
+use syntax::ast::Expression;
+use syntax::ast::Span;
 use syntax::program::File;
+use syntax::types;
 
 pub use crate::state::{Backend, SharedState};
 
@@ -281,19 +286,19 @@ impl Backend {
                 .find(|b| b.span.file_id == file_id && offset_in_span(offset, &b.span))
                 .map(|b| b.span)
         };
-        let binding_or_word_fallback = |resolved: Option<syntax::ast::Span>| {
+        let binding_or_word_fallback = |resolved: Option<Span>| {
             resolved
                 .or_else(&find_binding)
                 .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
         };
 
         let definition_span = match expression {
-            syntax::ast::Expression::Identifier {
+            Expression::Identifier {
                 resolution: IdentifierResolution::Binding(id),
                 ..
             } => snapshot.bindings().get(id).map(|b| b.span),
 
-            syntax::ast::Expression::Identifier {
+            Expression::Identifier {
                 value,
                 resolution: IdentifierResolution::Definition(qname),
                 span: id_span,
@@ -327,33 +332,29 @@ impl Backend {
                     .and_then(|d| d.name_span)
             }
 
-            syntax::ast::Expression::DotAccess {
+            Expression::DotAccess {
                 expression,
                 member,
                 span,
                 ..
             } => resolve_dot_access_definition(expression, member, *span, file, &snapshot),
 
-            syntax::ast::Expression::StructCall {
+            Expression::StructCall {
                 name,
                 field_assignments,
                 ty,
                 ..
             } => resolve_struct_call_field(field_assignments, name, ty, offset, file, &snapshot),
 
-            syntax::ast::Expression::Function { name_span, .. }
-                if offset_in_span(offset, name_span) =>
-            {
+            Expression::Function { name_span, .. } if offset_in_span(offset, name_span) => {
                 Some(*name_span)
             }
 
-            syntax::ast::Expression::Interface { name_span, .. }
-                if offset_in_span(offset, name_span) =>
-            {
+            Expression::Interface { name_span, .. } if offset_in_span(offset, name_span) => {
                 Some(*name_span)
             }
 
-            syntax::ast::Expression::TypeAlias {
+            Expression::TypeAlias {
                 name_span,
                 annotation,
                 ..
@@ -365,7 +366,7 @@ impl Backend {
                 }
             }
 
-            syntax::ast::Expression::Struct {
+            Expression::Struct {
                 name,
                 name_span,
                 fields,
@@ -384,7 +385,7 @@ impl Backend {
                     })
                 }),
 
-            syntax::ast::Expression::Enum {
+            Expression::Enum {
                 name,
                 name_span,
                 variants,
@@ -401,7 +402,7 @@ impl Backend {
                 })
                 .or_else(|| offset_in_span(offset, name_span).then_some(*name_span)),
 
-            syntax::ast::Expression::Identifier { value, .. } => {
+            Expression::Identifier { value, .. } => {
                 lookup_definition_span(value, file, &snapshot)
                     .or_else(|| {
                         resolve_import_span(
@@ -415,12 +416,11 @@ impl Backend {
                     .or_else(|| resolve_word_at_offset(&file.source, offset, file, &snapshot))
             }
 
-            syntax::ast::Expression::Match { arms, .. } => binding_or_word_fallback(
+            Expression::Match { arms, .. } => binding_or_word_fallback(
                 resolve_match_pattern_definition(arms, offset, file, &snapshot),
             ),
 
-            syntax::ast::Expression::IfLet { pattern, .. }
-            | syntax::ast::Expression::WhileLet { pattern, .. } => {
+            Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
                 binding_or_word_fallback(resolve_enum_in_pattern(pattern, offset, file, &snapshot))
             }
 
@@ -450,10 +450,10 @@ impl Backend {
         let line_index = document.line_index;
 
         fn expression_to_symbol(
-            expression: &syntax::ast::Expression,
+            expression: &Expression,
             line_index: &LineIndex,
         ) -> Option<DocumentSymbol> {
-            use syntax::ast::Expression;
+            use Expression;
 
             let (name, name_span, span, kind, detail) = match expression {
                 Expression::Function {
@@ -618,19 +618,19 @@ impl Backend {
         let offset = cursor.offset;
 
         let rename_response =
-            |span: syntax::ast::Span, placeholder: &str| -> Result<Option<PrepareRenameResponse>> {
+            |span: Span, placeholder: &str| -> Result<Option<PrepareRenameResponse>> {
                 Ok(Some(PrepareRenameResponse::RangeWithPlaceholder {
                     range: line_index.span_to_range(span),
                     placeholder: placeholder.to_string(),
                 }))
             };
         let rename_word_if_resolved =
-            |resolved: Option<syntax::ast::Span>| -> Result<Option<PrepareRenameResponse>> {
+            |resolved: Option<Span>| -> Result<Option<PrepareRenameResponse>> {
                 if let Some(definition_span) = resolved
                     && !is_generated_typedef_span(&snapshot, &definition_span)
                     && let Some((word, start, end)) = word_at_offset(&file.source, offset)
                 {
-                    let span = syntax::ast::Span::new(file_id, start as u32, (end - start) as u32);
+                    let span = Span::new(file_id, start as u32, (end - start) as u32);
                     return rename_response(span, word);
                 }
                 Ok(None)
@@ -647,7 +647,7 @@ impl Backend {
             return Ok(None);
         };
 
-        if let syntax::ast::Expression::StructCall {
+        if let Expression::StructCall {
             field_assignments,
             ty,
             ..
@@ -663,7 +663,7 @@ impl Backend {
         }
 
         match expression {
-            syntax::ast::Expression::Identifier {
+            Expression::Identifier {
                 value,
                 resolution: IdentifierResolution::Binding(id),
                 span,
@@ -678,7 +678,7 @@ impl Backend {
                 }
             }
 
-            syntax::ast::Expression::Identifier {
+            Expression::Identifier {
                 value,
                 resolution: IdentifierResolution::Definition(qname),
                 span,
@@ -686,19 +686,19 @@ impl Backend {
             } => {
                 validation::check_rename_guards(qname.as_str())?;
                 if snapshot.definitions().contains_key(qname.as_str()) {
-                    rename_response(*span, syntax::types::unqualified_name(value))
+                    rename_response(*span, types::unqualified_name(value))
                 } else {
                     Ok(None)
                 }
             }
 
-            syntax::ast::Expression::Function {
+            Expression::Function {
                 name, name_span, ..
             }
-            | syntax::ast::Expression::Interface {
+            | Expression::Interface {
                 name, name_span, ..
             }
-            | syntax::ast::Expression::TypeAlias {
+            | Expression::TypeAlias {
                 name, name_span, ..
             } => {
                 let qname = format!("{}.{}", file.package_id, name);
@@ -706,7 +706,7 @@ impl Backend {
                 rename_response(*name_span, name)
             }
 
-            syntax::ast::Expression::Struct {
+            Expression::Struct {
                 name,
                 name_span,
                 fields,
@@ -723,7 +723,7 @@ impl Backend {
                 rename_response(*name_span, name)
             }
 
-            syntax::ast::Expression::Enum {
+            Expression::Enum {
                 name,
                 name_span,
                 variants,
@@ -742,11 +742,11 @@ impl Backend {
                 rename_response(*name_span, name)
             }
 
-            syntax::ast::Expression::VariableDeclaration {
+            Expression::VariableDeclaration {
                 name, name_span, ..
             } => rename_response(*name_span, name),
 
-            syntax::ast::Expression::Const {
+            Expression::Const {
                 identifier,
                 identifier_span,
                 ..
@@ -756,7 +756,7 @@ impl Backend {
                 rename_response(*identifier_span, identifier)
             }
 
-            syntax::ast::Expression::DotAccess {
+            Expression::DotAccess {
                 expression,
                 member,
                 span,
@@ -767,7 +767,7 @@ impl Backend {
                 if let Some(definition_span) = resolved
                     && !is_generated_typedef_span(&snapshot, &definition_span)
                 {
-                    let member_span = syntax::ast::Span::new(
+                    let member_span = Span::new(
                         span.file_id,
                         span.byte_offset + span.byte_length - member.len() as u32,
                         member.len() as u32,
@@ -778,12 +778,11 @@ impl Backend {
                 }
             }
 
-            syntax::ast::Expression::Match { arms, .. } => rename_word_if_resolved(
+            Expression::Match { arms, .. } => rename_word_if_resolved(
                 resolve_match_pattern_definition(arms, offset, file, &snapshot),
             ),
 
-            syntax::ast::Expression::IfLet { pattern, .. }
-            | syntax::ast::Expression::WhileLet { pattern, .. } => {
+            Expression::IfLet { pattern, .. } | Expression::WhileLet { pattern, .. } => {
                 rename_word_if_resolved(resolve_enum_in_pattern(pattern, offset, file, &snapshot))
             }
 
@@ -811,10 +810,9 @@ impl Backend {
         let file = cursor.document.file;
         let offset = cursor.offset;
 
-        let mut edits: std::collections::HashMap<Url, Vec<TextEdit>> =
-            std::collections::HashMap::new();
+        let mut edits: HashMap<Url, Vec<TextEdit>> = HashMap::new();
 
-        if let Some(syntax::ast::Expression::Identifier {
+        if let Some(Expression::Identifier {
             resolution: IdentifierResolution::Definition(qname),
             ..
         }) = find_expression_at(&file.items, offset)
@@ -902,7 +900,7 @@ impl Backend {
                 })
                 .collect();
 
-            let mut changes = std::collections::HashMap::new();
+            let mut changes = HashMap::new();
             changes.insert(uri.clone(), text_edits);
 
             actions.push(CodeActionOrCommand::CodeAction(Box::new(CodeAction {
@@ -1029,7 +1027,7 @@ impl Backend {
     }
 }
 
-fn location_for(span: syntax::ast::Span, snapshot: &AnalysisSnapshot) -> Option<Location> {
+fn location_for(span: Span, snapshot: &AnalysisSnapshot) -> Option<Location> {
     if span.is_dummy() {
         return None;
     }
@@ -1267,10 +1265,7 @@ pub(crate) fn ranges_overlap(a: Range, b: Range) -> bool {
 
 /// Narrows a usage span to just the trailing member token, dropping any
 /// qualifier (`Color.Red`) and any payload (`Red(x)`).
-fn trailing_segment_span(
-    usage_span: syntax::ast::Span,
-    snapshot: &AnalysisSnapshot,
-) -> syntax::ast::Span {
+fn trailing_segment_span(usage_span: Span, snapshot: &AnalysisSnapshot) -> Span {
     let Some(source_file) = snapshot.files().get(&usage_span.file_id) else {
         return usage_span;
     };
@@ -1282,23 +1277,23 @@ fn trailing_segment_span(
     let usage_text = &source_file.source[start..end];
     match member_token_range(usage_text) {
         Some((offset, length)) => {
-            syntax::ast::Span::new(usage_span.file_id, usage_span.byte_offset + offset, length)
+            Span::new(usage_span.file_id, usage_span.byte_offset + offset, length)
         }
         None => usage_span,
     }
 }
 
 fn usage_locations(
-    snapshots: impl IntoIterator<Item = std::sync::Arc<AnalysisSnapshot>>,
+    snapshots: impl IntoIterator<Item = Arc<AnalysisSnapshot>>,
     definition_uri: &Url,
-    definition_span: syntax::ast::Span,
+    definition_span: Span,
 ) -> Vec<Location> {
     let mut locations = Vec::new();
     for snapshot in snapshots {
         let Some(target_document) = snapshot.document(definition_uri) else {
             continue;
         };
-        let target_span = syntax::ast::Span::new(
+        let target_span = Span::new(
             target_document.file_id,
             definition_span.byte_offset,
             definition_span.byte_length,

--- a/crates/lsp/src/patterns.rs
+++ b/crates/lsp/src/patterns.rs
@@ -5,6 +5,7 @@ use syntax::ast::{
     SequencePatternResolution, Span,
 };
 use syntax::program::DefinitionBody;
+use syntax::types;
 use syntax::types::{CompoundKind, Type, build_substitution_map, substitute, unqualified_name};
 
 use crate::snapshot::AnalysisSnapshot;
@@ -131,7 +132,7 @@ pub(crate) fn get_pattern_element_type(
 }
 
 fn pattern_type_args(snapshot: &AnalysisSnapshot, ty: &Type) -> Vec<Type> {
-    match syntax::types::peel_alias(ty, |id| snapshot.definitions().get(id)) {
+    match types::peel_alias(ty, |id| snapshot.definitions().get(id)) {
         Type::Nominal { params, .. } => params,
         _ => vec![],
     }

--- a/crates/lsp/src/protocol/mod.rs
+++ b/crates/lsp/src/protocol/mod.rs
@@ -16,7 +16,7 @@ use crate::state::Backend;
 
 pub use types::*;
 
-pub(crate) type RpcResult<T> = std::result::Result<T, Error>;
+pub(crate) type RpcResult<T> = Result<T, Error>;
 
 #[derive(Debug)]
 pub(crate) struct Error {

--- a/crates/lsp/src/protocol/uri.rs
+++ b/crates/lsp/src/protocol/uri.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 
 /// URI used by the Lisette language server.
 ///
@@ -22,7 +23,7 @@ impl fmt::Display for InvalidUri {
     }
 }
 
-impl std::error::Error for InvalidUri {}
+impl Error for InvalidUri {}
 
 impl Url {
     pub fn parse(value: &str) -> Result<Self, InvalidUri> {
@@ -175,10 +176,11 @@ fn hex(byte: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
 
     #[test]
     fn file_path_round_trip_preserves_spaces_and_unicode() {
-        let path = std::env::temp_dir().join("lisette uri ☃.lis");
+        let path = env::temp_dir().join("lisette uri ☃.lis");
         let uri = Url::from_file_path(&path).expect("absolute path");
 
         assert_eq!(uri.to_file_path(), Ok(path));

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -4,6 +4,7 @@ use syntax::ast::Expression;
 use syntax::types::unqualified_name;
 
 use crate::traversal::find_enclosing_call;
+use syntax::types::Type;
 pub(crate) fn handle(items: &[Expression], offset: u32) -> Option<SignatureHelp> {
     let call_expression = find_enclosing_call(items, offset)?;
 
@@ -16,10 +17,10 @@ pub(crate) fn handle(items: &[Expression], offset: u32) -> Option<SignatureHelp>
 
     let func_ty = expression.get_type();
     let func_ty_inner = match &func_ty {
-        syntax::types::Type::Forall { body, .. } => body.as_ref(),
+        Type::Forall { body, .. } => body.as_ref(),
         other => other,
     };
-    let syntax::types::Type::Function(f) = func_ty_inner else {
+    let Type::Function(f) = func_ty_inner else {
         return None;
     };
     let params = &f.params;

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -14,6 +14,7 @@ use crate::imports::{Importable, PackageResolver};
 use crate::paths::{ENTRY_PACKAGE_ID, package_file_to_path};
 use crate::position::LineIndex;
 use crate::project::ProjectConfig;
+use std::path::Path;
 
 pub(crate) struct AnalysisSnapshot {
     pub(crate) analysis: Analysis,
@@ -41,7 +42,7 @@ impl AnalysisSnapshot {
     pub(crate) fn new(
         analysis: Analysis,
         config: &ProjectConfig,
-        entry_dir: &std::path::Path,
+        entry_dir: &Path,
         external_test: bool,
         packages: PackageResolver,
     ) -> Self {
@@ -111,7 +112,7 @@ impl AnalysisSnapshot {
     }
 
     /// On-disk path of a `go:` typedef file, if `file_id` names one.
-    pub(crate) fn typedef_path(&self, file_id: u32) -> Option<&std::path::Path> {
+    pub(crate) fn typedef_path(&self, file_id: u32) -> Option<&Path> {
         self.analysis
             .emit_input
             .files

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -9,6 +9,7 @@ use crate::imports::PackageIndex;
 use crate::loader::ProjectState;
 use crate::position::LineIndex;
 use crate::snapshot::AnalysisSnapshot;
+use std::ops::Deref;
 
 pub struct SharedState {
     pub(crate) client: Client,
@@ -160,7 +161,7 @@ pub struct Backend {
     pub(crate) shared_state: Arc<SharedState>,
 }
 
-impl std::ops::Deref for Backend {
+impl Deref for Backend {
     type Target = SharedState;
     fn deref(&self) -> &SharedState {
         &self.shared_state

--- a/crates/lsp/src/validation.rs
+++ b/crates/lsp/src/validation.rs
@@ -1,3 +1,5 @@
+use crate::protocol::Error;
+use std::borrow::Cow;
 /// All keywords, including contextual ones (`var`, `self`).
 pub(crate) const KEYWORDS: &[&str] = &[
     "fn",
@@ -69,13 +71,11 @@ fn is_go_import(qualified_name: &str) -> bool {
     qualified_name.starts_with("go:")
 }
 
-pub(crate) fn rename_error(
-    message: impl Into<std::borrow::Cow<'static, str>>,
-) -> crate::protocol::Error {
-    crate::protocol::Error::invalid_params(message)
+pub(crate) fn rename_error(message: impl Into<Cow<'static, str>>) -> Error {
+    Error::invalid_params(message)
 }
 
-pub(crate) fn check_rename_guards(qualified_name: &str) -> Result<(), crate::protocol::Error> {
+pub(crate) fn check_rename_guards(qualified_name: &str) -> Result<(), Error> {
     if is_prelude_symbol(qualified_name) {
         return Err(rename_error("Cannot rename prelude symbol"));
     }

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -5,6 +5,10 @@ use lsp_harness::{
     TestClient, completion_items, completion_labels, cursor, cursors, definition_location,
     definition_target_text, doc_end, hover_content, inlay_hint_triples, symbol_names,
 };
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
 
 const TEST_URI: &str = "file:///test.lis";
 
@@ -864,19 +868,19 @@ fn hover_on_alias_target_primitive() {
 fn hover_on_alias_target_qualified() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let response_dir = src.join("response");
-    std::fs::create_dir_all(&response_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&response_dir).unwrap();
+    fs::write(
         response_dir.join("response.lis"),
         "pub enum Code { Ok, Err }",
     )
     .unwrap();
     let (main_content, line, character) =
         cursor("import \"response\"\n\ntype Code = response.C~ode\n");
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -987,12 +991,12 @@ fn hover_on_function_param_annotation() {
 fn hover_on_function_qualified_return_annotation() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let http_dir = src.join("http");
-    std::fs::create_dir_all(&http_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&http_dir).unwrap();
+    fs::write(
         http_dir.join("http.lis"),
         "pub struct HandlerFunc { name: string }",
     )
@@ -1000,7 +1004,7 @@ fn hover_on_function_qualified_return_annotation() {
     let (main_content, line, character) = cursor(
         "import \"http\"\n\nfn handle() -> http.Hand~lerFunc { http.HandlerFunc { name: \"\" } }\n",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -1106,7 +1110,7 @@ fn goto_definition_on_third_party_go_function_navigates_to_cache() {
         "[project]\nname = \"test\"\nversion = \"0.0.1\"\n\n[toolchain]\nlis = \"{}\"\n\n[dependencies.go]\n\"github.com/example/lib\" = \"v1.0.0\"\n",
         env!("CARGO_PKG_VERSION")
     );
-    std::fs::write(root.join("lisette.toml"), manifest).unwrap();
+    fs::write(root.join("lisette.toml"), manifest).unwrap();
 
     // Pre-populate the typedef cache for `github.com/example/lib@v1.0.0`.
     let pkg = deps::GoPackage {
@@ -1119,19 +1123,19 @@ fn goto_definition_on_third_party_go_function_navigates_to_cache() {
     };
     let cache_dir = deps::typedef_cache_dir(root);
     let typedef_path = pkg.typedef_path(&cache_dir, stdlib::Target::host());
-    std::fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
-    std::fs::write(
+    fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
+    fs::write(
         &typedef_path,
         "// Package: lib\n\npub fn DoStuff() -> int\n",
     )
     .unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let (main_content, line, character) =
         cursor("import \"go:github.com/example/lib\"\n\nfn main() {\n  let _ = lib.~DoStuff()\n}");
     let main_path = src.join("main.lis");
-    std::fs::write(&main_path, &main_content).unwrap();
+    fs::write(&main_path, &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -1479,21 +1483,21 @@ fn completion_struct_literal_respects_field_visibility() {
     let root = tempfile::tempdir().unwrap();
     let root_path = root.path();
 
-    std::fs::write(
+    fs::write(
         root_path.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/shapes")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/shapes")).unwrap();
+    fs::write(
         root_path.join("src/shapes/shapes.lis"),
         "pub struct Box { pub w: int, h: int }\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
+    fs::create_dir_all(root_path.join("src/main")).unwrap();
     let (main_source, line, character) =
         cursor("import \"shapes\"\nfn main() {\n  let b = shapes.Box { ~ }\n}\n");
-    std::fs::write(root_path.join("src/main/main.lis"), &main_source).unwrap();
+    fs::write(root_path.join("src/main/main.lis"), &main_source).unwrap();
 
     client.initialize_with_root(root_path);
 
@@ -1505,7 +1509,7 @@ fn completion_struct_literal_respects_field_visibility() {
 
     client.open(
         &shapes_uri,
-        &std::fs::read_to_string(root_path.join("src/shapes/shapes.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/shapes/shapes.lis")).unwrap(),
     );
     client.open(&main_uri, &main_source);
 
@@ -2455,17 +2459,17 @@ fn cross_package_goto_definition() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let main_content = "import \"utils\"\n\nfn main() { utils.helper() }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let utils_dir = src.join("utils");
-    std::fs::create_dir_all(&utils_dir).unwrap();
-    std::fs::write(utils_dir.join("utils.lis"), "pub fn helper() -> int { 42 }").unwrap();
+    fs::create_dir_all(&utils_dir).unwrap();
+    fs::write(utils_dir.join("utils.lis"), "pub fn helper() -> int { 42 }").unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -6244,10 +6248,10 @@ fn main() {
 fn stress_cross_package_hover_on_imported_function() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let (main_content, positions) = cursors(
         "\
@@ -6258,11 +6262,11 @@ fn main() {
   x
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let math_dir = src.join("math");
-    std::fs::create_dir_all(&math_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&math_dir).unwrap();
+    fs::write(
         math_dir.join("math.lis"),
         "pub fn double(n: int) -> int { n * 2 }",
     )
@@ -6296,14 +6300,14 @@ fn main() {
 fn stress_cross_package_completion_on_struct_methods() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let lib_dir = src.join("shapes");
-    std::fs::create_dir_all(&lib_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&lib_dir).unwrap();
+    fs::write(
         lib_dir.join("shapes.lis"),
         "\
 pub struct Circle { pub radius: float64 }
@@ -6322,7 +6326,7 @@ fn main() {
   ~c.~area~()
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -6350,14 +6354,14 @@ fn main() {
 fn stress_cross_package_enum_variant_completion() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let types_dir = src.join("types");
-    std::fs::create_dir_all(&types_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&types_dir).unwrap();
+    fs::write(
         types_dir.join("types.lis"),
         "\
 pub enum Color {
@@ -6375,7 +6379,7 @@ fn main() {
   let c = types.Color.Red
   c
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -6398,14 +6402,14 @@ fn main() {
 fn stress_cross_package_rename_local_binding() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let util_dir = src.join("util");
-    std::fs::create_dir_all(&util_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&util_dir).unwrap();
+    fs::write(
         util_dir.join("util.lis"),
         "pub fn greet() -> string { \"hi\" }",
     )
@@ -6420,7 +6424,7 @@ fn main() {
   msg
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7121,14 +7125,14 @@ fn main() {
 fn stress_cross_package_import_alias() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let helpers_dir = src.join("helpers");
-    std::fs::create_dir_all(&helpers_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&helpers_dir).unwrap();
+    fs::write(
         helpers_dir.join("helpers.lis"),
         "pub fn compute() -> int { 42 }",
     )
@@ -7142,7 +7146,7 @@ fn main() {
   h.~c~ompute()
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7645,14 +7649,14 @@ fn main() {
 fn stress_cross_package_enum_variant_goto_def() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let types_dir = src.join("types");
-    std::fs::create_dir_all(&types_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&types_dir).unwrap();
+    fs::write(
         types_dir.join("types.lis"),
         "\
 pub enum Color {
@@ -7679,7 +7683,7 @@ fn main() {
   types.is~_warm(c~)
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7707,14 +7711,14 @@ fn main() {
 fn goto_definition_const_pattern_resolves_exact_package() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let a_dir = src.join("week_a");
-    std::fs::create_dir_all(&a_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&a_dir).unwrap();
+    fs::write(
         a_dir.join("week_a.lis"),
         "\
 pub struct Weekday(int)
@@ -7723,8 +7727,8 @@ pub const Friday: Weekday = 5",
     .unwrap();
 
     let b_dir = src.join("week_b");
-    std::fs::create_dir_all(&b_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&b_dir).unwrap();
+    fs::write(
         b_dir.join("week_b.lis"),
         "\
 pub struct Workday(int)
@@ -7742,7 +7746,7 @@ fn classify(d: b.Workday) -> int {
     _ => 0,
   }
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7769,10 +7773,10 @@ fn classify(d: b.Workday) -> int {
 fn goto_definition_bare_const_pattern_resolves_local_constant() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let main_content = "\
 const MAX_SIZE = 1024
@@ -7783,7 +7787,7 @@ fn classify(n: int) -> int {
     _ => 0,
   }
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7841,14 +7845,14 @@ fn main() {
 fn stress_handlers_on_import_statement() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let lib_dir = src.join("mylib");
-    std::fs::create_dir_all(&lib_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&lib_dir).unwrap();
+    fs::write(
         lib_dir.join("mylib.lis"),
         "pub fn greet() -> string { \"hello\" }",
     )
@@ -7860,7 +7864,7 @@ import \"mylib\"
 fn main() {
   mylib.greet()
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -7957,14 +7961,14 @@ fn main() {
 fn stress_cross_package_type_error_diagnostics() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let lib_dir = src.join("mymod");
-    std::fs::create_dir_all(&lib_dir).unwrap();
-    std::fs::write(lib_dir.join("mymod.lis"), "pub fn get_num() -> int { 42 }").unwrap();
+    fs::create_dir_all(&lib_dir).unwrap();
+    fs::write(lib_dir.join("mymod.lis"), "pub fn get_num() -> int { 42 }").unwrap();
 
     let main_content = "\
 import \"mymod\"
@@ -7973,7 +7977,7 @@ fn main() {
   let x: string = mymod.get_num()
   x
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -8002,26 +8006,26 @@ fn main() {
 fn stress_cross_package_sibling_files() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let mod_dir = src.join("shapes");
-    std::fs::create_dir_all(&mod_dir).unwrap();
+    fs::create_dir_all(&mod_dir).unwrap();
 
-    std::fs::write(
+    fs::write(
         mod_dir.join("circle.lis"),
         "pub struct Circle { pub radius: float64 }",
     )
     .unwrap();
-    std::fs::write(
+    fs::write(
         mod_dir.join("rect.lis"),
         "pub struct Rect { pub width: float64, pub height: float64 }",
     )
     .unwrap();
     // Package entry file
-    std::fs::write(mod_dir.join("shapes.lis"), "").unwrap();
+    fs::write(mod_dir.join("shapes.lis"), "").unwrap();
 
     let (main_content, positions) = cursors(
         "\
@@ -8033,7 +8037,7 @@ fn main() {
   c.~radius + r.w~idth
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -8176,15 +8180,15 @@ fn main() {
 fn stress_cross_package_multiple_imports() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     for name in ["a", "b", "c"] {
         let d = src.join(name);
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(
+        fs::create_dir_all(&d).unwrap();
+        fs::write(
             d.join(format!("{name}.lis")),
             format!("pub fn f{name}() -> int {{ 1 }}"),
         )
@@ -8199,7 +8203,7 @@ import \"c\"
 fn main() {
   a.fa() + b.fb() + c.fc()
 }";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -8436,14 +8440,14 @@ fn main() {
 fn stress_cross_package_rename_function() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let lib_dir = src.join("lib");
-    std::fs::create_dir_all(&lib_dir).unwrap();
-    std::fs::write(lib_dir.join("lib.lis"), "pub fn compute() -> int { 42 }").unwrap();
+    fs::create_dir_all(&lib_dir).unwrap();
+    fs::write(lib_dir.join("lib.lis"), "pub fn compute() -> int { 42 }").unwrap();
 
     let (main_content, line, character) = cursor(
         "\
@@ -8455,7 +8459,7 @@ fn main() {
   x + y
 }",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -9232,7 +9236,7 @@ fn main() {
         assert_eq!(text_edit.new_text, "Vec2");
     }
 
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     for text_edit in edits {
         let key = (text_edit.range.start.line, text_edit.range.start.character);
         assert!(
@@ -9274,7 +9278,7 @@ fn main() {
         locations.len()
     );
 
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     for loc in &locations {
         let key = (loc.range.start.line, loc.range.start.character);
         assert!(
@@ -9396,7 +9400,7 @@ fn opening_prelude_typedef_publishes_no_diagnostics() {
     client.initialize();
 
     let path = deps::prelude_typedef_path().expect("prelude typedef path");
-    let content = std::fs::read_to_string(&path).expect("prelude cache file should exist");
+    let content = fs::read_to_string(&path).expect("prelude cache file should exist");
     let uri = Url::from_file_path(&path).expect("path to uri").to_string();
 
     client.open(&uri, &content);
@@ -9522,18 +9526,18 @@ fn references_cross_package_finds_call_sites() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let main_content = "import \"utils\"\n\nfn main() {\n  utils.helper()\n  utils.helper()\n}";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let utils_dir = src.join("utils");
-    std::fs::create_dir_all(&utils_dir).unwrap();
+    fs::create_dir_all(&utils_dir).unwrap();
     let utils_content = "pub fn helper() -> int { 42 }";
-    std::fs::write(utils_dir.join("utils.lis"), utils_content).unwrap();
+    fs::write(utils_dir.join("utils.lis"), utils_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -9579,21 +9583,21 @@ fn goto_definition_struct_field_cross_package() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let models_dir = src.join("models");
-    std::fs::create_dir_all(&models_dir).unwrap();
+    fs::create_dir_all(&models_dir).unwrap();
 
     let models_content = "pub struct Task {\n  pub id: int,\n  pub title: string,\n}";
-    std::fs::write(models_dir.join("models.lis"), models_content).unwrap();
+    fs::write(models_dir.join("models.lis"), models_content).unwrap();
 
     let (main_content, line, character) = cursor(
         "import \"models\"\n\nfn main() {\n  let t = models.Task { id: 1, title: \"hi\" }\n  let x = t.~id\n}",
     );
-    std::fs::write(src.join("main.lis"), &main_content).unwrap();
+    fs::write(src.join("main.lis"), &main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -9961,19 +9965,19 @@ fn completion_on_cross_package_enum_dot_access() {
     let root = tempfile::tempdir().unwrap();
     let root_path = root.path();
 
-    std::fs::write(
+    fs::write(
         root_path.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/colors")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/colors")).unwrap();
+    fs::write(
         root_path.join("src/colors/colors.lis"),
         "pub enum Color { Red, Green, Blue }\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/main")).unwrap();
+    fs::write(
         root_path.join("src/main/main.lis"),
         "import \"colors\"\nfn main() {\n  let c = colors.Color.Red\n}\n",
     )
@@ -9989,11 +9993,11 @@ fn completion_on_cross_package_enum_dot_access() {
 
     client.open(
         &colors_uri,
-        &std::fs::read_to_string(root_path.join("src/colors/colors.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/colors/colors.lis")).unwrap(),
     );
     client.open(
         &main_uri,
-        &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
     );
 
     let response = client.completion(&main_uri, 2, 23);
@@ -10023,19 +10027,19 @@ fn completion_dot_on_alias_to_cross_package_enum_shows_variants() {
     let root = tempfile::tempdir().unwrap();
     let root_path = root.path();
 
-    std::fs::write(
+    fs::write(
         root_path.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/utils")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/utils")).unwrap();
+    fs::write(
         root_path.join("src/utils/utils.lis"),
         "pub enum Kind { Int, String }\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/main")).unwrap();
+    fs::write(
         root_path.join("src/main/main.lis"),
         "import \"utils\"\ntype K = utils.Kind\nfn main() {\n  let o = K.\n}\n",
     )
@@ -10048,11 +10052,11 @@ fn completion_dot_on_alias_to_cross_package_enum_shows_variants() {
 
     client.open(
         &utils_uri,
-        &std::fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
     );
     client.open(
         &main_uri,
-        &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
     );
 
     let response = client.completion(&main_uri, 3, 12);
@@ -10080,13 +10084,13 @@ fn completion_dot_on_alias_to_cross_package_enum_hides_private_static_methods() 
     let root = tempfile::tempdir().unwrap();
     let root_path = root.path();
 
-    std::fs::write(
+    fs::write(
         root_path.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/utils")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/utils")).unwrap();
+    fs::write(
         root_path.join("src/utils/utils.lis"),
         "pub enum Kind { Int, String }\n\
 impl Kind {\n\
@@ -10095,8 +10099,8 @@ impl Kind {\n\
 }\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/main")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/main")).unwrap();
+    fs::write(
         root_path.join("src/main/main.lis"),
         "import \"utils\"\ntype K = utils.Kind\nfn main() {\n  let _ = K.\n}\n",
     )
@@ -10109,11 +10113,11 @@ impl Kind {\n\
 
     client.open(
         &utils_uri,
-        &std::fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/utils/utils.lis")).unwrap(),
     );
     client.open(
         &main_uri,
-        &std::fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
+        &fs::read_to_string(root_path.join("src/main/main.lis")).unwrap(),
     );
 
     let response = client.completion(&main_uri, 3, 12);
@@ -10816,18 +10820,18 @@ fn goto_definition_type_alias_rhs_with_shadowing_lhs_name() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
     let server_dir = src.join("server");
     let response_dir = server_dir.join("response");
-    std::fs::create_dir_all(&response_dir).unwrap();
+    fs::create_dir_all(&response_dir).unwrap();
 
     let response_content = "pub enum Code { Ok, NotFound }\n";
-    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+    fs::write(response_dir.join("response.lis"), response_content).unwrap();
 
     let routes_content = "import \"server/response\"\n\ntype Code = response.Code\n";
-    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+    fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -10863,18 +10867,18 @@ fn goto_definition_type_alias_inside_generic_param() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
     let server_dir = src.join("server");
     let response_dir = server_dir.join("response");
-    std::fs::create_dir_all(&response_dir).unwrap();
+    fs::create_dir_all(&response_dir).unwrap();
 
     let response_content = "pub enum Code { Ok, NotFound }\n";
-    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+    fs::write(response_dir.join("response.lis"), response_content).unwrap();
 
     let routes_content = "import \"server/response\"\n\ntype Codes = Slice<response.Code>\n";
-    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+    fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -10904,19 +10908,19 @@ fn goto_definition_type_alias_inside_function_annotation() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
     let server_dir = src.join("server");
     let response_dir = server_dir.join("response");
-    std::fs::create_dir_all(&response_dir).unwrap();
+    fs::create_dir_all(&response_dir).unwrap();
 
     let response_content = "pub enum Code { Ok, NotFound }\n";
-    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+    fs::write(response_dir.join("response.lis"), response_content).unwrap();
 
     let routes_content =
         "import \"server/response\"\n\ntype Handler = fn(response.Code) -> response.Code\n";
-    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+    fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -10945,18 +10949,18 @@ fn goto_definition_type_alias_inside_tuple_annotation() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
     let server_dir = src.join("server");
     let response_dir = server_dir.join("response");
-    std::fs::create_dir_all(&response_dir).unwrap();
+    fs::create_dir_all(&response_dir).unwrap();
 
     let response_content = "pub enum Code { Ok, NotFound }\n";
-    std::fs::write(response_dir.join("response.lis"), response_content).unwrap();
+    fs::write(response_dir.join("response.lis"), response_content).unwrap();
 
     let routes_content = "import \"server/response\"\n\ntype Pair = (response.Code, int)\n";
-    std::fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
+    fs::write(server_dir.join("routes.lis"), routes_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11052,24 +11056,24 @@ fn goto_definition_struct_pattern_field() {
 fn goto_definition_struct_name_in_aliased_struct_call() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let shapes_dir = src.join("shapes");
-    std::fs::create_dir_all(&shapes_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&shapes_dir).unwrap();
+    fs::write(
         shapes_dir.join("shapes.lis"),
         "pub struct Rect {\n  pub width: int,\n  pub height: int,\n}\n",
     )
     .unwrap();
 
     let main_content = "import s \"shapes\"\n\nfn main() {\n  let r = s.Rect { width: 10, height: 20 }\n  r.width\n}\n";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11092,24 +11096,24 @@ fn goto_definition_struct_name_in_aliased_struct_call() {
 fn rename_struct_from_aliased_struct_call() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let shapes_dir = src.join("shapes");
-    std::fs::create_dir_all(&shapes_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&shapes_dir).unwrap();
+    fs::write(
         shapes_dir.join("shapes.lis"),
         "pub struct Rect {\n  pub width: int,\n  pub height: int,\n}\n",
     )
     .unwrap();
 
     let main_content = "import s \"shapes\"\n\nfn main() {\n  let r = s.Rect { width: 10, height: 20 }\n  r.width\n}\n";
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11189,13 +11193,13 @@ fn diagnostics_invalid_manifest_surfaces_error() {
     let root = dir.path();
 
     // Write an invalid lisette.toml (missing required [project] section)
-    std::fs::write(root.join("lisette.toml"), "[invalid]\nfoo = 1\n").unwrap();
+    fs::write(root.join("lisette.toml"), "[invalid]\nfoo = 1\n").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let content = "fn main() { 1 }";
-    std::fs::write(src.join("main.lis"), content).unwrap();
+    fs::write(src.join("main.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11228,17 +11232,17 @@ fn diagnostics_toolchain_mismatch_surfaces_error() {
     let root = dir.path();
 
     // Pin a lis version that does not match the running binary
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n\n[toolchain]\nlis = \"99.99.99\"\n",
     )
     .unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let content = "fn main() { 1 }";
-    std::fs::write(src.join("main.lis"), content).unwrap();
+    fs::write(src.join("main.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11803,13 +11807,13 @@ fn inlay_hint_lambda_return_over_index_body() {
 #[test]
 fn opening_prelude_source_reports_no_foreign_type_errors() {
     let dir = tempfile::tempdir().unwrap();
-    let prelude_src = std::fs::read_to_string(concat!(
+    let prelude_src = fs::read_to_string(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../stdlib/prelude.d.lis"
     ))
     .unwrap();
     let path = dir.path().join("prelude.d.lis");
-    std::fs::write(&path, &prelude_src).unwrap();
+    fs::write(&path, &prelude_src).unwrap();
     let uri = Url::from_file_path(&path).unwrap().to_string();
 
     let mut client = TestClient::new();
@@ -11833,18 +11837,18 @@ fn opening_prelude_source_reports_no_foreign_type_errors() {
 fn editing_a_file_refreshes_diagnostics_in_dependent_open_files() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.0.1\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let foo_content = "pub struct Foo {}\n\nimpl Foo {\n  pub fn foo(self) {}\n}\n";
     let main_content = "fn main() {\n  let foo = Foo {}\n  foo.foo()\n}\n";
-    std::fs::write(src.join("foo.lis"), foo_content).unwrap();
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("foo.lis"), foo_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11890,18 +11894,18 @@ fn editing_a_file_refreshes_diagnostics_in_dependent_open_files() {
 fn closing_an_unsaved_file_refreshes_dependent_open_files() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.0.1\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
 
     let foo_content = "pub struct Foo {}\n\nimpl Foo {\n  pub fn foo(self) {}\n}\n";
     let main_content = "fn main() {\n  let foo = Foo {}\n  foo.foo()\n}\n";
-    std::fs::write(src.join("foo.lis"), foo_content).unwrap();
-    std::fs::write(src.join("main.lis"), main_content).unwrap();
+    fs::write(src.join("foo.lis"), foo_content).unwrap();
+    fs::write(src.join("main.lis"), main_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -11965,15 +11969,15 @@ fn exit_without_shutdown_signals_error_exit() {
 fn library_root_file_analyzes_cleanly() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"github.com/acme/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let content = "pub fn origin() -> int { 0 }";
-    std::fs::write(src.join("geo.lis"), content).unwrap();
+    fs::write(src.join("geo.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12001,21 +12005,21 @@ fn library_root_file_analyzes_cleanly() {
 fn library_cross_package_goto_definition_works() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"github.com/acme/lib\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(src.join("math")).unwrap();
-    std::fs::create_dir_all(src.join("calc")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(src.join("math")).unwrap();
+    fs::create_dir_all(src.join("calc")).unwrap();
+    fs::write(
         src.join("math/math.lis"),
         "pub fn double(n: int) -> int { n * 2 }",
     )
     .unwrap();
     let calc = "import \"math\"\n\npub fn quad(n: int) -> int {\n  math.double(n) * 2\n}";
-    std::fs::write(src.join("calc/calc.lis"), calc).unwrap();
+    fs::write(src.join("calc/calc.lis"), calc).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12043,15 +12047,15 @@ fn library_cross_package_goto_definition_works() {
 fn library_main_function_is_not_flagged() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"github.com/acme/lib\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let content = "pub fn main(x: int) -> int { x }";
-    std::fs::write(src.join("lib.lis"), content).unwrap();
+    fs::write(src.join("lib.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12081,15 +12085,15 @@ fn library_main_function_is_not_flagged() {
 fn creating_main_lis_flips_a_library_to_a_binary() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"github.com/acme/flip\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let content = "pub fn main(x: int) -> int { x }";
-    std::fs::write(src.join("flip.lis"), content).unwrap();
+    fs::write(src.join("flip.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12111,7 +12115,7 @@ fn creating_main_lis_flips_a_library_to_a_binary() {
         "library `main` should not be flagged: {diags:?}"
     );
 
-    std::fs::write(src.join("main.lis"), "fn main() {}").unwrap();
+    fs::write(src.join("main.lis"), "fn main() {}").unwrap();
     client.change(&uri, content, 2);
 
     let diags = client.await_diagnostics();
@@ -12129,29 +12133,29 @@ fn external_test_file_is_analyzed_with_visibility_rules() {
     let root = tempfile::tempdir().unwrap();
     let root_path = root.path();
 
-    std::fs::write(
+    fs::write(
         root_path.join("lisette.toml"),
         "[project]\nname = \"test\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("src/geometry")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root_path.join("src/geometry")).unwrap();
+    fs::write(
         root_path.join("src/main.lis"),
         "import \"geometry\"\nfn main() {\n  geometry.area()\n}\n",
     )
     .unwrap();
-    std::fs::write(
+    fs::write(
         root_path.join("src/geometry/geometry.lis"),
         "pub fn area() -> int {\n  hidden()\n}\n\nfn hidden() -> int {\n  4\n}\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root_path.join("tests")).unwrap();
+    fs::create_dir_all(root_path.join("tests")).unwrap();
     let ok_source =
         "import \"geometry\"\n\n#[test]\nfn uses_api() {\n  assert geometry.area() == 4\n}\n";
-    std::fs::write(root_path.join("tests/ok.test.lis"), ok_source).unwrap();
+    fs::write(root_path.join("tests/ok.test.lis"), ok_source).unwrap();
     let peek_source =
         "import \"geometry\"\n\n#[test]\nfn peeks() {\n  assert geometry.hidden() == 4\n}\n";
-    std::fs::write(root_path.join("tests/peek.test.lis"), peek_source).unwrap();
+    fs::write(root_path.join("tests/peek.test.lis"), peek_source).unwrap();
 
     client.initialize_with_root(root_path);
 
@@ -12178,21 +12182,21 @@ fn external_test_file_is_analyzed_with_visibility_rules() {
     client.shutdown();
 }
 
-fn geo_library_project() -> (tempfile::TempDir, std::path::PathBuf) {
+fn geo_library_project() -> (tempfile::TempDir, PathBuf) {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().to_path_buf();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
         root.join("src/geo.lis"),
         "pub struct Point { pub x: int, pub y: int }\npub fn distance(a: int, b: int) -> int { if a > b { a - b } else { b - a } }\n",
     )
     .unwrap();
-    std::fs::create_dir_all(root.join("tests")).unwrap();
+    fs::create_dir_all(root.join("tests")).unwrap();
     (dir, root)
 }
 
@@ -12201,7 +12205,7 @@ fn external_test_root_import_resolves() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn value() {\n  let p = root.Point { x: 1, y: 2 }\n  assert p.x == 1\n  assert root.distance(2, 9) == 7\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12232,17 +12236,17 @@ fn external_test_root_import_resolves() {
 fn external_test_root_import_in_binary_reports_error() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(root.join("lisette.toml"), "").unwrap();
+    fs::write(root.join("lisette.toml"), "").unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
-    std::fs::write(src.join("main.lis"), "fn main() {}\n").unwrap();
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("main.lis"), "fn main() {}\n").unwrap();
 
     let tests = root.join("tests");
-    std::fs::create_dir_all(&tests).unwrap();
+    fs::create_dir_all(&tests).unwrap();
     let content = "import \"root\"\n\n#[test]\nfn value() {\n  assert true\n}\n";
     let test_path = tests.join("api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12266,7 +12270,7 @@ fn external_test_goto_definition_into_root_resolves_to_src() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn value() {\n  let p = root.Point { x: 1, y: 2 }\n  assert p.x == 1\n  assert root.distance(2, 9) == 7\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12298,7 +12302,7 @@ fn external_test_hover_survives_reanalysis() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn value() {\n  let total = root.distance(2, 9)\n  assert total == 7\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12324,7 +12328,7 @@ fn external_test_non_test_file_is_flagged() {
     let (_dir, root) = geo_library_project();
     let content = "pub fn helper() -> int { 1 }\n";
     let helper_path = root.join("tests/helper.lis");
-    std::fs::write(&helper_path, content).unwrap();
+    fs::write(&helper_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12346,7 +12350,7 @@ fn external_test_misnamed_suffix_is_flagged() {
     let (_dir, root) = geo_library_project();
     let content = "#[test]\nfn t() {}\n";
     let misnamed = root.join("tests/api_test.lis");
-    std::fs::write(&misnamed, content).unwrap();
+    fs::write(&misnamed, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12369,21 +12373,21 @@ fn external_test_misnamed_suffix_is_flagged() {
 fn external_test_root_import_in_subpackage_only_library_is_rejected() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
 
     let shapes = root.join("src/shapes");
-    std::fs::create_dir_all(&shapes).unwrap();
-    std::fs::write(shapes.join("shapes.lis"), "pub fn area() -> int { 4 }\n").unwrap();
+    fs::create_dir_all(&shapes).unwrap();
+    fs::write(shapes.join("shapes.lis"), "pub fn area() -> int { 4 }\n").unwrap();
 
     let tests = root.join("tests");
-    std::fs::create_dir_all(&tests).unwrap();
+    fs::create_dir_all(&tests).unwrap();
     let content = "import \"root\"\n\n#[test]\nfn t() {\n  assert true\n}\n";
     let test_path = tests.join("api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12405,7 +12409,7 @@ fn external_test_root_namespace_hover_shows_root() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn t() {\n  assert root.distance(2, 9) == 11\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12435,8 +12439,8 @@ fn external_test_invalid_sibling_is_rejected() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn t() {\n  assert true\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
-    std::fs::write(
+    fs::write(&test_path, content).unwrap();
+    fs::write(
         root.join("tests/helper.lis"),
         "pub fn shared() -> int { 2 }\n",
     )
@@ -12461,17 +12465,17 @@ fn external_test_invalid_sibling_is_rejected() {
 fn src_tests_file_is_not_misclassified_as_external() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
 
     let src_tests = root.join("src/tests");
-    std::fs::create_dir_all(&src_tests).unwrap();
+    fs::create_dir_all(&src_tests).unwrap();
     let content = "fn f() -> int {\n  missing_symbol()\n}\n";
     let file_path = src_tests.join("helper.lis");
-    std::fs::write(&file_path, content).unwrap();
+    fs::write(&file_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12496,22 +12500,22 @@ fn src_tests_file_is_not_misclassified_as_external() {
 fn src_tests_siblings_load_from_src_directory() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
 
     let src_tests = root.join("src/tests");
-    std::fs::create_dir_all(&src_tests).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&src_tests).unwrap();
+    fs::write(
         src_tests.join("sibling.lis"),
         "pub fn from_sibling() -> int { 7 }\n",
     )
     .unwrap();
     let content = "fn use_it() -> int {\n  from_sibling()\n}\n";
     let file_path = src_tests.join("caller.lis");
-    std::fs::write(&file_path, content).unwrap();
+    fs::write(&file_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12532,27 +12536,27 @@ fn src_tests_siblings_load_from_src_directory() {
 fn src_tests_overlay_does_not_collide_with_external_tests() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
-    std::fs::write(
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/geo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
-    std::fs::write(src.join("geo.lis"), "pub fn distance() -> int { 1 }\n").unwrap();
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("geo.lis"), "pub fn distance() -> int { 1 }\n").unwrap();
 
     let src_tests = root.join("src/tests");
-    std::fs::create_dir_all(&src_tests).unwrap();
+    fs::create_dir_all(&src_tests).unwrap();
     let src_helper = src_tests.join("shared.test.lis");
     let src_helper_content = "fn from_src_tests() -> int { 1 }\n";
-    std::fs::write(&src_helper, src_helper_content).unwrap();
+    fs::write(&src_helper, src_helper_content).unwrap();
 
     let tests = root.join("tests");
-    std::fs::create_dir_all(&tests).unwrap();
+    fs::create_dir_all(&tests).unwrap();
     let api = tests.join("api.test.lis");
     let api_content = "import \"root\"\n\n#[test]\nfn t() {\n  assert from_src_tests() == 1\n}\n";
-    std::fs::write(&api, api_content).unwrap();
+    fs::write(&api, api_content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -12578,7 +12582,7 @@ fn external_test_inlay_hint_does_not_leak_entry() {
     let (_dir, root) = geo_library_project();
     let content = "import \"root\"\n\n#[test]\nfn t() {\n  let x = root\n  assert true\n}\n";
     let test_path = root.join("tests/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12604,19 +12608,19 @@ fn a_file_opened_without_a_workspace_root_resolves_its_own_project() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("proj");
     let src = root.join("src");
-    std::fs::create_dir_all(src.join("util")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(src.join("util")).unwrap();
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
-    std::fs::write(
+    fs::write(
         src.join("util/util.lis"),
         "pub fn greet() -> string {\n  \"hi\"\n}\n",
     )
     .unwrap();
     let content = "import \"util\"\n\nfn main() {\n  let _ = util.greet()\n}\n";
-    std::fs::write(src.join("main.lis"), content).unwrap();
+    fs::write(src.join("main.lis"), content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize();
@@ -12641,7 +12645,7 @@ fn a_file_with_no_project_above_it_is_told_how_to_make_one() {
     let dir = tempfile::tempdir().unwrap();
     let loose = dir.path().join("loose.lis");
     let content = "import \"nowhere\"\n\nfn main() {}\n";
-    std::fs::write(&loose, content).unwrap();
+    fs::write(&loose, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize();
@@ -12667,15 +12671,15 @@ fn a_file_with_no_project_above_it_is_told_how_to_make_one() {
 fn a_dotted_project_directory_is_not_a_dotted_package() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path().join("my.app");
-    std::fs::create_dir_all(root.join("src")).unwrap();
-    std::fs::write(
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"github.com/acme/myapp\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     let content = "pub struct VConf { pub a: int }\n";
     let path = root.join("src/conf.lis");
-    std::fs::write(&path, content).unwrap();
+    fs::write(&path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12698,9 +12702,9 @@ fn a_dotted_project_directory_is_not_a_dotted_package() {
 fn a_typedef_file_under_a_dotted_directory_is_exempt() {
     let (_dir, root) = geo_library_project();
     let content = "pub fn Ext() -> int\n";
-    std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+    fs::create_dir_all(root.join("src/v1.2")).unwrap();
     let path = root.join("src/v1.2/api.d.lis");
-    std::fs::write(&path, content).unwrap();
+    fs::write(&path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12723,11 +12727,11 @@ fn a_typedef_file_under_a_dotted_directory_is_exempt() {
 fn a_typedef_beside_a_compiled_sibling_under_a_dotted_directory_is_rejected() {
     for sibling in ["s.lis", "api.test.lis"] {
         let (_dir, root) = geo_library_project();
-        std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+        fs::create_dir_all(root.join("src/v1.2")).unwrap();
         let content = "pub fn Ext() -> int\n";
         let path = root.join("src/v1.2/api.d.lis");
-        std::fs::write(&path, content).unwrap();
-        std::fs::write(
+        fs::write(&path, content).unwrap();
+        fs::write(
             root.join("src/v1.2").join(sibling),
             "pub struct S { pub a: int }\n",
         )
@@ -12764,9 +12768,9 @@ fn a_typedef_tree_under_a_dotted_directory_tracks_the_whole_subtree() {
         ("src/v1.2/sub/api.d.lis", "src/v1.2/sub/x.lis"),
     ] {
         let (_dir, root) = geo_library_project();
-        std::fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
-        std::fs::write(root.join(open_at), typedef).unwrap();
-        std::fs::write(root.join(compiled_at), "pub fn f() -> int { 1 }\n").unwrap();
+        fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
+        fs::write(root.join(open_at), typedef).unwrap();
+        fs::write(root.join(compiled_at), "pub fn f() -> int { 1 }\n").unwrap();
 
         let mut client = TestClient::new();
         client.initialize_with_root(&root);
@@ -12783,9 +12787,9 @@ fn a_typedef_tree_under_a_dotted_directory_tracks_the_whole_subtree() {
     }
 
     let (_dir, root) = geo_library_project();
-    std::fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
-    std::fs::write(root.join("src/v1.2/api.d.lis"), typedef).unwrap();
-    std::fs::write(root.join("src/v1.2/sub/other.d.lis"), typedef).unwrap();
+    fs::create_dir_all(root.join("src/v1.2/sub")).unwrap();
+    fs::write(root.join("src/v1.2/api.d.lis"), typedef).unwrap();
+    fs::write(root.join("src/v1.2/sub/other.d.lis"), typedef).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12807,9 +12811,9 @@ fn a_typedef_tree_under_a_dotted_directory_tracks_the_whole_subtree() {
 fn dotted_external_test_directory_is_rejected() {
     let (_dir, root) = geo_library_project();
     let content = "struct VConf { a: int }\n\n#[test]\nfn value() {\n  let c = VConf { a: 1 }\n  assert c.a == 1\n}\n";
-    std::fs::create_dir_all(root.join("tests/v1.2")).unwrap();
+    fs::create_dir_all(root.join("tests/v1.2")).unwrap();
     let test_path = root.join("tests/v1.2/api.test.lis");
-    std::fs::write(&test_path, content).unwrap();
+    fs::write(&test_path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12832,9 +12836,9 @@ fn dotted_external_test_directory_is_rejected() {
 fn dotted_source_directory_is_rejected() {
     let (_dir, root) = geo_library_project();
     let content = "pub struct VConf { pub a: int }\n";
-    std::fs::create_dir_all(root.join("src/v1.2")).unwrap();
+    fs::create_dir_all(root.join("src/v1.2")).unwrap();
     let path = root.join("src/v1.2/vconf.lis");
-    std::fs::write(&path, content).unwrap();
+    fs::write(&path, content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(&root);
@@ -12864,9 +12868,9 @@ fn an_unsaved_test_file_in_a_dotted_directory_is_rejected() {
 
     for on_disk in [None, Some("api.d.lis")] {
         let (_dir, root) = geo_library_project();
-        std::fs::create_dir_all(root.join("tests/v1.2")).unwrap();
+        fs::create_dir_all(root.join("tests/v1.2")).unwrap();
         if let Some(sibling) = on_disk {
-            std::fs::write(
+            fs::write(
                 root.join("tests/v1.2").join(sibling),
                 "pub fn Ext() -> int\n",
             )
@@ -13204,7 +13208,7 @@ fn completion_after_unimported_third_party_package_offers_its_members_and_import
         "[project]\nname = \"test\"\nversion = \"0.0.1\"\n\n[toolchain]\nlis = \"{}\"\n\n[dependencies.go]\n\"github.com/example/go-lib\" = \"v1.0.0\"\n",
         env!("CARGO_PKG_VERSION")
     );
-    std::fs::write(root.join("lisette.toml"), manifest).unwrap();
+    fs::write(root.join("lisette.toml"), manifest).unwrap();
 
     let pkg = deps::GoPackage {
         module: deps::GoModule {
@@ -13215,18 +13219,18 @@ fn completion_after_unimported_third_party_package_offers_its_members_and_import
         package: "github.com/example/go-lib",
     };
     let typedef_path = pkg.typedef_path(&deps::typedef_cache_dir(root), stdlib::Target::host());
-    std::fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
-    std::fs::write(
+    fs::create_dir_all(typedef_path.parent().unwrap()).unwrap();
+    fs::write(
         &typedef_path,
         "// Generated by Lisette bindgen\n// Package: lib\n\npub fn DoStuff(n: int) -> int\n",
     )
     .unwrap();
 
     let src = root.join("src");
-    std::fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&src).unwrap();
     let (content, line, character) = cursor("fn main() {\n  let n = lib.~\n}\n");
     let main_path = src.join("main.lis");
-    std::fs::write(&main_path, &content).unwrap();
+    fs::write(&main_path, &content).unwrap();
 
     let mut client = TestClient::new();
     client.initialize_with_root(root);
@@ -13268,20 +13272,20 @@ fn completion_after_an_unknown_prefix_dot_offers_nothing() {
     client.shutdown();
 }
 
-fn project_with(root: &std::path::Path, files: &[(&str, &str)]) {
-    std::fs::write(
+fn project_with(root: &Path, files: &[(&str, &str)]) {
+    fs::write(
         root.join("lisette.toml"),
         "[project]\nname = \"example.com/you/app\"\nversion = \"0.1.0\"\n",
     )
     .unwrap();
     for (relative, content) in files {
         let path = root.join(relative);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, content).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
     }
 }
 
-fn uri_of(root: &std::path::Path, relative: &str) -> String {
+fn uri_of(root: &Path, relative: &str) -> String {
     Url::from_file_path(root.join(relative))
         .unwrap()
         .to_string()

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -7,6 +7,13 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use lisette_lsp::protocol::*;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process;
+use std::sync::OnceLock;
 
 /// A test client for communicating with the LSP server.
 pub struct TestClient {
@@ -24,11 +31,10 @@ impl Default for TestClient {
 }
 
 fn init_test_typedef_home() {
-    static HOME: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    static HOME: OnceLock<PathBuf> = OnceLock::new();
     HOME.get_or_init(|| {
-        let dir =
-            std::env::temp_dir().join(format!("lisette-lsp-test-home-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create test home dir");
+        let dir = env::temp_dir().join(format!("lisette-lsp-test-home-{}", process::id()));
+        fs::create_dir_all(&dir).expect("create test home dir");
         deps::set_typedef_home(dir.clone());
         dir
     });
@@ -39,8 +45,8 @@ impl TestClient {
     pub fn new() -> Self {
         init_test_typedef_home();
 
-        let (server_read, client_write) = std::io::pipe().expect("create client-to-server pipe");
-        let (client_read, server_write) = std::io::pipe().expect("create server-to-client pipe");
+        let (server_read, client_write) = io::pipe().expect("create client-to-server pipe");
+        let (client_read, server_write) = io::pipe().expect("create server-to-client pipe");
 
         let exit_code = thread::spawn(move || serve(server_read, server_write, None));
 
@@ -123,7 +129,7 @@ impl TestClient {
         result
     }
 
-    pub fn initialize_with_root(&mut self, root: &std::path::Path) -> InitializeResult {
+    pub fn initialize_with_root(&mut self, root: &Path) -> InitializeResult {
         let root_uri = Url::from_file_path(root).unwrap().to_string();
         let result = self.request(
             "initialize",
@@ -447,7 +453,7 @@ pub fn definition_target_text(location: &Location) -> String {
         .uri
         .to_file_path()
         .expect("location uri should be a file path");
-    let source = std::fs::read_to_string(&path).expect("definition file should be readable");
+    let source = fs::read_to_string(&path).expect("definition file should be readable");
     let line = source
         .lines()
         .nth(location.range.start.line as usize)

--- a/crates/lsp/tests/lsp_harness.rs
+++ b/crates/lsp/tests/lsp_harness.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use lisette_lsp::protocol::{self, *};
+use lisette_lsp::protocol::*;
 
 /// A test client for communicating with the LSP server.
 pub struct TestClient {
@@ -42,12 +42,12 @@ impl TestClient {
         let (server_read, client_write) = std::io::pipe().expect("create client-to-server pipe");
         let (client_read, server_write) = std::io::pipe().expect("create server-to-client pipe");
 
-        let exit_code = thread::spawn(move || protocol::serve(server_read, server_write, None));
+        let exit_code = thread::spawn(move || serve(server_read, server_write, None));
 
         let (sender, incoming) = mpsc::channel();
         thread::spawn(move || {
             let mut reader = BufReader::new(client_read);
-            while let Ok(Some(message)) = protocol::read_message(&mut reader) {
+            while let Ok(Some(message)) = read_message(&mut reader) {
                 if sender.send(message).is_err() {
                     break;
                 }
@@ -71,7 +71,7 @@ impl TestClient {
         let id = self.next_id;
         self.next_id += 1;
 
-        protocol::write_message(
+        write_message(
             &mut self.writer,
             &json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}),
         )
@@ -103,7 +103,7 @@ impl TestClient {
     }
 
     fn notify(&mut self, method: &str, params: Value) {
-        protocol::write_message(
+        write_message(
             &mut self.writer,
             &json!({"jsonrpc": "2.0", "method": method, "params": params}),
         )

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -14,6 +14,9 @@ use semantics::store::ENTRY_PACKAGE_ID;
 use semantics::{InferenceOutput, PARALLEL_THRESHOLD, run_inference};
 
 use crate::passes;
+use semantics::cache::CompiledPackage;
+use std::mem;
+use syntax::types;
 
 pub struct Analysis {
     pub emit_input: EmitInput,
@@ -54,7 +57,7 @@ impl Analysis {
     }
 
     pub fn take_diagnostics(&mut self) -> Vec<LisetteDiagnostic> {
-        std::mem::take(&mut self.diagnostics)
+        mem::take(&mut self.diagnostics)
     }
 
     fn error_count(&self) -> usize {
@@ -135,7 +138,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
             .iter()
             .any(|diagnostic| diagnostic.is_error());
         if !has_errors {
-            let save = |compiled: &semantics::cache::CompiledPackage| {
+            let save = |compiled: &CompiledPackage| {
                 let file_ids: HashSet<u32> = store
                     .get_package(&compiled.package_id)
                     .map(|m| m.file_ids().collect())
@@ -173,7 +176,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
     let go_package_ids: HashSet<String> = store
         .packages
         .keys()
-        .filter(|id| id.starts_with(syntax::types::GO_IMPORT_PREFIX))
+        .filter(|id| id.starts_with(types::GO_IMPORT_PREFIX))
         .cloned()
         .collect();
 

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -119,7 +119,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
     // Canonicalize diagnostic order so the output is stable regardless of
     // phase ordering, FxHashMap iteration, or parallel inference scheduling.
     let mut all_diagnostics = sink.into_diagnostics();
-    all_diagnostics.sort_by(diagnostics::LisetteDiagnostic::sort_key);
+    all_diagnostics.sort_by(LisetteDiagnostic::sort_key);
     all_diagnostics.splice(0..0, entry_parse_errors.into_iter().map(Into::into));
 
     let emit_stamps: Vec<EmitStamp> = compiled_packages

--- a/crates/passes/src/passes/checks/instantiation_cycle.rs
+++ b/crates/passes/src/passes/checks/instantiation_cycle.rs
@@ -10,6 +10,8 @@ use syntax::program::DotAccessKind;
 use syntax::types::{CompoundKind, FunctionType, Symbol, Type};
 
 use semantics::store::Store;
+use std::iter;
+use syntax::ast::Generic;
 
 pub(crate) fn run(store: &Store, sink: &LocalSink) {
     let targets = collect_generic_targets(store);
@@ -134,7 +136,7 @@ fn collect_generic_targets(store: &Store) -> Targets<'_> {
 
 fn collect_method<'a>(
     method: &'a Expression,
-    impl_generics: &'a [syntax::ast::Generic],
+    impl_generics: &'a [Generic],
     receiver_name: &EcoString,
     package_id: &str,
     targets: &mut Targets<'a>,
@@ -459,7 +461,7 @@ fn structural_children(ty: &Type) -> Vec<&Type> {
             .params
             .iter()
             .map(|param| &param.ty)
-            .chain(std::iter::once(function.return_type.as_ref()))
+            .chain(iter::once(function.return_type.as_ref()))
             .collect(),
         Type::Tuple(elements) => elements.iter().collect(),
         _ => Vec::new(),

--- a/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use semantics::store::Store;
 use syntax::ast::{EnumVariant, Generic, StructFieldDefinition};
+use syntax::program::AliasKind;
 use syntax::program::DefinitionBody;
 use syntax::types::Type;
 use syntax::types::{SubstitutionMap, build_substitution_map, substitute};
@@ -132,7 +133,7 @@ fn check_constructor_inhabited(
         DefinitionBody::TypeAlias {
             generics, alias, ..
         } => {
-            let syntax::program::AliasKind::Transparent { target, .. } = alias else {
+            let AliasKind::Transparent { target, .. } = alias else {
                 return true;
             };
             let map = build_substitution_map(generics, params);

--- a/crates/passes/src/passes/checks/pattern_analysis/mod.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/mod.rs
@@ -210,8 +210,7 @@ pub fn check(expression: &Expression, ctx: &mut PatternAnalysisContext) {
                 .collect();
 
             if let Err(witnesses) = check_exhaustiveness(&unguarded_rows, &unions) {
-                let mut cases: Vec<String> =
-                    witnesses.iter().map(witness::format_witness).collect();
+                let mut cases: Vec<String> = witnesses.iter().map(format_witness).collect();
                 cases.sort();
                 cases.dedup();
 

--- a/crates/passes/src/passes/checks/pattern_analysis/mod.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/mod.rs
@@ -21,6 +21,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{IssueKind, LocalSink};
 use semantics::store::Store;
+use std::slice;
+use syntax::ast::MatchArm;
 use syntax::ast::{
     ConstructorPatternResolution, Expression, IfLetAlternative, Literal, Pattern, SelectArm, Span,
 };
@@ -388,7 +390,7 @@ pub fn check(expression: &Expression, ctx: &mut PatternAnalysisContext) {
 }
 
 fn check_redundancy_with_guards(
-    arms: &[syntax::ast::MatchArm],
+    arms: &[MatchArm],
     unions: &mut UnionTable,
     norm_ctx: &NormalizationContext,
     cache: &mut InhabitanceCache,
@@ -419,14 +421,14 @@ fn check_redundancy_with_guards(
 
                 let covered_by_same_arm = current_arm_rows
                     .iter()
-                    .any(|prev| !is_useful(std::slice::from_ref(prev), current_row, unions));
+                    .any(|prev| !is_useful(slice::from_ref(prev), current_row, unions));
 
                 let help = if covered_by_same_arm {
                     "This alternative is unreachable because it is already covered by an earlier alternative in the same arm"
                         .to_string()
                 } else {
                     let covering = unguarded_previous.iter().find_map(|(orig_idx, prev)| {
-                        if !is_useful(std::slice::from_ref(prev), current_row, unions) {
+                        if !is_useful(slice::from_ref(prev), current_row, unions) {
                             Some((*orig_idx, prev))
                         } else {
                             None

--- a/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
@@ -1,4 +1,5 @@
 use semantics::store::Store;
+use std::slice;
 use syntax::ast::{
     ConstructorPatternResolution, EnumVariant, Generic, Literal, MatchArm, Pattern,
     RecordPatternResolution, SequencePatternResolution, StructFieldPattern,
@@ -495,7 +496,7 @@ fn normalize_slice(
     ctx: &NormalizationContext,
     cache: &mut InhabitanceCache,
 ) -> NormalizedPattern {
-    let type_name = make_type_key("Slice", std::slice::from_ref(element_type));
+    let type_name = make_type_key("Slice", slice::from_ref(element_type));
     register_union(unions, &type_name, || {
         let mut constructors = vec![Constructor {
             tag_id: "EmptySlice".to_string(),
@@ -593,10 +594,7 @@ fn normalize_array(
     ctx: &NormalizationContext,
     cache: &mut InhabitanceCache,
 ) -> NormalizedPattern {
-    let type_name = make_type_key(
-        &format!("Array{length}"),
-        std::slice::from_ref(element_type),
-    );
+    let type_name = make_type_key(&format!("Array{length}"), slice::from_ref(element_type));
 
     if length == 0 {
         register_union(unions, &type_name, || {

--- a/crates/passes/src/passes/checks/prelude_shadowing.rs
+++ b/crates/passes/src/passes/checks/prelude_shadowing.rs
@@ -2,6 +2,8 @@ use diagnostics::LocalSink;
 use syntax::ast::Expression;
 
 use semantics::store::Store;
+use syntax::program::NativeTypeKind;
+use syntax::program::Package;
 
 pub(crate) fn run(typed_ast: &[Expression], store: &Store, sink: &LocalSink) {
     let Some(prelude_package) = store.get_package("prelude") else {
@@ -13,11 +15,7 @@ pub(crate) fn run(typed_ast: &[Expression], store: &Store, sink: &LocalSink) {
     }
 }
 
-fn check_top_level_function(
-    item: &Expression,
-    prelude_package: &syntax::program::Package,
-    sink: &LocalSink,
-) {
+fn check_top_level_function(item: &Expression, prelude_package: &Package, sink: &LocalSink) {
     if let Expression::Function {
         name, name_span, ..
     } = item
@@ -31,11 +29,7 @@ fn check_top_level_function(
     }
 }
 
-fn visit_expression(
-    expression: &Expression,
-    prelude_package: &syntax::program::Package,
-    sink: &LocalSink,
-) {
+fn visit_expression(expression: &Expression, prelude_package: &Package, sink: &LocalSink) {
     match expression {
         Expression::Enum {
             name, name_span, ..
@@ -53,7 +47,7 @@ fn visit_expression(
             // `Array` that have no prelude definition but are still reserved.
             let qualified = format!("prelude.{}", name);
             if prelude_package.definitions.contains_key(qualified.as_str())
-                || syntax::program::NativeTypeKind::from_name(name).is_some()
+                || NativeTypeKind::from_name(name).is_some()
             {
                 sink.push(diagnostics::infer::prelude_type_shadowed(name, *name_span));
             }

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -4,12 +4,14 @@ use rustc_hash::FxHashSet as HashSet;
 use semantics::facts::{DeferredChecks, GenericBoundOrigin};
 use semantics::generics::bound_display_name;
 use semantics::store::Store;
+use semantics::zero;
+use syntax::types::Type;
 use syntax::types::{CompoundKind, TypeVarId};
 
 pub(crate) fn run(store: &Store, checks: &DeferredChecks, sink: &LocalSink) {
     let mut reported_vars: HashSet<(String, TypeVarId)> = HashSet::default();
     let mut collected = Vec::new();
-    let mut report_vars = |ty: &syntax::types::Type, package_id: &str| {
+    let mut report_vars = |ty: &Type, package_id: &str| {
         collected.clear();
         ty.collect_unbound_variables(&mut collected);
         reported_vars.extend(collected.iter().map(|v| (package_id.to_string(), *v)));
@@ -82,7 +84,7 @@ pub(crate) fn run(store: &Store, checks: &DeferredChecks, sink: &LocalSink) {
         if element_ty.is_error() || element_ty.is_variable() {
             continue;
         }
-        if let Err(no_zero) = semantics::zero::has_zero(store, element_ty, &check.package_id) {
+        if let Err(no_zero) = zero::has_zero(store, element_ty, &check.package_id) {
             sink.push(diagnostics::infer::slice_make_no_zero(
                 &no_zero.leaf_ty.stringify(),
                 no_zero.hidden_go_state(),

--- a/crates/passes/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/passes/src/passes/lints/ast_walk/attributes.rs
@@ -2,6 +2,7 @@ use crate::passes::walk::NodeCtx;
 use diagnostics::LocalSink;
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Attribute, AttributeArg, Expression, StructFieldDefinition};
+use syntax::attributes;
 use syntax::attributes::is_serialization_key;
 
 pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
@@ -56,11 +57,11 @@ pub fn check_struct_attributes(expression: &Expression, ctx: &NodeCtx) {
 fn check_unknown_attribute(attribute: &Attribute, sink: &LocalSink) {
     let name = &attribute.name;
 
-    if !syntax::attributes::is_known_attribute(name) {
+    if !attributes::is_known_attribute(name) {
         sink.push(diagnostics::lint::unknown_attribute(
             &attribute.span,
             name,
-            &syntax::attributes::known_attribute_names(),
+            &attributes::known_attribute_names(),
         ));
     }
 }

--- a/crates/passes/src/passes/lints/ast_walk/checks/float_equality_without_abs.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/float_equality_without_abs.rs
@@ -23,7 +23,7 @@ pub fn check_float_equality_without_abs(expression: &Expression, ctx: &NodeCtx) 
     };
 
     let Expression::Binary {
-        operator: BinaryOperator::Subtraction,
+        operator: Subtraction,
         left: minuend,
         right: subtrahend,
         span: difference_span,

--- a/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/helpers.rs
@@ -1,5 +1,6 @@
 use ecow::EcoString;
 use rustc_hash::FxHashSet as HashSet;
+use std::slice;
 use syntax::ast::{
     BinaryOperator, Binding, Expression, FormatStringPart, Literal, Pattern, Span, UnaryOperator,
 };
@@ -391,7 +392,7 @@ pub(super) fn enum_has_multiple_variants(ty: &Type, store: &Store) -> bool {
 pub(super) fn mentions_identifier(expression: &Expression, name: &str) -> bool {
     let mut found = false;
     visit_ast(
-        std::slice::from_ref(expression),
+        slice::from_ref(expression),
         &mut |node, _| {
             if let Expression::Identifier { value, .. } = node {
                 found |= value.as_str() == name;
@@ -408,7 +409,7 @@ pub(super) fn mentions_identifier(expression: &Expression, name: &str) -> bool {
 pub(super) fn has_escaping_control_flow(body: &Expression) -> bool {
     let mut found = false;
     visit_ast(
-        std::slice::from_ref(body),
+        slice::from_ref(body),
         &mut |node, _| {
             found |= matches!(
                 node,

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_find.rs
@@ -4,6 +4,7 @@ use super::helpers::{
 use crate::passes::walk::NodeCtx;
 use diagnostics::{Edit, Fix};
 use semantics::store::Store;
+use std::slice;
 use syntax::ast::{Expression, Span};
 use syntax::program::{CallKind, NativeTypeKind};
 
@@ -33,7 +34,7 @@ pub fn check_manual_find(expression: &Expression, ctx: &NodeCtx) {
     };
 
     let mut diagnostic = diagnostics::lint::manual_find(span, receiver_text, predicate_text);
-    if reads_as_method_call(receiver, std::slice::from_ref(predicate)) {
+    if reads_as_method_call(receiver, slice::from_ref(predicate)) {
         let replacement = format!(
             "{}.find({predicate_text})",
             as_tight_operand(receiver_text, receiver)

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_map_or.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_map_or.rs
@@ -3,6 +3,7 @@ use syntax::ast::{Expression, MatchArm, Pattern, RestPattern, Span};
 use syntax::types::unqualified_name;
 
 use super::helpers::{enum_variant_binding, has_escaping_control_flow, is_eager_safe};
+use std::slice;
 
 pub fn check_manual_map_or(expression: &Expression, ctx: &NodeCtx) {
     let Expression::Match {
@@ -115,7 +116,7 @@ fn maps_binding(body: &Expression, binding: &str) -> bool {
     let mut referenced = false;
     let mut shadowed = false;
     visit_ast(
-        std::slice::from_ref(body),
+        slice::from_ref(body),
         &mut |node, _| {
             if matches!(node, Expression::Identifier { value, .. } if value.as_str() == binding) {
                 referenced = true;

--- a/crates/passes/src/passes/lints/ast_walk/checks/unconditional_recursion.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unconditional_recursion.rs
@@ -1,4 +1,5 @@
 use crate::passes::walk::{FunctionRole, NodeCtx};
+use std::iter;
 use syntax::ast::{BinaryOperator, Expression, LetMode, MatchArm, Span};
 use syntax::program::resolved_definition;
 use syntax::types::{Symbol, Type};
@@ -55,7 +56,7 @@ fn scan(expression: &Expression, target: &str) -> Flow {
             span,
             ..
         } => {
-            let operands = std::iter::once(callee.as_ref())
+            let operands = iter::once(callee.as_ref())
                 .chain(args)
                 .chain(spread.as_deref());
             sequence(scan_sequence(operands, target), || {
@@ -133,7 +134,7 @@ fn scan_registered_call(expression: &Expression, target: &str) -> Flow {
             spread,
             ..
         } => {
-            let operands = std::iter::once(callee.as_ref())
+            let operands = iter::once(callee.as_ref())
                 .chain(args)
                 .chain(spread.as_deref());
             scan_sequence(operands, target)

--- a/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/unnecessary_map_on_constructor.rs
@@ -1,6 +1,7 @@
 use crate::passes::walk::NodeCtx;
 use diagnostics::{Edit, Fix};
 use semantics::store::Store;
+use std::slice;
 use syntax::ast::{Expression, Span};
 
 use super::helpers::{
@@ -63,7 +64,7 @@ fn push_map_on_constructor(
     let mut diagnostic = diagnostics::lint::unnecessary_map_on_constructor(span, variant, method);
     // A lambda mapper needs beta-reduction to inline, so it reports without a fix.
     if !matches!(mapper.unwrap_parens(), Expression::Lambda { .. })
-        && reads_as_method_call(receiver, std::slice::from_ref(mapper))
+        && reads_as_method_call(receiver, slice::from_ref(mapper))
         && let (Some(mapper_text), Some(payload_text)) = (
             span_text(ctx.source(), mapper),
             span_text(ctx.source(), payload),

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -25,6 +25,7 @@ use redundant_import_alias::check_redundant_aliases;
 use reference_graph::{
     EnumVariantId, ItemKind, MemberKind, PackageItemId, ReferenceGraph, StructFieldId,
 };
+use syntax::attributes;
 use syntax::attributes::SERIALIZATION_KEYS;
 use visibility_constraints::check_visibility_constraints;
 
@@ -317,7 +318,7 @@ fn collect_items(
 }
 
 fn function_is_entry(name: &str, visibility: Visibility, attributes: &[Attribute]) -> bool {
-    let is_test = syntax::attributes::has_test_attribute(attributes);
+    let is_test = attributes::has_test_attribute(attributes);
     visibility == Visibility::Public || name == "main" || is_test
 }
 

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -23,7 +23,7 @@ pub enum LintMode {
 
 pub(crate) const PARALLEL_THRESHOLD: usize = 4;
 
-pub(crate) fn source_file_work(store: &semantics::store::Store) -> Vec<(&Package, &File)> {
+pub(crate) fn source_file_work(store: &Store) -> Vec<(&Package, &File)> {
     let mut work: Vec<_> = store
         .packages
         .values()

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -14,6 +14,7 @@ mod lints;
 pub(crate) mod walk;
 
 pub use lints::Lint;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LintMode {
@@ -27,7 +28,7 @@ pub(crate) fn source_file_work(store: &Store) -> Vec<(&Package, &File)> {
     let mut work: Vec<_> = store
         .packages
         .values()
-        .map(std::sync::Arc::as_ref)
+        .map(Arc::as_ref)
         .flat_map(|package| package.source_files().map(move |file| (package, file)))
         .collect();
     work.sort_unstable_by(|a, b| {

--- a/crates/semantics/src/analysis/entry.rs
+++ b/crates/semantics/src/analysis/entry.rs
@@ -1,4 +1,5 @@
 use super::*;
+use syntax::ast::Expression;
 
 pub(super) enum EntryRegistration {
     Absent,
@@ -32,7 +33,7 @@ impl EntryRegistration {
 }
 
 struct ParsedEntry {
-    ast: Vec<syntax::ast::Expression>,
+    ast: Vec<Expression>,
     file_comment: Option<String>,
     outcome: EntryParseOutcome,
 }

--- a/crates/semantics/src/analysis/entry.rs
+++ b/crates/semantics/src/analysis/entry.rs
@@ -190,7 +190,7 @@ pub(super) fn compute_roots(
 /// Production packages the primary roots never reached.
 pub(super) fn find_unreachable_packages(
     discovered: &DiscoveredPackages,
-    graph_result: &crate::package_graph::PackageGraphResult,
+    graph_result: &PackageGraphResult,
 ) -> Vec<String> {
     let mut unreachable: Vec<String> = discovered
         .production_packages()

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -20,7 +20,7 @@ struct UnparsedPackage {
 struct ParsedPackage {
     files: Vec<File>,
     errors: Vec<ParseError>,
-    statuses: Vec<(u32, syntax::FileParseStatus)>,
+    statuses: Vec<(u32, FileParseStatus)>,
     pending: PendingPackage,
 }
 

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
 use super::*;
+use crate::checker::InferredFile;
+use crate::loader;
+use crate::path::DisplayPathBase;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap as HashMap;
 use syntax::program::UninferredExports;
@@ -40,7 +43,7 @@ impl UnparsedPackage {
         for scanned_file in scanned {
             let (mut file, file_errors, status) = scanned_file.parse(package_id, recover);
             if rewrite_root_import {
-                file.rewrite_import(crate::loader::ROOT_IMPORT, ENTRY_PACKAGE_ID);
+                file.rewrite_import(loader::ROOT_IMPORT, ENTRY_PACKAGE_ID);
             }
             statuses.push((file.id, status));
             files.push(file);
@@ -182,7 +185,7 @@ pub(super) fn infer_all_packages(
         let files = input.files.remove(&package_id).unwrap_or_default();
         let rewrite_root_import = input.scope.has_project_root()
             && input.project_kind == ProjectKind::Library
-            && crate::loader::is_external_test_package(&package_id);
+            && loader::is_external_test_package(&package_id);
         // Production-only hash drives dependents/emit; all-files hash drives own validity.
         let (production_hash, full_hash) = source_hashes
             .get(&package_id)
@@ -484,8 +487,8 @@ fn load_cache_candidates(
         });
     }
 
-    let src_base = crate::path::DisplayPathBase::new(&project_root.join("src"));
-    let root_base = crate::path::DisplayPathBase::new(project_root);
+    let src_base = DisplayPathBase::new(&project_root.join("src"));
+    let root_base = DisplayPathBase::new(project_root);
     let build = |job: CacheBuildJob| {
         build_cached_package(
             job.package_id,
@@ -613,7 +616,7 @@ fn infer_packages(checker: &mut TaskState, store: &mut Store, packages: Vec<Regi
         let seed = checker.worker_seed();
         let store_ref: &Store = store;
 
-        let outputs: Vec<(TaskOutput, Vec<crate::checker::InferredFile>)> = packages
+        let outputs: Vec<(TaskOutput, Vec<InferredFile>)> = packages
             .into_par_iter()
             .map(|package| {
                 let mut worker = seed.spawn();

--- a/crates/semantics/src/cache/disk.rs
+++ b/crates/semantics/src/cache/disk.rs
@@ -4,9 +4,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Serialize, de::DeserializeOwned};
+use std::env;
+use std::process;
 
 pub(super) fn global_path(file_name: &str) -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
+    let home = env::var("HOME").ok()?;
     Some(
         PathBuf::from(home)
             .join(".lisette")
@@ -49,7 +51,7 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn temp_path(final_path: &Path) -> PathBuf {
     let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    final_path.with_extension(format!("tmp.{}.{}", std::process::id(), counter))
+    final_path.with_extension(format!("tmp.{}.{}", process::id(), counter))
 }
 
 fn prune_legacy(dir: &Path, prefix: &str) {

--- a/crates/semantics/src/cache/go_stdlib.rs
+++ b/crates/semantics/src/cache/go_stdlib.rs
@@ -8,6 +8,7 @@ use super::disk;
 use super::types::CachedDefinition;
 use super::{CACHE_FORMAT_VERSION, COMPILER_VERSION_HASH, GO_STDLIB_HASH};
 use crate::store::Store;
+use std::fs;
 use syntax::program::File;
 
 #[derive(Serialize, Deserialize)]
@@ -41,7 +42,7 @@ pub fn try_load_go_stdlib_cache(target: Target) -> Option<GoStdlibCache> {
         || cache.content_hash != GO_STDLIB_HASH
         || cache.compiler_version != COMPILER_VERSION_HASH
     {
-        let _ = std::fs::remove_file(&path);
+        let _ = fs::remove_file(&path);
         return None;
     }
 

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -887,7 +887,7 @@ mod tests {
     fn apply_emit_stamps_round_trip() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        std::fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
+        fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
 
         let interface = PackageInterface {
             version: CACHE_FORMAT_VERSION,
@@ -900,21 +900,19 @@ mod tests {
             emit_stamp: None,
         };
         let path = cache_path(root, "greet");
-        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+        fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
 
         let stamp = EmitStamp {
             package_id: "greet".to_string(),
             artifact_hash: 999,
         };
         apply_emit_stamps(root, &[(stamp.clone(), Some(999))]).unwrap();
-        let reread: PackageInterface =
-            bincode::deserialize(&std::fs::read(&path).unwrap()).unwrap();
+        let reread: PackageInterface = bincode::deserialize(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(reread.emit_stamp, Some(999));
         assert_eq!(reread.full_hash, 100);
 
         apply_emit_stamps(root, &[(stamp, None)]).unwrap();
-        let reread: PackageInterface =
-            bincode::deserialize(&std::fs::read(&path).unwrap()).unwrap();
+        let reread: PackageInterface = bincode::deserialize(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(reread.emit_stamp, None);
     }
 
@@ -933,8 +931,8 @@ mod tests {
     fn apply_emit_stamps_removes_corrupt_cache() {
         let temp = tempfile::tempdir().unwrap();
         let path = cache_path(temp.path(), "corrupt");
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, b"invalid").unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"invalid").unwrap();
         let stamp = EmitStamp {
             package_id: "corrupt".to_string(),
             artifact_hash: 0,
@@ -949,9 +947,9 @@ mod tests {
     fn try_load_cache_rejects_unstamped_for_emit() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        std::fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
-        std::fs::create_dir_all(root.join("target").join("greet")).unwrap();
-        std::fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
+        fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
+        fs::create_dir_all(root.join("target").join("greet")).unwrap();
+        fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
 
         let interface = PackageInterface {
             version: CACHE_FORMAT_VERSION,
@@ -967,7 +965,7 @@ mod tests {
             emit_stamp: None,
         };
         let path = cache_path(root, "greet");
-        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+        fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
 
         let loaded = try_load_cache("greet", 100, &HashMap::default(), None, root);
         assert!(loaded.is_some(), "Check phase must accept unstamped cache");
@@ -989,9 +987,9 @@ mod tests {
     fn try_load_cache_rejects_after_sourcemap_invalidation() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        std::fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
-        std::fs::create_dir_all(root.join("target").join("greet")).unwrap();
-        std::fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
+        fs::create_dir_all(root.join("target").join(".lisette").join("cache")).unwrap();
+        fs::create_dir_all(root.join("target").join("greet")).unwrap();
+        fs::write(root.join("target").join("greet").join("greet.go"), "").unwrap();
 
         let artifact_hash = compute_emit_artifact_hash(100, "github.com/test/x");
 
@@ -1009,7 +1007,7 @@ mod tests {
             emit_stamp: Some(artifact_hash),
         };
         let path = cache_path(root, "greet");
-        std::fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
+        fs::write(&path, bincode::serialize(&interface).unwrap()).unwrap();
 
         assert!(
             try_load_cache("greet", 100, &HashMap::default(), Some(artifact_hash), root).is_some()

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -15,6 +15,7 @@ use syntax::program::{File, Package, is_test_file};
 
 use crate::loader::is_external_test_package;
 use crate::store::{ENTRY_PACKAGE_ID, Store};
+use std::env;
 use types::CachedDefinition;
 
 /// Current cache format version. Bump this when making breaking changes to the cache format.
@@ -420,7 +421,7 @@ pub fn apply_emit_stamps(
 }
 
 pub(crate) fn is_cache_disabled() -> bool {
-    std::env::var("LISETTE_NO_CACHE")
+    env::var("LISETTE_NO_CACHE")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
 }

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -8,6 +8,7 @@ use super::types::CachedDefinition;
 use super::{CACHE_FORMAT_VERSION, COMPILER_VERSION_HASH, PRELUDE_HASH};
 use crate::prelude::{PRELUDE_FILE_ID, PRELUDE_PACKAGE_ID};
 use crate::store::Store;
+use std::fs;
 
 #[derive(Serialize, Deserialize)]
 pub struct PreludeCache {
@@ -33,7 +34,7 @@ pub(crate) fn try_load_prelude_cache() -> Option<PreludeCache> {
         || cache.content_hash != PRELUDE_HASH
         || cache.compiler_version != COMPILER_VERSION_HASH
     {
-        let _ = std::fs::remove_file(&path);
+        let _ = fs::remove_file(&path);
         return None;
     }
 

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -2,6 +2,13 @@ use rustc_hash::FxHashMap as HashMap;
 
 use ecow::EcoString;
 use serde::{Deserialize, Serialize};
+use syntax::ast::Attribute;
+use syntax::ast::EnumFieldDefinition;
+use syntax::ast::EnumVariant;
+use syntax::ast::Literal;
+use syntax::ast::StructFieldDefinition;
+use syntax::ast::StructFieldKind;
+use syntax::ast::VariantFields;
 use syntax::ast::{
     Annotation, AttributeArg, FunctionAnnotationParameter, Generic, Span, StructFields,
     Visibility as FieldVisibility,
@@ -229,8 +236,8 @@ pub enum CachedLiteral {
 }
 
 impl CachedLiteral {
-    fn from_literal(lit: &syntax::ast::Literal) -> Self {
-        use syntax::ast::Literal;
+    fn from_literal(lit: &Literal) -> Self {
+        use Literal;
         match lit {
             Literal::Integer { value, text } => CachedLiteral::Integer {
                 value: *value,
@@ -256,8 +263,8 @@ impl CachedLiteral {
         }
     }
 
-    fn to_literal(&self) -> syntax::ast::Literal {
-        use syntax::ast::Literal;
+    fn to_literal(&self) -> Literal {
+        use Literal;
         match self {
             CachedLiteral::Integer { value, text } => Literal::Integer {
                 value: *value,
@@ -284,15 +291,15 @@ pub struct CachedAttribute {
 }
 
 impl CachedAttribute {
-    fn from_attribute(attribute: &syntax::ast::Attribute) -> Self {
+    fn from_attribute(attribute: &Attribute) -> Self {
         Self {
             name: attribute.name.clone(),
             args: attribute.args.clone(),
         }
     }
 
-    fn to_attribute(&self) -> syntax::ast::Attribute {
-        syntax::ast::Attribute {
+    fn to_attribute(&self) -> Attribute {
+        Attribute {
             name: self.name.clone(),
             args: self.args.clone(),
             span: Span::dummy(),
@@ -323,18 +330,15 @@ pub enum CachedStructFields {
 }
 
 impl CachedStructField {
-    fn from_field(
-        field: &syntax::ast::StructFieldDefinition,
-        file_id_to_index: &HashMap<u32, u32>,
-    ) -> Self {
+    fn from_field(field: &StructFieldDefinition, file_id_to_index: &HashMap<u32, u32>) -> Self {
         let kind = match &field.kind {
-            syntax::ast::StructFieldKind::Named { attributes } => CachedStructFieldKind::Named {
+            StructFieldKind::Named { attributes } => CachedStructFieldKind::Named {
                 attributes: attributes
                     .iter()
                     .map(CachedAttribute::from_attribute)
                     .collect(),
             },
-            syntax::ast::StructFieldKind::Embedded => CachedStructFieldKind::Embedded,
+            StructFieldKind::Embedded => CachedStructFieldKind::Embedded,
         };
         Self {
             name: field.name.clone(),
@@ -346,17 +350,17 @@ impl CachedStructField {
         }
     }
 
-    fn to_field(&self, file_ids: &[u32]) -> syntax::ast::StructFieldDefinition {
+    fn to_field(&self, file_ids: &[u32]) -> StructFieldDefinition {
         let kind = match &self.kind {
-            CachedStructFieldKind::Named { attributes } => syntax::ast::StructFieldKind::Named {
+            CachedStructFieldKind::Named { attributes } => StructFieldKind::Named {
                 attributes: attributes
                     .iter()
                     .map(CachedAttribute::to_attribute)
                     .collect(),
             },
-            CachedStructFieldKind::Embedded => syntax::ast::StructFieldKind::Embedded,
+            CachedStructFieldKind::Embedded => StructFieldKind::Embedded,
         };
-        syntax::ast::StructFieldDefinition {
+        StructFieldDefinition {
             doc: self.doc.clone(),
             name: self.name.clone(),
             name_span: self.name_span.to_span(file_ids),
@@ -384,36 +388,33 @@ pub enum CachedVariantFields {
 }
 
 impl CachedVariantFields {
-    fn from_variant_fields(fields: &syntax::ast::VariantFields) -> Self {
+    fn from_variant_fields(fields: &VariantFields) -> Self {
         match fields {
-            syntax::ast::VariantFields::Unit => CachedVariantFields::Unit,
-            syntax::ast::VariantFields::Tuple(fs) => {
+            VariantFields::Unit => CachedVariantFields::Unit,
+            VariantFields::Tuple(fs) => {
                 CachedVariantFields::Tuple(fs.iter().map(CachedEnumField::from_field).collect())
             }
-            syntax::ast::VariantFields::Struct(fs) => {
+            VariantFields::Struct(fs) => {
                 CachedVariantFields::Struct(fs.iter().map(CachedEnumField::from_field).collect())
             }
         }
     }
 
-    fn to_variant_fields(&self) -> syntax::ast::VariantFields {
+    fn to_variant_fields(&self) -> VariantFields {
         match self {
-            CachedVariantFields::Unit => syntax::ast::VariantFields::Unit,
+            CachedVariantFields::Unit => VariantFields::Unit,
             CachedVariantFields::Tuple(fs) => {
-                syntax::ast::VariantFields::Tuple(fs.iter().map(|f| f.to_field()).collect())
+                VariantFields::Tuple(fs.iter().map(|f| f.to_field()).collect())
             }
             CachedVariantFields::Struct(fs) => {
-                syntax::ast::VariantFields::Struct(fs.iter().map(|f| f.to_field()).collect())
+                VariantFields::Struct(fs.iter().map(|f| f.to_field()).collect())
             }
         }
     }
 }
 
 impl CachedEnumVariant {
-    fn from_variant(
-        variant: &syntax::ast::EnumVariant,
-        file_id_to_index: &HashMap<u32, u32>,
-    ) -> Self {
+    fn from_variant(variant: &EnumVariant, file_id_to_index: &HashMap<u32, u32>) -> Self {
         Self {
             name: variant.name.clone(),
             name_span: CachedSpan::from_span(&variant.name_span, file_id_to_index),
@@ -422,8 +423,8 @@ impl CachedEnumVariant {
         }
     }
 
-    fn to_variant(&self, file_ids: &[u32]) -> syntax::ast::EnumVariant {
-        syntax::ast::EnumVariant {
+    fn to_variant(&self, file_ids: &[u32]) -> EnumVariant {
+        EnumVariant {
             doc: self.doc.clone(),
             name: self.name.clone(),
             name_span: self.name_span.to_span(file_ids),
@@ -439,15 +440,15 @@ pub struct CachedEnumField {
 }
 
 impl CachedEnumField {
-    fn from_field(field: &syntax::ast::EnumFieldDefinition) -> Self {
+    fn from_field(field: &EnumFieldDefinition) -> Self {
         Self {
             name: field.name.clone(),
             ty: Clone::clone(&field.ty),
         }
     }
 
-    fn to_field(&self) -> syntax::ast::EnumFieldDefinition {
-        syntax::ast::EnumFieldDefinition {
+    fn to_field(&self) -> EnumFieldDefinition {
+        EnumFieldDefinition {
             name: self.name.clone(),
             name_span: Span::dummy(),
             ty: self.ty.clone(),

--- a/crates/semantics/src/checker/context.rs
+++ b/crates/semantics/src/checker/context.rs
@@ -1,6 +1,8 @@
 use super::resolution::{ImportState, PrefixedImport};
 use super::state::Cursor;
 use super::*;
+use crate::prelude;
+use std::mem;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum FileContext<'a> {
@@ -33,14 +35,8 @@ impl<'a> FileContext<'a> {
                 file_id,
                 imports,
             } => (package_id, file_id, imports),
-            Self::Prelude => (
-                crate::prelude::PRELUDE_PACKAGE_ID,
-                crate::prelude::PRELUDE_FILE_ID,
-                &[],
-            ),
-            Self::TestPrelude { file_id } => {
-                (crate::prelude::TEST_PRELUDE_PACKAGE_ID, file_id, &[])
-            }
+            Self::Prelude => (prelude::PRELUDE_PACKAGE_ID, prelude::PRELUDE_FILE_ID, &[]),
+            Self::TestPrelude { file_id } => (prelude::TEST_PRELUDE_PACKAGE_ID, file_id, &[]),
         }
     }
 }
@@ -71,19 +67,16 @@ impl TaskState {
     ) -> SavedFileContext {
         let (package_id, file_id, imports) = context.parts();
         let saved = SavedFileContext {
-            cursor: std::mem::replace(&mut self.cursor, Cursor::file(package_id, file_id)),
-            scopes: std::mem::take(&mut self.scopes),
-            imports: std::mem::take(&mut self.imports),
+            cursor: mem::replace(&mut self.cursor, Cursor::file(package_id, file_id)),
+            scopes: mem::take(&mut self.scopes),
+            imports: mem::take(&mut self.imports),
         };
 
         match context {
             FileContext::Standard { .. } => {
                 self.put_prelude_in_scope(store);
                 if self.current_file_is_test(store) {
-                    self.put_unprefixed_package_in_scope(
-                        store,
-                        crate::prelude::TEST_PRELUDE_PACKAGE_ID,
-                    );
+                    self.put_unprefixed_package_in_scope(store, prelude::TEST_PRELUDE_PACKAGE_ID);
                 }
                 self.put_unprefixed_package_in_scope(store, package_id);
             }

--- a/crates/semantics/src/checker/freeze.rs
+++ b/crates/semantics/src/checker/freeze.rs
@@ -6,10 +6,13 @@
 //! therefore do not need access to the checker's `TypeEnv`: the emitter maps
 //! any remaining unbound `Type::Var` to Go's `any`.
 
+use crate::facts::Facts;
+use crate::facts::GenericBoundOrigin;
 use syntax::ast::{
     Binding, EnumFieldDefinition, Expression, FormatStringPart, Literal, Pattern, SelectArm,
     SequencePatternResolution, StructFieldDefinition, StructSpread, VariantFields,
 };
+use syntax::types::Bound;
 use syntax::types::Type;
 
 use crate::checker::type_env::TypeEnv;
@@ -76,8 +79,8 @@ impl<'a> FreezeFolder<'a> {
         }
     }
 
-    fn normalize_bound(&self, bound: &syntax::types::Bound) -> syntax::types::Bound {
-        syntax::types::Bound {
+    fn normalize_bound(&self, bound: &Bound) -> Bound {
+        Bound {
             param_name: bound.param_name.clone(),
             generic: self.normalize_ref_aliases(&bound.generic),
             ty: self.normalize_ref_aliases(&bound.ty),
@@ -356,14 +359,14 @@ impl<'a> FreezeFolder<'a> {
         }
     }
 
-    pub fn freeze_facts(&self, facts: &mut crate::facts::Facts) {
+    pub fn freeze_facts(&self, facts: &mut Facts) {
         for check in &mut facts.deferred.generic_calls {
             self.env.resolve_in_place(&mut check.ty);
         }
         for obligation in &mut facts.deferred.generic_bounds {
             self.env.resolve_in_place(&mut obligation.argument);
             self.env.resolve_in_place(&mut obligation.required);
-            if let crate::facts::GenericBoundOrigin::Construction {
+            if let GenericBoundOrigin::Construction {
                 enclosing_return_type: Some(return_type),
                 ..
             } = &mut obligation.origin

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -7,6 +7,7 @@ use syntax::types::Type;
 use crate::checker::type_env::SpeculationOutcome;
 use crate::checker::{FileContext, TaskState};
 use crate::store::Store;
+use std::mem;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(super) enum UseContext {
@@ -305,7 +306,7 @@ impl<'a> InferCtx<'a> {
         context: UseContext,
         f: impl FnOnce(&mut Self) -> T,
     ) -> T {
-        let previous = std::mem::replace(&mut self.traversal.use_context, context);
+        let previous = mem::replace(&mut self.traversal.use_context, context);
         let result = f(self);
         self.traversal.use_context = previous;
         result
@@ -334,21 +335,21 @@ impl<'a> InferCtx<'a> {
     }
 
     pub(super) fn with_dot_access_base<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        let previous = std::mem::replace(&mut self.traversal.dot_access_base, true);
+        let previous = mem::replace(&mut self.traversal.dot_access_base, true);
         let result = f(self);
         self.traversal.dot_access_base = previous;
         result
     }
 
     pub(super) fn with_pattern<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        let previous = std::mem::replace(&mut self.traversal.in_pattern, true);
+        let previous = mem::replace(&mut self.traversal.in_pattern, true);
         let result = f(self);
         self.traversal.in_pattern = previous;
         result
     }
 
     pub(super) fn with_let_binding_rhs<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        let previous = std::mem::replace(&mut self.traversal.let_binding_rhs, true);
+        let previous = mem::replace(&mut self.traversal.let_binding_rhs, true);
         let result = f(self);
         self.traversal.let_binding_rhs = previous;
         result
@@ -414,14 +415,14 @@ impl<'a> InferCtx<'a> {
     }
 
     pub(crate) fn in_negation<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        let previous = std::mem::replace(&mut self.traversal.in_negation, true);
+        let previous = mem::replace(&mut self.traversal.in_negation, true);
         let result = f(self);
         self.traversal.in_negation = previous;
         result
     }
 
     pub(super) fn in_invariant_position<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        let previous = std::mem::replace(&mut self.traversal.in_invariant_position, true);
+        let previous = mem::replace(&mut self.traversal.in_invariant_position, true);
         let result = f(self);
         self.traversal.in_invariant_position = previous;
         result
@@ -452,10 +453,11 @@ impl DerefMut for InferCtx<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store;
 
     #[test]
     fn failed_speculation_rolls_back_diagnostics() {
-        let mut task = TaskState::for_package(crate::store::ENTRY_PACKAGE_ID);
+        let mut task = TaskState::for_package(store::ENTRY_PACKAGE_ID);
         let store = Store::new();
         let result: Result<(), ()> = {
             let mut ctx = InferCtx::new(&mut task, &store);
@@ -476,7 +478,7 @@ mod tests {
 
     #[test]
     fn successful_speculation_keeps_diagnostics() {
-        let mut task = TaskState::for_package(crate::store::ENTRY_PACKAGE_ID);
+        let mut task = TaskState::for_package(store::ENTRY_PACKAGE_ID);
         let store = Store::new();
         let result: Result<(), ()> = InferCtx::new(&mut task, &store).speculatively(|ctx| {
             ctx.sink

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -5,6 +5,8 @@ use syntax::program::DefinitionBody;
 use syntax::types::{Symbol, Type};
 
 use crate::checker::infer::InferCtx;
+use crate::facts::EmptyCollectionCheck;
+use crate::loader;
 
 enum ConstInitReject {
     NotSimple,
@@ -184,7 +186,7 @@ impl InferCtx<'_> {
             self.facts
                 .deferred
                 .empty_collections
-                .push(crate::facts::EmptyCollectionCheck {
+                .push(EmptyCollectionCheck {
                     name: name.to_string(),
                     ty: new_binding.ty.clone(),
                     span,
@@ -219,11 +221,8 @@ impl InferCtx<'_> {
                     store.get_definition(&qualified).map(|d| &d.body),
                     Some(DefinitionBody::Enum { .. })
                 ) {
-                    let type_name = format!(
-                        "{}.{}",
-                        crate::loader::import_display_name(package_id),
-                        member
-                    );
+                    let type_name =
+                        format!("{}.{}", loader::import_display_name(package_id), member);
                     self.sink.push(diagnostics::infer::let_binding_enum_type(
                         &type_name,
                         new_value.get_span(),

--- a/crates/semantics/src/checker/infer/expressions/branches.rs
+++ b/crates/semantics/src/checker/infer/expressions/branches.rs
@@ -5,6 +5,7 @@ use syntax::ast::{Expression, IfLetAlternative, MatchArm, Pattern, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
+use std::mem;
 
 /// Outcome of unifying branch types: kept first, widened to a supertype, or failed.
 enum BranchReconciliation {
@@ -82,7 +83,7 @@ impl InferCtx<'_> {
     }
 
     pub fn resolve_branch_subsumptions(&mut self) {
-        let obligations = std::mem::take(&mut self.file_checks.branch_subsumptions);
+        let obligations = mem::take(&mut self.file_checks.branch_subsumptions);
         for obligation in obligations.into_iter().rev() {
             for branch in &obligation.arms {
                 let arm = branch.ty.resolve_in(&self.env);

--- a/crates/semantics/src/checker/infer/expressions/call_effects.rs
+++ b/crates/semantics/src/checker/infer/expressions/call_effects.rs
@@ -7,6 +7,7 @@ use super::super::carry_mut::can_carry_mutation_across_fn_boundary;
 use super::calls::callee_label;
 use super::primitives::contains_deref;
 use crate::checker::infer::InferCtx;
+use syntax::program::AliasKind;
 
 impl InferCtx<'_> {
     pub(super) fn classify_call(&self, callee: &Expression) -> CallKind {
@@ -104,8 +105,8 @@ impl InferCtx<'_> {
                     methods.get(method).cloned().or_else(|| {
                         // Follow the alias to its underlying type.
                         let underlying = match alias {
-                            syntax::program::AliasKind::Transparent { target, .. } => target,
-                            syntax::program::AliasKind::Opaque(_) => return None,
+                            AliasKind::Transparent { target, .. } => target,
+                            AliasKind::Opaque(_) => return None,
                         };
                         let underlying_key: Option<String> = match underlying {
                             Type::Simple(kind) => Some(format!("prelude.{}", kind.leaf_name())),

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -1,5 +1,8 @@
 use crate::checker::EnvResolve;
+use crate::facts::GenericCallCheck;
+use crate::facts::SliceMakeCheck;
 use ecow::EcoString;
+use std::sync::Arc;
 use syntax::ast::CallTypeArguments;
 use syntax::ast::{Annotation, Expression, IdentifierResolution, Literal, Span, UnaryOperator};
 use syntax::program::{CallKind, NativeTypeKind};
@@ -418,24 +421,18 @@ impl InferCtx<'_> {
         let package_id = self.cursor.package_id().to_string();
         match target {
             DeferredCallCheckTarget::GenericCall => {
-                self.facts
-                    .deferred
-                    .generic_calls
-                    .push(crate::facts::GenericCallCheck {
-                        ty,
-                        span,
-                        package_id,
-                    });
+                self.facts.deferred.generic_calls.push(GenericCallCheck {
+                    ty,
+                    span,
+                    package_id,
+                });
             }
             DeferredCallCheckTarget::SliceMake => {
-                self.facts
-                    .deferred
-                    .slice_makes
-                    .push(crate::facts::SliceMakeCheck {
-                        ty,
-                        span,
-                        package_id,
-                    });
+                self.facts.deferred.slice_makes.push(SliceMakeCheck {
+                    ty,
+                    span,
+                    package_id,
+                });
             }
         }
     }
@@ -726,7 +723,7 @@ impl InferCtx<'_> {
                 && let Type::Function(ref mut f) = instantiated
                 && !f.params.is_empty()
             {
-                let f = std::sync::Arc::make_mut(f);
+                let f = Arc::make_mut(f);
                 let receiver_param = f.remove_receiver();
                 let receiver_ty_stripped = receiver_ty.strip_refs();
                 if receiver_param.is_ref() && !receiver_ty.is_ref() {

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -8,7 +8,7 @@ use syntax::types::{
     unqualified_name,
 };
 
-use super::super::context::{Expectation, ExpectationRole};
+use super::super::context::{Expectation, ExpectationRole, UseContext};
 use super::super::unify::Dispatched;
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
@@ -140,10 +140,9 @@ impl InferCtx<'_> {
         let store = self.store;
         let callee_ty = self.new_type_var();
 
-        let callee_expression = self.with_use_context(
-            crate::checker::infer::context::UseContext::Callee,
-            |state| state.infer_expression(*expression, &callee_ty),
-        );
+        let callee_expression = self.with_use_context(UseContext::Callee, |state| {
+            state.infer_expression(*expression, &callee_ty)
+        });
 
         let forall_ty = self.resolve_callee_forall_type(&callee_expression, &type_args);
         let (callee_ty, type_arguments) =

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -5,7 +5,9 @@ use crate::checker::TypeEnv;
 use crate::checker::infer::InferCtx;
 use crate::checker::scopes::Scopes;
 use crate::store::Store;
+use syntax::ast::Generic;
 use syntax::ast::{Annotation, Expression, Span, StructFields};
+use syntax::program::AliasKind;
 use syntax::program::{DefinitionBody, Visibility, interface_instances, interface_requirements};
 use syntax::types::{CompoundKind, Type, substitute};
 
@@ -279,7 +281,7 @@ fn reaches_definition(
             if !visited.insert(format!("{resolved:?}")) {
                 return false;
             }
-            let field_types: Vec<(Type, &[syntax::ast::Generic])> =
+            let field_types: Vec<(Type, &[Generic])> =
                 match store.get_definition(id.as_str()).map(|d| &d.body) {
                     Some(DefinitionBody::Struct {
                         generics, fields, ..
@@ -339,7 +341,7 @@ fn is_opaque_go_handle(store: &Store, ty: &Type) -> bool {
         && matches!(
             &definition.body,
             DefinitionBody::TypeAlias {
-                alias: syntax::program::AliasKind::Opaque(Annotation::Opaque { .. }),
+                alias: AliasKind::Opaque(Annotation::Opaque { .. }),
                 ..
             }
         )
@@ -594,7 +596,7 @@ impl InferCtx<'_> {
             return false;
         };
         let type_args = resolved.get_type_params().unwrap_or_default();
-        let (generics, field_types): (&[syntax::ast::Generic], Vec<Type>) = match &definition.body {
+        let (generics, field_types): (&[Generic], Vec<Type>) = match &definition.body {
             DefinitionBody::Struct {
                 fields: StructFields::Tuple(_),
                 ..

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -7,6 +7,8 @@ use syntax::types::{Symbol, Type, substitute};
 use super::calls::phantom_type_params;
 use crate::checker::infer::InferCtx;
 use crate::checker::promotion::{self, MemberKind, Resolution};
+use crate::loader;
+use crate::store::Store;
 
 pub(super) struct DotAccessResolutionArgs<'a> {
     pub(super) expression: &'a Expression,
@@ -429,7 +431,7 @@ impl InferCtx<'_> {
                     .find(|imported_package_id| *imported_package_id == package_id)
             })?;
         let package_id = package_id.to_string();
-        let display_package = crate::loader::import_display_name(type_name);
+        let display_package = loader::import_display_name(type_name);
         let package_ty = Type::ImportNamespace(package_id.clone().into());
 
         let resolved_definition = Symbol::from_parts(&package_id, args.member_name);
@@ -495,7 +497,7 @@ impl InferCtx<'_> {
     /// Rejects package members used in value position rather than called or used as a type.
     fn check_package_member_in_value_position(
         &mut self,
-        store: &crate::store::Store,
+        store: &Store,
         resolved_definition: &Symbol,
         member_type: &Type,
         display_package: &str,

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -6,6 +6,7 @@ use crate::analysis::ProjectKind;
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::context::{Expectation, ExpectationRole};
 use crate::checker::registration::test_functions::normalize_test_params;
+use crate::prelude;
 use crate::store::ENTRY_PACKAGE_ID;
 
 impl InferCtx<'_> {
@@ -13,7 +14,7 @@ impl InferCtx<'_> {
         let resolved = ty.resolve_in(&self.env).strip_refs();
         resolved.get_qualified_id().is_some_and(|id| {
             id.strip_suffix(".TestContext")
-                .is_some_and(|package| package == crate::prelude::TEST_PRELUDE_PACKAGE_ID)
+                .is_some_and(|package| package == prelude::TEST_PRELUDE_PACKAGE_ID)
         })
     }
 

--- a/crates/semantics/src/checker/infer/expressions/indexed_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/indexed_access.rs
@@ -24,7 +24,7 @@ impl InferCtx<'_> {
         &mut self,
         expression: Box<Expression>,
         index: Box<Expression>,
-        span: syntax::ast::Span,
+        span: Span,
         expected_ty: &Type,
     ) -> Expression {
         let store = self.store;
@@ -197,7 +197,7 @@ impl InferCtx<'_> {
         &mut self,
         expression: Box<Expression>,
         index: Box<Expression>,
-        span: syntax::ast::Span,
+        span: Span,
     ) -> Expression {
         let store = self.store;
         let collection_ty_var = self.new_type_var();
@@ -225,7 +225,7 @@ impl InferCtx<'_> {
         &mut self,
         expression: Box<Expression>,
         range: Box<Expression>,
-        span: syntax::ast::Span,
+        span: Span,
         expected_ty: &Type,
     ) -> Expression {
         let store = self.store;

--- a/crates/semantics/src/checker/infer/expressions/literals.rs
+++ b/crates/semantics/src/checker/infer/expressions/literals.rs
@@ -5,6 +5,7 @@ use syntax::lex::{interpolation_holes, rune_codepoint};
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
+use crate::facts::EmptyLiteralCheck;
 
 impl InferCtx<'_> {
     pub(super) fn infer_literal(
@@ -186,14 +187,11 @@ impl InferCtx<'_> {
 
                 if new_elements.is_empty() && unified {
                     let package_id = self.cursor.package_id().to_string();
-                    self.facts
-                        .deferred
-                        .empty_literals
-                        .push(crate::facts::EmptyLiteralCheck {
-                            ty: slice_ty.clone(),
-                            span,
-                            package_id,
-                        });
+                    self.facts.deferred.empty_literals.push(EmptyLiteralCheck {
+                        ty: slice_ty.clone(),
+                        span,
+                        package_id,
+                    });
                 }
 
                 Expression::Literal {

--- a/crates/semantics/src/checker/infer/expressions/operators.rs
+++ b/crates/semantics/src/checker/infer/expressions/operators.rs
@@ -6,7 +6,9 @@ use syntax::types::{SimpleKind, Type};
 use BinaryOperator::*;
 use UnaryOperator::*;
 
+use crate::checker::TypeEnv;
 use crate::checker::infer::InferCtx;
+use syntax::ast::Annotation;
 
 pub(super) struct InferredOperand {
     pub(super) expression: Expression,
@@ -773,7 +775,7 @@ impl InferCtx<'_> {
     pub(super) fn infer_cast(
         &mut self,
         expression: Box<Expression>,
-        target_type: syntax::ast::Annotation,
+        target_type: Annotation,
         span: Span,
         expected_ty: &Type,
     ) -> Expression {
@@ -858,7 +860,7 @@ fn is_float_literal(expression: &Expression) -> bool {
     }
 }
 
-fn is_integer_type(ty: &Type, env: &crate::checker::TypeEnv, store: &Store) -> bool {
+fn is_integer_type(ty: &Type, env: &TypeEnv, store: &Store) -> bool {
     let resolved = ty.resolve_in(env);
     let direct_match = matches!(
         resolved.get_name(),

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -1,5 +1,6 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+use std::sync::Arc;
 use syntax::ast::BindingKind;
 use syntax::ast::{
     ConstructorPatternResolution, EnumFieldDefinition, Expression, Literal, Pattern,
@@ -393,7 +394,7 @@ impl InferCtx<'_> {
 
         let (pattern_ty, params) = match self.instantiate(&constructor_ty).0 {
             Type::Function(f) => {
-                let f = std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
+                let f = Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone());
                 (*f.return_type, f.params)
             }
             other => (other, vec![]),

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -8,6 +8,7 @@ use syntax::types::Type;
 use super::super::addressability::{
     check_is_non_addressable, check_non_addressable_assignment_target,
 };
+use super::super::context::UseContext;
 use super::calls::phantom_type_params;
 use super::operators::InferredOperand;
 use crate::checker::infer::InferCtx;
@@ -393,10 +394,9 @@ impl InferCtx<'_> {
         // Complex targets like `a[i]` or `r.*` have subexpressions that ARE being read.
         let is_simple_target = matches!(&*target, Expression::Identifier { .. });
         let new_target = if is_simple_target {
-            self.with_use_context(
-                crate::checker::infer::context::UseContext::AssignmentTarget,
-                |state| state.infer_expression(*target, &target_ty),
-            )
+            self.with_use_context(UseContext::AssignmentTarget, |state| {
+                state.infer_expression(*target, &target_ty)
+            })
         } else {
             self.infer_expression(*target, &target_ty)
         };
@@ -630,10 +630,9 @@ impl InferCtx<'_> {
             };
 
             let inferred_item = if !is_last {
-                self.with_use_context(
-                    crate::checker::infer::context::UseContext::Statement,
-                    |state| state.infer_root_expression(item, &expression_ty),
-                )
+                self.with_use_context(UseContext::Statement, |state| {
+                    state.infer_root_expression(item, &expression_ty)
+                })
             } else {
                 self.infer_root_expression(item, &expression_ty)
             };

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -1,8 +1,11 @@
 use crate::checker::EnvResolve;
+use crate::facts::StatementTailCheck;
+use crate::store::Store;
 use syntax::EcoString;
 use syntax::ast::DeadCodeCause;
 use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, Span, UnaryOperator};
 use syntax::program::DefinitionBody;
+use syntax::types::CompoundKind;
 use syntax::types::Type;
 
 use super::super::addressability::{
@@ -136,7 +139,7 @@ impl InferCtx<'_> {
         if items.is_empty() {
             let unit_ty = self.type_unit();
             let resolved = expected_ty.resolve_in(&self.env);
-            if let Some((syntax::types::CompoundKind::Map, args)) = resolved.as_compound()
+            if let Some((CompoundKind::Map, args)) = resolved.as_compound()
                 && args.len() == 2
             {
                 let k = args[0].resolve_in(&self.env);
@@ -371,7 +374,7 @@ impl InferCtx<'_> {
         }
     }
 
-    fn enum_of_variant(&self, store: &crate::store::Store, value: &str) -> Option<EcoString> {
+    fn enum_of_variant(&self, store: &Store, value: &str) -> Option<EcoString> {
         let (type_part, variant_name) = value.rsplit_once('.')?;
         let qualified = self.lookup_qualified_name(store, type_part)?;
         store
@@ -509,12 +512,7 @@ impl InferCtx<'_> {
         }
     }
 
-    fn report_disallowed_mutation(
-        &mut self,
-        store: &crate::store::Store,
-        var_name: &str,
-        span: Span,
-    ) {
+    fn report_disallowed_mutation(&mut self, store: &Store, var_name: &str, span: Span) {
         let self_type_name = if var_name == "self" {
             self.lookup_type(store, "self")
                 .and_then(|t| t.get_name().map(str::to_owned))
@@ -609,7 +607,7 @@ impl InferCtx<'_> {
                     self.facts
                         .deferred
                         .statement_tails
-                        .push(crate::facts::StatementTailCheck {
+                        .push(StatementTailCheck {
                             expected_ty: last_item_expected_ty.clone(),
                             span: item_span,
                         });

--- a/crates/semantics/src/checker/infer/expressions/qualified_path.rs
+++ b/crates/semantics/src/checker/infer/expressions/qualified_path.rs
@@ -4,6 +4,7 @@ use syntax::program::{DefinitionBody, DotAccessResolution};
 use syntax::types::{Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
+use std::ptr;
 
 impl InferCtx<'_> {
     pub(super) fn infer_dot_access_or_qualified_path(
@@ -19,7 +20,7 @@ impl InferCtx<'_> {
             while let Expression::Paren { expression: e, .. } = inner {
                 inner = e;
             }
-            if !std::ptr::eq(inner, &*expression)
+            if !ptr::eq(inner, &*expression)
                 && let Some(path) = inner.as_dotted_path()
                 && inner.root_identifier().is_some_and(|root| {
                     self.lookup_qualified_name(store, root).is_some()

--- a/crates/semantics/src/checker/infer/expressions/select.rs
+++ b/crates/semantics/src/checker/infer/expressions/select.rs
@@ -5,6 +5,8 @@ use syntax::program::{ChannelOperation, channel_operation};
 use syntax::types::{Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
+use std::mem;
+use syntax::ast::BindingKind;
 
 fn select_arm_body_span(pattern: &SelectArm) -> Span {
     match pattern {
@@ -19,7 +21,7 @@ fn select_arm_body_span(pattern: &SelectArm) -> Span {
 
 impl InferCtx<'_> {
     pub fn resolve_select_exhaustiveness(&mut self) {
-        for check in std::mem::take(&mut self.file_checks.select_exhaustiveness) {
+        for check in mem::take(&mut self.file_checks.select_exhaustiveness) {
             let resolved = check.result_ty.resolve_in(&self.env);
             if !resolved.is_unit() && !resolved.is_variable() {
                 self.sink
@@ -217,7 +219,7 @@ impl InferCtx<'_> {
         let new_binding = self.infer_pattern(
             *binding,
             element_ty.clone(),
-            syntax::ast::BindingKind::Let { mutable: false },
+            BindingKind::Let { mutable: false },
         );
 
         let new_body = self.infer_root_expression(*body, result_ty);
@@ -295,7 +297,7 @@ impl InferCtx<'_> {
                     let new_pattern = this.infer_pattern(
                         match_arm.pattern,
                         pattern_ty.clone(),
-                        syntax::ast::BindingKind::MatchArm,
+                        BindingKind::MatchArm,
                     );
 
                     let bool_ty = this.type_bool();

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -8,6 +8,12 @@ use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
 use crate::checker::infer::InferCtx;
+use crate::store::Store;
+use crate::zero;
+use std::marker::PhantomData;
+use syntax::ast::EnumFieldDefinition;
+use syntax::go_names;
+use syntax::program::AliasKind;
 
 /// Inputs to `infer_structish_fields` shared between struct and enum-variant literals.
 struct StructishCtx<'a, 'b, F> {
@@ -18,7 +24,7 @@ struct StructishCtx<'a, 'b, F> {
     span: Span,
     all_fields: F,
     map: &'b SubstitutionMap,
-    _marker: std::marker::PhantomData<&'a ()>,
+    _marker: PhantomData<&'a ()>,
 }
 
 struct StructLiteral {
@@ -48,7 +54,7 @@ struct ResolvedStruct {
 }
 
 struct ResolvedVariant {
-    fields: Vec<syntax::ast::EnumFieldDefinition>,
+    fields: Vec<EnumFieldDefinition>,
     substitutions: SubstitutionMap,
     ty: Type,
 }
@@ -92,7 +98,7 @@ impl InferCtx<'_> {
                 body: DefinitionBody::TypeAlias { alias, .. },
                 ..
             }) = store.get_definition(&qualified_name)
-            && matches!(alias, syntax::program::AliasKind::Opaque(_))
+            && matches!(alias, AliasKind::Opaque(_))
             && literal.fields.is_empty()
         {
             let alias_ty = alias_ty.clone();
@@ -125,11 +131,7 @@ impl InferCtx<'_> {
         literal.with_type(Type::Error)
     }
 
-    fn as_struct(
-        &mut self,
-        store: &crate::store::Store,
-        literal: &StructLiteral,
-    ) -> Option<ResolvedStruct> {
+    fn as_struct(&mut self, store: &Store, literal: &StructLiteral) -> Option<ResolvedStruct> {
         let qualified_name = self.lookup_qualified_name(store, &literal.name)?;
         let Definition {
             ty: struct_ty,
@@ -161,7 +163,7 @@ impl InferCtx<'_> {
     }
 
     /// Resolve a `type Alias = Struct` name to its underlying struct.
-    fn as_alias_struct(&self, store: &crate::store::Store, name: &str) -> Option<ResolvedStruct> {
+    fn as_alias_struct(&self, store: &Store, name: &str) -> Option<ResolvedStruct> {
         let qualified_name = self.lookup_qualified_name(store, name)?;
         let Definition {
             ty: alias_ty,
@@ -172,7 +174,7 @@ impl InferCtx<'_> {
             return None;
         };
         let alias_ty = alias_ty.clone();
-        let is_opaque = matches!(alias, syntax::program::AliasKind::Opaque(_));
+        let is_opaque = matches!(alias, AliasKind::Opaque(_));
 
         let underlying = (!is_opaque).then(|| store.peel_alias(&alias_ty));
         let Some(Type::Nominal { id: struct_id, .. }) = &underlying else {
@@ -207,18 +209,14 @@ impl InferCtx<'_> {
         })
     }
 
-    fn as_alias_variant(
-        &mut self,
-        store: &crate::store::Store,
-        name: &str,
-    ) -> Option<ResolvedVariant> {
+    fn as_alias_variant(&mut self, store: &Store, name: &str) -> Option<ResolvedVariant> {
         let (type_part, variant_name) = name.rsplit_once('.')?;
         let qualified_name = self.lookup_qualified_name(store, type_part)?;
         let Definition {
             ty: alias_ty,
             body:
                 DefinitionBody::TypeAlias {
-                    alias: syntax::program::AliasKind::Transparent { .. },
+                    alias: AliasKind::Transparent { .. },
                     ..
                 },
             ..
@@ -251,7 +249,7 @@ impl InferCtx<'_> {
         })
     }
 
-    fn as_variant(&mut self, store: &crate::store::Store, name: &str) -> Option<ResolvedVariant> {
+    fn as_variant(&mut self, store: &Store, name: &str) -> Option<ResolvedVariant> {
         let ty = self.lookup_type(store, name)?;
         let (value_constructor_type, map) = self.instantiate(&ty);
 
@@ -327,7 +325,7 @@ impl InferCtx<'_> {
         if is_go_imported
             && !matches!(new_spread, StructSpread::From(_))
             && let Some(def) = store.get_definition(&qualified_name)
-            && crate::zero::go_struct_denies_zero(def, &struct_fields)
+            && zero::go_struct_denies_zero(def, &struct_fields)
         {
             self.sink.push(diagnostics::infer::hidden_state_no_zero(
                 &struct_call_ty,
@@ -344,7 +342,7 @@ impl InferCtx<'_> {
                 span,
                 all_fields: struct_fields.iter().map(|f| (&f.name, &f.ty)),
                 map: &map,
-                _marker: std::marker::PhantomData,
+                _marker: PhantomData,
             },
             |checker, assignment| {
                 let def = struct_fields.iter().find(|f| f.name == assignment.name)?;
@@ -365,7 +363,7 @@ impl InferCtx<'_> {
                 &struct_name,
                 struct_fields
                     .iter()
-                    .filter(|f| !(is_go_imported && crate::zero::hidden_embed_field(f)))
+                    .filter(|f| !(is_go_imported && zero::hidden_embed_field(f)))
                     .map(|f| (&f.name, &f.ty)),
                 &matched_fields,
                 &map,
@@ -456,7 +454,7 @@ impl InferCtx<'_> {
                 span,
                 all_fields: variant_fields.iter().map(|f| (&f.name, &f.ty)),
                 map: &map,
-                _marker: std::marker::PhantomData,
+                _marker: PhantomData,
             },
             |_checker, assignment| {
                 variant_fields
@@ -516,7 +514,7 @@ impl InferCtx<'_> {
         &mut self,
         resolved_enum: &Type,
         written_name: &str,
-        variant_fields: &[syntax::ast::EnumFieldDefinition],
+        variant_fields: &[EnumFieldDefinition],
         matched_fields: &HashSet<EcoString>,
         spread_span: Span,
     ) {
@@ -535,7 +533,7 @@ impl InferCtx<'_> {
         let Some(target_index) = variants.iter().position(|v| v.name == target_variant) else {
             return;
         };
-        let slots = syntax::go_names::enum_field_slots(enum_name, variants);
+        let slots = go_names::enum_field_slots(enum_name, variants);
         let missing: Vec<String> = variant_fields
             .iter()
             .enumerate()
@@ -569,9 +567,7 @@ impl InferCtx<'_> {
         let builtin_collisions = missing
             .iter()
             .filter(|field_name| {
-                syntax::go_names::is_builtin_enum_member(&syntax::go_names::snake_to_camel(
-                    field_name,
-                ))
+                go_names::is_builtin_enum_member(&go_names::snake_to_camel(field_name))
             })
             .count();
         let reason = if builtin_collisions == missing.len() {
@@ -714,7 +710,7 @@ impl InferCtx<'_> {
 
     pub(crate) fn has_zero(&self, ty: &Type, from_package: &str) -> Result<(), NoZero> {
         let store = self.store;
-        crate::zero::has_zero(store, ty, from_package)
+        zero::has_zero(store, ty, from_package)
     }
 }
 

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -8,6 +8,8 @@ use syntax::program::{DefinitionBody, InterfaceRequirement, Methods, interface_r
 use syntax::types::{GO_IMPORT_PREFIX, Symbol, Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
+use syntax::go_names;
+use syntax::go_names::ConformanceCandidate;
 
 struct ConformanceTraversal<'a> {
     receiver: &'a Type,
@@ -261,7 +263,7 @@ impl InferCtx<'_> {
                 let interface_is_public = store
                     .get_definition(&requirement.declaring_interface)
                     .is_some_and(|d| d.visibility.is_public());
-                let (impl_name, method_ty) = syntax::go_names::conformance_method(
+                let (impl_name, method_ty) = go_names::conformance_method(
                     &methods,
                     requirement.declaring_interface.as_str(),
                     interface_is_public,
@@ -294,25 +296,17 @@ impl InferCtx<'_> {
         Err(vec![])
     }
 
-    fn conformance_candidate(
-        &self,
-        receiver: &Type,
-        method: &str,
-    ) -> syntax::go_names::ConformanceCandidate {
+    fn conformance_candidate(&self, receiver: &Type, method: &str) -> ConformanceCandidate {
         let resolved = self
             .store
             .deep_resolve_alias(&receiver.strip_refs().resolve_in(&self.env));
         self.own_candidate(&resolved, method)
             .or_else(|| self.promoted_candidate(&resolved, method))
             .or_else(|| self.bound_candidate(&resolved, method))
-            .unwrap_or(syntax::go_names::ConformanceCandidate::Unresolved)
+            .unwrap_or(ConformanceCandidate::Unresolved)
     }
 
-    fn own_candidate(
-        &self,
-        resolved: &Type,
-        method: &str,
-    ) -> Option<syntax::go_names::ConformanceCandidate> {
+    fn own_candidate(&self, resolved: &Type, method: &str) -> Option<ConformanceCandidate> {
         let id = resolved.get_qualified_id()?;
         if self.store.get_interface(id).is_some() {
             self.store
@@ -322,18 +316,14 @@ impl InferCtx<'_> {
             self.store.get_method(id, method)?;
         }
         // UFCS-lowered methods emit as free functions, not selectors.
-        Some(syntax::go_names::ConformanceCandidate::Resolved {
+        Some(ConformanceCandidate::Resolved {
             depth: 0,
             owner: id.into(),
             shadowed: self.store.is_ufcs_method(id, method),
         })
     }
 
-    fn promoted_candidate(
-        &self,
-        resolved: &Type,
-        method: &str,
-    ) -> Option<syntax::go_names::ConformanceCandidate> {
+    fn promoted_candidate(&self, resolved: &Type, method: &str) -> Option<ConformanceCandidate> {
         let store = self.store;
         resolved.get_qualified_id()?;
         let promotion::Resolution::Found(member) =
@@ -345,13 +335,13 @@ impl InferCtx<'_> {
             return None;
         };
         let selector = if promoted.visibility.is_public() {
-            syntax::go_names::snake_to_camel(method)
+            go_names::snake_to_camel(method)
         } else {
-            syntax::go_names::unexported_method_go_name(method)
+            go_names::unexported_method_go_name(method)
         };
         let shadowed = promotion::field_selector_depth(store, resolved, &selector)
             .is_some_and(|field_depth| field_depth <= member.depth);
-        Some(syntax::go_names::ConformanceCandidate::Resolved {
+        Some(ConformanceCandidate::Resolved {
             depth: member.depth,
             owner: member.declaring_type.as_eco().clone(),
             shadowed,
@@ -359,11 +349,7 @@ impl InferCtx<'_> {
     }
 
     // Bound method sets merge as one Go constraint interface.
-    fn bound_candidate(
-        &self,
-        resolved: &Type,
-        method: &str,
-    ) -> Option<syntax::go_names::ConformanceCandidate> {
+    fn bound_candidate(&self, resolved: &Type, method: &str) -> Option<ConformanceCandidate> {
         let Type::Parameter(name) = resolved else {
             return None;
         };
@@ -375,7 +361,7 @@ impl InferCtx<'_> {
             self.store
                 .get_all_methods(&interface_ty, &Default::default())
                 .get(method)?;
-            Some(syntax::go_names::ConformanceCandidate::Resolved {
+            Some(ConformanceCandidate::Resolved {
                 depth: 0,
                 owner: qualified.as_eco().clone(),
                 shadowed: false,
@@ -411,12 +397,12 @@ impl InferCtx<'_> {
         let own_candidate = |name: &str| {
             store
                 .get_method(own_id, name)
-                .map(|_| syntax::go_names::ConformanceCandidate::Resolved {
+                .map(|_| ConformanceCandidate::Resolved {
                     depth: 0,
                     owner: own_id.into(),
                     shadowed: self.store.is_ufcs_method(own_id, name),
                 })
-                .unwrap_or(syntax::go_names::ConformanceCandidate::Unresolved)
+                .unwrap_or(ConformanceCandidate::Unresolved)
         };
         let interface_ty = Type::Nominal {
             id: interface_qualified_id.into(),
@@ -429,7 +415,7 @@ impl InferCtx<'_> {
                 let interface_is_public = store
                     .get_definition(&requirement.declaring_interface)
                     .is_some_and(|d| d.visibility.is_public());
-                syntax::go_names::conformance_method(
+                go_names::conformance_method(
                     own,
                     requirement.declaring_interface.as_str(),
                     interface_is_public,
@@ -541,7 +527,7 @@ impl InferCtx<'_> {
                             .any(|hint| hint == "comma_ok"),
                         impl_method_name.as_str(),
                     );
-                    let spelling_pinned = syntax::go_names::interface_matches_by_source_name(
+                    let spelling_pinned = go_names::interface_matches_by_source_name(
                         interface_qualified_id,
                         interface_is_public,
                     );
@@ -579,7 +565,7 @@ impl InferCtx<'_> {
     }
 
     fn select_impl_method(&self, site: &ConformanceSite<'_>, method_name: &str) -> SelectedMethod {
-        let selected = syntax::go_names::conformance_method(
+        let selected = go_names::conformance_method(
             site.symbol_methods,
             site.interface_qualified_id,
             site.interface_is_public,
@@ -608,7 +594,7 @@ impl InferCtx<'_> {
         method_name: &str,
         method_ty: &Type,
     ) -> Option<String> {
-        let (impl_name, impl_method) = syntax::go_names::conformance_method_if_public(
+        let (impl_name, impl_method) = go_names::conformance_method_if_public(
             site.symbol_methods,
             site.interface_qualified_id,
             site.interface_is_public,

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -1,4 +1,6 @@
 use crate::checker::EnvResolve;
+use crate::checker::promotion;
+use crate::checker::sealing::is_unexported_key;
 use crate::store::Store;
 use diagnostics::infer::{InterfaceMethodViolation, InterfaceViolation, MissingMethod};
 use syntax::ast::Span;
@@ -55,10 +57,8 @@ impl InferCtx<'_> {
         let owner = if store.get_method(id, method).is_some() {
             id.to_string()
         } else {
-            match crate::checker::promotion::resolve_selector(store, &resolved, method) {
-                crate::checker::promotion::Resolution::Found(member) => {
-                    member.declaring_type.to_string()
-                }
+            match promotion::resolve_selector(store, &resolved, method) {
+                promotion::Resolution::Found(member) => member.declaring_type.to_string(),
                 _ => return false,
             }
         };
@@ -149,7 +149,7 @@ impl InferCtx<'_> {
                     InterfaceMethodViolation::Missing(method) => Some(method),
                     InterfaceMethodViolation::Incompatible { .. } => None,
                 })
-                .any(|method| crate::checker::sealing::is_unexported_key(&method.name))
+                .any(|method| is_unexported_key(&method.name))
         }) {
             let type_name = resolved
                 .get_name()
@@ -334,7 +334,6 @@ impl InferCtx<'_> {
         resolved: &Type,
         method: &str,
     ) -> Option<syntax::go_names::ConformanceCandidate> {
-        use crate::checker::promotion;
         let store = self.store;
         resolved.get_qualified_id()?;
         let promotion::Resolution::Found(member) =
@@ -342,7 +341,7 @@ impl InferCtx<'_> {
         else {
             return None;
         };
-        let crate::checker::promotion::MemberKind::Method(promoted) = &member.kind else {
+        let promotion::MemberKind::Method(promoted) = &member.kind else {
             return None;
         };
         let selector = if promoted.visibility.is_public() {
@@ -711,12 +710,12 @@ impl InferCtx<'_> {
         if resolved_ty.get_qualified_id().is_none() {
             return;
         }
-        let crate::checker::promotion::Resolution::Found(member) =
-            crate::checker::promotion::resolve_selector(store, &resolved_ty, impl_method_name)
+        let promotion::Resolution::Found(member) =
+            promotion::resolve_selector(store, &resolved_ty, impl_method_name)
         else {
             return;
         };
-        let crate::checker::promotion::MemberKind::Method(method) = member.kind else {
+        let promotion::MemberKind::Method(method) = member.kind else {
             return;
         };
         let selected_comma_ok = method.go_hints.iter().any(|hint| hint == "comma_ok");

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -16,6 +16,8 @@ use super::freeze::FreezeFolder;
 use super::registration::{RegisteredPackage, RegistrationFile};
 use super::state::InferredFile;
 use super::{FileContext, TaskState};
+use crate::loader;
+use crate::prelude;
 use crate::store::Store;
 use syntax::ast::{Expression, Span};
 use syntax::program::FileImport;
@@ -159,7 +161,7 @@ impl InferCtx<'_> {
             if let Some(import_path) = alias_to_path.get(definition_name) {
                 self.sink.push(diagnostics::infer::name_shadows_import(
                     definition_name,
-                    crate::loader::import_display_name(import_path),
+                    loader::import_display_name(import_path),
                     name_span,
                 ));
             }
@@ -168,12 +170,12 @@ impl InferCtx<'_> {
 
     fn check_binding_shadows_import(&mut self, name: &str, span: Span, is_typedef: bool) {
         if !is_typedef
-            && name != crate::prelude::PRELUDE_PACKAGE_ID
+            && name != prelude::PRELUDE_PACKAGE_ID
             && let Some(import_path) = self.imports.package_id(name)
         {
             self.sink.push(diagnostics::infer::name_shadows_import(
                 name,
-                crate::loader::import_display_name(import_path),
+                loader::import_display_name(import_path),
                 span,
             ));
         }

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -318,7 +318,7 @@ impl InferCtx<'_> {
     }
 
     fn is_transparent_alias(&self, ty: &Type) -> bool {
-        let Type::Nominal { id, .. } = ty else {
+        let Nominal { id, .. } = ty else {
             return false;
         };
         self.store
@@ -340,7 +340,7 @@ impl InferCtx<'_> {
             Type::Var { id, .. } => {
                 let _ = self.unify_type_variable(id, &Type::Error, span, false);
             }
-            Type::Nominal { params, .. } => {
+            Nominal { params, .. } => {
                 for p in params {
                     self.collapse_vars_to_error(&p, span);
                 }
@@ -889,7 +889,7 @@ impl InferCtx<'_> {
             return format!("Cast with `as`, e.g. `value as {}`", expected_name);
         }
 
-        if let Some(Type::Function(function)) = self.store.resolve_to_function_type(expected)
+        if let Some(Function(function)) = self.store.resolve_to_function_type(expected)
             && function.return_type.as_ref() == actual
         {
             return "Remove the `()` so that the type matches".to_string();

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -8,6 +8,8 @@ use crate::checker::infer::InferCtx;
 use crate::checker::infer::carry_mut::can_carry_mutation_across_fn_boundary;
 use crate::checker::infer::context::{Expectation, ExpectationRole};
 use crate::checker::type_env::VarState;
+use syntax::types::FunctionParameter;
+use syntax::types::SimpleKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BuiltinBound {
@@ -638,7 +640,7 @@ impl InferCtx<'_> {
     fn check_function_bound(
         &mut self,
         bound: &Bound,
-        signature_params: &[syntax::types::FunctionParameter],
+        signature_params: &[FunctionParameter],
         span: &Span,
     ) {
         let store = self.store;
@@ -1082,8 +1084,8 @@ fn are_go_type_aliases(a: &str, b: &str) -> bool {
 
 /// Go-level aliases between scalar builtins: `byte` is an alias for `uint8`,
 /// and `rune` is an alias for `int32`.
-fn simple_kinds_are_go_aliases(a: syntax::types::SimpleKind, b: syntax::types::SimpleKind) -> bool {
-    use syntax::types::SimpleKind;
+fn simple_kinds_are_go_aliases(a: SimpleKind, b: SimpleKind) -> bool {
+    use SimpleKind;
     matches!(
         (a, b),
         (SimpleKind::Byte, SimpleKind::Uint8)

--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -4,6 +4,9 @@ use syntax::ast::{Expression, Span};
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
+use crate::store::Store;
+use syntax::ast::Literal;
+use syntax::ast::UnaryOperator;
 
 impl InferCtx<'_> {
     /// Validates that a cast from source_ty to target_ty is allowed.
@@ -154,14 +157,14 @@ impl InferCtx<'_> {
 
         match inner_expression {
             Expression::Literal {
-                literal: syntax::ast::Literal::Integer { .. },
+                literal: Literal::Integer { .. },
                 ..
             } if target_resolved.is_numeric() && !target_resolved.is_rune() => {
                 self.sink
                     .push(diagnostics::infer::redundant_cast(&target_resolved, span));
             }
             Expression::Literal {
-                literal: syntax::ast::Literal::Float { .. },
+                literal: Literal::Float { .. },
                 ..
             } if target_resolved.is_float() => {
                 self.sink
@@ -172,7 +175,7 @@ impl InferCtx<'_> {
     }
 }
 
-fn uintptr_scalar_conversion(store: &crate::store::Store, source: &Type, target: &Type) -> bool {
+fn uintptr_scalar_conversion(store: &Store, source: &Type, target: &Type) -> bool {
     let castable = |ty: &Type| {
         store.has_underlying_numeric_type(ty)
             || store.underlying_simple_kind(ty) == Some(SimpleKind::Uintptr)
@@ -186,7 +189,7 @@ fn unwrap_parens_and_negation(expression: &Expression) -> &Expression {
     match expression {
         Expression::Paren { expression, .. } => unwrap_parens_and_negation(expression),
         Expression::Unary {
-            operator: syntax::ast::UnaryOperator::Negative,
+            operator: UnaryOperator::Negative,
             expression,
             ..
         } => unwrap_parens_and_negation(expression),

--- a/crates/semantics/src/checker/infer/validation/numeric.rs
+++ b/crates/semantics/src/checker/infer/validation/numeric.rs
@@ -3,6 +3,8 @@ use syntax::ast::{Expression, Span};
 use syntax::types::{SimpleKind, Type};
 
 use crate::checker::infer::InferCtx;
+use syntax::ast::Literal;
+use syntax::ast::UnaryOperator;
 
 impl InferCtx<'_> {
     /// Validates that an integer literal fits within the target numeric type.
@@ -106,16 +108,16 @@ impl InferCtx<'_> {
 
         let (value, is_negative) = match expression.unwrap_parens() {
             Expression::Literal {
-                literal: syntax::ast::Literal::Integer { value, .. },
+                literal: Literal::Integer { value, .. },
                 ..
             } => (*value, false),
             Expression::Unary {
-                operator: syntax::ast::UnaryOperator::Negative,
+                operator: UnaryOperator::Negative,
                 expression: inner,
                 ..
             } => {
                 if let Expression::Literal {
-                    literal: syntax::ast::Literal::Integer { value, .. },
+                    literal: Literal::Integer { value, .. },
                     ..
                 } = inner.unwrap_parens()
                 {

--- a/crates/semantics/src/checker/infer/validation/select.rs
+++ b/crates/semantics/src/checker/infer/validation/select.rs
@@ -2,13 +2,11 @@ use syntax::ast::{Pattern, Span};
 use syntax::types::unqualified_name;
 
 use crate::checker::infer::InferCtx;
+use syntax::ast::MatchArm;
+use syntax::ast::SelectArm;
 
 impl InferCtx<'_> {
-    pub(crate) fn check_select_match_arms(
-        &mut self,
-        match_arms: &[syntax::ast::MatchArm],
-        receive_span: Span,
-    ) {
+    pub(crate) fn check_select_match_arms(&mut self, match_arms: &[MatchArm], receive_span: Span) {
         if match_arms.is_empty() {
             self.sink
                 .push(diagnostics::infer::select_match_missing_some_arm(
@@ -130,8 +128,8 @@ impl InferCtx<'_> {
     }
 
     /// Reject multiple `let Some(v) = ch.receive()` arms in one select.
-    pub(crate) fn check_multiple_select_receives(&mut self, arms: &[syntax::ast::SelectArm]) {
-        use syntax::ast::SelectArm;
+    pub(crate) fn check_multiple_select_receives(&mut self, arms: &[SelectArm]) {
+        use SelectArm;
 
         let mut first_receive_span: Option<Span> = None;
 
@@ -164,8 +162,8 @@ impl InferCtx<'_> {
         }
     }
 
-    pub(crate) fn check_duplicate_select_defaults(&mut self, arms: &[syntax::ast::SelectArm]) {
-        use syntax::ast::SelectArm;
+    pub(crate) fn check_duplicate_select_defaults(&mut self, arms: &[SelectArm]) {
+        use SelectArm;
 
         let mut first_default_span: Option<Span> = None;
 

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -3,6 +3,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::BTreeMap;
 
 use syntax::ast::{Generic, Visibility};
+use syntax::go_names;
 use syntax::program::{DefinitionBody, Method, Methods};
 use syntax::types::{
     CompoundKind, Symbol, Type, build_named_substitution_map, build_substitution_map, substitute,
@@ -84,7 +85,7 @@ pub(crate) fn field_selector_depth(store: &Store, outer: &Type, selector: &str) 
         let forces_export = definition.is_serialized();
         let claimed = fields
             .iter()
-            .any(|field| syntax::go_names::struct_field_go_name(field, forces_export) == selector);
+            .any(|field| go_names::struct_field_go_name(field, forces_export) == selector);
         if claimed && min.is_none_or(|m| entry.depth < m) {
             min = Some(entry.depth);
         }
@@ -402,6 +403,7 @@ fn instantiate_method(store: &Store, container: &Type, method_ty: &Type) -> Type
 mod tests {
     use super::*;
     use syntax::ast::{Annotation, Span, StructFieldDefinition, StructFieldKind, StructFields};
+    use syntax::program::MethodOrigin;
     use syntax::program::Visibility as ProgVis;
     use syntax::program::{Attributes, Definition, DefinitionBody, Interface};
     use syntax::types::FunctionParameter;
@@ -493,7 +495,7 @@ mod tests {
                         source_name: n.into(),
                         ty: t,
                         visibility: ProgVis::Public,
-                        origin: syntax::program::MethodOrigin::Declared,
+                        origin: MethodOrigin::Declared,
                         name_span: None,
                         doc: None,
                         allowed_lints: vec![],
@@ -527,7 +529,7 @@ mod tests {
                         source_name: n.into(),
                         ty: t,
                         visibility: ProgVis::Public,
-                        origin: syntax::program::MethodOrigin::Declared,
+                        origin: MethodOrigin::Declared,
                         name_span: None,
                         doc: None,
                         allowed_lints: vec![],
@@ -558,7 +560,7 @@ mod tests {
                         source_name: n.into(),
                         ty: interface_method(),
                         visibility: ProgVis::Public,
-                        origin: syntax::program::MethodOrigin::Declared,
+                        origin: MethodOrigin::Declared,
                         name_span: None,
                         doc: None,
                         allowed_lints: vec![],

--- a/crates/semantics/src/checker/registration/attributes.rs
+++ b/crates/semantics/src/checker/registration/attributes.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::checker::sealing::unexported_key;
 
 const KNOWN_GO_HINTS: &[&str] = &[
     "anon_struct",
@@ -189,5 +190,5 @@ pub(super) fn seal_method_key(
     } else {
         format!("{package_id}.{name}")
     };
-    crate::checker::sealing::unexported_key(&id)
+    unexported_key(&id)
 }

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -3,7 +3,9 @@ use crate::checker::infer::BuiltinBound;
 use crate::checker::infer::expressions::comparison::{
     check_never_comparable, check_never_comparable_with_bounds, check_not_comparable_with_bounds,
 };
+use std::mem;
 use syntax::EcoString;
+use syntax::ast::Literal;
 use syntax::ast::{Annotation, Generic, Span};
 use syntax::program::DefinitionBody;
 use syntax::types::{
@@ -514,7 +516,7 @@ impl TaskState {
                 .push(diagnostics::infer::array_size_computed_constant(name, span));
             return None;
         };
-        let syntax::ast::Literal::Integer { value, .. } = literal else {
+        let Literal::Integer { value, .. } = literal else {
             self.sink
                 .push(diagnostics::infer::array_size_not_integer_constant(
                     name, span,
@@ -546,14 +548,14 @@ impl TaskState {
     /// Settles the size constants whose type had not resolved at conversion time.
     pub(super) fn check_pending_array_size_checks(&mut self, store: &Store) {
         let mut seen = rustc_hash::FxHashSet::default();
-        for pending in std::mem::take(&mut self.pending.array_size_checks) {
+        for pending in mem::take(&mut self.pending.array_size_checks) {
             if !seen.insert((pending.span, pending.qualified_name.clone())) {
                 continue;
             }
             let Some(definition) = store.get_definition(&pending.qualified_name) else {
                 continue;
             };
-            let Some(syntax::ast::Literal::Integer { value, .. }) = definition.const_value() else {
+            let Some(Literal::Integer { value, .. }) = definition.const_value() else {
                 continue;
             };
             let outcome = store

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -337,8 +337,7 @@ impl TaskState {
         );
 
         if position == TypePosition::Value
-            && let Some(builtin) =
-                crate::checker::infer::BuiltinBound::from_qualified_id(&qualified_name)
+            && let Some(builtin) = BuiltinBound::from_qualified_id(&qualified_name)
         {
             self.sink
                 .push(diagnostics::infer::bound_only_in_value_position(

--- a/crates/semantics/src/checker/registration/declarations.rs
+++ b/crates/semantics/src/checker/registration/declarations.rs
@@ -1,4 +1,7 @@
 use super::*;
+use syntax::program::ValueKind;
+use syntax::types::CompoundKind;
+use syntax::types::SimpleKind;
 
 impl TaskState {
     pub(super) fn collect_package_type_name_entries(
@@ -134,10 +137,10 @@ impl TaskState {
             // dedicated Simple/Compound variants; everything else remains a
             // nominal Constructor.
             let canonical_ty = if package_id == "prelude" {
-                if let Some(simple) = syntax::types::SimpleKind::from_name(name) {
+                if let Some(simple) = SimpleKind::from_name(name) {
                     debug_assert!(args.is_empty(), "simple kinds have no generics");
                     Type::Simple(simple)
-                } else if let Some(compound) = syntax::types::CompoundKind::from_name(name) {
+                } else if let Some(compound) = CompoundKind::from_name(name) {
                     Type::Compound {
                         kind: compound,
                         args,
@@ -189,7 +192,7 @@ impl TaskState {
                     name_span: None,
                     doc: None,
                     body: DefinitionBody::Value {
-                        kind: syntax::program::ValueKind::Runtime,
+                        kind: ValueKind::Runtime,
                         allowed_lints: vec![],
                         go_hints: vec![],
                         go_name: None,

--- a/crates/semantics/src/checker/registration/display.rs
+++ b/crates/semantics/src/checker/registration/display.rs
@@ -7,6 +7,9 @@ use crate::checker::registration::derived_attributes::{
     DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
+use syntax::ast::Generic;
+use syntax::program::Method;
+use syntax::program::MethodOrigin;
 
 impl TaskState {
     pub(super) fn process_display_candidate(
@@ -112,11 +115,11 @@ impl TaskState {
         {
             methods.insert(
                 "to_string".into(),
-                syntax::program::Method {
+                Method {
                     source_name: "to_string".into(),
                     ty: method_ty,
                     visibility,
-                    origin: syntax::program::MethodOrigin::Synthesized,
+                    origin: MethodOrigin::Synthesized,
                     name_span,
                     doc: None,
                     allowed_lints: vec![],
@@ -127,7 +130,7 @@ impl TaskState {
     }
 }
 
-fn type_generics(definition: &Definition) -> Option<Vec<syntax::ast::Generic>> {
+fn type_generics(definition: &Definition) -> Option<Vec<Generic>> {
     match &definition.body {
         DefinitionBody::Struct { generics, .. } | DefinitionBody::Enum { generics, .. } => {
             Some(generics.clone())

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -13,6 +13,10 @@ use crate::checker::registration::derived_attributes::{
     DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
+use std::mem;
+use syntax::program::Method;
+use syntax::program::MethodOrigin;
+use syntax::types;
 
 fn equals_visibility(store: &Store, id: &str) -> Option<String> {
     match store.get_method(id, "equals") {
@@ -119,7 +123,7 @@ impl TaskState {
     /// Synthesize queued equality methods, build the verdict, and gate derivations.
     /// Run once after registration has completed every type definition.
     pub(super) fn finalize_equality(&mut self, store: &mut Store) {
-        let batches = std::mem::take(&mut self.pending.equality_attributes);
+        let batches = mem::take(&mut self.pending.equality_attributes);
         let mut derivations = Vec::new();
         for batch in &batches {
             for candidate in &batch.candidates {
@@ -141,7 +145,7 @@ impl TaskState {
                 .package_for_qualified_name(id)
                 .map(str::to_string)
                 .unwrap_or_default();
-            let name = syntax::types::unqualified_name(id).to_string();
+            let name = types::unqualified_name(id).to_string();
             self.gate_equality_derivation(store, &name, qualified, &package_id);
         }
     }
@@ -301,11 +305,11 @@ impl TaskState {
         {
             methods.insert(
                 "equals".into(),
-                syntax::program::Method {
+                Method {
                     source_name: "equals".into(),
                     ty: method_ty,
                     visibility,
-                    origin: syntax::program::MethodOrigin::Synthesized,
+                    origin: MethodOrigin::Synthesized,
                     name_span,
                     doc: None,
                     allowed_lints: vec![],

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -7,6 +7,7 @@ use crate::checker::infer::interface::interface_requires_methods;
 use crate::checker::infer::{BuiltinBound, InferCtx};
 use crate::generics::{apply_bounds, bound_implied, type_argument_children};
 use crate::store::Store;
+use std::mem;
 
 #[derive(Clone, Copy)]
 enum BoundCheckContext {
@@ -176,7 +177,7 @@ impl TaskState {
     }
 
     pub(super) fn check_pending_generic_bounds(&mut self, store: &Store) {
-        let pending = std::mem::take(&mut self.pending.pre_inference_bound_checks);
+        let pending = mem::take(&mut self.pending.pre_inference_bound_checks);
         let mut ctx = InferCtx::new(self, store);
         for (argument, required, span) in pending {
             ctx.check_concrete_bound(&argument, &required, &span);
@@ -184,7 +185,7 @@ impl TaskState {
     }
 
     pub(crate) fn check_pending_interface_bounds(&mut self, store: &Store) {
-        let pending = std::mem::take(&mut self.pending.post_inference_bound_checks);
+        let pending = mem::take(&mut self.pending.post_inference_bound_checks);
         let mut seen = rustc_hash::FxHashSet::default();
         let mut ctx = InferCtx::new(self, store);
         for (argument, required, span) in pending {

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -3,6 +3,7 @@ use syntax::types::{CompoundKind, Type, unqualified_name};
 
 use crate::checker::EnvResolve;
 use crate::checker::TaskState;
+use crate::checker::infer::interface::interface_requires_methods;
 use crate::checker::infer::{BuiltinBound, InferCtx};
 use crate::generics::{apply_bounds, bound_implied, type_argument_children};
 use crate::store::Store;
@@ -111,7 +112,7 @@ impl TaskState {
             let resolved_required = store.deep_resolve_alias(&required);
             if let Some(required_id) = resolved_required.get_qualified_id()
                 && store.get_interface(required_id).is_some()
-                && !crate::checker::infer::interface::interface_requires_methods(store, required_id)
+                && !interface_requires_methods(store, required_id)
             {
                 continue;
             }

--- a/crates/semantics/src/checker/registration/go.rs
+++ b/crates/semantics/src/checker/registration/go.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::diagnostics::ReplaceImporter;
+use std::mem;
+use syntax::ast::ImportAlias;
 
 impl TaskState {
     /// Register a Go package (stdlib or third-party). Unlike regular packages,
@@ -58,18 +61,16 @@ impl TaskState {
         let replace_importer = package_id.strip_prefix("go:").and_then(|pkg| {
             match locator.validate_declaration(pkg) {
                 deps::DeclarationStatus::DeclaredReplacement { .. } => {
-                    Some(crate::diagnostics::ReplaceImporter::Module(pkg))
+                    Some(ReplaceImporter::Module(pkg))
                 }
-                deps::DeclarationStatus::DeclaredLocal { .. } => {
-                    Some(crate::diagnostics::ReplaceImporter::Local(pkg))
-                }
+                deps::DeclarationStatus::DeclaredLocal { .. } => Some(ReplaceImporter::Local(pkg)),
                 _ => None,
             }
         });
 
         for import in &imports {
             if let Some(go_pkg) = import.name.strip_prefix("go:") {
-                if matches!(import.alias, Some(syntax::ast::ImportAlias::Blank(_))) {
+                if matches!(import.alias, Some(ImportAlias::Blank(_))) {
                     continue;
                 }
 
@@ -117,7 +118,7 @@ impl TaskState {
                 imports: &imports,
             },
             |this, store| {
-                let mut items = std::mem::take(
+                let mut items = mem::take(
                     &mut store
                         .get_file_mut(file_id)
                         .expect("file must exist after store_file")

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -6,6 +6,7 @@ use crate::checker::registration::derived_attributes::{
     DerivedAttribute, DerivedAttributeContext, DerivedAttributeTarget,
 };
 use crate::store::Store;
+use syntax::program::ValueKind;
 
 impl TaskState {
     pub(super) fn process_iterate_candidate(
@@ -89,7 +90,7 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: None,
                 body: DefinitionBody::Value {
-                    kind: syntax::program::ValueKind::Runtime,
+                    kind: ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,

--- a/crates/semantics/src/checker/registration/metadata.rs
+++ b/crates/semantics/src/checker/registration/metadata.rs
@@ -94,7 +94,7 @@ pub(super) fn enum_variant_constructor_type(
 pub(super) fn wrap_with_impl_generics(
     fn_ty: &Type,
     generics: &[Generic],
-    impl_bounds: &[syntax::types::Bound],
+    impl_bounds: &[Bound],
 ) -> Type {
     if generics.is_empty() {
         return fn_ty.clone();
@@ -102,7 +102,7 @@ pub(super) fn wrap_with_impl_generics(
 
     let impl_vars: Vec<syntax::EcoString> = generics.iter().map(|g| g.name.clone()).collect();
 
-    let add_impl_bounds = |existing_bounds: &[syntax::types::Bound]| -> Vec<syntax::types::Bound> {
+    let add_impl_bounds = |existing_bounds: &[Bound]| -> Vec<Bound> {
         impl_bounds
             .iter()
             .cloned()

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -1,7 +1,11 @@
+use crate::loader;
+use crate::prelude;
 use ecow::EcoString;
 use syntax::ast::{
     Annotation, Expression, Generic, Pattern, Span, Visibility as SyntacticVisibility,
 };
+use syntax::program::MethodOrigin;
+use syntax::program::ValueKind;
 use syntax::program::{
     Definition, DefinitionBody, Interface, Method, Visibility, interface_requirements,
 };
@@ -222,7 +226,7 @@ impl TaskState {
         let Some(receiver_qualified_name) = receiver_ty.get_qualified_name() else {
             self.sink.push(diagnostics::infer::impl_on_foreign_type(
                 type_name,
-                crate::prelude::PRELUDE_PACKAGE_ID,
+                prelude::PRELUDE_PACKAGE_ID,
                 *span,
             ));
             return None;
@@ -236,7 +240,7 @@ impl TaskState {
         {
             self.sink.push(diagnostics::infer::impl_on_foreign_type(
                 type_name,
-                crate::loader::import_display_name(type_package),
+                loader::import_display_name(type_package),
                 *span,
             ));
             return None;
@@ -392,7 +396,7 @@ impl TaskState {
                 source_name: fn_name.clone(),
                 ty: method_ty.clone(),
                 visibility: fn_visibility.clone(),
-                origin: syntax::program::MethodOrigin::Declared,
+                origin: MethodOrigin::Declared,
                 name_span: Some(*fn_name_span),
                 doc: fn_doc.clone(),
                 allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
@@ -424,7 +428,7 @@ impl TaskState {
                     name_span: Some(*fn_name_span),
                     doc: fn_doc,
                     body: DefinitionBody::Value {
-                        kind: syntax::program::ValueKind::Runtime,
+                        kind: ValueKind::Runtime,
                         allowed_lints: extract_attribute_flags(fn_attrs, "allow"),
                         go_hints,
                         go_name: None,
@@ -545,7 +549,7 @@ impl TaskState {
                             source_name: method_name.clone(),
                             ty: fn_ty,
                             visibility: visibility.clone(),
-                            origin: syntax::program::MethodOrigin::Declared,
+                            origin: MethodOrigin::Declared,
                             name_span: Some(*method_name_span),
                             doc: fn_doc,
                             allowed_lints: extract_attribute_flags(fn_attrs, "allow"),

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -20,6 +20,7 @@ use metadata::{
     declaration_value_position_types, enum_variant_constructor_type, function_signature_pairs,
     has_recursive_instantiation, wrap_with_impl_generics,
 };
+use std::mem;
 
 use std::path::PathBuf;
 
@@ -105,7 +106,7 @@ impl TaskState {
                 .map(|file| RegistrationFile {
                     id: file.id,
                     imports: file.imports(),
-                    items: std::mem::take(&mut file.items),
+                    items: mem::take(&mut file.items),
                 })
                 .collect::<Vec<_>>()
         };

--- a/crates/semantics/src/checker/registration/test_functions.rs
+++ b/crates/semantics/src/checker/registration/test_functions.rs
@@ -5,11 +5,13 @@ use syntax::program::TestFunction;
 use syntax::types::{Symbol, Type};
 
 use super::{RegistrationFile, TaskState};
+use crate::prelude;
 use crate::store::Store;
+use std::mem;
 
 fn test_context_type() -> Type {
     Type::Nominal {
-        id: Symbol::from_parts(crate::prelude::TEST_PRELUDE_PACKAGE_ID, "TestContext"),
+        id: Symbol::from_parts(prelude::TEST_PRELUDE_PACKAGE_ID, "TestContext"),
         params: vec![],
         writable: false,
     }
@@ -82,7 +84,7 @@ impl TaskState {
     }
 
     pub(super) fn finalize_tests(&mut self, store: &mut Store) {
-        for test in std::mem::take(&mut self.pending.test_functions) {
+        for test in mem::take(&mut self.pending.test_functions) {
             store.test_index.push(test);
         }
     }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -705,14 +705,10 @@ fn is_imported_nominal(ty: &Type) -> bool {
 }
 
 fn is_faithful_imported_embed_target(store: &Store, ty: &Type) -> bool {
-    is_faithful_imported_graph(store, ty, &mut rustc_hash::FxHashSet::default())
+    is_faithful_imported_graph(store, ty, &mut FxHashSet::default())
 }
 
-fn is_faithful_imported_graph(
-    store: &Store,
-    ty: &Type,
-    seen: &mut rustc_hash::FxHashSet<String>,
-) -> bool {
+fn is_faithful_imported_graph(store: &Store, ty: &Type, seen: &mut FxHashSet<String>) -> bool {
     let target = store.deep_resolve_alias(&embed_promotion_target(store, ty));
     let Type::Nominal { id, .. } = &target else {
         return false;
@@ -780,10 +776,7 @@ fn is_deferred_local_target(store: &Store, ty: &Type) -> bool {
 }
 
 fn has_selector_surface(store: &Store, ty: &Type) -> bool {
-    if !store
-        .get_all_methods(ty, &rustc_hash::FxHashMap::default())
-        .is_empty()
-    {
+    if !store.get_all_methods(ty, &FxHashMap::default()).is_empty() {
         return true;
     }
     let Type::Nominal { id, .. } = ty else {

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -1,11 +1,18 @@
 use crate::checker::EnvResolve;
 use rustc_hash::{FxHashMap, FxHashSet};
+use syntax::ast;
 use syntax::ast::{
     EnumFieldDefinition, EnumVariant, Expression, Generic, Span, StructFieldDefinition,
     StructFields, VariantFields,
 };
 use syntax::containment::{EnumPayloads, definition_contains_by_value};
+use syntax::go_names;
+use syntax::go_names::EnumFieldShape;
+use syntax::program::ValueKind;
 use syntax::program::{AliasKind, Definition, DefinitionBody, Methods, Visibility};
+use syntax::types;
+use syntax::types::CompoundKind;
+use syntax::types::SimpleKind;
 use syntax::types::Type;
 
 use super::enum_variant_constructor_type;
@@ -96,7 +103,7 @@ impl TaskState {
                 name_span: Some(variant_name_span),
                 doc: variant_doc,
                 body: DefinitionBody::Value {
-                    kind: syntax::program::ValueKind::Runtime,
+                    kind: ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,
@@ -138,16 +145,14 @@ impl TaskState {
             return;
         }
 
-        let slots = syntax::go_names::enum_field_slots(name, variants);
+        let slots = go_names::enum_field_slots(name, variants);
 
         // (variant_name, field_name, field shape, type, span)
-        let mut seen: FxHashMap<
-            String,
-            (&str, &str, syntax::go_names::EnumFieldShape, &Type, Span),
-        > = FxHashMap::default();
+        let mut seen: FxHashMap<String, (&str, &str, EnumFieldShape, &Type, Span)> =
+            FxHashMap::default();
 
         for (vi, variant) in variants.iter().enumerate() {
-            let Some(field_shape) = syntax::go_names::enum_field_shape(&variant.fields) else {
+            let Some(field_shape) = go_names::enum_field_shape(&variant.fields) else {
                 continue;
             };
 
@@ -177,12 +182,12 @@ impl TaskState {
                     continue;
                 }
 
-                let loc_a = if shape_a == syntax::go_names::EnumFieldShape::Struct {
+                let loc_a = if shape_a == EnumFieldShape::Struct {
                     format!("{}.{}.{}", name, v_a, f_a)
                 } else {
                     format!("{}.{}", name, v_a)
                 };
-                let loc_b = if field_shape == syntax::go_names::EnumFieldShape::Struct {
+                let loc_b = if field_shape == EnumFieldShape::Struct {
                     format!("{}.{}.{}", name, variant.name, field.name)
                 } else {
                     format!("{}.{}", name, variant.name)
@@ -512,9 +517,9 @@ impl TaskState {
                     .collect();
 
                 let canonical_ty = if self.cursor.package_id() == "prelude" {
-                    if let Some(simple) = syntax::types::SimpleKind::from_name(name) {
+                    if let Some(simple) = SimpleKind::from_name(name) {
                         Type::Simple(simple)
-                    } else if let Some(compound) = syntax::types::CompoundKind::from_name(name) {
+                    } else if let Some(compound) = CompoundKind::from_name(name) {
                         Type::Compound {
                             kind: compound,
                             args: params,
@@ -701,7 +706,7 @@ fn is_embeddable_nominal(ty: &Type) -> bool {
 }
 
 fn is_imported_nominal(ty: &Type) -> bool {
-    matches!(ty, Type::Nominal { id, .. } if id.as_str().starts_with(syntax::types::GO_IMPORT_PREFIX))
+    matches!(ty, Type::Nominal { id, .. } if id.as_str().starts_with(types::GO_IMPORT_PREFIX))
 }
 
 fn is_faithful_imported_embed_target(store: &Store, ty: &Type) -> bool {
@@ -713,7 +718,7 @@ fn is_faithful_imported_graph(store: &Store, ty: &Type, seen: &mut FxHashSet<Str
     let Type::Nominal { id, .. } = &target else {
         return false;
     };
-    if !id.as_str().starts_with(syntax::types::GO_IMPORT_PREFIX) {
+    if !id.as_str().starts_with(types::GO_IMPORT_PREFIX) {
         return false;
     }
     if !seen.insert(id.to_string()) {
@@ -759,7 +764,7 @@ fn is_deferred_local_target(store: &Store, ty: &Type) -> bool {
         return false;
     };
     let id = id.as_str();
-    if id.starts_with(syntax::types::GO_IMPORT_PREFIX) {
+    if id.starts_with(types::GO_IMPORT_PREFIX) {
         return false;
     }
     match store.get_definition(id).map(|definition| &definition.body) {
@@ -794,7 +799,7 @@ fn is_pointer_backed_newtype(store: &Store, ty: &Type) -> bool {
 }
 
 // Mirror the written type's own visibility: peel storage (`Option`/`Ref`), not aliases.
-fn embed_field_visibility(store: &Store, field_ty: &Type) -> syntax::ast::Visibility {
+fn embed_field_visibility(store: &Store, field_ty: &Type) -> ast::Visibility {
     let mut target = field_ty.clone();
     while target.is_option() || target.is_ref() {
         let Some(inner) = target.inner() else { break };
@@ -803,8 +808,8 @@ fn embed_field_visibility(store: &Store, field_ty: &Type) -> syntax::ast::Visibi
     let public = matches!(&target, Type::Nominal { id, .. }
         if store.get_definition(id.as_str()).is_some_and(|d| d.visibility.is_public()));
     if public {
-        syntax::ast::Visibility::Public
+        ast::Visibility::Public
     } else {
-        syntax::ast::Visibility::Private
+        ast::Visibility::Private
     }
 }

--- a/crates/semantics/src/checker/registration/values.rs
+++ b/crates/semantics/src/checker/registration/values.rs
@@ -1,6 +1,9 @@
 use super::*;
+use syntax::ast::Literal;
+use syntax::attributes;
+use syntax::program::ValueKind;
 
-fn canonical_const_literal(expression: &Expression) -> Option<syntax::ast::Literal> {
+fn canonical_const_literal(expression: &Expression) -> Option<Literal> {
     use syntax::ast::{Literal, UnaryOperator};
     match expression.unwrap_parens() {
         Expression::Literal { literal, .. } => match literal {
@@ -126,7 +129,7 @@ impl TaskState {
             this.put_in_scope(generics);
 
             let test_params;
-            let params: &[Binding] = if syntax::attributes::has_test_attribute(attributes) {
+            let params: &[Binding] = if attributes::has_test_attribute(attributes) {
                 test_params = test_functions::normalize_test_params(params.clone(), true);
                 &test_params
             } else {
@@ -163,7 +166,7 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Value {
-                    kind: syntax::program::ValueKind::Runtime,
+                    kind: ValueKind::Runtime,
                     allowed_lints: extract_attribute_flags(attributes, "allow"),
                     go_hints: extract_attribute_flags(attributes, "go"),
                     go_name: extract_go_name(attributes),
@@ -232,8 +235,8 @@ impl TaskState {
         }
 
         let kind = match expression.value().and_then(canonical_const_literal) {
-            Some(value) => syntax::program::ValueKind::Constant(value),
-            None => syntax::program::ValueKind::ConstantDeclaration,
+            Some(value) => ValueKind::Constant(value),
+            None => ValueKind::ConstantDeclaration,
         };
 
         self.current_package_mut(store).definitions.insert(
@@ -295,7 +298,7 @@ impl TaskState {
                 name_span: Some(*name_span),
                 doc: doc.clone(),
                 body: DefinitionBody::Value {
-                    kind: syntax::program::ValueKind::Runtime,
+                    kind: ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::loader;
+use std::iter;
 
 #[derive(Debug, Default)]
 pub(super) struct ImportState {
@@ -166,7 +168,7 @@ impl TaskState {
         }
 
         let in_test_file = self.current_file_is_test(store);
-        let package_ids = std::iter::once(self.cursor.package_id())
+        let package_ids = iter::once(self.cursor.package_id())
             .chain(self.imports.unprefixed_imports.iter().map(String::as_str));
 
         let mut value_fallback: Option<EcoString> = None;
@@ -409,7 +411,7 @@ impl TaskState {
         for import in imports {
             if seen_paths.contains(import.name.as_str()) {
                 self.sink.push(diagnostics::infer::duplicate_import_path(
-                    crate::loader::import_display_name(&import.name),
+                    loader::import_display_name(&import.name),
                     import.name_span,
                 ));
                 continue;
@@ -444,8 +446,8 @@ impl TaskState {
             {
                 self.sink.push(diagnostics::infer::import_conflict(
                     &effective,
-                    crate::loader::import_display_name(existing_path),
-                    crate::loader::import_display_name(&import.name),
+                    loader::import_display_name(existing_path),
+                    loader::import_display_name(&import.name),
                     import.name_span,
                 ));
                 continue;

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -1,5 +1,6 @@
 use ecow::EcoString;
 use rustc_hash::FxHashMap as HashMap;
+use std::mem;
 use syntax::ast::BindingId;
 use syntax::ast::Span;
 use syntax::types::{Symbol, Type};
@@ -393,7 +394,7 @@ impl Scopes {
             .function
             .as_mut()
             .and_then(FunctionContext::body_mut)
-            .map(|body| std::mem::take(&mut body.deferred_map_key_checks))
+            .map(|body| mem::take(&mut body.deferred_map_key_checks))
             .unwrap_or_default()
     }
 

--- a/crates/semantics/src/checker/state.rs
+++ b/crates/semantics/src/checker/state.rs
@@ -1,5 +1,8 @@
 use super::resolution::ImportState;
 use super::*;
+use crate::analysis::ProjectKind;
+use crate::analysis::ScriptUnit;
+use crate::store;
 use syntax::program::TestFunction;
 
 #[derive(Debug, Clone)]
@@ -92,8 +95,8 @@ impl PendingWork {
 /// A consistent read-only snapshot from which parallel checker tasks start.
 pub(crate) struct TaskSeed {
     binding_ids: Arc<BindingIdAllocator>,
-    project_kind: crate::analysis::ProjectKind,
-    script: Option<crate::analysis::ScriptUnit>,
+    project_kind: ProjectKind,
+    script: Option<ScriptUnit>,
 }
 
 impl TaskSeed {
@@ -102,7 +105,7 @@ impl TaskSeed {
             self.binding_ids.clone(),
             LocalSink::new(),
             self.project_kind,
-            crate::store::ENTRY_PACKAGE_ID,
+            store::ENTRY_PACKAGE_ID,
             self.script,
         )
     }
@@ -116,8 +119,8 @@ pub struct TaskState {
     pub(super) imports: ImportState,
     pub sink: LocalSink,
     pub facts: Facts,
-    pub(crate) project_kind: crate::analysis::ProjectKind,
-    pub(crate) script: Option<crate::analysis::ScriptUnit>,
+    pub(crate) project_kind: ProjectKind,
+    pub(crate) script: Option<ScriptUnit>,
     pub(crate) pending: PendingWork,
 }
 
@@ -125,9 +128,9 @@ impl TaskState {
     fn new(
         binding_ids: Arc<BindingIdAllocator>,
         sink: LocalSink,
-        project_kind: crate::analysis::ProjectKind,
+        project_kind: ProjectKind,
         package_id: impl Into<String>,
-        script: Option<crate::analysis::ScriptUnit>,
+        script: Option<ScriptUnit>,
     ) -> Self {
         Self {
             env: TypeEnv::new(),
@@ -146,7 +149,7 @@ impl TaskState {
         Self::new(
             Arc::new(BindingIdAllocator::new()),
             LocalSink::new(),
-            crate::analysis::ProjectKind::Binary,
+            ProjectKind::Binary,
             package_id,
             None,
         )
@@ -154,14 +157,14 @@ impl TaskState {
 
     pub(crate) fn with_sink(
         sink: LocalSink,
-        project_kind: crate::analysis::ProjectKind,
-        script: Option<crate::analysis::ScriptUnit>,
+        project_kind: ProjectKind,
+        script: Option<ScriptUnit>,
     ) -> Self {
         Self::new(
             Arc::new(BindingIdAllocator::new()),
             sink,
             project_kind,
-            crate::store::ENTRY_PACKAGE_ID,
+            store::ENTRY_PACKAGE_ID,
             script,
         )
     }

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -9,6 +9,8 @@
 //! innermost log; a successful nested region joins its parent, while a failed
 //! region restores its entries in reverse order.
 
+use std::mem;
+use syntax::types::FunctionParameter;
 use syntax::types::{Bound, Type, TypeVarId};
 
 #[derive(Debug, Clone)]
@@ -63,7 +65,7 @@ impl TypeEnv {
 
     pub(crate) fn bind(&mut self, id: TypeVarId, ty: Type) {
         let slot = Self::slot(id);
-        let old = std::mem::replace(&mut self.entries[slot], VarState::Bound(ty));
+        let old = mem::replace(&mut self.entries[slot], VarState::Bound(ty));
         if let Some(log) = self.undo_logs.last_mut() {
             log.push((id, old));
         }
@@ -186,9 +188,9 @@ impl TypeEnv {
 
     fn resolve_function_params(
         &self,
-        params: &[syntax::types::FunctionParameter],
-    ) -> Option<Vec<syntax::types::FunctionParameter>> {
-        let mut out: Option<Vec<syntax::types::FunctionParameter>> = None;
+        params: &[FunctionParameter],
+    ) -> Option<Vec<FunctionParameter>> {
+        let mut out: Option<Vec<FunctionParameter>> = None;
         for (index, param) in params.iter().enumerate() {
             match self.resolve_changed(&param.ty) {
                 Some(resolved) => {

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -5,6 +5,7 @@ use syntax::types::{Symbol, Type, build_substitution_map, substitute, unqualifie
 use crate::checker::infer::BuiltinBound;
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::expressions::comparison;
+use crate::checker::infer::interface::interface_requires_methods;
 use crate::checker::{EnvResolve, TaskState};
 use crate::facts::GenericBoundOrigin;
 use crate::store::Store;
@@ -122,8 +123,7 @@ pub fn bound_implied(store: &Store, available: &[Type], required: &Type) -> bool
 pub fn bound_requires_evidence(store: &Store, bound: &Type) -> bool {
     let resolved = store.deep_resolve_alias(bound);
     resolved.get_qualified_id().is_some_and(|id| {
-        BuiltinBound::from_qualified_id(id).is_some()
-            || crate::checker::infer::interface::interface_requires_methods(store, id)
+        BuiltinBound::from_qualified_id(id).is_some() || interface_requires_methods(store, id)
     })
 }
 

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -9,6 +9,8 @@ use crate::checker::infer::interface::interface_requires_methods;
 use crate::checker::{EnvResolve, TaskState};
 use crate::facts::GenericBoundOrigin;
 use crate::store::Store;
+use std::iter;
+use std::mem;
 
 #[derive(Debug, Clone)]
 pub struct AppliedGenericBound {
@@ -110,7 +112,7 @@ pub(crate) fn type_argument_children(ty: &Type) -> Vec<&Type> {
             .params
             .iter()
             .map(|param| &param.ty)
-            .chain(std::iter::once(function.return_type.as_ref()))
+            .chain(iter::once(function.return_type.as_ref()))
             .collect(),
         _ => Vec::new(),
     }
@@ -150,7 +152,7 @@ impl TaskState {
     }
 
     fn check_resolved_generic_obligations(&mut self, store: &Store) {
-        let obligations = std::mem::take(&mut self.facts.deferred.generic_bounds);
+        let obligations = mem::take(&mut self.facts.deferred.generic_bounds);
         let mut unresolved = Vec::new();
         let mut seen = rustc_hash::FxHashSet::default();
 

--- a/crates/semantics/src/loader.rs
+++ b/crates/semantics/src/loader.rs
@@ -1,3 +1,4 @@
+use crate::store;
 use rustc_hash::FxHashMap as HashMap;
 
 /// Source content plus a cwd-relative display path for diagnostics.
@@ -47,7 +48,7 @@ pub fn is_external_test_package(package_id: &str) -> bool {
 }
 
 pub fn import_display_name(package_id: &str) -> &str {
-    if package_id == crate::store::ENTRY_PACKAGE_ID {
+    if package_id == store::ENTRY_PACKAGE_ID {
         ROOT_IMPORT
     } else {
         package_id

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -12,6 +12,12 @@ use crate::loader as semantics_loader;
 use crate::loader::Loader;
 use crate::store::{ENTRY_PACKAGE_ID, Store};
 use diagnostics::LocalSink;
+use std::mem;
+use syntax::dependency_block;
+use syntax::dependency_block::DependencyBlock;
+use syntax::imports::scan_imports;
+use syntax::program;
+use syntax::program::FileImport;
 
 pub type PackageId = String;
 
@@ -183,7 +189,7 @@ pub struct ScannedFile {
     pub name: String,
     pub display_path: String,
     pub source: String,
-    pub imports: Vec<syntax::program::FileImport>,
+    pub imports: Vec<FileImport>,
 }
 
 impl ScannedFile {
@@ -192,7 +198,7 @@ impl ScannedFile {
     }
 
     pub fn is_test(&self) -> bool {
-        syntax::program::is_test_file(&self.name)
+        program::is_test_file(&self.name)
     }
 
     pub fn parse(
@@ -299,7 +305,7 @@ struct GraphBuilder<'a> {
 impl<'a> GraphBuilder<'a> {
     fn visit(&mut self, mut to_visit: Vec<PackageId>) {
         while !to_visit.is_empty() {
-            let drained: Vec<PackageId> = std::mem::take(&mut to_visit);
+            let drained: Vec<PackageId> = mem::take(&mut to_visit);
             let mut batch: Vec<PackageId> = Vec::with_capacity(drained.len());
             for package_id in drained {
                 if self.visited.insert(package_id.clone()) {
@@ -438,7 +444,7 @@ impl<'a> GraphBuilder<'a> {
 
 #[derive(Clone)]
 struct ClassifiedImport {
-    import: syntax::program::FileImport,
+    import: FileImport,
     kind: DependencyKind,
 }
 
@@ -577,7 +583,7 @@ fn read_folder(fs: &dyn Loader, package_id: &str) -> Vec<(String, semantics_load
 
 fn scan_one(job: ScanJob) -> (PackageId, ScannedFile) {
     let file = ScannedFile {
-        imports: syntax::imports::scan_imports(&job.source, job.file_id),
+        imports: scan_imports(&job.source, job.file_id),
         file_id: job.file_id,
         name: job.filename,
         display_path: job.display_path,
@@ -637,7 +643,7 @@ pub(crate) fn check_dependency_blocks(
     let script = scope.script_unit().is_some();
 
     for (file_id, source) in sources {
-        let blocks = syntax::dependency_block::scan_dependency_blocks(source, *file_id);
+        let blocks = dependency_block::scan_dependency_blocks(source, *file_id);
         let Some((first, rest)) = blocks.split_first() else {
             continue;
         };
@@ -679,7 +685,7 @@ pub(crate) fn check_dependency_blocks(
 }
 
 fn entry_span(
-    block: &syntax::dependency_block::DependencyBlock,
+    block: &DependencyBlock,
     table: &deps::DependencyTable,
     module_path: &str,
     file_id: u32,
@@ -890,10 +896,11 @@ fn process_file_imports(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syntax::program::FileImport;
+    use FileImport;
+    use std::path::PathBuf;
 
     const DIRECTORY_SCOPE: AnalysisScope = AnalysisScope::Directory;
-    const PROJECT_SCOPE: AnalysisScope = AnalysisScope::Project(std::path::PathBuf::new());
+    const PROJECT_SCOPE: AnalysisScope = AnalysisScope::Project(PathBuf::new());
 
     fn go_import(is_blank: bool, offset: u32) -> FileImport {
         let span = Span::new(0, offset, 1);

--- a/crates/semantics/src/path.rs
+++ b/crates/semantics/src/path.rs
@@ -1,9 +1,10 @@
+use std::env;
 use std::path::{Component, Path, PathBuf};
 
 /// Returns path relative to the cwd as a forward-slash string.
 /// Returns None if the cwd is unknown or the path lies outside it.
 pub fn relative_to_cwd(path: &Path) -> Option<String> {
-    relative_to_cwd_with(path, std::env::current_dir().ok().as_deref())
+    relative_to_cwd_with(path, env::current_dir().ok().as_deref())
 }
 
 /// Cwd-relative display paths under a fixed base dir, resolving prefixes once.
@@ -19,7 +20,7 @@ enum DisplayPathResolution {
 
 impl DisplayPathBase {
     pub fn new(base_dir: &Path) -> Self {
-        Self::with_cwd(base_dir, std::env::current_dir().ok())
+        Self::with_cwd(base_dir, env::current_dir().ok())
     }
 
     fn with_cwd(base_dir: &Path, cwd: Option<PathBuf>) -> Self {

--- a/crates/semantics/src/path.rs
+++ b/crates/semantics/src/path.rs
@@ -84,6 +84,7 @@ fn relativize(rel: &Path) -> Option<String> {
 mod tests {
     use super::*;
     use std::fs as stdfs;
+    use std::os::unix::fs::symlink;
 
     #[test]
     fn plain_path_inside_cwd() {
@@ -151,7 +152,7 @@ mod tests {
         stdfs::create_dir_all(real.join("src")).unwrap();
         stdfs::write(real.join("src/main.lis"), "").unwrap();
         let link = tmp.path().join("link");
-        std::os::unix::fs::symlink(&real, &link).unwrap();
+        symlink(&real, &link).unwrap();
 
         assert_eq!(
             relative_to_cwd_with(&real.join("src/main.lis"), Some(&link)),
@@ -208,7 +209,7 @@ mod tests {
         let real = tmp.path().join("real");
         stdfs::create_dir_all(real.join("src")).unwrap();
         let link = tmp.path().join("link");
-        std::os::unix::fs::symlink(&real, &link).unwrap();
+        symlink(&real, &link).unwrap();
 
         let base = DisplayPathBase::with_cwd(&real.join("src"), Some(link));
         assert_eq!(

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -4,11 +4,13 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::FileParseStatus;
+use syntax::ast::StructKind;
 use syntax::ast::{EnumVariant, Expression, StructFieldDefinition};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, Method, Methods, Package,
     TestIndex, UninferredExports, methods_for_type,
 };
+use syntax::types;
 use syntax::types::{SimpleKind, Symbol, Type};
 
 pub use crate::closed_domain::{ClosedDomain, ClosedMember, DomainValue};
@@ -298,10 +300,7 @@ impl Store {
     }
 
     pub fn package_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
-        syntax::types::package_for_qualified_name(
-            qualified_name,
-            self.packages.keys().map(String::as_str),
-        )
+        types::package_for_qualified_name(qualified_name, self.packages.keys().map(String::as_str))
     }
 
     pub(crate) fn is_const(&self, qualified_name: &str) -> bool {
@@ -336,14 +335,14 @@ impl Store {
         }
     }
 
-    pub fn struct_kind(&self, qualified_name: &str) -> Option<syntax::ast::StructKind> {
+    pub fn struct_kind(&self, qualified_name: &str) -> Option<StructKind> {
         match &self.get_definition(qualified_name)?.body {
             DefinitionBody::Struct { fields, .. } => Some(fields.kind()),
             _ => None,
         }
     }
 
-    pub fn deep_struct_kind(&self, ty: &Type) -> Option<syntax::ast::StructKind> {
+    pub fn deep_struct_kind(&self, ty: &Type) -> Option<StructKind> {
         self.struct_kind(self.deep_resolve_alias(ty).get_qualified_id()?)
     }
 
@@ -372,39 +371,39 @@ impl Store {
     }
 
     pub fn is_nilable_go_type(&self, ty: &Type) -> bool {
-        syntax::types::is_nilable_go_type(ty, |id| self.get_definition(id))
+        types::is_nilable_go_type(ty, |id| self.get_definition(id))
     }
 
     pub fn peel_alias(&self, ty: &Type) -> Type {
-        syntax::types::peel_alias(ty, |id| self.get_definition(id))
+        types::peel_alias(ty, |id| self.get_definition(id))
     }
 
     pub fn underlying_type(&self, ty: &Type) -> Option<Type> {
-        syntax::types::underlying_type(ty, |id| self.get_definition(id))
+        types::underlying_type(ty, |id| self.get_definition(id))
     }
 
     pub fn peel_underlying(&self, ty: &Type) -> Type {
-        syntax::types::peel_underlying(ty, |id| self.get_definition(id))
+        types::peel_underlying(ty, |id| self.get_definition(id))
     }
 
     pub fn underlying_simple_kind(&self, ty: &Type) -> Option<SimpleKind> {
-        syntax::types::underlying_simple_kind(ty, |id| self.get_definition(id))
+        types::underlying_simple_kind(ty, |id| self.get_definition(id))
     }
 
     pub fn underlying_numeric_type(&self, ty: &Type) -> Option<Type> {
-        syntax::types::underlying_numeric_type(ty, |id| self.get_definition(id))
+        types::underlying_numeric_type(ty, |id| self.get_definition(id))
     }
 
     pub fn literal_adaptation_target(&self, ty: &Type) -> Option<Type> {
-        syntax::types::literal_adaptation_target(ty, |id| self.get_definition(id))
+        types::literal_adaptation_target(ty, |id| self.get_definition(id))
     }
 
     pub fn is_numeric_compatible_with(&self, left: &Type, right: &Type) -> bool {
-        syntax::types::is_numeric_compatible_with(left, right, |id| self.get_definition(id))
+        types::is_numeric_compatible_with(left, right, |id| self.get_definition(id))
     }
 
     pub fn is_aliased_numeric_type(&self, ty: &Type) -> bool {
-        syntax::types::is_aliased_numeric_type(ty, |id| self.get_definition(id))
+        types::is_aliased_numeric_type(ty, |id| self.get_definition(id))
     }
 
     pub fn has_underlying_numeric_type(&self, ty: &Type) -> bool {
@@ -422,23 +421,23 @@ impl Store {
     }
 
     pub fn has_byte_or_rune_slice_underlying(&self, ty: &Type) -> bool {
-        syntax::types::has_byte_or_rune_slice_underlying(ty, |id| self.get_definition(id))
+        types::has_byte_or_rune_slice_underlying(ty, |id| self.get_definition(id))
     }
 
     pub fn is_orderable(&self, ty: &Type) -> bool {
-        syntax::types::is_orderable(ty, |id| self.get_definition(id))
+        types::is_orderable(ty, |id| self.get_definition(id))
     }
 
     pub fn satisfies_ordered_constraint(&self, ty: &Type) -> bool {
-        syntax::types::satisfies_ordered_constraint(ty, |id| self.get_definition(id))
+        types::satisfies_ordered_constraint(ty, |id| self.get_definition(id))
     }
 
     pub fn resolves_to_unknown(&self, ty: &Type) -> bool {
-        syntax::types::resolves_to_unknown(ty, |id| self.get_definition(id))
+        types::resolves_to_unknown(ty, |id| self.get_definition(id))
     }
 
     pub fn contains_unknown(&self, ty: &Type) -> bool {
-        syntax::types::contains_unknown(ty, |id| self.get_definition(id))
+        types::contains_unknown(ty, |id| self.get_definition(id))
     }
 
     pub fn resolve_to_function_type(&self, ty: &Type) -> Option<Type> {
@@ -666,9 +665,11 @@ mod clone_tests {
 #[cfg(test)]
 mod closed_domain_tests {
     use super::*;
+    use syntax::ast;
     use syntax::ast::{
         Annotation, Generic, Literal, Span, StructFieldDefinition, StructFieldKind, StructFields,
     };
+    use syntax::program::ValueKind;
     use syntax::program::{AliasKind, Attributes, TypeAttribute, Visibility};
     use syntax::types::CompoundKind;
 
@@ -710,7 +711,7 @@ mod closed_domain_tests {
                     name: "0".into(),
                     name_span: Span::dummy(),
                     annotation: Annotation::Unknown,
-                    visibility: syntax::ast::Visibility::Private,
+                    visibility: ast::Visibility::Private,
                     ty: Type::Simple(SimpleKind::Int),
                     kind: StructFieldKind::Named { attributes: vec![] },
                 }]),
@@ -743,7 +744,7 @@ mod closed_domain_tests {
             name_span: None,
             doc: None,
             body: DefinitionBody::Value {
-                kind: syntax::program::ValueKind::Constant(Literal::Integer { value, text: None }),
+                kind: ValueKind::Constant(Literal::Integer { value, text: None }),
                 allowed_lints: vec![],
                 go_hints: vec![],
                 go_name: None,
@@ -939,7 +940,7 @@ mod closed_domain_tests {
                         name: "0".into(),
                         name_span: Span::dummy(),
                         annotation: Annotation::Unknown,
-                        visibility: syntax::ast::Visibility::Private,
+                        visibility: ast::Visibility::Private,
                         ty: field_ty,
                         kind: StructFieldKind::Named { attributes: vec![] },
                     }]),

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -708,8 +708,8 @@ mod closed_domain_tests {
                 fields: StructFields::Tuple(vec![StructFieldDefinition {
                     doc: None,
                     name: "0".into(),
-                    name_span: syntax::ast::Span::dummy(),
-                    annotation: syntax::ast::Annotation::Unknown,
+                    name_span: Span::dummy(),
+                    annotation: Annotation::Unknown,
                     visibility: syntax::ast::Visibility::Private,
                     ty: Type::Simple(SimpleKind::Int),
                     kind: StructFieldKind::Named { attributes: vec![] },
@@ -937,8 +937,8 @@ mod closed_domain_tests {
                     fields: StructFields::Tuple(vec![StructFieldDefinition {
                         doc: None,
                         name: "0".into(),
-                        name_span: syntax::ast::Span::dummy(),
-                        annotation: syntax::ast::Annotation::Unknown,
+                        name_span: Span::dummy(),
+                        annotation: Annotation::Unknown,
                         visibility: syntax::ast::Visibility::Private,
                         ty: field_ty,
                         kind: StructFieldKind::Named { attributes: vec![] },

--- a/crates/semantics/src/zero.rs
+++ b/crates/semantics/src/zero.rs
@@ -2,7 +2,12 @@
 //! literal spreads) and by the `replaceable_with_autofill` lint.
 
 use ecow::EcoString;
+use syntax::ast::StructFieldDefinition;
+use syntax::ast::StructFields;
+use syntax::program::AliasKind;
+use syntax::program::Definition;
 use syntax::program::DefinitionBody;
+use syntax::types;
 use syntax::types::{
     CompoundKind, SimpleKind, SubstitutionMap, Symbol, Type, build_named_substitution_map,
     substitute,
@@ -253,7 +258,7 @@ fn has_zero_nominal_fields(
             Ok(())
         }
         DefinitionBody::TypeAlias { alias, .. } => {
-            if matches!(alias, syntax::program::AliasKind::Opaque(_)) {
+            if matches!(alias, AliasKind::Opaque(_)) {
                 if def.is_zero_safe() {
                     return Ok(());
                 }
@@ -281,7 +286,7 @@ fn has_zero_nominal_fields(
 /// `go:archive/zip.File` as `archive/zip.File`, so diagnostics name the package.
 fn go_display_name(id: &Symbol) -> EcoString {
     id.as_str()
-        .strip_prefix(syntax::types::GO_IMPORT_PREFIX)
+        .strip_prefix(types::GO_IMPORT_PREFIX)
         .unwrap_or(id.as_str())
         .into()
 }
@@ -291,10 +296,7 @@ fn go_display_name(id: &Symbol) -> EcoString {
 /// presumed zero-safe (matching Go's own struct literals) unless curated
 /// `zero_unsafe`. A struct whose only content is hidden state is opaque to
 /// callers, so it stays refused unless curated `zero_safe`.
-pub fn go_struct_denies_zero(
-    def: &syntax::program::Definition,
-    fields: &syntax::ast::StructFields,
-) -> bool {
+pub fn go_struct_denies_zero(def: &Definition, fields: &StructFields) -> bool {
     if def.is_zero_unsafe() {
         return true;
     }
@@ -307,7 +309,7 @@ pub fn go_struct_denies_zero(
 
 /// An unexported embed is hidden Go state like any dropped private field, so
 /// the struct-level verdict covers it and per-field zero checks skip it.
-pub fn hidden_embed_field(field: &syntax::ast::StructFieldDefinition) -> bool {
+pub fn hidden_embed_field(field: &StructFieldDefinition) -> bool {
     field.is_embedded() && !field.visibility.is_public()
 }
 

--- a/crates/stdlib/src/target.rs
+++ b/crates/stdlib/src/target.rs
@@ -1,3 +1,4 @@
+use std::env::consts;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -16,11 +17,11 @@ impl Target {
     }
 
     pub fn host() -> Self {
-        let goos = match std::env::consts::OS {
+        let goos = match consts::OS {
             "macos" => "darwin",
             other => other,
         };
-        let goarch = match std::env::consts::ARCH {
+        let goarch = match consts::ARCH {
             "x86_64" => "amd64",
             "aarch64" => "arm64",
             "x86" => "386",

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1548,7 +1548,7 @@ impl Expression {
         }
     }
 
-    pub fn as_option_constructor(&self) -> Option<std::result::Result<(), ()>> {
+    pub fn as_option_constructor(&self) -> Option<Result<(), ()>> {
         let variant = match self {
             Expression::Identifier { value, .. } => Some(value.as_str()),
             _ => None,
@@ -1565,7 +1565,7 @@ impl Expression {
         matches!(self.as_option_constructor(), Some(Err(())))
     }
 
-    pub fn as_result_constructor(&self) -> Option<std::result::Result<(), ()>> {
+    pub fn as_result_constructor(&self) -> Option<Result<(), ()>> {
         let variant = match self {
             Expression::Identifier { value, .. } => Some(value.as_str()),
             _ => None,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -1,7 +1,16 @@
 use ecow::EcoString;
 
 use crate::program::{CallKind, DotAccessResolution};
+use crate::types;
 use crate::types::Type;
+use fmt::Formatter;
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::ops::Index;
+use std::slice::Iter;
+use std::slice::IterMut;
 
 macro_rules! children {
     () => { Vec::new() };
@@ -36,8 +45,8 @@ impl Binding {
     }
 }
 
-impl std::fmt::Debug for Binding {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Binding {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("Binding");
         s.field("pattern", &self.pattern);
         s.field("annotation", &self.annotation);
@@ -260,8 +269,8 @@ impl MatchArm {
     }
 }
 
-impl std::fmt::Debug for MatchArm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for MatchArm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("MatchArm");
         s.field("pattern", &self.pattern);
         if self.guard.is_some() {
@@ -484,7 +493,7 @@ impl Pattern {
             p => p,
         };
         matches!(peeled, Pattern::EnumVariant { identifier, fields, .. }
-            if crate::types::unqualified_name(identifier) == "Some" && fields.len() == 1)
+            if types::unqualified_name(identifier) == "Some" && fields.len() == 1)
     }
 }
 
@@ -534,7 +543,7 @@ impl VariantFields {
         }
     }
 
-    pub fn iter(&self) -> std::slice::Iter<'_, EnumFieldDefinition> {
+    pub fn iter(&self) -> Iter<'_, EnumFieldDefinition> {
         self.as_slice().iter()
     }
 
@@ -545,7 +554,7 @@ impl VariantFields {
 
 impl<'a> IntoIterator for &'a VariantFields {
     type Item = &'a EnumFieldDefinition;
-    type IntoIter = std::slice::Iter<'a, EnumFieldDefinition>;
+    type IntoIter = Iter<'a, EnumFieldDefinition>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -618,7 +627,7 @@ impl StructFields {
     }
 }
 
-impl std::ops::Deref for StructFields {
+impl Deref for StructFields {
     type Target = [StructFieldDefinition];
 
     fn deref(&self) -> &Self::Target {
@@ -626,7 +635,7 @@ impl std::ops::Deref for StructFields {
     }
 }
 
-impl std::ops::DerefMut for StructFields {
+impl DerefMut for StructFields {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Record(fields) | Self::Tuple(fields) => fields,
@@ -636,7 +645,7 @@ impl std::ops::DerefMut for StructFields {
 
 impl<'a> IntoIterator for &'a StructFields {
     type Item = &'a StructFieldDefinition;
-    type IntoIter = std::slice::Iter<'a, StructFieldDefinition>;
+    type IntoIter = Iter<'a, StructFieldDefinition>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_slice().iter()
@@ -645,7 +654,7 @@ impl<'a> IntoIterator for &'a StructFields {
 
 impl<'a> IntoIterator for &'a mut StructFields {
     type Item = &'a mut StructFieldDefinition;
-    type IntoIter = std::slice::IterMut<'a, StructFieldDefinition>;
+    type IntoIter = IterMut<'a, StructFieldDefinition>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
@@ -775,7 +784,7 @@ impl<'a> ResolvedCallTypeArguments<'a> {
     }
 }
 
-impl std::ops::Index<usize> for ResolvedCallTypeArguments<'_> {
+impl Index<usize> for ResolvedCallTypeArguments<'_> {
     type Output = Type;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -783,8 +792,8 @@ impl std::ops::Index<usize> for ResolvedCallTypeArguments<'_> {
     }
 }
 
-impl std::fmt::Debug for CallTypeArguments {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for CallTypeArguments {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.0 {
             CallTypeArgumentState::None => f.write_str("None"),
             CallTypeArgumentState::Unresolved(annotations) => {
@@ -926,8 +935,8 @@ pub enum Annotation {
     },
 }
 
-impl std::fmt::Debug for Annotation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Annotation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Constructor {
                 name,
@@ -1013,8 +1022,8 @@ pub struct Generic {
     pub span: Span,
 }
 
-impl std::fmt::Debug for Generic {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Generic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let bounds = self.bounds().collect::<Vec<_>>();
         let resolved_bounds = self
             .resolved_bounds()
@@ -2395,8 +2404,8 @@ impl BinaryOperator {
     }
 }
 
-impl std::fmt::Display for BinaryOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for BinaryOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let symbol = match self {
             BinaryOperator::Addition => "+",
             BinaryOperator::Subtraction => "-",

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -1,6 +1,8 @@
 //! Canonical catalog of recognized attributes, shared by the `unknown_attribute`
 //! lint and LSP completions.
 
+use crate::ast::Attribute;
+use crate::ast::AttributeArg;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttributeTarget {
     Struct,
@@ -121,21 +123,18 @@ pub fn is_serialization_key(key: &str) -> bool {
     SERIALIZATION_KEYS.contains(&key)
 }
 
-pub fn struct_attribute_forces_field_export(attribute: &crate::ast::Attribute) -> bool {
+pub fn struct_attribute_forces_field_export(attribute: &Attribute) -> bool {
     if attribute.name == "tag" {
-        return matches!(
-            attribute.args.first(),
-            Some(crate::ast::AttributeArg::String(_))
-        );
+        return matches!(attribute.args.first(), Some(AttributeArg::String(_)));
     }
     is_serialization_key(&attribute.name)
 }
 
-pub(crate) fn field_attribute_forces_export(attribute: &crate::ast::Attribute) -> bool {
+pub(crate) fn field_attribute_forces_export(attribute: &Attribute) -> bool {
     if attribute.name == "tag" {
         return matches!(
             attribute.args.first(),
-            Some(crate::ast::AttributeArg::String(_) | crate::ast::AttributeArg::Raw(_))
+            Some(AttributeArg::String(_) | AttributeArg::Raw(_))
         );
     }
     is_serialization_key(&attribute.name)
@@ -149,10 +148,10 @@ pub fn attributes_for(target: AttributeTarget) -> impl Iterator<Item = &'static 
     ATTRIBUTES.iter().filter(move |a| a.applies_to(target))
 }
 
-pub fn test_attribute(attributes: &[crate::ast::Attribute]) -> Option<&crate::ast::Attribute> {
+pub fn test_attribute(attributes: &[Attribute]) -> Option<&Attribute> {
     attributes.iter().find(|a| a.name == "test")
 }
 
-pub fn has_test_attribute(attributes: &[crate::ast::Attribute]) -> bool {
+pub fn has_test_attribute(attributes: &[Attribute]) -> bool {
     test_attribute(attributes).is_some()
 }

--- a/crates/syntax/src/containment.rs
+++ b/crates/syntax/src/containment.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashSet as HashSet;
 
+use crate::program::AliasKind;
 use crate::program::{Definition, DefinitionBody};
 use crate::types::{CompoundKind, Type, peel_alias};
 
@@ -186,10 +187,10 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
                     return true;
                 };
                 match alias {
-                    crate::program::AliasKind::Transparent { target, .. } => {
+                    AliasKind::Transparent { target, .. } => {
                         self.parameter_stored_inline(target, &generic.name, checking, wrap_checking)
                     }
-                    crate::program::AliasKind::Opaque(_) => true,
+                    AliasKind::Opaque(_) => true,
                 }
             }
             DefinitionBody::Interface { .. } => false,

--- a/crates/syntax/src/dependency_block.rs
+++ b/crates/syntax/src/dependency_block.rs
@@ -2,6 +2,8 @@
 //! lexer never sees. Line offsets are kept, for mapping a TOML error back.
 
 use crate::ast::Span;
+use crate::lex;
+use std::ops::Range;
 
 pub const HEADER: &str = "[dependencies.go]";
 
@@ -13,7 +15,7 @@ pub struct DependencyBlock {
 }
 
 impl DependencyBlock {
-    pub fn map_span(&self, range: std::ops::Range<usize>, file_id: u32) -> Span {
+    pub fn map_span(&self, range: Range<usize>, file_id: u32) -> Span {
         let Some(line) = self.line_of(range.start) else {
             return self.span;
         };
@@ -139,8 +141,8 @@ fn line_break_len(rest: &str) -> usize {
 }
 
 fn prologue_start(source: &str) -> usize {
-    let bom = crate::lex::bom_len(source);
-    bom + crate::lex::shebang_len(&source[bom..]).unwrap_or(0)
+    let bom = lex::bom_len(source);
+    bom + lex::shebang_len(&source[bom..]).unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::program::is_internal_package_id;
+use crate::types::SimpleKind;
 use crate::types::{GO_IMPORT_PREFIX, Symbol, Type};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -144,7 +145,7 @@ impl Type {
             Type::ReceiverPlaceholder => "self".to_string(),
 
             Type::Simple(kind) => match kind {
-                crate::types::SimpleKind::Unit => "()".to_string(),
+                SimpleKind::Unit => "()".to_string(),
                 _ => kind.leaf_name().to_string(),
             },
 

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -5,7 +5,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::Cow;
 
 use crate::EcoString;
+use crate::ast::StructFieldDefinition;
 use crate::ast::{EnumVariant, VariantFields};
+use crate::attributes;
 use crate::program::Methods;
 use crate::types::{GO_IMPORT_PREFIX, Type};
 
@@ -177,22 +179,19 @@ pub fn escape_type_name(name: &str) -> Cow<'_, str> {
 }
 
 /// Whether a struct field emits its camelized Go name.
-pub fn struct_field_is_exported(
-    field: &crate::ast::StructFieldDefinition,
-    struct_forces_export: bool,
-) -> bool {
+pub fn struct_field_is_exported(field: &StructFieldDefinition, struct_forces_export: bool) -> bool {
     !field.is_embedded()
         && (field.visibility.is_public()
             || struct_forces_export
             || field
                 .attributes()
                 .iter()
-                .any(crate::attributes::field_attribute_forces_export))
+                .any(attributes::field_attribute_forces_export))
 }
 
 /// A struct field's emitted Go name under the shared export policy.
 pub fn struct_field_go_name(
-    field: &crate::ast::StructFieldDefinition,
+    field: &StructFieldDefinition,
     struct_forces_export: bool,
 ) -> Cow<'_, str> {
     if struct_field_is_exported(field, struct_forces_export) {
@@ -227,6 +226,8 @@ pub enum EnumFieldShape {
 #[cfg(test)]
 mod shape_tests {
     use super::*;
+    use crate::ast::Annotation;
+    use crate::ast::Span;
     use crate::ast::{EnumFieldDefinition, VariantFields};
     use crate::types::Type;
 
@@ -234,8 +235,8 @@ mod shape_tests {
     fn enum_field_shape_captures_only_name_relevant_layouts() {
         let field = EnumFieldDefinition {
             name: "field0".into(),
-            name_span: crate::ast::Span::dummy(),
-            annotation: crate::ast::Annotation::Unknown,
+            name_span: Span::dummy(),
+            annotation: Annotation::Unknown,
             ty: Type::uninferred(),
         };
 

--- a/crates/syntax/src/imports.rs
+++ b/crates/syntax/src/imports.rs
@@ -3,6 +3,7 @@
 use ecow::EcoString;
 
 use crate::ast::{ImportAlias, Span};
+use crate::lex;
 use crate::program::FileImport;
 
 pub fn scan_imports(source: &str, file_id: u32) -> Vec<FileImport> {
@@ -49,8 +50,8 @@ impl<'source> Scanner<'source> {
     }
 
     fn skip_shebang(&mut self) {
-        self.offset = crate::lex::bom_len(self.source);
-        if let Some(length) = crate::lex::shebang_len(&self.source[self.offset..]) {
+        self.offset = lex::bom_len(self.source);
+        if let Some(length) = lex::shebang_len(&self.source[self.offset..]) {
             self.offset += length;
         }
     }

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -1,11 +1,13 @@
 use super::{MAX_TUPLE_ARITY, ParamMode, Parser};
 use crate::EcoString;
+use crate::ast::FunctionAnnotationParameter;
 use crate::ast::{
     Annotation, Attribute, Expression, FunctionBody, Generic, Literal, Span, Visibility,
 };
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::types::Type;
+use std::string;
 
 impl<'source> Parser<'source> {
     pub(crate) fn parse_annotation(&mut self) -> Annotation {
@@ -287,7 +289,7 @@ impl<'source> Parser<'source> {
         while self.is_not(RightParen) && !self.at_recovery_boundary() {
             let start_position = self.stream.position;
             let mutable = self.advance_if(Mut);
-            params.push(crate::ast::FunctionAnnotationParameter {
+            params.push(FunctionAnnotationParameter {
                 annotation: self.parse_annotation(),
                 mutable,
             });
@@ -426,7 +428,7 @@ impl<'source> Parser<'source> {
 
     pub(crate) fn parse_interface_method(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Expression {
         self.ensure(Function);
@@ -461,7 +463,7 @@ impl<'source> Parser<'source> {
 
     pub(crate) fn parse_type_alias_with_doc(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Expression {
         let start = self.current_token();

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -427,7 +427,7 @@ impl<'source> Parser<'source> {
     pub(crate) fn parse_interface_method(
         &mut self,
         doc: Option<std::string::String>,
-        attributes: Vec<crate::ast::Attribute>,
+        attributes: Vec<Attribute>,
     ) -> Expression {
         self.ensure(Function);
 

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -10,9 +10,10 @@ use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::parse::error::ParseError;
 use crate::types::Type;
+use std::string;
 
 struct DefinitionHeader<'source> {
-    doc: Option<std::string::String>,
+    doc: Option<string::String>,
     attributes: Vec<Attribute>,
     name: EcoString,
     name_span: Span,
@@ -23,7 +24,7 @@ struct DefinitionHeader<'source> {
 impl<'source> Parser<'source> {
     fn parse_definition_header(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
         start: Token<'source>,
     ) -> DefinitionHeader<'source> {
@@ -170,7 +171,7 @@ impl<'source> Parser<'source> {
 
     pub(crate) fn parse_enum_definition(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Expression {
         let start = self.current_token();
@@ -252,10 +253,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_enum_variant_with_doc(
-        &mut self,
-        doc: Option<std::string::String>,
-    ) -> Option<EnumVariant> {
+    fn parse_enum_variant_with_doc(&mut self, doc: Option<string::String>) -> Option<EnumVariant> {
         if self.is_not(Identifier) {
             self.track_error(
                 "expected variant name",
@@ -398,7 +396,7 @@ impl<'source> Parser<'source> {
 
     pub(crate) fn parse_struct_definition(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Expression {
         let start = self.current_token();
@@ -512,7 +510,7 @@ impl<'source> Parser<'source> {
 
     fn parse_struct_field_with_doc(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Option<StructFieldDefinition> {
         let visibility = if self.advance_if(Pub) {
@@ -571,7 +569,7 @@ impl<'source> Parser<'source> {
 
     fn parse_embedded_field(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
     ) -> Option<StructFieldDefinition> {
         let start = self.current_token();
@@ -623,10 +621,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(crate) fn parse_const_definition(
-        &mut self,
-        doc: Option<std::string::String>,
-    ) -> Expression {
+    pub(crate) fn parse_const_definition(&mut self, doc: Option<string::String>) -> Expression {
         let start = self.current_token();
 
         self.ensure(Const);
@@ -662,7 +657,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(crate) fn parse_var_declaration(&mut self, doc: Option<std::string::String>) -> Expression {
+    pub(crate) fn parse_var_declaration(&mut self, doc: Option<string::String>) -> Expression {
         let start = self.current_token();
 
         self.ensure(Var);
@@ -782,10 +777,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    pub(crate) fn parse_interface_definition(
-        &mut self,
-        doc: Option<std::string::String>,
-    ) -> Expression {
+    pub(crate) fn parse_interface_definition(&mut self, doc: Option<string::String>) -> Expression {
         let start = self.current_token();
 
         self.ensure(Interface);
@@ -880,7 +872,7 @@ impl<'source> Parser<'source> {
 
     fn parse_interface_parent(
         &mut self,
-        item_doc: Option<(std::string::String, Span)>,
+        item_doc: Option<(string::String, Span)>,
         seen_parents: &mut Vec<(EcoString, Span)>,
         parents: &mut Vec<ParentInterface>,
     ) {

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -8,9 +8,11 @@ use crate::ast::{
     FormatStringPart, FunctionBody, IdentifierResolution, ImportAlias, LetMode, Literal, SelectArm,
     Span, StructFieldAssignment, StructSpread, UnaryOperator, Visibility,
 };
+use crate::lex::Token;
 use crate::lex::TokenKind::{self, *};
 use crate::program::{CallKind, DotAccessResolution};
 use crate::types::Type;
+use std::string;
 
 #[derive(Clone, Copy)]
 enum GoMakeKind {
@@ -100,7 +102,7 @@ impl<'source> Parser<'source> {
     pub(super) fn parse_range(
         &mut self,
         start: Option<Box<Expression>>,
-        span_start: crate::lex::Token<'source>,
+        span_start: Token<'source>,
         context: ExpressionContext,
     ) -> Expression {
         if matches!(start.as_deref(), Some(Expression::Range { .. })) {
@@ -857,8 +859,8 @@ impl<'source> Parser<'source> {
 
     fn parse_braced_items(
         &mut self,
-        span_start: crate::lex::Token<'source>,
-        opening_brace: crate::lex::Token<'source>,
+        span_start: Token<'source>,
+        opening_brace: Token<'source>,
     ) -> (Vec<Expression>, Span) {
         if let Some(result) = self.with_recursion(|parser| {
             let mut items = vec![];
@@ -920,7 +922,7 @@ impl<'source> Parser<'source> {
 
     pub(crate) fn parse_function(
         &mut self,
-        doc: Option<std::string::String>,
+        doc: Option<string::String>,
         attributes: Vec<Attribute>,
         param_mode: ParamMode,
     ) -> Expression {
@@ -1729,7 +1731,7 @@ impl<'source> Parser<'source> {
         self.next();
         Expression::Literal {
             literal: Literal::String {
-                value: std::string::String::new(),
+                value: string::String::new(),
                 raw: true,
             },
             ty: Type::uninferred(),

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -194,7 +194,7 @@ impl<'source> Parser<'source> {
         }
 
         if let Some(token) = pub_token {
-            let span = ast::Span::new(self.file_id, token.byte_offset, token.byte_length);
+            let span = Span::new(self.file_id, token.byte_offset, token.byte_length);
             match self.current_token().kind {
                 Impl => self.error_misplaced_pub(
                     span,
@@ -428,9 +428,9 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn collect_doc_comments(&mut self) -> Option<(std::string::String, ast::Span)> {
+    fn collect_doc_comments(&mut self) -> Option<(std::string::String, Span)> {
         let mut docs = Vec::new();
-        let mut first_span: Option<ast::Span> = None;
+        let mut first_span: Option<Span> = None;
 
         while self.is(DocComment) {
             let token = self.current_token();
@@ -542,16 +542,16 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn span_from_token(&self, token: Token<'source>) -> ast::Span {
-        ast::Span::new(self.file_id, token.byte_offset, token.byte_length)
+    fn span_from_token(&self, token: Token<'source>) -> Span {
+        Span::new(self.file_id, token.byte_offset, token.byte_length)
     }
 
-    fn span_from_offset(&self, start_byte_offset: u32) -> ast::Span {
+    fn span_from_offset(&self, start_byte_offset: u32) -> Span {
         let previous = self.stream.previous_code();
         let end_byte_offset = previous.byte_offset + previous.byte_length;
         let byte_length = end_byte_offset.saturating_sub(start_byte_offset);
 
-        ast::Span::new(self.file_id, start_byte_offset, byte_length)
+        Span::new(self.file_id, start_byte_offset, byte_length)
     }
 
     fn scan_type_args(&self) -> Option<TypeArgsScan> {
@@ -835,13 +835,13 @@ impl<'source> Parser<'source> {
         help: impl Into<std::string::String>,
     ) {
         let current = self.current_token();
-        let span = ast::Span::new(self.file_id, current.byte_offset, current.byte_length);
+        let span = Span::new(self.file_id, current.byte_offset, current.byte_length);
         self.track_error_at(span, label, help);
     }
 
     fn track_error_at(
         &mut self,
-        span: ast::Span,
+        span: Span,
         label: impl Into<std::string::String>,
         help: impl Into<std::string::String>,
     ) {
@@ -857,7 +857,7 @@ impl<'source> Parser<'source> {
 
     fn error_angle_brackets_for_generics(
         &mut self,
-        span: ast::Span,
+        span: Span,
         help: impl Into<std::string::String>,
     ) {
         if self.too_many_errors() {
@@ -870,7 +870,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_var_initializer(&mut self, span: ast::Span) {
+    fn error_var_initializer(&mut self, span: Span) {
         if self.too_many_errors() {
             return;
         }
@@ -883,7 +883,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_import_alias_after_path(&mut self, span: ast::Span, alias: &str, path: &str) {
+    fn error_import_alias_after_path(&mut self, span: Span, alias: &str, path: &str) {
         if self.too_many_errors() {
             return;
         }
@@ -896,7 +896,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_bare_multi_return(&mut self, span: ast::Span, suggestion: &str) {
+    fn error_bare_multi_return(&mut self, span: Span, suggestion: &str) {
         if self.too_many_errors() {
             return;
         }
@@ -913,7 +913,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_match_arm_missing_comma(&mut self, span: ast::Span) {
+    fn error_match_arm_missing_comma(&mut self, span: Span) {
         if self.too_many_errors() {
             return;
         }
@@ -924,7 +924,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_map_literal_not_supported(&mut self, span: ast::Span) {
+    fn error_map_literal_not_supported(&mut self, span: Span) {
         if self.too_many_errors() {
             return;
         }
@@ -935,7 +935,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_missing_initializer(&mut self, span: ast::Span) {
+    fn error_missing_initializer(&mut self, span: Span) {
         if self.too_many_errors() {
             return;
         }
@@ -962,7 +962,7 @@ impl<'source> Parser<'source> {
             _ => "unexpected_token",
         };
 
-        let span = ast::Span::new(self.file_id, current.byte_offset, current.byte_length);
+        let span = Span::new(self.file_id, current.byte_offset, current.byte_length);
         let error = ParseError::new("Syntax error", span, format!("expected {}", expected_token))
             .with_parse_code(error_code);
 
@@ -986,7 +986,7 @@ impl<'source> Parser<'source> {
     }
 
     fn error_unclosed_block(&mut self, open_brace: &Token) {
-        let span = ast::Span::new(self.file_id, open_brace.byte_offset, open_brace.byte_length);
+        let span = Span::new(self.file_id, open_brace.byte_offset, open_brace.byte_length);
         let error = ParseError::new("Unclosed block", span, "opening brace here")
             .with_parse_code("unclosed_block")
             .with_help("Add a closing `}`");
@@ -1151,11 +1151,7 @@ impl<'source> Parser<'source> {
         }
 
         let length = last.byte_offset + last.byte_length - first.byte_offset;
-        self.error_misplaced_file_comment_at(ast::Span::new(
-            self.file_id,
-            first.byte_offset,
-            length,
-        ));
+        self.error_misplaced_file_comment_at(Span::new(self.file_id, first.byte_offset, length));
     }
 
     fn error_misplaced_file_comment_at(&mut self, span: Span) {
@@ -1302,7 +1298,7 @@ impl<'source> Parser<'source> {
             format!("`{}`", token.text)
         };
 
-        let span = ast::Span::new(self.file_id, token.byte_offset, token.byte_length);
+        let span = Span::new(self.file_id, token.byte_offset, token.byte_length);
 
         let (label, error_code, help) = match ctx {
             "expr" => (
@@ -1446,7 +1442,7 @@ mod import_order_tests {
     use super::IMPORT_AFTER_ITEM_CODE;
     use crate::build_ast;
 
-    fn codes(source: &str) -> Vec<std::string::String> {
+    fn codes(source: &str) -> Vec<String> {
         build_ast(source, 0)
             .errors
             .iter()
@@ -1572,7 +1568,7 @@ mod import_order_tests {
 mod file_comment_tests {
     use crate::build_ast;
 
-    fn file_comment(source: &str) -> Option<std::string::String> {
+    fn file_comment(source: &str) -> Option<String> {
         let result = build_ast(source, 0);
         assert!(
             result.errors.is_empty(),

--- a/crates/syntax/src/parse/mod.rs
+++ b/crates/syntax/src/parse/mod.rs
@@ -4,7 +4,9 @@ use crate::lex;
 use crate::lex::TokenKind::*;
 use crate::lex::{Token, TokenKind};
 use crate::types::Type;
+use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
+use std::string;
 
 pub(crate) const MAX_TUPLE_ARITY: usize = 5;
 pub const TUPLE_FIELDS: &[&str] = &["First", "Second", "Third", "Fourth", "Fifth"];
@@ -40,7 +42,7 @@ pub use error::ParseError;
 pub struct ParseResult {
     pub ast: Vec<ast::Expression>,
     pub errors: Vec<ParseError>,
-    pub file_comment: Option<std::string::String>,
+    pub file_comment: Option<string::String>,
     pub truncated: bool,
     pub status: FileParseStatus,
 }
@@ -392,7 +394,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn collect_file_comments(&mut self, shebang_end: Option<u32>) -> Option<std::string::String> {
+    fn collect_file_comments(&mut self, shebang_end: Option<u32>) -> Option<string::String> {
         let mut docs = Vec::new();
         let mut previous_end: Option<u32> = None;
 
@@ -428,7 +430,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn collect_doc_comments(&mut self) -> Option<(std::string::String, Span)> {
+    fn collect_doc_comments(&mut self) -> Option<(string::String, Span)> {
         let mut docs = Vec::new();
         let mut first_span: Option<Span> = None;
 
@@ -829,11 +831,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn track_error(
-        &mut self,
-        label: impl Into<std::string::String>,
-        help: impl Into<std::string::String>,
-    ) {
+    fn track_error(&mut self, label: impl Into<string::String>, help: impl Into<string::String>) {
         let current = self.current_token();
         let span = Span::new(self.file_id, current.byte_offset, current.byte_length);
         self.track_error_at(span, label, help);
@@ -842,8 +840,8 @@ impl<'source> Parser<'source> {
     fn track_error_at(
         &mut self,
         span: Span,
-        label: impl Into<std::string::String>,
-        help: impl Into<std::string::String>,
+        label: impl Into<string::String>,
+        help: impl Into<string::String>,
     ) {
         if self.too_many_errors() {
             return;
@@ -855,11 +853,7 @@ impl<'source> Parser<'source> {
         self.errors.push(error);
     }
 
-    fn error_angle_brackets_for_generics(
-        &mut self,
-        span: Span,
-        help: impl Into<std::string::String>,
-    ) {
+    fn error_angle_brackets_for_generics(&mut self, span: Span, help: impl Into<string::String>) {
         if self.too_many_errors() {
             return;
         }
@@ -1232,9 +1226,9 @@ impl<'source> Parser<'source> {
 
     fn parse_integer_text_with(&mut self, text: &str, preserve_decimal_text: bool) -> ast::Literal {
         let clean = if text.contains('_') {
-            std::borrow::Cow::Owned(text.replace('_', ""))
+            Cow::Owned(text.replace('_', ""))
         } else {
-            std::borrow::Cow::Borrowed(text)
+            Cow::Borrowed(text)
         };
 
         let (n, is_decimal) = if clean.starts_with("0x") || clean.starts_with("0X") {
@@ -1440,6 +1434,7 @@ impl<'source> TokenStream<'source> {
 #[cfg(test)]
 mod import_order_tests {
     use super::IMPORT_AFTER_ITEM_CODE;
+    use crate::ast::Expression;
     use crate::build_ast;
 
     fn codes(source: &str) -> Vec<String> {
@@ -1525,7 +1520,7 @@ mod import_order_tests {
         let result = super::Parser::lex_and_parse_file("fn f() {}\nimport \"go:fmt\"", 0);
         assert!(matches!(
             result.ast.last(),
-            Some(crate::ast::Expression::PackageImport { .. })
+            Some(Expression::PackageImport { .. })
         ));
     }
 
@@ -1541,7 +1536,7 @@ mod import_order_tests {
         assert!(result.truncated);
         assert!(!result.ast.iter().any(|item| matches!(
             item,
-            crate::ast::Expression::Function { name, .. } if name == "last"
+            Expression::Function { name, .. } if name == "last"
         )));
     }
 

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -276,7 +276,7 @@ impl<'source> Parser<'source> {
         let s = start.text;
         let kind = start.kind;
         self.next();
-        let (value, raw) = if kind == crate::lex::TokenKind::RawString {
+        let (value, raw) = if kind == RawString {
             let stripped = if s.len() >= 3 && s.starts_with("r\"") && s.ends_with('"') {
                 &s[2..s.len() - 1]
             } else if s.len() >= 2 && s.starts_with("r\"") {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -9,6 +9,7 @@ use crate::ast::{
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
 use crate::types::Type;
+use std::string;
 
 impl<'source> Parser<'source> {
     pub(crate) fn parse_pattern_allowing_or(&mut self) -> Pattern {
@@ -473,10 +474,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_qualified_pattern_name(
-        &mut self,
-        initial: std::string::String,
-    ) -> std::string::String {
+    fn parse_qualified_pattern_name(&mut self, initial: string::String) -> string::String {
         let mut name = initial;
 
         while self.advance_if(Dot) {
@@ -491,11 +489,7 @@ impl<'source> Parser<'source> {
         name
     }
 
-    fn parse_struct_pattern(
-        &mut self,
-        name: std::string::String,
-        start: Token<'source>,
-    ) -> Pattern {
+    fn parse_struct_pattern(&mut self, name: string::String, start: Token<'source>) -> Pattern {
         self.ensure(LeftCurlyBrace);
 
         let mut fields = Vec::new();
@@ -562,7 +556,7 @@ impl<'source> Parser<'source> {
 
     fn parse_enum_variant_pattern(
         &mut self,
-        name: std::string::String,
+        name: string::String,
         start: Token<'source>,
     ) -> Pattern {
         self.ensure(LeftParen);

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -5,6 +5,7 @@ use crate::ast;
 use crate::lex::TokenKind::{self, *};
 use crate::program::DotAccessResolution;
 use crate::types::Type;
+use std::string;
 
 const RANGE_PREC: u8 = 6;
 const CAST_PREC: u8 = 9;
@@ -309,7 +310,7 @@ impl<'source> Parser<'source> {
                 let lhs_name = match &lhs {
                     ast::Expression::Identifier { value, .. } => value.to_string(),
                     ast::Expression::DotAccess { member, .. } => member.to_string(),
-                    _ => std::string::String::new(),
+                    _ => string::String::new(),
                 };
                 let colon_token = self.current_token();
                 let span = ast::Span::new(self.file_id, colon_token.byte_offset, 2);
@@ -499,7 +500,7 @@ impl<'source> Parser<'source> {
     }
 }
 
-fn format_annotation(ann: &ast::Annotation) -> std::string::String {
+fn format_annotation(ann: &ast::Annotation) -> string::String {
     match ann {
         ast::Annotation::Constructor { name, params, .. } => {
             if params.is_empty() {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -582,7 +582,7 @@ where
 /// Resolve the complete method set for a type, including inherited and alias methods.
 pub fn methods_for_type<'d, F>(
     ty: &Type,
-    trait_bounds: &HashMap<crate::types::Symbol, Vec<Type>>,
+    trait_bounds: &HashMap<Symbol, Vec<Type>>,
     lookup: F,
 ) -> Methods
 where
@@ -590,7 +590,7 @@ where
 {
     fn collect<'d, F>(
         ty: &Type,
-        trait_bounds: &HashMap<crate::types::Symbol, Vec<Type>>,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
         lookup: F,
         visited: &mut HashSet<String>,
     ) -> Methods
@@ -650,7 +650,7 @@ where
     collect(ty, trait_bounds, lookup, &mut HashSet::default())
 }
 
-fn method_lookup_key(ty: &Type) -> Option<crate::types::Symbol> {
+fn method_lookup_key(ty: &Type) -> Option<Symbol> {
     match ty {
         Type::Nominal { id, .. } => Some(id.clone()),
         Type::Compound { kind, .. } => Some(Symbol::from_parts("prelude", kind.leaf_name())),

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -3,6 +3,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use ecow::EcoString;
 
 use crate::ast::{Annotation, EnumVariant, Generic, Literal, Span, StructFields};
+use crate::types;
 use crate::types::{
     FunctionParameter, Symbol, Type, build_substitution_map, substitute, type_args_match_params,
 };
@@ -143,7 +144,7 @@ impl Definition {
                 DefinitionBody::Struct {
                     fields: StructFields::Tuple(fields),
                     ..
-                } if crate::types::peel_alias(&fields[0].ty, lookup).is_ref()
+                } if types::peel_alias(&fields[0].ty, lookup).is_ref()
             )
     }
 
@@ -483,7 +484,7 @@ where
     ) where
         F: Copy + Fn(&str) -> Option<&'d Definition>,
     {
-        let resolved = crate::types::peel_alias(interface_ty, lookup);
+        let resolved = types::peel_alias(interface_ty, lookup);
         let Type::Nominal { id, params, .. } = &resolved else {
             return;
         };
@@ -636,7 +637,7 @@ where
             .unwrap_or_default();
 
         if lookup(&qualified_name).is_some_and(Definition::is_transparent_type_alias) {
-            let underlying = crate::types::peel_alias(&stripped, lookup);
+            let underlying = types::peel_alias(&stripped, lookup);
             if underlying != stripped {
                 for (name, method) in collect(&underlying, trait_bounds, lookup, visited) {
                     methods.entry(name).or_insert(method);

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use ecow::{EcoString, eco_format};
 
 use crate::ast::{Expression, ImportAlias, Span};
+use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct File {
@@ -202,7 +203,7 @@ impl File {
         if let Some(stem) = self.name.strip_suffix(".test.lis") {
             return format!("{stem}_test.go");
         }
-        std::path::Path::new(&self.name)
+        Path::new(&self.name)
             .with_extension("go")
             .display()
             .to_string()

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -6,6 +6,10 @@ use ecow::EcoString;
 
 use crate::ast::Generic;
 use crate::program::{Definition, DefinitionBody};
+use fmt::Formatter;
+use std::fmt;
+use std::fmt::Display;
+use std::ops::Deref;
 
 /// Dot-qualified identifier for a named type, method, value, or variant.
 ///
@@ -82,7 +86,7 @@ impl AsRef<str> for Symbol {
     }
 }
 
-impl std::ops::Deref for Symbol {
+impl Deref for Symbol {
     type Target = str;
 
     fn deref(&self) -> &str {
@@ -96,8 +100,8 @@ impl From<&Symbol> for EcoString {
     }
 }
 
-impl std::fmt::Display for Symbol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -389,8 +393,8 @@ impl TypeVarId {
     }
 }
 
-impl std::fmt::Debug for TypeVarId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for TypeVarId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "#{}", self.0)
     }
 }
@@ -466,14 +470,14 @@ pub enum Type {
 
 struct TypePlaceholder(&'static str);
 
-impl std::fmt::Debug for TypePlaceholder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for TypePlaceholder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.0)
     }
 }
 
-impl std::fmt::Debug for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Type {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Type::Nominal {
                 id,
@@ -1897,6 +1901,7 @@ fn alpha_index(idx: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::iter;
 
     #[test]
     fn function_equality_ignores_param_names() {
@@ -1977,7 +1982,7 @@ mod tests {
             .params
             .iter()
             .map(|param| &param.ty)
-            .chain(std::iter::once(f.return_type.as_ref()))
+            .chain(iter::once(f.return_type.as_ref()))
             .map(|p| match p {
                 Type::Parameter(name) => name.to_string(),
                 other => panic!("expected parameter, got {:?}", other),

--- a/tests/_embed_harness/corpus.rs
+++ b/tests/_embed_harness/corpus.rs
@@ -316,7 +316,7 @@ pub fn reject_cases() -> Vec<RejectCase> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::_embed_harness::lisette_answer::declarations_register_cleanly;
+    use crate::_embed_harness::lisette_answer::{check_codes, declarations_register_cleanly};
 
     #[test]
     fn some_reject_cases_are_deferred() {
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn reject_cases_raise_their_codes() {
         for case in reject_cases() {
-            let codes = crate::_embed_harness::lisette_answer::check_codes(case.source)
+            let codes = check_codes(case.source)
                 .unwrap_or_else(|| panic!("{}: expected a rejection, but it compiled", case.name));
             assert!(
                 codes.iter().any(|c| c == case.code),

--- a/tests/_embed_harness/go_answerer.rs
+++ b/tests/_embed_harness/go_answerer.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::render_go::{GoMode, render_go};
 use super::scenario::{Question, Scenario};
+use std::fs;
 
 #[derive(Serialize)]
 struct Request<'a> {
@@ -196,7 +197,7 @@ pub fn go_questions(scenario: &Scenario) -> Vec<GoQuestion> {
 fn build_binary() -> Result<PathBuf, String> {
     let binary = answerer_binary_path();
     if let Some(parent) = binary.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("create answerer target dir: {e}"))?;
+        fs::create_dir_all(parent).map_err(|e| format!("create answerer target dir: {e}"))?;
     }
     let output = Command::new("go")
         .arg("build")

--- a/tests/_embed_harness/render_lis.rs
+++ b/tests/_embed_harness/render_lis.rs
@@ -332,6 +332,7 @@ fn sink_name(interface: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::_embed_harness::corpus::{generic_embed_promotes, imported_struct_embed};
     use crate::_embed_harness::fixtures;
     use crate::_embed_harness::render_go::{GoMode, render_go};
 
@@ -464,7 +465,7 @@ mod tests {
 
     #[test]
     fn generic_node_renders_in_both_languages() {
-        let scenario = crate::_embed_harness::corpus::generic_embed_promotes();
+        let scenario = generic_embed_promotes();
 
         let lis = render_lis_declarations(&scenario);
         assert!(lis.contains("struct N0<T>"), "lisette header:\n{lis}");
@@ -479,7 +480,7 @@ mod tests {
 
     #[test]
     fn imported_node_renders_as_package_reference() {
-        let scenario = crate::_embed_harness::corpus::imported_struct_embed();
+        let scenario = imported_struct_embed();
 
         let lis = render_lis_declarations(&scenario);
         assert!(

--- a/tests/_harness/build.rs
+++ b/tests/_harness/build.rs
@@ -5,6 +5,7 @@ use semantics::store::ENTRY_PACKAGE_ID;
 use semantics::{AnalysisScope, AnalyzeInput, EntryFile};
 
 use super::filesystem::MockFileSystem;
+use std::collections::BTreeMap;
 
 fn compile_with(
     fs: MockFileSystem,
@@ -90,7 +91,7 @@ pub fn compile_check_script(fs: MockFileSystem) -> Analysis {
 }
 
 pub fn locator_with_go_dep(module_path: &str, version: &str) -> deps::TypedefLocator {
-    let mut go_deps = std::collections::BTreeMap::new();
+    let mut go_deps = BTreeMap::new();
     go_deps.insert(
         module_path.to_string(),
         deps::GoDependency::Remote {

--- a/tests/_harness/builders.rs
+++ b/tests/_harness/builders.rs
@@ -1,3 +1,4 @@
+use syntax::types::FunctionParameter;
 use syntax::types::{CompoundKind, SimpleKind, Type};
 
 pub fn int_type() -> Type {
@@ -70,7 +71,7 @@ pub fn con_type(name: &str, args: Vec<Type>) -> Type {
 pub fn fun_type(args: Vec<Type>, ret: Type) -> Type {
     Type::function(
         args.into_iter()
-            .map(|ty| syntax::types::FunctionParameter::new(ty, false))
+            .map(|ty| FunctionParameter::new(ty, false))
             .collect(),
         vec![],
         Box::new(ret),

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -2,6 +2,7 @@ use emit::{OutputFile, Planner, TestEmitConfig};
 use syntax::program::File;
 
 use super::pipeline::TestPipeline;
+use syntax::program::TestIndex;
 
 pub fn emit_with_sourcemap(raw_source: &str) -> EmitResult {
     emit_inner(raw_source, Some(raw_source), &[])
@@ -43,7 +44,7 @@ fn emit_inner(
         file_comment: None,
     };
 
-    let test_index = syntax::program::TestIndex::default();
+    let test_index = TestIndex::default();
     let config = TestEmitConfig {
         definitions: &result.definitions,
         package_id: &result.package_id,

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -6,7 +6,13 @@ use semantics::{
     package_graph::Roots,
     package_graph::{PackageGraphOptions, build_package_graph},
 };
+use std::collections;
+use std::mem;
+use std::path::PathBuf;
 use stdlib::{Target, get_go_stdlib_typedef};
+use syntax::program::File;
+use syntax::types;
+use syntax::types::CompoundKind;
 use syntax::{
     ast::Expression,
     program::Definition,
@@ -71,14 +77,14 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
         PackageGraphOptions {
             loader: Some(&fs),
             sink: &sink,
-            scope: &semantics::AnalysisScope::Project(std::path::PathBuf::new()),
+            scope: &semantics::AnalysisScope::Project(PathBuf::new()),
             locator: &locator,
             include_tests: true,
             project_kind: semantics::ProjectKind::Binary,
         },
     );
 
-    let mut parsed: HashMap<String, Vec<syntax::program::File>> = graph_result
+    let mut parsed: HashMap<String, Vec<File>> = graph_result
         .files
         .drain()
         .map(|(package_id, files)| {
@@ -106,7 +112,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
         let mut checker = TaskState::for_package(package_name);
         checker.put_prelude_in_scope(&store);
 
-        let order = std::mem::take(&mut graph_result.order);
+        let order = mem::take(&mut graph_result.order);
         let mut to_infer = Vec::new();
         for package_id in order {
             if let Some(go_pkg) = package_id.strip_prefix("go:") {
@@ -433,7 +439,7 @@ fn is_slice_with_type_var(ty: &Type) -> bool {
                 && matches!(params[0], Type::Var { .. })
         }
         Type::Compound {
-            kind: syntax::types::CompoundKind::Slice,
+            kind: CompoundKind::Slice,
             args,
             ..
         } => args.len() == 1 && matches!(args[0], Type::Var { .. }),
@@ -445,8 +451,8 @@ fn is_slice_with_type_var(ty: &Type) -> bool {
 /// types being compared, so `fn(a) -> a` and `fn(a) -> b` are not conflated.
 #[derive(Default)]
 struct VarBijection {
-    forward: std::collections::HashMap<u32, u32>,
-    backward: std::collections::HashMap<u32, u32>,
+    forward: collections::HashMap<u32, u32>,
+    backward: collections::HashMap<u32, u32>,
 }
 
 impl VarBijection {
@@ -466,12 +472,12 @@ fn types_equal_with(
     vars: &mut VarBijection,
 ) -> bool {
     let resolved1 = if matches!(t1, Type::Nominal { .. }) {
-        syntax::types::peel_alias(t1, |id| definitions.get(id))
+        types::peel_alias(t1, |id| definitions.get(id))
     } else {
         t1.clone()
     };
     let resolved2 = if matches!(t2, Type::Nominal { .. }) {
-        syntax::types::peel_alias(t2, |id| definitions.get(id))
+        types::peel_alias(t2, |id| definitions.get(id))
     } else {
         t2.clone()
     };

--- a/tests/_harness/mod.rs
+++ b/tests/_harness/mod.rs
@@ -14,6 +14,7 @@ pub use emit::{emit_with_go_typedefs, emit_with_sourcemap};
 pub use filesystem::MockFileSystem;
 pub use formatting::snapshot_description;
 pub use infer::{InferResult, infer, infer_package, infer_with_go_typedefs};
+use syntax::program::ValueKind;
 
 pub const TEST_PACKAGE_ID: &str = "test";
 
@@ -61,7 +62,7 @@ fn register_test_builtins(store: &mut Store) {
                 name_span: None,
                 doc: None,
                 body: DefinitionBody::Value {
-                    kind: syntax::program::ValueKind::Runtime,
+                    kind: ValueKind::Runtime,
                     allowed_lints: vec![],
                     go_hints: vec![],
                     go_name: None,

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -2,7 +2,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::{LisetteDiagnostic, LocalSink};
 use semantics::{checker::TaskState, checker::infer::InferCtx};
+use std::mem;
 use stdlib::{Target, get_go_stdlib_typedef};
+use syntax::types;
 use syntax::{
     ast::{Expression, FunctionBody},
     lex::Lexer,
@@ -246,12 +248,12 @@ impl CompiledTest {
                 }
             }
 
-            let equality_index = std::mem::take(&mut store.equality_index);
+            let equality_index = mem::take(&mut store.equality_index);
             let go_package_names = store.go_package_names.clone();
             let go_package_ids: HashSet<String> = store
                 .packages
                 .keys()
-                .filter(|id| id.starts_with(syntax::types::GO_IMPORT_PREFIX))
+                .filter(|id| id.starts_with(types::GO_IMPORT_PREFIX))
                 .cloned()
                 .collect();
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -2142,7 +2143,7 @@ fn a_symlink_named_apart_from_its_target_still_runs() {
     let scratch = tempfile::tempdir().expect("create temp dir");
     let dir = scratch.path();
     fs::write(dir.join("greet-tool.lis"), GREETER).unwrap();
-    std::os::unix::fs::symlink(dir.join("greet-tool.lis"), dir.join("greet")).unwrap();
+    symlink(dir.join("greet-tool.lis"), dir.join("greet")).unwrap();
 
     let scratch_tmp = dir.join("tmp");
     fs::create_dir(&scratch_tmp).unwrap();
@@ -2228,7 +2229,7 @@ fn a_symlinked_parent_cannot_reach_the_script() {
     let scratch = tempfile::tempdir().expect("create temp dir");
     let dir = scratch.path();
     fs::create_dir(dir.join("real")).unwrap();
-    std::os::unix::fs::symlink("real", dir.join("link")).unwrap();
+    symlink("real", dir.join("link")).unwrap();
     fs::write(dir.join("real/greet.lis"), GREETER).unwrap();
 
     for args in [

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1,7 +1,9 @@
+use std::env;
 use std::fs;
 use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::process::Output;
 
 fn go_available() -> bool {
     Command::new("go").arg("version").output().is_ok()
@@ -45,7 +47,7 @@ fn main() {
     (project, invocation)
 }
 
-fn lis_run(project: &Path, invocation: &Path, extra: &[&str]) -> std::process::Output {
+fn lis_run(project: &Path, invocation: &Path, extra: &[&str]) -> Output {
     let manifest = repo().join("Cargo.toml");
     let mut cmd = Command::new("cargo");
     cmd.args(["run", "--quiet", "--manifest-path"])
@@ -58,7 +60,7 @@ fn lis_run(project: &Path, invocation: &Path, extra: &[&str]) -> std::process::O
     cmd.output().expect("failed to invoke lisette")
 }
 
-fn lis(project: &Path, subcommand: &str) -> std::process::Output {
+fn lis(project: &Path, subcommand: &str) -> Output {
     let manifest = repo().join("Cargo.toml");
     Command::new("cargo")
         .args(["run", "--quiet", "--manifest-path"])
@@ -90,7 +92,7 @@ import "box"
 pub struct Wrap<T> { pub value: box.Box<T> }
 "#;
 
-fn assert_rejected_at_check(output: &std::process::Output, expected: &str) {
+fn assert_rejected_at_check(output: &Output, expected: &str) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -1917,7 +1919,7 @@ fn a_tree_walk_reports_a_nested_project_with_no_sources() {
     }
 }
 
-fn lis_in(cwd: &Path, args: &[&str]) -> std::process::Output {
+fn lis_in(cwd: &Path, args: &[&str]) -> Output {
     let manifest = repo().join("Cargo.toml");
     Command::new("cargo")
         .args(["run", "--quiet", "--manifest-path"])
@@ -1930,7 +1932,7 @@ fn lis_in(cwd: &Path, args: &[&str]) -> std::process::Output {
         .expect("failed to invoke lisette")
 }
 
-fn combined(output: &std::process::Output) -> String {
+fn combined(output: &Output) -> String {
     format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
@@ -2553,7 +2555,7 @@ fn an_executable_script_runs_through_its_shebang() {
             .args(["alpha", "beta"])
             .env(
                 "PATH",
-                format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+                format!("{}:{}", bin.display(), env::var("PATH").unwrap()),
             )
             .env("NO_COLOR", "1")
             .output()

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 #[test]
@@ -7,14 +9,12 @@ fn e2e_smoke() {
         return;
     }
 
-    let repo = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap();
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
     let e2e_dir = repo.join("tests/e2e_smoke_project");
     let target_dir = e2e_dir.join("target");
 
     if target_dir.exists() {
-        std::fs::remove_dir_all(&target_dir).expect("failed to clean target/");
+        fs::remove_dir_all(&target_dir).expect("failed to clean target/");
     }
 
     let run = Command::new("cargo")

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -6,6 +6,9 @@ use emit::{Planner, TestEmitConfig};
 use syntax::program::File;
 
 use crate::_harness::pipeline::TestPipeline;
+use std::collections::HashSet;
+use std::io;
+use syntax::program::TestIndex;
 
 const PRELUDE_IMPORT_PATH: &str = "github.com/ivov/lisette/prelude";
 const GO_MODULE: &str = "lisette/e2e_suite_tests";
@@ -56,7 +59,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
         file_comment: None,
     };
 
-    let test_index = syntax::program::TestIndex::default();
+    let test_index = TestIndex::default();
     let config = TestEmitConfig {
         definitions: &result.definitions,
         package_id: &result.package_id,
@@ -259,7 +262,7 @@ pub fn write_subpackage(
     name: &str,
     go_code: &str,
     entry: Option<EntryPoint>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let pkg_dir = target_dir.join(format!("test_{name}"));
     fs::create_dir_all(&pkg_dir)?;
     fs::write(pkg_dir.join("test.go"), go_code)?;
@@ -274,11 +277,7 @@ pub fn write_subpackage(
     Ok(())
 }
 
-pub fn write_go_mod(
-    target_dir: &Path,
-    prelude_path: &Path,
-    go_version: &str,
-) -> std::io::Result<()> {
+pub fn write_go_mod(target_dir: &Path, prelude_path: &Path, go_version: &str) -> io::Result<()> {
     let abs = prelude_path.canonicalize()?;
     let content = format!(
         "module {GO_MODULE}\n\ngo {go_version}\n\nrequire {PRELUDE_IMPORT_PATH} v0.0.0\n\nreplace {PRELUDE_IMPORT_PATH} => {}\n",
@@ -359,10 +358,10 @@ pub fn target_dir() -> PathBuf {
     repo_root().join("target/e2e_suite")
 }
 
-pub fn read_skip_list() -> std::collections::HashSet<String> {
+pub fn read_skip_list() -> HashSet<String> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("e2e_suite/skip.txt");
     let Ok(content) = fs::read_to_string(&path) else {
-        return std::collections::HashSet::new();
+        return HashSet::new();
     };
     content
         .lines()
@@ -381,7 +380,7 @@ pub fn read_skip_list() -> std::collections::HashSet<String> {
         .collect()
 }
 
-pub fn read_go_version() -> std::io::Result<String> {
+pub fn read_go_version() -> io::Result<String> {
     let v = fs::read_to_string(repo_root().join("go-version"))?;
     let trimmed = v.trim();
     let mut parts = trimmed.split('.');

--- a/tests/embed_diff.rs
+++ b/tests/embed_diff.rs
@@ -10,6 +10,7 @@ use _embed_harness::corpus::differential_scenarios;
 use _embed_harness::go_answerer::{GoAnswerer, go_available};
 use _embed_harness::random_scenarios::generate;
 use _embed_harness::runner::{run_scenario, summarize};
+use std::env;
 
 /// Override with `EMBED_DIFF_N` for a deeper sweep.
 const DEFAULT_SEEDS: u64 = 200;
@@ -22,7 +23,7 @@ fn embed_differential() {
     }
 
     let answerer = GoAnswerer::build().expect("the go/types answerer builds");
-    let seeds: u64 = std::env::var("EMBED_DIFF_N")
+    let seeds: u64 = env::var("EMBED_DIFF_N")
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(DEFAULT_SEEDS);

--- a/tests/manifest_pins.rs
+++ b/tests/manifest_pins.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::process::Command;
 
 use serde::Deserialize;
+use std::env;
 
 #[derive(Deserialize)]
 struct Metadata {
@@ -26,7 +27,7 @@ struct Dep {
 /// `lisette` cannot resolve newer sibling libraries and mix releases.
 #[test]
 fn internal_crate_deps_are_exact_pinned() {
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".into());
     let manifest = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
 
     let output = Command::new(cargo)

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -1,3 +1,4 @@
+use crate::_harness::emit::emit_with_go_typedefs;
 use crate::{assert_emit_snapshot, assert_emit_snapshot_with_go_typedefs};
 
 #[test]
@@ -421,7 +422,7 @@ fn make() {
   let _ = dtls.Config {}
 }
 "#;
-    let result = crate::_harness::emit::emit_with_go_typedefs(
+    let result = emit_with_go_typedefs(
         input,
         &[
             ("go:example.com/sdp/v3", sdp),

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -7,8 +7,18 @@ use semantics::package_graph::{DependencyGraph, PackageGraphOptions, Roots, buil
 use semantics::store::Store;
 
 use crate::_harness::filesystem::MockFileSystem;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use syntax::ast::Span;
+use syntax::ast::StructFields;
+use syntax::program::Definition;
+use syntax::program::DefinitionBody;
+use syntax::program::Visibility;
+use syntax::types::Type;
 
-const PROJECT_SCOPE: AnalysisScope = AnalysisScope::Project(std::path::PathBuf::new());
+const PROJECT_SCOPE: AnalysisScope = AnalysisScope::Project(PathBuf::new());
 const SCRIPT_SCOPE: AnalysisScope = AnalysisScope::Script {
     inside_project: false,
 };
@@ -40,7 +50,7 @@ fn graph_options<'a>(
     }
 }
 
-fn host_module_cache_dir(project_root: &std::path::Path, module: &str) -> std::path::PathBuf {
+fn host_module_cache_dir(project_root: &Path, module: &str) -> PathBuf {
     deps::typedef_cache_dir(project_root)
         .join(stdlib::Target::host().cache_segment())
         .join(module)
@@ -730,7 +740,7 @@ fn graph_project_third_party_go_import_undeclared() {
 
 #[test]
 fn graph_declared_dep_missing_typedef() {
-    use std::collections::BTreeMap;
+    use BTreeMap;
 
     let mut fs = MockFileSystem::new();
     fs.add_file("main", "main.lis", r#"import "go:github.com/gorilla/mux""#);
@@ -774,7 +784,7 @@ fn graph_declared_dep_missing_typedef() {
 
 #[test]
 fn graph_subpackage_missing_typedef_points_at_add() {
-    use std::collections::BTreeMap;
+    use BTreeMap;
 
     let mut fs = MockFileSystem::new();
     fs.add_file("main", "main.lis", r#"import "go:k8s.io/api/core/v1""#);
@@ -832,18 +842,18 @@ fn store_get_definition_domain_style_go_package() {
     let package = store.get_package_mut("go:github.com/gorilla/mux").unwrap();
     package.definitions.insert(
         "go:github.com/gorilla/mux.Router".into(),
-        syntax::program::Definition {
-            visibility: syntax::program::Visibility::Public,
-            ty: syntax::types::Type::Nominal {
+        Definition {
+            visibility: Visibility::Public,
+            ty: Type::Nominal {
                 id: "go:github.com/gorilla/mux.Router".into(),
                 params: vec![],
                 writable: false,
             },
-            name_span: Some(syntax::ast::Span::dummy()),
+            name_span: Some(Span::dummy()),
             doc: None,
-            body: syntax::program::DefinitionBody::Struct {
+            body: DefinitionBody::Struct {
                 generics: vec![],
-                fields: syntax::ast::StructFields::Record(vec![]),
+                fields: StructFields::Record(vec![]),
                 methods: Default::default(),
                 attributes: Default::default(),
             },
@@ -931,16 +941,16 @@ fn store_package_for_qualified_name_nested_subpackage() {
 
 #[test]
 fn resolver_root_vs_subpackage_typedef_lookup() {
-    use std::collections::BTreeMap;
+    use BTreeMap;
 
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
 
     let root_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
     let sub_dir = root_dir.join("middleware");
-    std::fs::create_dir_all(&sub_dir).unwrap();
-    std::fs::write(root_dir.join("mux.d.lis"), "// root\n").unwrap();
-    std::fs::write(sub_dir.join("middleware.d.lis"), "// sub\n").unwrap();
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(root_dir.join("mux.d.lis"), "// root\n").unwrap();
+    fs::write(sub_dir.join("middleware.d.lis"), "// sub\n").unwrap();
 
     let mut go_deps = BTreeMap::new();
     go_deps.insert(
@@ -987,14 +997,14 @@ fn third_party_go_struct_impl_methods_registered() {
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
     let cache_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
-    std::fs::create_dir_all(&cache_dir).unwrap();
-    std::fs::write(
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::write(
         cache_dir.join("mux.d.lis"),
         "pub struct Router {}\nimpl Router {\n    fn route(self, path: string) -> string\n}\npub fn new_router() -> Router\n",
     )
     .unwrap();
 
-    let mut go_deps = std::collections::BTreeMap::new();
+    let mut go_deps = BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
         deps::GoDependency::Remote {
@@ -1077,10 +1087,10 @@ fn stdlib_cache_save_load_excludes_third_party() {
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
     let cache_dir = host_module_cache_dir(project_root, "github.com/gorilla/mux@v1.8.0");
-    std::fs::create_dir_all(&cache_dir).unwrap();
-    std::fs::write(cache_dir.join("mux.d.lis"), "pub const VERSION: string\n").unwrap();
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::write(cache_dir.join("mux.d.lis"), "pub const VERSION: string\n").unwrap();
 
-    let mut go_deps = std::collections::BTreeMap::new();
+    let mut go_deps = BTreeMap::new();
     go_deps.insert(
         "github.com/gorilla/mux".to_string(),
         deps::GoDependency::Remote {

--- a/tests/spec/imports.rs
+++ b/tests/spec/imports.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
+use std::fs;
 use syntax::build_ast;
 use syntax::imports::scan_imports;
 use syntax::program::{File, FileImport};
@@ -14,7 +15,7 @@ fn repository_root() -> PathBuf {
 }
 
 fn collect_lisette_files(directory: &Path, found: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(directory) else {
+    let Ok(entries) = fs::read_dir(directory) else {
         return;
     };
     for entry in entries.flatten() {
@@ -61,7 +62,7 @@ fn the_scanner_matches_the_parser_over_the_repository_corpus() {
     let mut compared = 0;
     let mut with_imports = 0;
     for path in &files {
-        let Ok(source) = std::fs::read_to_string(path) else {
+        let Ok(source) = fs::read_to_string(path) else {
             continue;
         };
         let Some(parsed) = parsed_imports(&source) else {

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1,4 +1,6 @@
 use crate::spec::infer::*;
+use syntax::ast::BinaryOperator;
+use syntax::ast::Expression;
 
 #[test]
 fn addition() {
@@ -499,11 +501,11 @@ fn pipeline_with_parenthesized_pipeline_target() {
 
 #[test]
 fn pipeline_is_absent_from_inferred_ast() {
-    fn contains_pipeline(expression: &syntax::ast::Expression) -> bool {
+    fn contains_pipeline(expression: &Expression) -> bool {
         matches!(
             expression,
-            syntax::ast::Expression::Binary {
-                operator: syntax::ast::BinaryOperator::Pipeline,
+            Expression::Binary {
+                operator: BinaryOperator::Pipeline,
                 ..
             }
         ) || expression.children().into_iter().any(contains_pipeline)

--- a/tests/spec/infer/post_inference.rs
+++ b/tests/spec/infer/post_inference.rs
@@ -356,7 +356,7 @@ fn user_static_named_make_is_a_legal_value() {
 
 #[test]
 fn map_make_recovery_infers_spread() {
-    let result = crate::_harness::infer::infer(
+    let result = infer(
         r#"
     fn test(xs: Slice<int>) {
       let m = Map.make<string, int>(xs...);
@@ -395,7 +395,7 @@ fn empty_literal_in_generic_call_errors() {
 
 #[test]
 fn empty_literal_unresolved_binding_reports_once() {
-    let result = crate::_harness::infer::infer("fn test() { let xs = []; let _ = xs }");
+    let result = infer("fn test() { let xs = []; let _ = xs }");
     let errors: Vec<_> = result
         .errors
         .iter()
@@ -471,7 +471,7 @@ fn empty_literal_in_generic_return_position_succeeds() {
 
 #[test]
 fn empty_literal_against_non_slice_param_reports_only_mismatch() {
-    let result = crate::_harness::infer::infer(
+    let result = infer(
         r#"
     fn take(x: int) -> int {
       x
@@ -497,7 +497,7 @@ fn empty_literal_against_non_slice_param_reports_only_mismatch() {
 
 #[test]
 fn empty_literal_in_uninferred_generic_call_reports_only_call() {
-    let result = crate::_harness::infer::infer(
+    let result = infer(
         r#"
     fn keep<T>(items: Slice<T>) -> Slice<T> {
       items
@@ -523,7 +523,7 @@ fn empty_literal_in_uninferred_generic_call_reports_only_call() {
 
 #[test]
 fn empty_literal_with_unrelated_var_reports_inside_uninferred_call() {
-    let result = crate::_harness::infer::infer(
+    let result = infer(
         r#"
     fn count<U>(items: Slice<U>) -> int {
       items.length()

--- a/tests/spec/parse/mod.rs
+++ b/tests/spec/parse/mod.rs
@@ -1,4 +1,6 @@
 use crate::{assert_parse_error_snapshot, assert_parse_snapshot};
+use std::fmt;
+use std::fmt::Error;
 
 #[test]
 fn array_literal_operand() {
@@ -3073,10 +3075,10 @@ fn compound_assignment_on_block_no_exponential_blowup() {
 
     struct Counter(usize);
     impl Write for Counter {
-        fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
             self.0 += s.len();
             if self.0 >= 100_000 {
-                Err(std::fmt::Error)
+                Err(Error)
             } else {
                 Ok(())
             }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8030,8 +8030,8 @@ fn main() {
 }
 "#;
 
-    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
-    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    let lex_result = Lexer::new(input, 0).lex();
+    let parse_result = Parser::new(lex_result.tokens, input).parse();
 
     assert!(
         parse_result.errors.len() == 1,
@@ -8059,8 +8059,8 @@ fn main() {
 }
 "#;
 
-    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
-    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    let lex_result = Lexer::new(input, 0).lex();
+    let parse_result = Parser::new(lex_result.tokens, input).parse();
 
     assert!(
         parse_result.errors.len() == 1,
@@ -8133,8 +8133,8 @@ var conf = Config {
 }
 "#;
 
-    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
-    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    let lex_result = Lexer::new(input, 0).lex();
+    let parse_result = Parser::new(lex_result.tokens, input).parse();
 
     assert!(
         parse_result.errors.len() == 1,
@@ -14632,8 +14632,8 @@ fn main() {
 fn other() {}
 "#;
 
-    let lex_result = syntax::lex::Lexer::new(input, 0).lex();
-    let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
+    let lex_result = Lexer::new(input, 0).lex();
+    let parse_result = Parser::new(lex_result.tokens, input).parse();
     assert!(!parse_result.errors.is_empty());
 
     assert_parse_error_snapshot!(input);

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3,7 +3,7 @@ use crate::_harness::filesystem::MockFileSystem;
 use crate::_harness::formatting::{
     format_diagnostic_for_snapshot, format_project_diagnostic_for_snapshot,
 };
-use crate::_harness::infer::{infer, infer_package};
+use crate::_harness::infer::{InferResult, checker_errors, infer, infer_package};
 use crate::{
     assert_infer_error_snapshot, assert_lex_error_snapshot,
     assert_multipackage_infer_error_snapshot, assert_parse_error_snapshot,
@@ -2953,7 +2953,7 @@ fn test(regs: Registry) {
   let _r = regs["x"]
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "map_read_no_zero"),
         "a bracket read through a map alias must be rejected, got: {:?}",
@@ -2970,7 +2970,7 @@ fn test(holders: Map<string, Holder>) {
   let _h = holders["x"]
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "map_read_no_zero"),
         "a bracket read yielding a struct with a Ref field must be rejected, got: {:?}",
@@ -3049,7 +3049,7 @@ fn test() {
   m["k"].* = 5
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "map_read_no_zero"),
         "writing through a bracket-read entry still reads the entry, got: {:?}",
@@ -3066,7 +3066,7 @@ fn test() {
   counts[m["j"].*] = "x"
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "map_read_no_zero"),
         "a bracket read inside an assignment target index must be rejected, got: {:?}",
@@ -3083,7 +3083,7 @@ fn test() {
   m["k"] = &x
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "a bracket write never reads the entry, so it must stay legal, got: {:?}",
@@ -3100,7 +3100,7 @@ fn test(ages: Map<string, int>, opts: Map<string, Option<Ref<int>>>, rows: Slice
   let _row = rows[0]
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "reads of zero-valued map entries and slice indexing must stay legal, got: {:?}",
@@ -4914,7 +4914,7 @@ fn test() {
   use_logger(File { path: "test.txt" })
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(!result.errors.is_empty(), "Expected errors");
 
     let mut output = String::new();
@@ -5260,7 +5260,7 @@ fn infer_valueless_const_missing_annotation_in_typedef() {
 }
 
 fn assert_go_hint_error_snapshot(name: &str, input: &str, package: &str, typedef: &str) {
-    let errors = crate::_harness::infer::checker_errors(input, &[(package, typedef)]);
+    let errors = checker_errors(input, &[(package, typedef)]);
     let error = errors
         .iter()
         .find(|e| e.code_str() == Some("attribute.unknown"))
@@ -5822,7 +5822,7 @@ fn main() {
     );
 }
 
-fn has_code(result: &crate::_harness::infer::InferResult, code: &str) -> bool {
+fn has_code(result: &InferResult, code: &str) -> bool {
     result
         .errors
         .iter()
@@ -7449,7 +7449,7 @@ fn main() {
   run(&mu)
 }
 "#;
-    crate::_harness::infer::infer(input).assert_infer_code("deferred_lock");
+    infer(input).assert_infer_code("deferred_lock");
 }
 
 #[test]
@@ -7473,7 +7473,7 @@ fn main() {
   c.inc()
 }
 "#;
-    crate::_harness::infer::infer(input).assert_no_errors();
+    infer(input).assert_no_errors();
 }
 
 #[test]
@@ -7492,7 +7492,7 @@ fn main() {
   defer r.Lock()
 }
 "#;
-    crate::_harness::infer::infer(input).assert_no_errors();
+    infer(input).assert_no_errors();
 }
 
 #[test]
@@ -7516,7 +7516,7 @@ fn main() {
   c.inc()
 }
 "#;
-    crate::_harness::infer::infer(input).assert_no_errors();
+    infer(input).assert_no_errors();
 }
 
 #[test]
@@ -8810,7 +8810,7 @@ fn main() {
   takes_ref(&x)
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors but got: {:?}",
@@ -8830,7 +8830,7 @@ fn main() {
   takes_ref(&Foo { value: 42 })
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors but got: {:?}",
@@ -9091,7 +9091,7 @@ fn pick(a: Animal) -> Option<Animal> {
   assert_type<Dog>(a)
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result
             .errors
@@ -9878,7 +9878,7 @@ fn wrapper<T: cmp.Ordered>(x: T) {
   requires_ordered(x)
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -9894,7 +9894,7 @@ import "go:cmp"
 fn less<T: cmp.Ordered>(a: T, b: T) -> bool { a < b }
 fn user() -> bool { less(1, 2) }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -9908,7 +9908,7 @@ fn infer_comparable_bound_allows_eq_in_body() {
 fn eq<T: Comparable>(a: T, b: T) -> bool { a == b }
 fn user() -> bool { eq(1, 1) }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -9957,7 +9957,7 @@ interface Bar<E: error> {}
 
 interface Foo<T: Bar<E>, E: error> {}
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -9972,7 +9972,7 @@ interface Wrapper<E: Comparable> {}
 
 interface Foo<T: Wrapper<E>, E: Comparable> {}
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10005,7 +10005,7 @@ interface Bar<E: Parent<string>> {}
 
 interface Foo<T: Bar<E>, E: Parent<string>> {}
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10038,7 +10038,7 @@ interface Bar<X, E: Parent<X>> {}
 
 interface Foo<T: Bar<string, E>, E: Parent<string>> {}
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10099,7 +10099,7 @@ impl<E> Box<E> {
   fn m<T: Bar<E>>(self, _x: T) {}
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10144,7 +10144,7 @@ interface Cloner<T: Cloner<T>> {
 
 fn squiggle<A: Cloner<B>, B>(_a: A, _b: B) {}
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10197,7 +10197,7 @@ fn wrapper<T: cmp.Ordered>(x: T) {
   requires_comparable(x)
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10248,7 +10248,7 @@ fn test_int() -> int { min(1, 2, 3) }
 fn test_float() -> float64 { max(1.0, 2.0) }
 fn test_string() -> string { min("a", "b", "c") }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10263,7 +10263,7 @@ import "go:cmp"
 
 fn pick<T: cmp.Ordered>(a: T, b: T) -> T { min(a, b) }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "Expected no errors, got: {:?}",
@@ -10408,7 +10408,7 @@ fn main() {
   fmt.Println(h.greet())
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     result.assert_no_errors();
 }
 
@@ -11942,7 +11942,7 @@ fn main() {
   let _ = c
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "type_used_as_value"),
         "a scalar type alias in value position must be rejected, got: {:?}",
@@ -11963,7 +11963,7 @@ fn main() {
   let _ = b
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "record_struct_value"),
         "bare struct and struct-alias names must be rejected by the native_value_usage pass, got: {:?}",
@@ -11988,7 +11988,7 @@ fn main() {
   let _ = b
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "record_struct_value"),
         "a multi-hop struct alias must get the struct-literal diagnostic, got: {:?}",
@@ -12078,7 +12078,7 @@ fn main() {
   let _ = c
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "type_used_as_value"),
         "an enum alias in value position must be rejected, got: {:?}",
@@ -12096,7 +12096,7 @@ fn main() {
   let _ = k
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert_eq!(
         result
             .errors
@@ -12121,7 +12121,7 @@ fn main() {
   let _ = e
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "type_used_as_value"),
         "is_empty on a type alias must be rejected, got: {:?}",
@@ -12141,7 +12141,7 @@ fn main() {
   let _ = c
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "static constructors and enum variant constructors must stay legal, got: {:?}",
@@ -12160,7 +12160,7 @@ fn main() {
   let _ = k
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "instance methods on value receivers must stay legal, got: {:?}",
@@ -12297,7 +12297,7 @@ fn main() {
   let _ = x
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         has_code(&result, "type_used_as_value"),
         "a bare interface name in value position must be rejected, got: {:?}",
@@ -12315,7 +12315,7 @@ fn main() {
   fmt.Println(time.Second.String())
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         result.errors.is_empty(),
         "a method call on an imported value member must stay legal, got: {:?}",
@@ -12963,7 +12963,7 @@ impl Pair<int> {
   }
 }
 "#;
-    crate::_harness::infer::infer(input).assert_no_errors();
+    infer(input).assert_no_errors();
 }
 
 #[test]
@@ -13317,7 +13317,7 @@ impl<T: Parent<int>> Box<T> {
   fn as_int_again(self) -> int { self.value.p() }
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     result.assert_no_errors();
 }
 
@@ -13877,7 +13877,7 @@ fn test(args: Slice<int>) {
   nofn(args...)
 }
 "#;
-    let result = crate::_harness::infer::infer(input);
+    let result = infer(input);
     assert!(
         !has_code(&result, "spread_on_non_variadic"),
         "an unresolved callee's variadic-ness is unknowable, got: {:?}",

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8,6 +8,10 @@ use crate::{
     assert_infer_error_snapshot, assert_lex_error_snapshot,
     assert_multipackage_infer_error_snapshot, assert_parse_error_snapshot,
 };
+use syntax::ast::Expression;
+use syntax::ast::StructFields;
+use syntax::ast::Visibility;
+use syntax::parse::ParseResult;
 
 use semantics::store::ENTRY_PACKAGE_ID;
 
@@ -14296,11 +14300,7 @@ fn main() {
     assert_multipackage_infer_error_snapshot!(result, source);
 }
 
-fn parse_expecting_errors(
-    input: &str,
-    expected_errors: usize,
-    context: &str,
-) -> syntax::parse::ParseResult {
+fn parse_expecting_errors(input: &str, expected_errors: usize, context: &str) -> ParseResult {
     let lex_result = syntax::lex::Lexer::new(input, 0).lex();
     let parse_result = syntax::parse::Parser::new(lex_result.tokens, input).parse();
     assert!(
@@ -14390,9 +14390,12 @@ fn main() {
 "#;
 
     let parse_result = parse_expecting_errors(input, 2, "unclosed params before a declaration");
-    assert!(parse_result.ast.iter().any(
-        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
-    ));
+    assert!(
+        parse_result
+            .ast
+            .iter()
+            .any(|item| matches!(item, Expression::Function { name, .. } if name == "main"))
+    );
 
     assert_parse_error_snapshot!(input);
 }
@@ -14409,9 +14412,12 @@ fn main() {
 
     let parse_result =
         parse_expecting_errors(input, 2, "unclosed typed params before a declaration");
-    assert!(parse_result.ast.iter().any(
-        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
-    ));
+    assert!(
+        parse_result
+            .ast
+            .iter()
+            .any(|item| matches!(item, Expression::Function { name, .. } if name == "main"))
+    );
 
     assert_parse_error_snapshot!(input);
 }
@@ -14428,9 +14434,12 @@ fn main() {
 
     let parse_result =
         parse_expecting_errors(input, 3, "an unclosed function type before a declaration");
-    assert!(parse_result.ast.iter().any(
-        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
-    ));
+    assert!(
+        parse_result
+            .ast
+            .iter()
+            .any(|item| matches!(item, Expression::Function { name, .. } if name == "main"))
+    );
 
     assert_parse_error_snapshot!(input);
 }
@@ -14447,9 +14456,12 @@ fn main() {
 
     let parse_result =
         parse_expecting_errors(input, 3, "an unclosed tuple type before a declaration");
-    assert!(parse_result.ast.iter().any(
-        |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == "main")
-    ));
+    assert!(
+        parse_result
+            .ast
+            .iter()
+            .any(|item| matches!(item, Expression::Function { name, .. } if name == "main"))
+    );
 
     assert_parse_error_snapshot!(input);
 }
@@ -14465,8 +14477,8 @@ struct S {
     let parse_result = parse_expecting_errors(input, 1, "a missing comma before a pub field");
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Struct {
-            fields: syntax::ast::StructFields::Record(fields),
+        Expression::Struct {
+            fields: StructFields::Record(fields),
             ..
         } if fields.len() == 2 && fields[1].visibility.is_public()
     )));
@@ -14488,7 +14500,7 @@ struct S {
         parse_expecting_errors(input, 2, "unclosed params before a struct declaration");
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Struct { name, .. } if name == "S"
+        Expression::Struct { name, .. } if name == "S"
     )));
 
     assert_parse_error_snapshot!(input);
@@ -14507,9 +14519,9 @@ pub fn helper() -> int {
     let parse_result = parse_expecting_errors(input, 2, "unclosed params before a pub declaration");
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Function {
+        Expression::Function {
             name,
-            visibility: syntax::ast::Visibility::Public,
+            visibility: Visibility::Public,
             ..
         } if name == "helper"
     )));
@@ -14532,7 +14544,7 @@ fn checks() {
         parse_expecting_errors(input, 2, "unclosed params before an attributed declaration");
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Function { name, attributes, .. }
+        Expression::Function { name, attributes, .. }
             if name == "checks" && attributes.iter().any(|a| a.name == "test")
     )));
 
@@ -14554,7 +14566,7 @@ fn documented() {
         parse_expecting_errors(input, 2, "unclosed params before a documented declaration");
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Function { name, doc: Some(_), .. } if name == "documented"
+        Expression::Function { name, doc: Some(_), .. } if name == "documented"
     )));
 
     assert_parse_error_snapshot!(input);
@@ -14577,9 +14589,9 @@ pub fn helper() -> int {
     );
     assert!(parse_result.ast.iter().any(|item| matches!(
         item,
-        syntax::ast::Expression::Function {
+        Expression::Function {
             name,
-            visibility: syntax::ast::Visibility::Public,
+            visibility: Visibility::Public,
             ..
         } if name == "helper"
     )));
@@ -14601,9 +14613,11 @@ fn main() {
 
     let parse_result = parse_expecting_errors(input, 1, "a function type without parens");
     for expected_fn in ["f", "main"] {
-        assert!(parse_result.ast.iter().any(
-            |item| matches!(item, syntax::ast::Expression::Function { name, .. } if name == expected_fn)
-        ));
+        assert!(
+            parse_result.ast.iter().any(
+                |item| matches!(item, Expression::Function { name, .. } if name == expected_fn)
+            )
+        );
     }
 
     assert_parse_error_snapshot!(input);

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2209,7 +2209,7 @@ fn main() {
 
 #[test]
 fn manual_replace_all_zero_count_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:strings"
 
@@ -2757,7 +2757,7 @@ fn main() {
 
 #[test]
 fn redundant_trim_guard_value_position_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:strings"
 
@@ -2782,7 +2782,7 @@ fn main() {
 
 #[test]
 fn redundant_trim_guard_block_tail_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:strings"
 
@@ -4806,7 +4806,7 @@ fn main() {
 
 #[test]
 fn nan_comparison_other_math_function_no_warning() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 import "go:math"
 fn main() {
@@ -4824,7 +4824,7 @@ fn main() {
 
 #[test]
 fn nan_comparison_user_defined_function_no_warning() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 fn nan() -> float64 {
   0.0
@@ -5139,7 +5139,7 @@ fn main() {
 
 #[test]
 fn always_true_disjunction_single_tautological_disjunct() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 fn main() {
   let x: uint8 = 5
@@ -5196,7 +5196,7 @@ fn main() {
 
 #[test]
 fn always_true_disjunction_single_diagnostic_for_chain() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 fn main() {
   let x = 5;
@@ -5846,7 +5846,7 @@ fn main() {
 /// Float operands are out of scope for the comparison-chain lints (PR 1), even
 /// though `float_cmp` legitimately flags the `==`/`!=` operands on its own.
 fn assert_no_chain_comparison_lints(source: &str) {
-    let diagnostics = crate::_harness::lint::lint(source);
+    let diagnostics = lint(source);
     let codes: Vec<&str> = diagnostics.iter().filter_map(|d| d.code_str()).collect();
     for code in [
         "infer.impossible_comparison",
@@ -8153,7 +8153,7 @@ fn main() {
 
 #[test]
 fn regexp_in_loop_nested_for_iterable() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:regexp"
 
@@ -8182,7 +8182,7 @@ fn main() {
 
 #[test]
 fn regexp_in_loop_top_level_for_iterable_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:regexp"
 
@@ -9951,7 +9951,7 @@ fn main() {
 
 #[test]
 fn no_dead_code_when_continue_is_last() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 fn main() {
   loop {
@@ -11294,7 +11294,7 @@ fn main() {
 
 #[test]
 fn function_parameter_reported_once() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 fn greet(userId: int) {
   let _ = userId;
@@ -12136,7 +12136,7 @@ pub fn test(x: int) -> int {
 
 #[test]
 fn match_on_bool_duplicate_true_no_suggestion() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 pub fn test(b: bool) -> int {
   match b {
@@ -12158,7 +12158,7 @@ pub fn test(b: bool) -> int {
 
 #[test]
 fn match_on_bool_duplicate_false_no_suggestion() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 pub fn test(b: bool) -> int {
   match b {
@@ -12285,7 +12285,7 @@ fn main() {
 
 #[test]
 fn redundant_pattern_matching_same_bool_no_suggestion() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 fn main() {
   let o: Option<int> = Some(1)
@@ -14140,7 +14140,7 @@ fn main() -> int {
 
 #[test]
 fn replaceable_with_autofill_incomplete_literal_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 struct Conf {
   title: string,
@@ -14388,7 +14388,7 @@ fn main() {
 
 #[test]
 fn discarded_loop_two_branches_two_diagnostics() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 fn test() {
   loop {
@@ -17145,7 +17145,7 @@ fn main() {
 
 #[test]
 fn lost_cancel_named_unused() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:context"
 
@@ -17170,7 +17170,7 @@ fn main() {
 
 #[test]
 fn lost_cancel_aliased_copy_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:context"
 
@@ -17208,7 +17208,7 @@ fn main() {
 
 #[test]
 fn lost_cancel_tuple_projection() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:context"
 
@@ -17229,7 +17229,7 @@ fn main() {
 
 #[test]
 fn lost_cancel_projection_of_binding_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 import "go:context"
 
@@ -19802,7 +19802,7 @@ fn main() {
 
 #[test]
 fn manual_extend_zero_filled_accumulator_no_warning() {
-    let warnings = crate::_harness::lint::lint(
+    let warnings = lint(
         r#"
 fn main() {
   let b = [1, 2, 3]
@@ -20495,7 +20495,7 @@ fn main() {
   let _ = s.contains("e")
 }
 "#;
-    let warnings = crate::_harness::lint::lint(source);
+    let warnings = lint(source);
     let codes: Vec<&str> = warnings.iter().filter_map(|w| w.code_str()).collect();
     assert!(
         codes.contains(&"lint.unused_function"),
@@ -20718,7 +20718,7 @@ fn main() {
 
 #[test]
 fn float_cmp_defers_nan_to_nan_comparison() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 import "go:math"
 fn main() {
@@ -21138,7 +21138,7 @@ fn main() {
 
 #[test]
 fn float_cmp_newtype_alias_symmetric() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 struct Distance(float64)
 type DA = Distance
@@ -21188,7 +21188,7 @@ fn main() {
 
 #[test]
 fn float_equality_without_abs_newtype_alias() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 struct Distance(float64)
 type DA = Distance
@@ -26056,7 +26056,7 @@ fn main() {
 
 #[test]
 fn duplicate_map_keys_reports_every_later_entry() {
-    let diagnostics = crate::_harness::lint::lint(
+    let diagnostics = lint(
         r#"
 fn main() {
   let _ = Map.from([("x", 1), ("x", 2), ("x", 3)])


### PR DESCRIPTION
Enables `clippy::absolute_paths` and `unused_qualifications`, both at `deny`. The `diagnostics` crate is exempt because cutting out the segments would make diagnostics calls unclear.