### PR TITLE
refactor: emit direct error checks for fallible Go calls

### DIFF
--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -14,9 +14,95 @@ use syntax::ast::{ConstructorPatternResolution, Expression, MatchArm, Pattern};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
-struct FusedShape {
+pub(super) struct ResultFusePlan<'a> {
+    subject: &'a Expression,
     shape: CallableReturnAbi,
     nil_guard: Option<NilGuard>,
+}
+
+pub(super) struct BoundResultCall {
+    pub(super) setup: Vec<LoweredStatement>,
+    pub(super) value: Option<String>,
+    pub(super) error: String,
+    pub(super) ok_condition: String,
+    pub(super) err_condition: String,
+}
+
+impl ResultFusePlan<'_> {
+    pub(super) fn has_nil_guard(&self) -> bool {
+        self.nil_guard.is_some()
+    }
+
+    pub(super) fn shape(&self) -> &CallableReturnAbi {
+        &self.shape
+    }
+
+    pub(super) fn carries_payload(&self) -> bool {
+        matches!(self.shape, CallableReturnAbi::Result { .. })
+    }
+
+    pub(super) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> BoundResultCall {
+        let temp = |planner: &mut Planner<'_>| {
+            let var = planner.fresh_var(Some("ret"));
+            planner.declare(&var);
+            var
+        };
+        let value = self
+            .carries_payload()
+            .then(|| match slot {
+                CommaOkValueSlot::Named(name) => Some(name),
+                CommaOkValueSlot::Temp => Some(temp(planner)),
+                CommaOkValueSlot::Unused => self.nil_guard.map(|_| temp(planner)),
+            })
+            .flatten();
+        let error = planner.fresh_var(Some("err"));
+        planner.declare(&error);
+
+        let (mut setup, call_str) = planner
+            .lower_call(self.subject, None, ExpressionContext::value())
+            .into_parts();
+        setup.push(LoweredStatement::RawGo(match &value {
+            Some(var) => format!("{}, {} := {}\n", var, error, call_str),
+            None => match self.shape {
+                CallableReturnAbi::Result { .. } => format!("_, {} := {}\n", error, call_str),
+                CallableReturnAbi::BareError => format!("{} := {}\n", error, call_str),
+                CallableReturnAbi::Tagged
+                | CallableReturnAbi::Direct
+                | CallableReturnAbi::Partial { .. }
+                | CallableReturnAbi::Option(_)
+                | CallableReturnAbi::Tuple { .. } => unreachable!("rejected by recognition"),
+            },
+        }));
+
+        let (ok_condition, err_condition) = match self.nil_guard {
+            Some(guard) => {
+                if guard.is_interface() {
+                    planner.require_stdlib();
+                }
+                let var = value.as_deref().expect("nil guard requires the value var");
+                (
+                    format!("{} == nil && {}", error, guard.non_nil(var)),
+                    format!("{} != nil || {}", error, guard.is_nil(var)),
+                )
+            }
+            None => (format!("{} == nil", error), format!("{} != nil", error)),
+        };
+
+        BoundResultCall {
+            setup,
+            value,
+            error,
+            ok_condition,
+            err_condition,
+        }
+    }
+}
+
+const UNIT_VALUE: &str = "struct{}{}";
+
+struct ResultArm<'a> {
+    arm: &'a MatchArm,
+    is_catch_all: bool,
 }
 
 /// How to render the subject declaration line, based on body usage.
@@ -47,7 +133,7 @@ impl Planner<'_> {
             return LoweredBlock { statements };
         }
 
-        if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place) {
+        if let Some(fused) = self.lower_fused_lowered_match(subject, arms, place, None) {
             statements.extend(fused);
             return LoweredBlock { statements };
         }
@@ -168,19 +254,17 @@ impl Planner<'_> {
         tree_emitter.lower(place)
     }
 
-    /// The shape a match subject fuses against: lowered Lisette `Result` callees
-    /// and single-value Go `(T, error)` calls. `None` falls through to the
-    /// Partial and Option fuses or the lift-then-match path.
-    fn fusable_result_shape(
+    /// Recognize a Lisette `Result` function or a Go `(T, error)` one.
+    pub(super) fn result_fuse_plan<'a>(
         &self,
-        subject: &Expression,
-        plan: &CallPlan<'_>,
-    ) -> Option<FusedShape> {
+        subject: &'a Expression,
+    ) -> Option<ResultFusePlan<'a>> {
+        let plan = self.plan_call(subject)?;
         let shape = plan.resolved.abi.result.clone();
         let nil_guard = match &plan.resolved.origin {
             CallableOrigin::GoInterop
                 if matches!(
-                    plan.resolved.abi.result,
+                    shape,
                     CallableReturnAbi::BareError | CallableReturnAbi::Result { .. }
                 ) =>
             {
@@ -203,97 +287,165 @@ impl Planner<'_> {
             shape,
             CallableReturnAbi::BareError | CallableReturnAbi::Result { .. }
         )
-        .then_some(FusedShape { shape, nil_guard })
+        .then_some(ResultFusePlan {
+            subject,
+            shape,
+            nil_guard,
+        })
     }
 
