### PR TITLE
refactor: consolidate duplicated semantics logic and state

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -2,7 +2,6 @@ use crate::cli_error;
 use crate::output::{format_backticks, use_color};
 use diagnostics::infer::levenshtein_distance;
 use semantics::cache::go_stdlib::{GoPackageCache, try_load_go_stdlib_cache};
-use semantics::cache::types::CachedDefinitionBody;
 use std::mem;
 use stdlib::{
     Target, format_targets, get_go_stdlib_package_targets, get_go_stdlib_packages,
@@ -10,6 +9,7 @@ use stdlib::{
 };
 use syntax::ast::EnumVariant;
 use syntax::ast::{Annotation, Binding, Expression, Generic, Pattern, StructFields, VariantFields};
+use syntax::program::DefinitionBody;
 
 #[derive(Debug, Clone, Copy)]
 enum TypeKind {
@@ -1555,15 +1555,16 @@ fn doc_go_package(query: &str) -> i32 {
 
 fn has_go_package_matches(package_cache: &GoPackageCache, query_lower: &str) -> bool {
     for (def_name, def) in &package_cache.definitions {
-        if matches!(def.body, CachedDefinitionBody::Value { .. })
+        let body = &def.as_definition().body;
+        if matches!(body, DefinitionBody::Value { .. })
             && def_name.to_lowercase().contains(query_lower)
         {
             return true;
         }
-        match &def.body {
-            CachedDefinitionBody::TypeAlias { methods, .. }
-            | CachedDefinitionBody::Enum { methods, .. }
-            | CachedDefinitionBody::Struct { methods, .. } => {
+        match body {
+            DefinitionBody::TypeAlias { methods, .. }
+            | DefinitionBody::Enum { methods, .. }
+            | DefinitionBody::Struct { methods, .. } => {
                 if methods
                     .keys()
                     .any(|m| m.to_lowercase().contains(query_lower))
@@ -1571,7 +1572,7 @@ fn has_go_package_matches(package_cache: &GoPackageCache, query_lower: &str) -> 
                     return true;
                 }
             }
-            CachedDefinitionBody::Interface { definition, .. }
+            DefinitionBody::Interface { definition, .. }
                 if definition
                     .methods
                     .keys()

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -10,7 +10,7 @@ use syntax::program::{EmitInput, MutationInfo, UnusedInfo, is_internal_package_i
 use semantics::AnalyzeInput;
 use semantics::cache::{EmitStamp, save_package_cache};
 use semantics::facts::{BindingFact, Usage};
-use semantics::store::ENTRY_PACKAGE_ID;
+use semantics::store::{ENTRY_FILE_ID, ENTRY_PACKAGE_ID};
 use semantics::{InferenceOutput, PARALLEL_THRESHOLD, run_inference};
 
 use crate::passes;
@@ -25,8 +25,6 @@ pub struct Analysis {
     bindings: HashMap<BindingId, BindingFact>,
     usages: HashSet<Usage>,
     diagnostics: Vec<LisetteDiagnostic>,
-    entry_parse_status: semantics::EntryParseStatus,
-    parse_statuses: HashMap<u32, FileParseStatus>,
 }
 
 impl Analysis {
@@ -70,18 +68,19 @@ impl Analysis {
     }
 
     pub fn has_parse_errors(&self) -> bool {
-        self.entry_parse_status != semantics::EntryParseStatus::Clean
+        self.parse_status(ENTRY_FILE_ID) != FileParseStatus::Clean
     }
 
     pub fn parse_status(&self, file_id: u32) -> FileParseStatus {
-        self.parse_statuses
+        self.emit_input
+            .files
             .get(&file_id)
-            .copied()
+            .map(|file| file.parse_status)
             .unwrap_or_default()
     }
 
     pub fn entry_parse_failed(&self) -> bool {
-        self.entry_parse_status == semantics::EntryParseStatus::Failed
+        self.parse_status(ENTRY_FILE_ID) == FileParseStatus::Failed
     }
 }
 
@@ -95,15 +94,17 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         cached_packages,
         cache_root,
         unreachable_packages,
-        entry_parse,
+        entry_parse_errors,
     } = run_inference(input);
-    let lint_mode = if entry_parse.is_clean() {
+    let entry_parse_status = store
+        .get_file(ENTRY_FILE_ID)
+        .map(|file| file.parse_status)
+        .unwrap_or_default();
+    let lint_mode = if entry_parse_status == FileParseStatus::Clean {
         passes::LintMode::Run
     } else {
         passes::LintMode::Skip
     };
-    let entry_parse_status = entry_parse.status();
-    let entry_parse_errors = entry_parse.into_errors();
 
     let unused = if has_pre_check_errors {
         UnusedInfo::default()
@@ -186,7 +187,6 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         }
     }
 
-    let parse_statuses = store.parse_statuses.clone();
     let mut files = HashMap::default();
     let mut definitions = HashMap::default();
 
@@ -236,8 +236,6 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         bindings,
         usages,
         diagnostics: order_diagnostics_by_severity(all_diagnostics),
-        entry_parse_status,
-        parse_statuses,
     }
 }
 
@@ -310,5 +308,38 @@ mod tests {
                 .any(|usage| usage.definition_span == value_span),
             "value usage should link back to its retained binding"
         );
+    }
+
+    #[test]
+    fn analysis_derives_recovered_entry_status_from_the_file() {
+        let source = "fn valid() {}\nfn broken(";
+        let loader = MemoryLoader::new();
+        let locator = Default::default();
+
+        let analysis = analyze(AnalyzeInput {
+            load_siblings: false,
+            scope: AnalysisScope::Script {
+                inside_project: false,
+            },
+            loader: &loader,
+            entry: Some(EntryFile::recovering(
+                source.to_string(),
+                "main.lis".to_string(),
+                "main.lis".to_string(),
+            )),
+            compile_phase: CompilePhase::Check,
+            project_kind: ProjectKind::Binary,
+            locator: &locator,
+            go_module: "",
+            disable_cache: true,
+            recover_target: semantics::RecoverTarget::None,
+        });
+
+        assert_eq!(
+            analysis.parse_status(ENTRY_FILE_ID),
+            FileParseStatus::Recovered
+        );
+        assert!(analysis.has_parse_errors());
+        assert!(!analysis.entry_parse_failed());
     }
 }

--- a/crates/semantics/src/analysis/entry.rs
+++ b/crates/semantics/src/analysis/entry.rs
@@ -1,41 +1,27 @@
 use super::*;
+use syntax::ParseError;
 use syntax::ast::Expression;
 
-pub(super) enum EntryRegistration {
-    Absent,
-    Present {
-        filename: String,
-        parse: EntryParseOutcome,
-    },
+pub(super) struct EntryRegistration {
+    filename: Option<String>,
+    errors: Vec<ParseError>,
 }
 
 impl EntryRegistration {
     pub(super) fn filename(&self) -> Option<&str> {
-        match self {
-            Self::Absent => None,
-            Self::Present { filename, .. } => Some(filename),
-        }
+        self.filename.as_deref()
     }
 
-    pub(super) fn parse_failed(&self) -> bool {
-        match self {
-            Self::Absent => false,
-            Self::Present { parse, .. } => parse.is_failed(),
-        }
-    }
-
-    pub(super) fn into_parse(self) -> EntryParseOutcome {
-        match self {
-            Self::Absent => EntryParseOutcome::Clean,
-            Self::Present { parse, .. } => parse,
-        }
+    pub(super) fn into_errors(self) -> Vec<ParseError> {
+        self.errors
     }
 }
 
 struct ParsedEntry {
     ast: Vec<Expression>,
     file_comment: Option<String>,
-    outcome: EntryParseOutcome,
+    status: FileParseStatus,
+    errors: Vec<ParseError>,
 }
 
 /// Parses and registers the entry file (`main.lis`, or the library root).
@@ -46,16 +32,20 @@ pub(super) fn register_entry_file(
     include_tests: bool,
 ) -> EntryRegistration {
     let Some(entry) = entry else {
-        return EntryRegistration::Absent;
+        return EntryRegistration {
+            filename: None,
+            errors: Vec::new(),
+        };
     };
 
     let ParsedEntry {
         ast,
         file_comment,
-        outcome,
+        status,
+        errors,
     } = parse_entry_file(&entry.source, entry.parse_mode);
 
-    if !outcome.is_failed() {
+    if status != FileParseStatus::Failed {
         if entry.filename.ends_with("_test.lis") {
             sink.push(diagnostics::package_graph::wrong_test_file_suffix(
                 &entry.display_path,
@@ -67,26 +57,21 @@ pub(super) fn register_entry_file(
         }
     }
 
-    store.record_parse_status(
-        ENTRY_FILE_ID,
-        match outcome.status() {
-            EntryParseStatus::Clean => FileParseStatus::Clean,
-            EntryParseStatus::Recovered => FileParseStatus::Recovered,
-            EntryParseStatus::Failed => FileParseStatus::Failed,
-        },
-    );
-
-    store.store_entry_file(
-        &entry.filename,
-        &entry.display_path,
-        &entry.source,
-        ast,
+    store.store_file(File {
+        id: ENTRY_FILE_ID,
+        package_id: ENTRY_PACKAGE_ID.to_string(),
+        parse_status: status,
+        name: entry.filename.clone(),
+        display_path: entry.display_path,
+        source_path: None,
+        source: entry.source,
+        items: ast,
         file_comment,
-    );
+    });
 
-    EntryRegistration::Present {
-        filename: entry.filename,
-        parse: outcome,
+    EntryRegistration {
+        filename: Some(entry.filename),
+        errors,
     }
 }
 
@@ -95,15 +80,11 @@ fn parse_entry_file(source: &str, mode: EntryParseMode) -> ParsedEntry {
         EntryParseMode::Strict => syntax::build_ast(source, ENTRY_FILE_ID),
         EntryParseMode::Recover => syntax::build_ast_recovering(source, ENTRY_FILE_ID),
     };
-    let outcome = match result.status {
-        FileParseStatus::Clean => EntryParseOutcome::Clean,
-        FileParseStatus::Recovered => EntryParseOutcome::Recovered(result.errors),
-        FileParseStatus::Failed => EntryParseOutcome::Failed(result.errors),
-    };
     ParsedEntry {
         ast: result.ast,
         file_comment: result.file_comment,
-        outcome,
+        status: result.status,
+        errors: result.errors,
     }
 }
 
@@ -138,11 +119,11 @@ pub(super) fn load_sibling_files(
         } else {
             syntax::build_ast(&content.source, file_id)
         };
-        store.record_parse_status(file_id, result.status);
         sink.extend_parse_errors(result.errors);
         store.store_file(File {
             id: file_id,
             package_id: ENTRY_PACKAGE_ID.to_string(),
+            parse_status: result.status,
             name: filename,
             display_path: content.display_path,
             source_path: None,
@@ -210,26 +191,26 @@ mod tests {
     fn strict_entry_parsing_rejects_partial_ast() {
         let parsed = parse_entry_file("fn valid() {}\nfn incomplete(", EntryParseMode::Strict);
 
-        assert!(parsed.ast.is_empty() && matches!(parsed.outcome, EntryParseOutcome::Failed(_)));
+        assert!(parsed.ast.is_empty() && parsed.status == FileParseStatus::Failed);
     }
 
     #[test]
     fn recovering_entry_parsing_keeps_partial_ast() {
         let parsed = parse_entry_file("fn valid() {}\nfn incomplete(", EntryParseMode::Recover);
 
-        assert!(
-            !parsed.ast.is_empty() && matches!(parsed.outcome, EntryParseOutcome::Recovered(_))
-        );
+        assert!(!parsed.ast.is_empty() && parsed.status == FileParseStatus::Recovered);
     }
 
     #[test]
     fn recovering_entry_parsing_still_rejects_lex_errors() {
         let parsed = parse_entry_file("fn main() { \"unterminated }", EntryParseMode::Recover);
 
-        assert!(matches!(
-            parsed.outcome,
-            EntryParseOutcome::Failed(errors)
-                if errors.first().is_some_and(|error| error.code.starts_with("lex."))
-        ));
+        assert!(
+            parsed.status == FileParseStatus::Failed
+                && parsed
+                    .errors
+                    .first()
+                    .is_some_and(|error| error.code.starts_with("lex."))
+        );
     }
 }

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 
 use diagnostics::LocalSink;
 use syntax::FileParseStatus;
-use syntax::ParseError;
 use syntax::program::{File, Package};
 
 use deps::TypedefLocator;
@@ -134,45 +133,6 @@ enum EntryParseMode {
     Recover,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum EntryParseStatus {
-    #[default]
-    Clean,
-    Recovered,
-    Failed,
-}
-
-pub enum EntryParseOutcome {
-    Clean,
-    Recovered(Vec<ParseError>),
-    Failed(Vec<ParseError>),
-}
-
-impl EntryParseOutcome {
-    pub fn is_clean(&self) -> bool {
-        matches!(self, Self::Clean)
-    }
-
-    pub fn is_failed(&self) -> bool {
-        matches!(self, Self::Failed(_))
-    }
-
-    pub fn status(&self) -> EntryParseStatus {
-        match self {
-            Self::Clean => EntryParseStatus::Clean,
-            Self::Recovered(_) => EntryParseStatus::Recovered,
-            Self::Failed(_) => EntryParseStatus::Failed,
-        }
-    }
-
-    pub fn into_errors(self) -> Vec<ParseError> {
-        match self {
-            Self::Clean => Vec::new(),
-            Self::Recovered(errors) | Self::Failed(errors) => errors,
-        }
-    }
-}
-
 pub struct AnalyzeInput<'a> {
     pub load_siblings: bool,
     pub scope: AnalysisScope,
@@ -254,7 +214,7 @@ pub struct InferenceOutput {
     pub cached_packages: HashSet<String>,
     pub cache_root: Option<PathBuf>,
     pub unreachable_packages: Vec<String>,
-    pub entry_parse: EntryParseOutcome,
+    pub entry_parse_errors: Vec<syntax::ParseError>,
 }
 
 #[derive(Clone, Copy)]
@@ -347,7 +307,10 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
 
     store.init_entry_package();
     let entry = register_entry_file(&mut store, &sink, input.entry, include_tests);
-    if entry.parse_failed() {
+    if store
+        .get_file(ENTRY_FILE_ID)
+        .is_some_and(|file| file.parse_status == FileParseStatus::Failed)
+    {
         let checker = TaskState::with_sink(sink, input.project_kind, input.scope.script_unit());
         return InferenceOutput {
             store,
@@ -358,7 +321,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
             cached_packages: HashSet::default(),
             cache_root: None,
             unreachable_packages: Vec::new(),
-            entry_parse: entry.into_parse(),
+            entry_parse_errors: entry.into_errors(),
         };
     }
     if input.load_siblings {
@@ -372,7 +335,7 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         );
     }
 
-    let entry_package = store.entry_package_id().to_string();
+    let entry_package = ENTRY_PACKAGE_ID.to_string();
     let discovered = if input.scope.has_project_root() {
         input.loader.discover_packages()
     } else {
@@ -455,6 +418,6 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
         cached_packages: package_output.cached_packages,
         cache_root,
         unreachable_packages,
-        entry_parse: entry.into_parse(),
+        entry_parse_errors: entry.into_errors(),
     }
 }

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -6,6 +6,7 @@ use crate::loader;
 use crate::path::DisplayPathBase;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap as HashMap;
+use syntax::ParseError;
 use syntax::program::UninferredExports;
 
 struct CacheCandidate {
@@ -23,7 +24,6 @@ struct UnparsedPackage {
 struct ParsedPackage {
     files: Vec<File>,
     errors: Vec<ParseError>,
-    statuses: Vec<(u32, FileParseStatus)>,
     pending: PendingPackage,
 }
 
@@ -39,13 +39,11 @@ impl UnparsedPackage {
         let recover = recover_target.covers(package_id);
         let mut files = Vec::with_capacity(scanned.len());
         let mut errors = Vec::new();
-        let mut statuses = Vec::new();
         for scanned_file in scanned {
-            let (mut file, file_errors, status) = scanned_file.parse(package_id, recover);
+            let (mut file, file_errors) = scanned_file.parse(package_id, recover);
             if rewrite_root_import {
                 file.rewrite_import(loader::ROOT_IMPORT, ENTRY_PACKAGE_ID);
             }
-            statuses.push((file.id, status));
             files.push(file);
             errors.extend(file_errors);
         }
@@ -53,7 +51,6 @@ impl UnparsedPackage {
         ParsedPackage {
             files,
             errors,
-            statuses,
             pending,
         }
     }
@@ -341,11 +338,11 @@ fn parse_and_store_packages(
 
     let mut has_parse_errors = false;
     for package in parsed {
-        has_parse_errors |= !package.errors.is_empty();
+        has_parse_errors |= package
+            .files
+            .iter()
+            .any(|file| file.parse_status != FileParseStatus::Clean);
         checker.sink.extend_parse_errors(package.errors);
-        for (file_id, status) in package.statuses {
-            store.record_parse_status(file_id, status);
-        }
         store.store_package(package.pending.package_id(), package.files);
         to_infer.push(package.pending);
     }
@@ -364,19 +361,14 @@ fn store_uninferred_packages(
         }
         let recover = recover_target.covers(&package_id);
         let mut files = Vec::with_capacity(scanned.len());
-        let mut parsed = true;
-        let mut statuses = Vec::with_capacity(files.capacity());
+        let mut all_files_clean = true;
         for scanned_file in scanned {
-            let (file, errors, status) = scanned_file.parse(&package_id, recover);
-            parsed &= errors.is_empty();
+            let (file, errors) = scanned_file.parse(&package_id, recover);
+            all_files_clean &= file.parse_status == FileParseStatus::Clean;
             checker.sink.extend_parse_errors(errors);
-            statuses.push((file.id, status));
             files.push(file);
         }
-        for (file_id, status) in statuses {
-            store.record_parse_status(file_id, status);
-        }
-        let exports = if parsed {
+        let exports = if all_files_clean {
             UninferredExports::Known(
                 files
                     .iter()

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -431,7 +431,7 @@ mod tests {
     use super::*;
     use rustc_hash::FxHashSet as HashSet;
     use syntax::ast::{Annotation, Generic, Span, StructFields};
-    use syntax::program::{Attributes, Definition, DefinitionBody, Visibility};
+    use syntax::program::{Attributes, ConstantValue, Definition, DefinitionBody, Visibility};
     use syntax::types::{FunctionParameter, Symbol, Type};
 
     fn generic_struct_definition(visibility: Visibility, file_id: u32) -> Definition {
@@ -594,7 +594,6 @@ mod tests {
 
     #[test]
     fn build_cached_package_preserves_constant_kind() {
-        use syntax::ast::Literal;
         use syntax::program::{Definition, DefinitionBody, ValueKind, Visibility};
 
         let make_value = |kind| Definition {
@@ -616,7 +615,7 @@ mod tests {
         };
 
         let empty_files = HashMap::default();
-        let const_def = make_value(ValueKind::Constant(Literal::Integer {
+        let const_def = make_value(ValueKind::Constant(ConstantValue::Integer {
             value: 5,
             text: None,
         }));

--- a/crates/semantics/src/cache/prelude.rs
+++ b/crates/semantics/src/cache/prelude.rs
@@ -77,6 +77,7 @@ pub(crate) fn register_cached_prelude(store: &mut Store, cached: PreludeCache) {
     store.store_file(File {
         id: PRELUDE_FILE_ID,
         package_id: PRELUDE_PACKAGE_ID.to_string(),
+        parse_status: syntax::FileParseStatus::Clean,
         name: "prelude.d.lis".to_string(),
         display_path: "prelude.d.lis".to_string(),
         source_path: deps::prelude_typedef_path(),

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -1,646 +1,40 @@
 use rustc_hash::FxHashMap as HashMap;
-
-use ecow::EcoString;
 use serde::{Deserialize, Serialize};
-use syntax::ast::Attribute;
-use syntax::ast::EnumFieldDefinition;
-use syntax::ast::EnumVariant;
-use syntax::ast::Literal;
-use syntax::ast::StructFieldDefinition;
-use syntax::ast::StructFieldKind;
-use syntax::ast::VariantFields;
 use syntax::ast::{
-    Annotation, AttributeArg, Generic, Span, StructFields, Visibility as FieldVisibility,
+    Annotation, Attribute, EnumFieldDefinition, EnumVariant, Generic, Span, StructFieldDefinition,
+    StructFieldKind, VariantFields,
 };
-use syntax::program::{
-    AliasKind, Attributes, Definition, DefinitionBody, Interface, Methods, Package, ValueKind,
-    Visibility,
-};
-use syntax::types::{Symbol, Type};
+use syntax::program::{AliasKind, Definition, DefinitionBody, Interface, Method, Package};
+use syntax::types::Symbol;
 
-/// Span stored as file index + byte offsets.
-/// file_index refers to position in PackageInterface.files array (sorted by filename).
-/// When loading from cache, file indices are remapped to newly assigned file IDs.
+/// A definition whose span file IDs are cache-local file indices.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedSpan {
-    file_index: u32,
-    byte_offset: u32,
-    byte_length: u32,
-}
-
-impl CachedSpan {
-    fn from_span(span: &Span, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        Self {
-            file_index: *file_id_to_index.get(&span.file_id).unwrap_or(&0),
-            byte_offset: span.byte_offset,
-            byte_length: span.byte_length,
-        }
-    }
-
-    fn to_span(&self, file_ids: &[u32]) -> Span {
-        Span {
-            file_id: file_ids.get(self.file_index as usize).copied().unwrap_or(0),
-            byte_offset: self.byte_offset,
-            byte_length: self.byte_length,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedGeneric {
-    name: EcoString,
-    bounds: Vec<CachedGenericBound>,
-    span: CachedSpan,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-struct CachedGenericBound {
-    annotation: CachedAnnotation,
-    ty: Type,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-enum CachedAnnotation {
-    Constructor {
-        name: EcoString,
-        params: Vec<Self>,
-        writable: bool,
-        span: CachedSpan,
-    },
-    Function {
-        params: Vec<Self>,
-        return_type: Box<Self>,
-        span: CachedSpan,
-    },
-    Tuple {
-        elements: Vec<Self>,
-        span: CachedSpan,
-    },
-    Unknown,
-    Opaque {
-        span: CachedSpan,
-    },
-    Constant {
-        value: u64,
-        text: Option<String>,
-        span: CachedSpan,
-    },
-}
-
-impl CachedAnnotation {
-    fn from_annotation(annotation: &Annotation, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        match annotation {
-            Annotation::Constructor {
-                name,
-                params,
-                writable,
-                span,
-            } => Self::Constructor {
-                writable: *writable,
-                name: name.clone(),
-                params: params
-                    .iter()
-                    .map(|annotation| Self::from_annotation(annotation, file_id_to_index))
-                    .collect(),
-                span: CachedSpan::from_span(span, file_id_to_index),
-            },
-            Annotation::Function {
-                params,
-                return_type,
-                span,
-            } => Self::Function {
-                params: params
-                    .iter()
-                    .map(|param| Self::from_annotation(param, file_id_to_index))
-                    .collect(),
-                return_type: Box::new(Self::from_annotation(return_type, file_id_to_index)),
-                span: CachedSpan::from_span(span, file_id_to_index),
-            },
-            Annotation::Tuple { elements, span } => Self::Tuple {
-                elements: elements
-                    .iter()
-                    .map(|annotation| Self::from_annotation(annotation, file_id_to_index))
-                    .collect(),
-                span: CachedSpan::from_span(span, file_id_to_index),
-            },
-            Annotation::Unknown => Self::Unknown,
-            Annotation::Opaque { span } => Self::Opaque {
-                span: CachedSpan::from_span(span, file_id_to_index),
-            },
-            Annotation::Constant { value, text, span } => Self::Constant {
-                value: *value,
-                text: text.clone(),
-                span: CachedSpan::from_span(span, file_id_to_index),
-            },
-        }
-    }
-
-    fn to_annotation(&self, file_ids: &[u32]) -> Annotation {
-        match self {
-            Self::Constructor {
-                name,
-                params,
-                writable,
-                span,
-            } => Annotation::Constructor {
-                writable: *writable,
-                name: name.clone(),
-                params: params
-                    .iter()
-                    .map(|annotation| annotation.to_annotation(file_ids))
-                    .collect(),
-                span: span.to_span(file_ids),
-            },
-            Self::Function {
-                params,
-                return_type,
-                span,
-            } => Annotation::Function {
-                params: params
-                    .iter()
-                    .map(|param| param.to_annotation(file_ids))
-                    .collect(),
-                return_type: Box::new(return_type.to_annotation(file_ids)),
-                span: span.to_span(file_ids),
-            },
-            Self::Tuple { elements, span } => Annotation::Tuple {
-                elements: elements
-                    .iter()
-                    .map(|annotation| annotation.to_annotation(file_ids))
-                    .collect(),
-                span: span.to_span(file_ids),
-            },
-            Self::Unknown => Annotation::Unknown,
-            Self::Opaque { span } => Annotation::Opaque {
-                span: span.to_span(file_ids),
-            },
-            Self::Constant { value, text, span } => Annotation::Constant {
-                value: *value,
-                text: text.clone(),
-                span: span.to_span(file_ids),
-            },
-        }
-    }
-}
-
-impl CachedGeneric {
-    fn from_generic(generic: &Generic, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        let resolved = generic
-            .resolved_bounds()
-            .expect("generic bounds must be resolved before caching");
-        Self {
-            name: generic.name.clone(),
-            bounds: generic
-                .bounds()
-                .zip(resolved)
-                .map(|(annotation, ty)| CachedGenericBound {
-                    annotation: CachedAnnotation::from_annotation(annotation, file_id_to_index),
-                    ty: ty.clone(),
-                })
-                .collect(),
-            span: CachedSpan::from_span(&generic.span, file_id_to_index),
-        }
-    }
-
-    fn to_generic(&self, file_ids: &[u32]) -> Generic {
-        Generic::resolved(
-            self.name.clone(),
-            self.bounds
-                .iter()
-                .map(|bound| (bound.annotation.to_annotation(file_ids), bound.ty.clone())),
-            self.span.to_span(file_ids),
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedLiteral {
-    Integer { value: u64, text: Option<String> },
-    Float { value: f64, text: Option<String> },
-    Boolean(bool),
-    String(String),
-    Char(String),
-}
-
-impl CachedLiteral {
-    fn from_literal(lit: &Literal) -> Self {
-        use Literal;
-        match lit {
-            Literal::Integer { value, text } => CachedLiteral::Integer {
-                value: *value,
-                text: text.clone(),
-            },
-            Literal::Float { value, text } => CachedLiteral::Float {
-                value: *value,
-                text: text.clone(),
-            },
-            Literal::Boolean(v) => CachedLiteral::Boolean(*v),
-            Literal::String { value, raw } => {
-                assert!(
-                    !raw,
-                    "cached const literals are canonicalized to non-raw strings"
-                );
-                CachedLiteral::String(value.clone())
-            }
-            Literal::Char(v) => CachedLiteral::Char(v.clone()),
-            // Canonical const literals are never one of these kinds.
-            Literal::Imaginary(_) | Literal::FormatString(_) | Literal::Slice(_) => {
-                unreachable!("only canonical const literals can be cached")
-            }
-        }
-    }
-
-    fn to_literal(&self) -> Literal {
-        use Literal;
-        match self {
-            CachedLiteral::Integer { value, text } => Literal::Integer {
-                value: *value,
-                text: text.clone(),
-            },
-            CachedLiteral::Float { value, text } => Literal::Float {
-                value: *value,
-                text: text.clone(),
-            },
-            CachedLiteral::Boolean(v) => Literal::Boolean(*v),
-            CachedLiteral::String(v) => Literal::String {
-                value: v.clone(),
-                raw: false,
-            },
-            CachedLiteral::Char(v) => Literal::Char(v.clone()),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedAttribute {
-    name: String,
-    args: Vec<AttributeArg>,
-}
-
-impl CachedAttribute {
-    fn from_attribute(attribute: &Attribute) -> Self {
-        Self {
-            name: attribute.name.clone(),
-            args: attribute.args.clone(),
-        }
-    }
-
-    fn to_attribute(&self) -> Attribute {
-        Attribute {
-            name: self.name.clone(),
-            args: self.args.clone(),
-            span: Span::dummy(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedStructField {
-    name: EcoString,
-    name_span: CachedSpan,
-    ty: Type,
-    visibility: FieldVisibility,
-    doc: Option<String>,
-    kind: CachedStructFieldKind,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-enum CachedStructFieldKind {
-    Named { attributes: Vec<CachedAttribute> },
-    Embedded,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedStructFields {
-    Record(Vec<CachedStructField>),
-    Tuple(Vec<CachedStructField>),
-}
-
-impl CachedStructField {
-    fn from_field(field: &StructFieldDefinition, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        let kind = match &field.kind {
-            StructFieldKind::Named { attributes } => CachedStructFieldKind::Named {
-                attributes: attributes
-                    .iter()
-                    .map(CachedAttribute::from_attribute)
-                    .collect(),
-            },
-            StructFieldKind::Embedded => CachedStructFieldKind::Embedded,
-        };
-        Self {
-            name: field.name.clone(),
-            name_span: CachedSpan::from_span(&field.name_span, file_id_to_index),
-            ty: Clone::clone(&field.ty),
-            visibility: field.visibility,
-            doc: field.doc.clone(),
-            kind,
-        }
-    }
-
-    fn to_field(&self, file_ids: &[u32]) -> StructFieldDefinition {
-        let kind = match &self.kind {
-            CachedStructFieldKind::Named { attributes } => StructFieldKind::Named {
-                attributes: attributes
-                    .iter()
-                    .map(CachedAttribute::to_attribute)
-                    .collect(),
-            },
-            CachedStructFieldKind::Embedded => StructFieldKind::Embedded,
-        };
-        StructFieldDefinition {
-            doc: self.doc.clone(),
-            name: self.name.clone(),
-            name_span: self.name_span.to_span(file_ids),
-            ty: self.ty.clone(),
-            visibility: self.visibility,
-            annotation: Annotation::Unknown,
-            kind,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedEnumVariant {
-    name: EcoString,
-    name_span: CachedSpan,
-    fields: CachedVariantFields,
-    doc: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedVariantFields {
-    Unit,
-    Tuple(Vec<CachedEnumField>),
-    Struct(Vec<CachedEnumField>),
-}
-
-impl CachedVariantFields {
-    fn from_variant_fields(fields: &VariantFields) -> Self {
-        match fields {
-            VariantFields::Unit => CachedVariantFields::Unit,
-            VariantFields::Tuple(fs) => {
-                CachedVariantFields::Tuple(fs.iter().map(CachedEnumField::from_field).collect())
-            }
-            VariantFields::Struct(fs) => {
-                CachedVariantFields::Struct(fs.iter().map(CachedEnumField::from_field).collect())
-            }
-        }
-    }
-
-    fn to_variant_fields(&self) -> VariantFields {
-        match self {
-            CachedVariantFields::Unit => VariantFields::Unit,
-            CachedVariantFields::Tuple(fs) => {
-                VariantFields::Tuple(fs.iter().map(|f| f.to_field()).collect())
-            }
-            CachedVariantFields::Struct(fs) => {
-                VariantFields::Struct(fs.iter().map(|f| f.to_field()).collect())
-            }
-        }
-    }
-}
-
-impl CachedEnumVariant {
-    fn from_variant(variant: &EnumVariant, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        Self {
-            name: variant.name.clone(),
-            name_span: CachedSpan::from_span(&variant.name_span, file_id_to_index),
-            fields: CachedVariantFields::from_variant_fields(&variant.fields),
-            doc: variant.doc.clone(),
-        }
-    }
-
-    fn to_variant(&self, file_ids: &[u32]) -> EnumVariant {
-        EnumVariant {
-            doc: self.doc.clone(),
-            name: self.name.clone(),
-            name_span: self.name_span.to_span(file_ids),
-            fields: self.fields.to_variant_fields(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedEnumField {
-    name: EcoString,
-    ty: Type,
-}
-
-impl CachedEnumField {
-    fn from_field(field: &EnumFieldDefinition) -> Self {
-        Self {
-            name: field.name.clone(),
-            ty: Clone::clone(&field.ty),
-        }
-    }
-
-    fn to_field(&self) -> EnumFieldDefinition {
-        EnumFieldDefinition {
-            name: self.name.clone(),
-            name_span: Span::dummy(),
-            ty: self.ty.clone(),
-            annotation: Annotation::Unknown,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedInterface {
-    generics: Vec<CachedGeneric>,
-    parents: Vec<Type>,
-    pub methods: Methods,
-}
-
-impl CachedInterface {
-    fn from_interface(iface: &Interface, file_id_to_index: &HashMap<u32, u32>) -> Self {
-        Self {
-            generics: iface
-                .generics
-                .iter()
-                .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
-                .collect(),
-            parents: iface.parents.iter().map(Clone::clone).collect(),
-            methods: iface.methods.clone(),
-        }
-    }
-
-    fn to_interface(&self, file_ids: &[u32]) -> Interface {
-        Interface {
-            generics: self
-                .generics
-                .iter()
-                .map(|g| g.to_generic(file_ids))
-                .collect(),
-            parents: self.parents.to_vec(),
-            methods: self.methods.clone(),
-        }
-    }
-}
-
-/// Serializable version of Definition. Types are frozen before the cache
-/// writer is reached, so `Var` cannot appear. Mirrors the in-memory
-/// `Definition` shape: common fields up top, variant-specific data in `body`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CachedDefinition {
-    visibility: Visibility,
-    ty: Type,
-    name_span: Option<CachedSpan>,
-    doc: Option<String>,
-    pub body: CachedDefinitionBody,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedValueKind {
-    Runtime,
-    ConstantDeclaration,
-    Constant(CachedLiteral),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedDefinitionBody {
-    TypeAlias {
-        generics: Vec<CachedGeneric>,
-        methods: Methods,
-        alias: CachedAliasKind,
-        attributes: Attributes,
-    },
-    Enum {
-        generics: Vec<CachedGeneric>,
-        variants: Vec<CachedEnumVariant>,
-        methods: Methods,
-        attributes: Attributes,
-    },
-    Struct {
-        generics: Vec<CachedGeneric>,
-        fields: CachedStructFields,
-        methods: Methods,
-        attributes: Attributes,
-    },
-    Interface {
-        definition: CachedInterface,
-    },
-    Value {
-        kind: CachedValueKind,
-        allowed_lints: Vec<String>,
-        go_hints: Vec<String>,
-        go_name: Option<String>,
-        go_type_param_recipe: Option<String>,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum CachedAliasKind {
-    Opaque,
-    Transparent(Type),
-}
+#[serde(transparent)]
+pub struct CachedDefinition(Definition);
 
 impl CachedDefinition {
-    /// Create a cached production definition from its in-memory form.
+    pub fn as_definition(&self) -> &Definition {
+        &self.0
+    }
+
     pub(crate) fn from_definition(
         definition: &Definition,
         file_id_to_index: &HashMap<u32, u32>,
     ) -> Self {
-        let Definition {
-            ty,
-            name_span,
-            doc,
-            body,
-            ..
-        } = definition;
-        let body = match body {
-            DefinitionBody::TypeAlias {
-                generics,
-                alias,
-                methods,
-                attributes,
-            } => CachedDefinitionBody::TypeAlias {
-                generics: generics
-                    .iter()
-                    .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
-                    .collect(),
-                methods: methods.clone(),
-                alias: match alias {
-                    AliasKind::Opaque(_) => CachedAliasKind::Opaque,
-                    AliasKind::Transparent { target, .. } => {
-                        CachedAliasKind::Transparent(target.clone())
-                    }
-                },
-                attributes: attributes.clone(),
-            },
-            DefinitionBody::Enum {
-                generics,
-                variants,
-                methods,
-                attributes,
-            } => CachedDefinitionBody::Enum {
-                generics: generics
-                    .iter()
-                    .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
-                    .collect(),
-                variants: variants
-                    .iter()
-                    .map(|v| CachedEnumVariant::from_variant(v, file_id_to_index))
-                    .collect(),
-                methods: methods.clone(),
-                attributes: attributes.clone(),
-            },
-            DefinitionBody::Struct {
-                generics,
-                fields,
-                methods,
-                attributes,
-            } => CachedDefinitionBody::Struct {
-                generics: generics
-                    .iter()
-                    .map(|g| CachedGeneric::from_generic(g, file_id_to_index))
-                    .collect(),
-                fields: match fields {
-                    StructFields::Record(fields) => CachedStructFields::Record(
-                        fields
-                            .iter()
-                            .map(|f| CachedStructField::from_field(f, file_id_to_index))
-                            .collect(),
-                    ),
-                    StructFields::Tuple(fields) => CachedStructFields::Tuple(
-                        fields
-                            .iter()
-                            .map(|f| CachedStructField::from_field(f, file_id_to_index))
-                            .collect(),
-                    ),
-                },
-                methods: methods.clone(),
-                attributes: attributes.clone(),
-            },
-            DefinitionBody::Interface { definition } => CachedDefinitionBody::Interface {
-                definition: CachedInterface::from_interface(definition, file_id_to_index),
-            },
-            DefinitionBody::Value {
-                kind,
-                allowed_lints,
-                go_hints,
-                go_name,
-                go_type_param_recipe,
-            } => CachedDefinitionBody::Value {
-                kind: match kind {
-                    ValueKind::Runtime => CachedValueKind::Runtime,
-                    ValueKind::ConstantDeclaration => CachedValueKind::ConstantDeclaration,
-                    ValueKind::Constant(value) => {
-                        CachedValueKind::Constant(CachedLiteral::from_literal(value))
-                    }
-                },
-                allowed_lints: allowed_lints.clone(),
-                go_hints: go_hints.clone(),
-                go_name: go_name.clone(),
-                go_type_param_recipe: go_type_param_recipe.clone(),
-            },
-        };
-        CachedDefinition {
-            visibility: definition.visibility.clone(),
-            ty: ty.clone(),
-            name_span: name_span.map(|s| CachedSpan::from_span(&s, file_id_to_index)),
-            doc: doc.clone(),
-            body,
-        }
+        debug_assert!(
+            definition
+                .body
+                .generics()
+                .is_none_or(|generics| generics.iter().all(Generic::bounds_are_resolved)),
+            "generic bounds must be resolved before caching",
+        );
+        let mut definition = definition.clone();
+        remap_definition_spans(&mut definition, &mut |span| {
+            if !span.is_dummy() {
+                span.file_id = file_id_to_index.get(&span.file_id).copied().unwrap_or(0);
+            }
+        });
+        Self(definition)
     }
 
     pub(crate) fn install_into(
@@ -649,87 +43,305 @@ impl CachedDefinition {
         qualified_name: Symbol,
         file_ids: &[u32],
     ) {
-        let definition = self.to_definition(file_ids);
-        package.definitions.insert(qualified_name, definition);
+        package
+            .definitions
+            .insert(qualified_name, self.to_definition(file_ids));
     }
 
     pub(crate) fn to_definition(&self, file_ids: &[u32]) -> Definition {
-        let body = match &self.body {
-            CachedDefinitionBody::TypeAlias {
-                generics,
-                methods,
-                alias,
-                attributes,
-            } => DefinitionBody::TypeAlias {
-                generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
-                alias: match alias {
-                    CachedAliasKind::Opaque => AliasKind::Opaque(Annotation::Opaque {
-                        span: Span::dummy(),
-                    }),
-                    CachedAliasKind::Transparent(target) => AliasKind::Transparent {
-                        annotation: Annotation::Unknown,
-                        target: target.clone(),
-                    },
-                },
-                methods: methods.clone(),
-                attributes: attributes.clone(),
-            },
-            CachedDefinitionBody::Enum {
-                generics,
-                variants,
-                methods,
-                attributes,
-            } => DefinitionBody::Enum {
-                generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
-                variants: variants.iter().map(|v| v.to_variant(file_ids)).collect(),
-                methods: methods.clone(),
-                attributes: attributes.clone(),
-            },
-            CachedDefinitionBody::Struct {
-                generics,
-                fields,
-                methods,
-                attributes,
-            } => DefinitionBody::Struct {
-                generics: generics.iter().map(|g| g.to_generic(file_ids)).collect(),
-                fields: match fields {
-                    CachedStructFields::Record(fields) => {
-                        StructFields::Record(fields.iter().map(|f| f.to_field(file_ids)).collect())
-                    }
-                    CachedStructFields::Tuple(fields) => {
-                        StructFields::Tuple(fields.iter().map(|f| f.to_field(file_ids)).collect())
-                    }
-                },
-                methods: methods.clone(),
-                attributes: attributes.clone(),
-            },
-            CachedDefinitionBody::Interface { definition } => DefinitionBody::Interface {
-                definition: definition.to_interface(file_ids),
-            },
-            CachedDefinitionBody::Value {
-                kind,
-                allowed_lints,
-                go_hints,
-                go_name,
-                go_type_param_recipe,
-            } => DefinitionBody::Value {
-                kind: match kind {
-                    CachedValueKind::Runtime => ValueKind::Runtime,
-                    CachedValueKind::ConstantDeclaration => ValueKind::ConstantDeclaration,
-                    CachedValueKind::Constant(value) => ValueKind::Constant(value.to_literal()),
-                },
-                allowed_lints: allowed_lints.clone(),
-                go_hints: go_hints.clone(),
-                go_name: go_name.clone(),
-                go_type_param_recipe: go_type_param_recipe.clone(),
+        let mut definition = self.0.clone();
+        remap_definition_spans(&mut definition, &mut |span| {
+            if !span.is_dummy() {
+                span.file_id = file_ids.get(span.file_id as usize).copied().unwrap_or(0);
+            }
+        });
+        definition
+    }
+}
+
+fn remap_definition_spans(definition: &mut Definition, remap: &mut impl FnMut(&mut Span)) {
+    let Definition {
+        visibility: _,
+        ty: _,
+        name_span,
+        doc: _,
+        body,
+    } = definition;
+    if let Some(span) = name_span {
+        remap(span);
+    }
+
+    match body {
+        DefinitionBody::TypeAlias {
+            generics,
+            alias,
+            methods,
+            attributes: _,
+        } => {
+            remap_generics(generics, remap);
+            match alias {
+                AliasKind::Opaque(annotation)
+                | AliasKind::Transparent {
+                    annotation,
+                    target: _,
+                } => remap_annotation(annotation, remap),
+            }
+            remap_methods(methods.values_mut(), remap);
+        }
+        DefinitionBody::Enum {
+            generics,
+            variants,
+            methods,
+            attributes: _,
+        } => {
+            remap_generics(generics, remap);
+            for variant in variants {
+                remap_variant(variant, remap);
+            }
+            remap_methods(methods.values_mut(), remap);
+        }
+        DefinitionBody::Struct {
+            generics,
+            fields,
+            methods,
+            attributes: _,
+        } => {
+            remap_generics(generics, remap);
+            for field in fields {
+                remap_struct_field(field, remap);
+            }
+            remap_methods(methods.values_mut(), remap);
+        }
+        DefinitionBody::Interface { definition } => remap_interface(definition, remap),
+        DefinitionBody::Value {
+            kind: _,
+            allowed_lints: _,
+            go_hints: _,
+            go_name: _,
+            go_type_param_recipe: _,
+        } => {}
+    }
+}
+
+fn remap_generics(generics: &mut [Generic], remap: &mut impl FnMut(&mut Span)) {
+    for generic in generics {
+        remap(&mut generic.span);
+        generic.for_each_bound_annotation_mut(|annotation| remap_annotation(annotation, remap));
+    }
+}
+
+fn remap_annotation(annotation: &mut Annotation, remap: &mut impl FnMut(&mut Span)) {
+    match annotation {
+        Annotation::Constructor {
+            name: _,
+            params,
+            writable: _,
+            span,
+        } => {
+            remap(span);
+            for param in params {
+                remap_annotation(param, remap);
+            }
+        }
+        Annotation::Function {
+            params,
+            return_type,
+            span,
+        } => {
+            remap(span);
+            for param in params {
+                remap_annotation(param, remap);
+            }
+            remap_annotation(return_type, remap);
+        }
+        Annotation::Tuple { elements, span } => {
+            remap(span);
+            for element in elements {
+                remap_annotation(element, remap);
+            }
+        }
+        Annotation::Opaque { span } | Annotation::Constant { span, .. } => remap(span),
+        Annotation::Unknown => {}
+    }
+}
+
+fn remap_methods<'a>(
+    methods: impl Iterator<Item = &'a mut Method>,
+    remap: &mut impl FnMut(&mut Span),
+) {
+    for method in methods {
+        let Method {
+            source_name: _,
+            ty: _,
+            visibility: _,
+            origin: _,
+            name_span,
+            doc: _,
+            allowed_lints: _,
+            go_hints: _,
+        } = method;
+        if let Some(span) = name_span {
+            remap(span);
+        }
+    }
+}
+
+fn remap_variant(variant: &mut EnumVariant, remap: &mut impl FnMut(&mut Span)) {
+    let EnumVariant {
+        doc: _,
+        name: _,
+        name_span,
+        fields,
+    } = variant;
+    remap(name_span);
+    match fields {
+        VariantFields::Unit => {}
+        VariantFields::Tuple(fields) | VariantFields::Struct(fields) => {
+            for field in fields {
+                let EnumFieldDefinition {
+                    name: _,
+                    name_span,
+                    annotation,
+                    ty: _,
+                } = field;
+                remap(name_span);
+                remap_annotation(annotation, remap);
+            }
+        }
+    }
+}
+
+fn remap_struct_field(field: &mut StructFieldDefinition, remap: &mut impl FnMut(&mut Span)) {
+    let StructFieldDefinition {
+        doc: _,
+        name: _,
+        name_span,
+        annotation,
+        visibility: _,
+        ty: _,
+        kind,
+    } = field;
+    remap(name_span);
+    remap_annotation(annotation, remap);
+    if let StructFieldKind::Named { attributes } = kind {
+        for attribute in attributes {
+            let Attribute {
+                name: _,
+                args: _,
+                span,
+            } = attribute;
+            remap(span);
+        }
+    }
+}
+
+fn remap_interface(interface: &mut Interface, remap: &mut impl FnMut(&mut Span)) {
+    let Interface {
+        generics,
+        parents: _,
+        methods,
+    } = interface;
+    remap_generics(generics, remap);
+    remap_methods(methods.values_mut(), remap);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ecow::EcoString;
+    use syntax::ast::{StructFields, Visibility as AstVisibility};
+    use syntax::program::{MethodOrigin, Methods, ValueKind, Visibility};
+    use syntax::types::Type;
+
+    #[test]
+    fn dummy_spans_are_not_remapped() {
+        let mut definition = Definition {
+            visibility: Visibility::Private,
+            ty: Type::Error,
+            name_span: Some(Span::dummy()),
+            doc: None,
+            body: DefinitionBody::Value {
+                kind: ValueKind::Runtime,
+                allowed_lints: Vec::new(),
+                go_hints: Vec::new(),
+                go_name: None,
+                go_type_param_recipe: None,
             },
         };
-        Definition {
-            visibility: self.visibility.clone(),
-            ty: self.ty.clone(),
-            name_span: self.name_span.as_ref().map(|s| s.to_span(file_ids)),
-            doc: self.doc.clone(),
-            body,
-        }
+
+        remap_definition_spans(&mut definition, &mut |span| {
+            if !span.is_dummy() {
+                span.file_id = 7;
+            }
+        });
+
+        assert!(definition.name_span.is_some_and(|span| span.is_dummy()));
+    }
+
+    #[test]
+    fn definition_round_trip_remaps_nested_spans() {
+        let source_file = 17;
+        let cached_file = 91;
+        let span = || Span::new(source_file, 2, 3);
+        let annotation = || Annotation::Constructor {
+            name: EcoString::from("Item"),
+            params: vec![Annotation::Opaque { span: span() }],
+            writable: false,
+            span: span(),
+        };
+        let mut methods = Methods::default();
+        methods.insert(
+            EcoString::from("get"),
+            Method {
+                source_name: EcoString::from("get"),
+                ty: Type::Error,
+                visibility: Visibility::Public,
+                origin: MethodOrigin::Declared,
+                name_span: Some(span()),
+                doc: None,
+                allowed_lints: Vec::new(),
+                go_hints: Vec::new(),
+            },
+        );
+        let definition = Definition {
+            visibility: Visibility::Public,
+            ty: Type::Error,
+            name_span: Some(span()),
+            doc: None,
+            body: DefinitionBody::Struct {
+                generics: vec![Generic::resolved(
+                    "T",
+                    [(annotation(), Type::Error)],
+                    span(),
+                )],
+                fields: StructFields::Record(vec![StructFieldDefinition {
+                    doc: None,
+                    name: EcoString::from("field"),
+                    name_span: span(),
+                    annotation: annotation(),
+                    visibility: AstVisibility::Private,
+                    ty: Type::Error,
+                    kind: StructFieldKind::Named {
+                        attributes: vec![Attribute {
+                            name: "go".to_string(),
+                            args: Vec::new(),
+                            span: span(),
+                        }],
+                    },
+                }]),
+                methods,
+                attributes: Default::default(),
+            },
+        };
+        let file_map = [(source_file, 0)].into_iter().collect();
+
+        let cached = CachedDefinition::from_definition(&definition, &file_map);
+        let bytes = bincode::serialize(&cached).unwrap();
+        let cached: CachedDefinition = bincode::deserialize(&bytes).unwrap();
+        let restored = cached.to_definition(&[cached_file]);
+        let mut expected = definition;
+        remap_definition_spans(&mut expected, &mut |span| span.file_id = cached_file);
+
+        assert_eq!(restored, expected);
     }
 }

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -107,6 +107,54 @@ pub(super) enum ValueSource {
     Call(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LetMutability {
+    NoFix,
+    AddMut,
+    RestoreWriteWithMut,
+}
+
+impl LetMutability {
+    pub(super) fn can_add_mut(self) -> bool {
+        !matches!(self, Self::NoFix)
+    }
+
+    pub(super) fn was_demoted(self) -> bool {
+        matches!(self, Self::RestoreWriteWithMut)
+    }
+}
+
+pub(super) struct LetInference {
+    pub(super) mutability: LetMutability,
+    pub(super) source: Option<ValueSource>,
+}
+
+pub(super) struct LoopElementInference {
+    pub(super) collection: Option<String>,
+    pub(super) was_demoted: bool,
+}
+
+pub(super) enum BindingInference {
+    Let(LetInference),
+    LoopElement(LoopElementInference),
+}
+
+impl BindingInference {
+    pub(super) fn as_let(&self) -> Option<&LetInference> {
+        match self {
+            Self::Let(inference) => Some(inference),
+            Self::LoopElement(_) => None,
+        }
+    }
+
+    pub(super) fn as_loop_element(&self) -> Option<&LoopElementInference> {
+        match self {
+            Self::LoopElement(inference) => Some(inference),
+            Self::Let(_) => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct Expectation {
     pub(super) role: ExpectationRole,
@@ -227,17 +275,8 @@ pub struct InferCtx<'a> {
     pub(super) file_checks: FileChecks,
     pub(crate) satisfying_stack: FxHashSet<(String, String)>,
     pub(super) reported_immutable: FxHashSet<BindingId>,
-    /// Identifier-pattern lets, the only bindings where inserting `mut` is valid.
-    pub(super) plain_lets: FxHashSet<BindingId>,
-    /// Plain lets whose initializer was writable, where inserting `mut` restores the write.
-    pub(super) demoted_writable_lets: FxHashSet<BindingId>,
-    /// Plain loop bindings over writable elements, where `for mut` restores the write.
-    pub(super) demoted_writable_loops: FxHashSet<BindingId>,
-    /// Loop element bindings, each with its collection's name: writes to the
-    /// binding itself stay on the loop copy.
-    pub(super) loop_element_bindings: FxHashMap<BindingId, Option<String>>,
+    pub(super) binding_inference: FxHashMap<BindingId, BindingInference>,
     pub(super) reported_read_only_writes: FxHashSet<(BindingId, String)>,
-    pub(super) value_sources: FxHashMap<BindingId, ValueSource>,
     traversal: TraversalContext,
 }
 
@@ -249,12 +288,8 @@ impl<'a> InferCtx<'a> {
             file_checks: FileChecks::default(),
             satisfying_stack: FxHashSet::default(),
             reported_immutable: FxHashSet::default(),
-            plain_lets: FxHashSet::default(),
-            demoted_writable_lets: FxHashSet::default(),
-            demoted_writable_loops: FxHashSet::default(),
-            loop_element_bindings: FxHashMap::default(),
+            binding_inference: FxHashMap::default(),
             reported_read_only_writes: FxHashSet::default(),
-            value_sources: FxHashMap::default(),
             traversal: TraversalContext::default(),
         }
     }
@@ -345,6 +380,19 @@ impl<'a> InferCtx<'a> {
 
     pub(super) fn with_value_context<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         self.with_use_context(UseContext::Value, f)
+    }
+
+    pub(super) fn with_callee_context<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> (T, Option<String>) {
+        debug_assert!(
+            self.traversal.pending_writable_receiver.is_none(),
+            "a writable receiver must be consumed by its enclosing call"
+        );
+        let result = self.with_use_context(UseContext::Callee, f);
+        let writable_receiver = self.traversal.pending_writable_receiver.take();
+        (result, writable_receiver)
     }
 
     pub(super) fn with_expectation<T>(
@@ -491,11 +539,11 @@ impl<'a> InferCtx<'a> {
     }
 
     pub(super) fn stash_writable_receiver(&mut self, place: String) {
+        debug_assert!(
+            self.traversal.pending_writable_receiver.is_none(),
+            "one callee cannot register multiple writable receivers"
+        );
         self.traversal.pending_writable_receiver = Some(place);
-    }
-
-    pub(super) fn take_writable_receiver(&mut self) -> Option<String> {
-        self.traversal.pending_writable_receiver.take()
     }
 
     pub(super) fn in_flipped_qualifier_variance<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {

--- a/crates/semantics/src/checker/infer/expressions/bindings.rs
+++ b/crates/semantics/src/checker/infer/expressions/bindings.rs
@@ -5,6 +5,7 @@ use syntax::program::DefinitionBody;
 use syntax::types::{Symbol, Type};
 
 use crate::checker::infer::InferCtx;
+use crate::checker::infer::context::{BindingInference, LetInference, LetMutability};
 use crate::facts::EmptyCollectionCheck;
 use crate::loader;
 
@@ -201,21 +202,19 @@ impl InferCtx<'_> {
         if is_plain_identifier
             && let Some(name) = inferred_pattern.get_identifier()
             && let Some(binding_id) = self.scopes.lookup_binding_id(&name)
-            && let Some(source) = self.value_source(new_value.unwrap_parens(), &name)
         {
-            self.value_sources.insert(binding_id, source);
-        }
-
-        if !mutable
-            && is_plain_identifier
-            && !is_assert
-            && let Some(name) = inferred_pattern.get_identifier()
-            && let Some(binding_id) = self.scopes.lookup_binding_id(&name)
-        {
-            self.plain_lets.insert(binding_id);
-            if demoted_from_writable {
-                self.demoted_writable_lets.insert(binding_id);
-            }
+            let mutability = if mutable || is_assert {
+                LetMutability::NoFix
+            } else if demoted_from_writable {
+                LetMutability::RestoreWriteWithMut
+            } else {
+                LetMutability::AddMut
+            };
+            let source = self.value_source(new_value.unwrap_parens(), &name);
+            self.binding_inference.insert(
+                binding_id,
+                BindingInference::Let(LetInference { mutability, source }),
+            );
         }
 
         let new_binding = Binding {
@@ -224,15 +223,6 @@ impl InferCtx<'_> {
             ty: binding_ty,
             mut_span,
         };
-
-        if !mutable
-            && !is_assert
-            && new_binding.pattern.is_identifier()
-            && let Some(ref name) = binding_name
-            && let Some(binding_id) = self.scopes.lookup_binding_id(name)
-        {
-            self.plain_lets.insert(binding_id);
-        }
 
         if !has_annotation
             && new_value.is_empty_collection()

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -11,7 +11,7 @@ use syntax::types::{
     unqualified_name,
 };
 
-use super::super::context::{Expectation, ExpectationRole, UseContext};
+use super::super::context::{Expectation, ExpectationRole};
 use super::super::unify::Dispatched;
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
@@ -145,11 +145,8 @@ impl InferCtx<'_> {
         let store = self.store;
         let callee_ty = self.new_type_var();
 
-        let callee_expression = self.with_use_context(UseContext::Callee, |state| {
-            state.infer_expression(*expression, &callee_ty)
-        });
-
-        let writable_receiver = self.take_writable_receiver();
+        let (callee_expression, writable_receiver) =
+            self.with_callee_context(|state| state.infer_expression(*expression, &callee_ty));
 
         let forall_ty = self.resolve_callee_forall_type(&callee_expression, &type_args);
         let (callee_ty, type_arguments) =
@@ -1092,7 +1089,9 @@ impl InferCtx<'_> {
                     && self
                         .scopes
                         .lookup_binding_id(&name)
-                        .is_some_and(|id| self.demoted_writable_lets.contains(&id))
+                        .and_then(|id| self.binding_inference.get(&id))
+                        .and_then(|binding| binding.as_let())
+                        .is_some_and(|inference| inference.mutability.was_demoted())
                 {
                     let store = self.store;
                     self.report_disallowed_mutation(

--- a/crates/semantics/src/checker/infer/expressions/loops.rs
+++ b/crates/semantics/src/checker/infer/expressions/loops.rs
@@ -1,5 +1,5 @@
 use crate::checker::EnvResolve;
-use crate::checker::infer::context::LoopContext;
+use crate::checker::infer::context::{BindingInference, LoopContext, LoopElementInference};
 use syntax::ast::BindingKind;
 use syntax::ast::{Binding, Expression, Pattern, Span};
 use syntax::types::Type;
@@ -162,12 +162,15 @@ impl InferCtx<'_> {
             if let Some(name) = inferred_pattern.get_identifier()
                 && let Some(binding_id) = this.scopes.lookup_binding_id(&name)
             {
-                if demoted_from_writable {
-                    this.demoted_writable_loops.insert(binding_id);
-                }
                 let collection = super::aliasing::place_root_name(new_iterable.unwrap_parens())
                     .map(|root| root.to_string());
-                this.loop_element_bindings.insert(binding_id, collection);
+                this.binding_inference.insert(
+                    binding_id,
+                    BindingInference::LoopElement(LoopElementInference {
+                        collection,
+                        was_demoted: demoted_from_writable,
+                    }),
+                );
             }
 
             let new_binding = Binding {

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -622,7 +622,7 @@ impl InferCtx<'_> {
             self.facts.add_usage(span, definition_span);
         }
 
-        let resolution = match definition.const_value().cloned() {
+        let resolution = match definition.const_value().map(|value| value.to_literal()) {
             Some(value) => ConstructorPatternResolution::ConstValue {
                 qualified_name: qualified,
                 value,

--- a/crates/semantics/src/checker/infer/expressions/permission.rs
+++ b/crates/semantics/src/checker/infer/expressions/permission.rs
@@ -387,10 +387,14 @@ impl InferCtx<'_> {
 
     fn binding_context(&self, name: &str) -> Option<diagnostics::infer::WriteContext> {
         let binding_id = self.scopes.lookup_binding_id(name)?;
-        if let Some(collection) = self.loop_element_bindings.get(&binding_id) {
+        if let Some(inference) = self
+            .binding_inference
+            .get(&binding_id)
+            .and_then(|binding| binding.as_loop_element())
+        {
             return Some(diagnostics::infer::WriteContext::LoopElement {
                 binding: name.to_string(),
-                collection: collection.clone(),
+                collection: inference.collection.clone(),
             });
         }
         let kind = self
@@ -404,7 +408,13 @@ impl InferCtx<'_> {
                 name.to_string(),
             ));
         }
-        match self.value_sources.get(&binding_id)? {
+        match self
+            .binding_inference
+            .get(&binding_id)?
+            .as_let()?
+            .source
+            .as_ref()?
+        {
             ValueSource::Place(source) => Some(diagnostics::infer::WriteContext::AliasOf {
                 binding: name.to_string(),
                 source: source.clone(),
@@ -551,7 +561,13 @@ impl InferCtx<'_> {
     fn owner_origin(&self, owner: &Expression) -> Option<String> {
         let name = owner.unwrap_parens().get_var_name()?;
         let binding_id = self.scopes.lookup_binding_id(&name)?;
-        match self.value_sources.get(&binding_id)? {
+        match self
+            .binding_inference
+            .get(&binding_id)?
+            .as_let()?
+            .source
+            .as_ref()?
+        {
             ValueSource::Call(callee) => Some(callee.clone()),
             ValueSource::Place(_) => None,
         }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -221,12 +221,15 @@ impl InferCtx<'_> {
             {
                 self.facts.mark_alias_mutated(binding_id);
                 if ref_ty.is_writable()
-                    && let Some(collection) = self.loop_element_bindings.get(&binding_id).cloned()
+                    && let Some(inference) = self
+                        .binding_inference
+                        .get(&binding_id)
+                        .and_then(|binding| binding.as_loop_element())
                     && self.reported_immutable.insert(binding_id)
                 {
                     self.sink.push(diagnostics::infer::loop_copy_write(
                         &var_name,
-                        collection.as_deref(),
+                        inference.collection.as_deref(),
                         span,
                     ));
                 }
@@ -487,7 +490,9 @@ impl InferCtx<'_> {
                     if receiver_needs_mut {
                         self.report_disallowed_mutation(store, "self", span, false, None);
                     } else if root_binding
-                        .is_some_and(|id| self.demoted_writable_lets.contains(&id))
+                        .and_then(|id| self.binding_inference.get(&id))
+                        .and_then(|binding| binding.as_let())
+                        .is_some_and(|inference| inference.mutability.was_demoted())
                     {
                         self.report_disallowed_mutation(
                             store,
@@ -496,9 +501,12 @@ impl InferCtx<'_> {
                             false,
                             None,
                         );
-                    } else if let Some(id) =
-                        root_binding.filter(|id| self.demoted_writable_loops.contains(id))
-                    {
+                    } else if let Some(id) = root_binding.filter(|id| {
+                        self.binding_inference
+                            .get(id)
+                            .and_then(|binding| binding.as_loop_element())
+                            .is_some_and(|inference| inference.was_demoted)
+                    }) {
                         if self.reported_immutable.insert(id) {
                             self.sink.push(diagnostics::infer::loop_binding_read_only(
                                 &root.expect("rooted"),
@@ -522,12 +530,15 @@ impl InferCtx<'_> {
                     let rhs_is_ref = store.peel_alias(&value_ty.resolve_in(&self.env)).is_ref();
                     self.report_disallowed_mutation(store, &name, span, rhs_is_ref, None);
                 } else if let Some(id) = self.scopes.lookup_binding_id(&name)
-                    && let Some(collection) = self.loop_element_bindings.get(&id).cloned()
+                    && let Some(inference) = self
+                        .binding_inference
+                        .get(&id)
+                        .and_then(|binding| binding.as_loop_element())
                     && self.reported_immutable.insert(id)
                 {
                     self.sink.push(diagnostics::infer::loop_copy_write(
                         &name,
-                        collection.as_deref(),
+                        inference.collection.as_deref(),
                         span,
                     ));
                 }
@@ -597,11 +608,14 @@ impl InferCtx<'_> {
             return;
         }
         if let Some(id) = binding_id
-            && let Some(collection) = self.loop_element_bindings.get(&id).cloned()
+            && let Some(inference) = self
+                .binding_inference
+                .get(&id)
+                .and_then(|binding| binding.as_loop_element())
         {
             self.sink.push(diagnostics::infer::immutable_loop_binding(
                 var_name,
-                collection.as_deref(),
+                inference.collection.as_deref(),
                 span,
             ));
             return;
@@ -636,7 +650,11 @@ impl InferCtx<'_> {
         if !is_const
             && pointer_type.is_none()
             && let Some(id) = binding_id
-            && self.plain_lets.contains(&id)
+            && self
+                .binding_inference
+                .get(&id)
+                .and_then(|binding| binding.as_let())
+                .is_some_and(|inference| inference.mutability.can_add_mut())
             && let Some(declaration) = self.facts.bindings.get(&id).map(|b| b.span)
         {
             diagnostic = diagnostic.with_fix(diagnostics::Fix::new(

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -5,9 +5,8 @@ use crate::checker::infer::expressions::comparison::{
 };
 use std::mem;
 use syntax::EcoString;
-use syntax::ast::Literal;
 use syntax::ast::{Annotation, Generic, Span, VariantFields};
-use syntax::program::{AliasKind, DefinitionBody};
+use syntax::program::{AliasKind, ConstantValue, DefinitionBody};
 use syntax::types::{
     FunctionParameter, SimpleKind, Symbol, Type, build_named_substitution_map, substitute,
     unqualified_name,
@@ -543,7 +542,7 @@ impl TaskState {
                 .push(diagnostics::infer::array_size_computed_constant(name, span));
             return None;
         };
-        let Literal::Integer { value, .. } = literal else {
+        let ConstantValue::Integer { value, .. } = literal else {
             self.sink
                 .push(diagnostics::infer::array_size_not_integer_constant(
                     name, span,
@@ -582,7 +581,7 @@ impl TaskState {
             let Some(definition) = store.get_definition(&pending.qualified_name) else {
                 continue;
             };
-            let Some(Literal::Integer { value, .. }) = definition.const_value() else {
+            let Some(ConstantValue::Integer { value, .. }) = definition.const_value() else {
                 continue;
             };
             let outcome = store

--- a/crates/semantics/src/checker/registration/go.rs
+++ b/crates/semantics/src/checker/registration/go.rs
@@ -48,6 +48,7 @@ impl TaskState {
         let file = File {
             id: file_id,
             package_id: package_id.to_string(),
+            parse_status: build_result.status,
             name: filename.clone(),
             display_path: filename,
             source_path: cache_path,

--- a/crates/semantics/src/checker/registration/values.rs
+++ b/crates/semantics/src/checker/registration/values.rs
@@ -1,38 +1,34 @@
 use super::*;
-use syntax::ast::Literal;
 use syntax::attributes;
-use syntax::program::ValueKind;
+use syntax::program::{ConstantValue, ValueKind};
 
-fn canonical_const_literal(expression: &Expression) -> Option<Literal> {
+fn canonical_const_value(expression: &Expression) -> Option<ConstantValue> {
     use syntax::ast::{Literal, UnaryOperator};
     match expression.unwrap_parens() {
         Expression::Literal { literal, .. } => match literal {
-            Literal::Integer { value, .. } => Some(Literal::Integer {
+            Literal::Integer { value, .. } => Some(ConstantValue::Integer {
                 value: *value,
                 text: None,
             }),
-            Literal::Float { value, .. } => Some(Literal::Float {
+            Literal::Float { value, .. } => Some(ConstantValue::Float {
                 value: *value,
                 text: None,
             }),
-            Literal::Boolean(b) => Some(Literal::Boolean(*b)),
-            Literal::String { value, .. } => Some(Literal::String {
-                value: value.clone(),
-                raw: false,
-            }),
-            Literal::Char(c) => Some(Literal::Char(c.clone())),
+            Literal::Boolean(value) => Some(ConstantValue::Boolean(*value)),
+            Literal::String { value, .. } => Some(ConstantValue::String(value.clone())),
+            Literal::Char(value) => Some(ConstantValue::Char(value.clone())),
             _ => None,
         },
         Expression::Unary {
             operator: UnaryOperator::Negative,
             expression,
             ..
-        } => match canonical_const_literal(expression)? {
-            Literal::Integer { value, .. } => Some(Literal::Integer {
+        } => match canonical_const_value(expression)? {
+            ConstantValue::Integer { value, .. } => Some(ConstantValue::Integer {
                 value: value.wrapping_neg(),
                 text: None,
             }),
-            Literal::Float { value, .. } => Some(Literal::Float {
+            ConstantValue::Float { value, .. } => Some(ConstantValue::Float {
                 value: -value,
                 text: None,
             }),
@@ -234,7 +230,7 @@ impl TaskState {
             ));
         }
 
-        let kind = match expression.value().and_then(canonical_const_literal) {
+        let kind = match expression.value().and_then(canonical_const_value) {
             Some(value) => ValueKind::Constant(value),
             None => ValueKind::ConstantDeclaration,
         };

--- a/crates/semantics/src/closed_domain.rs
+++ b/crates/semantics/src/closed_domain.rs
@@ -112,16 +112,18 @@ impl Store {
             .definitions
             .iter()
             .filter_map(|(qualified_name, definition)| {
-                let literal = definition.const_value()?;
+                let value = definition.const_value()?;
                 let Type::Nominal { id, .. } = &definition.ty else {
                     return None;
                 };
-                if id != type_id || DomainValue::from_literal(literal, base).is_none() {
+                if id != type_id {
                     return None;
                 }
+                let literal = value.to_literal();
+                DomainValue::from_literal(&literal, base)?;
                 Some(ClosedMember {
                     display_name: domain_display_name(qualified_name.as_str()).into(),
-                    literal: literal.clone(),
+                    literal,
                 })
             })
             .collect();

--- a/crates/semantics/src/lib.rs
+++ b/crates/semantics/src/lib.rs
@@ -13,6 +13,6 @@ pub mod store;
 pub mod zero;
 
 pub use analysis::{
-    AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, EntryParseOutcome, EntryParseStatus,
-    InferenceOutput, PARALLEL_THRESHOLD, ProjectKind, RecoverTarget, run_inference,
+    AnalysisScope, AnalyzeInput, CompilePhase, EntryFile, InferenceOutput, PARALLEL_THRESHOLD,
+    ProjectKind, RecoverTarget, run_inference,
 };

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -201,20 +201,16 @@ impl ScannedFile {
         program::is_test_file(&self.name)
     }
 
-    pub fn parse(
-        self,
-        package_id: &str,
-        recover: bool,
-    ) -> (File, Vec<syntax::ParseError>, syntax::FileParseStatus) {
+    pub fn parse(self, package_id: &str, recover: bool) -> (File, Vec<syntax::ParseError>) {
         let result = if recover {
             syntax::build_ast_recovering(&self.source, self.file_id)
         } else {
             syntax::build_ast(&self.source, self.file_id)
         };
-        let status = result.status;
         let file = File {
             id: self.file_id,
             package_id: package_id.to_string(),
+            parse_status: result.status,
             name: self.name,
             display_path: self.display_path,
             source_path: None,
@@ -222,7 +218,7 @@ impl ScannedFile {
             items: result.ast,
             file_comment: result.file_comment,
         };
-        (file, result.errors, status)
+        (file, result.errors)
     }
 }
 
@@ -492,7 +488,7 @@ struct ScanJob {
 /// Reads and scans every file of the given packages. The parse waits for the cache.
 fn batch_scan_packages(
     packages: &[PackageId],
-    store: &Store,
+    store: &mut Store,
     loader: Option<&dyn Loader>,
     sink: &LocalSink,
     include_tests: bool,

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -21,6 +21,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
     store.store_file(File {
         id: PRELUDE_FILE_ID,
         package_id: PRELUDE_PACKAGE_ID.to_string(),
+        parse_status: result.status,
         name: "prelude.d.lis".to_string(),
         display_path: "prelude.d.lis".to_string(),
         source_path: deps::prelude_typedef_path(),
@@ -67,6 +68,7 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
     store.store_file(File {
         id: file_id,
         package_id: TEST_PRELUDE_PACKAGE_ID.to_string(),
+        parse_status: result.status,
         name: "test_prelude.d.lis".to_string(),
         display_path: "test_prelude.d.lis".to_string(),
         source_path: None,

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use syntax::FileParseStatus;
 use syntax::ast::StructKind;
-use syntax::ast::{EnumVariant, Expression, StructFieldDefinition, VariantFields};
+use syntax::ast::{EnumVariant, StructFieldDefinition, VariantFields};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, Method, Methods, Package,
     TestIndex, UninferredExports, methods_for_type,
@@ -15,10 +13,11 @@ use syntax::types::{CompoundKind, SimpleKind, Symbol, Type};
 
 pub use crate::closed_domain::{ClosedDomain, ClosedMember, DomainValue};
 pub use syntax::ENTRY_PACKAGE_ID;
-pub(crate) const ENTRY_FILE_ID: u32 = 0;
+pub const ENTRY_FILE_ID: u32 = 0;
 // A linear scan wins for small stores by avoiding a second hash lookup.
 const DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD: usize = 16;
 
+#[derive(Clone)]
 pub struct Store {
     /// `Arc` so registration workers share a read view; [`Arc::make_mut`]
     /// writes stay zero-copy while a package has a single owner.
@@ -28,25 +27,9 @@ pub struct Store {
     /// Go package ID -> package name from the typedef `// Package:` directive.
     pub go_package_names: HashMap<String, String>,
     /// File ID counter. Starts at 2 because 0 is reserved for entry, 1 for prelude.
-    next_file_id: AtomicU32,
+    next_file_id: u32,
     pub equality_index: EqualityIndex,
     pub test_index: TestIndex,
-    /// Files that parsed to less than their full contents. Absent means clean.
-    pub parse_statuses: HashMap<u32, FileParseStatus>,
-}
-
-impl Clone for Store {
-    fn clone(&self) -> Self {
-        Self {
-            packages: self.packages.clone(),
-            file_packages: self.file_packages.clone(),
-            go_package_names: self.go_package_names.clone(),
-            next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
-            equality_index: self.equality_index.clone(),
-            test_index: self.test_index.clone(),
-            parse_statuses: self.parse_statuses.clone(),
-        }
-    }
 }
 
 impl Default for Store {
@@ -71,54 +54,27 @@ impl Store {
             packages,
             file_packages: None,
             go_package_names: Default::default(),
-            next_file_id: AtomicU32::new(2), // 0 = entrypoint, 1 = prelude
+            next_file_id: 2, // 0 = entrypoint, 1 = prelude
             equality_index: Default::default(),
             test_index: Default::default(),
-            parse_statuses: Default::default(),
         }
     }
 
-    pub fn record_parse_status(&mut self, file_id: u32, status: FileParseStatus) {
-        if status != FileParseStatus::Clean {
-            self.parse_statuses.insert(file_id, status);
-        }
+    pub fn new_file_id(&mut self) -> u32 {
+        let id = self.next_file_id;
+        self.next_file_id += 1;
+        id
     }
 
-    pub fn new_file_id(&self) -> u32 {
-        self.next_file_id.fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub(crate) fn reserve_file_ids(&self, count: u32) -> u32 {
-        self.next_file_id.fetch_add(count, Ordering::Relaxed)
-    }
-
-    pub(crate) fn entry_package_id(&self) -> &'static str {
-        ENTRY_PACKAGE_ID
+    pub(crate) fn reserve_file_ids(&mut self, count: u32) -> u32 {
+        let first = self.next_file_id;
+        self.next_file_id += count;
+        first
     }
 
     /// Creates the entry package (empty for a library, whose root files load as siblings).
     pub(crate) fn init_entry_package(&mut self) {
         self.add_package(ENTRY_PACKAGE_ID);
-    }
-
-    pub(crate) fn store_entry_file(
-        &mut self,
-        filename: &str,
-        display_path: &str,
-        source: &str,
-        ast: Vec<Expression>,
-        file_comment: Option<String>,
-    ) {
-        self.store_file(File {
-            id: ENTRY_FILE_ID,
-            package_id: ENTRY_PACKAGE_ID.to_string(),
-            name: filename.to_string(),
-            display_path: display_path.to_string(),
-            source_path: None,
-            source: source.to_string(),
-            items: ast,
-            file_comment,
-        });
     }
 
     pub fn store_package(&mut self, package_id: &str, files: Vec<File>) {
@@ -271,10 +227,9 @@ impl Store {
             packages: self.packages.clone(),
             file_packages: self.file_packages.clone(),
             go_package_names: self.go_package_names.clone(),
-            next_file_id: AtomicU32::new(self.next_file_id.load(Ordering::Relaxed)),
+            next_file_id: self.next_file_id,
             equality_index: EqualityIndex::default(),
             test_index: TestIndex::default(),
-            parse_statuses: HashMap::default(),
         }
     }
 
@@ -747,8 +702,8 @@ mod clone_tests {
 
     #[test]
     fn clone_has_an_independent_file_id_counter() {
-        let store = Store::new();
-        let cloned = store.clone();
+        let mut store = Store::new();
+        let mut cloned = store.clone();
 
         assert_eq!(store.new_file_id(), cloned.new_file_id());
     }
@@ -765,7 +720,7 @@ mod clone_tests {
     }
 
     #[test]
-    fn prebuilt_package_files_are_added_to_the_lookup_index() {
+    fn prebuilt_package_files_are_available_by_id() {
         let mut store = Store::new();
         for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
             store.add_package(&format!("package{index}"));
@@ -784,7 +739,7 @@ mod clone_tests {
     }
 
     #[test]
-    fn stored_files_are_added_after_the_lookup_index_is_enabled() {
+    fn stored_files_are_indexed_after_the_threshold() {
         let mut store = Store::new();
         for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
             store.add_package(&format!("package{index}"));

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -760,10 +760,10 @@ mod closed_domain_tests {
     use super::*;
     use syntax::ast;
     use syntax::ast::{
-        Annotation, Generic, Literal, Span, StructFieldDefinition, StructFieldKind, StructFields,
+        Annotation, Generic, Span, StructFieldDefinition, StructFieldKind, StructFields,
     };
-    use syntax::program::ValueKind;
     use syntax::program::{AliasKind, Attributes, TypeAttribute, Visibility};
+    use syntax::program::{ConstantValue, ValueKind};
     use syntax::types::CompoundKind;
 
     fn nominal_int(id: &str) -> Type {
@@ -837,7 +837,7 @@ mod closed_domain_tests {
             name_span: None,
             doc: None,
             body: DefinitionBody::Value {
-                kind: ValueKind::Constant(Literal::Integer { value, text: None }),
+                kind: ValueKind::Constant(ConstantValue::Integer { value, text: None }),
                 allowed_lints: vec![],
                 go_hints: vec![],
                 go_name: None,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -512,6 +512,7 @@ pub struct FunctionDefinitionView<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum VariantFields {
     Unit,
     Tuple(Vec<EnumFieldDefinition>),
@@ -559,6 +560,7 @@ impl<'a> IntoIterator for &'a VariantFields {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnumVariant {
     pub doc: Option<String>,
     pub name: EcoString,
@@ -567,6 +569,7 @@ pub struct EnumVariant {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnumFieldDefinition {
     pub name: EcoString,
     pub name_span: Span,
@@ -575,6 +578,7 @@ pub struct EnumFieldDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Attribute {
     pub name: String,
     pub args: Vec<AttributeArg>,
@@ -604,6 +608,7 @@ pub enum StructKind {
 /// The field collection carries the struct's shape so it cannot disagree with
 /// the fields it describes.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StructFields {
     Record(Vec<StructFieldDefinition>),
     Tuple(Vec<StructFieldDefinition>),
@@ -661,6 +666,7 @@ impl<'a> IntoIterator for &'a mut StructFields {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StructFieldDefinition {
     pub doc: Option<String>,
     pub name: EcoString,
@@ -672,6 +678,7 @@ pub struct StructFieldDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StructFieldKind {
     Named { attributes: Vec<Attribute> },
     Embedded,
@@ -1006,6 +1013,7 @@ impl Annotation {
 }
 
 #[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Generic {
     pub name: EcoString,
     bounds: GenericBounds,
@@ -1031,12 +1039,14 @@ impl fmt::Debug for Generic {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum GenericBounds {
     Unresolved(Vec<Annotation>),
     Resolved(Vec<ResolvedGenericBound>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct ResolvedGenericBound {
     annotation: Annotation,
     ty: Type,
@@ -1111,6 +1121,17 @@ impl Generic {
             return None;
         };
         Some(bounds.iter().map(|bound| &bound.ty))
+    }
+
+    pub fn for_each_bound_annotation_mut(&mut self, mut visit: impl FnMut(&mut Annotation)) {
+        match &mut self.bounds {
+            GenericBounds::Unresolved(annotations) => annotations.iter_mut().for_each(visit),
+            GenericBounds::Resolved(bounds) => {
+                bounds
+                    .iter_mut()
+                    .for_each(|bound| visit(&mut bound.annotation));
+            }
+        }
     }
 
     pub fn resolve_bounds_with(&mut self, mut resolve: impl FnMut(&Annotation) -> Type) {

--- a/crates/syntax/src/imports.rs
+++ b/crates/syntax/src/imports.rs
@@ -205,6 +205,7 @@ mod tests {
         File {
             id: 7,
             package_id: "m".into(),
+            parse_status: result.status,
             name: "m.lis".into(),
             display_path: "m.lis".into(),
             source_path: None,

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -8,7 +8,8 @@ use crate::types::{
     FunctionParameter, Symbol, Type, build_substitution_map, substitute, type_args_match_params,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Definition {
     pub visibility: Visibility,
     pub ty: Type,
@@ -36,14 +37,47 @@ pub enum TypeAttribute {
 
 pub type Attributes = HashSet<TypeAttribute>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ValueKind {
     Runtime,
     ConstantDeclaration,
-    Constant(Literal),
+    Constant(ConstantValue),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ConstantValue {
+    Integer { value: u64, text: Option<String> },
+    Float { value: f64, text: Option<String> },
+    Boolean(bool),
+    String(String),
+    Char(String),
+}
+
+impl ConstantValue {
+    pub fn to_literal(&self) -> Literal {
+        match self {
+            Self::Integer { value, text } => Literal::Integer {
+                value: *value,
+                text: text.clone(),
+            },
+            Self::Float { value, text } => Literal::Float {
+                value: *value,
+                text: text.clone(),
+            },
+            Self::Boolean(value) => Literal::Boolean(*value),
+            Self::String(value) => Literal::String {
+                value: value.clone(),
+                raw: false,
+            },
+            Self::Char(value) => Literal::Char(value.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DefinitionBody {
     TypeAlias {
         generics: Vec<Generic>,
@@ -79,7 +113,8 @@ pub enum DefinitionBody {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AliasKind {
     Opaque(Annotation),
     Transparent {
@@ -269,7 +304,7 @@ impl Definition {
         }
     }
 
-    pub fn const_value(&self) -> Option<&Literal> {
+    pub fn const_value(&self) -> Option<&ConstantValue> {
         match &self.body {
             DefinitionBody::Value {
                 kind: ValueKind::Constant(value),
@@ -684,6 +719,7 @@ impl Visibility {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Interface {
     pub generics: Vec<Generic>,
     pub parents: Vec<Type>,

--- a/crates/syntax/src/program/file.rs
+++ b/crates/syntax/src/program/file.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use ecow::{EcoString, eco_format};
 
+use crate::FileParseStatus;
 use crate::ast::{Expression, ImportAlias, Span};
 use std::path::Path;
 
@@ -11,6 +12,7 @@ use std::path::Path;
 pub struct File {
     pub id: u32,
     pub package_id: String,
+    pub parse_status: FileParseStatus,
     /// Stable bare filename (e.g. `greet.lis`); identity key for caching and
     /// LSP path reconstruction.
     pub name: String,
@@ -93,6 +95,7 @@ impl File {
         Self {
             id,
             package_id: package_id.to_string(),
+            parse_status: FileParseStatus::Clean,
             name: name.to_string(),
             display_path: display_path.to_string(),
             source_path: None,

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -5,7 +5,7 @@ mod package;
 mod resolution;
 
 pub use definition::{
-    AliasKind, Attributes, Definition, DefinitionBody, Interface, InterfaceInstance,
+    AliasKind, Attributes, ConstantValue, Definition, DefinitionBody, Interface, InterfaceInstance,
     InterfaceRequirement, Method, MethodOrigin, Methods, TypeAttribute, ValueKind, Visibility,
     interface_instances, interface_requirements, methods_for_type,
 };

--- a/tests/_harness/emit.rs
+++ b/tests/_harness/emit.rs
@@ -36,6 +36,7 @@ fn emit_inner(
     let file = File {
         id: 0,
         package_id: result.package_id.clone(),
+        parse_status: syntax::FileParseStatus::Clean,
         name: "test.lis".to_string(),
         display_path: "src/test.lis".to_string(),
         source_path: None,

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -91,7 +91,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
             let files = files
                 .into_iter()
                 .map(|file| {
-                    let (file, errors, _) = file.parse(&package_id, false);
+                    let (file, errors) = file.parse(&package_id, false);
                     sink.extend_parse_errors(errors);
                     file
                 })

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -88,6 +88,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     let typed_file = File {
         id: file_id,
         package_id: TEST_PACKAGE_ID.to_string(),
+        parse_status: syntax::FileParseStatus::Clean,
         name: "test.lis".to_string(),
         display_path: "test.lis".to_string(),
         source_path: None,

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -1,25 +1,10 @@
 use diagnostics::{Fix, LisetteDiagnostic, apply_fixes};
-use semantics::{checker::TaskState, checker::infer::InferCtx};
-use stdlib::{Target, get_go_stdlib_typedef};
-use syntax::{
-    ast::Expression,
-    lex::Lexer,
-    parse::Parser,
-    program::{File, FileImport, Visibility},
-};
+use syntax::{lex::Lexer, parse::Parser};
 
-use super::new_test_store;
-
-use super::TEST_PACKAGE_ID;
+use super::pipeline::{InferredTestFile, TEST_FILE_ID, infer_test_file};
 
 pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
-    let mut store = new_test_store();
-    store.add_package(TEST_PACKAGE_ID);
-
-    // Parser::new hardcodes file_id=0 in spans, so pin the test file to that id too.
-    let file_id = 0u32;
-
-    let lex_result = Lexer::new(source, file_id).lex();
+    let lex_result = Lexer::new(source, TEST_FILE_ID).lex();
     if lex_result.failed() {
         panic!("Lexing failed in lint test: {:?}", lex_result.errors);
     }
@@ -29,75 +14,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
         panic!("Parsing failed in lint test: {:?}", parse_result.errors);
     }
 
-    let mut ast = parse_result.ast;
-
-    let mut checker = TaskState::for_package(TEST_PACKAGE_ID);
-    checker.put_prelude_in_scope(&store);
-
-    let locator = deps::TypedefLocator::default();
-    let imports: Vec<FileImport> = ast
-        .iter()
-        .filter_map(|item| {
-            let Expression::PackageImport {
-                name,
-                name_span,
-                alias,
-                span,
-            } = item
-            else {
-                return None;
-            };
-            if let Some(go_pkg) = name.strip_prefix("go:")
-                && let Some(typedef) = get_go_stdlib_typedef(go_pkg, Target::host())
-            {
-                checker.parse_and_register_go_package(&mut store, name, typedef, None, &locator);
-            }
-            Some(FileImport {
-                name: name.clone(),
-                name_span: *name_span,
-                alias: alias.clone(),
-                span: *span,
-            })
-        })
-        .collect();
-    checker.put_imported_packages_in_scope(&store, &imports);
-
-    checker.register_types_and_values(&mut store, &mut ast, &Visibility::Private);
-    checker.finalize_registration(&mut store);
-
-    let mut typed_ast = vec![];
-    {
-        let mut ctx = InferCtx::new(&mut checker, &store);
-        for expression in ast {
-            let type_var = ctx.new_type_var();
-            let typed_expression = ctx.infer_root_expression(expression, &type_var);
-            typed_ast.push(typed_expression);
-        }
-
-        ctx.resolve_branch_subsumptions();
-        ctx.resolve_select_exhaustiveness();
-    }
-
-    {
-        let folder = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store);
-        folder.freeze_facts(&mut checker.facts);
-    }
-    typed_ast =
-        semantics::checker::freeze::FreezeFolder::new(&checker.env, &store).freeze_items(typed_ast);
-
-    let typed_file = File {
-        id: file_id,
-        package_id: TEST_PACKAGE_ID.to_string(),
-        parse_status: syntax::FileParseStatus::Clean,
-        name: "test.lis".to_string(),
-        display_path: "test.lis".to_string(),
-        source_path: None,
-        source: source.to_string(),
-        items: typed_ast,
-        file_comment: None,
-    };
-
-    store.store_file(typed_file);
+    let InferredTestFile { store, checker } = infer_test_file(source, parse_result.ast, &[]);
     let inference_checkpoint = checker.sink.checkpoint();
 
     passes::run(&store, &checker.facts, &checker.sink, passes::LintMode::Run);
@@ -125,7 +42,7 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
 }
 
 pub fn apply_parse_fixes(source: &str) -> String {
-    let result = syntax::build_ast(source, 0);
+    let result = syntax::build_ast(source, TEST_FILE_ID);
     let errors_before = result.errors.len();
     let diagnostics: Vec<LisetteDiagnostic> = result.errors.into_iter().map(Into::into).collect();
     let fixes: Vec<&Fix> = diagnostics
@@ -134,7 +51,7 @@ pub fn apply_parse_fixes(source: &str) -> String {
         .collect();
     let fixed = apply_fixes(source, fixes).source;
 
-    let errors_after = syntax::build_ast(&fixed, 0).errors.len();
+    let errors_after = syntax::build_ast(&fixed, TEST_FILE_ID).errors.len();
     if errors_after >= errors_before {
         panic!("Applied fixes must reduce the parse error count:\n{fixed}");
     }
@@ -157,7 +74,7 @@ pub fn apply_lint_fixes(source: &str) -> String {
     let fixes: Vec<&Fix> = lints.iter().filter_map(LisetteDiagnostic::fix).collect();
     let fixed = apply_fixes(source, fixes).source;
 
-    let reparsed = syntax::build_ast(&fixed, 0);
+    let reparsed = syntax::build_ast(&fixed, TEST_FILE_ID);
     if !reparsed.errors.is_empty() {
         panic!(
             "Applied fix produced source that no longer parses:\n{fixed}\nerrors: {:?}",

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -152,6 +152,7 @@ impl CompiledTest {
             store.store_file(File {
                 id: test_file_id,
                 package_id: TEST_PACKAGE_ID.to_string(),
+                parse_status: syntax::FileParseStatus::Clean,
                 name: "test.lis".to_string(),
                 display_path: "test.lis".to_string(),
                 source_path: None,
@@ -192,6 +193,7 @@ impl CompiledTest {
                 store.store_file(File {
                     id: test_file_id,
                     package_id: TEST_PACKAGE_ID.to_string(),
+                    parse_status: syntax::FileParseStatus::Clean,
                     name: "test.lis".to_string(),
                     display_path: "test.lis".to_string(),
                     source_path: None,

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -1,7 +1,8 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use diagnostics::{LisetteDiagnostic, LocalSink};
-use semantics::{checker::TaskState, checker::infer::InferCtx};
+use diagnostics::LisetteDiagnostic;
+use semantics::checker::TaskState;
+use semantics::store::Store;
 use std::mem;
 use stdlib::{Target, get_go_stdlib_typedef};
 use syntax::types;
@@ -9,7 +10,7 @@ use syntax::{
     ast::{Expression, FunctionBody},
     lex::Lexer,
     parse::Parser,
-    program::{Definition, EqualityIndex, File, FileImport, MutationInfo, UnusedInfo, Visibility},
+    program::{Definition, EqualityIndex, File, MutationInfo, UnusedInfo},
     types::Symbol,
 };
 
@@ -17,6 +18,58 @@ use super::new_test_store;
 
 use super::TEST_PACKAGE_ID;
 use super::wrap::{TEST_WRAPPER_NAME, wrap};
+
+pub(super) const TEST_FILE_ID: u32 = 0;
+
+pub(super) struct InferredTestFile {
+    pub(super) store: Store,
+    pub(super) checker: TaskState,
+}
+
+/// Runs a synthetic single-file package through the production registration and inference path.
+pub(super) fn infer_test_file(
+    source: &str,
+    ast: Vec<Expression>,
+    extra_go_typedefs: &[(String, String)],
+) -> InferredTestFile {
+    let mut store = new_test_store();
+    store.add_package(TEST_PACKAGE_ID);
+
+    let mut checker = TaskState::for_package(TEST_PACKAGE_ID);
+    let locator = deps::TypedefLocator::default();
+
+    for (name, typedef) in extra_go_typedefs {
+        checker.parse_and_register_go_package(&mut store, name, typedef, None, &locator);
+    }
+
+    for item in &ast {
+        if let Expression::PackageImport { name, .. } = item
+            && let Some(go_pkg) = name.strip_prefix("go:")
+            && let Some(typedef) = get_go_stdlib_typedef(go_pkg, Target::host())
+        {
+            checker.parse_and_register_go_package(&mut store, name, typedef, None, &locator);
+        }
+    }
+
+    store.store_file(File {
+        id: TEST_FILE_ID,
+        package_id: TEST_PACKAGE_ID.to_string(),
+        parse_status: syntax::FileParseStatus::Clean,
+        name: "test.lis".to_string(),
+        display_path: "test.lis".to_string(),
+        source_path: None,
+        source: source.to_string(),
+        items: ast,
+        file_comment: None,
+    });
+
+    let package = checker.register_package(&mut store, TEST_PACKAGE_ID);
+    checker.finalize_registration(&mut store);
+    checker.infer_package(&mut store, package);
+    checker.check_post_inference_bounds(&store);
+
+    InferredTestFile { store, checker }
+}
 
 pub struct TestPipeline {
     source: String,
@@ -57,7 +110,7 @@ impl TestPipeline {
     }
 
     pub fn compile(self) -> CompiledTest {
-        let lex_result = Lexer::new(&self.source, 0).lex();
+        let lex_result = Lexer::new(&self.source, TEST_FILE_ID).lex();
         if lex_result.failed() {
             panic!("Lexing failed in test: {:?}", lex_result.errors);
         }
@@ -69,6 +122,7 @@ impl TestPipeline {
 
         CompiledTest {
             ast: parse_result.ast,
+            source: self.source,
             wrapped: self.wrapped,
             e2e_suite_mode: self.e2e_suite_mode,
             extra_go_typedefs: self.extra_go_typedefs,
@@ -78,6 +132,7 @@ impl TestPipeline {
 
 pub struct CompiledTest {
     ast: Vec<Expression>,
+    source: String,
     wrapped: bool,
     e2e_suite_mode: bool,
     extra_go_typedefs: Vec<(String, String)>,
@@ -86,18 +141,18 @@ pub struct CompiledTest {
 impl CompiledTest {
     pub fn run_inference(self) -> InferenceResult {
         let Self {
-            mut ast,
+            ast,
+            source,
             wrapped,
             e2e_suite_mode,
             extra_go_typedefs,
         } = self;
-        let mut store = new_test_store();
-        store.add_package(TEST_PACKAGE_ID);
-
-        let sink = LocalSink::new();
+        let InferredTestFile { mut store, checker } =
+            infer_test_file(&source, ast, &extra_go_typedefs);
 
         let (
             typed_ast,
+            errors,
             definitions,
             unused,
             mutations,
@@ -105,102 +160,12 @@ impl CompiledTest {
             go_package_names,
             go_package_ids,
         ) = {
-            let mut checker = TaskState::for_package(TEST_PACKAGE_ID);
-            checker.put_prelude_in_scope(&store);
-
-            let locator = deps::TypedefLocator::default();
-
-            for (name, typedef) in &extra_go_typedefs {
-                checker.parse_and_register_go_package(&mut store, name, typedef, None, &locator);
-            }
-
-            let imports: Vec<FileImport> = ast
-                .iter()
-                .filter_map(|item| {
-                    if let Expression::PackageImport {
-                        name,
-                        name_span,
-                        alias,
-                        span,
-                    } = item
-                    {
-                        if let Some(go_pkg) = name.strip_prefix("go:")
-                            && let Some(typedef) = get_go_stdlib_typedef(go_pkg, Target::host())
-                        {
-                            checker.parse_and_register_go_package(
-                                &mut store, name, typedef, None, &locator,
-                            );
-                        }
-                        Some(FileImport {
-                            name: name.clone(),
-                            name_span: *name_span,
-                            alias: alias.clone(),
-                            span: *span,
-                        })
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            checker.put_imported_packages_in_scope(&store, &imports);
-
-            checker.register_types_and_values(&mut store, &mut ast, &Visibility::Private);
-            InferCtx::new(&mut checker, &store).check_const_cycles(&[ast.as_slice()]);
-
-            let test_file_id = store.new_file_id();
-            store.store_file(File {
-                id: test_file_id,
-                package_id: TEST_PACKAGE_ID.to_string(),
-                parse_status: syntax::FileParseStatus::Clean,
-                name: "test.lis".to_string(),
-                display_path: "test.lis".to_string(),
-                source_path: None,
-                source: String::new(),
-                items: ast.clone(),
-                file_comment: None,
-            });
-            checker.finalize_registration(&mut store);
-
-            let mut typed_ast = vec![];
-            {
-                let mut ctx = InferCtx::new(&mut checker, &store);
-                for expression in ast {
-                    let type_var = ctx.new_type_var();
-                    let typed_expression = ctx.infer_root_expression(expression, &type_var);
-                    typed_ast.push(typed_expression);
-
-                    if ctx.failed() {
-                        break;
-                    }
-                }
-
-                ctx.check_map_bracket_reads(&typed_ast);
-                ctx.resolve_branch_subsumptions();
-                ctx.resolve_select_exhaustiveness();
-            }
-
-            {
-                let folder = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store);
-                folder.freeze_facts(&mut checker.facts);
-            }
-            typed_ast = semantics::checker::freeze::FreezeFolder::new(&checker.env, &store)
-                .freeze_items(typed_ast);
-            checker.check_post_inference_bounds(&store);
+            let mut typed_ast = store
+                .get_file(TEST_FILE_ID)
+                .expect("inferred test file must remain in the store")
+                .items
+                .clone();
             if !checker.failed() {
-                // Overwrite the stored file with the typed AST so passes::run
-                // sees post-inference items when iterating store.packages.
-                store.store_file(File {
-                    id: test_file_id,
-                    package_id: TEST_PACKAGE_ID.to_string(),
-                    parse_status: syntax::FileParseStatus::Clean,
-                    name: "test.lis".to_string(),
-                    display_path: "test.lis".to_string(),
-                    source_path: None,
-                    source: String::new(),
-                    items: typed_ast.clone(),
-                    file_comment: None,
-                });
                 passes::run(
                     &store,
                     &checker.facts,
@@ -222,13 +187,16 @@ impl CompiledTest {
                             if let Expression::Function { ref name, .. } = expr
                                 && name == TEST_WRAPPER_NAME
                             {
-                                return Some(unwrap_test_wrapper(expr));
+                                return unwrap_test_wrapper(expr);
                             }
                             None
                         })
                         .collect();
                 } else {
-                    typed_ast = typed_ast.into_iter().map(unwrap_test_wrapper).collect();
+                    typed_ast = typed_ast
+                        .into_iter()
+                        .filter_map(unwrap_test_wrapper)
+                        .collect();
                 }
             }
 
@@ -259,10 +227,11 @@ impl CompiledTest {
                 .cloned()
                 .collect();
 
-            sink.extend(checker.sink.into_diagnostics());
+            let errors = checker.sink.into_diagnostics();
 
             (
                 typed_ast,
+                errors,
                 definitions,
                 unused,
                 mutations,
@@ -274,7 +243,7 @@ impl CompiledTest {
 
         InferenceResult {
             ast: typed_ast,
-            errors: sink.into_diagnostics(),
+            errors,
             definitions,
             package_id: TEST_PACKAGE_ID.to_string(),
             unused,
@@ -298,13 +267,13 @@ pub struct InferenceResult {
     pub go_package_ids: HashSet<String>,
 }
 
-fn unwrap_test_wrapper(expression: Expression) -> Expression {
+fn unwrap_test_wrapper(expression: Expression) -> Option<Expression> {
     let Expression::Function { name, .. } = &expression else {
-        return expression;
+        return Some(expression);
     };
 
     if name != TEST_WRAPPER_NAME {
-        return expression;
+        return Some(expression);
     }
 
     let Expression::Function { body, .. } = expression else {
@@ -321,8 +290,61 @@ fn unwrap_test_wrapper(expression: Expression) -> Expression {
         );
     };
 
-    items
-        .into_iter()
-        .next_back()
-        .expect("Expected at least one expression in wrapped test function body")
+    items.into_iter().next_back()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestPipeline;
+
+    #[test]
+    fn production_file_checks_reject_definitions_that_shadow_imports() {
+        let result = TestPipeline::new(
+            r#"
+import "go:fmt"
+
+fn fmt() {}
+"#,
+        )
+        .compile()
+        .run_inference();
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.code_str() == Some("resolve.name_shadows_import")),
+            "expected name_shadows_import, got: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn production_file_checks_reject_reference_aliasing_between_siblings() {
+        let result = TestPipeline::new(
+            r#"
+fn bump(value: mut Ref<int>) -> int {
+  value.* = value.* + 1
+  value.*
+}
+
+fn main() {
+  let mut value = 1
+  let pair = (bump(&value), value)
+  let _ = pair
+}
+"#,
+        )
+        .compile()
+        .run_inference();
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.code_str() == Some("infer.reference_aliases_sibling")),
+            "expected reference_aliases_sibling, got: {:?}",
+            result.errors
+        );
+    }
 }

--- a/tests/e2e_suite/harness.rs
+++ b/tests/e2e_suite/harness.rs
@@ -51,6 +51,7 @@ pub fn compile_e2e_suite_test(input: &str, package_name: &str) -> Result<Emitted
     let file = File {
         id: 0,
         package_id: result.package_id.clone(),
+        parse_status: syntax::FileParseStatus::Clean,
         name: "test.lis".to_string(),
         display_path: "test.lis".to_string(),
         source_path: None,

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -1406,7 +1406,7 @@ fn let_else_or_pattern() {
 enum E { A(int), B(int), C }
 
 fn test(e: E) -> int {
-  let A(x) | B(x) = e else { return 0; };
+  let E.A(x) | E.B(x) = e else { return 0; };
   x
 }
 "#;
@@ -1838,7 +1838,7 @@ enum E { A(int), B(int) }
 fn test() -> int {
   let mut current: Option<E> = Some(E.A(5));
   let mut sum = 0;
-  while let Some(A(x)) | Some(B(x)) = current {
+  while let Some(E.A(x)) | Some(E.B(x)) = current {
     sum = sum + x;
     current = None;
   }

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -51,7 +51,7 @@ struct Handler<T> { callback: fn(T) -> int }
 enum E { A(Handler<string>), B(Handler<string>) }
 
 fn test(e: E) -> int {
-  let A(Handler { callback }) | B(Handler { callback }) = e else { return 0; };
+  let E.A(Handler { callback }) | E.B(Handler { callback }) = e else { return 0; };
   callback("test")
 }
 "#;
@@ -65,7 +65,7 @@ struct Pair<T> { coords: (T, T) }
 enum E { A(Pair<int>), B(Pair<int>) }
 
 fn test(e: E) -> int {
-  let A(Pair { coords: (x, y) }) | B(Pair { coords: (x, y) }) = e else { return 0; };
+  let E.A(Pair { coords: (x, y) }) | E.B(Pair { coords: (x, y) }) = e else { return 0; };
   x + y
 }
 "#;
@@ -78,7 +78,7 @@ fn slice_pattern_rest_or_pattern() {
 enum E { A(Slice<int>), B(Slice<int>) }
 
 fn test(e: E) -> int {
-  let A([first, ..rest]) | B([first, ..rest]) = e else { return 0; };
+  let E.A([first, ..rest]) | E.B([first, ..rest]) = e else { return 0; };
   first
 }
 "#;
@@ -140,7 +140,7 @@ enum Message {
 }
 
 fn make_move() -> Message {
-  Move { x: 10, y: 20 }
+  Message.Move { x: 10, y: 20 }
 }
 "#;
     assert_emit_snapshot!(input);
@@ -681,7 +681,7 @@ enum E { A(int), B(int), C }
 
 fn test(e: E) -> int {
   let x = 1
-  let A(x) | B(x) = e else { return 0; };
+  let E.A(x) | E.B(x) = e else { return 0; };
   x
 }
 "#;

--- a/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
+++ b/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
@@ -5,7 +5,7 @@ description: |
   enum Color { Red, Green, Blue }
   
   fn test() -> Color {
-    Red
+    Color.Red
   }
 ---
 package main

--- a/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
@@ -5,7 +5,7 @@ description: |
   enum Either<L, R> { Left(L), Right(R) }
   
   fn test() -> Either<int, string> {
-    Left(42)
+    Either.Left(42)
   }
 ---
 package main

--- a/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
@@ -5,7 +5,7 @@ description: |
   enum MyResult<T> { Success(T), Failure }
   
   fn test() -> MyResult<int> {
-    Success(42)
+    MyResult.Success(42)
   }
 ---
 package main

--- a/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
@@ -6,7 +6,7 @@ description: |
   enum E { A(Handler<string>), B(Handler<string>) }
   
   fn test(e: E) -> int {
-    let A(Handler { callback }) | B(Handler { callback }) = e else { return 0; };
+    let E.A(Handler { callback }) | E.B(Handler { callback }) = e else { return 0; };
     callback("test")
   }
 ---

--- a/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
@@ -6,7 +6,7 @@ description: |
   enum E { A(Pair<int>), B(Pair<int>) }
   
   fn test(e: E) -> int {
-    let A(Pair { coords: (x, y) }) | B(Pair { coords: (x, y) }) = e else { return 0; };
+    let E.A(Pair { coords: (x, y) }) | E.B(Pair { coords: (x, y) }) = e else { return 0; };
     x + y
   }
 ---

--- a/tests/spec/emit/snapshots/let_else_or_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern.snap
@@ -5,7 +5,7 @@ description: |
   enum E { A(int), B(int), C }
   
   fn test(e: E) -> int {
-    let A(x) | B(x) = e else { return 0; };
+    let E.A(x) | E.B(x) = e else { return 0; };
     x
   }
 ---

--- a/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
@@ -7,7 +7,7 @@ description: |
   fn test() -> int {
     let mut current: Option<E> = Some(E.A(5));
     let mut sum = 0;
-    while let Some(A(x)) | Some(B(x)) = current {
+    while let Some(E.A(x)) | Some(E.B(x)) = current {
       sum = sum + x;
       current = None;
     }

--- a/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
@@ -6,7 +6,7 @@ description: |
   
   fn test(e: E) -> int {
     let x = 1
-    let A(x) | B(x) = e else { return 0; };
+    let E.A(x) | E.B(x) = e else { return 0; };
     x
   }
 ---

--- a/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
@@ -5,7 +5,7 @@ description: |
   enum E { A(Slice<int>), B(Slice<int>) }
   
   fn test(e: E) -> int {
-    let A([first, ..rest]) | B([first, ..rest]) = e else { return 0; };
+    let E.A([first, ..rest]) | E.B([first, ..rest]) = e else { return 0; };
     first
   }
 ---

--- a/tests/spec/emit/snapshots/struct_variant_construction.snap
+++ b/tests/spec/emit/snapshots/struct_variant_construction.snap
@@ -7,7 +7,7 @@ description: |
   }
   
   fn make_move() -> Message {
-    Move { x: 10, y: 20 }
+    Message.Move { x: 10, y: 20 }
   }
 ---
 package main

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1200,7 +1200,7 @@ fn enum_variant_construction_simple() {
 enum Color { Red, Green, Blue }
 
 fn test() -> Color {
-  Red
+  Color.Red
 }
 "#;
     assert_emit_snapshot!(input);
@@ -1707,7 +1707,7 @@ fn generic_enum_with_variant_field() {
 enum MyResult<T> { Success(T), Failure }
 
 fn test() -> MyResult<int> {
-  Success(42)
+  MyResult.Success(42)
 }
 "#;
     assert_emit_snapshot!(input);
@@ -1719,7 +1719,7 @@ fn generic_enum_with_multiple_variant_fields() {
 enum Either<L, R> { Left(L), Right(R) }
 
 fn test() -> Either<int, string> {
-  Left(42)
+  Either.Left(42)
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/imports.rs
+++ b/tests/spec/imports.rs
@@ -41,6 +41,7 @@ fn parsed_imports(source: &str) -> Option<Vec<FileImport>> {
         File {
             id: 0,
             package_id: "corpus".to_string(),
+            parse_status: result.status,
             name: "corpus.lis".to_string(),
             display_path: "corpus.lis".to_string(),
             source_path: None,

--- a/tests/spec/infer/basics.rs
+++ b/tests/spec/infer/basics.rs
@@ -443,14 +443,14 @@ fn slice_literal_adapts_negative_int8_elements() {
 }
 
 #[test]
-fn enum_variant_unqualified() {
+fn custom_enum_variant_constructor_must_be_qualified() {
     infer(
         r#"{
     enum Color { Red, Green, Blue }
     Red
     }"#,
     )
-    .assert_no_errors();
+    .assert_not_found();
 }
 
 #[test]
@@ -594,7 +594,7 @@ fn enum_unit_variant() {
     infer(
         r#"{
     enum Status { Running, Stopped }
-    let s = Running;
+    let s = Status.Running;
     match s {
       Running => "active",
       Stopped => "inactive",
@@ -609,7 +609,7 @@ fn enum_variant_in_let_binding() {
     infer(
         r#"{
     enum Color { Red, Green, Blue }
-    let c = Red;
+    let c = Color.Red;
     c
     }"#,
     )
@@ -662,7 +662,7 @@ fn enum_tuple_variant() {
     infer(
         r#"{
     enum IpAddress { V4(int, int, int, int), V6(string) }
-    V4(192, 168, 1, 1)
+    IpAddress.V4(192, 168, 1, 1)
     }"#,
     )
     .assert_no_errors();
@@ -705,7 +705,7 @@ fn enum_pattern_undefined_variant() {
     infer(
         r#"{
     enum Color { Red, Green }
-    let c = Red;
+    let c = Color.Red;
     match c {
       Red => 1,
       Blue => 2,
@@ -762,7 +762,7 @@ fn enum_with_numeric_like_variant() {
     infer(
         r#"{
     enum HttpStatus { Status200, Status404, Status500 }
-    Status200
+    HttpStatus.Status200
     }"#,
     )
     .assert_no_errors();

--- a/tests/spec/infer/types.rs
+++ b/tests/spec/infer/types.rs
@@ -2476,7 +2476,7 @@ fn never_in_generic_expected_position_rejects_inhabited() {
     }
 
     fn main() {
-      let x: MyResult<Never, int> = MyOk(1);
+      let x: MyResult<Never, int> = MyResult.MyOk(1);
     }
         "#,
     )
@@ -2497,7 +2497,7 @@ fn never_in_generic_actual_position_coerces() {
     }
 
     fn test() -> MyResult<int, int> {
-      MyOk(diverges())
+      MyResult.MyOk(diverges())
     }
         "#,
     )

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -1655,7 +1655,7 @@ fn infer_enum_variant_not_found_in_pattern() {
 enum Status { Active, Inactive }
 
 fn test() {
-  let s: Status = Active;
+  let s: Status = Status.Active;
   match s {
     Nope => {}
   }
@@ -4440,7 +4440,7 @@ fn match_redundant_pattern() {
 enum Status { Active, Inactive }
 
 fn test() {
-  let s: Status = Active;
+  let s: Status = Status.Active;
   match s {
     Active => 1,
     Inactive => 2,
@@ -4457,7 +4457,7 @@ fn match_redundant_after_wildcard() {
 enum Status { Active, Inactive }
 
 fn test() {
-  let s: Status = Active;
+  let s: Status = Status.Active;
   match s {
     _ => 0,
     Active => 1,
@@ -4473,7 +4473,7 @@ fn match_redundant_or_pattern_duplicate() {
 enum Color { Red, Green, Blue }
 
 fn test() {
-  let c: Color = Red;
+  let c: Color = Color.Red;
   match c {
     Red | Red => 1,
     Green | Blue => 2,
@@ -6928,7 +6928,7 @@ enum MyResult<T, E> {
 }
 
 fn main() {
-  let x: MyResult<Never, int> = MyOk(1);
+  let x: MyResult<Never, int> = MyResult.MyOk(1);
 }
 "#;
     assert_infer_error_snapshot!(input);
@@ -6943,7 +6943,7 @@ enum Either<L, R> {
 }
 
 fn main() {
-  let x = Left("oops");
+  let x = Either.Left("oops");
   let _: Either<int, string> = x;
 }
 "#;

--- a/tests/ui/errors/snapshots/infer_never_in_generic_expected_position.snap
+++ b/tests/ui/errors/snapshots/infer_never_in_generic_expected_position.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
-   ╭─[test.lis:8:38]
+   ╭─[test.lis:8:47]
  7 │ fn main() {
- 8 │   let x: MyResult<Never, int> = MyOk(1);
-   ·                                      ┬
-   ·                                      ╰── expected `Never`, found `int`
+ 8 │   let x: MyResult<Never, int> = MyResult.MyOk(1);
+   ·                                               ┬
+   ·                                               ╰── expected `Never`, found `int`
  9 │ }
    ╰────
-  help: `MyOk()` expects `Never` for its first argument. Convert the value to `Never` · code: [infer.type_mismatch]
+  help: `MyResult.MyOk()` expects `Never` for its first argument. Convert the value to `Never` · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_type_variable_hint_preserves_param_names.snap
+++ b/tests/ui/errors/snapshots/infer_type_variable_hint_preserves_param_names.snap
@@ -3,7 +3,7 @@ source: tests/ui/errors/mod.rs
 ---
   ✕ Type mismatch
     ╭─[test.lis:9:32]
-  8 │   let x = Left("oops");
+  8 │   let x = Either.Left("oops");
   9 │   let _: Either<int, string> = x;
     ·                                ┬
     ·                                ╰── expected `Either<int, string>`, found `Either<string, R>`

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -13086,7 +13086,7 @@ fn refutable_or_pattern_if_let_no_warning() {
 enum E { A, B, C }
 
 fn test(e: E) {
-  if let A | B = e {
+  if let E.A | E.B = e {
     ();
   }
 }


### PR DESCRIPTION
- Parse status lived in a `Store` side map and in an `EntryParseStatus` enum that mirrored `FileParseStatus`. It now lives on `File`.
- Five `BindingId` maps in the inference context recorded overlapping facts about one binding. They collapse into one map of a keyed enum.
- The package cache mirrored the `Definition` family into a parallel `Cached*` family. It now serializes `Definition` directly, with one walker that remaps span file IDs.
- The test harness reimplemented a part of registration and inference pipeline. It now reuses the production pipeline.
