### PR TITLE
fix: align `Slice.contains` with `Slice.equals`

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -495,6 +495,22 @@ impl Planner<'_> {
             }
         }
 
+        if ctx.method == "contains" && matches!(ctx.native_type, NativeGoType::Slice) {
+            let receiver_ty = self.facts.strip_and_peel(&receiver_expression.get_type());
+            if receiver_ty.is_slice()
+                && let Some(element) = receiver_ty.inner()
+                && self.needs_custom_equality(&element, &[])
+            {
+                let mut staged = self.stage_native_method(ctx, form);
+                self.require_slices();
+                let searched = staged.arguments[0].clone();
+                let target = self.hoist_tmp_value_statement(&mut staged.setup, "want", &searched);
+                let predicate = self.contains_predicate(&element, &target, &[]);
+                let body = format!("slices.ContainsFunc({}, {predicate})", staged.receiver);
+                return staged.finish(body);
+            }
+        }
+
         if matches!(ctx.native_type, NativeGoType::Array)
             && is_native_array_method(ctx.method)
             && matches!(
@@ -970,6 +986,13 @@ impl Planner<'_> {
         let b = self.fresh_var(Some("b"));
         let body = self.render_equality(&a, &b, ty, generics);
         format!("func({a} {go_ty}, {b} {go_ty}) bool {{ return {body} }}")
+    }
+
+    fn contains_predicate(&mut self, ty: &Type, target: &str, generics: &[Generic]) -> String {
+        let go_ty = self.use_go_type(ty);
+        let element = self.fresh_var(Some("e"));
+        let body = self.render_equality(&element, target, ty, generics);
+        format!("func({element} {go_ty}) bool {{ return {body} }}")
     }
 
     fn needs_custom_equality(&self, ty: &Type, generics: &[Generic]) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -300,7 +300,7 @@ impl InferCtx<'_> {
         }
 
         self.check_native_mutating_call(&callee_expression, &span);
-        self.check_native_equals_ufcs(&callee_expression, &new_args);
+        self.check_native_equality_ufcs(&callee_expression, &new_args);
 
         let return_check_recorded = self.is_generic_callee(&callee_expression)
             && type_args.is_empty()

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -731,12 +731,15 @@ impl InferCtx<'_> {
         }
     }
 
