### PR TITLE
fix: emit promoted Go fields against their declaring type

### DIFF
--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -1,4 +1,4 @@
-use syntax::types::{CompoundKind, Type};
+use syntax::types::{CompoundKind, Symbol, Type};
 
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
@@ -343,11 +343,15 @@ impl Planner<'_> {
     pub(crate) fn field_slot_layout(
         &self,
         owner_type: &Type,
+        declaring_type: Option<&Symbol>,
         field: &str,
         value_type: &Type,
     ) -> Option<ValueLayout> {
-        let owner = self.resolve_nominal(owner_type)?;
-        let slot = self.facts.go_field(owner.id.as_str(), field)?;
+        let owner = match declaring_type {
+            Some(declaring) => declaring.clone(),
+            None => self.resolve_nominal(owner_type)?.id,
+        };
+        let slot = self.facts.go_field(owner.as_str(), field)?;
         Some(self.value_layout_with_declaration(value_type, slot.origin, &slot.declared_type))
     }
 

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -3,7 +3,7 @@ use syntax::parse;
 use syntax::program::{
     Definition, DefinitionBody, DotAccessKind as SemanticDotKind, ReceiverCoercion,
 };
-use syntax::types::Type;
+use syntax::types::{Symbol, Type};
 
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
@@ -18,6 +18,7 @@ struct NullableFieldAccess<'a> {
     member: &'a str,
     field: &'a str,
     expression_ty: &'a Type,
+    declaring_type: Option<&'a Symbol>,
     result_ty: &'a Type,
 }
 
@@ -95,6 +96,7 @@ impl Planner<'_> {
                 member,
                 field: &field,
                 expression_ty: &expression_ty,
+                declaring_type: resolution.declaring_type(),
                 result_ty,
             },
         ) {
@@ -233,9 +235,11 @@ impl Planner<'_> {
             member,
             field,
             expression_ty,
+            declaring_type,
             result_ty,
         } = access;
