### PR TITLE
feat: bind `VarArgs<T>` as `Slice<T>` in function bodies

### DIFF
--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -191,6 +191,26 @@ fn goto_definition_promoted_field() {
     client.shutdown();
 }
 
+/// A body use is a `Slice<T>`, as `gopls` reports for Go's `...T`.
+#[test]
+fn hover_on_varargs_param_in_body_shows_a_slice() {
+    let mut client = TestClient::new();
+    client.initialize();
+    let (source, line, character) = cursor(
+        "fn f(xs: VarArgs<int>) -> int {\n  ~xs.length()\n}\n\nfn main() {\n  let _ = f(1, 2)\n}",
+    );
+    client.open(TEST_URI, &source);
+
+    let hover = client.hover(TEST_URI, line, character).expect("hover");
+    let content = hover_content(&hover);
+    assert!(
+        content.contains("Slice<int>"),
+        "expected the body binding to hover as a slice, got: {content}"
+    );
+
+    client.shutdown();
+}
+
 #[test]
 fn hover_on_explicit_type_arg_call_shows_substituted_signature() {
     let mut client = TestClient::new();

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -399,11 +399,7 @@ impl InferCtx<'_> {
                     self.with_value_context(|s| s.infer_expression(*spread_expr, &expected));
                 if variadic.parameter.mutable {
                     let callee_label = callee_label(callee_expression);
-                    self.check_arg_against_mut_param(
-                        &inferred,
-                        &variadic.parameter.ty,
-                        &callee_label,
-                    );
+                    self.check_arg_against_mut_param(&inferred, &expected, &callee_label);
                 }
                 inferred
             }

--- a/crates/semantics/src/checker/infer/expressions/functions.rs
+++ b/crates/semantics/src/checker/infer/expressions/functions.rs
@@ -1,6 +1,6 @@
 use crate::checker::{EnvResolve, resolved_generic_bounds};
 use syntax::ast::{Annotation, Binding, BindingKind, Expression, Pattern, Span};
-use syntax::types::{FunctionParameter, Type};
+use syntax::types::{CompoundKind, FunctionParameter, Type};
 
 use crate::analysis::ProjectKind;
 use crate::checker::infer::InferCtx;
@@ -348,9 +348,18 @@ impl InferCtx<'_> {
                 });
 
                 let mutable = binding.is_mutable();
+                // A `...T` parameter is a `[]T` in the body, as in Go. `Binding.ty`
+                // stays `VarArgs<T>`: call-site arity and emit's parameter
+                // declaration read it, so matching the two would emit `[]T`.
+                let body_ty = match binding_ty.get_type_params() {
+                    Some([element]) if binding_ty.is_native(CompoundKind::VarArgs) => {
+                        self.type_slice(element.clone())
+                    }
+                    _ => binding_ty.clone(),
+                };
                 let new_pattern = self.infer_pattern(
                     binding.pattern,
-                    binding_ty.clone(),
+                    body_ty,
                     BindingKind::Parameter { mutable },
                 );
 

--- a/crates/stdlib/prelude.d.lis
+++ b/crates/stdlib/prelude.d.lis
@@ -606,8 +606,16 @@ type Ordered
 /// Zero or more arguments of type `T`. Only valid as the last parameter
 /// of a function. Corresponds to Go's `...T` syntax.
 ///
-/// For Go interop only. Consuming the args inside a Lisette function body 
-/// is currently unsupported.
+/// Inside the function body the parameter is a `Slice<T>`, as in Go. A spread
+/// call shares the caller's slice, so mutating through a `mut` parameter is
+/// visible to the caller.
+///
+/// Example:
+///   fn sum(numbers: VarArgs<int>) -> int {
+///     let mut total = 0
+///     for n in numbers { total += n }
+///     total
+///   }
 type VarArgs<T>
 
 /// A value captured from a `recover` block after a panic.

--- a/docs/reference/13-go-interop.md
+++ b/docs/reference/13-go-interop.md
@@ -61,7 +61,7 @@ Compound types are different:
 | `Channel<T>`    | `chan T`                     |
 | `Sender<T>`     | `chan<- T`                   |
 | `Receiver<T>`   | `<-chan T`                   |
-| `VarArgs<T>`    | `...T` (call-site only)      |
+| `VarArgs<T>`    | `...T`                       |
 | `Unknown`       | `any` or `interface{}`       |
 
 ### Named primitive types
