### PR TITLE
fix: align unused warnings across `lis` commands

### DIFF
--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -85,6 +85,11 @@ impl Analysis {
 }
 
 pub fn analyze(input: AnalyzeInput) -> Analysis {
+    let unused_item_reporting = if input.compile_phase.includes_tests() {
+        passes::UnusedItemReporting::Report
+    } else {
+        passes::UnusedItemReporting::Suppress
+    };
     let InferenceOutput {
         store,
         facts,
@@ -109,7 +114,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
     let unused = if has_pre_check_errors {
         UnusedInfo::default()
     } else {
-        passes::run(&store, &facts, &sink, lint_mode)
+        passes::run(&store, &facts, &sink, lint_mode, unused_item_reporting)
     };
     let mut mutations = MutationInfo::default();
     for (&binding_id, b) in facts.bindings.iter() {

--- a/crates/passes/src/lib.rs
+++ b/crates/passes/src/lib.rs
@@ -2,4 +2,4 @@ mod analyze;
 mod passes;
 
 pub use analyze::{Analysis, analyze};
-pub use passes::{Lint, LintMode, run};
+pub use passes::{Lint, LintMode, UnusedItemReporting, run};

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -7,8 +7,8 @@ use rayon::prelude::*;
 use rustc_hash::FxHashSet as HashSet;
 use std::sync::Arc;
 
-use crate::passes::PARALLEL_THRESHOLD;
 use crate::passes::lints::span_edit::statement_deletion;
+use crate::passes::{PARALLEL_THRESHOLD, UnusedItemReporting};
 use diagnostics::LisetteDiagnostic;
 use diagnostics::LocalSink;
 use diagnostics::{Edit, Fix};
@@ -35,7 +35,11 @@ struct RefLintResult {
     unused_definition_spans: Vec<Span>,
 }
 
-pub(crate) fn run(store: &Store, facts: &Facts) -> (Vec<LisetteDiagnostic>, UnusedInfo) {
+pub(crate) fn run(
+    store: &Store,
+    facts: &Facts,
+    unused_item_reporting: UnusedItemReporting,
+) -> (Vec<LisetteDiagnostic>, UnusedInfo) {
     let mut packages: Vec<&Package> = store
         .packages
         .values()
@@ -49,7 +53,14 @@ pub(crate) fn run(store: &Store, facts: &Facts) -> (Vec<LisetteDiagnostic>, Unus
     if packages.len() < PARALLEL_THRESHOLD {
         let sink = LocalSink::new();
         for package in &packages {
-            apply_ref_lints(package, facts, store, &mut unused, &sink);
+            apply_ref_lints(
+                package,
+                facts,
+                store,
+                unused_item_reporting,
+                &mut unused,
+                &sink,
+            );
         }
         return (sink.into_diagnostics(), unused);
     }
@@ -60,7 +71,14 @@ pub(crate) fn run(store: &Store, facts: &Facts) -> (Vec<LisetteDiagnostic>, Unus
         .map(|package| {
             let local_sink = LocalSink::new();
             let mut local_unused = UnusedInfo::default();
-            apply_ref_lints(package, facts, store, &mut local_unused, &local_sink);
+            apply_ref_lints(
+                package,
+                facts,
+                store,
+                unused_item_reporting,
+                &mut local_unused,
+                &local_sink,
+            );
             (local_sink, local_unused)
         })
         .collect();
@@ -77,10 +95,11 @@ fn apply_ref_lints(
     package: &Package,
     facts: &Facts,
     store: &Store,
+    unused_item_reporting: UnusedItemReporting,
     unused: &mut UnusedInfo,
     sink: &LocalSink,
 ) {
-    let result = run_ref_lints(package, facts, store);
+    let result = run_ref_lints(package, facts, store, unused_item_reporting);
     if !result.unused_import_aliases.is_empty() {
         unused.imports_by_package.insert(
             package.id.clone().into(),
@@ -106,7 +125,13 @@ fn apply_ref_lints(
     sink.extend(diagnostics);
 }
 
-fn run_ref_lints(package: &Package, facts: &Facts, store: &Store) -> RefLintResult {
+fn run_ref_lints(
+    package: &Package,
+    facts: &Facts,
+    store: &Store,
+    unused_item_reporting: UnusedItemReporting,
+) -> RefLintResult {
+    let report_unused_items = unused_item_reporting == UnusedItemReporting::Report;
     let files = &package.files;
     let equality_index = &store.equality_index;
     let mut diagnostics = Vec::new();
@@ -148,6 +173,9 @@ fn run_ref_lints(package: &Package, facts: &Facts, store: &Store) -> RefLintResu
         if info.kind == ItemKind::Function {
             unused_definition_spans.push(info.span);
         }
+        if !report_unused_items {
+            continue;
+        }
         let mut diagnostic = create_unused_diagnostic(info.kind, &info.span);
         if let ItemKind::Import { statement_span } = info.kind
             && let Some(file) = files.get(&statement_span.file_id)
@@ -168,11 +196,13 @@ fn run_ref_lints(package: &Package, facts: &Facts, store: &Store) -> RefLintResu
 
     check_visibility_constraints(package, files, &mut diagnostics);
 
-    for (kind, span) in graph.unused_members() {
-        diagnostics.push(match kind {
-            MemberKind::StructField => diagnostics::lint::unused_field(span),
-            MemberKind::EnumVariant => diagnostics::lint::unused_variant(span),
-        });
+    if report_unused_items {
+        for (kind, span) in graph.unused_members() {
+            diagnostics.push(match kind {
+                MemberKind::StructField => diagnostics::lint::unused_field(span),
+                MemberKind::EnumVariant => diagnostics::lint::unused_variant(span),
+            });
+        }
     }
 
     RefLintResult {

--- a/crates/passes/src/passes/mod.rs
+++ b/crates/passes/src/passes/mod.rs
@@ -22,6 +22,12 @@ pub enum LintMode {
     Run,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnusedItemReporting {
+    Report,
+    Suppress,
+}
+
 pub(crate) const PARALLEL_THRESHOLD: usize = 4;
 
 pub(crate) fn source_file_work(store: &Store) -> Vec<(&Package, &File)> {
@@ -51,7 +57,13 @@ pub(crate) fn is_trivial_expression(expression: &Expression) -> bool {
     }
 }
 
-pub fn run(store: &Store, facts: &Facts, sink: &LocalSink, lint_mode: LintMode) -> UnusedInfo {
+pub fn run(
+    store: &Store,
+    facts: &Facts,
+    sink: &LocalSink,
+    lint_mode: LintMode,
+    unused_item_reporting: UnusedItemReporting,
+) -> UnusedInfo {
     let ((checks_diagnostics, pattern_lints), lint_outputs) = rayon::join(
         || checks::run_all(store, facts, lint_mode),
         || match lint_mode {
@@ -62,7 +74,7 @@ pub fn run(store: &Store, facts: &Facts, sink: &LocalSink, lint_mode: LintMode) 
                     || {
                         rayon::join(
                             || lints::ast_walk::run(store, facts),
-                            || lints::ref_graph::run(store, facts),
+                            || lints::ref_graph::run(store, facts, unused_item_reporting),
                         )
                     },
                 );

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -43,7 +43,7 @@ pub enum CompilePhase {
 }
 
 impl CompilePhase {
-    fn includes_tests(self) -> bool {
+    pub fn includes_tests(self) -> bool {
         matches!(self, Self::Check | Self::Test)
     }
 

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -156,6 +156,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
                 &checker.facts,
                 &checker.sink,
                 passes::LintMode::Skip,
+                passes::UnusedItemReporting::Report,
             );
         }
 

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -17,7 +17,13 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     let InferredTestFile { store, checker } = infer_test_file(source, parse_result.ast, &[]);
     let inference_checkpoint = checker.sink.checkpoint();
 
-    passes::run(&store, &checker.facts, &checker.sink, passes::LintMode::Run);
+    passes::run(
+        &store,
+        &checker.facts,
+        &checker.sink,
+        passes::LintMode::Run,
+        passes::UnusedItemReporting::Report,
+    );
 
     // Deferred inference errors surface during passes::run, mixed in with
     // the error-severity lint diagnostics the tests assert on.

--- a/tests/_harness/pipeline.rs
+++ b/tests/_harness/pipeline.rs
@@ -171,6 +171,7 @@ impl CompiledTest {
                     &checker.facts,
                     &checker.sink,
                     passes::LintMode::Skip,
+                    passes::UnusedItemReporting::Report,
                 );
             }
 

--- a/tests/e2e_run.rs
+++ b/tests/e2e_run.rs
@@ -1441,6 +1441,96 @@ fn single_file_check_ignores_unrelated_test_packages() {
 }
 
 #[test]
+fn build_does_not_report_items_used_only_by_tests() {
+    if !go_available() {
+        eprintln!("skipping build_does_not_report_items_used_only_by_tests: `go` not found");
+        return;
+    }
+
+    let scratch = tempfile::tempdir().expect("create temp dir");
+    let project = scratch.path().join("proj");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("lisette.toml"),
+        "[project]\nname = \"testonly\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.lis"),
+        r#"import "go:fmt"
+import "go:strings"
+
+const GREETING = "hi"
+
+type Name = string
+
+struct Point { x: int, y: int }
+
+enum Color { Red, Blue }
+
+fn helper(n: int) -> int {
+  n + 1
+}
+
+fn joined() -> string {
+  strings.Join(["a", "b"], ",")
+}
+
+fn main() {
+  fmt.Println("Hello world!")
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/main.test.lis"),
+        r#"#[test]
+fn uses_everything() {
+  assert helper(1) == 2
+  assert joined() == "a,b"
+  assert GREETING == "hi"
+  let n: Name = "x"
+  assert n == "x"
+  let p = Point { x: 1, y: 2 }
+  assert p.x + p.y == 3
+  assert Color.Red == Color.Red
+}
+"#,
+    )
+    .unwrap();
+
+    let build = lis(&project, "build");
+    let build_out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+    assert!(
+        build.status.success(),
+        "`lis build` must succeed:\n{build_out}"
+    );
+    assert!(
+        !build_out.contains("lint.unused_"),
+        "`lis build` must not report items that the test files use:\n{build_out}"
+    );
+
+    let check = lis(&project, "check");
+    let check_out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr)
+    );
+    assert!(
+        check.status.success(),
+        "`lis check` must succeed:\n{check_out}"
+    );
+    assert!(
+        check_out.contains("lint.unused_enum_variant"),
+        "`lis check` must still report a variant nothing uses:\n{check_out}"
+    );
+}
+
+#[test]
 fn loose_dir_check_does_not_duplicate_child_diagnostics() {
     let scratch = tempfile::tempdir().expect("create temp dir");
     let dir = scratch.path();


### PR DESCRIPTION
`lis build` was warning `never called` on a function that a test file called. Unused-item warnings now come from `lis check` and `lis test`, which see the test files and report the truth.
