### PR TITLE
fix: stack overflow on undefined type inside generic

### DIFF
--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -566,7 +566,9 @@ impl PartialEq for Type {
             ) => id1 == id2 && params1 == params2 && w1 == w2,
             (Type::Function(f1), Type::Function(f2)) => f1 == f2,
             (Type::Var { id: id1, .. }, Type::Var { id: id2, .. }) => id1 == id2,
-            (Type::Uninferred, Type::Uninferred) | (Type::Ignored, Type::Ignored) => true,
+            (Type::Uninferred, Type::Uninferred)
+            | (Type::Ignored, Type::Ignored)
+            | (Type::Error, Type::Error) => true,
             (
                 Type::Forall {
                     vars: vars1,
@@ -2003,6 +2005,18 @@ fn alpha_index(idx: usize) -> String {
 mod tests {
     use super::*;
     use std::iter;
+
+    #[test]
+    fn error_type_equals_itself() {
+        let nominal_over_error = || Type::Nominal {
+            id: Symbol::from_parts("prelude", "Option"),
+            params: vec![Type::Error],
+            writable: false,
+        };
+
+        assert_eq!(Type::Error, Type::Error);
+        assert_eq!(nominal_over_error(), nominal_over_error());
+    }
 
     #[test]
     fn function_equality_ignores_param_names() {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3442,6 +3442,15 @@ fn test() {
 }
 
 #[test]
+fn infer_type_not_found_nested_in_generic_annotation() {
+    let input = r#"
+fn test(items: Slice<Option<UnknownType>>) {
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_type_not_found_float_suggests_float64() {
     let input = r#"
 struct Circle { radius: float }

--- a/tests/ui/errors/snapshots/infer_type_not_found_nested_in_generic_annotation.snap
+++ b/tests/ui/errors/snapshots/infer_type_not_found_nested_in_generic_annotation.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type not found
+   ╭─[test.lis:2:29]
+ 1 │ 
+ 2 │ fn test(items: Slice<Option<UnknownType>>) {
+   ·                             ─────┬─────
+   ·                                  ╰── not declared or imported
+ 3 │ }
+   ╰────
+  help: Define or import this type · code: [resolve.type_not_found]


### PR DESCRIPTION
An undefined type name nested inside a generic crashed the compiler with a stack overflow instead of reporting `Type not found`.

```rs
fn t(p: Slice<Option<UndefinedType>>) {}
```

Fix #1276
