### PR TITLE
fix: emit Go-imported type and field names verbatim

### DIFF
--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -467,7 +467,7 @@ fn go_field_name(
     if is_prelude_type {
         go_name::snake_to_camel(member)
     } else {
-        go_name::make_exported(member)
+        go_name::exported_member(expression_ty, member)
     }
 }
 

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -321,7 +321,7 @@ impl Planner<'_> {
                     continue;
                 };
                 let go_field_name = if self.struct_field_is_exported(ty, &name) {
-                    go_name::make_exported(&name)
+                    go_name::exported_member(ty, &name)
                 } else if self.field_is_embedded(ty, &name) {
                     go_name::escape_keyword(&name).into_owned()
                 } else {
@@ -421,7 +421,7 @@ impl Planner<'_> {
                     let go_name = if is_tuple {
                         format!("F{}", index)
                     } else if self.struct_field_is_exported(ty, &name) {
-                        go_name::make_exported(&name)
+                        go_name::exported_member(ty, &name)
                     } else if self.field_is_embedded(ty, &name) {
                         go_name::escape_keyword(&name).into_owned()
                     } else {
@@ -544,13 +544,15 @@ impl Planner<'_> {
                 } else {
                     String::new()
                 };
-                let pkg = self.require_package_import(&self.canonical_package(package));
-                return format!(
-                    "{}.{}{}",
-                    pkg,
-                    go_name::snake_to_camel(type_name),
-                    type_args
-                );
+                let canonical = self.canonical_package(package);
+                // `snake_to_camel` would fold `Stat_t` to `StatT`.
+                let member = if go_name::is_go_import(&canonical) {
+                    type_name.to_string()
+                } else {
+                    go_name::snake_to_camel(type_name)
+                };
+                let pkg = self.require_package_import(&canonical);
+                return format!("{}.{}{}", pkg, member, type_args);
             }
         }
 
@@ -625,11 +627,11 @@ impl Planner<'_> {
     ) -> String {
         if let Some(ref enum_ctx) = ctx.enum_ctx {
             self.enum_struct_field_name(&enum_ctx.enum_id, &enum_ctx.variant_name, field_name)
-                .unwrap_or_else(|| go_name::make_exported(field_name))
+                .unwrap_or_else(|| go_name::exported_member(ctx.ty, field_name))
         } else if self.field_is_embedded(ctx.ty, field_name) {
             go_name::escape_keyword(field_name).into_owned()
         } else if self.struct_field_is_exported(ctx.ty, field_name) {
-            go_name::make_exported(field_name)
+            go_name::exported_member(ctx.ty, field_name)
         } else {
             go_name::unexported_method_go_name(field_name)
         }

--- a/crates/emit/src/names/go_name.rs
+++ b/crates/emit/src/names/go_name.rs
@@ -53,6 +53,15 @@ pub(crate) fn make_exported(name: &str) -> String {
     escape_keyword(&snake_to_camel(name)).into_owned()
 }
 
+pub(crate) fn exported_member(owner: &Type, member: &str) -> String {
+    let owner = owner.strip_refs();
+    if owner.get_qualified_id().is_some_and(is_go_import) && member.starts_with(char::is_uppercase)
+    {
+        return member.to_string();
+    }
+    make_exported(member)
+}
+
 pub fn go_test_function_name(fn_name: &str) -> String {
     format!("Test{}", snake_to_camel(fn_name))
 }

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -273,7 +273,7 @@ impl Planner<'_> {
         let field = if resolution_exports_field(resolution)
             || self.struct_field_is_exported(expression_ty, member)
         {
-            go_name::make_exported(member)
+            go_name::exported_member(expression_ty, member)
         } else if self.field_is_embedded(expression_ty, member) {
             go_name::escape_keyword(member).into_owned()
         } else {

--- a/tests/spec/emit/imports.rs
+++ b/tests/spec/emit/imports.rs
@@ -366,6 +366,27 @@ fn test() -> Wrapper {
 }
 
 #[test]
+fn go_underscored_type_and_field_names_stay_verbatim() {
+    let input = r#"
+import "go:example.com/lib"
+
+fn test() -> int {
+  let mut s = lib.Stat_t{..}
+  s.Pad_cgo_0 = 1
+  let t = lib.Stat_t{ Pad_cgo_0: s.Pad_cgo_0, .. }
+  t.Pad_cgo_0
+}
+"#;
+    let typedef = r#"
+pub struct Stat_t {
+  pub Pad_cgo_0: int,
+  pub Size: int,
+}
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/lib", typedef)]);
+}
+
+#[test]
 fn third_party_go_import_path_emitted_in_full() {
     let input = r#"
 import "go:github.com/bwmarrin/discordgo"

--- a/tests/spec/emit/snapshots/go_underscored_type_and_field_names_stay_verbatim.snap
+++ b/tests/spec/emit/snapshots/go_underscored_type_and_field_names_stay_verbatim.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/imports.rs
+description: |
+  
+  import "go:example.com/lib"
+  
+  fn test() -> int {
+    let mut s = lib.Stat_t{..}
+    s.Pad_cgo_0 = 1
+    let t = lib.Stat_t{ Pad_cgo_0: s.Pad_cgo_0, .. }
+    t.Pad_cgo_0
+  }
+---
+package main
+
+import "example.com/lib"
+
+func test() int {
+	s := lib.Stat_t{}
+	s.Pad_cgo_0 = 1
+	t := lib.Stat_t{Pad_cgo_0: s.Pad_cgo_0}
+	return t.Pad_cgo_0
+}


### PR DESCRIPTION
The emitter was rewriting a Go type named with an underscore: `syscall.Stat_t` → `syscall.StatT`, and `Pad_cgo_0` → `PadCgo0`. These names now reach the emitted Go unchanged.

```rs
import "go:fmt"
import "go:syscall"

fn main() {
  let s = syscall.Stat_t{..}
  fmt.Println(s.Pad_cgo_0)
}
```