-    /// Fuse the lift+match into one `if err == nil { ... } else { ... }`
-    /// when the scrutinee is a lowered call with simple `Ok`/`Err` arms.
+    /// Bind `let x = match ...` straight into `x`.
+    pub(crate) fn lower_fused_result_match_into(
+        &mut self,
+        value: &Expression,
+        go_name: &str,
+    ) -> Option<Vec<LoweredStatement>> {
+        let Expression::Match { subject, arms, .. } = value.unwrap_parens() else {
+            return None;
+        };
+        self.lower_fused_lowered_match(subject, arms, &PlacePlan::Statement, Some(go_name))
+    }
+
+    /// The payload name an arm binds, or `None` when the body never reads it.
+    fn arm_payload_name<'a>(&self, arm: &'a MatchArm) -> Option<&'a str> {
+        let Pattern::EnumVariant { fields, .. } = &arm.pattern else {
+            return None;
+        };
+        let [field] = fields.as_slice() else {
+            return None;
+        };
+        if self.facts.is_unused_binding(field) {
+            return None;
+        }
+        simple_payload_binding(arm).filter(|name| *name != "_")
+    }
+
+    /// Test a fallible call with one `if`, building no `Result`. A
+    /// `destination` makes the call write into that name, leaving only the
+    /// failure arm.
     fn lower_fused_lowered_match(
         &mut self,
         subject: &Expression,
         arms: &[MatchArm],
         place: &PlacePlan,
+        destination: Option<&str>,
     ) -> Option<Vec<LoweredStatement>> {
-        let plan = self.plan_call(subject)?;
-        let FusedShape { shape, nil_guard } = self.fusable_result_shape(subject, &plan)?;
-        let (ok_arm, err_arm) = classify_result_arms(arms)?;
+        let fuse = self.result_fuse_plan(subject)?;
+        let (ok, err) = classify_result_arms(arms)?;
 
         // Err always carries a payload; Ok may not under BareError.
-        let ok_binding = simple_payload_binding(ok_arm);
-        let err_binding = simple_payload_binding(err_arm);
-        err_binding?;
-        if ok_binding.is_none() && !ok_arm_payload_is_omitted(ok_arm, &shape) {
-            return None;
-        }
-        let ok_name = ok_binding.filter(|n| *n != "_");
-        let err_name = err_binding.filter(|n| *n != "_");
-
-        let need_val = matches!(shape, CallableReturnAbi::Result { .. })
-            && (ok_name.is_some() || nil_guard.is_some());
-        let val_var = need_val.then(|| {
-            let v = self.fresh_var(Some("ret"));
-            self.declare(&v);
-            v
-        });
-        let err_var = self.fresh_var(Some("ret"));
-        self.declare(&err_var);
-
-        let (mut statements, call_str) = self
-            .lower_call(subject, None, ExpressionContext::value())
-            .into_parts();
-        let bind_line = match &val_var {
-            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
-            None => match shape {
-                CallableReturnAbi::Result { .. } => format!("_, {} := {}\n", err_var, call_str),
-                CallableReturnAbi::BareError => format!("{} := {}\n", err_var, call_str),
-                CallableReturnAbi::Tagged
-                | CallableReturnAbi::Direct
-                | CallableReturnAbi::Partial { .. }
-                | CallableReturnAbi::Option(_)
-                | CallableReturnAbi::Tuple { .. } => unreachable!("rejected above"),
-            },
-        };
-        statements.push(LoweredStatement::RawGo(bind_line));
-
-        let (then_body, _) = self.lower_fused_arm(
-            &[ok_name.zip(val_var.as_deref())],
-            &ok_arm.expression,
-            place,
-        );
-        let (mut else_body, err_used) = self.lower_fused_arm(
-            &[err_name.map(|n| (n, err_var.as_str()))],
-            &err_arm.expression,
-            place,
-        );
-
-        let condition = match nil_guard {
-            Some(guard) => {
-                let val = val_var
-                    .as_deref()
-                    .expect("nil guard requires the value var");
-                if guard.is_interface() {
-                    self.require_stdlib();
-                }
-                if err_used {
-                    self.require_errors();
-                    else_body.statements.insert(
-                        0,
-                        LoweredStatement::RawGo(format!(
-                            "if {err_var} == nil {{\n{err_var} = errors.New(\"unexpected nil\")\n}}\n"
-                        )),
-                    );
-                }
-                format!("{} == nil && {}", err_var, guard.non_nil(val))
+        let ok_name = if ok.is_catch_all {
+            None
+        } else {
+            if simple_payload_binding(ok.arm).is_none()
+                && !ok_arm_payload_is_omitted(ok.arm, fuse.shape())
+            {
+                return None;
             }
-            None => format!("{} == nil", err_var),
+            self.arm_payload_name(ok.arm)
+        };
+        let err_name = if err.is_catch_all {
+            None
+        } else {
+            simple_payload_binding(err.arm)?;
+            self.arm_payload_name(err.arm)
         };
 
-        statements.push(LoweredStatement::If(IfPlan {
-            condition_setup: Vec::new(),
-            condition,
-            then_body,
-            else_arm: ElseArm::from_body(else_body, false),
-        }));
+        if let Some(name) = destination {
+            // Safe only if the failure arm always leaves and the success arm
+            // returns the payload unchanged.
+            let payload = simple_payload_binding(ok.arm).filter(|name| *name != "_")?;
+            if !fuse.carries_payload()
+                || ok.is_catch_all
+                || err.is_catch_all
+                || !err.arm.expression.get_type().is_never()
+                || arm_body_is_identifier(&ok.arm.expression) != Some(payload)
+            {
+                return None;
+            }
+            self.declare(name);
+        } else if matches!(place, PlacePlan::Statement)
+            && ok_name.is_none()
+            && err_name.is_none()
+            && arm_body_is_noop(&ok.arm.expression)
+            && arm_body_is_noop(&err.arm.expression)
+        {
+            // Nothing reads the outcome, so keep the call and drop the test.
+            let (mut statements, call_str) = self
+                .lower_call(subject, None, ExpressionContext::value())
+                .into_parts();
+            statements.push(LoweredStatement::RawGo(format!("{call_str}\n")));
+            return Some(statements);
+        }
+
+        let has_nil_guard = fuse.has_nil_guard();
+        let carries_payload = fuse.carries_payload();
+        let slot = match destination {
+            Some(name) => CommaOkValueSlot::Named(name.to_string()),
+            None if ok_name.is_some() => CommaOkValueSlot::Temp,
+            None => CommaOkValueSlot::Unused,
+        };
+        let bound = fuse.bind(self, slot);
+        let mut statements = bound.setup;
+
+        let then_body = destination.is_none().then(|| {
+            // A call returning only `error` has no value, so `Ok(x)` takes unit.
+            let ok_value = if carries_payload {
+                bound.value.as_deref()
+            } else {
+                Some(UNIT_VALUE)
+            };
+            self.lower_fused_arm(&[ok_name.zip(ok_value)], &ok.arm.expression, place)
+                .0
+        });
+        let arm_place = if destination.is_some() {
+            &PlacePlan::Statement
+        } else {
+            place
+        };
+        let (mut else_body, err_used) = self.lower_fused_arm(
+            &[err_name.map(|n| (n, bound.error.as_str()))],
+            &err.arm.expression,
+            arm_place,
+        );
+
+        if has_nil_guard && err_used {
+            self.require_errors();
+            let error = &bound.error;
+            else_body.statements.insert(
+                0,
+                LoweredStatement::RawGo(format!(
+                    "if {error} == nil {{\n{error} = errors.New(\"unexpected nil\")\n}}\n"
+                )),
+            );
+        }
+
+        let Some(then_body) = then_body else {
+            statements.push(LoweredStatement::If(IfPlan {
+                condition_setup: Vec::new(),
+                condition: bound.err_condition,
+                then_body: else_body,
+                else_arm: ElseArm::None,
+            }));
+            return Some(statements);
+        };
+
+        let plan = if then_body.renders_empty() && !else_body.renders_empty() {
+            IfPlan {
+                condition_setup: Vec::new(),
+                condition: bound.err_condition,
+                then_body: else_body,
+                else_arm: ElseArm::None,
+            }
+        } else {
+            IfPlan {
+                condition_setup: Vec::new(),
+                condition: bound.ok_condition,
+                then_body,
+                else_arm: ElseArm::from_body(else_body, false),
+            }
+        };
+        statements.push(LoweredStatement::If(plan));
         Some(statements)
     }
 
@@ -465,15 +617,14 @@ impl Planner<'_> {
             let mut statements = Vec::new();
             let mut any_referenced = false;
             for (go_name, value) in bound.iter().flatten() {
+                if !used.contains(go_name) {
+                    continue;
+                }
                 statements.push(LoweredStatement::TempBind {
                     name: go_name.clone(),
                     value: value.clone(),
                 });
-                if used.contains(go_name) {
-                    any_referenced = true;
-                } else {
-                    statements.push(LoweredStatement::RawGo(format!("_ = {}\n", go_name)));
-                }
+                any_referenced = true;
             }
             statements.extend(body_block.statements);
             (LoweredBlock { statements }, any_referenced)
@@ -604,12 +755,17 @@ fn arm_tested_elements(planner: &Planner, pattern: &Pattern, arity: usize) -> Op
     }
 }
 
