### PR TITLE
perf: cut redundant definition clones and method-set builds

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -302,7 +302,9 @@ impl InferCtx<'_> {
         self.check_native_mutating_call(&callee_expression, &span);
         self.check_native_equality_ufcs(&callee_expression, &new_args);
 
-        let return_check_recorded = self.is_generic_callee(&callee_expression)
+        // Nothing below unifies, so one resolution answers both checks on the callee.
+        let declared_callee_ty = self.declared_callee_type(&callee_expression);
+        let return_check_recorded = matches!(declared_callee_ty, Type::Forall { .. })
             && type_args.is_empty()
             && !self.is_enum_type(store, &resolved_return);
         if return_check_recorded {
@@ -332,7 +334,7 @@ impl InferCtx<'_> {
             }
         }
 
-        if type_args.is_empty() && self.callee_has_phantom_type_param(&callee_expression) {
+        if type_args.is_empty() && !phantom_type_params(&declared_callee_ty).is_empty() {
             self.sink
                 .push(diagnostics::infer::cannot_infer_type_argument(span));
         }
@@ -709,12 +711,9 @@ impl InferCtx<'_> {
             } => {
                 let receiver_ty = receiver.get_type().resolve_in(&self.env);
 
-                if let Some(method_ty) = self
-                    .get_all_methods(store, &receiver_ty.strip_refs())
-                    .get(member)
-                    .cloned()
+                if let Some(method) = self.method_of_type(store, &receiver_ty.strip_refs(), member)
                 {
-                    return method_ty.ty;
+                    return method.ty;
                 }
 
                 let stripped = receiver_ty.strip_refs();
@@ -740,10 +739,6 @@ impl InferCtx<'_> {
 
     fn is_generic_callee(&mut self, expression: &Expression) -> bool {
         matches!(self.declared_callee_type(expression), Type::Forall { .. })
-    }
-
-    fn callee_has_phantom_type_param(&mut self, expression: &Expression) -> bool {
-        !phantom_type_params(&self.declared_callee_type(expression)).is_empty()
     }
 
     fn instantiate_callee_type(

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -252,7 +252,7 @@ impl InferCtx<'_> {
             return true;
         }
 
-        self.get_all_methods(store, &deref_ty).contains_key(member)
+        self.method_of_type(store, &deref_ty, member).is_some()
     }
 
     fn as_struct_field(&mut self, args: &DotAccessResolutionArgs) -> Option<Expression> {

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -24,9 +24,8 @@ impl InferCtx<'_> {
             &args.deref_ty
         {
             (
-                self.get_all_methods(store, &args.deref_ty)
-                    .get(args.member_name)
-                    .map(|method| method.ty.clone())?,
+                self.method_of_type(store, &args.deref_ty, args.member_name)
+                    .map(|method| method.ty)?,
                 true,
                 self.resolve_instance_method_definition(&args.deref_ty, args.member_name),
             )
@@ -38,10 +37,7 @@ impl InferCtx<'_> {
                 return None;
             }
 
-            let method_ty = self
-                .get_all_methods(store, &args.deref_ty)
-                .get(args.member_name)
-                .cloned()?;
+            let method_ty = self.method_of_type(store, &args.deref_ty, args.member_name)?;
 
             if self.is_type_level_receiver(args.expression)
                 && self.method_is_promoted(&args.deref_ty, args.member_name)
@@ -460,8 +456,8 @@ impl InferCtx<'_> {
         };
 
         if self
-            .get_all_methods(store, &args.deref_ty)
-            .contains_key(args.member_name)
+            .method_of_type(store, &args.deref_ty, args.member_name)
+            .is_some()
         {
             return None;
         }

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -4,7 +4,10 @@ use crate::checker::sealing::is_unexported_key;
 use crate::store::Store;
 use diagnostics::infer::{InterfaceMethodViolation, InterfaceViolation, MissingMethod};
 use syntax::ast::Span;
