### PR TITLE
refactor: derive enum constructors after type bodies register

### DIFF
--- a/crates/passes/src/passes/checks/receivers.rs
+++ b/crates/passes/src/passes/checks/receivers.rs
@@ -33,7 +33,7 @@ fn check_method_receiver(method: &Expression, impl_ty: &Type, sink: &LocalSink) 
     };
 
     let receiver_ty = first_param.ty.strip_refs();
-    let types_match = receiver_ty == *impl_ty;
+    let types_match = receiver_ty.shallow_demoted() == impl_ty.shallow_demoted();
 
     if types_match && identifier != "self" {
         sink.push(diagnostics::infer::receiver_must_be_named_self(

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -122,7 +122,7 @@ impl TaskState {
         annotation: &Annotation,
         span: &Span,
     ) -> Type {
-        self.convert_to_type_mode(
+        let ty = self.convert_to_type_mode(
             store,
             annotation,
             span,
@@ -131,7 +131,8 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
             },
-        )
+        );
+        store.normalized_annotation_type(&ty)
     }
 
     pub(crate) fn convert_variadic_to_type(
@@ -140,7 +141,7 @@ impl TaskState {
         annotation: &Annotation,
         span: &Span,
     ) -> Type {
-        self.convert_to_type_mode(
+        let ty = self.convert_to_type_mode(
             store,
             annotation,
             span,
@@ -149,7 +150,8 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
             },
-        )
+        );
+        store.normalized_annotation_type(&ty)
     }
 
     pub(crate) fn convert_receiver_to_type(
@@ -158,7 +160,7 @@ impl TaskState {
         annotation: &Annotation,
         span: &Span,
     ) -> Type {
-        self.convert_to_type_mode(
+        let ty = self.convert_to_type_mode(
             store,
             annotation,
             span,
@@ -167,7 +169,8 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::Descendants,
                 position: TypePosition::Value,
             },
-        )
+        );
+        store.normalized_annotation_type(&ty)
     }
 
     fn convert_to_type_mode(
@@ -311,6 +314,14 @@ impl TaskState {
                 self.sink.push(diagnostics::infer::self_type_not_supported(
                     annotation_span,
                     receiver.as_deref(),
+                ));
+            } else if let Some((kind, help)) = self.classify_unregistered_variant(store, type_name)
+            {
+                self.sink.push(diagnostics::infer::value_in_type_position(
+                    type_name,
+                    kind,
+                    annotation_span,
+                    help,
                 ));
             } else if !self.may_name_uninferred_export(store, type_name) {
                 self.sink.push(diagnostics::infer::type_not_found(
@@ -578,6 +589,32 @@ impl TaskState {
         } else {
             true
         }
+    }
+
+    /// Classifies `Enum.Variant` in type position before its constructor value exists.
+    fn classify_unregistered_variant(
+        &self,
+        store: &Store,
+        type_name: &str,
+    ) -> Option<(&'static str, Option<String>)> {
+        let (parent, variant_name) = type_name.rsplit_once('.')?;
+        let qualified = self.lookup_qualified_name_in_type_position(store, parent)?;
+        let Some(DefinitionBody::Enum { variants, .. }) =
+            store.get_definition(&qualified).map(|d| &d.body)
+        else {
+            return None;
+        };
+        let variant = variants.iter().find(|v| v.name == variant_name)?;
+        let enum_name = unqualified_name(&qualified);
+        let help = if variant.fields.is_empty() {
+            format!("Use `{}` for the enum type", enum_name)
+        } else {
+            format!(
+                "Use `{}` for the enum type, or call `{}(...)` to construct a value",
+                enum_name, type_name
+            )
+        };
+        Some(("enum variant", Some(help)))
     }
 
     fn classify_non_type_name(

--- a/crates/semantics/src/checker/registration/declarations.rs
+++ b/crates/semantics/src/checker/registration/declarations.rs
@@ -59,6 +59,8 @@ impl TaskState {
         self.register_type_names(store, items, visibility);
         self.register_constants(store, items, visibility);
         self.register_type_definitions(store, items);
+        normalize_registered_component_types(store, &package_id);
+        self.derive_enum_constructor_values(store, items);
         self.check_type_generic_bounds(store, items);
         self.register_impl_blocks(store, items);
         self.register_non_const_values(store, items, visibility);

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -159,6 +159,20 @@ impl TaskState {
             );
         }
 
+        normalize_registered_component_types(store, &id);
+
+        for file in &mut files {
+            self.with_file_context_mut(
+                store,
+                FileContext::Standard {
+                    package_id: &id,
+                    file_id: file.id,
+                    imports: &file.imports,
+                },
+                |this, store| this.derive_enum_constructor_values(store, &file.items),
+            );
+        }
+
         for file in &mut files {
             self.with_file_context_mut(
                 store,
@@ -181,5 +195,63 @@ impl TaskState {
 
         self.register_package_tests(store, &id, &files);
         RegisteredPackage { id, files }
+    }
+}
+
+/// A forward or self reference converts before its definition exists.
+pub(crate) fn normalize_registered_component_types(store: &mut Store, package_id: &str) {
+    let Some(package) = store.get_package(package_id) else {
+        return;
+    };
+    let mut changed: Vec<(Symbol, Definition)> = Vec::new();
+    for (name, definition) in &package.definitions {
+        let mut updated = definition.clone();
+        let mut any = false;
+        let mut normalize = |ty: &mut Type| {
+            let normalized = store.normalized_annotation_type(ty);
+            if normalized != *ty {
+                *ty = normalized;
+                any = true;
+            }
+        };
+        match &mut updated.body {
+            DefinitionBody::Struct { fields, .. } => {
+                let (StructFields::Record(fields) | StructFields::Tuple(fields)) = fields;
+                for field in fields {
+                    normalize(&mut field.ty);
+                }
+            }
+            DefinitionBody::Enum { variants, .. } => {
+                for variant in variants {
+                    match &mut variant.fields {
+                        VariantFields::Unit => {}
+                        VariantFields::Tuple(fields) | VariantFields::Struct(fields) => {
+                            for field in fields {
+                                normalize(&mut field.ty);
+                            }
+                        }
+                    }
+                }
+            }
+            DefinitionBody::TypeAlias {
+                alias: AliasKind::Transparent { target, .. },
+                ..
+            } => {
+                normalize(target);
+            }
+            _ => {}
+        }
+        if any {
+            changed.push((name.clone(), updated));
+        }
+    }
+    if changed.is_empty() {
+        return;
+    }
+    let Some(package) = store.get_package_mut(package_id) else {
+        return;
+    };
+    for (name, definition) in changed {
+        package.definitions.insert(name, definition);
     }
 }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -53,38 +53,12 @@ impl TaskState {
 
         self.check_enum_field_slot_collisions(name, &new_variants);
 
-        for new_variant in &new_variants {
-            self.add_enum_variant_to_scope(new_variant, name, &enum_ty, &generics);
-        }
-
         let visibility = self
             .current_package(&*store)
             .definitions
             .get(qualified_name.as_str())
             .map(|definition| definition.visibility.clone())
             .unwrap_or(Visibility::Private);
-
-        let is_prelude = self.cursor.package_id() == "prelude";
-
-        let variant_definitions: Vec<_> = new_variants
-            .iter()
-            .map(|v| {
-                let variant_ty = enum_variant_constructor_type(v, &enum_ty, &generics);
-                let qualified_variant_name = qualified_name.with_segment(&v.name);
-                let simple_qualified_name = if is_prelude {
-                    Some(self.qualify_name(&v.name))
-                } else {
-                    None
-                };
-                (
-                    qualified_variant_name,
-                    simple_qualified_name,
-                    variant_ty,
-                    v.name_span,
-                    v.doc.clone(),
-                )
-            })
-            .collect();
 
         if self.is_lis(&*store) && self.type_definition_exists(&*store, &qualified_name) {
             self.sink.push(diagnostics::infer::duplicate_definition(
@@ -93,34 +67,6 @@ impl TaskState {
         }
 
         let package = self.current_package_mut(store);
-
-        for (qualified_variant_name, simple_name, variant_ty, variant_name_span, variant_doc) in
-            variant_definitions
-        {
-            let definition = Definition {
-                visibility: visibility.clone(),
-                ty: variant_ty,
-                name_span: Some(variant_name_span),
-                doc: variant_doc,
-                body: DefinitionBody::Value {
-                    kind: ValueKind::Runtime,
-                    allowed_lints: vec![],
-                    go_hints: vec![],
-                    go_name: None,
-                    go_type_param_recipe: None,
-                },
-            };
-            package
-                .definitions
-                .insert(qualified_variant_name, definition.clone());
-
-            if let Some(simple_qualified_name) = simple_name {
-                package
-                    .definitions
-                    .entry(simple_qualified_name)
-                    .or_insert(definition);
-            }
-        }
 
         package.definitions.insert(
             qualified_name.clone(),
@@ -137,6 +83,90 @@ impl TaskState {
                 },
             },
         );
+    }
+
+    /// Runs after `normalize_registered_component_types`.
+    pub(crate) fn derive_enum_constructor_values(
+        &mut self,
+        store: &mut Store,
+        items: &[Expression],
+    ) {
+        for item in items {
+            let Expression::Enum { name, .. } = item else {
+                continue;
+            };
+            let qualified_name = self.qualify_name(name);
+            let Some(definition) = store.get_definition(&qualified_name) else {
+                continue;
+            };
+            let DefinitionBody::Enum {
+                generics, variants, ..
+            } = &definition.body
+            else {
+                continue;
+            };
+            let visibility = definition.visibility.clone();
+            let generics = generics.clone();
+            let variants = variants.clone();
+            let Some(enum_ty) = store.get_type(&qualified_name).cloned() else {
+                continue;
+            };
+            let is_prelude = self.cursor.package_id() == "prelude";
+
+            for variant in &variants {
+                self.add_enum_variant_to_scope(variant, name, &enum_ty, &generics);
+            }
+
+            let variant_definitions: Vec<_> = variants
+                .iter()
+                .map(|v| {
+                    let variant_ty = enum_variant_constructor_type(v, &enum_ty, &generics);
+                    let qualified_variant_name = qualified_name.with_segment(&v.name);
+                    let simple_qualified_name = if is_prelude {
+                        Some(self.qualify_name(&v.name))
+                    } else {
+                        None
+                    };
+                    (
+                        qualified_variant_name,
+                        simple_qualified_name,
+                        variant_ty,
+                        v.name_span,
+                        v.doc.clone(),
+                    )
+                })
+                .collect();
+
+            let package = self.current_package_mut(store);
+
+            for (qualified_variant_name, simple_name, variant_ty, variant_name_span, variant_doc) in
+                variant_definitions
+            {
+                let definition = Definition {
+                    visibility: visibility.clone(),
+                    ty: variant_ty,
+                    name_span: Some(variant_name_span),
+                    doc: variant_doc,
+                    body: DefinitionBody::Value {
+                        kind: ValueKind::Runtime,
+                        allowed_lints: vec![],
+                        go_hints: vec![],
+                        go_name: None,
+                        go_type_param_recipe: None,
+                    },
+                };
+                package
+                    .definitions
+                    .insert(qualified_variant_name, definition.clone());
+
+                if let Some(simple_qualified_name) = simple_name {
+                    package
+                        .definitions
+                        .entry(simple_qualified_name)
+                        .or_insert(definition);
+                }
+            }
+        }
     }
 
     /// Emit's layout dedupes by Go name, so a survivor would take the first type.

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -2,6 +2,7 @@ use diagnostics::LocalSink;
 use stdlib::{LIS_PRELUDE_SOURCE, LIS_TEST_PRELUDE_SOURCE};
 use syntax::program::{File, Visibility};
 
+use crate::checker::registration::normalize_registered_component_types;
 use crate::checker::{FileContext, TaskState};
 use crate::store::Store;
 
@@ -42,6 +43,10 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
             checker.register_constants(store, &file.items, &Visibility::Public);
             checker.register_type_definitions(store, &mut file.items);
+        }
+        normalize_registered_component_types(store, PRELUDE_PACKAGE_ID);
+        for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
+            checker.derive_enum_constructor_values(store, &file.items);
             checker.register_impl_blocks(store, &mut file.items);
             checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
         }
@@ -87,6 +92,10 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
             for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
                 checker.register_constants(store, &file.items, &Visibility::Public);
                 checker.register_type_definitions(store, &mut file.items);
+            }
+            normalize_registered_component_types(store, TEST_PRELUDE_PACKAGE_ID);
+            for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
+                checker.derive_enum_constructor_values(store, &file.items);
                 checker.register_impl_blocks(store, &mut file.items);
                 checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
             }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -440,6 +440,76 @@ impl Store {
         types::contains_unknown(ty, |id| self.get_definition(id))
     }
 
+    pub fn demoted(&self, ty: &Type) -> Type {
+        types::demoted(ty, &|id| self.get_definition(id))
+    }
+
+    pub fn demotion_changes(&self, ty: &Type) -> bool {
+        types::demotion_changes(ty, &|id| self.get_definition(id))
+    }
+
+    /// Canonical form for a type built from an annotation.
+    pub fn normalized_annotation_type(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => {
+                let mut args: Vec<Type> = args
+                    .iter()
+                    .map(|arg| self.normalized_annotation_type(arg))
+                    .collect();
+                if kind.carries_write_permission()
+                    && !writable
+                    && args.iter().any(|arg| self.demotion_changes(arg))
+                {
+                    args = args.iter().map(|arg| self.demoted(arg)).collect();
+                }
+                Type::Compound {
+                    kind: *kind,
+                    args,
+                    writable: *writable,
+                }
+            }
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => Type::Nominal {
+                id: id.clone(),
+                params: params
+                    .iter()
+                    .map(|param| self.normalized_annotation_type(param))
+                    .collect(),
+                writable: *writable,
+            },
+            Type::Tuple(elements) => Type::Tuple(
+                elements
+                    .iter()
+                    .map(|element| self.normalized_annotation_type(element))
+                    .collect(),
+            ),
+            Type::Array { length, element } => Type::Array {
+                length: *length,
+                element: Box::new(self.normalized_annotation_type(element)),
+            },
+            Type::Function(f) => f.rebuild(
+                f.params
+                    .iter()
+                    .map(|param| param.with_type(self.normalized_annotation_type(&param.ty)))
+                    .collect(),
+                f.bounds.clone(),
+                Box::new(self.normalized_annotation_type(&f.return_type)),
+            ),
+            Type::Forall { vars, body } => Type::Forall {
+                vars: vars.clone(),
+                body: Box::new(self.normalized_annotation_type(body)),
+            },
+            _ => ty.clone(),
+        }
+    }
+
     pub fn resolve_to_function_type(&self, ty: &Type) -> Option<Type> {
         let resolved = self.peel_alias(ty);
         if matches!(resolved, Type::Function(_)) {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -675,6 +675,31 @@ impl Type {
         }
     }
 
+    /// This type with its own write permission removed, type arguments untouched.
+    pub fn shallow_demoted(&self) -> Type {
+        match self {
+            Type::Compound {
+                kind,
+                args,
+                writable: _,
+            } => Type::Compound {
+                kind: *kind,
+                args: args.clone(),
+                writable: false,
+            },
+            Type::Nominal {
+                id,
+                params,
+                writable: _,
+            } => Type::Nominal {
+                id: id.clone(),
+                params: params.clone(),
+                writable: false,
+            },
+            other => other.clone(),
+        }
+    }
+
     pub fn demoted(&self) -> Type {
         match self {
             Type::Compound {
@@ -1596,6 +1621,82 @@ where
     }
 
     contains(ty, &lookup)
+}
+
+/// Alias-aware demotion. An occurrence whose alias hides permission demotes
+/// by expansion to the demoted underlying type.
+pub fn demoted<'d, F>(ty: &Type, lookup: &F) -> Type
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    match ty {
+        Type::Nominal {
+            id,
+            params,
+            writable: _,
+        } => {
+            let cleared = Type::Nominal {
+                id: id.clone(),
+                params: params.iter().map(|param| demoted(param, lookup)).collect(),
+                writable: false,
+            };
+            let peeled = peel_alias(&cleared, lookup);
+            if peeled != cleared && demotion_changes(&peeled, lookup) {
+                demoted(&peeled, lookup)
+            } else {
+                cleared
+            }
+        }
+        Type::Compound {
+            kind,
+            args,
+            writable: _,
+        } => Type::Compound {
+            kind: *kind,
+            args: args.iter().map(|arg| demoted(arg, lookup)).collect(),
+            writable: false,
+        },
+        Type::Tuple(elements) => Type::Tuple(
+            elements
+                .iter()
+                .map(|element| demoted(element, lookup))
+                .collect(),
+        ),
+        Type::Array { length, element } => Type::Array {
+            length: *length,
+            element: Box::new(demoted(element, lookup)),
+        },
+        _ => ty.clone(),
+    }
+}
+
+/// Whether `demoted` returns a different type. Must mirror `demoted`.
+pub fn demotion_changes<'d, F>(ty: &Type, lookup: &F) -> bool
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    match ty {
+        Type::Nominal {
+            params, writable, ..
+        } => {
+            if *writable {
+                return true;
+            }
+            let peeled = peel_alias(ty, lookup);
+            if peeled != *ty {
+                return demotion_changes(&peeled, lookup);
+            }
+            params.iter().any(|param| demotion_changes(param, lookup))
+        }
+        Type::Compound { args, writable, .. } => {
+            *writable || args.iter().any(|arg| demotion_changes(arg, lookup))
+        }
+        Type::Tuple(elements) => elements
+            .iter()
+            .any(|element| demotion_changes(element, lookup)),
+        Type::Array { element, .. } => demotion_changes(element, lookup),
+        _ => false,
+    }
 }
 
 pub fn underlying_simple_kind<'d, F>(ty: &Type, lookup: F) -> Option<SimpleKind>


### PR DESCRIPTION
An enum variant constructor takes its parameter types from the enum's fields. Those constructors until now were built while type bodies were still being registered, so a constructor could copy a field type before that type was final. Registration now runs in two phases: every type body registers, then we settle struct fields, enum payloads and alias targets, then the constructors are built from the finished types.