### PR TITLE
fix: reject non-identifier package dir

### DIFF
--- a/crates/cli/src/handlers/build.rs
+++ b/crates/cli/src/handlers/build.rs
@@ -725,6 +725,14 @@ pub(super) struct ProjectLayout {
     pub test_sources: Vec<PathBuf>,
 }
 
+fn is_package_identifier(element: &str) -> bool {
+    let mut characters = element.chars();
+    characters
+        .next()
+        .is_some_and(|first| first.is_alphabetic() || first == '_')
+        && characters.all(|character| character.is_alphanumeric() || character == '_')
+}
+
 pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayout> {
     if project_path.join("main.lis").exists() {
         cli_error!(
@@ -787,6 +795,26 @@ pub(super) fn resolve_project_layout(project_path: &Path) -> Option<ProjectLayou
                 rel.display()
             ),
             "Rename the package"
+        );
+        return None;
+    }
+
+    if let Some((rel, element)) = sources.iter().find_map(|path| {
+        let rel = path.strip_prefix(&src).ok()?;
+        let bad = rel
+            .parent()?
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .find(|element| !is_package_identifier(element))?;
+        Some((rel.to_path_buf(), bad.to_string()))
+    }) {
+        cli_error!(
+            "Invalid package directory",
+            format!(
+                "`src/{}` sits under `{element}/`, and a package directory names the package, so it must read as an identifier",
+                rel.display()
+            ),
+            "Rename the directory using letters, digits and `_`, starting with a letter or `_`"
         );
         return None;
     }

--- a/tests/e2e_external_tests.rs
+++ b/tests/e2e_external_tests.rs
@@ -503,6 +503,27 @@ fn src_root_directory_is_reserved() {
 }
 
 #[test]
+fn hyphenated_package_directory_is_rejected() {
+    let (_dir, project) = scaffold("example.com/acme/geo");
+    fs::write(project.join("src/geo.lis"), "pub fn x() -> int { 1 }\n").unwrap();
+    fs::create_dir_all(project.join("src/my-pkg")).unwrap();
+    fs::write(
+        project.join("src/my-pkg/p.lis"),
+        "pub fn y() -> int { 2 }\n",
+    )
+    .unwrap();
+
+    let check = lis(&project, &["check"]);
+    let out = combined(&check);
+    assert!(!check.status.success(), "expected failure: {out}");
+    assert!(out.contains("Invalid package directory"), "got: {out}");
+    assert!(
+        out.contains("my-pkg"),
+        "the offending directory must be named: {out}"
+    );
+}
+
+#[test]
 fn src_entry_directory_is_reserved() {
     let (_dir, project) = scaffold("example.com/acme/geo");
     fs::write(project.join("src/geo.lis"), "pub fn x() -> int { 1 }\n").unwrap();


### PR DESCRIPTION
A dir under `src/` names the package it holds, and that name reaches the emitted Go, so it must read as an identifier. `lis check` and `lis build` now say so instead of letting the emitted package fail later.