### PR TITLE
fix: carry write permission through interface satisfaction

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2834,6 +2834,44 @@ pub fn pointer_receiver_interface_mismatch(
         ))
 }
 
+pub fn interface_needs_writable_receiver(
+    interface_name: &str,
+    type_name: &str,
+    methods: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    let methods_str = methods
+        .iter()
+        .map(|m| format!("`{}.{}`", type_name, m))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let writes = if methods.len() == 1 {
+        format!(
+            "{} writes through `self: mut Ref<{}>`",
+            methods_str, type_name
+        )
+    } else {
+        format!(
+            "{} write through `self: mut Ref<{}>`",
+            methods_str, type_name
+        )
+    };
+    LisetteDiagnostic::error("Missing write permission")
+        .with_infer_code("needs_writable")
+        .with_span_label(
+            &span,
+            format!(
+                "expected `mut Ref<{}>`, found `Ref<{}>`",
+                type_name, type_name
+            ),
+        )
+        .with_help(format!(
+            "{}, so `{}` needs a writable reference. Make the value writable where it is created, \
+             or take the reference from a `let mut` binding",
+            writes, interface_name
+        ))
+}
+
 pub fn unknown_in_bound_position(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Invalid `Unknown` bound")
         .with_infer_code("unknown_in_bound_position")

--- a/crates/semantics/src/checker/infer/expressions/call_effects.rs
+++ b/crates/semantics/src/checker/infer/expressions/call_effects.rs
@@ -250,18 +250,33 @@ impl InferCtx<'_> {
             .map(|arg| super::aliasing::place_key(arg.unwrap_parens()))
             .collect();
 
+        let parameter_at = |i: usize| {
+            parameters.get(i).or(if i >= parameters.len() {
+                variadic
+            } else {
+                None
+            })
+        };
+
         let writable_positions: Vec<bool> = (0..args.len())
             .map(|i| {
-                parameters
-                    .get(i)
-                    .or(if i >= parameters.len() {
-                        variadic
-                    } else {
-                        None
-                    })
-                    .is_some_and(|param| {
-                        self.store
-                            .parameter_grants_write(&param.ty.resolve_in(&self.env))
+                parameter_at(i).is_some_and(|param| {
+                    self.store
+                        .parameter_grants_write(&param.ty.resolve_in(&self.env))
+                })
+            })
+            .collect();
+
+        let mutating_positions: Vec<bool> = (0..args.len())
+            .map(|i| {
+                writable_positions[i]
+                    || parameter_at(i).is_some_and(|param| {
+                        let param_ty = param.ty.resolve_in(&self.env);
+                        self.store.is_interface(&param_ty)
+                            && self.interface_writes_through_receiver(
+                                &args[i].get_type().resolve_in(&self.env),
+                                &param_ty,
+                            )
                     })
             })
             .collect();
@@ -271,7 +286,7 @@ impl InferCtx<'_> {
             let Some(place) = places[i].as_deref() else {
                 continue;
             };
-            if writable_position
+            if mutating_positions[i]
                 && let Some(binding_id) = arg
                     .get_var_name()
                     .and_then(|name| self.scopes.lookup_binding_id(&name))

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -249,15 +249,61 @@ impl InferCtx<'_> {
         span: &Span,
     ) -> Result<(), Vec<InterfaceViolation>> {
         let store = self.store;
-        if store.peel_alias(ty).is_ref() {
+        let peeled = store.peel_alias(ty);
+        let value_is_ref = peeled.is_ref();
+        if value_is_ref && peeled.is_writable() {
             return Ok(());
         }
         let interface_ty = store.deep_resolve_alias(interface_ty);
         let Some(interface_qualified_id) = interface_ty.get_qualified_id() else {
             return Ok(());
         };
+        let ptr_methods = self
+            .reference_receiver_conformance(ty, &interface_ty)
+            .into_iter()
+            .filter(|(_, writes_through_receiver)| !value_is_ref || *writes_through_receiver)
+            .map(|(impl_name, _)| impl_name)
+            .collect::<Vec<_>>();
+
+        if ptr_methods.is_empty() {
+            return Ok(());
+        }
+
+        let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
+        let diagnostic = if value_is_ref {
+            let pointee = store.deep_resolve_alias(&ty.strip_refs().resolve_in(&self.env));
+            let pointee_name = pointee
+                .get_name()
+                .map_or_else(|| pointee.to_string(), str::to_owned);
+            diagnostics::infer::interface_needs_writable_receiver(
+                unqualified_name(interface_qualified_id),
+                &pointee_name,
+                &ptr_methods,
+                *span,
+            )
+        } else {
+            diagnostics::infer::pointer_receiver_interface_mismatch(
+                unqualified_name(interface_qualified_id),
+                &type_name,
+                &ptr_methods,
+                *span,
+            )
+        };
+        self.sink.push(diagnostic);
+        Err(vec![])
+    }
+
+    /// The conformance methods of `interface_ty` on `ty` that take a reference
+    /// receiver, each paired with whether that receiver is writable. Methods in
+    /// the value method set are absent, because a value satisfies those.
+    fn reference_receiver_conformance(
+        &mut self,
+        ty: &Type,
+        interface_ty: &Type,
+    ) -> Vec<(String, bool)> {
+        let store = self.store;
         let methods = self.get_all_methods(store, ty);
-        let ptr_methods = interface_requirements(&interface_ty, |id| store.get_definition(id))
+        interface_requirements(interface_ty, |id| store.get_definition(id))
             .into_iter()
             .filter_map(|requirement| {
                 let interface_is_public = store
@@ -274,26 +320,37 @@ impl InferCtx<'_> {
                     Type::Forall { body, .. } => body.as_ref(),
                     other => other,
                 };
-                let has_pointer_receiver = matches!(func, Type::Function(f)
-                    if f.params.first().is_some_and(|param| param.ty.is_ref()));
-                (has_pointer_receiver && !self.method_in_value_method_set(ty, impl_name))
-                    .then(|| impl_name.to_string())
+                let Type::Function(f) = func else {
+                    return None;
+                };
+                let receiver = &f.params.first()?.ty;
+                if !receiver.is_ref() || self.method_in_value_method_set(ty, impl_name) {
+                    return None;
+                }
+                Some((impl_name.to_string(), receiver.is_writable()))
             })
-            .collect::<Vec<_>>();
+            .collect()
+    }
 
-        if ptr_methods.is_empty() {
-            return Ok(());
+    /// A reference passed as `interface_ty` reaches a method that writes through
+    /// the receiver, so the call can mutate the referent. The interface hides
+    /// the receiver qualifier, so a caller cannot read this off the signature.
+    pub(super) fn interface_writes_through_receiver(
+        &mut self,
+        ty: &Type,
+        interface_ty: &Type,
+    ) -> bool {
+        let store = self.store;
+        if !store.peel_alias(ty).is_ref() {
+            return false;
         }
-
-        let type_name = ty.get_name().map_or_else(|| ty.to_string(), str::to_owned);
-        self.sink
-            .push(diagnostics::infer::pointer_receiver_interface_mismatch(
-                unqualified_name(interface_qualified_id),
-                &type_name,
-                &ptr_methods,
-                *span,
-            ));
-        Err(vec![])
+        let interface_ty = store.deep_resolve_alias(interface_ty);
+        if interface_ty.get_qualified_id().is_none() {
+            return false;
+        }
+        self.reference_receiver_conformance(ty, &interface_ty)
+            .into_iter()
+            .any(|(_, writes_through_receiver)| writes_through_receiver)
     }
 
     fn conformance_candidate(&self, receiver: &Type, method: &str) -> ConformanceCandidate {

--- a/tests/e2e_smoke_project/src/go_interop.test.lis
+++ b/tests/e2e_smoke_project/src/go_interop.test.lis
@@ -215,7 +215,7 @@ fn get_duration_multiplier() -> int {
 }
 
 fn serve(h: httpx.Handler) -> int {
-  let rec = httptest.NewRecorder()
+  let mut rec = httptest.NewRecorder()
   let req = httptest.NewRequest("GET", "/", bytes.NewBufferString(""))
   h.ServeHTTP(rec, req)
   rec.Code

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -123,6 +123,44 @@ fn main() {
 }
 
 #[test]
+fn unnecessary_mut_silent_on_writing_interface_argument() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        r#"
+import "go:io"
+import "go:strings"
+import "go:fmt"
+
+fn main() {
+    let mut reader = strings.NewReader("hello")
+    match io.ReadAll(reader) {
+        Partial.Ok(_) => fmt.Print("ok"),
+        Partial.Both(_, _) => fmt.Print("both"),
+        Partial.Err(_) => fmt.Print("err"),
+    }
+}
+"#,
+    );
+    let analysis = compile_check(fs);
+    assert!(
+        analysis
+            .diagnostics()
+            .iter()
+            .all(|d| !d.code_str().is_some_and(|c| c.starts_with("infer."))),
+        "a writable reference satisfies `io.Reader`, the program must check clean"
+    );
+    assert!(
+        analysis
+            .diagnostics()
+            .iter()
+            .all(|d| d.code_str() != Some("lint.unnecessary_mut")),
+        "`Reader.Read` writes through the receiver, so the interface argument uses the `mut`"
+    );
+}
+
+#[test]
 fn unnecessary_mut_silent_on_for_mut_element_write() {
     let mut fs = MockFileSystem::new();
     fs.add_file(
@@ -647,7 +685,7 @@ import "go:strings"
 import "go:fmt"
 
 fn main() {
-  let reader = strings.NewReader("hello")
+  let mut reader = strings.NewReader("hello")
   match io.ReadAll(reader) {
     Partial.Ok(_) => fmt.Print("ok"),
     Partial.Both(_, _) => fmt.Print("both"),
@@ -4015,7 +4053,7 @@ import "go:strings"
 import "go:fmt"
 
 fn main() {
-  let body = strings.NewReader("hello")
+  let mut body = strings.NewReader("hello")
   let req = http.NewRequest("POST", "https://example.com", Some(body))
   let unwrap_2 = 7
   let _ = unwrap_2

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1241,7 +1241,7 @@ import "go:strings"
 import "go:fmt"
 
 fn main() {
-  let body = strings.NewReader("hello")
+  let mut body = strings.NewReader("hello")
   let req = http.NewRequest("POST", "https://example.com", Some(body))
   fmt.Println(req)
 }

--- a/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
+++ b/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
@@ -7,7 +7,7 @@ description: |
   import "go:fmt"
   
   fn main() {
-    let body = strings.NewReader("hello")
+    let mut body = strings.NewReader("hello")
     let req = http.NewRequest("POST", "https://example.com", Some(body))
     fmt.Println(req)
   }

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -1082,6 +1082,64 @@ impl mut Batch {
 }
 
 #[test]
+fn read_only_reference_does_not_satisfy_writing_interface() {
+    infer(
+        r#"interface Sink {
+  fn push(value: int)
+}
+
+struct Bag {
+  items: mut Slice<int>,
+}
+
+impl Bag {
+  fn push(self: mut Ref<Bag>, value: int) {
+    self.items[0] = value
+  }
+}
+
+fn feed(s: Sink) {
+  s.push(1)
+}
+
+fn main() {
+  let bag = Bag { items: [0] }
+  feed(&bag)
+}"#,
+    )
+    .assert_infer_code("needs_writable");
+}
+
+#[test]
+fn writable_reference_satisfies_writing_interface() {
+    infer(
+        r#"interface Sink {
+  fn push(value: int)
+}
+
+struct Bag {
+  items: mut Slice<int>,
+}
+
+impl Bag {
+  fn push(self: mut Ref<Bag>, value: int) {
+    self.items[0] = value
+  }
+}
+
+fn feed(s: Sink) {
+  s.push(1)
+}
+
+fn main() {
+  let mut bag = Bag { items: [0] }
+  feed(&bag)
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn mut_on_type_parameter_refused() {
     infer(
         r#"fn hold<T>(x: mut T) {


### PR DESCRIPTION
Mutation of a read-only value was being allowed when passing it to a function as an interface value. The interface now carries the write permission, so a read-only ref satisfies an interface only when no method of that interface writes through the receiver.

```rs
interface Sink {
  fn push(value: int)
}

struct Bag { items: mut Slice<int> }

impl Bag {
  fn push(self: mut Ref<Bag>, value: int) { self.items[0] = value }
}

fn feed(s: Sink) { s.push(1) }

let bag = Bag { items: [0] }
feed(&bag) // error: expected `mut Ref<Bag>`, found `Ref<Bag>`

let mut bag = Bag { items: [0] }
feed(&bag) // ok
```