### PR TITLE
fix: exempt `#[iterate]` variants from unused variant lint

### DIFF
--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -267,10 +267,11 @@ fn collect_items(
                     graph.add_item(id, *name_span, ItemKind::Type, is_public);
 
                     let has_serialization_attr = has_serialization_attr(attributes);
+                    let has_iterate_attr = attributes.iter().any(|a| a.name == "iterate");
 
                     for enum_variant in variants {
                         let variant_id = EnumVariantId::new(name, &enum_variant.name);
-                        if !is_public && !has_serialization_attr {
+                        if !is_public && !has_serialization_attr && !has_iterate_attr {
                             graph.add_enum_variant(variant_id, enum_variant.name_span);
                         }
                     }

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -9752,6 +9752,49 @@ fn main() {
 }
 
 #[test]
+fn unused_enum_variant_iterate_attr_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+#[iterate]
+#[display]
+enum Direction {
+  North,
+  East,
+  West,
+  South,
+}
+
+fn main() {
+  for d in Direction.variants() {
+    fmt.Println(d)
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn unused_enum_variant_display_attr_still_warns() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+#[display]
+enum Color {
+  Red,
+  Unused,
+}
+
+fn main() {
+  fmt.Println(Color.Red)
+}
+"#
+    );
+}
+
+#[test]
 fn public_enum_variants_not_unused() {
     assert_no_lint_warnings!(
         r#"

--- a/tests/ui/lint/snapshots/unused_enum_variant_display_attr_still_warns.snap
+++ b/tests/ui/lint/snapshots/unused_enum_variant_display_attr_still_warns.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Unused variant
+   ╭─[test.lis:7:3]
+ 6 │   Red,
+ 7 │   Unused,
+   ·   ───┬──
+   ·      ╰── never constructed or matched
+ 8 │ }
+   ╰────
+  help: Use or remove this enum variant · code: [lint.unused_enum_variant]


### PR DESCRIPTION
The `unused_enum_variant` lint no longer fires on the variants of an enum marked `#[iterate]`. The `variants()` method constructs every variant, so none of them is dead, so the lint was asking to delete working code.

```rs
import "go:fmt"

#[iterate]
#[display]
enum Direction { North, East, West, South }

fn main() {
  for d in Direction.variants() {
    fmt.Println(d)
  }
}
```

`#[display]` alone still does not exempt a variant, because displaying a variant does not construct one.
