### PR TITLE
refactor: decouple bindgen's target from environment

### DIFF
--- a/bindgen/internal/cli/cli.go
+++ b/bindgen/internal/cli/cli.go
@@ -50,8 +50,9 @@ func PrintUsage() {
 func RunPkg(args []string, defaultCfgJSON []byte) {
 	fs := flag.NewFlagSet("pkg", flag.ExitOnError)
 	configPath := fs.String("config", "", "path to bindgen config file")
+	targetFlag := fs.String("target", "", "GOOS/GOARCH to type-check against (default: host)")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: bindgen pkg <package>\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: bindgen pkg [-target <goos>/<goarch>] <package>\n\n")
 		fmt.Fprintf(os.Stderr, "Generates .d.lis type definitions for a Go package.\n\n")
 		fmt.Fprintf(os.Stderr, "Examples:\n")
 		fmt.Fprintf(os.Stderr, "  bindgen pkg fmt                            # Go stdlib\n")
@@ -76,7 +77,13 @@ func RunPkg(args []string, defaultCfgJSON []byte) {
 		os.Exit(1)
 	}
 
-	result, err := GeneratePkg(pkgPath, lisVersion, goVersion, &cfg)
+	target, err := ParseTarget(*targetFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bindgen: %v\n", err)
+		os.Exit(1)
+	}
+
+	result, err := GeneratePkg(pkgPath, lisVersion, goVersion, &cfg, target)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bindgen: %v\n", err)
 		os.Exit(1)
@@ -148,6 +155,21 @@ func resolveTargets(flagValue string) ([]Target, error) {
 		return ParseTargets(envList)
 	}
 	return nil, fmt.Errorf("no targets specified: pass -targets or set BINDGEN_TARGETS (e.g. linux/amd64,darwin/arm64)")
+}
+
+// ParseTarget accepts one `GOOS/GOARCH`, the empty string meaning the host.
+func ParseTarget(s string) (Target, error) {
+	if s == "" {
+		return Target{}, nil
+	}
+	targets, err := ParseTargets(s)
+	if err != nil {
+		return Target{}, err
+	}
+	if len(targets) != 1 {
+		return Target{}, fmt.Errorf("target %q: expected one GOOS/GOARCH", s)
+	}
+	return targets[0], nil
 }
 
 func ParseTargets(s string) ([]Target, error) {

--- a/bindgen/internal/cli/generate_pkg.go
+++ b/bindgen/internal/cli/generate_pkg.go
@@ -11,8 +11,8 @@ import (
 )
 
 // GeneratePkg generates a `.d.lis` file for a Go package path.
-func GeneratePkg(pkgPath, lisetteVersion, goVersion string, cfg *config.Config) (GeneratePkgResult, error) {
-	pkg, err := extract.LoadPackage(pkgPath)
+func GeneratePkg(pkgPath, lisetteVersion, goVersion string, cfg *config.Config, target Target) (GeneratePkgResult, error) {
+	pkg, err := extract.LoadPackage(pkgPath, target.goos, target.goarch)
 	if err != nil {
 		return GeneratePkgResult{}, fmt.Errorf("failed to load package %s: %w", pkgPath, err)
 	}

--- a/bindgen/internal/cli/generate_pkgs.go
+++ b/bindgen/internal/cli/generate_pkgs.go
@@ -51,8 +51,9 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 	configPath := fs.String("config", "", "path to bindgen config file")
 	versionOverride := fs.String("version", "", "override Lisette version in generated headers")
 	transitive := fs.Bool("transitive", false, "also emit the requested packages' transitive re-exports")
+	targetFlag := fs.String("target", "", "GOOS/GOARCH to type-check against (default: host)")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: bindgen pkgs [-config <path>] [-version <ver>] [-transitive]\n\n")
+		fmt.Fprintf(os.Stderr, "Usage: bindgen pkgs [-config <path>] [-version <ver>] [-transitive] [-target <goos>/<goarch>]\n\n")
 		fmt.Fprintf(os.Stderr, "Generates .d.lis type definitions for many Go packages in one shared\n")
 		fmt.Fprintf(os.Stderr, "type-check pass. Reads package paths from stdin, one per line. Emits a\n")
 		fmt.Fprintf(os.Stderr, "JSON manifest on stdout with embedded content.\n")
@@ -77,7 +78,13 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 		effectiveVersion = *versionOverride
 	}
 
-	manifest := GeneratePkgs(pkgPaths, effectiveVersion, goVersion, &cfg, *transitive)
+	target, err := ParseTarget(*targetFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bindgen: %v\n", err)
+		os.Exit(1)
+	}
+
+	manifest := GeneratePkgs(pkgPaths, effectiveVersion, goVersion, &cfg, *transitive, target)
 
 	if err := json.NewEncoder(os.Stdout).Encode(manifest); err != nil {
 		fmt.Fprintf(os.Stderr, "bindgen: failed to encode manifest: %v\n", err)
@@ -85,7 +92,7 @@ func RunPkgs(args []string, defaultCfgJSON []byte) {
 	}
 }
 
-func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *config.Config, transitive bool) Manifest {
+func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *config.Config, transitive bool, target Target) Manifest {
 	manifest := Manifest{
 		Ok:     make([]ManifestOk, 0, len(pkgPaths)),
 		Errors: make([]ManifestError, 0),
@@ -95,7 +102,7 @@ func GeneratePkgs(pkgPaths []string, lisetteVersion, goVersion string, cfg *conf
 		return manifest
 	}
 
-	pkgs, err := extract.LoadPackagesAll(pkgPaths)
+	pkgs, err := extract.LoadPackagesAll(pkgPaths, target.goos, target.goarch)
 	if err != nil {
 		for _, p := range pkgPaths {
 			manifest.Errors = append(manifest.Errors, ManifestError{

--- a/bindgen/internal/cli/partition_test.go
+++ b/bindgen/internal/cli/partition_test.go
@@ -44,6 +44,28 @@ func TestPartitionByTargetDoesNotMutateCapturedHeaderStub(t *testing.T) {
 	}
 }
 
+func TestParseTargetReadsOneTargetAndTreatsEmptyAsHost(t *testing.T) {
+	target, err := ParseTarget("linux/amd64")
+	if err != nil {
+		t.Fatalf("ParseTarget failed: %v", err)
+	}
+	if target.goos != "linux" || target.goarch != "amd64" {
+		t.Fatalf("ParseTarget = %v, want linux/amd64", target)
+	}
+
+	host, err := ParseTarget("")
+	if err != nil {
+		t.Fatalf("ParseTarget(\"\") failed: %v", err)
+	}
+	if host != (Target{}) {
+		t.Fatalf("ParseTarget(\"\") = %v, want the zero target", host)
+	}
+
+	if _, err := ParseTarget("linux/amd64,darwin/arm64"); err == nil {
+		t.Fatal("ParseTarget accepted a list")
+	}
+}
+
 func TestParseTargetsRejectsInvalidAndDuplicateTargets(t *testing.T) {
 	invalid := []string{
 		"/amd64",

--- a/bindgen/internal/extract/extractor.go
+++ b/bindgen/internal/extract/extractor.go
@@ -5,6 +5,7 @@ import (
 	"go/doc"
 	"go/types"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -47,9 +48,9 @@ func currentLoadConfig(targetGOOS, targetGOARCH string, cgo bool) *packages.Conf
 	}
 }
 
-// buildLoaderEnv cross-compiles when targetGOOS/targetGOARCH are set (empty = host
-// default). cgo is enabled only for host loads of third-party packages. Stdlib
-// generation keeps it off so the cross-target builds need no C cross-toolchains.
+// buildLoaderEnv cross-compiles when targetGOOS/targetGOARCH are set, and an
+// empty one keeps the ambient value. Stdlib generation keeps cgo off so the
+// cross-target builds need no C cross-toolchains.
 func buildLoaderEnv(targetGOOS, targetGOARCH string, cgo bool) []string {
 	env := os.Environ()
 	if targetGOOS != "" || targetGOARCH != "" {
@@ -77,8 +78,21 @@ func buildLoaderEnv(targetGOOS, targetGOARCH string, cgo bool) []string {
 	return append(env, cgoEnabled, "GOFLAGS=-mod=mod")
 }
 
-func LoadPackage(path string) (*packages.Package, error) {
-	pkgs, err := packages.Load(currentLoadConfig("", "", true), path)
+// A zero target means the host, never the ambient GOOS. A cross load keeps cgo
+// off, as `go build` does when it cross-compiles.
+func packageLoadConfig(targetGOOS, targetGOARCH string) *packages.Config {
+	if targetGOOS == "" {
+		targetGOOS = runtime.GOOS
+	}
+	if targetGOARCH == "" {
+		targetGOARCH = runtime.GOARCH
+	}
+	cgo := targetGOOS == runtime.GOOS && targetGOARCH == runtime.GOARCH
+	return currentLoadConfig(targetGOOS, targetGOARCH, cgo)
+}
+
+func LoadPackage(path, targetGOOS, targetGOARCH string) (*packages.Package, error) {
+	pkgs, err := packages.Load(packageLoadConfig(targetGOOS, targetGOARCH), path)
 	if err != nil {
 		return nil, err
 	}
@@ -139,8 +153,8 @@ func loadCheckedPackages(patterns []string, targetGOOS, targetGOARCH string, ski
 }
 
 // Like LoadPackages but keeps errored packages so the caller can classify them.
-func LoadPackagesAll(paths []string) ([]*packages.Package, error) {
-	return packages.Load(currentLoadConfig("", "", true), paths...)
+func LoadPackagesAll(paths []string, targetGOOS, targetGOARCH string) ([]*packages.Package, error) {
+	return packages.Load(packageLoadConfig(targetGOOS, targetGOARCH), paths...)
 }
 
 func ExtractExports(pkg *packages.Package, embedFaithful func(*types.Var) bool) []SymbolExport {

--- a/bindgen/internal/extract/extractor_test.go
+++ b/bindgen/internal/extract/extractor_test.go
@@ -1,0 +1,50 @@
+package extract
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func lastValue(env []string, key string) string {
+	value := ""
+	for _, entry := range env {
+		if rest, ok := strings.CutPrefix(entry, key+"="); ok {
+			value = rest
+		}
+	}
+	return value
+}
+
+func TestPackageLoadConfigPinsTheZeroTargetToTheHost(t *testing.T) {
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+
+	env := packageLoadConfig("", "").Env
+
+	if got := lastValue(env, "GOOS"); got != runtime.GOOS {
+		t.Errorf("GOOS = %q, want %q", got, runtime.GOOS)
+	}
+	if got := lastValue(env, "GOARCH"); got != runtime.GOARCH {
+		t.Errorf("GOARCH = %q, want %q", got, runtime.GOARCH)
+	}
+	if got := lastValue(env, "CGO_ENABLED"); got != "1" {
+		t.Errorf("CGO_ENABLED = %q, want 1 for a host load", got)
+	}
+}
+
+func TestPackageLoadConfigKeepsCgoOffForACrossTarget(t *testing.T) {
+	goos := "windows"
+	if runtime.GOOS == goos {
+		goos = "linux"
+	}
+
+	env := packageLoadConfig(goos, "amd64").Env
+
+	if got := lastValue(env, "GOOS"); got != goos {
+		t.Errorf("GOOS = %q, want %q", got, goos)
+	}
+	if got := lastValue(env, "CGO_ENABLED"); got != "0" {
+		t.Errorf("CGO_ENABLED = %q, want 0 for a cross load", got)
+	}
+}

--- a/bindgen/tests/bindgen_test.go
+++ b/bindgen/tests/bindgen_test.go
@@ -95,7 +95,7 @@ func runBindgen(t *testing.T, pkgPath string) []byte {
 		cfg = &loaded
 	}
 
-	result, err := cli.GeneratePkg("./"+pkgPath, "0.0.0", "0.0.0", cfg)
+	result, err := cli.GeneratePkg("./"+pkgPath, "0.0.0", "0.0.0", cfg, cli.Target{})
 	if err != nil {
 		t.Fatalf("bindgen failed: %v", err)
 	}
@@ -104,7 +104,7 @@ func runBindgen(t *testing.T, pkgPath string) []byte {
 }
 
 func TestGenerateError(t *testing.T) {
-	_, err := cli.GeneratePkg("/nonexistent/path/to/package", "0.0.0", "0.0.0", nil)
+	_, err := cli.GeneratePkg("/nonexistent/path/to/package", "0.0.0", "0.0.0", nil, cli.Target{})
 	if err == nil {
 		t.Error("expected error for nonexistent package, got nil")
 	}
@@ -149,7 +149,7 @@ func TestGeneratePkgs_FullEmit(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
-	manifest := cli.GeneratePkgs([]string{"fmt", "os"}, "0.0.0", "0.0.0", nil, false)
+	manifest := cli.GeneratePkgs([]string{"fmt", "os"}, "0.0.0", "0.0.0", nil, false, cli.Target{})
 
 	if len(manifest.Errors) != 0 {
 		t.Fatalf("expected no errors, got %v", manifest.Errors)
@@ -172,7 +172,7 @@ func TestGeneratePkgs_HardFail(t *testing.T) {
 		t.Skip("skipping in short mode")
 	}
 
-	manifest := cli.GeneratePkgs([]string{"definitely/nonexistent/foo"}, "0.0.0", "0.0.0", nil, false)
+	manifest := cli.GeneratePkgs([]string{"definitely/nonexistent/foo"}, "0.0.0", "0.0.0", nil, false, cli.Target{})
 
 	if len(manifest.Ok) != 0 {
 		t.Errorf("expected no ok entries, got %d", len(manifest.Ok))
@@ -192,7 +192,7 @@ func TestGeneratePkgs_MixedBatch(t *testing.T) {
 
 	manifest := cli.GeneratePkgs(
 		[]string{"fmt", "definitely/nonexistent/foo"},
-		"0.0.0", "0.0.0", nil, false,
+		"0.0.0", "0.0.0", nil, false, cli.Target{},
 	)
 
 	if len(manifest.Ok) != 1 {
@@ -204,7 +204,7 @@ func TestGeneratePkgs_MixedBatch(t *testing.T) {
 }
 
 func TestGeneratePkgs_Empty(t *testing.T) {
-	manifest := cli.GeneratePkgs(nil, "0.0.0", "0.0.0", nil, false)
+	manifest := cli.GeneratePkgs(nil, "0.0.0", "0.0.0", nil, false, cli.Target{})
 	if len(manifest.Ok) != 0 || len(manifest.Errors) != 0 {
 		t.Errorf("expected empty manifest, got %v", manifest)
 	}

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -248,6 +248,8 @@ impl<'a> GoWorkspace<'a> {
     /// Build a `Command` invoking the bindgen binary with the given subcommand.
     /// Dev builds use the local `bindgen/bin/bindgen`; release builds shell out to
     /// `go run` against the version-pinned module.
+    /// The tool runs here, so it is built for the host, and `-target` carries
+    /// the typedefs' target instead.
     fn bindgen_command(&self, sub: &str) -> Command {
         let mut cmd = if let Some(bin) = dev_bindgen_path() {
             let mut c = Command::new(bin);
@@ -255,10 +257,11 @@ impl<'a> GoWorkspace<'a> {
             c
         } else {
             let bindgen_at_version = format!("{}@v{}", BINDGEN_GO_MODULE, BINDGEN_VERSION);
-            let mut c = go_cli::go_command(self.target);
+            let mut c = go_cli::go_command(stdlib::Target::host());
             c.args(["run", &bindgen_at_version, sub]);
             c
         };
+        cmd.args(["-target", &self.target.to_string()]);
         cmd.current_dir(self.root);
         cmd
     }


### PR DESCRIPTION
`bindgen pkg` and `bindgen pkgs` take the typedef target as `-target` instead of reading `GOOS`, to separate the platform the typedefs describe from the platform the tool itself is built for.