-use syntax::program::{DefinitionBody, InterfaceRequirement, Methods, interface_requirements};
+use syntax::program::{
+    DefinitionBody, InterfaceRequirement, Methods, interface_declares_any_method,
+    interface_requirements,
+};
 use syntax::types::{GO_IMPORT_PREFIX, Symbol, Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
@@ -367,8 +370,7 @@ impl InferCtx<'_> {
         let id = resolved.get_qualified_id()?;
         if self.store.get_interface(id).is_some() {
             self.store
-                .get_all_methods(resolved, &Default::default())
-                .get(method)?;
+                .get_method_for_type(resolved, &Default::default(), method)?;
         } else {
             self.store.get_method(id, method)?;
         }
@@ -416,8 +418,7 @@ impl InferCtx<'_> {
             let interface_ty = self.store.deep_resolve_alias(bound);
             interface_ty.get_qualified_id()?;
             self.store
-                .get_all_methods(&interface_ty, &Default::default())
-                .get(method)?;
+                .get_method_for_type(&interface_ty, &Default::default(), method)?;
             Some(ConformanceCandidate::Resolved {
                 depth: 0,
                 owner: qualified.as_eco().clone(),
@@ -814,7 +815,7 @@ pub(crate) fn interface_requires_methods(store: &Store, id: &str) -> bool {
         params: vec![],
         writable: false,
     };
-    !interface_requirements(&interface_ty, |id| store.get_definition(id)).is_empty()
+    interface_declares_any_method(&interface_ty, |id| store.get_definition(id))
 }
 
 /// Lift impl return T to Option<T> when the interface is Go-imported, the

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -20,7 +20,7 @@ use registration::derived_attributes::EqualityAttributes;
 use scopes::Scopes;
 use syntax::ast::{Annotation, Expression, Generic, ImportAlias, Span};
 use syntax::program::{
-    Definition, DefinitionBody, FileImport, Methods, NativeTypeKind, Package,
+    Definition, DefinitionBody, FileImport, Method, Methods, NativeTypeKind, Package,
     go_import_default_name,
 };
 use syntax::types::{Bound, SubstitutionMap, Symbol, Type, substitute};

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeMap;
 
 use syntax::ast::{Generic, Visibility};
 use syntax::go_names;
-use syntax::program::{Definition, DefinitionBody, Method, Methods, methods_for_type};
+use syntax::program::{
+    Definition, DefinitionBody, Method, Methods, method_for_type, methods_for_type,
+};
 use syntax::types::{
     self, CompoundKind, Symbol, Type, build_named_substitution_map, build_substitution_map,
     substitute,
@@ -58,6 +60,17 @@ pub fn resolve_selector(store: &Store, outer: &Type, name: &str) -> Resolution {
     let lookup = |id: &str| store.get_definition(id);
     let entries = walk(outer, lookup);
     resolve_in_entries(&entries, outer, name, lookup)
+}
+
+/// One promoted or own method, without building the whole promoted set.
+pub(crate) fn promoted_method(store: &Store, outer: &Type, name: &str) -> Option<Method> {
+    match resolve_selector(store, outer, name) {
+        Resolution::Found(ResolvedMember {
+            kind: MemberKind::Method(method),
+            ..
+        }) => Some(method),
+        Resolution::Found(_) | Resolution::Ambiguous { .. } | Resolution::NotFound => None,
+    }
 }
 
 pub(crate) fn promoted_method_set(store: &Store, outer: &Type) -> Methods {
@@ -252,8 +265,7 @@ where
     let id = ty.get_qualified_id()?;
 
     if lookup(id).is_some_and(Definition::is_interface) {
-        let methods = methods_for_type(ty, &Default::default(), lookup);
-        let method = methods.get(name)?.clone();
+        let method = method_for_type(ty, &Default::default(), lookup, name)?;
         return Some(Candidate {
             declaring_type: Symbol::from_raw(id),
             kind: MemberKind::Method(method),

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -650,6 +650,10 @@ impl TaskState {
             }
         }
 
+        if interface.parents.is_empty() {
+            return;
+        }
+
         let mut seen: rustc_hash::FxHashMap<String, (Type, String)> =
             rustc_hash::FxHashMap::default();
         let interface_ty = store

--- a/crates/semantics/src/checker/registration/mod.rs
+++ b/crates/semantics/src/checker/registration/mod.rs
@@ -205,14 +205,14 @@ pub(crate) fn normalize_registered_component_types(store: &mut Store, package_id
     };
     let mut changed: Vec<(Symbol, Definition)> = Vec::new();
     for (name, definition) in &package.definitions {
+        if !any_component_type(&definition.body, |ty| {
+            store.normalized_annotation_type(ty) != *ty
+        }) {
+            continue;
+        }
         let mut updated = definition.clone();
-        let mut any = false;
-        let mut normalize = |ty: &mut Type| {
-            let normalized = store.normalized_annotation_type(ty);
-            if normalized != *ty {
-                *ty = normalized;
-                any = true;
-            }
+        let normalize = |ty: &mut Type| {
+            *ty = store.normalized_annotation_type(ty);
         };
         match &mut updated.body {
             DefinitionBody::Struct { fields, .. } => {
@@ -241,9 +241,7 @@ pub(crate) fn normalize_registered_component_types(store: &mut Store, package_id
             }
             _ => {}
         }
-        if any {
-            changed.push((name.clone(), updated));
-        }
+        changed.push((name.clone(), updated));
     }
     if changed.is_empty() {
         return;
@@ -253,5 +251,27 @@ pub(crate) fn normalize_registered_component_types(store: &mut Store, package_id
     };
     for (name, definition) in changed {
         package.definitions.insert(name, definition);
+    }
+}
+
+/// Whether any type written in a definition's components satisfies `predicate`.
+fn any_component_type(body: &DefinitionBody, mut predicate: impl FnMut(&Type) -> bool) -> bool {
+    match body {
+        DefinitionBody::Struct { fields, .. } => {
+            let (StructFields::Record(fields) | StructFields::Tuple(fields)) = fields;
+            fields.iter().any(|field| predicate(&field.ty))
+        }
+        DefinitionBody::Enum { variants, .. } => variants
+            .iter()
+            .flat_map(|variant| match &variant.fields {
+                VariantFields::Unit => [].as_slice(),
+                VariantFields::Tuple(fields) | VariantFields::Struct(fields) => fields,
+            })
+            .any(|field| predicate(&field.ty)),
+        DefinitionBody::TypeAlias {
+            alias: AliasKind::Transparent { target, .. },
+            ..
+        } => predicate(target),
+        _ => false,
     }
 }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -827,7 +827,7 @@ fn is_deferred_local_target(store: &Store, ty: &Type) -> bool {
 }
 
 fn has_selector_surface(store: &Store, ty: &Type) -> bool {
-    if !store.get_all_methods(ty, &FxHashMap::default()).is_empty() {
+    if store.type_has_any_method(ty) {
         return true;
     }
     let Type::Nominal { id, .. } = ty else {

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -388,6 +388,39 @@ impl TaskState {
         }
     }
 
+    pub(super) fn method_of_type(
+        &mut self,
+        store: &Store,
+        ty: &Type,
+        name: &str,
+    ) -> Option<Method> {
+        if let Type::Parameter(parameter) = ty {
+            let trait_bounds = self.scopes.collect_all_trait_bounds();
+            let qualified_name = self.qualify_name(parameter);
+            return store.get_method_from_bounds(&qualified_name, &trait_bounds, name);
+        }
+
+        let resolved = ty.strip_refs().resolve_in(&self.env);
+        match &resolved {
+            Type::Nominal { .. } | Type::Compound { .. } | Type::Simple(_) | Type::Array { .. } => {
+            }
+            _ => return None,
+        }
+
+        let peeled = store.peel_alias(&resolved);
+        if let Type::Nominal { id, .. } = &peeled
+            && store.get_interface(id).is_some()
+        {
+            let empty = HashMap::default();
+            store.get_method_for_type(&peeled, &empty, name)
+        } else if promotion::has_direct_embed(store, &resolved) {
+            promotion::promoted_method(store, &resolved, name)
+        } else {
+            let empty = HashMap::default();
+            store.get_method_for_type(&resolved, &empty, name)
+        }
+    }
+
     pub fn failed(&self) -> bool {
         self.sink.has_errors()
     }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -6,7 +6,7 @@ use syntax::ast::StructKind;
 use syntax::ast::{EnumVariant, StructFieldDefinition, VariantFields};
 use syntax::program::{
     Definition, DefinitionBody, EqualityIndex, File, Interface, Method, Methods, Package,
-    TestIndex, UninferredExports, methods_for_type,
+    TestIndex, UninferredExports, method_for_type, methods_for_type, type_has_any_method,
 };
 use syntax::types;
 use syntax::types::{CompoundKind, SimpleKind, Symbol, Type};
@@ -676,6 +676,32 @@ impl Store {
         trait_bounds: &HashMap<Symbol, Vec<Type>>,
     ) -> Methods {
         methods_for_type(ty, trait_bounds, |id| self.get_definition(id))
+    }
+
+    pub(crate) fn get_method_for_type(
+        &self,
+        ty: &Type,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
+        name: &str,
+    ) -> Option<Method> {
+        method_for_type(ty, trait_bounds, |id| self.get_definition(id), name)
+    }
+
+    pub(crate) fn type_has_any_method(&self, ty: &Type) -> bool {
+        type_has_any_method(ty, |id| self.get_definition(id))
+    }
+
+    pub(crate) fn get_method_from_bounds(
+        &self,
+        qualified_name: &str,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
+        name: &str,
+    ) -> Option<Method> {
+        trait_bounds
+            .get(qualified_name)?
+            .iter()
+            .filter_map(|interface_ty| self.get_method_for_type(interface_ty, trait_bounds, name))
+            .next_back()
     }
 
     pub(crate) fn get_methods_from_bounds(

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -707,6 +707,140 @@ where
     collect(ty, trait_bounds, lookup, &mut HashSet::default())
 }
 
+/// Whether an interface or any of its parents declares a method.
+pub fn interface_declares_any_method<'d, F>(interface_ty: &Type, lookup: F) -> bool
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    interface_instances(interface_ty, lookup)
+        .into_iter()
+        .any(|instance| {
+            let Type::Nominal { id, .. } = instance.ty else {
+                return false;
+            };
+            matches!(
+                lookup(&id),
+                Some(Definition {
+                    body: DefinitionBody::Interface { definition },
+                    ..
+                }) if !definition.methods.is_empty()
+            )
+        })
+}
+
+pub fn method_for_type<'d, F>(
+    ty: &Type,
+    trait_bounds: &HashMap<Symbol, Vec<Type>>,
+    lookup: F,
+    wanted: &str,
+) -> Option<Method>
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    fn collect<'d, F>(
+        ty: &Type,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
+        lookup: F,
+        visited: &mut HashSet<Symbol>,
+        wanted: &str,
+    ) -> Option<Method>
+    where
+        F: Copy + Fn(&str) -> Option<&'d Definition>,
+    {
+        let stripped = ty.strip_refs();
+        let qualified_name = method_lookup_key(&stripped)?;
+
+        if !visited.insert(qualified_name.clone()) {
+            return None;
+        }
+
+        if lookup(&qualified_name)
+            .is_some_and(|definition| matches!(definition.body, DefinitionBody::Interface { .. }))
+        {
+            return interface_requirements(&stripped, lookup)
+                .into_iter()
+                .rfind(|requirement| requirement.name == wanted)
+                .map(|requirement| {
+                    requirement
+                        .method
+                        .with_type(requirement.ty)
+                        .with_receiver_placeholder()
+                });
+        }
+
+        // The shared visited set makes bound order matter.
+        if let Some(bounds) = trait_bounds.get(&qualified_name) {
+            let mut found = None;
+            for bound in bounds {
+                if let Some(method) = collect(bound, trait_bounds, lookup, visited, wanted) {
+                    found = Some(method);
+                }
+            }
+            return found;
+        }
+
+        let own = lookup(&qualified_name)
+            .and_then(Definition::methods)
+            .and_then(|methods| methods.get(wanted))
+            .cloned();
+
+        if lookup(&qualified_name).is_some_and(Definition::is_transparent_type_alias) {
+            let underlying = types::peel_alias(&stripped, lookup);
+            if underlying != stripped {
+                let inherited = collect(&underlying, trait_bounds, lookup, visited, wanted);
+                return own.or(inherited);
+            }
+        }
+
+        own
+    }
+
+    collect(ty, trait_bounds, lookup, &mut HashSet::default(), wanted)
+}
+
+pub fn type_has_any_method<'d, F>(ty: &Type, lookup: F) -> bool
+where
+    F: Copy + Fn(&str) -> Option<&'d Definition>,
+{
+    fn collect<'d, F>(ty: &Type, lookup: F, visited: &mut HashSet<Symbol>) -> bool
+    where
+        F: Copy + Fn(&str) -> Option<&'d Definition>,
+    {
+        let stripped = ty.strip_refs();
+        let Some(qualified_name) = method_lookup_key(&stripped) else {
+            return false;
+        };
+
+        if !visited.insert(qualified_name.clone()) {
+            return false;
+        }
+
+        if lookup(&qualified_name)
+            .is_some_and(|definition| matches!(definition.body, DefinitionBody::Interface { .. }))
+        {
+            return interface_declares_any_method(&stripped, lookup);
+        }
+
+        if lookup(&qualified_name)
+            .and_then(Definition::methods)
+            .is_some_and(|methods| !methods.is_empty())
+        {
+            return true;
+        }
+
+        if lookup(&qualified_name).is_some_and(Definition::is_transparent_type_alias) {
+            let underlying = types::peel_alias(&stripped, lookup);
+            if underlying != stripped {
+                return collect(&underlying, lookup, visited);
+            }
+        }
+
+        false
+    }
+
+    collect(ty, lookup, &mut HashSet::default())
+}
+
 fn method_lookup_key(ty: &Type) -> Option<Symbol> {
     match ty {
         Type::Nominal { id, .. } => Some(id.clone()),
@@ -817,5 +951,309 @@ mod tests {
         let definition = definition(method(&["T"], receiver(vec![Type::int()])));
 
         assert!(definition.is_ufcs_method("map"));
+    }
+
+    fn nominal(id: &str) -> Type {
+        Type::Nominal {
+            id: Symbol::from_raw(id),
+            params: vec![],
+            writable: false,
+        }
+    }
+
+    fn named_method(name: &str, return_type: Type) -> (EcoString, Method) {
+        let ty = Type::function(
+            vec![FunctionParameter::new(nominal("m.Receiver"))],
+            Default::default(),
+            Box::new(return_type),
+        );
+        (
+            name.into(),
+            Method {
+                source_name: name.into(),
+                ty,
+                visibility: Visibility::Public,
+                origin: MethodOrigin::Declared,
+                name_span: None,
+                doc: None,
+                allowed_lints: vec![],
+                go_hints: vec![],
+            },
+        )
+    }
+
+    fn struct_definition(id: &str, methods: Methods) -> Definition {
+        Definition {
+            visibility: Visibility::Public,
+            ty: nominal(id),
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::Struct {
+                generics: vec![],
+                fields: StructFields::Record(vec![]),
+                methods,
+                attributes: Attributes::default(),
+            },
+        }
+    }
+
+    fn interface_definition(id: &str, parents: Vec<Type>, methods: Methods) -> Definition {
+        Definition {
+            visibility: Visibility::Public,
+            ty: nominal(id),
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::Interface {
+                definition: Interface {
+                    generics: vec![],
+                    parents,
+                    methods,
+                },
+            },
+        }
+    }
+
+    fn alias_definition(id: &str, target: Type, methods: Methods) -> Definition {
+        Definition {
+            visibility: Visibility::Public,
+            ty: nominal(id),
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::TypeAlias {
+                generics: vec![],
+                alias: AliasKind::Transparent {
+                    annotation: Annotation::Unknown,
+                    target,
+                },
+                methods,
+                attributes: Attributes::default(),
+            },
+        }
+    }
+
+    fn table(entries: Vec<(&str, Definition)>) -> HashMap<String, Definition> {
+        entries
+            .into_iter()
+            .map(|(id, definition)| (id.to_string(), definition))
+            .collect()
+    }
+
+    /// The narrow lookup must answer exactly what the whole method set holds.
+    fn assert_narrow_matches_broad(
+        table: &HashMap<String, Definition>,
+        trait_bounds: &HashMap<Symbol, Vec<Type>>,
+        ty: &Type,
+        name: &str,
+    ) {
+        let lookup = |id: &str| table.get(id);
+        let broad = methods_for_type(ty, trait_bounds, lookup)
+            .get(name)
+            .cloned();
+        let narrow = method_for_type(ty, trait_bounds, lookup, name);
+
+        assert_eq!(narrow, broad);
+    }
+
+    #[test]
+    fn a_parent_interface_method_shadows_the_child_declaration() {
+        let table = table(vec![
+            (
+                "m.Child",
+                interface_definition(
+                    "m.Child",
+                    vec![nominal("m.Parent")],
+                    HashMap::from_iter([named_method("run", Type::int())]),
+                ),
+            ),
+            (
+                "m.Parent",
+                interface_definition(
+                    "m.Parent",
+                    vec![],
+                    HashMap::from_iter([named_method("run", Type::string())]),
+                ),
+            ),
+        ]);
+
+        assert_narrow_matches_broad(&table, &HashMap::default(), &nominal("m.Child"), "run");
+    }
+
+    #[test]
+    fn the_last_bound_that_declares_a_method_wins() {
+        let table = table(vec![
+            (
+                "m.First",
+                interface_definition(
+                    "m.First",
+                    vec![],
+                    HashMap::from_iter([named_method("run", Type::int())]),
+                ),
+            ),
+            (
+                "m.Second",
+                interface_definition(
+                    "m.Second",
+                    vec![],
+                    HashMap::from_iter([named_method("run", Type::string())]),
+                ),
+            ),
+        ]);
+        let trait_bounds = HashMap::from_iter([(
+            Symbol::from_raw("m.T"),
+            vec![nominal("m.First"), nominal("m.Second")],
+        )]);
+
+        assert_narrow_matches_broad(&table, &trait_bounds, &nominal("m.T"), "run");
+    }
+
+    fn generic_interface_definition(id: &str, methods: Methods) -> Definition {
+        Definition {
+            visibility: Visibility::Public,
+            ty: nominal(id),
+            name_span: None,
+            doc: None,
+            body: DefinitionBody::Interface {
+                definition: Interface {
+                    generics: vec![generic("T")],
+                    parents: vec![],
+                    methods,
+                },
+            },
+        }
+    }
+
+    fn instantiated(id: &str, argument: Type) -> Type {
+        Type::Nominal {
+            id: Symbol::from_raw(id),
+            params: vec![argument],
+            writable: false,
+        }
+    }
+
+    #[test]
+    fn bounds_that_share_a_nominal_key_agree_with_the_whole_method_set() {
+        let table = table(vec![(
+            "m.Boxed",
+            generic_interface_definition(
+                "m.Boxed",
+                HashMap::from_iter([named_method("run", Type::Parameter("T".into()))]),
+            ),
+        )]);
+        let trait_bounds = HashMap::from_iter([(
+            Symbol::from_raw("m.T"),
+            vec![
+                instantiated("m.Boxed", Type::int()),
+                instantiated("m.Boxed", Type::string()),
+            ],
+        )]);
+
+        assert_narrow_matches_broad(&table, &trait_bounds, &nominal("m.T"), "run");
+    }
+
+    #[test]
+    fn a_self_referential_bound_terminates() {
+        let table = table(vec![]);
+        let trait_bounds = HashMap::from_iter([(Symbol::from_raw("m.T"), vec![nominal("m.T")])]);
+
+        assert_narrow_matches_broad(&table, &trait_bounds, &nominal("m.T"), "run");
+    }
+
+    #[test]
+    fn an_alias_method_shadows_the_underlying_type_method() {
+        let table = table(vec![
+            (
+                "m.Alias",
+                alias_definition(
+                    "m.Alias",
+                    nominal("m.Target"),
+                    HashMap::from_iter([named_method("run", Type::int())]),
+                ),
+            ),
+            (
+                "m.Target",
+                struct_definition(
+                    "m.Target",
+                    HashMap::from_iter([named_method("run", Type::string())]),
+                ),
+            ),
+        ]);
+
+        assert_narrow_matches_broad(&table, &HashMap::default(), &nominal("m.Alias"), "run");
+    }
+
+    #[test]
+    fn an_alias_inherits_the_underlying_type_methods() {
+        let table = table(vec![
+            (
+                "m.Alias",
+                alias_definition("m.Alias", nominal("m.Target"), Methods::default()),
+            ),
+            (
+                "m.Target",
+                struct_definition(
+                    "m.Target",
+                    HashMap::from_iter([named_method("run", Type::string())]),
+                ),
+            ),
+        ]);
+
+        assert_narrow_matches_broad(&table, &HashMap::default(), &nominal("m.Alias"), "run");
+        assert!(type_has_any_method(&nominal("m.Alias"), |id| table.get(id)));
+    }
+
+    #[test]
+    fn an_alias_to_a_type_without_methods_has_no_method() {
+        let table = table(vec![
+            (
+                "m.Alias",
+                alias_definition("m.Alias", nominal("m.Target"), Methods::default()),
+            ),
+            (
+                "m.Target",
+                struct_definition("m.Target", Methods::default()),
+            ),
+        ]);
+
+        assert!(!type_has_any_method(&nominal("m.Alias"), |id| table.get(id)));
+    }
+
+    #[test]
+    fn an_interface_declares_a_method_through_its_parent() {
+        let table = table(vec![
+            (
+                "m.Child",
+                interface_definition("m.Child", vec![nominal("m.Parent")], Methods::default()),
+            ),
+            (
+                "m.Parent",
+                interface_definition(
+                    "m.Parent",
+                    vec![],
+                    HashMap::from_iter([named_method("run", Type::int())]),
+                ),
+            ),
+        ]);
+        let lookup = |id: &str| table.get(id);
+
+        assert!(interface_declares_any_method(&nominal("m.Child"), lookup));
+        assert!(type_has_any_method(&nominal("m.Child"), lookup));
+    }
+
+    #[test]
+    fn an_interface_without_any_declared_method_is_reported_empty() {
+        let table = table(vec![
+            (
+                "m.Child",
+                interface_definition("m.Child", vec![nominal("m.Parent")], Methods::default()),
+            ),
+            (
+                "m.Parent",
+                interface_definition("m.Parent", vec![], Methods::default()),
+            ),
+        ]);
+        let lookup = |id: &str| table.get(id);
+
+        assert!(!interface_declares_any_method(&nominal("m.Child"), lookup));
+        assert!(!type_has_any_method(&nominal("m.Child"), lookup));
     }
 }

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -7,7 +7,8 @@ mod resolution;
 pub use definition::{
     AliasKind, Attributes, ConstantValue, Definition, DefinitionBody, Interface, InterfaceInstance,
     InterfaceRequirement, Method, MethodOrigin, Methods, TypeAttribute, ValueKind, Visibility,
-    interface_instances, interface_requirements, methods_for_type,
+    interface_declares_any_method, interface_instances, interface_requirements, method_for_type,
+    methods_for_type, type_has_any_method,
 };
 pub use emit_input::{
     BindingMutation, EmitInput, EqualityIndex, MutationInfo, TestFunction, TestIndex, UnusedInfo,

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -1804,6 +1804,22 @@ fn main() {
 }
 
 #[test]
+fn forward_referenced_alias_target_stays_writable() {
+    infer(
+        r#"type Handle = mut Ref<Node>
+struct Node { v: mut Slice<int> }
+fn poke(h: Handle) {
+  h.v[0] = 9
+}
+fn main() {
+  let mut node = Node { v: [1] }
+  poke(&node)
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn generic_method_initializer_construction_accepted() {
     infer(
         r#"struct Holder { items: mut Slice<int> }


### PR DESCRIPTION
Removes unnecessary analysis work:

- Registration copied every type definition in a package to find the few that needed rewriting. It now tests first and copies only those.
- Registration expanded the full inherited method list of every interface, to look for a conflict with an ancestor. An interface without parents has no ancestor, so the check now stops early.
- Found lookups asking for a type's whole method set and using one method. Narrower methods beside the broad ones now answer them directly.
- Inference resolved the type of a called function twice, with nothing between the two points that could change the answer.

These are mostly wins on call and allocation counts.
