### PR TITLE
feat: autofix for writes to immutable bindings

### DIFF
--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -512,11 +512,11 @@ struct FixSummary {
 
 fn apply_result_fixes(result: &CompileResult, summary: &mut FixSummary) {
     let mut by_file: HashMap<u32, Vec<&Fix>> = HashMap::default();
-    for lint in result.lints() {
-        let Some(fix) = lint.fix() else {
+    for diagnostic in result.diagnostics.iter() {
+        let Some(fix) = diagnostic.fix() else {
             continue;
         };
-        let Some(file_id) = lint.file_id() else {
+        let Some(file_id) = diagnostic.file_id() else {
             continue;
         };
         by_file.entry(file_id).or_default().push(fix);
@@ -536,10 +536,9 @@ fn apply_result_fixes(result: &CompileResult, summary: &mut FixSummary) {
             continue;
         }
 
-        if !syntax::build_ast(&applied.source, file_id)
-            .errors
-            .is_empty()
-        {
+        let errors_before = syntax::build_ast(&info.source, file_id).errors.len();
+        let errors_after = syntax::build_ast(&applied.source, file_id).errors.len();
+        if errors_after >= errors_before.max(1) {
             cli_error!(
                 "Skipped a fix",
                 format!(

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use rustc_hash::FxHashSet;
-use syntax::ast::Span;
+use syntax::ast::{BindingId, Span};
 use syntax::types::Type;
 
 use crate::checker::type_env::SpeculationOutcome;
@@ -214,6 +214,9 @@ pub struct InferCtx<'a> {
     pub(crate) store: &'a Store,
     pub(super) file_checks: FileChecks,
     pub(crate) satisfying_stack: FxHashSet<(String, String)>,
+    pub(super) reported_immutable: FxHashSet<BindingId>,
+    /// Identifier-pattern lets, the only bindings where inserting `mut` is valid.
+    pub(super) plain_lets: FxHashSet<BindingId>,
     traversal: TraversalContext,
 }
 
@@ -224,6 +227,8 @@ impl<'a> InferCtx<'a> {
             store,
             file_checks: FileChecks::default(),
             satisfying_stack: FxHashSet::default(),
+            reported_immutable: FxHashSet::default(),
+            plain_lets: FxHashSet::default(),
             traversal: TraversalContext::default(),
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -136,7 +136,8 @@ impl InferCtx<'_> {
         let binding_name = binding.pattern.get_identifier();
         let pattern_span = binding.pattern.get_span();
 
-        if mode.is_assert() && !self.scopes.has_test_handle() {
+        let is_assert = mode.is_assert();
+        if is_assert && !self.scopes.has_test_handle() {
             self.sink
                 .push(diagnostics::infer::assert_without_test_context(
                     pattern_span,
@@ -177,6 +178,15 @@ impl InferCtx<'_> {
             ty: ty.clone(),
             mut_span,
         };
+
+        if !mutable
+            && !is_assert
+            && new_binding.pattern.is_identifier()
+            && let Some(ref name) = binding_name
+            && let Some(binding_id) = self.scopes.lookup_binding_id(name)
+        {
+            self.plain_lets.insert(binding_id);
+        }
 
         if !has_annotation
             && new_value.is_empty_collection()

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -513,25 +513,43 @@ impl InferCtx<'_> {
     }
 
     fn report_disallowed_mutation(&mut self, store: &Store, var_name: &str, span: Span) {
+        let binding_id = self.scopes.lookup_binding_id(var_name);
+        if let Some(id) = binding_id
+            && !self.reported_immutable.insert(id)
+        {
+            return;
+        }
         let self_type_name = if var_name == "self" {
             self.lookup_type(store, "self")
                 .and_then(|t| t.get_name().map(str::to_owned))
         } else {
             None
         };
-        let binding_kind = self
-            .scopes
-            .lookup_binding_id(var_name)
+        let binding_kind = binding_id
             .and_then(|id| self.facts.bindings.get(&id))
             .map(|b| b.kind);
         let is_const = self.is_const_var(store, var_name);
-        self.sink.push(diagnostics::infer::disallowed_mutation(
+        let mut diagnostic = diagnostics::infer::disallowed_mutation(
             var_name,
             span,
             self_type_name.as_deref(),
             binding_kind,
             is_const,
-        ));
+        );
+        if !is_const
+            && let Some(id) = binding_id
+            && self.plain_lets.contains(&id)
+            && let Some(declaration) = self.facts.bindings.get(&id).map(|b| b.span)
+        {
+            diagnostic = diagnostic.with_fix(diagnostics::Fix::new(
+                format!("Declare `{var_name}` mutable"),
+                diagnostics::Edit::replacement(
+                    Span::new(declaration.file_id, declaration.byte_offset, 0),
+                    "mut ",
+                ),
+            ));
+        }
+        self.sink.push(diagnostic);
     }
 
     pub(super) fn infer_tuple(

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -123,6 +123,17 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     diagnostics
 }
 
+pub fn apply_infer_fixes(source: &str) -> String {
+    let result = super::infer::infer(source);
+    let fixes: Vec<&Fix> = result
+        .errors
+        .iter()
+        .filter_map(LisetteDiagnostic::fix)
+        .collect();
+    assert!(!fixes.is_empty(), "expected at least one fix");
+    apply_fixes(source, fixes).source
+}
+
 pub fn apply_lint_fixes(source: &str) -> String {
     let lints = lint(source);
     let fixes: Vec<&Fix> = lints.iter().filter_map(LisetteDiagnostic::fix).collect();

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1,3 +1,4 @@
+use crate::_harness::lint::apply_infer_fixes;
 use crate::spec::infer::*;
 use syntax::ast::BinaryOperator;
 use syntax::ast::Expression;
@@ -2622,4 +2623,65 @@ fn sibling_ref_ampersand_before_read_in_short_circuit_is_flagged() {
         "#,
     );
     infer_package("main", fs).assert_infer_code("reference_aliases_sibling");
+}
+
+#[test]
+fn immutable_let_fix_inserts_mut() {
+    let fixed = apply_infer_fixes(
+        r#"fn main() {
+  let n = 1;
+  n = 2;
+  let _ = n
+}"#,
+    );
+    assert!(
+        fixed.contains("let mut n = 1"),
+        "the fix must make the binding mutable: {fixed}"
+    );
+}
+
+#[test]
+fn container_let_write_fix_inserts_mut() {
+    let fixed = apply_infer_fixes(
+        r#"fn main() {
+  let scores = [70, 85]
+  scores[0] = 100
+  let _ = scores
+}"#,
+    );
+    assert!(
+        fixed.contains("let mut scores = [70, 85]"),
+        "the fix must make the binding mutable: {fixed}"
+    );
+}
+
+#[test]
+fn immutable_destructured_binding_gets_no_fix() {
+    let result = infer(
+        r#"fn main() {
+  let (a, b) = (1, 2);
+  a = b;
+  let _ = (a, b)
+}"#,
+    );
+    assert!(
+        result
+            .errors
+            .iter()
+            .all(|diagnostic| diagnostic.fix().is_none()),
+        "`mut` is not spellable in a pattern, so no fix may be offered"
+    );
+}
+
+#[test]
+fn immutable_binding_reports_once() {
+    infer(
+        r#"fn main() {
+  let n = 1;
+  n = 2;
+  n = 3;
+  let _ = n
+}"#,
+    )
+    .assert_infer_code_count("immutable", 1);
 }


### PR DESCRIPTION
`lis check --fix` now fixes writes to an immutable `let` by inserting `mut` at the declaration.