### PR TITLE
fix: emit a Go newtype autofill as its zero value

### DIFF
--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -110,6 +110,10 @@ impl<'a> EmitFacts<'a> {
         types::underlying_type(ty, |id| self.definition(id))
     }
 
+    pub(crate) fn peel_underlying(&self, ty: &Type) -> Type {
+        types::peel_underlying(ty, |id| self.definition(id))
+    }
+
     pub(crate) fn underlying_simple_kind(&self, ty: &Type) -> Option<SimpleKind> {
         types::underlying_simple_kind(ty, |id| self.definition(id))
     }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -143,13 +143,16 @@ impl Planner<'_> {
                     value
                 }
             }
-            StructSpread::Autofill { .. } => {
-                self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
-                GoExpression::composite_literal(
-                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
-                    fields_contain_deferred_evaluation,
-                )
-            }
+            StructSpread::Autofill { .. } => match self.go_imported_newtype_zero(ty) {
+                Some(zero) => GoExpression::opaque(zero),
+                None => {
+                    self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
+                    GoExpression::composite_literal(
+                        emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                        fields_contain_deferred_evaluation,
+                    )
+                }
+            },
             StructSpread::None => GoExpression::composite_literal(
                 emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
                 fields_contain_deferred_evaluation,
@@ -282,19 +285,47 @@ impl Planner<'_> {
             &map,
         ))
     }