-        let source_layout = self.field_slot_layout(expression_ty, member, result_ty)?;
+        let source_layout =
+            self.field_slot_layout(expression_ty, declaring_type, member, result_ty)?;
         let target_layout = self.value_layout(result_ty, SlotOrigin::Lisette);
         let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
         if coercion.is_identity() {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -87,7 +87,7 @@ impl Planner<'_> {
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
             let field_layout =
-                self.field_slot_layout(ty, &f.name, field_ty.as_ref().unwrap_or(&value_ty));
+                self.field_slot_layout(ty, None, &f.name, field_ty.as_ref().unwrap_or(&value_ty));
             value = self.coerce_struct_field(
                 &mut setup,
                 value,
@@ -220,7 +220,7 @@ impl Planner<'_> {
 
     /// Empty-map literal in the field's Go type, sound as empty needs no coercion.
     fn go_field_map_zero(&mut self, owner: &Type, field: &str, field_ty: &Type) -> Option<String> {
-        let layout = self.field_slot_layout(owner, field, field_ty)?;
+        let layout = self.field_slot_layout(owner, None, field, field_ty)?;
         if !layout_is_map(&layout) {
             return None;
         }

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -510,9 +510,15 @@ impl Planner<'_> {
             expression: receiver,
             member,
             ty,
+            resolution,
             ..
         } = target
-            && let Some(target_layout) = self.field_slot_layout(&receiver.get_type(), member, ty)
+            && let Some(target_layout) = self.field_slot_layout(
+                &receiver.get_type(),
+                resolution.declaring_type(),
+                member,
+                ty,
+            )
         {
             let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
             let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -10,6 +10,7 @@ use crate::state::bindings::BindingValue;
 use syntax::ast::Literal;
 use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
 use syntax::parse::TUPLE_FIELDS;
+use syntax::program::DotAccessResolution;
 use syntax::types::Type;
 
 impl Planner<'_> {
@@ -38,9 +39,15 @@ impl Planner<'_> {
                 expression,
                 member,
                 ty,
+                resolution,
                 ..
             } => self
-                .field_slot_layout(&expression.get_type(), member, ty)
+                .field_slot_layout(
+                    &expression.get_type(),
+                    resolution.declaring_type(),
+                    member,
+                    ty,
+                )
                 .map(|layout| (ty.clone(), layout)),
             _ => None,
         };
@@ -188,12 +195,15 @@ impl Planner<'_> {
                 .unwrap_or(value)
                 .to_string(),
             Expression::DotAccess {
-                expression, member, ..
+                expression,
+                member,
+                resolution,
+                ..
             } => {
                 let base = expression.deref_inner().unwrap_or(expression);
                 let base_str = self.capture_operand_into(setup, base);
                 let expression_ty = expression.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member)
+                self.format_dot_access_lvalue(&base_str, &expression_ty, member, resolution)
             }
             Expression::IndexedAccess {
                 expression, index, ..
@@ -250,6 +260,7 @@ impl Planner<'_> {
         base_str: &str,
         expression_ty: &Type,
         member: &str,
+        resolution: &DotAccessResolution,
     ) -> String {
         if let Ok(index) = member.parse::<usize>() {
             let access = self.try_emit_tuple_struct_field_access(base_str, expression_ty, index);
@@ -259,7 +270,9 @@ impl Planner<'_> {
             let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
             return format!("{}.{}", base_str, field);
         }
-        let field = if self.struct_field_is_exported(expression_ty, member) {
+        let field = if resolution_exports_field(resolution)
+            || self.struct_field_is_exported(expression_ty, member)
+        {
             go_name::make_exported(member)
         } else if self.field_is_embedded(expression_ty, member) {
             go_name::escape_keyword(member).into_owned()
@@ -301,6 +314,7 @@ impl Planner<'_> {
             Expression::DotAccess {
                 expression: base,
                 member,
+                resolution,
                 ..
             } => {
                 let base_str = if let Some(inner) = base.deref_inner() {
@@ -329,7 +343,7 @@ impl Planner<'_> {
                     self.emit_left_value(setup, base)
                 };
                 let expression_ty = base.get_type();
-                self.format_dot_access_lvalue(&base_str, &expression_ty, member)
+                self.format_dot_access_lvalue(&base_str, &expression_ty, member, resolution)
             }
             Expression::Unary {
                 operator: UnaryOperator::Deref,
@@ -406,6 +420,16 @@ fn assignment_has_setup(right_hand_side: Option<&ValuePlan>) -> bool {
 
 fn assignment_has_effectful_call(right_hand_side: Option<&ValuePlan>) -> bool {
     right_hand_side.is_some_and(|value| value.evaluation.effect.has_effectful_call())
+}
+
+fn resolution_exports_field(resolution: &DotAccessResolution) -> bool {
+    matches!(
+        resolution,
+        DotAccessResolution::StructField {
+            is_exported: true,
+            ..
+        }
+    )
 }
 
 fn assignment_requires_target_capture(right_hand_side: Option<&ValuePlan>) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -1,6 +1,7 @@
 use crate::checker::EnvResolve;
 use ecow::EcoString;
 use syntax::ast::{Expression, IdentifierResolution, Span, StructFields, StructKind};
+use syntax::go_names;
 use syntax::program::{Definition, DefinitionBody, DotAccessResolution, NativeTypeKind};
 use syntax::types::{Symbol, Type, substitute};
 
@@ -332,7 +333,10 @@ impl InferCtx<'_> {
         let resolution = if struct_kind == StructKind::Tuple {
             DotAccessResolution::TupleStructField { is_newtype }
         } else {
-            DotAccessResolution::StructField { is_exported }
+            DotAccessResolution::StructField {
+                is_exported,
+                declaring_type: None,
+            }
         };
 
         Some(args.build_dot_access(field_ty, resolution))
@@ -365,12 +369,23 @@ impl InferCtx<'_> {
         self.mark_component_grant(args.expression, args.expression_ty, &field_ty);
         let field_ty = self.granted_component_type(&field_ty, args.expression_ty);
 
-        if let Some(field) = store
+        let declared_field = store
             .fields_of(member.declaring_type.as_str())
-            .and_then(|fields| fields.iter().find(|f| f.name == args.member_name))
-        {
+            .and_then(|fields| fields.iter().find(|f| f.name == args.member_name));
+        if let Some(field) = declared_field {
             self.facts.add_usage(*args.span, field.name_span);
         }
+
+        // Go names the field where it is declared, not at the receiver.
+        let emits_exported_name = match declared_field {
+            Some(field) => {
+                let forces_export = store
+                    .get_definition(&member.declaring_type)
+                    .is_some_and(Definition::is_serialized);
+                go_names::struct_field_is_exported(field, forces_export)
+            }
+            None => visibility.is_public(),
+        };
 
         let declaring_package = store
             .package_for_qualified_name(member.declaring_type.as_str())
@@ -390,7 +405,8 @@ impl InferCtx<'_> {
         Some(args.build_dot_access(
             field_ty,
             DotAccessResolution::StructField {
-                is_exported: visibility.is_public() || is_cross_package,
+                is_exported: emits_exported_name || is_cross_package,
+                declaring_type: Some(member.declaring_type),
             },
         ))
     }

--- a/crates/syntax/src/program/resolution.rs
+++ b/crates/syntax/src/program/resolution.rs
@@ -117,6 +117,7 @@ pub enum DotAccessResolution {
     Unresolved,
     StructField {
         is_exported: bool,
+        declaring_type: Option<Symbol>,
     },
     TupleStructField {
         is_newtype: bool,
@@ -148,7 +149,7 @@ impl DotAccessResolution {
     pub fn kind(&self) -> Option<DotAccessKind> {
         Some(match self {
             Self::Unresolved => return None,
-            Self::StructField { is_exported } => DotAccessKind::StructField {
+            Self::StructField { is_exported, .. } => DotAccessKind::StructField {
                 is_exported: *is_exported,
             },
             Self::TupleStructField { is_newtype } => DotAccessKind::TupleStructField {
@@ -172,6 +173,13 @@ impl DotAccessResolution {
                 is_exported: *is_exported,
             },
         })
+    }
+
+    pub fn declaring_type(&self) -> Option<&Symbol> {
+        match self {
+            Self::StructField { declaring_type, .. } => declaring_type.as_ref(),
+            _ => None,
+        }
     }
 
     pub fn receiver_coercion(&self) -> Option<ReceiverCoercion> {

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -2802,3 +2802,169 @@ pub fn Lookup() -> Option<Index>
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/reg", typedef)]);
 }
+
+#[test]
+fn interop_promoted_nullable_field_wraps_option() {
+    let input = r#"
+import "go:errors"
+import "go:example.com/promoted"
+
+fn handler(client: Ref<promoted.Client>) -> Result<promoted.Handler, error> {
+  client.Handler.ok_or_else(|| errors.New("handler is unavailable"))
+}
+
+fn group(client: Ref<promoted.Client>) -> Result<Ref<promoted.Group>, error> {
+  client.Group.ok_or_else(|| errors.New("group is unavailable"))
+}
+"#;
+    let typedef = r#"
+pub type Handler = fn()
+
+pub struct Group {}
+
+pub struct API {
+  pub Handler: Option<Handler>,
+  pub Group: Option<Ref<Group>>,
+}
+
+pub struct Client {
+  embed mut Ref<API>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
+}
+
+#[test]
+fn interop_twice_promoted_nullable_field_wraps_option() {
+    let input = r#"
+import "go:errors"
+import "go:example.com/promoted"
+
+fn group(client: Ref<promoted.Client>) -> Result<Ref<promoted.Group>, error> {
+  client.Group.ok_or_else(|| errors.New("group is unavailable"))
+}
+"#;
+    let typedef = r#"
+pub struct Group {}
+
+pub struct API {
+  pub Group: Option<Ref<Group>>,
+}
+
+pub struct Base {
+  embed mut Ref<API>,
+}
+
+pub struct Client {
+  embed mut Base,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
+}
+
+#[test]
+fn interop_promoted_nullable_field_write_unwraps_option() {
+    let input = r#"
+import "go:example.com/promoted"
+
+fn clear(client: mut Ref<promoted.Client>) {
+  client.Group = None
+}
+"#;
+    let typedef = r#"
+pub struct Group {}
+
+pub struct API {
+  pub Group: Option<mut Ref<Group>>,
+}
+
+pub struct Client {
+  embed mut Ref<API>,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
+}
+
+#[test]
+fn interop_promoted_nullable_field_round_trip() {
+    let input = r#"
+import "go:errors"
+import "go:fmt"
+import "go:text/template"
+import "go:text/template/parse"
+
+fn root(t: mut Ref<template.Template>) -> Result<mut Ref<parse.ListNode>, error> {
+  t.Root.ok_or_else(|| errors.New("root is unavailable"))
+}
+
+fn main() {
+  let mut t = template.New("greeting")
+  match t.Parse("hello {{.}}") {
+    Ok(parsed) => {
+      match root(parsed) {
+        Ok(_) => fmt.Println("root is available"),
+        Err(e) => fmt.Println("error", e),
+      }
+      parsed.Root = None
+      match root(parsed) {
+        Ok(_) => fmt.Println("root is available"),
+        Err(e) => fmt.Println("error", e),
+      }
+    },
+    Err(e) => fmt.Println("parse failed", e),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_promoted_nullable_field_shadowed_by_direct_field() {
+    let input = r#"
+import "go:example.com/promoted"
+
+fn group(client: Ref<promoted.Client>) -> promoted.Group {
+  client.Group
+}
+"#;
+    let typedef = r#"
+pub struct Group {}
+
+pub struct API {
+  pub Group: Option<Ref<Group>>,
+}
+
+pub struct Client {
+  embed mut Ref<API>,
+  pub Group: Group,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
+}
+
+#[test]
+fn interop_promoted_nullable_field_shadowed_by_method() {
+    let input = r#"
+import "go:example.com/promoted"
+
+fn group(client: Ref<promoted.Client>) -> Option<Ref<promoted.Group>> {
+  client.Group()
+}
+"#;
+    let typedef = r#"
+pub struct Group {}
+
+pub struct API {
+  pub Group: Option<Ref<Group>>,
+}
+
+pub struct Client {
+  embed mut Ref<API>,
+}
+
+impl Client {
+  fn Group(self: Ref<Client>) -> Option<Ref<Group>>
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
+}

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
@@ -1,0 +1,86 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:errors"
+  import "go:fmt"
+  import "go:text/template"
+  import "go:text/template/parse"
+  
+  fn root(t: mut Ref<template.Template>) -> Result<mut Ref<parse.ListNode>, error> {
+    t.Root.ok_or_else(|| errors.New("root is unavailable"))
+  }
+  
+  fn main() {
+    let mut t = template.New("greeting")
+    match t.Parse("hello {{.}}") {
+      Ok(parsed) => {
+        match root(parsed) {
+          Ok(_) => fmt.Println("root is available"),
+          Err(e) => fmt.Println("error", e),
+        }
+        parsed.Root = None
+        match root(parsed) {
+          Ok(_) => fmt.Println("root is available"),
+          Err(e) => fmt.Println("error", e),
+        }
+      },
+      Err(e) => fmt.Println("parse failed", e),
+    }
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"text/template"
+	"text/template/parse"
+)
+
+func root(t *template.Template) (*parse.ListNode, error) {
+	raw_1 := t.Root
+	option_2 := lisette.OptionFromNilable[*parse.ListNode](raw_1, raw_1 == nil)
+	v_3 := lisette.OptionOkOrElse(option_2, func() error {
+		return errors.New("root is unavailable")
+	})
+	if v_3.Tag == lisette.ResultOk {
+		return v_3.OkVal, nil
+	}
+	return nil, v_3.ErrVal
+}
+
+func main() {
+	t := template.New("greeting")
+	ret_1, err_2 := t.Parse("hello {{.}}")
+	if err_2 == nil && ret_1 != nil {
+		parsed := ret_1
+		_, err_3 := root(parsed)
+		if err_3 == nil {
+			fmt.Println("root is available")
+		} else {
+			e := err_3
+			fmt.Println("error", e)
+		}
+		opt_4 := lisette.MakeOptionNone[*parse.ListNode]()
+		var unwrap_5 *parse.ListNode
+		if opt_4.Tag == lisette.OptionSome {
+			unwrap_5 = opt_4.SomeVal
+		}
+		parsed.Root = unwrap_5
+		_, err_6 := root(parsed)
+		if err_6 == nil {
+			fmt.Println("root is available")
+		} else {
+			e := err_6
+			fmt.Println("error", e)
+		}
+	} else {
+		if err_2 == nil {
+			err_2 = errors.New("unexpected nil")
+		}
+		e := err_2
+		fmt.Println("parse failed", e)
+	}
+}

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_shadowed_by_direct_field.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_shadowed_by_direct_field.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/promoted"
+  
+  fn group(client: Ref<promoted.Client>) -> promoted.Group {
+    client.Group
+  }
+---
+package main
+
+import "example.com/promoted"
+
+func group(client *promoted.Client) promoted.Group {
+	return client.Group
+}

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_shadowed_by_method.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_shadowed_by_method.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/promoted"
+  
+  fn group(client: Ref<promoted.Client>) -> Option<Ref<promoted.Group>> {
+    client.Group()
+  }
+---
+package main
+
+import "example.com/promoted"
+
+func group(client *promoted.Client) *promoted.Group {
+	return client.Group()
+}

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_wraps_option.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_wraps_option.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:errors"
+  import "go:example.com/promoted"
+  
+  fn handler(client: Ref<promoted.Client>) -> Result<promoted.Handler, error> {
+    client.Handler.ok_or_else(|| errors.New("handler is unavailable"))
+  }
+  
+  fn group(client: Ref<promoted.Client>) -> Result<Ref<promoted.Group>, error> {
+    client.Group.ok_or_else(|| errors.New("group is unavailable"))
+  }
+---
+package main
+
+import (
+	"errors"
+	"example.com/promoted"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func handler(client *promoted.Client) (promoted.Handler, error) {
+	raw_1 := client.Handler
+	option_2 := lisette.OptionFromNilable[promoted.Handler](raw_1, raw_1 == nil)
+	v_3 := lisette.OptionOkOrElse(option_2, func() error {
+		return errors.New("handler is unavailable")
+	})
+	if v_3.Tag == lisette.ResultOk {
+		return v_3.OkVal, nil
+	}
+	return *new(promoted.Handler), v_3.ErrVal
+}
+
+func group(client *promoted.Client) (*promoted.Group, error) {
+	raw_1 := client.Group
+	option_2 := lisette.OptionFromNilable[*promoted.Group](raw_1, raw_1 == nil)
+	v_3 := lisette.OptionOkOrElse(option_2, func() error {
+		return errors.New("group is unavailable")
+	})
+	if v_3.Tag == lisette.ResultOk {
+		return v_3.OkVal, nil
+	}
+	return nil, v_3.ErrVal
+}

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_write_unwraps_option.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_write_unwraps_option.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/promoted"
+  
+  fn clear(client: mut Ref<promoted.Client>) {
+    client.Group = None
+  }
+---
+package main
+
+import (
+	"example.com/promoted"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func clear_(client *promoted.Client) {
+	opt_1 := lisette.MakeOptionNone[*promoted.Group]()
+	var unwrap_2 *promoted.Group
+	if opt_1.Tag == lisette.OptionSome {
+		unwrap_2 = opt_1.SomeVal
+	}
+	client.Group = unwrap_2
+}

--- a/tests/spec/emit/snapshots/interop_twice_promoted_nullable_field_wraps_option.snap
+++ b/tests/spec/emit/snapshots/interop_twice_promoted_nullable_field_wraps_option.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:errors"
+  import "go:example.com/promoted"
+  
+  fn group(client: Ref<promoted.Client>) -> Result<Ref<promoted.Group>, error> {
+    client.Group.ok_or_else(|| errors.New("group is unavailable"))
+  }
+---
+package main
+
+import (
+	"errors"
+	"example.com/promoted"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func group(client *promoted.Client) (*promoted.Group, error) {
+	raw_1 := client.Group
+	option_2 := lisette.OptionFromNilable[*promoted.Group](raw_1, raw_1 == nil)
+	v_3 := lisette.OptionOkOrElse(option_2, func() error {
+		return errors.New("group is unavailable")
+	})
+	if v_3.Tag == lisette.ResultOk {
+		return v_3.OkVal, nil
+	}
+	return nil, v_3.ErrVal
+}

--- a/tests/spec/emit/snapshots/promoted_field_write_matches_read_name.snap
+++ b/tests/spec/emit/snapshots/promoted_field_write_matches_read_name.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  pub struct Base { pub id: int, tag: string }
+  
+  struct Outer {
+    embed Base,
+  }
+  
+  fn main() {
+    let mut o = Outer { Base: Base { id: 1, tag: "a" } }
+    o.id = 2
+    o.tag = "b"
+    let _ = o.id
+    let _ = o.tag
+  }
+---
+package main
+
+type Base struct {
+	Id  int
+	tag string
+}
+
+type Outer struct {
+	Base
+}
+
+func main() {
+	o := Outer{Base: Base{
+		Id:  1,
+		tag: "a",
+	}}
+	o.Id = 2
+	o.tag = "b"
+	_ = o.Id
+	_ = o.tag
+}

--- a/tests/spec/emit/snapshots/promoted_field_write_survives_specialized_method_name.snap
+++ b/tests/spec/emit/snapshots/promoted_field_write_survives_specialized_method_name.snap
@@ -1,0 +1,46 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  pub struct Base { pub id: int }
+  
+  struct Outer<T> {
+    embed Base,
+    pub value: T,
+  }
+  
+  impl Outer<int> {
+    fn id(self) -> int {
+      0
+    }
+  }
+  
+  fn main() {
+    let mut o: Outer<int> = Outer { Base: Base { id: 1 }, value: 5 }
+    o.id = 2
+    let _ = o.id
+  }
+---
+package main
+
+type Base struct {
+	Id int
+}
+
+type Outer[T any] struct {
+	Base
+	Value T
+}
+
+func Outer_id(_ Outer[int]) int {
+	return 0
+}
+
+func main() {
+	o := Outer[int]{
+		Base:  Base{Id: 1},
+		Value: 5,
+	}
+	o.Id = 2
+	_ = o.Id
+}

--- a/tests/spec/emit/snapshots/promoted_json_field_keeps_forced_export_name.snap
+++ b/tests/spec/emit/snapshots/promoted_json_field_keeps_forced_export_name.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[json]
+  struct Base {
+    value: int,
+    other_name: string,
+  }
+  
+  struct Outer {
+    embed Base,
+  }
+  
+  fn main() {
+    let mut o = Outer { Base: Base { value: 1, other_name: "a" } }
+    o.value = 2
+    o.other_name = "b"
+    let _ = o.value
+    let _ = o.other_name
+  }
+---
+package main
+
+type Base struct {
+	Value     int    `json:"value"`
+	OtherName string `json:"other_name"`
+}
+
+type Outer struct {
+	Base
+}
+
+func main() {
+	o := Outer{Base: Base{
+		Value:     1,
+		OtherName: "a",
+	}}
+	o.Value = 2
+	o.OtherName = "b"
+	_ = o.Value
+	_ = o.OtherName
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -27,6 +27,75 @@ fn make() -> Outer {
 }
 
 #[test]
+fn promoted_field_write_matches_read_name() {
+    let input = r#"
+pub struct Base { pub id: int, tag: string }
+
+struct Outer {
+  embed Base,
+}
+
+fn main() {
+  let mut o = Outer { Base: Base { id: 1, tag: "a" } }
+  o.id = 2
+  o.tag = "b"
+  let _ = o.id
+  let _ = o.tag
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn promoted_json_field_keeps_forced_export_name() {
+    let input = r#"
+#[json]
+struct Base {
+  value: int,
+  other_name: string,
+}
+
+struct Outer {
+  embed Base,
+}
+
+fn main() {
+  let mut o = Outer { Base: Base { value: 1, other_name: "a" } }
+  o.value = 2
+  o.other_name = "b"
+  let _ = o.value
+  let _ = o.other_name
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn promoted_field_write_survives_specialized_method_name() {
+    let input = r#"
+pub struct Base { pub id: int }
+
+struct Outer<T> {
+  embed Base,
+  pub value: T,
+}
+
+impl Outer<int> {
+  fn id(self) -> int {
+    0
+  }
+}
+
+fn main() {
+  let mut o: Outer<int> = Outer { Base: Base { id: 1 }, value: 5 }
+  o.id = 2
+  let _ = o.id
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn embedded_pointer_field_emits_star_type() {
     let input = r#"
 pub struct Base { pub id: int }


### PR DESCRIPTION
Accessing a nilable Go field that comes from an embedded struct now emits Go that compiles. The emitter was looking for the field on the outer struct, which does not declare it, and so skipped the `Option` conversion.

```rs
import "go:errors"
import "go:example.test/promoted"

// `promoted.Client` embeds `*promoted.API`, where `Handler` is declared

fn handler(client: Ref<promoted.Client>) -> Result<promoted.Handler, error> {
  client.Handler.ok_or_else(|| errors.New("handler is unavailable"))
}

fn main() {
  let api = promoted.API { Handler: None, Group: None }
  let _ = handler(&promoted.Client { API: &api })
}
```

Writes were wrong for the same reason. A promoted field took its Go name from the outer struct, so assigning to one emitted a field name Go does not know.

Fix #1308
