### PR TITLE
fix: reject map reads that yield a nil map

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1303,9 +1303,39 @@ pub fn field_no_zero(
         .with_help(main)
 }
 
-pub fn map_read_no_zero(value_ty: &Type, receiver: &str, span: Span) -> LisetteDiagnostic {
-    let (label, help) = if matches!(value_ty, Type::Parameter(_)) {
-        (
+pub enum MapReadNoZeroCause<'a> {
+    NilMap,
+    ContainsNilMap(&'a Type),
+    NoZero,
+}
+
+pub fn map_read_no_zero(
+    value_ty: &Type,
+    receiver: &str,
+    cause: MapReadNoZeroCause<'_>,
+    span: Span,
+) -> LisetteDiagnostic {
+    let (title, label, help) = match cause {
+        MapReadNoZeroCause::NilMap => (
+            "Nil map for missing key",
+            format!("`{value_ty}` is nil when the key is missing"),
+            format!(
+                "Bracket reads return a zero value when the key is missing, and the zero value \
+                 of `{value_ty}` is a nil map, which panics on write, so this bracket read is \
+                 disallowed. Use `{receiver}.get(key)` instead"
+            ),
+        ),
+        MapReadNoZeroCause::ContainsNilMap(leaf_ty) => (
+            "Nil map for missing key",
+            format!("`{value_ty}` contains `{leaf_ty}`, which is nil when the key is missing"),
+            format!(
+                "Bracket reads return a zero value when the key is missing, and the zero value \
+                 of `{value_ty}` contains a nil `{leaf_ty}`, which panics on write, so this \
+                 bracket read is disallowed. Use `{receiver}.get(key)` instead"
+            ),
+        ),
+        MapReadNoZeroCause::NoZero if matches!(value_ty, Type::Parameter(_)) => (
+            "No zero value for missing key",
             format!("`{value_ty}` is not guaranteed to have a zero value"),
             format!(
                 "Bracket reads can return a zero value when the key is missing, but the type \
@@ -1313,18 +1343,18 @@ pub fn map_read_no_zero(value_ty: &Type, receiver: &str, span: Span) -> LisetteD
                  such as `Ref<T>`, so this bracket read is disallowed. Use \
                  `{receiver}.get(key)` instead"
             ),
-        )
-    } else {
-        (
+        ),
+        MapReadNoZeroCause::NoZero => (
+            "No zero value for missing key",
             format!("`{value_ty}` has no zero value"),
             format!(
                 "Bracket reads can return a zero value when the key is missing, but \
                  `{value_ty}` has no zero value, so this bracket read is disallowed. Use \
                  `{receiver}.get(key)` instead"
             ),
-        )
+        ),
     };
-    LisetteDiagnostic::error("No zero value for missing key")
+    LisetteDiagnostic::error(title)
         .with_infer_code("map_read_no_zero")
         .with_span_label(&span, label)
         .with_help(help)

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -35,8 +35,8 @@ impl Planner<'_> {
                     format!("{}.MapCloneFunc({value}, {clone})", go_name::GO_STDLIB_PKG)
                 }
                 None => {
-                    self.require_maps();
-                    format!("maps.Clone({value})")
+                    self.require_stdlib();
+                    format!("{}.MapClone({value})", go_name::GO_STDLIB_PKG)
                 }
             },
             _ => value.to_string(),

--- a/crates/passes/src/passes/deferred.rs
+++ b/crates/passes/src/passes/deferred.rs
@@ -5,6 +5,7 @@ use semantics::facts::{DeferredChecks, GenericBoundOrigin};
 use semantics::generics::bound_display_name;
 use semantics::store::Store;
 use semantics::zero;
+use semantics::zero::MapZero;
 use syntax::types::Type;
 use syntax::types::{CompoundKind, TypeVarId};
 
@@ -84,7 +85,7 @@ pub(crate) fn run(store: &Store, checks: &DeferredChecks, sink: &LocalSink) {
         if element_ty.is_error() || element_ty.is_variable() {
             continue;
         }
-        if let Err(no_zero) = zero::has_zero(store, element_ty, &check.package_id) {
+        if let Err(no_zero) = zero::has_zero(store, element_ty, &check.package_id, MapZero::Built) {
             sink.push(diagnostics::infer::slice_make_no_zero(
                 &no_zero.leaf_ty.stringify(),
                 no_zero.hidden_go_state(),

--- a/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
@@ -7,7 +7,7 @@ use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 use super::helpers::replacement_drops_comment;
 use crate::passes::walk::NodeCtx;
 use semantics::store::Store;
-use semantics::zero::has_zero;
+use semantics::zero::{MapZero, has_zero};
 
 const ZERO_FIELD_THRESHOLD: usize = 3;
 
@@ -121,9 +121,10 @@ fn rewrite_would_typecheck(
         return false;
     };
     let is_cross_package = struct_package(ty).is_some_and(|m| m.as_str() != from_package);
-    omitted
-        .iter()
-        .all(|f| (!is_cross_package || f.is_public) && has_zero(store, &f.ty, from_package).is_ok())
+    omitted.iter().all(|f| {
+        (!is_cross_package || f.is_public)
+            && has_zero(store, &f.ty, from_package, MapZero::Built).is_ok()
+    })
 }
 
 struct OmittedField {

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -16,6 +16,7 @@ use super::super::unify::Dispatched;
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
 use crate::checker::scopes::DeferredMapKeyCheck;
+use crate::zero::MapZero;
 
 struct TypeConversionCall {
     callee: Expression,
@@ -655,7 +656,7 @@ impl InferCtx<'_> {
             Some((elem, len)) => {
                 let array_ty = self.type_array(len, elem);
                 let from_package = self.cursor.package_id().to_string();
-                if let Err(no_zero) = self.has_zero(&array_ty, &from_package) {
+                if let Err(no_zero) = self.has_zero(&array_ty, &from_package, MapZero::Built) {
                     self.sink.push(diagnostics::infer::array_new_no_zero(
                         &no_zero.leaf_ty.stringify(),
                         span,

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::checker::EnvResolve;
-use crate::zero::{NoZero, NoZeroReason};
+use crate::zero::{MapZero, NoZero, NoZeroReason};
 use ecow::EcoString;
 use syntax::ast::{Expression, Span, StructFieldAssignment, StructFields, StructSpread};
 use syntax::program::{Definition, DefinitionBody};
@@ -105,7 +105,10 @@ impl InferCtx<'_> {
             let (instantiated_ty, _) = self.instantiate(&alias_ty);
             self.unify(expected_ty, &instantiated_ty, &literal.span);
             let from_package = self.cursor.package_id().to_string();
-            if self.has_zero(&instantiated_ty, &from_package).is_err() {
+            if self
+                .has_zero(&instantiated_ty, &from_package, MapZero::Built)
+                .is_err()
+            {
                 self.sink.push(diagnostics::infer::hidden_state_no_zero(
                     &instantiated_ty,
                     literal.span,
@@ -756,7 +759,7 @@ impl InferCtx<'_> {
                 continue;
             }
             let resolved = substitute(ty, map).resolve_in(&self.env);
-            let Err(no_zero) = self.has_zero(&resolved, &from_package) else {
+            let Err(no_zero) = self.has_zero(&resolved, &from_package, MapZero::Built) else {
                 continue;
             };
             let chain: Vec<&str> = no_zero.chain.iter().map(EcoString::as_str).collect();
@@ -773,7 +776,9 @@ impl InferCtx<'_> {
                 NoZeroReason::HiddenGoState { go_type } => {
                     diagnostics::infer::FieldNoZeroCause::HiddenGoState { go_type }
                 }
-                NoZeroReason::NoZeroForType => diagnostics::infer::FieldNoZeroCause::Type,
+                NoZeroReason::NoZeroForType | NoZeroReason::NilMap => {
+                    diagnostics::infer::FieldNoZeroCause::Type
+                }
             };
             self.sink.push(diagnostics::infer::field_no_zero(
                 owner_name,
@@ -786,9 +791,14 @@ impl InferCtx<'_> {
         }
     }
 
-    pub(crate) fn has_zero(&self, ty: &Type, from_package: &str) -> Result<(), NoZero> {
+    pub(crate) fn has_zero(
+        &self,
+        ty: &Type,
+        from_package: &str,
+        map_zero: MapZero,
+    ) -> Result<(), NoZero> {
         let store = self.store;
-        zero::has_zero(store, ty, from_package)
+        zero::has_zero(store, ty, from_package, map_zero)
     }
 }
 

--- a/crates/semantics/src/checker/infer/validation/map_reads.rs
+++ b/crates/semantics/src/checker/infer/validation/map_reads.rs
@@ -1,13 +1,15 @@
+use diagnostics::infer::MapReadNoZeroCause;
 use syntax::ast::{Expression, Span};
-use syntax::types::CompoundKind;
+use syntax::types::{CompoundKind, Type};
 
 use crate::checker::EnvResolve;
 use crate::checker::infer::InferCtx;
+use crate::zero::{MapZero, NoZeroReason};
 
 impl InferCtx<'_> {
-    /// Reject map bracket reads whose value type has no zero value. A missing
-    /// key surfaces the Go zero value, which for types like `Ref<T>` is a nil
-    /// pointer with no Lisette equivalent.
+    /// Reject map bracket reads whose value type has no usable zero value. A
+    /// missing key surfaces the Go zero value, which for `Ref<T>` is a nil
+    /// pointer, and for a contained `Map` is a nil map that panics on write.
     pub fn check_map_bracket_reads(&mut self, items: &[Expression]) {
         for item in items {
             self.walk_map_bracket_reads(item, false);
@@ -61,13 +63,32 @@ impl InferCtx<'_> {
         if value_ty.is_error() || value_ty.is_variable() {
             return;
         }
-        let from_package = self.cursor.package_id().to_string();
-        if self.has_zero(value_ty, &from_package).is_err() {
-            let receiver = collection.root_identifier().unwrap_or("m");
-            let full_span = collection.get_span().merge(span);
-            self.sink.push(diagnostics::infer::map_read_no_zero(
-                value_ty, receiver, full_span,
-            ));
+        if store.peel_alias(value_ty).is_map() {
+            self.report_map_read(collection, span, value_ty, MapReadNoZeroCause::NilMap);
+            return;
         }
+        let from_package = self.cursor.package_id().to_string();
+        let Err(no_zero) = self.has_zero(value_ty, &from_package, MapZero::Nil) else {
+            return;
+        };
+        let cause = match no_zero.reason {
+            NoZeroReason::NilMap => MapReadNoZeroCause::ContainsNilMap(&no_zero.leaf_ty),
+            _ => MapReadNoZeroCause::NoZero,
+        };
+        self.report_map_read(collection, span, value_ty, cause);
+    }
+
+    fn report_map_read(
+        &mut self,
+        collection: &Expression,
+        span: Span,
+        value_ty: &Type,
+        cause: MapReadNoZeroCause<'_>,
+    ) {
+        let receiver = collection.root_identifier().unwrap_or("m");
+        let full_span = collection.get_span().merge(span);
+        self.sink.push(diagnostics::infer::map_read_no_zero(
+            value_ty, receiver, cause, full_span,
+        ));
     }
 }

--- a/crates/semantics/src/zero.rs
+++ b/crates/semantics/src/zero.rs
@@ -47,140 +47,263 @@ pub enum NoZeroReason {
     },
     /// A Go type curated as broken at its zero value, named for the diagnostic.
     HiddenGoState { go_type: EcoString },
+    /// The leaf type is a `Map`, whose Go zero is nil.
+    NilMap,
+}
+
+/// Who supplies the zero value of a `Map` reached while walking a type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MapZero {
+    /// The compiler builds an empty map.
+    Built,
+    /// Go leaves it nil, and a nil map panics on write.
+    Nil,
 }
 
 /// Predicate: does `ty` have a Lisette-side zero, constructible from `from_package`?
 /// Returns `Err(NoZero)` with a chain of field accesses to the offending leaf when
 /// no zero is available; `Ok(())` otherwise.
-pub fn has_zero(store: &Store, ty: &Type, from_package: &str) -> Result<(), NoZero> {
-    has_zero_seen(store, ty, from_package, &mut Vec::new())
-}
-
-fn has_zero_seen(
+pub fn has_zero(
     store: &Store,
     ty: &Type,
     from_package: &str,
-    visited: &mut Vec<Type>,
+    map_zero: MapZero,
 ) -> Result<(), NoZero> {
-    match ty {
-        Type::Simple(kind) => match kind {
-            SimpleKind::Bool
-            | SimpleKind::String
-            | SimpleKind::Int
-            | SimpleKind::Int8
-            | SimpleKind::Int16
-            | SimpleKind::Int32
-            | SimpleKind::Int64
-            | SimpleKind::Uint
-            | SimpleKind::Uint8
-            | SimpleKind::Uint16
-            | SimpleKind::Uint32
-            | SimpleKind::Uint64
-            | SimpleKind::Uintptr
-            | SimpleKind::Byte
-            | SimpleKind::Float32
-            | SimpleKind::Float64
-            | SimpleKind::Complex64
-            | SimpleKind::Complex128
-            | SimpleKind::Rune
-            | SimpleKind::Unit => Ok(()),
-        },
-        Type::Compound { kind, .. } => match kind {
-            // Slice<T>, Map<K,V> always have a zero (empty, non-nil).
-            CompoundKind::Slice | CompoundKind::Map | CompoundKind::EnumeratedSlice => Ok(()),
-            // Ref<T>, Channel<T>, Sender<T>, Receiver<T>, VarArgs<T> have no zero.
-            CompoundKind::Ref
-            | CompoundKind::Channel
-            | CompoundKind::Sender
-            | CompoundKind::Receiver
-            | CompoundKind::VarArgs => Err(NoZero {
+    ZeroWalk {
+        store,
+        from_package,
+        map_zero,
+        visited: Vec::new(),
+    }
+    .walk(ty)
+}
+
+struct ZeroWalk<'a> {
+    store: &'a Store,
+    from_package: &'a str,
+    map_zero: MapZero,
+    visited: Vec<Type>,
+}
+
+impl ZeroWalk<'_> {
+    const MAX_ZERO_DEPTH: usize = 256;
+
+    fn walk(&mut self, ty: &Type) -> Result<(), NoZero> {
+        match ty {
+            Type::Simple(kind) => match kind {
+                SimpleKind::Bool
+                | SimpleKind::String
+                | SimpleKind::Int
+                | SimpleKind::Int8
+                | SimpleKind::Int16
+                | SimpleKind::Int32
+                | SimpleKind::Int64
+                | SimpleKind::Uint
+                | SimpleKind::Uint8
+                | SimpleKind::Uint16
+                | SimpleKind::Uint32
+                | SimpleKind::Uint64
+                | SimpleKind::Uintptr
+                | SimpleKind::Byte
+                | SimpleKind::Float32
+                | SimpleKind::Float64
+                | SimpleKind::Complex64
+                | SimpleKind::Complex128
+                | SimpleKind::Rune
+                | SimpleKind::Unit => Ok(()),
+            },
+            Type::Compound { kind, .. } => match kind {
+                CompoundKind::Map => match self.map_zero {
+                    MapZero::Built => Ok(()),
+                    MapZero::Nil => Err(NoZero {
+                        chain: vec![],
+                        reason: NoZeroReason::NilMap,
+                        leaf_ty: Box::new(ty.clone()),
+                    }),
+                },
+                // A nil slice reads, lengths, and appends like an empty one.
+                CompoundKind::Slice | CompoundKind::EnumeratedSlice => Ok(()),
+                // Ref<T>, Channel<T>, Sender<T>, Receiver<T>, VarArgs<T> have no zero.
+                CompoundKind::Ref
+                | CompoundKind::Channel
+                | CompoundKind::Sender
+                | CompoundKind::Receiver
+                | CompoundKind::VarArgs => Err(NoZero {
+                    chain: vec![],
+                    reason: NoZeroReason::NoZeroForType,
+                    leaf_ty: Box::new(ty.clone()),
+                }),
+            },
+            Type::Tuple(elements) => {
+                for (i, e) in elements.iter().enumerate() {
+                    if let Err(mut nz) = self.walk(e) {
+                        let mut chain = vec![EcoString::from(i.to_string())];
+                        chain.append(&mut nz.chain);
+                        nz.chain = chain;
+                        return Err(nz);
+                    }
+                }
+                Ok(())
+            }
+            Type::Array { length, element } => {
+                if *length == 0 {
+                    Ok(())
+                } else {
+                    self.walk(element)
+                }
+            }
+            Type::Function(_) => Err(NoZero {
                 chain: vec![],
                 reason: NoZeroReason::NoZeroForType,
                 leaf_ty: Box::new(ty.clone()),
             }),
-        },
-        Type::Tuple(elements) => {
-            for (i, e) in elements.iter().enumerate() {
-                if let Err(mut nz) = has_zero_seen(store, e, from_package, visited) {
-                    let mut chain = vec![EcoString::from(i.to_string())];
-                    chain.append(&mut nz.chain);
-                    nz.chain = chain;
-                    return Err(nz);
+            Type::Nominal { id, params, .. } => {
+                if id.as_str() == "prelude.Option" {
+                    // Option<T>'s zero is None regardless of T. Stop recursion.
+                    return Ok(());
                 }
+                self.walk_nominal(id, params, ty)
             }
-            Ok(())
-        }
-        Type::Array { length, element } => {
-            if *length == 0 {
-                Ok(())
-            } else {
-                has_zero_seen(store, element, from_package, visited)
+            Type::Forall { body, .. } => self.walk(body),
+            Type::Var { .. }
+            | Type::Uninferred
+            | Type::Ignored
+            | Type::Parameter(_)
+            | Type::ReceiverPlaceholder => {
+                // Conservative: unresolved/abstract types have no known zero.
+                Err(NoZero {
+                    chain: vec![],
+                    reason: NoZeroReason::NoZeroForType,
+                    leaf_ty: Box::new(ty.clone()),
+                })
             }
-        }
-        Type::Function(_) => Err(NoZero {
-            chain: vec![],
-            reason: NoZeroReason::NoZeroForType,
-            leaf_ty: Box::new(ty.clone()),
-        }),
-        Type::Nominal { id, params, .. } => {
-            if id.as_str() == "prelude.Option" {
-                // Option<T>'s zero is None regardless of T. Stop recursion.
-                return Ok(());
-            }
-            has_zero_nominal(store, id, params, from_package, ty, visited)
-        }
-        Type::Forall { body, .. } => has_zero_seen(store, body, from_package, visited),
-        Type::Var { .. }
-        | Type::Uninferred
-        | Type::Ignored
-        | Type::Parameter(_)
-        | Type::ReceiverPlaceholder => {
-            // Conservative: unresolved/abstract types have no known zero.
-            Err(NoZero {
+            Type::Never | Type::Error | Type::ImportNamespace(_) => Err(NoZero {
                 chain: vec![],
                 reason: NoZeroReason::NoZeroForType,
                 leaf_ty: Box::new(ty.clone()),
-            })
+            }),
         }
-        Type::Never | Type::Error | Type::ImportNamespace(_) => Err(NoZero {
-            chain: vec![],
-            reason: NoZeroReason::NoZeroForType,
-            leaf_ty: Box::new(ty.clone()),
-        }),
     }
-}
 
-const MAX_ZERO_DEPTH: usize = 256;
-
-fn has_zero_nominal(
-    store: &Store,
-    id: &Symbol,
-    params: &[Type],
-    from_package: &str,
-    original_ty: &Type,
-    visited: &mut Vec<Type>,
-) -> Result<(), NoZero> {
-    let size = type_node_count(original_ty);
-    let is_recursion = visited.iter().any(|ancestor| match ancestor {
-        Type::Nominal {
-            id: ancestor_id, ..
-        } => ancestor_id.as_str() == id.as_str() && type_node_count(ancestor) <= size,
-        _ => false,
-    });
-    if is_recursion {
-        return Ok(());
-    }
-    if visited.len() >= MAX_ZERO_DEPTH {
-        return Err(NoZero {
-            chain: vec![],
-            reason: NoZeroReason::NoZeroForType,
-            leaf_ty: Box::new(original_ty.clone()),
+    fn walk_nominal(
+        &mut self,
+        id: &Symbol,
+        params: &[Type],
+        original_ty: &Type,
+    ) -> Result<(), NoZero> {
+        let size = type_node_count(original_ty);
+        let is_recursion = self.visited.iter().any(|ancestor| match ancestor {
+            Type::Nominal {
+                id: ancestor_id, ..
+            } => ancestor_id.as_str() == id.as_str() && type_node_count(ancestor) <= size,
+            _ => false,
         });
+        if is_recursion {
+            return Ok(());
+        }
+        if self.visited.len() >= Self::MAX_ZERO_DEPTH {
+            return Err(NoZero {
+                chain: vec![],
+                reason: NoZeroReason::NoZeroForType,
+                leaf_ty: Box::new(original_ty.clone()),
+            });
+        }
+        self.visited.push(original_ty.clone());
+        let result = self.walk_nominal_fields(id, params, original_ty);
+        self.visited.pop();
+        result
     }
-    visited.push(original_ty.clone());
-    let result = has_zero_nominal_fields(store, id, params, from_package, original_ty, visited);
-    visited.pop();
-    result
+
+    fn walk_nominal_fields(
+        &mut self,
+        id: &Symbol,
+        params: &[Type],
+        original_ty: &Type,
+    ) -> Result<(), NoZero> {
+        let Some(def) = self.store.get_definition(id.as_str()) else {
+            // Unknown nominal, conservatively reject.
+            return Err(NoZero {
+                chain: vec![],
+                reason: NoZeroReason::NoZeroForType,
+                leaf_ty: Box::new(original_ty.clone()),
+            });
+        };
+
+        match &def.body {
+            DefinitionBody::Struct { fields, .. } => {
+                let is_go_struct = id.as_str().starts_with("go:");
+                if is_go_struct && go_struct_denies_zero(def, fields) {
+                    return Err(NoZero {
+                        chain: vec![],
+                        reason: NoZeroReason::HiddenGoState {
+                            go_type: go_display_name(id),
+                        },
+                        leaf_ty: Box::new(original_ty.clone()),
+                    });
+                }
+                let def_ty = &def.ty;
+                let map = build_substitution(def_ty, params);
+                let struct_package = self
+                    .store
+                    .package_for_qualified_name(id.as_str())
+                    .unwrap_or(self.from_package);
+                let struct_is_foreign = struct_package != self.from_package;
+
+                let struct_name: EcoString = id.last_segment().into();
+                for f in fields {
+                    if is_go_struct && hidden_embed_field(f) {
+                        continue;
+                    }
+                    if struct_is_foreign && !f.visibility.is_public() && !is_go_struct {
+                        return Err(NoZero {
+                            chain: vec![f.name.clone()],
+                            reason: NoZeroReason::PrivateField {
+                                struct_name: struct_name.clone(),
+                                field: f.name.clone(),
+                                owning_package: EcoString::from(struct_package),
+                            },
+                            leaf_ty: Box::new(f.ty.clone()),
+                        });
+                    }
+                    let resolved = if map.is_empty() {
+                        f.ty.clone()
+                    } else {
+                        substitute(&f.ty, &map)
+                    };
+                    if let Err(mut nz) = self.walk(&resolved) {
+                        let mut chain = vec![f.name.clone()];
+                        chain.append(&mut nz.chain);
+                        nz.chain = chain;
+                        return Err(nz);
+                    }
+                }
+                Ok(())
+            }
+            DefinitionBody::TypeAlias { alias, .. } => {
+                if matches!(alias, AliasKind::Opaque(_)) {
+                    if def.is_zero_safe() {
+                        return Ok(());
+                    }
+                    return Err(NoZero {
+                        chain: vec![],
+                        reason: NoZeroReason::NoZeroForType,
+                        leaf_ty: Box::new(original_ty.clone()),
+                    });
+                }
+                let resolved = def
+                    .instantiate_alias_target(params, false)
+                    .expect("transparent alias has a target");
+                self.walk(&resolved)
+            }
+            // Enums and other definitions have no zero unless we add a designated
+            // default-variant mechanism later.
+            _ => Err(NoZero {
+                chain: vec![],
+                reason: NoZeroReason::NoZeroForType,
+                leaf_ty: Box::new(original_ty.clone()),
+            }),
+        }
+    }
 }
 
 fn type_node_count(ty: &Type) -> usize {
@@ -189,98 +312,6 @@ fn type_node_count(ty: &Type) -> usize {
         .iter()
         .map(|c| type_node_count(c))
         .sum::<usize>()
-}
-
-fn has_zero_nominal_fields(
-    store: &Store,
-    id: &Symbol,
-    params: &[Type],
-    from_package: &str,
-    original_ty: &Type,
-    visited: &mut Vec<Type>,
-) -> Result<(), NoZero> {
-    let Some(def) = store.get_definition(id.as_str()) else {
-        // Unknown nominal, conservatively reject.
-        return Err(NoZero {
-            chain: vec![],
-            reason: NoZeroReason::NoZeroForType,
-            leaf_ty: Box::new(original_ty.clone()),
-        });
-    };
-
-    match &def.body {
-        DefinitionBody::Struct { fields, .. } => {
-            let is_go_struct = id.as_str().starts_with("go:");
-            if is_go_struct && go_struct_denies_zero(def, fields) {
-                return Err(NoZero {
-                    chain: vec![],
-                    reason: NoZeroReason::HiddenGoState {
-                        go_type: go_display_name(id),
-                    },
-                    leaf_ty: Box::new(original_ty.clone()),
-                });
-            }
-            let def_ty = &def.ty;
-            let map = build_substitution(def_ty, params);
-            let struct_package = store
-                .package_for_qualified_name(id.as_str())
-                .unwrap_or(from_package);
-            let struct_is_foreign = struct_package != from_package;
-
-            let struct_name: EcoString = id.last_segment().into();
-            for f in fields {
-                if is_go_struct && hidden_embed_field(f) {
-                    continue;
-                }
-                if struct_is_foreign && !f.visibility.is_public() && !is_go_struct {
-                    return Err(NoZero {
-                        chain: vec![f.name.clone()],
-                        reason: NoZeroReason::PrivateField {
-                            struct_name: struct_name.clone(),
-                            field: f.name.clone(),
-                            owning_package: EcoString::from(struct_package),
-                        },
-                        leaf_ty: Box::new(f.ty.clone()),
-                    });
-                }
-                let resolved = if map.is_empty() {
-                    f.ty.clone()
-                } else {
-                    substitute(&f.ty, &map)
-                };
-                if let Err(mut nz) = has_zero_seen(store, &resolved, from_package, visited) {
-                    let mut chain = vec![f.name.clone()];
-                    chain.append(&mut nz.chain);
-                    nz.chain = chain;
-                    return Err(nz);
-                }
-            }
-            Ok(())
-        }
-        DefinitionBody::TypeAlias { alias, .. } => {
-            if matches!(alias, AliasKind::Opaque(_)) {
-                if def.is_zero_safe() {
-                    return Ok(());
-                }
-                return Err(NoZero {
-                    chain: vec![],
-                    reason: NoZeroReason::NoZeroForType,
-                    leaf_ty: Box::new(original_ty.clone()),
-                });
-            }
-            let resolved = def
-                .instantiate_alias_target(params, false)
-                .expect("transparent alias has a target");
-            has_zero_seen(store, &resolved, from_package, visited)
-        }
-        // Enums and other definitions have no zero unless we add a designated
-        // default-variant mechanism later.
-        _ => Err(NoZero {
-            chain: vec![],
-            reason: NoZeroReason::NoZeroForType,
-            leaf_ty: Box::new(original_ty.clone()),
-        }),
-    }
 }
 
 /// `go:archive/zip.File` as `archive/zip.File`, so diagnostics name the package.

--- a/prelude/map.go
+++ b/prelude/map.go
@@ -1,5 +1,7 @@
 package lisette
 
+import "maps"
+
 func MapGet[K comparable, V any](m map[K]V, key K) Option[V] {
 	val, ok := m[key]
 	if ok {
@@ -16,10 +18,13 @@ func MapFrom[K comparable, V any](pairs []Tuple2[K, V]) map[K]V {
 	return result
 }
 
+func MapClone[M ~map[K]V, K comparable, V any](m M) M {
+	out := make(M, len(m))
+	maps.Copy(out, m)
+	return out
+}
+
 func MapCloneFunc[M ~map[K]V, K comparable, V any](m M, clone func(V) V) M {
-	if m == nil {
-		return nil
-	}
 	out := make(M, len(m))
 	for k, v := range m {
 		out[k] = clone(v)

--- a/prelude/map_test.go
+++ b/prelude/map_test.go
@@ -1,0 +1,48 @@
+package lisette
+
+import "testing"
+
+func TestMapCloneOfNilIsWritable(t *testing.T) {
+	var m map[string]int
+	out := MapClone(m)
+	if out == nil {
+		t.Fatal("MapClone of a nil map returned nil, want an empty map")
+	}
+	out["k"] = 1
+	if out["k"] != 1 {
+		t.Errorf("out[%q] = %d, want 1", "k", out["k"])
+	}
+}
+
+func TestMapCloneCopiesEntries(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2}
+	out := MapClone(m)
+	out["a"] = 9
+	if m["a"] != 1 {
+		t.Errorf("clone shares storage: m[%q] = %d, want 1", "a", m["a"])
+	}
+	if out["b"] != 2 {
+		t.Errorf("out[%q] = %d, want 2", "b", out["b"])
+	}
+}
+
+func TestMapCloneFuncOfNilIsWritable(t *testing.T) {
+	var m map[string][]int
+	out := MapCloneFunc(m, func(v []int) []int { return append([]int(nil), v...) })
+	if out == nil {
+		t.Fatal("MapCloneFunc of a nil map returned nil, want an empty map")
+	}
+	out["k"] = []int{1}
+	if len(out["k"]) != 1 {
+		t.Errorf("len(out[%q]) = %d, want 1", "k", len(out["k"]))
+	}
+}
+
+func TestMapCloneFuncClonesValues(t *testing.T) {
+	m := map[string][]int{"a": {1, 2}}
+	out := MapCloneFunc(m, func(v []int) []int { return append([]int(nil), v...) })
+	out["a"][0] = 9
+	if m["a"][0] != 1 {
+		t.Errorf("value clone shares storage: m[%q][0] = %d, want 1", "a", m["a"][0])
+	}
+}

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -2410,10 +2410,9 @@ fn make_i() -> int {
 }
 
 fn main() {
-  let mut maps: mut Map<int, mut Map<string, Box>> = Map.new()
   let mut inner = Map.new<string, Box>()
   inner["k"] = Box { x: 0 }
-  maps[0] = inner
+  let mut maps: mut Slice<mut Map<string, Box>> = [inner]
   let i = make_i()
   let mut entry = maps[i]["k"]
   entry.x = 1

--- a/tests/spec/emit/snapshots/map_clone.snap
+++ b/tests/spec/emit/snapshots/map_clone.snap
@@ -8,8 +8,8 @@ description: |
 ---
 package main
 
-import "maps"
+import lisette "github.com/ivov/lisette/prelude"
 
 func test(m map[string]int) map[string]int {
-	return maps.Clone(m)
+	return lisette.MapClone(m)
 }

--- a/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/map_field_assignment_map_expr_evaluated_once.snap
@@ -12,10 +12,9 @@ description: |
   }
   
   fn main() {
-    let mut maps: mut Map<int, mut Map<string, Box>> = Map.new()
     let mut inner = Map.new<string, Box>()
     inner["k"] = Box { x: 0 }
-    maps[0] = inner
+    let mut maps: mut Slice<mut Map<string, Box>> = [inner]
     let i = make_i()
     let mut entry = maps[i]["k"]
     entry.x = 1
@@ -36,10 +35,9 @@ func makeI() int {
 }
 
 func main() {
-	maps_ := make(map[int]map[string]Box)
 	inner := make(map[string]Box)
 	inner["k"] = Box{x: 0}
-	maps_[0] = inner
+	maps_ := []map[string]Box{inner}
 	i := makeI()
 	entry := maps_[i]["k"]
 	entry.x = 1

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -3063,6 +3063,158 @@ fn test(holders: Map<string, Holder>) {
 }
 
 #[test]
+fn infer_map_read_no_zero_for_map_value() {
+    let input = r#"
+fn test() {
+  let mut outer = Map.new<string, mut Map<string, int>>()
+  let mut inner = outer["missing"]
+  inner["k"] = 1
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_read_no_zero_for_map_value_through_alias() {
+    let input = r#"
+type Counts = Map<string, int>
+
+fn test(outer: Map<string, Counts>) {
+  let _c = outer["x"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read yielding a map behind an alias must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_for_chained_map_read() {
+    let input = r#"
+fn test(outer: Map<string, Map<string, int>>) {
+  let _n = outer["x"]["y"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "the outer read of a chained map read must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_for_struct_with_map_field() {
+    let input = r#"
+struct Bag { pub items: mut Map<string, int> }
+
+fn test(outer: Map<string, Bag>) {
+  let _b = outer["x"]
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_map_read_no_zero_for_tuple_with_map_element() {
+    let input = r#"
+fn test(outer: Map<string, (mut Map<string, int>, int)>) {
+  let _p = outer["x"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read yielding a tuple that holds a map must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_for_array_of_maps() {
+    let input = r#"
+fn test(outer: Map<string, Array<mut Map<string, int>, 2>>) {
+  let _a = outer["x"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        has_code(&result, "map_read_no_zero"),
+        "a bracket read yielding an array of maps must be rejected, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_allows_empty_array_of_maps() {
+    let input = r#"
+fn test(outer: Map<string, Array<mut Map<string, int>, 0>>) {
+  let _a = outer["x"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        !has_code(&result, "map_read_no_zero"),
+        "an empty array holds no map, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_read_no_zero_allows_struct_without_map_field() {
+    let input = r#"
+struct Bag { pub count: int, pub tags: Slice<string> }
+
+fn test(outer: Map<string, Bag>) {
+  let _b = outer["x"]
+}
+"#;
+    let result = infer(input);
+    assert!(
+        !has_code(&result, "map_read_no_zero"),
+        "a struct of int and slice fields has a usable zero, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_struct_autofill_allows_map_field() {
+    let input = r#"
+struct Bag { pub items: mut Map<string, int>, pub count: int }
+
+fn test() {
+  let _b = Bag { count: 1, .. }
+}
+"#;
+    let result = infer(input);
+    assert!(
+        !has_code(&result, "field_no_zero"),
+        "a struct literal builds an empty map for a map field, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn infer_map_bracket_write_of_map_value_allowed() {
+    let input = r#"
+fn test() {
+  let inner = Map.new<string, int>()
+  let mut outer = Map.new<string, Map<string, int>>()
+  outer["k"] = inner
+}
+"#;
+    let result = infer(input);
+    assert!(
+        !has_code(&result, "map_read_no_zero"),
+        "storing a map under a key never reads the entry, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn infer_no_make_constructor_map() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_map_read_no_zero_for_map_value.snap
+++ b/tests/ui/errors/snapshots/infer_map_read_no_zero_for_map_value.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Nil map for missing key
+   ╭─[test.lis:4:19]
+ 3 │   let mut outer = Map.new<string, mut Map<string, int>>()
+ 4 │   let mut inner = outer["missing"]
+   ·                   ────────┬───────
+   ·                           ╰── `mut Map<string, int>` is nil when the key is missing
+ 5 │   inner["k"] = 1
+   ╰────
+  help: Bracket reads return a zero value when the key is missing, and the zero value of `mut Map<string, int>` is a nil map, which panics on write, so this bracket read is disallowed. Use `outer.get(key)` instead · code: [infer.map_read_no_zero]

--- a/tests/ui/errors/snapshots/infer_map_read_no_zero_for_struct_with_map_field.snap
+++ b/tests/ui/errors/snapshots/infer_map_read_no_zero_for_struct_with_map_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Nil map for missing key
+   ╭─[test.lis:5:12]
+ 4 │ fn test(outer: Map<string, Bag>) {
+ 5 │   let _b = outer["x"]
+   ·            ─────┬────
+   ·                 ╰── `Bag` contains `mut Map<string, int>`, which is nil when the key is missing
+ 6 │ }
+   ╰────
+  help: Bracket reads return a zero value when the key is missing, and the zero value of `Bag` contains a nil `mut Map<string, int>`, which panics on write, so this bracket read is disallowed. Use `outer.get(key)` instead · code: [infer.map_read_no_zero]


### PR DESCRIPTION
A bracket-style access on a map where the value type is (or contains) a `Map` was panicking at runtime with `assignment to entry in nil map`. This access is now rejected, with a diagnostic pointing the user to `.get()`.

```rs
fn main() {
  let mut outer = Map.new<string, mut Map<string, int>>()
  let mut inner = outer["missing"]
  inner["k"] = 1
}
```

Relatedly, `.clone()` on a map now builds a map instead of passing a nil one through, so cloning a nil map that came from Go gives writable storage.