@@ -101,7 +101,31 @@ fmt.Println(parts...)
 fmt.Println("prefix:", parts...)
 ```
 
-`...` is only valid as the last argument, and only when the receiving parameter is `VarArgs<T>`. Consuming a `VarArgs<T>` inside a Lisette function body is not currently supported.
+`...` is only valid as the last argument, and only when the receiving parameter is `VarArgs<T>`.
+
+Inside the function body the parameter is a `Slice<T>`, exactly as in Go:
+
+```rust
+fn sum(numbers: VarArgs<int>) -> int {
+  let mut total = 0
+  for n in numbers {
+    total += n
+  }
+  total
+}
+```
+
+A spread call passes the caller's slice rather than a copy, so a `mut` parameter mutates the caller's data. The call site must then pass a mutable binding:
+
+```rust
+fn overwrite(mut xs: VarArgs<int>) {
+  xs[0] = 99
+}
+
+let mut nums = [1, 2]
+overwrite(nums...)  // nums is now [99, 2]
+overwrite(1, 2)     // separate arguments are collected into a new slice, so nothing is shared
+```
 
 ### `Unknown`
 

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -2132,6 +2132,21 @@ fn build() -> IntList {
     assert_emit_snapshot!(input);
 }
 
+// `...T` in the signature, `[]T` in the body, as in Go.
+#[test]
+fn varargs_param_declares_variadic_and_bodies_use_a_slice() {
+    let input = r#"
+fn test(xs: VarArgs<int>) -> int {
+  let mut n = xs.length() + xs[0]
+  for x in xs {
+    n = n + x
+  };
+  n
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
 // Zero variadic args, so `T` must be forwarded explicitly: `first[int]()`.
 #[test]
 fn empty_varargs_call_forwards_inferred_type_arg() {

--- a/tests/spec/emit/snapshots/varargs_param_declares_variadic_and_bodies_use_a_slice.snap
+++ b/tests/spec/emit/snapshots/varargs_param_declares_variadic_and_bodies_use_a_slice.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn test(xs: VarArgs<int>) -> int {
+    let mut n = xs.length() + xs[0]
+    for x in xs {
+      n = n + x
+    };
+    n
+  }
+---
+package main
+
+func test(xs ...int) int {
+	n := len(xs) + xs[0]
+	for _, x := range xs {
+		n += x
+	}
+	return n
+}

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -2877,6 +2877,94 @@ fn main() {
 }
 
 #[test]
+fn varargs_param_is_a_slice_in_the_body() {
+    infer(
+        r#"
+fn test(xs: VarArgs<int>) -> int {
+  let ys: Slice<int> = xs
+  let mut n = xs.length() + xs[0]
+  for x in xs { n += x }
+  n + ys.length()
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn varargs_param_body_keeps_the_element_type() {
+    infer(
+        r#"
+fn test(xs: VarArgs<int>) -> Slice<string> {
+  xs
+}
+"#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn varargs_param_can_be_forwarded_with_spread() {
+    infer(
+        r#"
+fn inner(xs: VarArgs<int>) -> int { xs.length() }
+
+fn test(xs: VarArgs<int>) -> int {
+  inner(xs...)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_varargs_param_can_be_written_through() {
+    infer(
+        r#"
+fn overwrite(mut xs: VarArgs<int>) {
+  xs[0] = 9
+}
+
+fn main() {
+  let mut a = [1, 2]
+  overwrite(a...)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn varargs_param_without_mut_cannot_be_written_through() {
+    infer(
+        r#"
+fn test(xs: VarArgs<int>) {
+  xs[0] = 9
+}
+"#,
+    )
+    .assert_infer_code("immutable");
+}
+
+#[test]
+fn individual_args_to_mut_varargs_need_no_mutable_binding() {
+    infer(
+        r#"
+fn overwrite(mut xs: VarArgs<int>) {
+  xs[0] = 9
+}
+
+fn main() {
+  let a = 1
+  let b = 2
+  overwrite(a, b)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn generic_function_with_phantom_param_passed_as_argument_rejected() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -14021,6 +14021,23 @@ fn main() {
     assert_infer_error_snapshot!(input);
 }
 
+// The spread source is a `Slice<int>`, which carries mutation even though `int`
+// does not, so checking against the element type would miss it.
+#[test]
+fn infer_immutable_spread_to_mut_variadic_param_scalar_element() {
+    let input = r#"
+fn overwrite(mut xs: VarArgs<int>) {
+  xs[0] = 99
+}
+
+fn main() {
+  let ys = [1, 2]
+  overwrite(ys...)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
 #[test]
 fn infer_immutable_args_to_mut_variadic_param() {
     let input = r#"

--- a/tests/ui/errors/snapshots/infer_immutable_spread_to_mut_variadic_param_scalar_element.snap
+++ b/tests/ui/errors/snapshots/infer_immutable_spread_to_mut_variadic_param_scalar_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Immutable argument passed to `mut` parameter
+   ╭─[test.lis:8:13]
+ 7 │   let ys = [1, 2]
+ 8 │   overwrite(ys...)
+   ·             ─┬
+   ·              ╰── expected mutable, found immutable
+ 9 │ }
+   ╰────
+  help: `overwrite()` may mutate `ys`, so declare it mutable using `let mut ys = ...` · code: [infer.immutable_arg_to_mut_param]


### PR DESCRIPTION
Currently `VarArgs<T>` cant be consumed in any way, and only exists for Go interop. This change unblocks that limitation, and treats a `VarArgs<T>` as a `Slice<T>` inside a function body (similar to how Go treats varargs).

The main motivation for this is to allow the user to write nicer DSLs, and generally allowing a vararg to be consumed in pure lisette code via looping etc.

Eg. a SQL builder I'm working on has a function like this:

```rust
pub fn where(self, exprs: Slice<Expr<Tbl>>) -> SelectDataset<Tbl> {
    // impl
}
```

Optimally I want to accept **one** or more clauses without having to use a `Slice<T>` and resort to a runtime checks for the user provided parameters.

The code below would have a compile time check for the first argument, and allow more as needed. The call site is also cleaner, as you can pass the clauses directly instead of wrapping them in brackets.

```rust
pub fn where(self, required: Expr<Tbl>, optional: VarArgs<Expr<Tbl>>) -> SelectDataset<Tbl> {
    // impl
}
```

The signature still emits `...T`, only the body binding becomes a `Slice<T>`. `Binding.ty` stays `VarArgs<T>` because the arity check and the emitted parameter declaration both read it, and collapsing them would emit `[]T`.

The param can also be `mut` now, with Go's aliasing. `f(xs...)` passes the caller's slice, so writes are visible to the caller and the spread argument has to be a mutable binding. Separate args (`func(1, 2)`) are collected into a new slice, but the elements are still shared, so a `Slice` or `Map` argument needs `mut` as usual.

Also changed the LPS hover to report a vararg as `Slice<T>` inside the function. The signature still says `VarArgs<T>`.