### PR TITLE
fix: lsp auto-complete on embedded structs

### DIFF
--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -1,4 +1,5 @@
 use crate::protocol::*;
+use semantics::checker::promotion::{self, MemberKind};
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::attributes::{AttributeInfo, AttributeTarget, attributes_for};
 use syntax::lex::{Lexer, Token, TokenKind as Tk};
@@ -215,8 +216,9 @@ pub(crate) fn detect_dot_context(
 pub(crate) fn get_instance_completions(
     type_id: &str,
     snapshot: &AnalysisSnapshot,
-    same_package: bool,
+    current_package: &str,
 ) -> Vec<CompletionItem> {
+    let same_package = id_is_in_package(type_id, current_package);
     let mut items = Vec::new();
     struct_field_completions(type_id, snapshot, same_package, &mut items);
 
@@ -240,7 +242,52 @@ pub(crate) fn get_instance_completions(
         }
     }
 
+    promoted_member_completions(&ty, snapshot, current_package, &mut items);
+
     items
+}
+
+/// The fields and methods an embed promotes onto `ty`. Visibility is judged
+/// per declaring type, so an embed cannot leak a foreign type's private
+/// members.
+fn promoted_member_completions(
+    ty: &Type,
+    snapshot: &AnalysisSnapshot,
+    current_package: &str,
+    items: &mut Vec<CompletionItem>,
+) {
+    for (name, member) in promotion::promoted_members(ty, |id| snapshot.definitions().get(id)) {
+        let is_public = match &member.kind {
+            MemberKind::Field { visibility, .. } => visibility.is_public(),
+            MemberKind::Method(method) => method.visibility.is_public(),
+        };
+        if !is_public && !id_is_in_package(member.declaring_type.as_str(), current_package) {
+            continue;
+        }
+        let item = match &member.kind {
+            MemberKind::Field { ty, .. } => CompletionItem {
+                label: name.to_string(),
+                kind: Some(CompletionItemKind::FIELD),
+                detail: Some(ty.to_string()),
+                ..Default::default()
+            },
+            MemberKind::Method(method) => CompletionItem {
+                label: method.source_name.to_string(),
+                kind: Some(CompletionItemKind::METHOD),
+                detail: Some(method.ty.to_string()),
+                ..Default::default()
+            },
+        };
+        // Own members never reach here, so a label already taken belongs to a
+        // UFCS method, which promotion skips and the checker resolves past.
+        match items
+            .iter_mut()
+            .find(|existing| existing.label == item.label)
+        {
+            Some(existing) => *existing = item,
+            None => items.push(item),
+        }
+    }
 }
 
 /// A struct's own field completions, honoring visibility. No methods.

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -1090,8 +1090,7 @@ fn dot_context_completions(
     let ctx = detect_dot_context(file, offset, snapshot)?;
     Some(match ctx {
         DotContext::Instance(type_id) => {
-            let same_package = id_is_in_package(&type_id, &file.package_id);
-            get_instance_completions(&type_id, snapshot, same_package)
+            get_instance_completions(&type_id, snapshot, &file.package_id)
         }
         DotContext::TypeLevel(type_id) => {
             get_type_completions(&type_id, snapshot, &file.package_id)
@@ -1112,7 +1111,7 @@ fn package_prefix_completions(
     if prefix == "self" {
         if let Some(impl_type) = traversal::find_enclosing_impl_type(&file.items, offset) {
             let type_id = format!("{}.{}", file.package_id, impl_type);
-            return get_instance_completions(&type_id, snapshot, true);
+            return get_instance_completions(&type_id, snapshot, &file.package_id);
         }
         return Vec::new();
     }
@@ -1138,8 +1137,7 @@ fn package_prefix_completions(
 
     let indexed = offset as usize >= 2 && file.source.as_bytes()[offset as usize - 2] == b']';
     if let Some(type_id) = resolve_variable_type(prefix, file, offset, snapshot, indexed) {
-        let same_package = id_is_in_package(&type_id, &file.package_id);
-        return get_instance_completions(&type_id, snapshot, same_package);
+        return get_instance_completions(&type_id, snapshot, &file.package_id);
     }
 
     let packages = snapshot.importable_packages();

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -191,6 +191,87 @@ fn goto_definition_promoted_field() {
     client.shutdown();
 }
 
+#[test]
+fn completion_offers_promoted_members() {
+    let mut client = TestClient::new();
+    client.initialize();
+    let (source, line, character) = cursor(&format!(
+        "{EMBED_SRC}\n\nfn use_dot(w: Wrapper) {{\n  w.~\n}}"
+    ));
+    client.open(TEST_URI, &source);
+
+    let labels = completion_labels(
+        &client
+            .completion(TEST_URI, line, character)
+            .expect("completions"),
+    );
+    for promoted in ["id", "describe"] {
+        assert!(
+            labels.iter().any(|l| l == promoted),
+            "expected `{promoted}` promoted from the embedded `Base`; got: {labels:?}"
+        );
+    }
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_offers_members_promoted_through_a_ref_embed_and_two_levels() {
+    let mut client = TestClient::new();
+    client.initialize();
+    let (source, line, character) = cursor(
+        "struct A {\n  pub a: int,\n}\nimpl A {\n  pub fn am(self) -> int { self.a }\n}\nstruct B {\n  embed Ref<A>,\n  pub b: int,\n}\nstruct C {\n  embed B,\n}\nfn f(c: C) -> int {\n  c.~\n  0\n}",
+    );
+    client.open(TEST_URI, &source);
+
+    let labels = completion_labels(
+        &client
+            .completion(TEST_URI, line, character)
+            .expect("completions"),
+    );
+    for promoted in ["b", "a", "am"] {
+        assert!(
+            labels.iter().any(|l| l == promoted),
+            "expected `{promoted}` promoted onto `C`; got: {labels:?}"
+        );
+    }
+
+    client.shutdown();
+}
+
+/// `b.dup` resolves to the promoted field and is not callable, so the
+/// same-named UFCS method must not be offered beside it.
+#[test]
+fn completion_offers_one_entry_when_a_ufcs_method_collides_with_a_promoted_field() {
+    let mut client = TestClient::new();
+    client.initialize();
+    let (source, line, character) = cursor(
+        "struct A {\n  pub dup: int,\n}\nstruct B {\n  embed A,\n}\nimpl B {\n  pub fn dup<T>(self, x: T) -> T { x }\n}\nfn f(b: B) -> int {\n  b.~\n  0\n}",
+    );
+    client.open(TEST_URI, &source);
+
+    let response = client
+        .completion(TEST_URI, line, character)
+        .expect("completions");
+    let dups: Vec<_> = completion_items(&response)
+        .iter()
+        .filter(|item| item.label == "dup")
+        .collect();
+    assert_eq!(
+        dups.len(),
+        1,
+        "`dup` should be offered once; got: {:?}",
+        completion_labels(&response)
+    );
+    assert_eq!(
+        dups[0].kind,
+        Some(CompletionItemKind::FIELD),
+        "`b.dup` resolves to the promoted field, so the field is the entry to keep"
+    );
+
+    client.shutdown();
+}
+
 /// A body use is a `Slice<T>`, as `gopls` reports for Go's `...T`.
 #[test]
 fn hover_on_varargs_param_in_body_shows_a_slice() {
@@ -2506,6 +2587,56 @@ fn cross_package_goto_definition() {
         completion.is_some(),
         "server should still respond with cross-package code"
     );
+
+    client.shutdown();
+}
+
+#[test]
+fn completion_hides_promoted_members_private_to_the_embedded_type() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    fs::write(root.join("lisette.toml"), "").unwrap();
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+
+    let utils_dir = src.join("utils");
+    fs::create_dir_all(&utils_dir).unwrap();
+    fs::write(
+        utils_dir.join("utils.lis"),
+        "pub struct Base {\n  pub id: int,\n  hidden: int,\n}\nimpl Base {\n  pub fn shown(self) -> int { self.id }\n  fn concealed(self) -> int { self.hidden }\n}",
+    )
+    .unwrap();
+
+    let (main_content, line, character) = cursor(
+        "import \"utils\"\n\nstruct Wrapper {\n  embed utils.Base,\n}\n\nfn f(w: Wrapper) -> int {\n  w.~\n  0\n}",
+    );
+    let main_path = src.join("main.lis");
+    fs::write(&main_path, &main_content).unwrap();
+
+    let mut client = TestClient::new();
+    client.initialize_with_root(root);
+    let main_uri = Url::from_file_path(&main_path).unwrap().to_string();
+    client.open(&main_uri, &main_content);
+
+    let labels = completion_labels(
+        &client
+            .completion(&main_uri, line, character)
+            .expect("completions"),
+    );
+    for public in ["id", "shown"] {
+        assert!(
+            labels.iter().any(|l| l == public),
+            "expected the promoted public `{public}`; got: {labels:?}"
+        );
+    }
+    for private in ["hidden", "concealed"] {
+        assert!(
+            !labels.iter().any(|l| l == private),
+            "`{private}` is private to `utils.Base`, promotion must not leak it; got: {labels:?}"
+        );
+    }
 
     client.shutdown();
 }

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -4,9 +4,10 @@ use std::collections::BTreeMap;
 
 use syntax::ast::{Generic, Visibility};
 use syntax::go_names;
-use syntax::program::{DefinitionBody, Method, Methods};
+use syntax::program::{Definition, DefinitionBody, Method, Methods, methods_for_type};
 use syntax::types::{
-    CompoundKind, Symbol, Type, build_named_substitution_map, build_substitution_map, substitute,
+    self, CompoundKind, Symbol, Type, build_named_substitution_map, build_substitution_map,
+    substitute,
 };
 
 use crate::store::Store;
@@ -37,46 +38,86 @@ pub enum Resolution {
 }
 
 pub fn has_direct_embed(store: &Store, ty: &Type) -> bool {
-    let Type::Nominal { id, .. } = store.deep_resolve_alias(&ty.strip_refs()) else {
+    has_embed(ty, |id| store.get_definition(id))
+}
+
+/// Whether `ty` embeds anything: the cheap precondition for `walk`.
+fn has_embed<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    let Type::Nominal { id, .. } = types::peel_alias(&ty.strip_refs(), lookup) else {
         return false;
     };
-    store
-        .fields_of(id.as_str())
+    lookup(id.as_str())
+        .and_then(Definition::fields)
         .is_some_and(|fields| fields.iter().any(|field| field.is_embedded()))
 }
 
 pub fn resolve_selector(store: &Store, outer: &Type, name: &str) -> Resolution {
-    let entries = walk(store, outer);
-    resolve_in_entries(store, &entries, outer, name)
+    let lookup = |id: &str| store.get_definition(id);
+    let entries = walk(outer, lookup);
+    resolve_in_entries(&entries, outer, name, lookup)
 }
 
 pub(crate) fn promoted_method_set(store: &Store, outer: &Type) -> Methods {
-    let entries = walk(store, outer);
+    member_set(outer, |id| store.get_definition(id))
+        .into_iter()
+        .filter_map(|(name, member)| match member.kind {
+            MemberKind::Method(method) => Some((name, method)),
+            MemberKind::Field { .. } => None,
+        })
+        .collect()
+}
+
+/// The members `outer` gains from its embeds. Its own members are already
+/// reachable, and an ambiguous name is not a valid selector.
+pub fn promoted_members<'d, F>(outer: &Type, lookup: F) -> Vec<(EcoString, ResolvedMember)>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    if !has_embed(outer, lookup) {
+        return Vec::new();
+    }
+
+    member_set(outer, lookup)
+        .into_iter()
+        .filter(|(_, member)| member.depth > 0)
+        .collect()
+}
+
+/// Every selector `outer` resolves, own and promoted, one winner per name.
+fn member_set<'d, F>(outer: &Type, lookup: F) -> Vec<(EcoString, ResolvedMember)>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    let entries = walk(outer, lookup);
 
     let mut names: HashSet<EcoString> = HashSet::default();
     for entry in &entries {
-        collect_member_names(store, &entry.ty, &mut names);
+        collect_member_names(&entry.ty, lookup, &mut names);
     }
 
-    let mut result = Methods::default();
-    for name in names {
-        if let Resolution::Found(member) = resolve_in_entries(store, &entries, outer, &name)
-            && let MemberKind::Method(method) = member.kind
-        {
-            result.insert(name, method);
-        }
-    }
-    result
+    names
+        .into_iter()
+        .filter_map(
+            |name| match resolve_in_entries(&entries, outer, &name, lookup) {
+                Resolution::Found(member) => Some((name, member)),
+                Resolution::Ambiguous { .. } | Resolution::NotFound => None,
+            },
+        )
+        .collect()
 }
 
 /// Shallowest depth at which any field of `outer` emits `selector` as its Go name.
 pub(crate) fn field_selector_depth(store: &Store, outer: &Type, selector: &str) -> Option<usize> {
+    let lookup = |id: &str| store.get_definition(id);
     let mut min: Option<usize> = None;
-    for entry in walk(store, outer) {
+    for entry in walk(outer, lookup) {
         let Some(id) = entry.ty.get_qualified_id() else {
             continue;
         };
-        let Some(definition) = store.get_definition(id) else {
+        let Some(definition) = lookup(id) else {
             continue;
         };
         let DefinitionBody::Struct { fields, .. } = &definition.body else {
@@ -103,11 +144,14 @@ struct Entry {
     multiples: bool,
 }
 
-fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
+fn walk<'d, F>(outer: &Type, lookup: F) -> Vec<Entry>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
     let mut visited: Vec<Entry> = Vec::new();
     let mut seen: HashSet<String> = HashSet::default();
 
-    let Some(root) = nominal_entry(store, outer.clone(), 0, false, false) else {
+    let Some(root) = nominal_entry(outer.clone(), 0, false, false, lookup) else {
         return visited;
     };
     let mut current = vec![root];
@@ -127,25 +171,25 @@ fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
             let Some(id) = entry.ty.get_qualified_id() else {
                 continue;
             };
-            if store.get_interface(id).is_some() {
+            if lookup(id).is_some_and(Definition::is_interface) {
                 continue;
             }
-            let Some(fields) = store.fields_of(id) else {
+            let Some(fields) = lookup(id).and_then(Definition::fields) else {
                 continue;
             };
             for field in fields {
                 if !field.is_embedded() {
                     continue;
                 }
-                let field_ty = instantiate_field(store, &entry.ty, &field.ty);
-                let resolved_field = store.deep_resolve_alias(&field_ty);
+                let field_ty = instantiate_field(&entry.ty, &field.ty, lookup);
+                let resolved_field = types::peel_alias(&field_ty, lookup);
                 let (target, is_pointer) = deref_once(&resolved_field);
                 if let Some(child) = nominal_entry(
-                    store,
                     target,
                     depth + 1,
                     entry.indirect || is_pointer,
                     entry.multiples,
+                    lookup,
                 ) {
                     next.push(child);
                 }
@@ -161,10 +205,13 @@ fn walk(store: &Store, outer: &Type) -> Vec<Entry> {
 
 /// Resolve `name` to its shallowest candidate; a lone non-`multiples` hit wins,
 /// anything else is ambiguous.
-fn resolve_in_entries(store: &Store, entries: &[Entry], outer: &Type, name: &str) -> Resolution {
+fn resolve_in_entries<'d, F>(entries: &[Entry], outer: &Type, name: &str, lookup: F) -> Resolution
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
     let mut by_depth: BTreeMap<usize, Vec<(&Entry, Candidate)>> = BTreeMap::new();
     for entry in entries {
-        if let Some(candidate) = entry_candidate(store, &entry.ty, name) {
+        if let Some(candidate) = entry_candidate(&entry.ty, name, lookup) {
             by_depth
                 .entry(entry.depth)
                 .or_default()
@@ -198,11 +245,14 @@ struct Candidate {
 
 /// The field or method a type declares under `name`. A method shadows a
 /// same-named field, as gc checks attached methods first.
-fn entry_candidate(store: &Store, ty: &Type, name: &str) -> Option<Candidate> {
+fn entry_candidate<'d, F>(ty: &Type, name: &str, lookup: F) -> Option<Candidate>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
     let id = ty.get_qualified_id()?;
 
-    if store.get_interface(id).is_some() {
-        let methods = store.get_all_methods(ty, &Default::default());
+    if lookup(id).is_some_and(Definition::is_interface) {
+        let methods = methods_for_type(ty, &Default::default(), lookup);
         let method = methods.get(name)?.clone();
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
@@ -210,23 +260,25 @@ fn entry_candidate(store: &Store, ty: &Type, name: &str) -> Option<Candidate> {
         });
     }
 
-    if !store.is_ufcs_method(id, name)
-        && let Some(method) = store.get_own_methods(id).and_then(|m| m.get(name))
+    if !lookup(id).is_some_and(|d| d.is_ufcs_method(name))
+        && let Some(method) = lookup(id)
+            .and_then(Definition::methods)
+            .and_then(|m| m.get(name))
     {
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
-            kind: MemberKind::Method(method.with_type(instantiate_method(store, ty, &method.ty))),
+            kind: MemberKind::Method(method.with_type(instantiate_method(ty, &method.ty, lookup))),
         });
     }
 
-    if let Some(field) = store
-        .fields_of(id)
+    if let Some(field) = lookup(id)
+        .and_then(Definition::fields)
         .and_then(|fields| fields.iter().find(|f| f.name == name))
     {
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
             kind: MemberKind::Field {
-                ty: instantiate_field(store, ty, &field.ty),
+                ty: instantiate_field(ty, &field.ty, lookup),
                 visibility: field.visibility,
             },
         });
@@ -270,22 +322,25 @@ fn build_member(outer: &Type, entry: &Entry, candidate: &Candidate) -> ResolvedM
 }
 
 /// Every field and method name a type exposes.
-fn collect_member_names(store: &Store, ty: &Type, names: &mut HashSet<EcoString>) {
+fn collect_member_names<'d, F>(ty: &Type, lookup: F, names: &mut HashSet<EcoString>)
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
     let Some(id) = ty.get_qualified_id() else {
         return;
     };
-    if store.get_interface(id).is_some() {
-        for key in store.get_all_methods(ty, &Default::default()).keys() {
+    if lookup(id).is_some_and(Definition::is_interface) {
+        for key in methods_for_type(ty, &Default::default(), lookup).keys() {
             names.insert(key.clone());
         }
         return;
     }
-    if let Some(methods) = store.get_own_methods(id) {
+    if let Some(methods) = lookup(id).and_then(Definition::methods) {
         for key in methods.keys() {
             names.insert(key.clone());
         }
     }
-    if let Some(fields) = store.fields_of(id) {
+    if let Some(fields) = lookup(id).and_then(Definition::fields) {
         for field in fields {
             names.insert(field.name.clone());
         }
@@ -293,14 +348,17 @@ fn collect_member_names(store: &Store, ty: &Type, names: &mut HashSet<EcoString>
 }
 
 /// Build an entry for `target` if it resolves (through aliases) to a nominal type.
-fn nominal_entry(
-    store: &Store,
+fn nominal_entry<'d, F>(
     target: Type,
     depth: usize,
     indirect: bool,
     multiples: bool,
-) -> Option<Entry> {
-    let resolved = store.deep_resolve_alias(&target);
+    lookup: F,
+) -> Option<Entry>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    let resolved = types::peel_alias(&target, lookup);
     if !matches!(resolved, Type::Nominal { .. }) {
         return None;
     }
@@ -369,8 +427,11 @@ fn ref_of(ty: &Type) -> Type {
     Type::compound(CompoundKind::Ref, vec![ty.clone()])
 }
 
-fn declaring_generics<'a>(store: &'a Store, id: &str) -> &'a [Generic] {
-    match store.get_definition(id).map(|d| &d.body) {
+fn declaring_generics<'d, F>(id: &str, lookup: F) -> &'d [Generic]
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
+    match lookup(id).map(|d| &d.body) {
         Some(
             DefinitionBody::Struct { generics, .. }
             | DefinitionBody::Enum { generics, .. }
@@ -381,7 +442,10 @@ fn declaring_generics<'a>(store: &'a Store, id: &str) -> &'a [Generic] {
     }
 }
 
-fn instantiate_field(store: &Store, container: &Type, member_ty: &Type) -> Type {
+fn instantiate_field<'d, F>(container: &Type, member_ty: &Type, lookup: F) -> Type
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
     let Some(id) = container.get_qualified_id() else {
         return member_ty.clone();
     };
@@ -391,15 +455,18 @@ fn instantiate_field(store: &Store, container: &Type, member_ty: &Type) -> Type 
     }
     substitute(
         member_ty,
-        &build_substitution_map(declaring_generics(store, id), args),
+        &build_substitution_map(declaring_generics(id, lookup), args),
     )
 }
 
-fn instantiate_method(store: &Store, container: &Type, method_ty: &Type) -> Type {
+fn instantiate_method<'d, F>(container: &Type, method_ty: &Type, lookup: F) -> Type
+where
+    F: Fn(&str) -> Option<&'d Definition>,
+{
     let Some(id) = container.get_qualified_id() else {
         return method_ty.clone();
     };
-    let arity = declaring_generics(store, id).len();
+    let arity = declaring_generics(id, lookup).len();
     let args = container.get_type_params().unwrap_or_default();
     if args.is_empty() || arity == 0 {
         return method_ty.clone();

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -284,10 +284,7 @@ impl Store {
     }
 
     pub(crate) fn fields_of(&self, qualified_name: &str) -> Option<&[StructFieldDefinition]> {
-        match &self.get_definition(qualified_name)?.body {
-            DefinitionBody::Struct { fields, .. } => Some(fields.as_slice()),
-            _ => None,
-        }
+        self.get_definition(qualified_name)?.fields()
     }
 
     pub fn struct_kind(&self, qualified_name: &str) -> Option<StructKind> {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -2,7 +2,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use ecow::EcoString;
 
-use crate::ast::{Annotation, EnumVariant, Generic, Literal, Span, StructFields};
+use crate::ast::{
+    Annotation, EnumVariant, Generic, Literal, Span, StructFieldDefinition, StructFields,
+};
 use crate::types;
 use crate::types::{
     FunctionParameter, Symbol, Type, build_substitution_map, substitute, type_args_match_params,
@@ -342,6 +344,17 @@ impl Definition {
             DefinitionBody::Interface { definition } => Some(&definition.methods),
             DefinitionBody::Value { .. } => None,
         }
+    }
+
+    pub fn fields(&self) -> Option<&[StructFieldDefinition]> {
+        match &self.body {
+            DefinitionBody::Struct { fields, .. } => Some(fields.as_slice()),
+            _ => None,
+        }
+    }
+
+    pub fn is_interface(&self) -> bool {
+        matches!(self.body, DefinitionBody::Interface { .. })
     }
 
     pub fn is_ufcs_method(&self, method: &str) -> bool {


### PR DESCRIPTION
This change adds lsp auto-complete support for embedded struct members. Previously the lsp only autocompleted the inner struct by name, but did not offer members directly.

Also, a few minor refactors:

- The embed walk used to ask for a whole `Store`, but the only thing it ever did with one was look up a definition by name, so it now asks for exactly that: a function from name to definition.
- The compiler hands it the `Store` as before and the language server hands it the definition map from its snapshot, so both run the same walk instead of the language server needing its own copy.
- `promoted_method_set` could only list promoted methods and completion needs the fields too, so both it and the new `promoted_members` now read from one shared `member_set` that resolves every name once.
- `get_instance_completions` takes the current package name instead of a "same package" boolean.
- Helpers inside the walk were copies of `Store` methods, so `Definition` grew `fields()` and `is_interface()` and both sides call those instead of matching on `DefinitionBody` themselves.