-/// Recognize `[Ok(<...>), Err(<...>)]` (in either order, no guards).
-fn classify_result_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm)> {
+/// `[Ok(..), Err(..)]` in either order, plus the shape `if let` desugars to.
+/// A wildcard fits only the second arm, since the checker rejects any arm
+/// after a catch-all.
+fn classify_result_arms(arms: &[MatchArm]) -> Option<(ResultArm<'_>, ResultArm<'_>)> {
     if arms.len() != 2 || arms.iter().any(|a| a.has_guard()) {
         return None;
     }
-    let kind = |arm: &MatchArm| -> Option<&str> {
+    let kind = |arm: &MatchArm| -> Option<&'static str> {
+        if matches!(arm.pattern, Pattern::WildCard { .. }) {
+            return Some("_");
+        }
         let Pattern::EnumVariant {
             identifier, rest, ..
         } = &arm.pattern
@@ -625,11 +781,19 @@ fn classify_result_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm)> {
             _ => None,
         }
     };
-    let a0 = kind(&arms[0])?;
-    let a1 = kind(&arms[1])?;
-    match (a0, a1) {
-        ("Ok", "Err") => Some((&arms[0], &arms[1])),
-        ("Err", "Ok") => Some((&arms[1], &arms[0])),
+    let explicit = |arm| ResultArm {
+        arm,
+        is_catch_all: false,
+    };
+    let catch_all = |arm| ResultArm {
+        arm,
+        is_catch_all: true,
+    };
+    match (kind(&arms[0])?, kind(&arms[1])?) {
+        ("Ok", "Err") => Some((explicit(&arms[0]), explicit(&arms[1]))),
+        ("Err", "Ok") => Some((explicit(&arms[1]), explicit(&arms[0]))),
+        ("Ok", "_") => Some((explicit(&arms[0]), catch_all(&arms[1]))),
+        ("Err", "_") => Some((catch_all(&arms[1]), explicit(&arms[0]))),
         _ => None,
     }
 }
@@ -729,6 +893,49 @@ fn classify_option_arms(arms: &[MatchArm]) -> Option<OptionArms<'_>> {
         }),
         _ => None,
     }
