### PR TITLE
chore: blank line before fix summary

### DIFF
--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -572,6 +572,8 @@ fn apply_result_fixes(result: &CompileResult, summary: &mut FixSummary) {
 fn print_fix_summary(summary: &FixSummary, elapsed: Duration) {
     let time_display = output::format_elapsed(elapsed);
 
+    eprintln!();
+
     if summary.files_changed == 0 {
         eprintln!("  ✓ No fixes applied {}", time_display);
     } else {


### PR DESCRIPTION
Print a blank line before the `lis check --fix` summary, so it matches `check`, `format`, and `emit`.
