### PR TITLE
refactor: pass build target through build path

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -42,7 +42,7 @@ pub fn emit(path: Option<String>, sourcemap: bool, output: Option<String>) -> i3
             if reject_project_output(output.as_deref(), "writes Go to `target/`").is_err() {
                 return 1;
             }
-            with_locked_project(&root, |prep| {
+            with_locked_project(&root, stdlib::Target::host(), |prep| {
                 match build_locked(prep, BuildPurpose::Emit { sourcemap }) {
                     Ok(_) => 0,
                     Err(code) => code,
@@ -60,6 +60,7 @@ pub fn build(
 ) -> i32 {
     let target = path.unwrap_or_else(|| ".".to_string());
     let target_path = Path::new(&target);
+    let build_target = stdlib::Target::host();
 
     let root = match resolve_target(target_path, "Failed to build") {
         Err(code) => return code,
@@ -70,6 +71,7 @@ pub fn build(
                 &go_flags,
                 output.as_deref(),
                 inside_project,
+                build_target,
             );
         }
         Ok(BuildTarget::Project(root)) => root,
@@ -84,7 +86,7 @@ pub fn build(
         return 1;
     }
 
-    with_locked_project(&root, |prep| {
+    with_locked_project(&root, build_target, |prep| {
         if prep.kind == ProjectKind::Library {
             if go_flags.iter().any(|f| go_cli::is_go_output_flag(f)) {
                 cli_error!(
@@ -101,14 +103,12 @@ pub fn build(
             return code;
         }
 
-        let target = stdlib::Target::host();
-
         if prep.kind == ProjectKind::Library {
-            return build_library(prep, &go_flags, target);
+            return build_library(prep, &go_flags, build_target);
         }
 
         let output_path =
-            match link_project_binary(prep, &go_flags, target, "Failed to build project") {
+            match link_project_binary(prep, &go_flags, build_target, "Failed to build project") {
                 Ok(p) => p,
                 Err(code) => return code,
             };
@@ -211,8 +211,12 @@ pub(super) fn project_root_for(target: &Path) -> PathBuf {
     }
 }
 
-pub(super) fn with_locked_project(path: &Path, f: impl FnOnce(&LockedProject) -> i32) -> i32 {
-    let project = match LockedProject::acquire(path) {
+pub(super) fn with_locked_project(
+    path: &Path,
+    target: stdlib::Target,
+    f: impl FnOnce(&LockedProject) -> i32,
+) -> i32 {
+    let project = match LockedProject::acquire(path, target) {
         Ok(project) => project,
         Err(code) => return code,
     };
@@ -250,23 +254,24 @@ pub(super) fn link_project_binary(
     Ok(output_path)
 }
 
-fn prepare_project_build(project_path: &Path) -> Result<BuildPrep, i32> {
+fn prepare_project_build(project_path: &Path, target: stdlib::Target) -> Result<BuildPrep, i32> {
     let layout = match validate_project(project_path) {
         Some(layout) => layout,
         None => return Err(1),
     };
 
-    let (manifest, locator) = match deps::TypedefLocator::from_project_with_manifest(project_path) {
-        Ok(pair) => pair,
-        Err(msg) => {
-            cli_error!(
-                "Failed to compile Lisette project to Go",
-                msg,
-                "Run `lis new <name>` to create a project, or fix `lisette.toml`"
-            );
-            return Err(1);
-        }
-    };
+    let (manifest, locator) =
+        match deps::TypedefLocator::from_project_with_manifest(project_path, target) {
+            Ok(pair) => pair,
+            Err(msg) => {
+                cli_error!(
+                    "Failed to compile Lisette project to Go",
+                    msg,
+                    "Run `lis new <name>` to create a project, or fix `lisette.toml`"
+                );
+                return Err(1);
+            }
+        };
 
     let target_dir = project_path.join("target");
     if let Err(e) = fs::create_dir_all(&target_dir) {
@@ -305,8 +310,8 @@ pub(super) struct LockedProject {
 }
 
 impl LockedProject {
-    pub(super) fn acquire(project_path: &Path) -> Result<Self, i32> {
-        let prep = prepare_project_build(project_path)?;
+    pub(super) fn acquire(project_path: &Path, target: stdlib::Target) -> Result<Self, i32> {
+        let prep = prepare_project_build(project_path, target)?;
         let target_lock = acquire_target_lock(&prep.target_dir)?;
         Ok(Self {
             prep,

--- a/crates/cli/src/handlers/check.rs
+++ b/crates/cli/src/handlers/check.rs
@@ -143,13 +143,14 @@ fn check_project(project_path: &Path, options: &CheckOptions) -> i32 {
         None => return 1,
     };
 
-    let (manifest, locator) = match TypedefLocator::from_project_with_manifest(project_path) {
-        Ok(pair) => pair,
-        Err(msg) => {
-            cli_error!("Failed to check project", msg, "Fix `lisette.toml`");
-            return 1;
-        }
-    };
+    let (manifest, locator) =
+        match TypedefLocator::from_project_with_manifest(project_path, stdlib::Target::host()) {
+            Ok(pair) => pair,
+            Err(msg) => {
+                cli_error!("Failed to check project", msg, "Fix `lisette.toml`");
+                return 1;
+            }
+        };
 
     let target_dir = project_path.join("target");
     if let Err(e) = fs::create_dir_all(&target_dir) {

--- a/crates/cli/src/handlers/run.rs
+++ b/crates/cli/src/handlers/run.rs
@@ -85,7 +85,8 @@ fn run_project(
     sourcemap: bool,
     go_flags: &[String],
 ) -> i32 {
-    let project = match super::build::LockedProject::acquire(project_path) {
+    let target = stdlib::Target::host();
+    let project = match super::build::LockedProject::acquire(project_path, target) {
         Ok(project) => project,
         Err(code) => return code,
     };
@@ -103,7 +104,6 @@ fn run_project(
     }
 
     let heading = "Failed to run project";
-    let target = stdlib::Target::host();
 
     if let Err(code) =
         super::build::build_locked(&project, super::build::BuildPurpose::Run { sourcemap })
@@ -127,7 +127,13 @@ fn run_script(
     inside_project: bool,
 ) -> i32 {
     let heading = "Failed to run script";
-    let build = match super::script::prepare(Path::new(file), sourcemap, inside_project, heading) {
+    let build = match super::script::prepare(
+        Path::new(file),
+        sourcemap,
+        inside_project,
+        heading,
+        stdlib::Target::host(),
+    ) {
         Ok(build) => build,
         Err(code) => return code,
     };

--- a/crates/cli/src/handlers/script.rs
+++ b/crates/cli/src/handlers/script.rs
@@ -29,10 +29,11 @@ pub(super) fn prepare(
     sourcemap: bool,
     inside_project: bool,
     heading: &str,
+    target: stdlib::Target,
 ) -> Result<ScriptBuild, i32> {
     let dir = build_dir(file, heading)?;
     let source = read_source(file, heading)?;
-    let locator = resolve_locator(&source, &dir);
+    let locator = resolve_locator(&source, &dir, target);
     if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
         cli_error!(heading, e, "Check file permissions");
         return Err(1);
@@ -40,7 +41,6 @@ pub(super) fn prepare(
 
     let (mut result, diagnostics_shown) =
         compile_file(file, &source, sourcemap, inside_project, &locator)?;
-    let target = locator.target();
 
     for file in &mut result.output {
         if let Some(staged) = stage_name(&file.name) {
@@ -103,7 +103,7 @@ pub(super) fn emit(
     let Ok(source) = read_source(file, heading) else {
         return 1;
     };
-    let locator = resolve_locator(&source, &dir);
+    let locator = resolve_locator(&source, &dir, stdlib::Target::host());
     if let Err(e) = go_cli::write_go_mod(&dir, GO_MODULE, &locator) {
         cli_error!(heading, e, "Check file permissions");
         return 1;
@@ -159,6 +159,7 @@ pub(super) fn build(
     go_flags: &[String],
     output: Option<&str>,
     inside_project: bool,
+    target: stdlib::Target,
 ) -> i32 {
     let heading = "Failed to build script";
     if let Some(flag) = go_flags.iter().find(|flag| go_cli::is_go_output_flag(flag)) {
@@ -173,7 +174,6 @@ pub(super) fn build(
         return 1;
     }
 
-    let target = stdlib::Target::host();
     let requested = match output {
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(go_cli::binary_name(stem(file), target)),
@@ -183,7 +183,7 @@ pub(super) fn build(
         Err(code) => return code,
     };
 
-    let build = match prepare(file, sourcemap, inside_project, heading) {
+    let build = match prepare(file, sourcemap, inside_project, heading, target) {
         Ok(build) => build,
         Err(code) => return code,
     };
@@ -207,13 +207,16 @@ pub(crate) fn script_locator(
 
     if deps.is_empty() {
         return Ok((
-            super::script_deps::locator(Default::default(), &dir, mode),
+            super::script_deps::locator(Default::default(), &dir, mode, stdlib::Target::host()),
             None,
         ));
     }
 
     ensure_build_dir(&dir)?;
-    Ok((super::script_deps::locator(deps, &dir, mode), Some(dir)))
+    Ok((
+        super::script_deps::locator(deps, &dir, mode, stdlib::Target::host()),
+        Some(dir),
+    ))
 }
 
 fn report_module_needed(locator: &deps::TypedefLocator) {
@@ -239,11 +242,12 @@ fn read_source(file: &Path, heading: &str) -> Result<String, i32> {
     })
 }
 
-fn resolve_locator(source: &str, dir: &Path) -> deps::TypedefLocator {
+fn resolve_locator(source: &str, dir: &Path, target: stdlib::Target) -> deps::TypedefLocator {
     super::script_deps::locator(
         super::script_deps::script_deps(source),
         dir,
         super::script_deps::Mode::Online,
+        target,
     )
 }
 

--- a/crates/cli/src/handlers/script_deps.rs
+++ b/crates/cli/src/handlers/script_deps.rs
@@ -44,8 +44,8 @@ pub(crate) fn locator(
     deps: BTreeMap<String, GoDependency>,
     dir: &Path,
     mode: Mode,
+    target: Target,
 ) -> TypedefLocator {
-    let target = Target::host();
     let locator = TypedefLocator::new(deps, Some(dir.to_path_buf()), target);
     if mode == Mode::Offline || locator.deps().is_empty() {
         return locator;

--- a/crates/cli/src/handlers/script_edit.rs
+++ b/crates/cli/src/handlers/script_edit.rs
@@ -60,7 +60,12 @@ pub(super) fn script_dir(file: &Path, heading: &str) -> Result<PathBuf, i32> {
 }
 
 pub(super) fn write_go_mod(dir: &Path, table: &ScriptTable, heading: &str) -> Result<(), i32> {
-    let locator = super::script_deps::locator(table.deps(), dir, super::script_deps::Mode::Offline);
+    let locator = super::script_deps::locator(
+        table.deps(),
+        dir,
+        super::script_deps::Mode::Offline,
+        stdlib::Target::host(),
+    );
     if let Err(message) = go_cli::write_go_mod(dir, super::script::GO_MODULE, &locator) {
         cli_error!(heading, message, "Check permissions on the temp dir");
         return Err(1);

--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -20,7 +20,7 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelectio
     output::print_preview_notice("Test runner", false);
     let target = path.unwrap_or_else(|| ".".to_string());
     let root = project_root_for(Path::new(&target));
-    with_locked_project(&root, |prep| {
+    with_locked_project(&root, stdlib::Target::host(), |prep| {
         let outcome = match build_locked(prep, BuildPurpose::Test) {
             Ok(outcome) => outcome,
             Err(code) => return code,

--- a/crates/cli/src/pipeline.rs
+++ b/crates/cli/src/pipeline.rs
@@ -222,7 +222,9 @@ mod tests {
     use tempfile::tempdir;
 
     fn check_diagnostics(project_dir: &Path) -> Vec<(bool, Option<String>)> {
-        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let (_, locator) =
+            TypedefLocator::from_project_with_manifest(project_dir, stdlib::Target::host())
+                .unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();
         let config = CompileConfig {
@@ -276,7 +278,8 @@ mod tests {
         };
         stdfs::write(root.join("src").join(filename), source).unwrap();
 
-        let (_, locator) = TypedefLocator::from_project_with_manifest(root).unwrap();
+        let (_, locator) =
+            TypedefLocator::from_project_with_manifest(root, stdlib::Target::host()).unwrap();
         let source_path = root.join("src").join(filename);
         let config = CompileConfig {
             mode: match target_phase {
@@ -498,7 +501,9 @@ mod tests {
     }
 
     fn analyze_cache_state(project_dir: &Path) -> (Vec<String>, Vec<(bool, Option<String>)>) {
-        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let (_, locator) =
+            TypedefLocator::from_project_with_manifest(project_dir, stdlib::Target::host())
+                .unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();
         let working_dir = src_main
@@ -596,7 +601,9 @@ mod tests {
     }
 
     fn test_index_names(project_dir: &Path) -> Vec<String> {
-        let (_, locator) = TypedefLocator::from_project_with_manifest(project_dir).unwrap();
+        let (_, locator) =
+            TypedefLocator::from_project_with_manifest(project_dir, stdlib::Target::host())
+                .unwrap();
         let src_main = project_dir.join("src").join("main.lis");
         let source = stdfs::read_to_string(&src_main).unwrap();
         let working_dir = src_main

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1046,7 +1046,7 @@ impl BindgenSetup for WorkspaceBindgenSetup {
         project_root: &Path,
         target: stdlib::Target,
     ) -> Result<BindgenSession, String> {
-        let (manifest, _) = TypedefLocator::from_project_with_manifest(project_root)?;
+        let (manifest, _) = TypedefLocator::from_project_with_manifest(project_root, target)?;
 
         let target_dir = project_root.join("target");
         if target_dir.is_file() {

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -269,21 +269,20 @@ impl TypedefLocator {
     }
 
     pub fn from_project(project_root: &Path) -> Result<Self, String> {
-        let (_, locator) = Self::from_project_with_manifest(project_root)?;
+        let (_, locator) = Self::from_project_with_manifest(project_root, Target::host())?;
         Ok(locator)
     }
 
-    pub fn from_project_with_manifest(project_root: &Path) -> Result<(Manifest, Self), String> {
+    pub fn from_project_with_manifest(
+        project_root: &Path,
+        target: Target,
+    ) -> Result<(Manifest, Self), String> {
         let manifest = parse_manifest(project_root)?;
 
         check_toolchain_version(&manifest)?;
         check_no_subpackage_deps(&manifest)?;
 
-        let locator = Self::new(
-            manifest.go_deps(),
-            Some(project_root.to_path_buf()),
-            Target::host(),
-        );
+        let locator = Self::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
 
         Ok((manifest, locator))
     }


### PR DESCRIPTION
Six functions in the build path called `Target::host()` themselves, and they now take the target as a param that each command fills with it.
