### PR TITLE
fix: element-depth write permission on Go returns

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -544,6 +544,9 @@
         "io/ioutil": {
           "ReadDir": []
         },
+        "maps": {
+          "Clone": ["0:[m]"]
+        },
         "net": {
           "Interfaces": []
         }

--- a/bindgen/internal/convert/returns.go
+++ b/bindgen/internal/convert/returns.go
@@ -232,71 +232,100 @@ func shouldConvertToOption(boolName string, conv *Converter, qualifiedName strin
 // crates/syntax/src/parse/mod.rs.
 const maxReturnTupleArity = 5
 
-// resultWritable reports whether one logical result is writable: a pointer, or a container that is fresh or views only mutated storage.
-func (c *Converter) resultWritable(obj types.Object, results *types.Tuple, index int, qualifiedName string) bool {
-	t := results.At(index).Type()
+func concreteResultType(t types.Type) types.Type {
 	if typeParam, ok := types.Unalias(t).(*types.TypeParam); ok {
 		if core := coreType(typeParam); core != nil {
-			t = core
+			return core
 		}
 	}
+	return t
+}
+
+// resultPermission is how much of one logical result may be written.
+type resultPermission uint8
+
+const (
+	resultReadOnly resultPermission = iota
+	resultOuterWritable
+	resultFullyWritable
+)
+
+// permissionFor keeps the container around element sharing fresh, since the
+// shared storage sits inside the result.
+func permissionFor(depth ViewDepth) resultPermission {
+	if depth == DepthElement {
+		return resultOuterWritable
+	}
+	return resultReadOnly
+}
+
+// resultPermissionOf reports how much of one logical result is writable: a
+// pointer, or a container that is fresh or views only mutated storage.
+func (c *Converter) resultPermissionOf(obj types.Object, results *types.Tuple, index int, qualifiedName string) resultPermission {
+	t := concreteResultType(results.At(index).Type())
 	if !goWritableCapability(t) {
-		return false
+		return resultReadOnly
 	}
 	if _, isPointer := t.Underlying().(*types.Pointer); isPointer {
-		return true
+		return resultFullyWritable
 	}
 	if c == nil || c.mutation == nil || obj == nil {
-		return false
+		return resultReadOnly
 	}
 	fn, isFunc := obj.(*types.Func)
 	if !isFunc {
-		return false
+		return resultReadOnly
 	}
 	sig, isSig := fn.Type().(*types.Signature)
 	if !isSig {
-		return false
+		return resultReadOnly
 	}
 	views, recorded := c.mutation.Views(obj)
 	overrides, hasOverride := c.cfg.ViewOverrides(c.currentPkgPath, qualifiedName)
 	if (!recorded || !views.Analyzed) && !hasOverride {
-		return false
+		return resultReadOnly
 	}
 	views, _ = ResolveViews(views, overrides, hasOverride, sig)
 	if index >= len(views.Results) {
-		return false
+		return resultReadOnly
 	}
 	view := views.Results[index]
 	if view.Opaque || view.Shared {
-		return false
+		return resultReadOnly
 	}
 	mutation, _ := c.mutation.Function(obj)
 	mutParams := c.cfg.MutatingParams(c.currentPkgPath, qualifiedName)
 	params := sig.Params()
+	permission := resultFullyWritable
 	for i, depth := range view.Params {
 		if depth == DepthNone {
 			continue
 		}
+		// A variadic source has no `mut` spelling, so it never proves writability.
 		if i >= params.Len() || (sig.Variadic() && i == params.Len()-1) {
-			return false
+			permission = min(permission, permissionFor(depth))
+			continue
 		}
 		source := params.At(i)
 		if !isMutableParam(mutation.Mutates(i), mutParams, source.Name(), source.Type(), fn.Name()) {
-			return false
+			permission = min(permission, permissionFor(depth))
 		}
 	}
 	if view.Receiver != DepthNone && !mutation.ReceiverMutates &&
 		!c.cfg.MutatesReceiver(c.currentPkgPath, qualifiedName) {
-		return false
+		permission = min(permission, permissionFor(view.Receiver))
 	}
-	return true
+	return permission
 }
 
 // resultType renders one logical result, writable at every layer when the facts allow.
 func (c *Converter) resultType(obj types.Object, results *types.Tuple, index int, seen map[types.Type]bool, substitutions map[string]string, qualifiedName string) TypeResult {
 	t := results.At(index).Type()
-	if c.resultWritable(obj, results, index, qualifiedName) {
+	switch c.resultPermissionOf(obj, results, index, qualifiedName) {
+	case resultFullyWritable:
 		return writableRecursive(t, seen, c, substitutions, false)
+	case resultOuterWritable:
+		return outerWritableType(t, seen, c, substitutions)
 	}
 	return toLisetteRecursive(t, seen, c, substitutions)
 }

--- a/bindgen/internal/convert/types.go
+++ b/bindgen/internal/convert/types.go
@@ -391,6 +391,21 @@ func writableParamType(t types.Type, optional bool, conv *Converter, substitutio
 	return writableRecursive(t, make(map[types.Type]bool), conv, substitutions, optional)
 }
 
+// outerWritableType carries `mut` on the outermost layer only. A named type
+// is left alone, since its qualifier unlocks the whole declaration rather
+// than one layer, and the shared storage sits inside.
+func outerWritableType(t types.Type, seen map[types.Type]bool, conv *Converter, substitutions map[string]string) TypeResult {
+	rendered := toLisetteRecursive(t, seen, conv, substitutions)
+	concrete := concreteResultType(t)
+	if rendered.SkipReason != nil || !goWritableCapability(concrete) {
+		return rendered
+	}
+	if _, named := types.Unalias(concrete).(*types.Named); named {
+		return rendered
+	}
+	return TypeResult{LisetteType: "mut " + rendered.LisetteType}
+}
+
 // writableBase is the read-only rendering the writable one decorates.
 func writableBase(t types.Type, seen map[types.Type]bool, conv *Converter, substitutions map[string]string, nilable bool) TypeResult {
 	if nilable {

--- a/bindgen/tests/testdata/provenance_std.golden
+++ b/bindgen/tests/testdata/provenance_std.golden
@@ -868,7 +868,7 @@ log/syslog.Writer.Notice (opaque r0) (shared r0): r0<-recv
 log/syslog.Writer.Warning (opaque r0) (shared r0): r0<-recv
 log/syslog.Writer.Write (opaque r1) (shared r1): r1<-b r1<-recv
 maps.All (opaque r0): r0<-m
-maps.Clone (opaque r0): r0<-m
+maps.Clone: r0<-[m]
 maps.Collect (opaque r0): 
 maps.Keys (opaque r0): r0<-m
 maps.Values: r0<-[m]

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -281,7 +281,7 @@ impl Planner<'_> {
         {
             return None;
         }
-        if value.get_type() != *binding_ty {
+        if value.get_type().demoted() != binding_ty.demoted() {
             return None;
         }
         let plan = self.plan_call(value)?;

--- a/crates/passes/src/passes/lints/ast_walk/checks/manual_extend.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/manual_extend.rs
@@ -148,7 +148,7 @@ fn extending_loop<'a>(
 
     // Per-element append widens each element to the accumulator's element type,
     // the spread form does not.
-    if receiver.ty != iterable.ty {
+    if receiver.ty.demoted() != iterable.ty.demoted() {
         return None;
     }
 

--- a/crates/stdlib/typedefs/bytes.d.lis
+++ b/crates/stdlib/typedefs/bytes.d.lis
@@ -73,7 +73,7 @@ pub fn EqualFold(s: Slice<byte>, t: Slice<byte>) -> bool
 /// empty slice if s contains only white space. Every element of the returned slice is
 /// non-empty. Unlike [Split], leading and trailing runs of white space characters
 /// are discarded.
-pub fn Fields(s: Slice<byte>) -> Slice<Slice<byte>>
+pub fn Fields(s: Slice<byte>) -> mut Slice<Slice<byte>>
 
 /// FieldsFunc interprets s as a sequence of UTF-8-encoded code points.
 /// It splits the slice s at each run of code points c satisfying f(c) and
@@ -84,7 +84,7 @@ pub fn Fields(s: Slice<byte>) -> Slice<Slice<byte>>
 /// 
 /// FieldsFunc makes no guarantees about the order in which it calls f(c)
 /// and assumes that f always returns the same value for a given c.
-pub fn FieldsFunc(s: Slice<byte>, f: fn(rune) -> bool) -> Slice<Slice<byte>>
+pub fn FieldsFunc(s: Slice<byte>, f: fn(rune) -> bool) -> mut Slice<Slice<byte>>
 
 /// FieldsFuncSeq returns an iterator over subslices of s split around runs of
 /// Unicode code points satisfying f(c).
@@ -222,13 +222,13 @@ pub fn Runes(s: Slice<byte>) -> mut Slice<rune>
 /// It is equivalent to SplitN with a count of -1.
 /// 
 /// To split around the first instance of a separator, see [Cut].
-pub fn Split(s: Slice<byte>, sep: Slice<byte>) -> Slice<Slice<byte>>
+pub fn Split(s: Slice<byte>, sep: Slice<byte>) -> mut Slice<Slice<byte>>
 
 /// SplitAfter slices s into all subslices after each instance of sep and
 /// returns a slice of those subslices.
 /// If sep is empty, SplitAfter splits after each UTF-8 sequence.
 /// It is equivalent to SplitAfterN with a count of -1.
-pub fn SplitAfter(s: Slice<byte>, sep: Slice<byte>) -> Slice<Slice<byte>>
+pub fn SplitAfter(s: Slice<byte>, sep: Slice<byte>) -> mut Slice<Slice<byte>>
 
 /// SplitAfterN slices s into subslices after each instance of sep and
 /// returns a slice of those subslices.
@@ -237,7 +237,7 @@ pub fn SplitAfter(s: Slice<byte>, sep: Slice<byte>) -> Slice<Slice<byte>>
 ///   - n > 0: at most n subslices; the last subslice will be the unsplit remainder;
 ///   - n == 0: the result is nil (zero subslices);
 ///   - n < 0: all subslices.
-pub fn SplitAfterN(s: Slice<byte>, sep: Slice<byte>, n: int) -> Slice<Slice<byte>>
+pub fn SplitAfterN(s: Slice<byte>, sep: Slice<byte>, n: int) -> mut Slice<Slice<byte>>
 
 /// SplitAfterSeq returns an iterator over subslices of s split after each instance of sep.
 /// The iterator yields the same subslices that would be returned by [SplitAfter](s, sep),
@@ -254,7 +254,7 @@ pub fn SplitAfterSeq(s: Slice<byte>, sep: Slice<byte>) -> iter.Seq<Slice<byte>>
 ///   - n < 0: all subslices.
 /// 
 /// To split around the first instance of a separator, see [Cut].
-pub fn SplitN(s: Slice<byte>, sep: Slice<byte>, n: int) -> Slice<Slice<byte>>
+pub fn SplitN(s: Slice<byte>, sep: Slice<byte>, n: int) -> mut Slice<Slice<byte>>
 
 /// SplitSeq returns an iterator over all subslices of s separated by sep.
 /// The iterator yields the same subslices that would be returned by [Split](s, sep),

--- a/crates/stdlib/typedefs/crypto/x509.d.lis
+++ b/crates/stdlib/typedefs/crypto/x509.d.lis
@@ -672,7 +672,7 @@ impl CertPool {
   /// 
   /// Deprecated: if s was returned by [SystemCertPool], Subjects
   /// will not include the system roots.
-  fn Subjects(self: Ref<CertPool>) -> Slice<Slice<byte>>
+  fn Subjects(self: Ref<CertPool>) -> mut Slice<Slice<byte>>
 }
 
 impl Certificate {

--- a/crates/stdlib/typedefs/maps.d.lis
+++ b/crates/stdlib/typedefs/maps.d.lis
@@ -14,7 +14,7 @@ pub fn All<K: Comparable, V>(m: Map<K, V>) -> iter.Seq2<K, V>
 /// Clone returns a copy of m.  This is a shallow clone:
 /// the new keys and values are set using ordinary assignment.
 #[go(collapsed_type_params, "Map<K, V>, K, V")]
-pub fn Clone<K: Comparable, V>(m: Map<K, V>) -> Map<K, V>
+pub fn Clone<K: Comparable, V>(m: Map<K, V>) -> mut Map<K, V>
 
 /// Collect collects key-value pairs from seq into a new map
 /// and returns it.

--- a/crates/stdlib/typedefs/regexp.d.lis
+++ b/crates/stdlib/typedefs/regexp.d.lis
@@ -136,7 +136,7 @@ impl Regexp {
   /// matches of the expression, as defined by the 'All' description in the
   /// package comment.
   /// A return value of nil indicates no match.
-  fn FindAll(self: Ref<Regexp>, b: Slice<byte>, n: int) -> Slice<Slice<byte>>
+  fn FindAll(self: Ref<Regexp>, b: Slice<byte>, n: int) -> mut Slice<Slice<byte>>
 
   /// FindAllIndex is the 'All' version of [Regexp.FindIndex]; it returns a slice of all
   /// successive matches of the expression, as defined by the 'All' description
@@ -173,7 +173,7 @@ impl Regexp {
   /// of all successive matches of the expression, as defined by the 'All'
   /// description in the package comment.
   /// A return value of nil indicates no match.
-  fn FindAllSubmatch(self: Ref<Regexp>, b: Slice<byte>, n: int) -> Slice<Slice<Slice<byte>>>
+  fn FindAllSubmatch(self: Ref<Regexp>, b: Slice<byte>, n: int) -> mut Slice<Slice<Slice<byte>>>
 
   /// FindAllSubmatchIndex is the 'All' version of [Regexp.FindSubmatchIndex]; it returns
   /// a slice of all successive matches of the expression, as defined by the
@@ -233,7 +233,7 @@ impl Regexp {
   /// subexpressions, as defined by the 'Submatch' descriptions in the package
   /// comment.
   /// A return value of nil indicates no match.
-  fn FindSubmatch(self: Ref<Regexp>, b: Slice<byte>) -> Slice<Slice<byte>>
+  fn FindSubmatch(self: Ref<Regexp>, b: Slice<byte>) -> mut Slice<Slice<byte>>
 
   /// FindSubmatchIndex returns a slice holding the index pairs identifying the
   /// leftmost match of the regular expression in b and the matches, if any, of

--- a/crates/stdlib/typedefs/slices.d.lis
+++ b/crates/stdlib/typedefs/slices.d.lis
@@ -57,7 +57,7 @@ pub fn Clip<E>(s: Slice<E>) -> Slice<E>
 /// The result may have additional unused capacity.
 /// The result preserves the nilness of s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Clone<E>(s: Slice<E>) -> Slice<E>
+pub fn Clone<E>(s: Slice<E>) -> mut Slice<E>
 
 /// Collect collects values from seq into a new slice and returns it.
 /// If seq is empty, the result is nil.
@@ -100,7 +100,7 @@ pub fn CompareFunc<E1, E2>(s1: Slice<E1>, s2: Slice<E2>, cmp: fn(E1, E2) -> int)
 /// Concat returns a new slice concatenating the passed in slices.
 /// If the concatenation is empty, the result is nil.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Concat<E>(slices: VarArgs<Slice<E>>) -> Slice<E>
+pub fn Concat<E>(slices: VarArgs<Slice<E>>) -> mut Slice<E>
 
 /// Contains reports whether v is present in s.
 #[go(collapsed_type_params, "Slice<E>, E")]
@@ -171,7 +171,7 @@ pub fn IndexFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> int
 /// This function is O(len(s) + len(v)).
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Insert<E>(s: mut Slice<E>, i: int, v: VarArgs<E>) -> Slice<E>
+pub fn Insert<E>(s: mut Slice<E>, i: int, v: VarArgs<E>) -> mut Slice<E>
 
 /// IsSorted reports whether x is sorted in ascending order.
 #[go(collapsed_type_params, "Slice<E>, E")]
@@ -212,7 +212,7 @@ pub fn MinFunc<E>(x: Slice<E>, cmp: fn(E, E) -> int) -> E
 /// Repeat panics if count is negative or if the result of (len(x) * count)
 /// overflows.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Repeat<E>(x: Slice<E>, count: int) -> Slice<E>
+pub fn Repeat<E>(x: Slice<E>, count: int) -> mut Slice<E>
 
 /// Replace replaces the elements s[i:j] by the given v, and returns the
 /// modified slice.
@@ -220,7 +220,7 @@ pub fn Repeat<E>(x: Slice<E>, count: int) -> Slice<E>
 /// When len(v) < (j-i), Replace zeroes the elements between the new length and the original length.
 /// If the result is empty, it has the same nilness as s.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Replace<E>(s: mut Slice<E>, i: int, j: int, v: VarArgs<E>) -> Slice<E>
+pub fn Replace<E>(s: mut Slice<E>, i: int, j: int, v: VarArgs<E>) -> mut Slice<E>
 
 /// Reverse reverses the elements of the slice in place.
 #[go(collapsed_type_params, "Slice<E>, E")]

--- a/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_amd64.d.lis
@@ -675,7 +675,7 @@ pub fn ParseDirent(buf: Slice<byte>, max: int, names: mut Slice<string>) -> (int
 /// slice containing the [RoutingMessage] interfaces.
 /// 
 /// Deprecated: Use golang.org/x/net/route instead.
-pub fn ParseRoutingMessage(b: Slice<byte>) -> Result<Slice<RoutingMessage>, error>
+pub fn ParseRoutingMessage(b: Slice<byte>) -> Result<mut Slice<RoutingMessage>, error>
 
 /// ParseRoutingSockaddr parses msg's payload as raw sockaddrs and
 /// returns the slice containing the [Sockaddr] interfaces.
@@ -685,7 +685,7 @@ pub fn ParseRoutingSockaddr(msg: RoutingMessage) -> Result<mut Slice<Sockaddr>, 
 
 /// ParseSocketControlMessage parses b as an array of socket control
 /// messages.
-pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<Slice<SocketControlMessage>, error>
+pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<mut Slice<SocketControlMessage>, error>
 
 /// ParseUnixRights decodes a socket control message that contains an
 /// integer array of open file descriptors from another process.

--- a/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_darwin_arm64.d.lis
@@ -678,7 +678,7 @@ pub fn ParseDirent(buf: Slice<byte>, max: int, names: mut Slice<string>) -> (int
 /// slice containing the [RoutingMessage] interfaces.
 /// 
 /// Deprecated: Use golang.org/x/net/route instead.
-pub fn ParseRoutingMessage(b: Slice<byte>) -> Result<Slice<RoutingMessage>, error>
+pub fn ParseRoutingMessage(b: Slice<byte>) -> Result<mut Slice<RoutingMessage>, error>
 
 /// ParseRoutingSockaddr parses msg's payload as raw sockaddrs and
 /// returns the slice containing the [Sockaddr] interfaces.
@@ -688,7 +688,7 @@ pub fn ParseRoutingSockaddr(msg: RoutingMessage) -> Result<mut Slice<Sockaddr>, 
 
 /// ParseSocketControlMessage parses b as an array of socket control
 /// messages.
-pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<Slice<SocketControlMessage>, error>
+pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<mut Slice<SocketControlMessage>, error>
 
 /// ParseUnixRights decodes a socket control message that contains an
 /// integer array of open file descriptors from another process.

--- a/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_amd64.d.lis
@@ -826,16 +826,16 @@ pub fn ParseDirent(buf: Slice<byte>, max: int, names: mut Slice<string>) -> (int
 
 /// ParseNetlinkMessage parses b as an array of netlink messages and
 /// returns the slice containing the NetlinkMessage structures.
-pub fn ParseNetlinkMessage(b: Slice<byte>) -> Result<Slice<NetlinkMessage>, error>
+pub fn ParseNetlinkMessage(b: Slice<byte>) -> Result<mut Slice<NetlinkMessage>, error>
 
 /// ParseNetlinkRouteAttr parses m's payload as an array of netlink
 /// route attributes and returns the slice containing the
 /// NetlinkRouteAttr structures.
-pub fn ParseNetlinkRouteAttr(m: Ref<NetlinkMessage>) -> Result<Slice<NetlinkRouteAttr>, error>
+pub fn ParseNetlinkRouteAttr(m: Ref<NetlinkMessage>) -> Result<mut Slice<NetlinkRouteAttr>, error>
 
 /// ParseSocketControlMessage parses b as an array of socket control
 /// messages.
-pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<Slice<SocketControlMessage>, error>
+pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<mut Slice<SocketControlMessage>, error>
 
 /// ParseUnixCredentials decodes a socket control message that contains
 /// credentials in a Ucred structure. To receive such a message, the

--- a/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
+++ b/crates/stdlib/typedefs/syscall_linux_arm64.d.lis
@@ -825,16 +825,16 @@ pub fn ParseDirent(buf: Slice<byte>, max: int, names: mut Slice<string>) -> (int
 
 /// ParseNetlinkMessage parses b as an array of netlink messages and
 /// returns the slice containing the NetlinkMessage structures.
-pub fn ParseNetlinkMessage(b: Slice<byte>) -> Result<Slice<NetlinkMessage>, error>
+pub fn ParseNetlinkMessage(b: Slice<byte>) -> Result<mut Slice<NetlinkMessage>, error>
 
 /// ParseNetlinkRouteAttr parses m's payload as an array of netlink
 /// route attributes and returns the slice containing the
 /// NetlinkRouteAttr structures.
-pub fn ParseNetlinkRouteAttr(m: Ref<NetlinkMessage>) -> Result<Slice<NetlinkRouteAttr>, error>
+pub fn ParseNetlinkRouteAttr(m: Ref<NetlinkMessage>) -> Result<mut Slice<NetlinkRouteAttr>, error>
 
 /// ParseSocketControlMessage parses b as an array of socket control
 /// messages.
-pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<Slice<SocketControlMessage>, error>
+pub fn ParseSocketControlMessage(b: Slice<byte>) -> Result<mut Slice<SocketControlMessage>, error>
 
 /// ParseUnixCredentials decodes a socket control message that contains
 /// credentials in a Ucred structure. To receive such a message, the


### PR DESCRIPTION
When a Go result shares storage with a param only at element level, the return type now keeps mut on its outermost layer instead of dropping the `mut` qualifier altogether. For example:

```rs
// bytes.d.lis
pub fn Split(s: Slice<byte>, sep: Slice<byte>) -> mut Slice<Slice<byte>>
```

The outer slice is fresh and may be appended to. The inner slices view `s` and stay read-only.