### PR TITLE
fix: type aliases to `Option`, `Result` and `Partial`

### DIFF
--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -147,6 +147,7 @@ impl Planner<'_> {
         payload_bridge: Option<&LayoutBridge>,
         target: WrapperTarget<'_>,
     ) -> (Vec<LoweredStatement>, Option<String>) {
+        let result_ty = &self.facts.peel_alias(result_ty);
         match abi {
             CallableReturnAbi::Tagged
             | CallableReturnAbi::Direct
@@ -215,7 +216,7 @@ impl Planner<'_> {
         result_ty: &Type,
     ) -> Option<LayoutBridge> {
         let source = abi.return_payload_layout.as_ref()?;
-        let target_type = result_ty.ok_type();
+        let target_type = self.facts.peel_alias(result_ty).ok_type();
         let target = self.value_layout(&target_type, SlotOrigin::Lisette);
         let bridge = resolve_layout_bridge(self, source, &target);
         (!bridge.is_identity()).then_some(bridge)

--- a/crates/emit/src/control_flow/fallible_blocks.rs
+++ b/crates/emit/src/control_flow/fallible_blocks.rs
@@ -18,7 +18,8 @@ impl Planner<'_> {
         self.require_stdlib();
 
         let return_ctx = self.return_ctx();
-        let effective_ty = resolve_fallible_block_type(items, ty, Some(&return_ctx));
+        let ty = self.facts.peel_alias(ty);
+        let effective_ty = resolve_fallible_block_type(items, &ty, Some(&return_ctx));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("`try` block must have Result or Option type");
 
@@ -177,7 +178,8 @@ impl Planner<'_> {
         self.require_stdlib();
 
         let return_ctx = self.return_ctx();
-        let effective_ty = resolve_fallible_block_type(items, ty, Some(&return_ctx));
+        let ty = self.facts.peel_alias(ty);
+        let effective_ty = resolve_fallible_block_type(items, &ty, Some(&return_ctx));
         let fallible = Fallible::from_type(&effective_ty)
             .expect("recover block type must be Result<T, PanicValue>");
 

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -48,7 +48,7 @@ impl Planner<'_> {
         expression: &Expression,
         result_var_name: Option<&str>,
     ) -> (Vec<LoweredStatement>, String) {
-        let expression_ty = expression.get_type();
+        let expression_ty = self.facts.peel_alias(&expression.get_type());
         let fallible = Fallible::from_type(&expression_ty)
             .expect("lower_propagate called on non-Result/Option type");
 
@@ -412,7 +412,7 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
     ) -> Option<Vec<LoweredStatement>> {
-        let expression_ty = expression.get_type();
+        let expression_ty = self.facts.peel_alias(&expression.get_type());
         let return_ctx = self.return_ctx();
 
         let return_ty = return_ctx

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -272,6 +272,7 @@ impl Planner<'_> {
 
 impl<'a> Planner<'a> {
     fn return_context_for_type(&self, return_ty: Type) -> ReturnContext {
+        let return_ty = self.facts.peel_alias(&return_ty);
         match self.classify_direct_emission(&return_ty) {
             Some(shape) => ReturnContext::Lowered { return_ty, shape },
             None => ReturnContext::Tagged(return_ty),

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -456,9 +456,9 @@ impl Planner<'_> {
         expression: &Expression,
     ) -> Vec<LoweredStatement> {
         let ty = target_ty
+            .map(|t| self.facts.peel_alias(t))
             .filter(|t| t.is_option() || t.is_result())
-            .cloned()
-            .unwrap_or_else(|| expression.get_type());
+            .unwrap_or_else(|| self.facts.peel_alias(&expression.get_type()));
         let Some(fallible) = Fallible::from_type(&ty) else {
             return self.lower_plain_assign(target_var, expression);
         };

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -333,15 +333,17 @@ impl Planner<'_> {
         }
         let return_ctx = self.return_ctx();
         let resolved_ty = resolve_let_temp_declaration_ty(self, value, binding_ty);
+        let peeled_resolved = self.facts.peel_alias(&resolved_ty);
+        let peeled_binding = self.facts.peel_alias(binding_ty);
         let needs_context = |ty: &Type| ty.is_variable() || ty.is_placeholder();
         let has_contextual_ok_ty = matches!(
             value,
             Expression::TryBlock { .. } | Expression::RecoverBlock { .. }
-        ) && !needs_context(&resolved_ty)
-            && needs_context(&resolved_ty.ok_type());
+        ) && !needs_context(&peeled_resolved)
+            && needs_context(&peeled_resolved.ok_type());
 
         let var_ty = if has_contextual_ok_ty {
-            if !needs_context(binding_ty) && !needs_context(&binding_ty.ok_type()) {
+            if !needs_context(&peeled_binding) && !needs_context(&peeled_binding.ok_type()) {
                 self.go_type_string(binding_ty)
             } else if let Some(ctx_ty) = return_ctx.ty().cloned() {
                 if Fallible::from_type(&ctx_ty).is_some() {

--- a/crates/semantics/src/checker/infer/expressions/propagate.rs
+++ b/crates/semantics/src/checker/infer/expressions/propagate.rs
@@ -27,7 +27,7 @@ impl InferCtx<'_> {
 
         let tried_ty = self.new_type_var();
         let new_expression = self.infer_expression(*expression, &tried_ty);
-        let resolved_tried_ty = new_expression.get_type().resolve_in(&self.env);
+        let resolved_tried_ty = self.resolve_carrier(&new_expression.get_type());
 
         if resolved_tried_ty.is_partial() {
             self.sink
@@ -170,12 +170,12 @@ impl InferCtx<'_> {
             ok_ty
         } else if tried_ty.is_option() {
             let some_ty = tried_ty.ok_type();
-            let resolved_fn_return = fn_return_ty.resolve_in(&self.env);
+            let resolved_fn_return = self.resolve_carrier(&fn_return_ty);
 
             if resolved_fn_return.is_option() {
                 let new_some = self.new_type_var();
                 let expected_return = self.type_option(store, new_some);
-                self.unify(&expected_return, &fn_return_ty, &span);
+                self.unify(&expected_return, &resolved_fn_return, &span);
             } else {
                 self.sink.push(diagnostics::infer::try_return_type_mismatch(
                     "Option<T>",

--- a/tests/spec/emit/snapshots/let_binds_call_returning_nullable_option_alias.snap
+++ b/tests/spec/emit/snapshots/let_binds_call_returning_nullable_option_alias.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Point {
+    pub x: int,
+  }
+  
+  type MaybePoint = Option<Ref<Point>>
+  
+  fn source(p: Ref<Point>) -> MaybePoint {
+    Some(p)
+  }
+  
+  fn main() {
+    let point = Point { x: 1 }
+    let a = source(&point)
+    let _ = a
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Point struct {
+	X int
+}
+
+type MaybePoint = lisette.Option[*Point]
+
+func source(p *Point) *Point {
+	return p
+}
+
+func main() {
+	point := Point{X: 1}
+	raw_1 := source(&point)
+	a := lisette.OptionFromNilable[*Point](raw_1, raw_1 == nil)
+	_ = a
+}

--- a/tests/spec/emit/snapshots/let_binds_call_returning_option_alias.snap
+++ b/tests/spec/emit/snapshots/let_binds_call_returning_option_alias.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyOpt = Option<int>
+  
+  fn source() -> MyOpt {
+    Some(3)
+  }
+  
+  fn main() {
+    let a = source()
+    let _ = a
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyOpt = lisette.Option[int]
+
+func source() (int, bool) {
+	return 3, true
+}
+
+func main() {
+	a := lisette.OptionFromCommaOk[int](source())
+	_ = a
+}

--- a/tests/spec/emit/snapshots/let_binds_call_returning_partial_alias.snap
+++ b/tests/spec/emit/snapshots/let_binds_call_returning_partial_alias.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyPartial = Partial<int, error>
+  
+  fn source() -> MyPartial {
+    Partial.Ok(3)
+  }
+  
+  fn main() {
+    let a = source()
+    let _ = a
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyPartial = lisette.Partial[int, error]
+
+func source() (int, error) {
+	return 3, nil
+}
+
+func main() {
+	ret_1, ret_2 := source()
+	var a lisette.Partial[int, error]
+	if ret_2 != nil {
+		a = lisette.MakePartialBoth[int, error](ret_1, ret_2)
+	} else {
+		a = lisette.MakePartialOk[int, error](ret_1)
+	}
+	_ = a
+}

--- a/tests/spec/emit/snapshots/let_binds_call_returning_result_alias.snap
+++ b/tests/spec/emit/snapshots/let_binds_call_returning_result_alias.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyRes = Result<int, error>
+  
+  fn source() -> MyRes {
+    Ok(3)
+  }
+  
+  fn main() {
+    let a = source()
+    let _ = a
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyRes = lisette.Result[int, error]
+
+func source() (int, error) {
+	return 3, nil
+}
+
+func main() {
+	ret_1, ret_2 := source()
+	var a lisette.Result[int, error]
+	if ret_2 != nil {
+		a = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		a = lisette.MakeResultOk[int, error](ret_1)
+	}
+	_ = a
+}

--- a/tests/spec/emit/snapshots/propagates_call_returning_option_alias.snap
+++ b/tests/spec/emit/snapshots/propagates_call_returning_option_alias.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyOpt = Option<int>
+  
+  fn source() -> MyOpt {
+    Some(5)
+  }
+  
+  fn consume() -> Option<int> {
+    let n = source()?
+    Some(n + 1)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyOpt = lisette.Option[int]
+
+func source() (int, bool) {
+	return 5, true
+}
+
+func consume() (int, bool) {
+	ret_1, ret_2 := source()
+	if !ret_2 {
+		return 0, false
+	}
+	n := ret_1
+	return n + 1, true
+}

--- a/tests/spec/emit/snapshots/propagates_call_returning_result_alias.snap
+++ b/tests/spec/emit/snapshots/propagates_call_returning_result_alias.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyRes = Result<int, error>
+  
+  fn source() -> MyRes {
+    Ok(5)
+  }
+  
+  fn consume() -> Result<int, error> {
+    let n = source()?
+    Ok(n + 1)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyRes = lisette.Result[int, error]
+
+func source() (int, error) {
+	return 5, nil
+}
+
+func consume() (int, error) {
+	ret_1, ret_2 := source()
+	if ret_2 != nil {
+		return 0, ret_2
+	}
+	n := ret_1
+	return n + 1, nil
+}

--- a/tests/spec/emit/snapshots/recover_block_annotated_with_result_alias.snap
+++ b/tests/spec/emit/snapshots/recover_block_annotated_with_result_alias.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type Recovered = Result<int, PanicValue>
+  
+  fn main() {
+    let r: Recovered = recover {
+      42
+    }
+    let _ = r
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Recovered = lisette.Result[int, lisette.PanicValue]
+
+func main() {
+	r := lisette.RecoverBlock(func() int {
+		return 42
+	})
+	_ = r
+}

--- a/tests/spec/emit/snapshots/tail_call_forwards_option_alias_return.snap
+++ b/tests/spec/emit/snapshots/tail_call_forwards_option_alias_return.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyOpt = Option<int>
+  
+  fn source() -> MyOpt {
+    Some(3)
+  }
+  
+  fn forward() -> MyOpt {
+    source()
+  }
+  
+  fn main() {
+    let _ = forward()
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyOpt = lisette.Option[int]
+
+func source() (int, bool) {
+	return 3, true
+}
+
+func forward() (int, bool) {
+	return source()
+}
+
+func main() {
+	forward()
+}

--- a/tests/spec/emit/snapshots/try_block_annotated_with_result_alias.snap
+++ b/tests/spec/emit/snapshots/try_block_annotated_with_result_alias.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type MyRes = Result<int, error>
+  
+  fn source() -> MyRes {
+    Ok(5)
+  }
+  
+  fn main() {
+    let r: MyRes = try {
+      let n = source()?
+      n + 1
+    }
+    let _ = r
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type MyRes = lisette.Result[int, error]
+
+func source() (int, error) {
+	return 5, nil
+}
+
+func main() {
+	var r lisette.Result[int, error]
+	tryResult_1 := func() lisette.Result[int, error] {
+		ret_2, ret_3 := source()
+		if ret_3 != nil {
+			return lisette.MakeResultErr[int, error](ret_3)
+		}
+		n := ret_2
+		return lisette.MakeResultOk[int, error](n + 1)
+	}()
+	r = tryResult_1
+	_ = r
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2601,6 +2601,168 @@ fn test() -> Maybe<int> {
 }
 
 #[test]
+fn let_binds_call_returning_option_alias() {
+    let input = r#"
+type MyOpt = Option<int>
+
+fn source() -> MyOpt {
+  Some(3)
+}
+
+fn main() {
+  let a = source()
+  let _ = a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_binds_call_returning_result_alias() {
+    let input = r#"
+type MyRes = Result<int, error>
+
+fn source() -> MyRes {
+  Ok(3)
+}
+
+fn main() {
+  let a = source()
+  let _ = a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_binds_call_returning_partial_alias() {
+    let input = r#"
+type MyPartial = Partial<int, error>
+
+fn source() -> MyPartial {
+  Partial.Ok(3)
+}
+
+fn main() {
+  let a = source()
+  let _ = a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_binds_call_returning_nullable_option_alias() {
+    let input = r#"
+struct Point {
+  pub x: int,
+}
+
+type MaybePoint = Option<Ref<Point>>
+
+fn source(p: Ref<Point>) -> MaybePoint {
+  Some(p)
+}
+
+fn main() {
+  let point = Point { x: 1 }
+  let a = source(&point)
+  let _ = a
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagates_call_returning_result_alias() {
+    let input = r#"
+type MyRes = Result<int, error>
+
+fn source() -> MyRes {
+  Ok(5)
+}
+
+fn consume() -> Result<int, error> {
+  let n = source()?
+  Ok(n + 1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagates_call_returning_option_alias() {
+    let input = r#"
+type MyOpt = Option<int>
+
+fn source() -> MyOpt {
+  Some(5)
+}
+
+fn consume() -> Option<int> {
+  let n = source()?
+  Some(n + 1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn try_block_annotated_with_result_alias() {
+    let input = r#"
+type MyRes = Result<int, error>
+
+fn source() -> MyRes {
+  Ok(5)
+}
+
+fn main() {
+  let r: MyRes = try {
+    let n = source()?
+    n + 1
+  }
+  let _ = r
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn recover_block_annotated_with_result_alias() {
+    let input = r#"
+type Recovered = Result<int, PanicValue>
+
+fn main() {
+  let r: Recovered = recover {
+    42
+  }
+  let _ = r
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tail_call_forwards_option_alias_return() {
+    let input = r#"
+type MyOpt = Option<int>
+
+fn source() -> MyOpt {
+  Some(3)
+}
+
+fn forward() -> MyOpt {
+  source()
+}
+
+fn main() {
+  let _ = forward()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn prelude_type_shadowing_struct_and_methods() {
     let input = r#"
 struct Span {

--- a/tests/spec/infer/try.rs
+++ b/tests/spec/infer/try.rs
@@ -1145,6 +1145,63 @@ fn propagate_widens_into_aliased_result_return_type() {
 }
 
 #[test]
+fn propagate_accepts_aliased_result_operand() {
+    infer(
+        r#"
+    type Outcome = Result<int, error>
+
+    fn source() -> Outcome {
+      Ok(5)
+    }
+
+    fn load() -> Result<int, error> {
+      let n = source()?
+      Ok(n + 1)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_accepts_aliased_option_operand() {
+    infer(
+        r#"
+    type Maybe = Option<int>
+
+    fn source() -> Maybe {
+      Some(5)
+    }
+
+    fn load() -> Option<int> {
+      let n = source()?
+      Some(n + 1)
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn propagate_on_aliased_partial_operand_is_rejected() {
+    infer(
+        r#"
+    type Outcome = Partial<int, error>
+
+    fn source() -> Outcome {
+      Partial.Ok(3)
+    }
+
+    fn load() -> Result<int, error> {
+      let n = source()?
+      Ok(n)
+    }
+        "#,
+    )
+    .assert_infer_code("propagate_on_partial");
+}
+
+#[test]
 fn aliased_try_block_annotation_seeds_the_error_slot() {
     infer(
         r#"


### PR DESCRIPTION
Fix #1286