+}
+
+fn arm_body_is_noop(body: &Expression) -> bool {
+    match body.unwrap_parens() {
+        Expression::Unit { .. } => true,
+        Expression::Block { items, .. } => items.is_empty(),
+        _ => false,
+    }
+}
+
+/// The name an arm returns when its body is nothing but that name.
+fn arm_body_is_identifier(body: &Expression) -> Option<&str> {
+    let body = match body.unwrap_parens() {
+        Expression::Block { items, .. } => match items.as_slice() {
+            [single] => single.unwrap_parens(),
+            _ => return None,
+        },
+        other => other,
+    };
+    match body {
+        Expression::Identifier { value, .. } => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+/// The single payload field of an `Ok(<identifier|_>)` pattern.
+pub(super) fn ok_pattern_field(pattern: &Pattern) -> Option<&Pattern> {
+    let Pattern::EnumVariant {
+        identifier,
+        fields,
+        rest,
+        ..
+    } = pattern
+    else {
+        return None;
+    };
+    if *rest || !matches!(identifier.as_str(), "Ok" | "Result.Ok") {
+        return None;
+    }
+    let [field] = fields.as_slice() else {
+        return None;
+    };
+    matches!(field, Pattern::Identifier { .. } | Pattern::WildCard { .. }).then_some(field)
 }
 
 /// The single payload field of a `Some(<identifier|_>)` pattern.

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -14,7 +14,7 @@ use crate::patterns::binding_emit::{
     tree_assignment_statements, tree_binding_statements, with_tree_bindings,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, SubjectRoot, render_condition};
-use crate::patterns::matching::{field_binding, some_pattern_field};
+use crate::patterns::matching::{field_binding, ok_pattern_field, some_pattern_field};
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
 };
@@ -206,11 +206,17 @@ impl Planner<'_> {
         scrutinee: &Expression,
         fail: RefutableFail,
     ) -> Vec<LoweredStatement> {
-        if let RefutableFail::ElseBlock(else_block) = fail
-            && let Some(statements) =
+        if let RefutableFail::ElseBlock(else_block) = fail {
+            if let Some(statements) =
                 self.lower_fused_option_let_else(ap.pattern, scrutinee, else_block)
-        {
-            return statements;
+            {
+                return statements;
+            }
+            if let Some(statements) =
+                self.lower_fused_result_let_else(ap.pattern, scrutinee, else_block)
+            {
+                return statements;
+            }
         }
 
         let value_ty = scrutinee.get_type();
@@ -242,6 +248,50 @@ impl Planner<'_> {
         }
         statements.extend(body_block.statements);
         statements
+    }
+
+    /// Fuse `let Ok(x) = <Go (T, error) call> else { ... }` into a direct error test.
+    fn lower_fused_result_let_else(
+        &mut self,
+        pattern: &Pattern,
+        scrutinee: &Expression,
+        else_block: &Expression,
+    ) -> Option<Vec<LoweredStatement>> {
+        let field = ok_pattern_field(pattern)?;
+        let fuse = self.result_fuse_plan(scrutinee)?;
+        if !fuse.carries_payload() {
+            return None;
+        }
+
+        let binding = self.go_name_for_binding(field).map(|name| {
+            let escaped = go_name::escape_reserved(&name).into_owned();
+            let go_name = if self.is_declared(&escaped) {
+                self.fresh_var(Some(&name))
+            } else {
+                escaped
+            };
+            self.declare(&go_name);
+            (name, go_name)
+        });
+        let slot = match &binding {
+            Some((_, go_name)) => CommaOkValueSlot::Named(go_name.clone()),
+            None => CommaOkValueSlot::Unused,
+        };
+        let bound = fuse.bind(self, slot);
+        let mut statements = bound.setup;
+
+        // The else block sees the enclosing scope, so it lowers before the binding installs.
+        let fail_body = self.lower_block_as_body(else_block);
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: bound.err_condition,
+            then_body: fail_body,
+            else_arm: ElseArm::None,
+        }));
+        if let Some((name, go_name)) = binding {
+            self.scope.bind(name, go_name);
+        }
+        Some(statements)
     }
 
     /// Fuse `let Some(x) = <comma-ok source> else { ... }` into a direct pair test.

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -126,6 +126,16 @@ impl Planner<'_> {
         };
         if needs_temp {
             let go_identifier = escape_reserved(raw_go_name);
+            if !self.is_declared(&go_identifier)
+                && !expression_contains_binding(value, identifier)
+                && !self.scope.is_active_assign_target(&go_identifier)
+                && !self.scope.has_binding_for_go_name(&go_identifier)
+                && value.get_type().demoted() == binding_ty.demoted()
+                && let Some(statements) = self.lower_fused_result_match_into(value, &go_identifier)
+            {
+                self.scope.bind(identifier, raw_go_name);
+                return statements;
+            }
             if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
                 let fresh = self.fresh_var(Some(identifier));
                 let statements = self.lower_let_temp(&fresh, value, binding_ty);

--- a/tests/e2e_smoke_project/src/go_interop.test.lis
+++ b/tests/e2e_smoke_project/src/go_interop.test.lis
@@ -2,6 +2,8 @@ import "go:bytes"
 import "go:math"
 import httpx "go:net/http"
 import "go:net/http/httptest"
+import "go:net/url"
+import "go:os"
 import "go:path"
 import "go:strconv"
 import "go:strings"
@@ -217,4 +219,101 @@ fn serve(h: httpx.Handler) -> int {
   let req = httptest.NewRequest("GET", "/", bytes.NewBufferString(""))
   h.ServeHTTP(rec, req)
   rec.Code
+}
+
+fn classify_path(path_name: string) -> string {
+  let Ok(info) = os.Stat(path_name) else {
+    return "missing"
+  }
+  if info.IsDir() { "dir" } else { "file" }
+}
+
+fn open_via_match(name: string) -> string {
+  let file = match os.Open(name) {
+    Ok(f) => f,
+    Err(e) => {
+      return "missing"
+    },
+  }
+  defer file.Close()
+  file.Name()
+}
+
+fn parse_scheme(text: string) -> string {
+  let Ok(parsed) = url.Parse(text) else {
+    return "bad"
+  }
+  parsed.Scheme
+}
+
+#[test]
+fn go_if_let_err_inverts_condition() {
+  let mut seen = "none"
+  if let Err(e) = strconv.Atoi("nope") {
+    seen = "err"
+  }
+  assert seen == "err"
+
+  let mut ok_seen = "none"
+  if let Err(e) = strconv.Atoi("42") {
+    ok_seen = "err"
+  }
+  assert ok_seen == "none"
+}
+
+#[test]
+fn go_if_let_err_inverts_nil_interface_guard() {
+  let mut missing = false
+  if let Err(e) = os.Stat("./__lisette_missing__") {
+    missing = true
+  }
+  assert missing
+
+  let mut here = false
+  if let Err(e) = os.Stat(".") {
+    here = true
+  }
+  assert !here
+}
+
+#[test]
+fn go_if_let_err_reads_payload() {
+  let mut message = ""
+  if let Err(e) = strconv.Atoi("nope") {
+    message = e.Error()
+  }
+  assert strings.Contains(message, "nope")
+}
+
+#[test]
+fn go_if_let_ok_binds_payload() {
+  let mut value = 0
+  if let Ok(parsed) = strconv.Atoi("42") {
+    value = parsed
+  }
+  assert value == 42
+
+  let mut missed = -1
+  if let Ok(parsed) = strconv.Atoi("nope") {
+    missed = parsed
+  }
+  assert missed == -1
+}
+
+#[test]
+fn go_let_else_result_pointer_return() {
+  assert parse_scheme("https://example.com/a") == "https"
+  assert parse_scheme("://missing-scheme") == "bad"
+}
+
+#[test]
+fn go_let_else_result_interface_return() {
+  assert classify_path(".") == "dir"
+  assert classify_path("./__lisette_missing__") == "missing"
+}
+
+#[test]
+fn go_let_match_result_binds_call_slot() {
+  assert open_via_match("./__lisette_missing__") == "missing"
+  assert strings.HasSuffix(open_via_match("."), ".")
 }

--- a/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
+++ b/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
@@ -14,8 +14,8 @@ func main() {
 	x := 100
 	fmt.Println(x)
 	x_1 := 200
-	ret_2, ret_3 := parse()
-	if ret_3 == nil {
+	ret_2, err_3 := parse()
+	if err_3 == nil {
 		x := ret_2
 		fmt.Println(x)
 	} else {

--- a/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
+++ b/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
@@ -11,12 +11,12 @@ import (
 
 func main() {
 	parse := strconv.Atoi
-	ret_1, ret_2 := parse("42")
-	if ret_2 == nil {
+	ret_1, err_2 := parse("42")
+	if err_2 == nil {
 		n := ret_1
 		fmt.Printf("parsed: %d\n", n)
 	} else {
-		e := ret_2
+		e := err_2
 		msg := e.Error()
 		fmt.Println(msg)
 	}

--- a/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
+++ b/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
@@ -14,12 +14,12 @@ func parseInt(s string) (int, error) {
 }
 
 func main() {
-	ret_1, ret_2 := parseInt("42")
-	if ret_2 == nil {
+	ret_1, err_2 := parseInt("42")
+	if err_2 == nil {
 		n := ret_1
 		fmt.Println(n)
 	} else {
-		e := ret_2
+		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -19,12 +19,12 @@ func (w Widget) MarshalJSON() ([]uint8, error) {
 
 func main() {
 	w := Widget{id: 7}
-	ret_1, ret_2 := json.Marshal(w)
-	if ret_2 == nil {
+	ret_1, err_2 := json.Marshal(w)
+	if err_2 == nil {
 		b := ret_1
 		fmt.Println(string(b))
 	} else {
-		e := ret_2
+		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -775,6 +775,300 @@ fn test() {
 }
 
 #[test]
+fn fused_go_result_if_let_err() {
+    let input = r#"
+import "go:os"
+
+fn test(name: string) -> string {
+  if let Err(e) = os.Stat(name) {
+    return name
+  }
+  "found"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_if_let_err_reads_payload() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test(name: string) {
+  if let Err(e) = os.Stat(name) {
+    fmt.Println(e)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_if_let_ok() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test(name: string) {
+  if let Ok(info) = os.Stat(name) {
+    fmt.Println(info.Name())
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_if_let_ok_with_else() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test(name: string) {
+  if let Ok(info) = os.Stat(name) {
+    fmt.Println(info.Name())
+  } else {
+    fmt.Println("missing")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_if_let_err_on_pointer_return() {
+    let input = r#"
+import "go:os"
+
+fn test(name: string) -> bool {
+  if let Err(e) = os.Open(name) {
+    return false
+  }
+  true
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_let_else_pointer_return() {
+    let input = r#"
+import "go:net/url"
+
+fn test(raw: string) -> string {
+  let Ok(parsed) = url.Parse(raw) else {
+    return "bad"
+  }
+  parsed.Scheme
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_let_else_interface_return() {
+    let input = r#"
+import "go:os"
+
+fn test(name: string) -> bool {
+  let Ok(info) = os.Stat(name) else {
+    return false
+  }
+  info.IsDir()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_let_else_discarded_payload() {
+    let input = r#"
+import "go:os"
+
+fn test(name: string) -> bool {
+  let Ok(_) = os.Stat(name) else {
+    return false
+  }
+  true
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_let_else_without_nil_guard() {
+    let input = r#"
+import "go:strconv"
+
+fn test(text: string) -> int {
+  let Ok(parsed) = strconv.Atoi(text) else {
+    return -1
+  }
+  parsed
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_let_else_shadows_outer_binding() {
+    let input = r#"
+import "go:strconv"
+import "go:fmt"
+
+fn test(text: string) -> int {
+  let parsed = "outer"
+  fmt.Println(parsed)
+  let Ok(parsed) = strconv.Atoi(text) else {
+    return -1
+  }
+  parsed
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_lisette_result_let_else() {
+    let input = r#"
+import "go:errors"
+
+fn fallible(ok: bool) -> Result<int, error> {
+  if ok { Ok(1) } else { Err(errors.New("nope")) }
+}
+
+fn test() -> int {
+  let Ok(x) = fallible(true) else {
+    return -1
+  }
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_on_result_value_is_not_fused() {
+    let input = r#"
+fn test(res: Result<int, string>) -> int {
+  let Ok(x) = res else {
+    return -1
+  }
+  x
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_go_result_match_both_arms_empty() {
+    let input = r#"
+import "go:strconv"
+
+fn test(text: string) {
+  match strconv.Atoi(text) {
+    Ok(_) => (),
+    Err(_) => (),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_bare_error_match_binds_unit_payload() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test() {
+  match os.Remove("f") {
+    Ok(x) => { fmt.Println(x) },
+    Err(e) => { fmt.Println(e) },
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_fused_go_result_match_binds_call_slot() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test(name: string) {
+  let file = match os.Open(name) {
+    Ok(f) => f,
+    Err(e) => {
+      fmt.Println("cannot open")
+      return
+    },
+  }
+  fmt.Println(file.Name())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_fused_go_result_match_binds_interface_call_slot() {
+    let input = r#"
+import "go:net"
+import "go:fmt"
+
+fn test(addr: string) {
+  let conn = match net.Dial("tcp", addr) {
+    Ok(c) => c,
+    Err(e) => {
+      fmt.Println("cannot dial")
+      return
+    },
+  }
+  let _ = conn
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_match_with_non_diverging_err_arm_keeps_declaration() {
+    let input = r#"
+import "go:strconv"
+
+fn test(text: string) -> int {
+  let parsed = match strconv.Atoi(text) {
+    Ok(n) => n,
+    Err(e) => -1,
+  }
+  parsed
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_match_with_computed_ok_arm_keeps_declaration() {
+    let input = r#"
+import "go:os"
+import "go:fmt"
+
+fn test(name: string) {
+  let label = match os.Open(name) {
+    Ok(f) => f.Name(),
+    Err(e) => {
+      fmt.Println("cannot open")
+      return
+    },
+  }
+  fmt.Println(label)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn while_let_option_function_call() {
     let input = r#"
 import "go:fmt"

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -35,8 +35,8 @@ func (l Loader) Load(_ string) (int, error) {
 }
 
 func run(s svc.Alias) int {
-	ret_1, ret_2 := s.Load("k")
-	if ret_2 == nil {
+	ret_1, err_2 := s.Load("k")
+	if err_2 == nil {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
+++ b/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
@@ -48,17 +48,17 @@ func bail(flag bool) (int, error) {
 }
 
 func test() {
-	_, ret_1 := bail(true)
-	if ret_1 == nil {
+	_, err_1 := bail(true)
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		e := ret_1
+		e := err_1
 		if e.Error() != "a failed" {
 			panic("wrong literal error")
 		}
 	}
-	ret_2, ret_3 := bail(false)
-	if ret_3 == nil {
+	ret_2, err_3 := bail(false)
+	if err_3 == nil {
 		v := ret_2
 		if v != 1 {
 			panic("wrong ok value")

--- a/tests/spec/emit/snapshots/fused_bare_error_match_binds_unit_payload.snap
+++ b/tests/spec/emit/snapshots/fused_bare_error_match_binds_unit_payload.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test() {
+    match os.Remove("f") {
+      Ok(x) => { fmt.Println(x) },
+      Err(e) => { fmt.Println(e) },
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func test() {
+	err_1 := os.Remove("f")
+	if err_1 == nil {
+		x := struct{}{}
+		fmt.Println(x)
+	} else {
+		e := err_1
+		fmt.Println(e)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
@@ -21,14 +21,14 @@ import (
 )
 
 func test() {
-	ret_1, ret_2 := os.Create("f")
-	if ret_2 == nil && ret_1 != nil {
+	ret_1, err_2 := os.Create("f")
+	if err_2 == nil && ret_1 != nil {
 		fmt.Println("made")
 	} else {
-		if ret_2 == nil {
-			ret_2 = errors.New("unexpected nil")
+		if err_2 == nil {
+			err_2 = errors.New("unexpected nil")
 		}
-		e := ret_2
+		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
@@ -25,16 +25,12 @@ import (
 )
 
 func test() {
-	var file *os.File
-	ret_1, ret_2 := os.Create("f")
-	if ret_2 == nil && ret_1 != nil {
-		f := ret_1
-		file = f
-	} else {
-		if ret_2 == nil {
-			ret_2 = errors.New("unexpected nil")
+	file, err_1 := os.Create("f")
+	if err_1 != nil || file == nil {
+		if err_1 == nil {
+			err_1 = errors.New("unexpected nil")
 		}
-		e := ret_2
+		e := err_1
 		fmt.Println(e)
 		return
 	}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  
+  fn test(name: string) -> string {
+    if let Err(e) = os.Stat(name) {
+      return name
+    }
+    "found"
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func test(name string) string {
+	ret_1, err_2 := os.Stat(name)
+	if err_2 != nil || lisette.IsNilInterface(ret_1) {
+		return name
+	}
+	return "found"
+}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  
+  fn test(name: string) -> bool {
+    if let Err(e) = os.Open(name) {
+      return false
+    }
+    true
+  }
+---
+package main
+
+import "os"
+
+func test(name string) bool {
+	ret_1, err_2 := os.Open(name)
+	if err_2 != nil || ret_1 == nil {
+		return false
+	}
+	return true
+}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
@@ -2,13 +2,12 @@
 source: tests/spec/emit/result_option_patterns.rs
 description: |
   
-  import "go:net"
+  import "go:os"
   import "go:fmt"
   
-  fn test() {
-    match net.Dial("tcp", "addr") {
-      Ok(conn) => { let _ = conn },
-      Err(e) => fmt.Println(e),
+  fn test(name: string) {
+    if let Err(e) = os.Stat(name) {
+      fmt.Println(e)
     }
   }
 ---
@@ -18,15 +17,12 @@ import (
 	"errors"
 	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
-	"net"
+	"os"
 )
 
-func test() {
-	ret_1, err_2 := net.Dial("tcp", "addr")
-	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
-		conn := ret_1
-		_ = conn
-	} else {
+func test(name string) {
+	ret_1, err_2 := os.Stat(name)
+	if err_2 != nil || lisette.IsNilInterface(ret_1) {
 		if err_2 == nil {
 			err_2 = errors.New("unexpected nil")
 		}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test(name: string) {
+    if let Ok(info) = os.Stat(name) {
+      fmt.Println(info.Name())
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func test(name string) {
+	ret_1, err_2 := os.Stat(name)
+	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
+		info := ret_1
+		fmt.Println(info.Name())
+	}
+}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test(name: string) {
+    if let Ok(info) = os.Stat(name) {
+      fmt.Println(info.Name())
+    } else {
+      fmt.Println("missing")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func test(name string) {
+	ret_1, err_2 := os.Stat(name)
+	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
+		info := ret_1
+		fmt.Println(info.Name())
+	} else {
+		fmt.Println("missing")
+	}
+}

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  
+  fn test(name: string) -> bool {
+    let Ok(_) = os.Stat(name) else {
+      return false
+    }
+    true
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func test(name string) bool {
+	ret_1, err_2 := os.Stat(name)
+	if err_2 != nil || lisette.IsNilInterface(ret_1) {
+		return false
+	}
+	return true
+}

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_interface_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_interface_return.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  
+  fn test(name: string) -> bool {
+    let Ok(info) = os.Stat(name) else {
+      return false
+    }
+    info.IsDir()
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func test(name string) bool {
+	info, err_1 := os.Stat(name)
+	if err_1 != nil || lisette.IsNilInterface(info) {
+		return false
+	}
+	return info.IsDir()
+}

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_pointer_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_pointer_return.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:net/url"
+  
+  fn test(raw: string) -> string {
+    let Ok(parsed) = url.Parse(raw) else {
+      return "bad"
+    }
+    parsed.Scheme
+  }
+---
+package main
+
+import "net/url"
+
+func test(raw string) string {
+	parsed, err_1 := url.Parse(raw)
+	if err_1 != nil || parsed == nil {
+		return "bad"
+	}
+	return parsed.Scheme
+}

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_shadows_outer_binding.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_shadows_outer_binding.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  import "go:fmt"
+  
+  fn test(text: string) -> int {
+    let parsed = "outer"
+    fmt.Println(parsed)
+    let Ok(parsed) = strconv.Atoi(text) else {
+      return -1
+    }
+    parsed
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func test(text string) int {
+	parsed := "outer"
+	fmt.Println(parsed)
+	parsed_1, err_2 := strconv.Atoi(text)
+	if err_2 != nil {
+		return -1
+	}
+	return parsed_1
+}

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_without_nil_guard.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_without_nil_guard.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn test(text: string) -> int {
+    let Ok(parsed) = strconv.Atoi(text) else {
+      return -1
+    }
+    parsed
+  }
+---
+package main
+
+import "strconv"
+
+func test(text string) int {
+	parsed, err_1 := strconv.Atoi(text)
+	if err_1 != nil {
+		return -1
+	}
+	return parsed
+}

--- a/tests/spec/emit/snapshots/fused_go_result_match_both_arms_empty.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_match_both_arms_empty.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn test(text: string) {
+    match strconv.Atoi(text) {
+      Ok(_) => (),
+      Err(_) => (),
+    }
+  }
+---
+package main
+
+import "strconv"
+
+func test(text string) {
+	strconv.Atoi(text)
+}

--- a/tests/spec/emit/snapshots/fused_lisette_result_let_else.snap
+++ b/tests/spec/emit/snapshots/fused_lisette_result_let_else.snap
@@ -8,11 +8,11 @@ description: |
     if ok { Ok(1) } else { Err(errors.New("nope")) }
   }
   
-  fn test() {
-    match fallible(true) {
-      Ok(_) => {},
-      Err(e) => { let _ = e },
+  fn test() -> int {
+    let Ok(x) = fallible(true) else {
+      return -1
     }
+    x
   }
 ---
 package main
@@ -26,10 +26,10 @@ func fallible(ok bool) (int, error) {
 	return 0, errors.New("nope")
 }
 
-func test() {
-	_, err_1 := fallible(true)
+func test() int {
+	x, err_1 := fallible(true)
 	if err_1 != nil {
-		e := err_1
-		_ = e
+		return -1
 	}
+	return x
 }

--- a/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
@@ -27,12 +27,9 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	ret_1, ret_2 := fallible(true)
-	if ret_2 == nil {
+	ret_1, err_2 := fallible(true)
+	if err_2 == nil {
 		x := ret_1
 		_ = x
-	} else {
-		e := ret_2
-		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
@@ -27,12 +27,9 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	ret_1, ret_2 := fallible(true)
-	if ret_2 == nil {
-		x := ret_1
-		_ = x
-	} else {
-		e := ret_2
+	_, err_1 := fallible(true)
+	if err_1 != nil {
+		e := err_1
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
+++ b/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
@@ -25,8 +25,8 @@ import (
 )
 
 func parseWith(f func(string) (int, error), s string) int {
-	ret_1, ret_2 := f(s)
-	if ret_2 == nil {
+	ret_1, err_2 := f(s)
+	if err_2 == nil {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
@@ -42,8 +42,8 @@ func main() {
 		}
 		return wrapped_4, ret_3
 	}
-	ret_7, ret_8 := f()
-	if ret_8 == nil {
+	ret_7, err_8 := f()
+	if err_8 == nil {
 		xs := ret_7
 		for _, x := range xs {
 			if x.Tag == lisette.OptionSome {
@@ -53,7 +53,7 @@ func main() {
 			}
 		}
 	} else {
-		e := ret_8
+		e := err_8
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -16,8 +16,8 @@ package main
 import "example.com/legacy"
 
 func main() {
-	ret_1, ret_2 := legacy.Close()
-	if ret_2 == nil {
+	ret_1, err_2 := legacy.Close()
+	if err_2 == nil {
 		stored := ret_1
 		_ = stored
 	}

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -48,8 +48,8 @@ func sumParsed(a, b string) (int, error) {
 }
 
 func main() {
-	ret_1, ret_2 := sumParsed("3", "4")
-	if ret_2 == nil {
+	ret_1, err_2 := sumParsed("3", "4")
+	if err_2 == nil {
 		n := ret_1
 		_ = n
 	}

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -60,8 +60,8 @@ func openAndCheck(path, n string) (int, error) {
 }
 
 func main() {
-	ret_1, ret_2 := openAndCheck("/tmp/x", "7")
-	if ret_2 == nil {
+	ret_1, err_2 := openAndCheck("/tmp/x", "7")
+	if err_2 == nil {
 		v := ret_1
 		_ = v
 	}

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -58,8 +58,8 @@ func run() (string, error) {
 
 func test() {
 	var text_1 string
-	ret_2, ret_3 := run()
-	if ret_3 == nil {
+	ret_2, err_3 := run()
+	if err_3 == nil {
 		text := ret_2
 		text_1 = text
 	} else {

--- a/tests/spec/emit/snapshots/let_else_on_result_value_is_not_fused.snap
+++ b/tests/spec/emit/snapshots/let_else_on_result_value_is_not_fused.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn test(res: Result<int, string>) -> int {
+    let Ok(x) = res else {
+      return -1
+    }
+    x
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(res lisette.Result[int, string]) int {
+	if res.Tag != lisette.ResultOk {
+		return -1
+	}
+	x := res.OkVal
+	return x
+}

--- a/tests/spec/emit/snapshots/let_fused_go_result_match_binds_call_slot.snap
+++ b/tests/spec/emit/snapshots/let_fused_go_result_match_binds_call_slot.snap
@@ -5,15 +5,15 @@ description: |
   import "go:os"
   import "go:fmt"
   
-  fn test() {
-    let file = match os.Create("f") {
+  fn test(name: string) {
+    let file = match os.Open(name) {
       Ok(f) => f,
       Err(e) => {
-        fmt.Println("error")
+        fmt.Println("cannot open")
         return
       },
     }
-    defer file.Close()
+    fmt.Println(file.Name())
   }
 ---
 package main
@@ -23,11 +23,11 @@ import (
 	"os"
 )
 
-func test() {
-	file, err_1 := os.Create("f")
+func test(name string) {
+	file, err_1 := os.Open(name)
 	if err_1 != nil || file == nil {
-		fmt.Println("error")
+		fmt.Println("cannot open")
 		return
 	}
-	defer file.Close()
+	fmt.Println(file.Name())
 }

--- a/tests/spec/emit/snapshots/let_fused_go_result_match_binds_interface_call_slot.snap
+++ b/tests/spec/emit/snapshots/let_fused_go_result_match_binds_interface_call_slot.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:net"
+  import "go:fmt"
+  
+  fn test(addr: string) {
+    let conn = match net.Dial("tcp", addr) {
+      Ok(c) => c,
+      Err(e) => {
+        fmt.Println("cannot dial")
+        return
+      },
+    }
+    let _ = conn
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"net"
+)
+
+func test(addr string) {
+	conn, err_1 := net.Dial("tcp", addr)
+	if err_1 != nil || lisette.IsNilInterface(conn) {
+		fmt.Println("cannot dial")
+		return
+	}
+	_ = conn
+}

--- a/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:fmt"
+  
+  fn test(name: string) {
+    let label = match os.Open(name) {
+      Ok(f) => f.Name(),
+      Err(e) => {
+        fmt.Println("cannot open")
+        return
+      },
+    }
+    fmt.Println(label)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func test(name string) {
+	var label string
+	ret_1, err_2 := os.Open(name)
+	if err_2 == nil && ret_1 != nil {
+		f := ret_1
+		label = f.Name()
+	} else {
+		fmt.Println("cannot open")
+		return
+	}
+	fmt.Println(label)
+}

--- a/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn test(text: string) -> int {
+    let parsed = match strconv.Atoi(text) {
+      Ok(n) => n,
+      Err(e) => -1,
+    }
+    parsed
+  }
+---
+package main
+
+import "strconv"
+
+func test(text string) int {
+	var parsed int
+	ret_1, err_2 := strconv.Atoi(text)
+	if err_2 == nil {
+		n := ret_1
+		parsed = n
+	} else {
+		parsed = -1
+	}
+	return parsed
+}

--- a/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
@@ -69,17 +69,17 @@ func load(name string) (string, error) {
 }
 
 func test() {
-	_, ret_1 := load("")
-	if ret_1 == nil {
+	_, err_1 := load("")
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		e := ret_1
+		e := err_1
 		if e.Error() != "name: required" {
 			panic("wrong widened error")
 		}
 	}
-	ret_2, ret_3 := load("ada")
-	if ret_3 == nil {
+	ret_2, err_3 := load("ada")
+	if err_3 == nil {
 		v := ret_2
 		if v != "ada" {
 			panic("wrong ok value")

--- a/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
@@ -67,11 +67,11 @@ func widen() (int, Failing[lisette.Result[int, error]]) {
 }
 
 func main() {
-	_, ret_1 := widen()
-	if ret_1 == nil {
+	_, err_1 := widen()
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		f := ret_1
+		f := err_1
 		subject_2 := f.get()
 		if subject_2.Tag == lisette.ResultOk {
 			if subject_2.OkVal != 1 {

--- a/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
@@ -52,11 +52,11 @@ func load() (int, error) {
 }
 
 func test() {
-	_, ret_1 := load()
-	if ret_1 == nil {
+	_, err_1 := load()
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		e := ret_1
+		e := err_1
 		if e.Error() != "cannot open a.txt" {
 			panic("wrong ref error")
 		}

--- a/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
@@ -78,17 +78,17 @@ func handler(ok bool) (int, AppError) {
 }
 
 func test() {
-	_, ret_1 := handler(false)
-	if ret_1 == nil {
+	_, err_1 := handler(false)
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		e := ret_1
+		e := err_1
 		if e.Status() != 500 || e.Error() != "db down" {
 			panic("wrong app error")
 		}
 	}
-	ret_2, ret_3 := handler(true)
-	if ret_3 == nil {
+	ret_2, err_3 := handler(true)
+	if err_3 == nil {
 		n := ret_2
 		if n != 3 {
 			panic("wrong ok length")

--- a/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
@@ -36,11 +36,11 @@ func bail() (int, error) {
 }
 
 func test() {
-	_, ret_1 := bail()
-	if ret_1 == nil {
+	_, err_1 := bail()
+	if err_1 == nil {
 		panic("expected error")
 	} else {
-		e := ret_1
+		e := err_1
 		if e.Error() != "a failed" {
 			panic("wrong returned error")
 		}

--- a/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
@@ -44,8 +44,8 @@ func bail() (int, Failing[lisette.Result[int, error]]) {
 }
 
 func main() {
-	_, ret_1 := bail()
-	if ret_1 == nil {
+	_, err_1 := bail()
+	if err_1 == nil {
 		panic("expected error")
 	}
 }


### PR DESCRIPTION
Fix #1284
