### PR TITLE
refactor: collapse representations of `mut` in annotations

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -72,8 +72,13 @@ struct GoPackageIndex {
 
 fn annotation_to_string(ann: &Annotation) -> String {
     match ann {
-        Annotation::Constructor { name, params, .. } => {
-            if params.is_empty() {
+        Annotation::Constructor {
+            name,
+            params,
+            writable,
+            ..
+        } => {
+            let rendered = if params.is_empty() {
                 name.to_string()
             } else {
                 format!(
@@ -85,6 +90,11 @@ fn annotation_to_string(ann: &Annotation) -> String {
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
+            };
+            if *writable {
+                format!("mut {}", rendered)
+            } else {
+                rendered
             }
         }
         Annotation::Function {
@@ -94,14 +104,7 @@ fn annotation_to_string(ann: &Annotation) -> String {
         } => {
             let params_str = params
                 .iter()
-                .map(|param| {
-                    let rendered = annotation_to_string(&param.annotation);
-                    if param.mutable {
-                        format!("mut {}", rendered)
-                    } else {
-                        rendered
-                    }
-                })
+                .map(annotation_to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
             let ret = annotation_to_string(return_type);

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -538,17 +538,7 @@ impl<'a> Formatter<'a> {
                 return_type,
                 ..
             } => {
-                let param_docs: Vec<_> = params
-                    .iter()
-                    .map(|param| {
-                        let doc = Self::annotation(&param.annotation);
-                        if param.mutable {
-                            Document::str("mut ").append(doc)
-                        } else {
-                            doc
-                        }
-                    })
-                    .collect();
+                let param_docs: Vec<_> = params.iter().map(Self::annotation).collect();
                 Document::str("fn(")
                     .append(join(param_docs, Document::str(", ")))
                     .append(") -> ")

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -233,7 +233,6 @@ pub(crate) fn resolve_annotation_definition(
             ..
         } => params
             .iter()
-            .map(|param| &param.annotation)
             .find_map(recurse)
             .or_else(|| recurse(return_type.as_ref())),
         Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -90,7 +90,6 @@ fn resolve_annotation_hover(
             ..
         } => params
             .iter()
-            .map(|param| &param.annotation)
             .find_map(recurse)
             .or_else(|| recurse(return_type.as_ref())),
         Annotation::Tuple { elements, .. } => elements.iter().find_map(recurse),

--- a/crates/passes/src/passes/diagnostic_producers/generics.rs
+++ b/crates/passes/src/passes/diagnostic_producers/generics.rs
@@ -184,7 +184,7 @@ fn annotation_remove_names(annotation: &Annotation, names: &mut HashSet<EcoStrin
             ..
         } => {
             for p in params {
-                annotation_remove_names(&p.annotation, names);
+                annotation_remove_names(p, names);
             }
             annotation_remove_names(return_type, names);
         }

--- a/crates/passes/src/passes/lints/ref_graph/extract.rs
+++ b/crates/passes/src/passes/lints/ref_graph/extract.rs
@@ -661,7 +661,7 @@ fn walk_annotation(
             ..
         } => {
             for p in params {
-                walk_annotation(package, &p.annotation, graph, alias_map, from);
+                walk_annotation(package, p, graph, alias_map, from);
             }
             walk_annotation(package, return_type, graph, alias_map, from);
         }

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -10,8 +10,7 @@ use syntax::ast::StructFieldDefinition;
 use syntax::ast::StructFieldKind;
 use syntax::ast::VariantFields;
 use syntax::ast::{
-    Annotation, AttributeArg, FunctionAnnotationParameter, Generic, Span, StructFields,
-    Visibility as FieldVisibility,
+    Annotation, AttributeArg, Generic, Span, StructFields, Visibility as FieldVisibility,
 };
 use syntax::program::{
     AliasKind, Attributes, Definition, DefinitionBody, Interface, Methods, Package, ValueKind,
@@ -69,7 +68,7 @@ enum CachedAnnotation {
         span: CachedSpan,
     },
     Function {
-        params: Vec<CachedFunctionAnnotationParameter>,
+        params: Vec<Self>,
         return_type: Box<Self>,
         span: CachedSpan,
     },
@@ -86,12 +85,6 @@ enum CachedAnnotation {
         text: Option<String>,
         span: CachedSpan,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-struct CachedFunctionAnnotationParameter {
-    annotation: CachedAnnotation,
-    mutable: bool,
 }
 
 impl CachedAnnotation {
@@ -118,10 +111,7 @@ impl CachedAnnotation {
             } => Self::Function {
                 params: params
                     .iter()
-                    .map(|param| CachedFunctionAnnotationParameter {
-                        annotation: Self::from_annotation(&param.annotation, file_id_to_index),
-                        mutable: param.mutable,
-                    })
+                    .map(|param| Self::from_annotation(param, file_id_to_index))
                     .collect(),
                 return_type: Box::new(Self::from_annotation(return_type, file_id_to_index)),
                 span: CachedSpan::from_span(span, file_id_to_index),
@@ -168,10 +158,7 @@ impl CachedAnnotation {
             } => Annotation::Function {
                 params: params
                     .iter()
-                    .map(|param| FunctionAnnotationParameter {
-                        annotation: param.annotation.to_annotation(file_ids),
-                        mutable: param.mutable,
-                    })
+                    .map(|param| param.to_annotation(file_ids))
                     .collect(),
                 return_type: Box::new(return_type.to_annotation(file_ids)),
                 span: span.to_span(file_ids),

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -195,7 +195,7 @@ impl TaskState {
                     .map(|(index, param)| {
                         self.convert_to_type_mode(
                             store,
-                            &param.annotation,
+                            param,
                             span,
                             ConvertMode {
                                 variadic_allowed: index == last_param,
@@ -215,9 +215,8 @@ impl TaskState {
                 Type::function(
                     new_params
                         .into_iter()
-                        .zip(params)
-                        .map(|(ty, param)| {
-                            let (ty, mutable) = bridge_parameter_permission(ty, param.mutable);
+                        .map(|ty| {
+                            let (ty, mutable) = bridge_parameter_permission(ty, false);
                             FunctionParameter::new(ty, mutable)
                         })
                         .collect(),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -732,13 +732,6 @@ impl StructSpread {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct FunctionAnnotationParameter {
-    pub annotation: Annotation,
-    pub mutable: bool,
-}
-
 #[derive(Clone, PartialEq)]
 pub struct CallTypeArguments(CallTypeArgumentState);
 
@@ -914,7 +907,7 @@ pub enum Annotation {
         span: Span,
     },
     Function {
-        params: Vec<FunctionAnnotationParameter>,
+        params: Vec<Self>,
         return_type: Box<Self>,
         span: Span,
     },

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -1,6 +1,5 @@
 use super::{MAX_TUPLE_ARITY, ParamMode, Parser};
 use crate::EcoString;
-use crate::ast::FunctionAnnotationParameter;
 use crate::ast::{
     Annotation, Attribute, Expression, FunctionBody, Generic, Literal, Span, Visibility,
 };
@@ -288,11 +287,7 @@ impl<'source> Parser<'source> {
 
         while self.is_not(RightParen) && !self.at_recovery_boundary() {
             let start_position = self.stream.position;
-            let mutable = self.advance_if(Mut);
-            params.push(FunctionAnnotationParameter {
-                annotation: self.parse_annotation(),
-                mutable,
-            });
+            params.push(self.parse_annotation());
             if self.at_recovery_boundary() {
                 break;
             }

--- a/crates/syntax/src/parse/expressions.rs
+++ b/crates/syntax/src/parse/expressions.rs
@@ -1787,7 +1787,7 @@ mod tests {
     }
 
     #[test]
-    fn function_type_annotation_captures_per_param_mutability() {
+    fn function_type_annotation_captures_per_param_writability() {
         let result = build_ast("fn run(action: fn(mut Bar, Baz) -> ()) {}", 0);
         assert!(result.errors.is_empty(), "{:?}", result.errors);
 
@@ -1812,7 +1812,7 @@ mod tests {
         assert_eq!(
             type_params
                 .iter()
-                .map(|param| param.mutable)
+                .map(|param| matches!(param, Annotation::Constructor { writable: true, .. }))
                 .collect::<Vec<_>>(),
             vec![true, false]
         );

--- a/crates/syntax/src/parse/pratt.rs
+++ b/crates/syntax/src/parse/pratt.rs
@@ -502,8 +502,13 @@ impl<'source> Parser<'source> {
 
 fn format_annotation(ann: &ast::Annotation) -> string::String {
     match ann {
-        ast::Annotation::Constructor { name, params, .. } => {
-            if params.is_empty() {
+        ast::Annotation::Constructor {
+            name,
+            params,
+            writable,
+            ..
+        } => {
+            let rendered = if params.is_empty() {
                 name.to_string()
             } else {
                 format!(
@@ -515,6 +520,11 @@ fn format_annotation(ann: &ast::Annotation) -> string::String {
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
+            };
+            if *writable {
+                format!("mut {}", rendered)
+            } else {
+                rendered
             }
         }
         ast::Annotation::Tuple { elements, .. } => {
@@ -536,14 +546,7 @@ fn format_annotation(ann: &ast::Annotation) -> string::String {
                 "fn({}) -> {}",
                 params
                     .iter()
-                    .map(|param| {
-                        let rendered = format_annotation(&param.annotation);
-                        if param.mutable {
-                            format!("mut {}", rendered)
-                        } else {
-                            rendered
-                        }
-                    })
+                    .map(format_annotation)
                     .collect::<Vec<_>>()
                     .join(", "),
                 format_annotation(return_type)

--- a/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
+++ b/tests/spec/parse/snapshots/call_with_function_type_in_type_args.snap
@@ -64,29 +64,23 @@ description: |
                                 },
                                 Function {
                                     params: [
-                                        FunctionAnnotationParameter {
-                                            annotation: Constructor {
-                                                name: "int",
-                                                params: [],
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 32,
-                                                    byte_length: 3,
-                                                },
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 32,
+                                                byte_length: 3,
                                             },
-                                            mutable: false,
                                         },
-                                        FunctionAnnotationParameter {
-                                            annotation: Constructor {
-                                                name: "int",
-                                                params: [],
-                                                span: Span {
-                                                    file_id: 0,
-                                                    byte_offset: 37,
-                                                    byte_length: 3,
-                                                },
+                                        Constructor {
+                                            name: "int",
+                                            params: [],
+                                            span: Span {
+                                                file_id: 0,
+                                                byte_offset: 37,
+                                                byte_length: 3,
                                             },
-                                            mutable: false,
                                         },
                                     ],
                                     return_type: Constructor {

--- a/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
+++ b/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
@@ -37,17 +37,14 @@ description: |
                             },
                             annotation: Function {
                                 params: [
-                                    FunctionAnnotationParameter {
-                                        annotation: Constructor {
-                                            name: "int",
-                                            params: [],
-                                            span: Span {
-                                                file_id: 0,
-                                                byte_offset: 17,
-                                                byte_length: 3,
-                                            },
+                                    Constructor {
+                                        name: "int",
+                                        params: [],
+                                        span: Span {
+                                            file_id: 0,
+                                            byte_offset: 17,
+                                            byte_length: 3,
                                         },
-                                        mutable: false,
                                     },
                                 ],
                                 return_type: Constructor {

--- a/tests/spec/parse/snapshots/tuple_struct_function_type_field.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_function_type_field.snap
@@ -27,17 +27,14 @@ description: |
                     },
                     annotation: Function {
                         params: [
-                            FunctionAnnotationParameter {
-                                annotation: Constructor {
-                                    name: "byte",
-                                    params: [],
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 22,
-                                        byte_length: 4,
-                                    },
+                            Constructor {
+                                name: "byte",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 22,
+                                    byte_length: 4,
                                 },
-                                mutable: false,
                             },
                         ],
                         return_type: Constructor {

--- a/tests/spec/parse/snapshots/tuple_struct_function_type_field_after_other_field.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_function_type_field_after_other_field.snap
@@ -52,17 +52,14 @@ description: |
                     },
                     annotation: Function {
                         params: [
-                            FunctionAnnotationParameter {
-                                annotation: Constructor {
-                                    name: "int",
-                                    params: [],
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 24,
-                                        byte_length: 3,
-                                    },
+                            Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 24,
+                                    byte_length: 3,
                                 },
-                                mutable: false,
                             },
                         ],
                         return_type: Constructor {

--- a/tests/spec/parse/snapshots/tuple_struct_multiple_function_type_fields.snap
+++ b/tests/spec/parse/snapshots/tuple_struct_multiple_function_type_fields.snap
@@ -60,17 +60,14 @@ description: |
                     },
                     annotation: Function {
                         params: [
-                            FunctionAnnotationParameter {
-                                annotation: Constructor {
-                                    name: "int",
-                                    params: [],
-                                    span: Span {
-                                        file_id: 0,
-                                        byte_offset: 34,
-                                        byte_length: 3,
-                                    },
+                            Constructor {
+                                name: "int",
+                                params: [],
+                                span: Span {
+                                    file_id: 0,
+                                    byte_offset: 34,
+                                    byte_length: 3,
                                 },
-                                mutable: false,
                             },
                         ],
                         return_type: Unknown,

--- a/tests/spec/parse/snapshots/type_function.snap
+++ b/tests/spec/parse/snapshots/type_function.snap
@@ -17,29 +17,23 @@ description: |
         generics: [],
         annotation: Function {
             params: [
-                FunctionAnnotationParameter {
-                    annotation: Constructor {
-                        name: "int",
-                        params: [],
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 20,
-                            byte_length: 3,
-                        },
+                Constructor {
+                    name: "int",
+                    params: [],
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 20,
+                        byte_length: 3,
                     },
-                    mutable: false,
                 },
-                FunctionAnnotationParameter {
-                    annotation: Constructor {
-                        name: "string",
-                        params: [],
-                        span: Span {
-                            file_id: 0,
-                            byte_offset: 25,
-                            byte_length: 6,
-                        },
+                Constructor {
+                    name: "string",
+                    params: [],
+                    span: Span {
+                        file_id: 0,
+                        byte_offset: 25,
+                        byte_length: 6,
                     },
-                    mutable: false,
                 },
             ],
             return_type: Constructor {


### PR DESCRIPTION
The parser recorded `mut` two ways, namely folded into the type for a declaration and in a separate per-param flag for a fn type. This drops the second, so both keep the qualifier in one place and the write-permission work has a single representation to build on.
