### PR TITLE
perf: plan each emitted call once

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -12,7 +12,7 @@ use crate::calls::native::native_method_lowers_to_plain_call;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::calls::CallableOrigin;
+use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
@@ -97,7 +97,7 @@ fn extract_return_type_param(function: &Expression) -> Option<Type> {
     params.first().cloned()
 }
 
-impl Planner<'_> {
+impl<'a> Planner<'a> {
     fn resolve_element_type(
         &mut self,
         function: &Expression,
@@ -436,6 +436,20 @@ impl Planner<'_> {
         call_ty: Option<&Type>,
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
+        let plan = self
+            .plan_call(call_expression)
+            .expect("plan_call yields Some for a Call expression");
+        self.lower_call_with_plan(call_expression, call_ty, ctx, plan)
+    }
+
+    /// Lower a call whose plan the caller already built.
+    pub(crate) fn lower_call_with_plan(
+        &mut self,
+        call_expression: &Expression,
+        call_ty: Option<&Type>,
+        ctx: ExpressionContext<'_>,
+        plan: CallPlan<'a>,
+    ) -> ValuePlan {
         let Expression::Call {
             expression: callee,
             args,
@@ -451,10 +465,6 @@ impl Planner<'_> {
         let resolved_type_args = type_arguments
             .resolved_types()
             .expect("emission requires checked call type arguments");
-
-        let plan = self
-            .plan_call(call_expression)
-            .expect("plan_call yields Some for a Call expression");
 
         match &plan.resolved.origin {
             CallableOrigin::TupleStructConstructor => {

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -944,11 +944,14 @@ impl<'a> Planner<'a> {
     }
 
     fn go_physical_expression_layout(&self, expression: &Expression) -> Option<ValueLayout> {
-        if let Some(plan) = self.plan_call(expression)
-            && matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+        if self.call_target_is_go(expression)
+            && let Some(plan) = self.plan_call(expression)
             && matches!(plan.resolved.abi.result, CallableReturnAbi::Direct)
         {
             return Some(plan.resolved.abi.return_layout.clone());
+        }
+        if !self.is_go_callable(expression) {
+            return None;
         }
         let callable = self.resolve_callable_value(expression)?;
         matches!(callable.origin, CallableOrigin::GoInterop).then(|| ValueLayout::Function {

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -25,7 +25,8 @@ impl Planner<'_> {
         expression: &Expression,
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
-        if let Some(callee) = self.resolve_callable_value(expression)
+        if self.is_go_callable(expression)
+            && let Some(callee) = self.resolve_callable_value(expression)
             && matches!(callee.origin, CallableOrigin::GoInterop)
         {
             let abi = &callee.abi.result;
@@ -109,11 +110,12 @@ impl Planner<'_> {
             .plan_call(expression)
             .expect("plan_call yields Some for a Call expression");
         let layout_bridge = self.call_result_layout_bridge(&plan, result_type);
+        let result_transition = plan.result_transition;
 
         if let Some(bridge) = layout_bridge {
             let call_type =
-                matches!(plan.result_transition, AbiTransition::Identity).then_some(result_type);
-            let call = self.lower_call(expression, call_type, context);
+                matches!(result_transition, AbiTransition::Identity).then_some(result_type);
+            let call = self.lower_call_with_plan(expression, call_type, context, plan);
             return call.map_rendered_as_observable_computed(
                 |setup, call_string, _contains_deferred_evaluation| {
                     let (bridge_setup, value) = bridge.lower(self, call_string);
@@ -123,8 +125,10 @@ impl Planner<'_> {
             );
         }
 
-        match plan.result_transition {
-            AbiTransition::Identity => self.lower_call(expression, Some(result_type), context),
+        match result_transition {
+            AbiTransition::Identity => {
+                self.lower_call_with_plan(expression, Some(result_type), context, plan)
+            }
             AbiTransition::WrapToTagged => {
                 self.lower_go_abi_wrapped_call(expression, &plan.resolved.abi, result_type)
             }

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -474,8 +474,16 @@ impl<'a> Planner<'a> {
         self.facts.classify_go_return_type(return_ty, go_hints)
     }
 
-    fn is_go_callable(&self, expression: &Expression) -> bool {
+    pub(crate) fn is_go_callable(&self, expression: &Expression) -> bool {
         resolved_definition(expression).is_some_and(|definition| definition.starts_with("go:"))
+    }
+
+    pub(crate) fn call_target_is_go(&self, expression: &Expression) -> bool {
+        matches!(
+            expression,
+            Expression::Call { expression: callee, .. }
+                if self.is_go_callable(callee.unwrap_parens())
+        )
     }
 }
 


### PR DESCRIPTION
Removes unnecessary emit work:

- Emit in some spots planned a call, then planned it again to lower it.
- Two Go-interop checks built a call plan or callee resolution to read a single flag.

Again, mostly wins on call and allocation counts.

Follow-up to #1322