### PR TITLE
fix: reject `defer` inside `try` and `recover`

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2139,6 +2139,13 @@ pub fn continue_in_try_block(span: Span) -> LisetteDiagnostic {
         .with_help("Use `continue` inside a loop, or use `Err(...)?` to exit the `try` block early")
 }
 
+pub fn defer_in_try_block(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`defer` in `try` block")
+        .with_infer_code("try_block_defer")
+        .with_span_label(&span, "not inside a function")
+        .with_help("Move the `defer` outside the `try` block, so it runs when the function returns")
+}
+
 pub fn recover_block_empty(span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::warn("Empty `recover` block")
         .with_infer_code("recover_block_empty")
@@ -2174,6 +2181,15 @@ pub fn continue_in_recover_block(span: Span) -> LisetteDiagnostic {
         .with_infer_code("recover_block_continue")
         .with_span_label(&span, "not allowed inside `recover` block")
         .with_help("Remove the `continue`, or move it inside a loop within the `recover` block")
+}
+
+pub fn defer_in_recover_block(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`defer` in `recover` block")
+        .with_infer_code("recover_block_defer")
+        .with_span_label(&span, "not inside a function")
+        .with_help(
+            "Move the `defer` outside the `recover` block, so it runs when the function returns",
+        )
 }
 
 pub fn expected_channel_receive(ty: &Type, span: Span) -> LisetteDiagnostic {

--- a/crates/semantics/src/checker/infer/expressions/control_flow.rs
+++ b/crates/semantics/src/checker/infer/expressions/control_flow.rs
@@ -90,6 +90,8 @@ impl InferCtx<'_> {
             self.sink.push(diagnostics::infer::defer_in_loop(span));
         }
 
+        self.check_defer_in_fallible_block(span);
+
         let unit_ty = self.type_unit();
         self.unify(expected_ty, &unit_ty, &span);
 
@@ -166,8 +168,17 @@ impl InferCtx<'_> {
 
         // task spawns a new goroutine, enclosing loop context doesn't apply
         let task_ty = self.new_type_var();
-        let new_expression =
-            self.without_enclosing_loop(|this| this.infer_expression(*expression, &task_ty));
+        let store = self.store;
+        let new_expression = self.without_enclosing_loop(|this| {
+            this.with_scope(|this| {
+                let task_unit = this.type_unit();
+                this.scopes.mark_lambda_scope();
+                this.scopes.set_fn_return_type(task_unit);
+                let new_expression = this.infer_expression(*expression, &task_ty);
+                this.check_deferred_map_key_bounds(store);
+                new_expression
+            })
+        });
 
         Expression::Task {
             expression: new_expression.into(),

--- a/crates/semantics/src/checker/infer/validation/control_flow.rs
+++ b/crates/semantics/src/checker/infer/validation/control_flow.rs
@@ -2,6 +2,7 @@ use syntax::ast::{Expression, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
+use crate::checker::scopes::FallibleBlockKind;
 
 fn is_sync_lock_type(ty: &Type) -> bool {
     matches!(
@@ -48,6 +49,19 @@ impl InferCtx<'_> {
 
         self.sink
             .push(diagnostics::infer::deferred_lock(*span, locked, unlock));
+    }
+
+    pub(crate) fn check_defer_in_fallible_block(&mut self, span: Span) {
+        match self.scopes.lookup_fallible_block_kind() {
+            Some(FallibleBlockKind::Try) => {
+                self.sink.push(diagnostics::infer::defer_in_try_block(span));
+            }
+            Some(FallibleBlockKind::Recover) => {
+                self.sink
+                    .push(diagnostics::infer::defer_in_recover_block(span));
+            }
+            None => {}
+        }
     }
 
     pub(crate) fn check_return_in_try_block(&mut self, span: Span) {

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -59,6 +59,12 @@ enum PropagationContext {
     Recover(RecoverBlockContext),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FallibleBlockKind {
+    Try,
+    Recover,
+}
+
 #[derive(Debug)]
 pub(crate) enum DeferredMapKeyCheck {
     Comparable { key: Type, span: Span },
@@ -429,6 +435,21 @@ impl Scopes {
         for scope in self.stack.iter().rev() {
             if let PropagationContext::Recover(context) = &scope.propagation_context {
                 return Some(context);
+            }
+            if scope.is_function_boundary() {
+                return None;
+            }
+        }
+        None
+    }
+
+    /// Look up the innermost `try` or `recover` block, stopping at function boundaries.
+    pub(crate) fn lookup_fallible_block_kind(&self) -> Option<FallibleBlockKind> {
+        for scope in self.stack.iter().rev() {
+            match &scope.propagation_context {
+                PropagationContext::Try(_) => return Some(FallibleBlockKind::Try),
+                PropagationContext::Recover(_) => return Some(FallibleBlockKind::Recover),
+                PropagationContext::None => {}
             }
             if scope.is_function_boundary() {
                 return None;

--- a/docs/reference/04-control-flow.md
+++ b/docs/reference/04-control-flow.md
@@ -249,7 +249,7 @@ defer {
 }
 ```
 
-The compiler rejects `defer` in loops, `?` inside defer, and `return`, `break`, or `continue` inside defer.
+The compiler rejects `defer` in loops and in `try` or `recover` blocks, `?` inside defer, and `return`, `break`, or `continue` inside defer.
 
 ```
   ✕ `defer` inside loop

--- a/tests/spec/infer/try.rs
+++ b/tests/spec/infer/try.rs
@@ -770,6 +770,254 @@ fn task_defer_as_statement_valid() {
 }
 
 #[test]
+fn defer_in_lambda_inside_try_block_valid() {
+    infer(
+        r#"
+    fn work() {}
+    fn run(f: fn() -> int) -> int { f() }
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      let result = try {
+        let base = risky()?
+        run(|| {
+          defer work()
+          base
+        })
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn defer_outside_try_block_valid() {
+    infer(
+        r#"
+    fn work() {}
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      defer work()
+      let result = try {
+        risky()?
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn defer_in_plain_block_valid() {
+    infer(
+        r#"
+    fn work() {}
+    fn f() {
+      {
+        defer work()
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn defer_in_if_expression_valid() {
+    infer(
+        r#"
+    fn work() {}
+    fn f() {
+      let n = if true {
+        defer work()
+        1
+      } else {
+        0
+      }
+      let _ = n
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn defer_in_task_inside_try_block_valid() {
+    infer(
+        r#"
+    fn work() {}
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      let result = try {
+        let base = risky()?
+        task {
+          defer work()
+        }
+        base
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn unbounded_map_key_in_task_rejected() {
+    infer(
+        r#"
+    fn f<T>() {
+      task {
+        let m = Map.new<T, int>()
+        let _ = m
+      }
+    }
+        "#,
+    )
+    .assert_infer_code("missing_map_key_bound");
+}
+
+#[test]
+fn bounded_map_key_in_task_valid() {
+    infer(
+        r#"
+    fn f<T: Comparable>() {
+      task {
+        let m = Map.new<T, int>()
+        let _ = m
+      }
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn bare_return_in_task_valid() {
+    infer(
+        r#"
+    fn f() -> int {
+      task {
+        return
+      }
+      1
+    }
+        "#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn value_return_in_task_rejected() {
+    infer(
+        r#"
+    fn f() -> int {
+      task {
+        return 5
+      }
+      1
+    }
+        "#,
+    )
+    .assert_type_mismatch();
+}
+
+#[test]
+fn propagate_in_task_rejected() {
+    infer(
+        r#"
+    fn risky() -> Option<int> { Some(1) }
+    fn f() -> Option<int> {
+      task {
+        let n = risky()?
+        let _ = n
+      }
+      Some(1)
+    }
+        "#,
+    )
+    .assert_infer_code("try_return_type_mismatch");
+}
+
+#[test]
+fn propagate_in_task_inside_try_block_rejected() {
+    infer(
+        r#"
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      let result = try {
+        let base = risky()?
+        task {
+          let n = risky()?
+          let _ = n
+        }
+        base
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_infer_code("try_return_type_mismatch");
+}
+
+#[test]
+fn defer_in_try_block_inside_task_rejected() {
+    infer(
+        r#"
+    fn work() {}
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      task {
+        let inner = try {
+          defer work()
+          risky()?
+        }
+        let _ = inner
+      }
+    }
+        "#,
+    )
+    .assert_infer_code("try_block_defer");
+}
+
+#[test]
+fn defer_in_try_block_rejected() {
+    infer(
+        r#"
+    fn work() {}
+    fn risky() -> Option<int> { Some(1) }
+    fn f() {
+      let result = try {
+        defer work()
+        risky()?
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_infer_code("try_block_defer");
+}
+
+#[test]
+fn defer_in_recover_block_rejected() {
+    infer(
+        r#"
+    fn work() {}
+    fn f() {
+      let result = recover {
+        defer work()
+        1
+      }
+      let _ = result
+    }
+        "#,
+    )
+    .assert_infer_code("recover_block_defer");
+}
+
+#[test]
 fn return_break_rejected() {
     infer(
         r#"

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -8094,6 +8094,72 @@ fn test() {
 }
 
 #[test]
+fn infer_try_block_defer() {
+    let input = r#"
+fn cleanup() {}
+
+fn test() {
+  let result = try {
+    defer cleanup()
+    Some(42)?
+  };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_recover_block_defer() {
+    let input = r#"
+fn cleanup() {}
+
+fn test() {
+  let result = recover {
+    defer cleanup()
+    42
+  };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_try_block_defer_inside_recover_names_the_inner_block() {
+    let input = r#"
+fn cleanup() {}
+
+fn test() {
+  let result = recover {
+    let inner = try {
+      defer cleanup()
+      Some(42)?
+    };
+    inner.unwrap_or(0)
+  };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_recover_block_defer_inside_try_names_the_inner_block() {
+    let input = r#"
+fn cleanup() {}
+
+fn test() {
+  let result = try {
+    let inner = recover {
+      defer cleanup()
+      1
+    };
+    Some(42)? + inner.unwrap_or(0)
+  };
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_try_block_mixed_carriers() {
     let input = r#"
 fn get_result() -> Result<int, string> { Ok(1) }

--- a/tests/ui/errors/snapshots/infer_recover_block_defer.snap
+++ b/tests/ui/errors/snapshots/infer_recover_block_defer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `defer` in `recover` block
+   ╭─[test.lis:6:5]
+ 5 │   let result = recover {
+ 6 │     defer cleanup()
+   ·     ───────┬───────
+   ·            ╰── not inside a function
+ 7 │     42
+   ╰────
+  help: Move the `defer` outside the `recover` block, so it runs when the function returns · code: [infer.recover_block_defer]

--- a/tests/ui/errors/snapshots/infer_recover_block_defer_inside_try_names_the_inner_block.snap
+++ b/tests/ui/errors/snapshots/infer_recover_block_defer_inside_try_names_the_inner_block.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `defer` in `recover` block
+   ╭─[test.lis:7:7]
+ 6 │     let inner = recover {
+ 7 │       defer cleanup()
+   ·       ───────┬───────
+   ·              ╰── not inside a function
+ 8 │       1
+   ╰────
+  help: Move the `defer` outside the `recover` block, so it runs when the function returns · code: [infer.recover_block_defer]

--- a/tests/ui/errors/snapshots/infer_try_block_defer.snap
+++ b/tests/ui/errors/snapshots/infer_try_block_defer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `defer` in `try` block
+   ╭─[test.lis:6:5]
+ 5 │   let result = try {
+ 6 │     defer cleanup()
+   ·     ───────┬───────
+   ·            ╰── not inside a function
+ 7 │     Some(42)?
+   ╰────
+  help: Move the `defer` outside the `try` block, so it runs when the function returns · code: [infer.try_block_defer]

--- a/tests/ui/errors/snapshots/infer_try_block_defer_inside_recover_names_the_inner_block.snap
+++ b/tests/ui/errors/snapshots/infer_try_block_defer_inside_recover_names_the_inner_block.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `defer` in `try` block
+   ╭─[test.lis:7:7]
+ 6 │     let inner = try {
+ 7 │       defer cleanup()
+   ·       ───────┬───────
+   ·              ╰── not inside a function
+ 8 │       Some(42)?
+   ╰────
+  help: Move the `defer` outside the `try` block, so it runs when the function returns · code: [infer.try_block_defer]


### PR DESCRIPTION
`defer` now reports an error inside a `try` or `recover` block. A `defer` runs when the enclosing function returns, so placing one inside a block that is not a fn boundary reads as if it runs at the end of that block, which it never did.

```
  ✕ `defer` in `try` block
   ╭─[test.lis:6:5]
 5 │   let result = try {
 6 │     defer cleanup()
   ·     ───────┬───────
   ·            ╰── not inside a function
 7 │     Some(42)?
   ╰────
  help: Move the `defer` outside the `try` block, so it runs when the function 
        returns · code: [infer.try_block_defer]
```
