### PR TITLE
chore: tighten missing bound diagnostic

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -1537,8 +1537,8 @@ pub fn param_needs_ordered_bound(param: &str, span: Span) -> LisetteDiagnostic {
         .with_infer_code("type_mismatch")
         .with_span_label(&span, format!("expected orderable, found `{}`", param))
         .with_help(format!(
-            "`{param}` is an unconstrained type parameter. Add a `cmp.Ordered` bound to compare it, \
-             e.g. `<{param}: cmp.Ordered>` and add `import \"go:cmp\"` at the top"
+            "`{param}` is an unconstrained type parameter. Add the bound where `{param}` is \
+             declared: `<{param}: Ordered>`"
         ))
 }
 
@@ -1583,6 +1583,68 @@ pub fn not_equatable(ty: &Type, reason: &str, span: Span) -> LisetteDiagnostic {
         .with_span_label(&span, "cannot be compared")
         .with_help(format!(
             "`{ty}` cannot be compared because {reason} cannot be compared"
+        ))
+}
+
+/// `<T: Comparable>` for one parameter, `<A: Comparable, B: Comparable>` for several.
+fn comparable_bound_list(parameters: &[String]) -> String {
+    let bounds = parameters
+        .iter()
+        .map(|parameter| format!("{parameter}: Comparable"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("<{bounds}>")
+}
+
+fn declared_where(parameters: &[String]) -> String {
+    match parameters {
+        [one] => format!("where `{one}` is declared"),
+        _ => "where they are declared".to_string(),
+    }
+}
+
+pub fn param_needs_comparable_bound(
+    ty: &Type,
+    parameters: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Missing comparable bound")
+        .with_infer_code("param_needs_comparable_bound")
+        .with_span_label(&span, format!("`{ty}` cannot be compared with `==`"))
+        .with_help(format!(
+            "Add the bound {}: `{}`",
+            declared_where(parameters),
+            comparable_bound_list(parameters)
+        ))
+}
+
+pub fn param_needs_comparable_bound_for_equals(
+    ty: &Type,
+    parameters: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Missing comparable bound")
+        .with_infer_code("param_needs_comparable_bound")
+        .with_span_label(&span, format!("`{ty}` cannot be compared"))
+        .with_help(format!(
+            "Add the bound {}: `{}`",
+            declared_where(parameters),
+            comparable_bound_list(parameters)
+        ))
+}
+
+pub fn param_needs_comparable_bound_then_equals(
+    ty: &Type,
+    parameters: &[String],
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Missing comparable bound")
+        .with_infer_code("param_needs_comparable_bound")
+        .with_span_label(&span, format!("`{ty}` cannot be compared with `==`"))
+        .with_help(format!(
+            "Add the bound {}: `{}`, then use `.equals()`",
+            declared_where(parameters),
+            comparable_bound_list(parameters)
         ))
 }
 

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::checker::EnvResolve;
@@ -12,6 +14,12 @@ use syntax::program::{DefinitionBody, Visibility, interface_instances, interface
 use syntax::types::{CompoundKind, Type, substitute};
 
 const RECURSIVE_TYPES: &str = "recursive types";
+
+fn dedup_sorted(mut names: Vec<String>) -> Vec<String> {
+    names.sort_unstable();
+    names.dedup();
+    names
+}
 
 fn nested_reason(inner: &'static str, wrapper: &'static str) -> &'static str {
     if inner == RECURSIVE_TYPES {
@@ -499,6 +507,46 @@ pub(crate) fn param_is_equatable(
 }
 
 impl InferCtx<'_> {
+    fn comparable_bound_would_fix(&self, ty: &Type) -> Vec<String> {
+        let mut missing = Vec::new();
+        let remaining =
+            check_not_comparable_with_bounds(&self.env, self.store, ty, &mut |parameter| {
+                self.record_unbounded(parameter, &mut missing);
+                true
+            });
+        if remaining.is_some() {
+            return Vec::new();
+        }
+        dedup_sorted(missing)
+    }
+
+    fn equatable_bound_would_fix(&self, ty: &Type) -> Vec<String> {
+        let missing = RefCell::new(Vec::new());
+        let collect = |parameter: &str| {
+            self.record_unbounded(parameter, &mut missing.borrow_mut());
+            true
+        };
+        let remaining = check_not_equatable(
+            &self.env,
+            self.store,
+            ty,
+            self.cursor.package_id(),
+            &collect,
+            &collect,
+        );
+        if remaining.is_some() {
+            return Vec::new();
+        }
+        dedup_sorted(missing.into_inner())
+    }
+
+    fn record_unbounded(&self, parameter: &str, missing: &mut Vec<String>) {
+        if !self.parameter_satisfies_bound(parameter, super::super::unify::BuiltinBound::Comparable)
+        {
+            missing.push(parameter.to_string());
+        }
+    }
+
     fn is_comparable_with_param_bounds(&self, ty: &Type) -> bool {
         let resolved = ty.resolve_in(&self.env);
         check_not_comparable_with_bounds(&self.env, self.store, &resolved, &mut |parameter| {
@@ -524,12 +572,21 @@ impl InferCtx<'_> {
         let Some(reason) = check_not_comparable(&self.env, store, &resolved) else {
             return true;
         };
+        let bound_fix = self.comparable_bound_would_fix(&resolved);
+        let equals_bound_fix = self.equatable_bound_would_fix(&resolved);
         if is_interface_or_unknown(store, &resolved) {
             self.sink.push(diagnostics::infer::not_comparable_interface(
                 &resolved, *span,
             ));
         } else if operands_match && let Some(element) = self.container_equals_element(&resolved) {
             match self.not_equatable_reason(&element) {
+                Some(_) if !equals_bound_fix.is_empty() => self.sink.push(
+                    diagnostics::infer::param_needs_comparable_bound_then_equals(
+                        &resolved,
+                        &equals_bound_fix,
+                        *span,
+                    ),
+                ),
                 Some(element_reason) => self.sink.push(
                     diagnostics::infer::not_comparable_no_equals(&resolved, element_reason, *span),
                 ),
@@ -539,6 +596,11 @@ impl InferCtx<'_> {
                         &resolved, reason, *span,
                     )),
             }
+        } else if !bound_fix.is_empty() {
+            self.sink
+                .push(diagnostics::infer::param_needs_comparable_bound(
+                    &resolved, &bound_fix, *span,
+                ));
         } else if operands_match
             && type_has_usable_equals(store, &resolved, self.cursor.package_id())
         {
@@ -647,8 +709,16 @@ impl InferCtx<'_> {
             return;
         }
         if let Some(reason) = self.not_equatable_reason(&receiver) {
-            self.sink
-                .push(diagnostics::infer::not_equatable(&receiver, reason, span));
+            let bound_fix = self.equatable_bound_would_fix(&receiver);
+            if bound_fix.is_empty() {
+                self.sink
+                    .push(diagnostics::infer::not_equatable(&receiver, reason, span));
+            } else {
+                self.sink
+                    .push(diagnostics::infer::param_needs_comparable_bound_for_equals(
+                        &receiver, &bound_fix, span,
+                    ));
+            }
         }
     }
 

--- a/tests/spec/infer/arrays.rs
+++ b/tests/spec/infer/arrays.rs
@@ -121,7 +121,7 @@ fn bounded_generic_array_equality_is_allowed() {
 #[test]
 fn unbounded_generic_array_equality_is_rejected() {
     infer("fn eq<T>(a: Array<T, 2>, b: Array<T, 2>) -> bool { a == b }")
-        .assert_infer_code("type_mismatch");
+        .assert_infer_code("param_needs_comparable_bound");
 }
 
 #[test]

--- a/tests/spec/infer/expressions.rs
+++ b/tests/spec/infer/expressions.rs
@@ -1819,7 +1819,7 @@ fn equality_on_unbounded_generic_rejected() {
     fn main() {}
         "#,
     )
-    .assert_infer_code("type_mismatch");
+    .assert_infer_code("param_needs_comparable_bound");
 }
 
 #[test]
@@ -1839,7 +1839,7 @@ fn not_equal_on_unbounded_generic_rejected() {
     fn main() {}
         "#,
     )
-    .assert_infer_code("type_mismatch");
+    .assert_infer_code("param_needs_comparable_bound");
 }
 
 #[test]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9653,6 +9653,40 @@ fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
 }
 
 #[test]
+fn infer_compare_unbounded_container_suggests_bound_then_equals() {
+    let input = r#"
+fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
+  a == b
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_compare_names_every_unbounded_param() {
+    let input = r#"
+struct Pair<A, B> { pub a: A, pub b: B }
+
+fn compare<A, B>(x: Pair<A, B>, y: Pair<A, B>) -> bool {
+  x == y
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_compare_struct_with_function_field_suggests_no_bound() {
+    let input = r#"
+struct S<T> { pub f: fn() -> (), pub t: T }
+
+fn compare<T>(x: S<T>, y: S<T>) -> bool {
+  x == y
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_equals_rejects_map_function_value() {
     let input = r#"
 fn test(a: Map<string, fn() -> int>, b: Map<string, fn() -> int>) {

--- a/tests/ui/errors/snapshots/infer_compare_names_every_unbounded_param.snap
+++ b/tests/ui/errors/snapshots/infer_compare_names_every_unbounded_param.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing comparable bound
+   ╭─[test.lis:5:3]
+ 4 │ fn compare<A, B>(x: Pair<A, B>, y: Pair<A, B>) -> bool {
+ 5 │   x == y
+   ·   ┬
+   ·   ╰── `Pair<A, B>` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: Add the bound where they are declared: `<A: Comparable, B: Comparable>` · code: [infer.param_needs_comparable_bound]

--- a/tests/ui/errors/snapshots/infer_compare_struct_with_function_field_suggests_no_bound.snap
+++ b/tests/ui/errors/snapshots/infer_compare_struct_with_function_field_suggests_no_bound.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:5:3]
+ 4 │ fn compare<T>(x: S<T>, y: S<T>) -> bool {
+ 5 │   x == y
+   ·   ┬
+   ·   ╰── `S<T>` cannot be compared with `==`
+ 6 │ }
+   ╰────
+  help: The `==` and `!=` operators cannot be used on a struct containing non-comparable fields because they are not comparable in Go · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_compare_unbounded_container_suggests_bound_then_equals.snap
+++ b/tests/ui/errors/snapshots/infer_compare_unbounded_container_suggests_bound_then_equals.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing comparable bound
+   ╭─[test.lis:3:3]
+ 2 │ fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
+ 3 │   a == b
+   ·   ┬
+   ·   ╰── `Slice<T>` cannot be compared with `==`
+ 4 │ }
+   ╰────
+  help: Add the bound where `T` is declared: `<T: Comparable>`, then use `.equals()` · code: [infer.param_needs_comparable_bound]

--- a/tests/ui/errors/snapshots/infer_compare_unbounded_param_suggests_ordered_bound.snap
+++ b/tests/ui/errors/snapshots/infer_compare_unbounded_param_suggests_ordered_bound.snap
@@ -9,4 +9,4 @@ source: tests/ui/errors/mod.rs
    ·      ╰── expected orderable, found `T`
  4 │ }
    ╰────
-  help: `T` is an unconstrained type parameter. Add a `cmp.Ordered` bound to compare it, e.g. `<T: cmp.Ordered>` and add `import "go:cmp"` at the top · code: [infer.type_mismatch]
+  help: `T` is an unconstrained type parameter. Add the bound where `T` is declared: `<T: Ordered>` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_equals_rejects_unbounded_generic_element.snap
+++ b/tests/ui/errors/snapshots/infer_equals_rejects_unbounded_generic_element.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Invalid comparison
+  ✕ Missing comparable bound
    ╭─[test.lis:3:3]
  2 │ fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
  3 │   a.equals(b)
    ·   ┬
-   ·   ╰── cannot be compared
+   ·   ╰── `Slice<T>` cannot be compared
  4 │ }
    ╰────
-  help: `Slice<T>` cannot be compared because type parameters cannot be compared · code: [infer.not_equatable]
+  help: Add the bound where `T` is declared: `<T: Comparable>` · code: [infer.param_needs_comparable_bound]


### PR DESCRIPTION
Comparing an unbounded type param told the user the comparison was impossible. Adding a bound fixes it, so the diagnostic now says so and which bound to add.

```rs
fn compare<T>(a: Slice<T>, b: Slice<T>) -> bool {
  a.equals(b)
}
```

Before:

```
help: `Slice<T>` cannot be compared because type parameters cannot be compared
```

After:

```
help: Add the bound where `T` is declared: `<T: Comparable>`
```