### PR TITLE
fix: stop inferred `Unknown` from absorbing branch mismatches

### DIFF
--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -247,9 +247,16 @@ pub(super) struct BranchArm {
     pub(super) span: Span,
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum ArmAgreement {
+    NotCompared,
+    Conflicting,
+}
+
 pub(super) struct BranchSubsumption {
     pub(super) result_ty: Type,
     pub(super) arms: Vec<BranchArm>,
+    pub(super) arm_agreement: ArmAgreement,
 }
 
 pub(super) struct SelectExhaustivenessCheck {

--- a/crates/semantics/src/checker/infer/expressions/branches.rs
+++ b/crates/semantics/src/checker/infer/expressions/branches.rs
@@ -1,5 +1,7 @@
 use crate::checker::EnvResolve;
-use crate::checker::infer::context::{BranchArm, BranchSubsumption, Expectation, ExpectationRole};
+use crate::checker::infer::context::{
+    ArmAgreement, BranchArm, BranchSubsumption, Expectation, ExpectationRole,
+};
 use syntax::ast::BindingKind;
 use syntax::ast::{Expression, IfLetAlternative, MatchArm, Pattern, Span};
 use syntax::types::Type;
@@ -48,7 +50,7 @@ impl InferCtx<'_> {
             .iter()
             .any(|branch| self.contains_pending_branch_var(&branch.ty))
         {
-            self.record_branch_subsumption(result_ty, branches);
+            self.record_branch_subsumption(result_ty, branches, ArmAgreement::NotCompared);
             return;
         }
         match self.reconcile_branch_types(branches, span) {
@@ -59,17 +61,23 @@ impl InferCtx<'_> {
                 self.unify(result_ty, &ty, span);
             }
             BranchReconciliation::Failed => {
-                self.record_branch_subsumption(result_ty, branches);
+                self.record_branch_subsumption(result_ty, branches, ArmAgreement::Conflicting);
             }
         }
     }
 
-    fn record_branch_subsumption(&mut self, result_ty: &Type, branches: &[BranchArm]) {
+    fn record_branch_subsumption(
+        &mut self,
+        result_ty: &Type,
+        branches: &[BranchArm],
+        arm_agreement: ArmAgreement,
+    ) {
         self.file_checks
             .branch_subsumptions
             .push(BranchSubsumption {
                 result_ty: result_ty.clone(),
                 arms: branches.to_vec(),
+                arm_agreement,
             });
     }
 
@@ -85,16 +93,25 @@ impl InferCtx<'_> {
     pub fn resolve_branch_subsumptions(&mut self) {
         let obligations = mem::take(&mut self.file_checks.branch_subsumptions);
         for obligation in obligations.into_iter().rev() {
+            let result_ty = if matches!(obligation.arm_agreement, ArmAgreement::Conflicting)
+                && self
+                    .store
+                    .resolves_to_unknown(&obligation.result_ty.resolve_in(&self.env))
+            {
+                self.new_type_var()
+            } else {
+                obligation.result_ty
+            };
             for branch in &obligation.arms {
                 let arm = branch.ty.resolve_in(&self.env);
                 if arm.is_never() || arm.is_error() {
                     continue;
                 }
                 let (unification, reported) = self.tracking_diagnostics(|this| {
-                    this.try_unify(&obligation.result_ty, &branch.ty, &branch.span)
+                    this.try_unify(&result_ty, &branch.ty, &branch.span)
                 });
                 if unification.is_err() && !reported {
-                    let result = obligation.result_ty.resolve_in(&self.env);
+                    let result = result_ty.resolve_in(&self.env);
                     self.sink.push(diagnostics::infer::branch_type_mismatch(
                         &arm,
                         branch.span,

--- a/tests/spec/infer/control_flow.rs
+++ b/tests/spec/infer/control_flow.rs
@@ -3029,6 +3029,95 @@ fn if_branches_scalar_mismatch_errors() {
 }
 
 #[test]
+fn if_branches_scalar_mismatch_errors_at_unknown_use_site() {
+    infer(
+        r#"
+import "go:fmt"
+fn test() {
+  let x = if true { 1 } else { 2.0 }
+  fmt.Println(x)
+}
+"#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn if_branches_scalar_mismatch_errors_at_unknown_alias_use_site() {
+    infer(
+        r#"
+type Any = Unknown
+fn takes(value: Any) -> Any { value }
+fn test() {
+  let x = if true { 1 } else { 2.0 }
+  let _ = takes(x)
+}
+"#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn nested_if_branches_scalar_mismatch_errors_at_unknown_use_site() {
+    infer(
+        r#"
+import "go:fmt"
+fn test() {
+  let x = if true { if false { 1 } else { 2.0 } } else { 3 }
+  fmt.Println(x)
+}
+"#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn match_arms_scalar_mismatch_errors_at_unknown_use_site() {
+    infer(
+        r#"
+import "go:fmt"
+fn test() {
+  let x = match 1 {
+    1 => 1,
+    _ => "x",
+  }
+  fmt.Println(x)
+}
+"#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn if_branches_widen_to_written_unknown_ok() {
+    infer(
+        r#"
+import "go:fmt"
+fn test() {
+  let x: Unknown = if true { 1 } else { 2.0 }
+  fmt.Println(x)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn if_branches_widen_to_written_unknown_alias_ok() {
+    infer(
+        r#"
+type Any = Unknown
+fn takes(value: Any) -> Any { value }
+fn test() {
+  let x: Any = if true { 1 } else { 2.0 }
+  let _ = takes(x)
+}
+"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn match_value_ref_arm_with_diverging_arm_resolves_receiver() {
     infer(
         r#"


### PR DESCRIPTION
An `if` or `match` where the arms disagree now reports the mismatch even when the value later flows into an `Unknown` position.

```rs
import "go:fmt"

fn main() {
  let cond = true
  let a = if cond { 1 } else { 2.0 }
  fmt.Println(a) // before the fix, this was wideining the value to `var a any`
}
```

Widening to `Unknown` still works annotated: `let a: Unknown = if cond { 1 } else { 2.0 }`.