+
+    /// Zero for `T{..}` on a Go-imported newtype, a named non-struct with
+    /// no fields for the autofill to name.
+    fn go_imported_newtype_zero(&mut self, ty: &Type) -> Option<String> {
+        let Type::Nominal { id, .. } = ty else {
+            return None;
+        };
+        if !go_name::is_go_import(id.as_str()) {
+            return None;
+        }
+        let underlying = self.get_newtype_underlying(ty)?;
+        let go_ty = self.use_go_type(ty);
+        self.go_newtype_zero(&go_ty, &underlying)
+    }
+
+    /// Zero for a Go named non-struct, in a form Go takes as an operand.
+    fn go_newtype_zero(&mut self, go_ty: &str, underlying: &Type) -> Option<String> {
+        let underlying = self.facts.peel_underlying(underlying);
+        if underlying.is_map() || matches!(underlying, Type::Array { .. }) {
+            return Some(format!("{}{{}}", go_ty));
+        }
+        if underlying.is_slice() {
+            return Some(format!("{}(nil)", go_ty));
+        }
+        matches!(underlying, Type::Simple(_)).then(|| {
+            let inner = self.lisette_zero(&underlying);
+            format!("{}({})", go_ty, inner)
+        })
+    }
+
     fn go_imported_zero(&mut self, ty: &Type, id: &str) -> String {
         if self.facts.is_interface(ty) || self.facts.resolve_to_function_type(ty).is_some() {
             return "nil".to_string();
         }
         let go_ty = self.use_go_type(ty);
-        // A newtype over a scalar takes no composite literal; over a map it does.
         let is_newtype = self.facts.definition(id).is_some_and(|d| d.is_newtype());
         if is_newtype {
-            if self
-                .get_newtype_underlying(ty)
-                .is_some_and(|underlying| underlying.is_map())
+            if let Some(underlying) = self.get_newtype_underlying(ty)
+                && let Some(zero) = self.go_newtype_zero(&go_ty, &underlying)
             {
-                return format!("{}{{}}", go_ty);
+                return zero;
             }
             return format!("*new({})", go_ty);
         }

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -310,6 +310,77 @@ fn test() -> string {
 }
 
 #[test]
+fn go_named_map_type_autofill_emits_empty_go_literal() {
+    let input = r#"
+import "go:net/url"
+
+fn test() -> string {
+  let mut v = url.Values{..}
+  v.Add("key", "value")
+  v.Get("key")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn go_named_scalar_type_autofill_emits_conversion() {
+    let input = r#"
+import "go:time"
+
+fn test() -> string {
+  time.Duration{..}.String()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn go_named_slice_type_autofill_emits_nil_conversion() {
+    let input = r#"
+import "go:sort"
+
+fn test() -> int {
+  sort.StringSlice{..}.Len()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn go_chained_named_type_autofill_peels_to_its_go_underlying() {
+    let input = r#"
+import "go:example.com/lib"
+
+fn index() -> lib.Index {
+  lib.Index{..}
+}
+
+fn tally() -> lib.Tally {
+  lib.Tally{..}
+}
+
+fn roster() -> lib.Roster {
+  lib.Roster{..}
+}
+"#;
+    let typedef = r#"
+pub struct Table(mut Map<string, int>)
+
+pub struct Index(mut Table)
+
+pub struct Count(int64)
+
+pub struct Tally(Count)
+
+pub struct Names(mut Slice<string>)
+
+pub struct Roster(mut Names)
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
+}
+
+#[test]
 fn go_opaque_type_autofill_spread() {
     let input = r#"
 import "go:sync"
@@ -343,6 +414,20 @@ fn lisette_struct_with_go_named_scalar_autofills() {
 import "go:time"
 
 struct Wrapper { d: time.Duration }
+
+fn test() -> Wrapper {
+  Wrapper { .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn lisette_struct_with_go_named_slice_autofills_to_nil() {
+    let input = r#"
+import "go:sort"
+
+struct Wrapper { s: mut sort.StringSlice }
 
 fn test() -> Wrapper {
   Wrapper { .. }

--- a/tests/spec/emit/snapshots/go_chained_named_type_autofill_peels_to_its_go_underlying.snap
+++ b/tests/spec/emit/snapshots/go_chained_named_type_autofill_peels_to_its_go_underlying.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:example.com/lib"
+  
+  fn index() -> lib.Index {
+    lib.Index{..}
+  }
+  
+  fn tally() -> lib.Tally {
+    lib.Tally{..}
+  }
+  
+  fn roster() -> lib.Roster {
+    lib.Roster{..}
+  }
+---
+package main
+
+import "example.com/lib"
+
+func index() lib.Index {
+	return lib.Index{}
+}
+
+func tally() lib.Tally {
+	return lib.Tally(0)
+}
+
+func roster() lib.Roster {
+	return lib.Roster(nil)
+}

--- a/tests/spec/emit/snapshots/go_named_map_type_autofill_emits_empty_go_literal.snap
+++ b/tests/spec/emit/snapshots/go_named_map_type_autofill_emits_empty_go_literal.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:net/url"
+  
+  fn test() -> string {
+    let mut v = url.Values{..}
+    v.Add("key", "value")
+    v.Get("key")
+  }
+---
+package main
+
+import "net/url"
+
+func test() string {
+	v := url.Values{}
+	v.Add("key", "value")
+	return v.Get("key")
+}

--- a/tests/spec/emit/snapshots/go_named_scalar_type_autofill_emits_conversion.snap
+++ b/tests/spec/emit/snapshots/go_named_scalar_type_autofill_emits_conversion.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:time"
+  
+  fn test() -> string {
+    time.Duration{..}.String()
+  }
+---
+package main
+
+import "time"
+
+func test() string {
+	return time.Duration(0).String()
+}

--- a/tests/spec/emit/snapshots/go_named_slice_type_autofill_emits_nil_conversion.snap
+++ b/tests/spec/emit/snapshots/go_named_slice_type_autofill_emits_nil_conversion.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:sort"
+  
+  fn test() -> int {
+    sort.StringSlice{..}.Len()
+  }
+---
+package main
+
+import "sort"
+
+func test() int {
+	return sort.StringSlice(nil).Len()
+}

--- a/tests/spec/emit/snapshots/lisette_struct_with_go_named_slice_autofills_to_nil.snap
+++ b/tests/spec/emit/snapshots/lisette_struct_with_go_named_slice_autofills_to_nil.snap
@@ -2,9 +2,9 @@
 source: tests/spec/emit/imports.rs
 description: |
   
-  import "go:time"
+  import "go:sort"
   
-  struct Wrapper { d: time.Duration }
+  struct Wrapper { s: mut sort.StringSlice }
   
   fn test() -> Wrapper {
     Wrapper { .. }
@@ -12,12 +12,12 @@ description: |
 ---
 package main
 
-import "time"
+import "sort"
 
 type Wrapper struct {
-	d time.Duration
+	s sort.StringSlice
 }
 
 func test() Wrapper {
-	return Wrapper{d: time.Duration(0)}
+	return Wrapper{s: sort.StringSlice(nil)}
 }


### PR DESCRIPTION
Fix #1314