-    /// Gates `Slice.equals(a, b)`, which parses as one identifier (not a dot access) so `infer_dot_access` never sees it.
-    pub(super) fn check_native_equals_ufcs(&mut self, callee: &Expression, args: &[Expression]) {
+    /// Gates `Slice.equals(a, b)` and its siblings, which parse as one identifier (not a dot access) so `infer_dot_access` never sees them.
+    pub(super) fn check_native_equality_ufcs(&mut self, callee: &Expression, args: &[Expression]) {
         let Expression::Identifier { value, .. } = callee.unwrap_parens() else {
             return;
         };
-        if value.as_str() != "Slice.equals" && value.as_str() != "Map.equals" {
+        if !matches!(
+            value.as_str(),
+            "Slice.equals" | "Map.equals" | "Slice.contains"
+        ) {
             return;
         }
         let Some(receiver) = args.first() else {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -95,7 +95,7 @@ impl InferCtx<'_> {
                 self.sink
                     .push(diagnostics::infer::ref_slice_growth(&member, span));
             }
-            if member.as_str() == "equals" && self.is_callee_context() {
+            if matches!(member.as_str(), "equals" | "contains") && self.is_callee_context() {
                 self.gate_container_equals(&args.deref_ty, args.expression.get_span());
             }
             if !self.is_callee_context()

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -811,6 +811,79 @@ fn test(a: Slice<int>, b: Slice<int>) -> bool {
 }
 
 #[test]
+fn slice_contains_comparable_element() {
+    let input = r#"
+fn test(a: Slice<int>, value: int) -> bool {
+  a.contains(value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nested_slice_contains() {
+    let input = r#"
+fn test(a: Slice<Slice<int>>, value: Slice<int>) -> bool {
+  a.contains(value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_of_map_contains() {
+    let input = r#"
+fn test(a: Slice<Map<string, int>>, value: Map<string, int>) -> bool {
+  a.contains(value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_contains_comparable_generic() {
+    let input = r#"
+fn test<T: Comparable>(a: Slice<T>, value: T) -> bool {
+  a.contains(value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_contains_ufcs() {
+    let input = r#"
+fn test(a: Slice<Slice<int>>, value: Slice<int>) -> bool {
+  Slice.contains(a, value)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_contains_evaluates_its_target_once() {
+    let input = r#"
+fn target(calls: mut Ref<int>) -> Slice<int> {
+  calls.* += 1
+  [9]
+}
+
+fn main() {
+  let xs: Slice<Slice<int>> = [[1], [2], [3]]
+  let mut calls = 0
+  let found = xs.contains(target(&calls))
+  if found {
+    panic("9 is not in the slice")
+  }
+  if calls != 1 {
+    panic(f"expected 1 call, got {calls}")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_equals() {
     let input = r#"
 fn test(a: Map<string, int>, b: Map<string, int>) -> bool {

--- a/tests/spec/emit/snapshots/nested_slice_contains.snap
+++ b/tests/spec/emit/snapshots/nested_slice_contains.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(a: Slice<Slice<int>>, value: Slice<int>) -> bool {
+    a.contains(value)
+  }
+---
+package main
+
+import "slices"
+
+func test(a [][]int, value []int) bool {
+	want_1 := value
+	return slices.ContainsFunc(a, func(e_2 []int) bool { return slices.Equal(e_2, want_1) })
+}

--- a/tests/spec/emit/snapshots/slice_contains_comparable_element.snap
+++ b/tests/spec/emit/snapshots/slice_contains_comparable_element.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(a: Slice<int>, value: int) -> bool {
+    a.contains(value)
+  }
+---
+package main
+
+import "slices"
+
+func test(a []int, value int) bool {
+	return slices.Contains(a, value)
+}

--- a/tests/spec/emit/snapshots/slice_contains_comparable_generic.snap
+++ b/tests/spec/emit/snapshots/slice_contains_comparable_generic.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test<T: Comparable>(a: Slice<T>, value: T) -> bool {
+    a.contains(value)
+  }
+---
+package main
+
+import "slices"
+
+func test[T comparable](a []T, value T) bool {
+	return slices.Contains(a, value)
+}

--- a/tests/spec/emit/snapshots/slice_contains_evaluates_its_target_once.snap
+++ b/tests/spec/emit/snapshots/slice_contains_evaluates_its_target_once.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn target(calls: mut Ref<int>) -> Slice<int> {
+    calls.* += 1
+    [9]
+  }
+  
+  fn main() {
+    let xs: Slice<Slice<int>> = [[1], [2], [3]]
+    let mut calls = 0
+    let found = xs.contains(target(&calls))
+    if found {
+      panic("9 is not in the slice")
+    }
+    if calls != 1 {
+      panic(f"expected 1 call, got {calls}")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+func target(calls *int) []int {
+	*calls++
+	return []int{9}
+}
+
+func main() {
+	xs := [][]int{{1}, {2}, {3}}
+	calls := 0
+	want_1 := target(&calls)
+	found := slices.ContainsFunc(xs, func(e_2 []int) bool { return slices.Equal(e_2, want_1) })
+	if found {
+		panic("9 is not in the slice")
+	}
+	if calls != 1 {
+		panic(fmt.Sprintf("expected 1 call, got %d", calls))
+	}
+}

--- a/tests/spec/emit/snapshots/slice_contains_keeps_user_equals_live.snap
+++ b/tests/spec/emit/snapshots/slice_contains_keeps_user_equals_live.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Point { x: int, y: int }
+  
+  impl Point {
+    fn equals(self, other: Point) -> bool {
+      self.x == other.x
+    }
+  }
+  
+  fn main() {
+    let xs: Slice<Point> = [Point { x: 1, y: 0 }]
+    if !xs.contains(Point { x: 1, y: 9 }) {
+      panic("contains must use the user equals, not Go ==")
+    }
+  }
+---
+package main
+
+import "slices"
+
+type Point struct {
+	x int
+	y int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func main() {
+	xs := []Point{{
+		x: 1,
+		y: 0,
+	}}
+	want_1 := Point{
+		x: 1,
+		y: 9,
+	}
+	if !slices.ContainsFunc(xs, func(e_2 Point) bool { return e_2.equals(want_1) }) {
+		panic("contains must use the user equals, not Go ==")
+	}
+}

--- a/tests/spec/emit/snapshots/slice_contains_ufcs.snap
+++ b/tests/spec/emit/snapshots/slice_contains_ufcs.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(a: Slice<Slice<int>>, value: Slice<int>) -> bool {
+    Slice.contains(a, value)
+  }
+---
+package main
+
+import "slices"
+
+func test(a [][]int, value []int) bool {
+	want_1 := value
+	return slices.ContainsFunc(a, func(e_2 []int) bool { return slices.Equal(e_2, want_1) })
+}

--- a/tests/spec/emit/snapshots/slice_of_map_contains.snap
+++ b/tests/spec/emit/snapshots/slice_of_map_contains.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(a: Slice<Map<string, int>>, value: Map<string, int>) -> bool {
+    a.contains(value)
+  }
+---
+package main
+
+import (
+	"maps"
+	"slices"
+)
+
+func test(a []map[string]int, value map[string]int) bool {
+	want_1 := value
+	return slices.ContainsFunc(a, func(e_2 map[string]int) bool { return maps.Equal(e_2, want_1) })
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -1066,6 +1066,27 @@ fn test(a: Slice<Point>, b: Slice<Point>) -> bool {
 }
 
 #[test]
+fn slice_contains_keeps_user_equals_live() {
+    let input = r#"
+struct Point { x: int, y: int }
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn main() {
+  let xs: Slice<Point> = [Point { x: 1, y: 0 }]
+  if !xs.contains(Point { x: 1, y: 9 }) {
+    panic("contains must use the user equals, not Go ==")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn map_equals_keeps_user_equals_live() {
     let input = r#"
 struct Point { x: int }

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9859,6 +9859,64 @@ fn test(a: Slice<fn() -> int>, b: Slice<fn() -> int>) {
 }
 
 #[test]
+fn infer_contains_rejects_function_element() {
+    let input = r#"
+fn test(a: Slice<fn() -> int>, value: fn() -> int) {
+  let result = a.contains(value);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_contains_rejects_noncomparable_struct_element() {
+    let input = r#"
+struct Holder {
+  items: Slice<int>,
+}
+
+fn test(a: Slice<Holder>, value: Holder) {
+  let result = a.contains(value);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_contains_rejects_unbounded_generic_element() {
+    let input = r#"
+fn has<T>(a: Slice<T>, value: T) -> bool {
+  a.contains(value)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_contains_ufcs_rejects_function_element() {
+    let input = r#"
+fn test(a: Slice<fn() -> int>, value: fn() -> int) {
+  let result = Slice.contains(a, value);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_contains_rejects_interface_element() {
+    let input = r#"
+interface Shape {
+  fn area() -> int
+}
+
+fn test(a: Slice<Shape>, value: Shape) {
+  let result = a.contains(value);
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_not_comparable_function() {
     let input = r#"
 fn test() {

--- a/tests/ui/errors/snapshots/infer_contains_rejects_function_element.snap
+++ b/tests/ui/errors/snapshots/infer_contains_rejects_function_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+   ╭─[test.lis:3:16]
+ 2 │ fn test(a: Slice<fn() -> int>, value: fn() -> int) {
+ 3 │   let result = a.contains(value);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Slice<fn () -> int>` cannot be compared because functions cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_contains_rejects_interface_element.snap
+++ b/tests/ui/errors/snapshots/infer_contains_rejects_interface_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+   ╭─[test.lis:7:16]
+ 6 │ fn test(a: Slice<Shape>, value: Shape) {
+ 7 │   let result = a.contains(value);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 8 │ }
+   ╰────
+  help: `Slice<Shape>` cannot be compared because interface values cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_contains_rejects_noncomparable_struct_element.snap
+++ b/tests/ui/errors/snapshots/infer_contains_rejects_noncomparable_struct_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+   ╭─[test.lis:7:16]
+ 6 │ fn test(a: Slice<Holder>, value: Holder) {
+ 7 │   let result = a.contains(value);
+   ·                ┬
+   ·                ╰── cannot be compared
+ 8 │ }
+   ╰────
+  help: `Slice<Holder>` cannot be compared because a struct containing non-comparable fields cannot be compared · code: [infer.not_equatable]

--- a/tests/ui/errors/snapshots/infer_contains_rejects_unbounded_generic_element.snap
+++ b/tests/ui/errors/snapshots/infer_contains_rejects_unbounded_generic_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing comparable bound
+   ╭─[test.lis:3:3]
+ 2 │ fn has<T>(a: Slice<T>, value: T) -> bool {
+ 3 │   a.contains(value)
+   ·   ┬
+   ·   ╰── `Slice<T>` cannot be compared
+ 4 │ }
+   ╰────
+  help: Add the bound where `T` is declared: `<T: Comparable>` · code: [infer.param_needs_comparable_bound]

--- a/tests/ui/errors/snapshots/infer_contains_ufcs_rejects_function_element.snap
+++ b/tests/ui/errors/snapshots/infer_contains_ufcs_rejects_function_element.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Invalid comparison
+   ╭─[test.lis:3:31]
+ 2 │ fn test(a: Slice<fn() -> int>, value: fn() -> int) {
+ 3 │   let result = Slice.contains(a, value);
+   ·                               ┬
+   ·                               ╰── cannot be compared
+ 4 │ }
+   ╰────
+  help: `Slice<fn () -> int>` cannot be compared because functions cannot be compared · code: [infer.not_equatable]


### PR DESCRIPTION
`Slice.contains` now compares elements the same way `Slice.equals` does. It was using Go's `==`, which ignored a user-defined `equals` and rejected element types Go cannot compare.

```rs
import "go:fmt"

struct Ver { major: int, minor: int }

impl Ver {
  fn equals(self, other: Ver) -> bool {
    self.major == other.major
  }
}

fn main() {
  let xs: Slice<Ver> = [Ver { major: 1, minor: 0 }]
  fmt.Println(xs.contains(Ver { major: 1, minor: 9 }))
  fmt.Println(xs.equals([Ver { major: 1, minor: 9 }]))
}
```

This used to print `false` then `true`. Both print `true` now.