### PR TITLE
fix: parenthesize newtype conversions

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -7,6 +7,7 @@ use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::names::go_name;
 use crate::plan::bodies::{LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::types::go_type::render_conversion;
 
 use super::callable::AbiTransition;
 use super::layout::{FunctionLayout, ValueLayout};
@@ -139,7 +140,7 @@ impl CoercionPlan {
             }
             Self::WrapNewtype { ty } => {
                 let type_name = planner.use_go_type(&ty);
-                format!("{}({})", type_name, value)
+                render_conversion(&type_name, &value)
             }
             Self::Layout(bridge) => planner.plan_layout_bridge(&mut statements, &value, &bridge),
             Self::RebuildArray {

--- a/crates/emit/src/definitions/structs.rs
+++ b/crates/emit/src/definitions/structs.rs
@@ -3,6 +3,7 @@ use crate::definitions::enum_layout::{ENUM_GO_STRINGER_METHOD, ENUM_STRINGER_MET
 use crate::definitions::tags::{format_tag_string, interpret_field_attributes};
 use crate::expressions::top_items::emit_doc;
 use crate::names::go_name::{self, prelude_qualifier};
+use crate::types::go_type::render_conversion;
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use rustc_hash::FxHashSet;
 use syntax::ast::{Attribute, Generic, StructFieldDefinition, StructFields};
@@ -376,13 +377,7 @@ impl Planner<'_> {
         if !self.synthesizes_debug_string(name) {
             return;
         }
-        let uses_prelude = if field_is_function.is_empty() {
-            false
-        } else if underlying.is_some() {
-            true
-        } else {
-            field_is_function.iter().any(|is_function| !is_function)
-        };
+        let uses_prelude = field_is_function.iter().any(|is_function| !is_function);
         if !field_is_function.is_empty() {
             self.require_fmt();
         }
@@ -576,13 +571,6 @@ impl<'a> StringFormat<'a> {
         }
     }
 
-    fn tuple_verb(self, is_function: bool) -> &'static str {
-        match self {
-            StringFormat::Display { .. } => "%v",
-            StringFormat::Debug { .. } => self.verb(is_function),
-        }
-    }
-
     pub(crate) fn argument(self, value: String, is_function: bool) -> String {
         match (self, is_function) {
             (StringFormat::Display { .. }, _) | (StringFormat::Debug { .. }, true) => value,
@@ -706,15 +694,16 @@ fn emit_tuple_struct_format_method(
         );
     }
     if let Some(underlying) = underlying_go_type {
-        let value = format.argument(format!("{underlying}({receiver})"), false);
+        let is_function = field_is_function[0];
+        let value = format.argument(render_conversion(underlying, &receiver), is_function);
         return format!(
             "func ({receiver} {receiver_type}) {method}() string {{\nreturn fmt.Sprintf(\"{name}({})\", {value})\n}}",
-            format.tuple_verb(false)
+            format.verb(is_function)
         );
     }
     let placeholders: Vec<&str> = field_is_function
         .iter()
-        .map(|is_function| format.tuple_verb(*is_function))
+        .map(|is_function| format.verb(*is_function))
         .collect();
     let args: Vec<String> = field_is_function
         .iter()

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -302,7 +302,7 @@ impl Planner<'_> {
         } else {
             expression_string.to_string()
         };
-        Some(if conversion_needs_parens(&go_type) {
+        Some(if conversion_needs_parens(&go_type, &field_ty) {
             format!("({})({})", go_type, operand)
         } else {
             format!("{}({})", go_type, operand)

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -12,6 +12,7 @@ use crate::context::expression::ExpressionContext;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
+use crate::types::go_type::conversion_needs_parens;
 
 struct NullableFieldAccess<'a> {
     expression_string: &'a str,
@@ -301,7 +302,7 @@ impl Planner<'_> {
         } else {
             expression_string.to_string()
         };
-        Some(if go_type.starts_with('*') {
+        Some(if conversion_needs_parens(&go_type) {
             format!("({})({})", go_type, operand)
         } else {
             format!("{}({})", go_type, operand)
@@ -372,7 +373,7 @@ impl Planner<'_> {
     }
 
     pub(crate) fn try_emit_tuple_struct_field_access(
-        &mut self,
+        &self,
         expression_string: &str,
         expression_ty: &Type,
         index: usize,
@@ -385,8 +386,7 @@ impl Planner<'_> {
         let Some(Definition {
             body:
                 DefinitionBody::Struct {
-                    fields: StructFields::Tuple(fields),
-                    generics,
+                    fields: StructFields::Tuple(_),
                     ..
                 },
             ..
@@ -394,16 +394,6 @@ impl Planner<'_> {
         else {
             return None;
         };
-
-        if fields.len() == 1 && generics.is_empty() {
-            let underlying_ty = self.use_go_type(&fields[0].ty);
-            let expression = if expression_ty.is_ref() {
-                format!("*{}", expression_string)
-            } else {
-                expression_string.to_string()
-            };
-            return Some(format!("{}({})", underlying_ty, expression));
-        }
 
         Some(format!("{}.F{}", expression_string, index))
     }

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -12,7 +12,7 @@ use crate::context::expression::ExpressionContext;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
-use crate::types::go_type::conversion_needs_parens;
+use crate::types::go_type::render_conversion;
 
 struct NullableFieldAccess<'a> {
     expression_string: &'a str,
@@ -302,11 +302,7 @@ impl Planner<'_> {
         } else {
             expression_string.to_string()
         };
-        Some(if conversion_needs_parens(&go_type, &field_ty) {
-            format!("({})({})", go_type, operand)
-        } else {
-            format!("{}({})", go_type, operand)
-        })
+        Some(render_conversion(&go_type, &operand))
     }
 
     /// Compute whether a dot access context requires exported (capitalized) Go names.

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -13,6 +13,7 @@ use crate::definitions::enum_layout;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::types::go_type::render_conversion;
 use crate::utils::is_order_sensitive;
 use syntax::program::AliasKind;
 use syntax::types;
@@ -307,11 +308,11 @@ impl Planner<'_> {
             return Some(format!("{}{{}}", go_ty));
         }
         if underlying.is_slice() {
-            return Some(format!("{}(nil)", go_ty));
+            return Some(render_conversion(go_ty, "nil"));
         }
         matches!(underlying, Type::Simple(_)).then(|| {
             let inner = self.lisette_zero(&underlying);
-            format!("{}({})", go_ty, inner)
+            render_conversion(go_ty, &inner)
         })
     }
 
@@ -382,7 +383,8 @@ impl Planner<'_> {
                 ValueLayout::Slice { element, .. },
             ) => {
                 let element = element.go_type(self);
-                format!("([]{})(nil)", self.use_rendered_go_type(element))
+                let go_type = format!("[]{}", self.use_rendered_go_type(element));
+                render_conversion(&go_type, "nil")
             }
             (
                 Type::Compound {
@@ -439,7 +441,7 @@ impl Planner<'_> {
         if let Some(underlying) = self.get_newtype_underlying(ty) {
             let go_ty = self.use_go_type(ty);
             let inner = self.lisette_zero(&underlying);
-            return format!("{}({})", go_ty, inner);
+            return render_conversion(&go_ty, &inner);
         }
         if let Some(fields) = self.lookup_unspecified_fields(ty, "", None, &HashSet::default()) {
             let go_ty = self.use_go_type(ty);

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -29,7 +29,10 @@ pub(crate) enum PathSegment {
     /// `(*expression)`: auto-pointer deref for recursive enum fields.
     Deref,
     /// `GoType(expression)`: newtype cast to underlying Go type.
-    NewtypeCast(String),
+    NewtypeCast {
+        go_type: String,
+        needs_parens: bool,
+    },
     /// `expression.(GoType)`: Go interface type assertion, inserted when a
     /// concrete pattern targets a Go interface at a non-root path.
     AssertedAs(String),
@@ -116,11 +119,14 @@ impl AccessPath {
                         result = format!("(*{})", result);
                     }
                 }
-                PathSegment::NewtypeCast(ty) => {
-                    result = if conversion_needs_parens(ty) {
-                        format!("({})({})", ty, result)
+                PathSegment::NewtypeCast {
+                    go_type,
+                    needs_parens,
+                } => {
+                    result = if *needs_parens {
+                        format!("({})({})", go_type, result)
                     } else {
-                        format!("{}({})", ty, result)
+                        format!("{}({})", go_type, result)
                     }
                 }
                 PathSegment::AssertedAs(ty) => {
@@ -148,7 +154,7 @@ impl AccessPath {
                 segment,
                 PathSegment::ArraySliceFrom { .. }
                     | PathSegment::Deref
-                    | PathSegment::NewtypeCast(_)
+                    | PathSegment::NewtypeCast { .. }
                     | PathSegment::AssertedAs(_)
             )
         })
@@ -1246,7 +1252,11 @@ fn collect_newtype_checks(
     };
     let go_underlying = planner.go_type(&underlying_ty);
     collector.packages.extend(go_underlying.requirements());
-    let field_path = path.push(PathSegment::NewtypeCast(go_underlying.code));
+    let needs_parens = conversion_needs_parens(&go_underlying.code, &underlying_ty);
+    let field_path = path.push(PathSegment::NewtypeCast {
+        go_type: go_underlying.code,
+        needs_parens,
+    });
     if let Some(field) = variant.fields.first() {
         collect_checks_and_bindings(
             planner,

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -13,7 +13,7 @@ use crate::Planner;
 use crate::names::packages::PackageRequirements;
 use crate::names::{generics, go_name};
 use crate::patterns::binding_decls::emit_pattern_literal;
-use crate::types::go_type::conversion_needs_parens;
+use crate::types::go_type::render_conversion;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PathSegment {
@@ -29,10 +29,7 @@ pub(crate) enum PathSegment {
     /// `(*expression)`: auto-pointer deref for recursive enum fields.
     Deref,
     /// `GoType(expression)`: newtype cast to underlying Go type.
-    NewtypeCast {
-        go_type: String,
-        needs_parens: bool,
-    },
+    NewtypeCast(String),
     /// `expression.(GoType)`: Go interface type assertion, inserted when a
     /// concrete pattern targets a Go interface at a non-root path.
     AssertedAs(String),
@@ -110,7 +107,7 @@ impl AccessPath {
                 PathSegment::Index(index) => result = format!("{}[{}]", result, index),
                 PathSegment::SliceFrom(offset) => result = format!("{}[{}:]", result, offset),
                 PathSegment::ArraySliceFrom { offset, go_type } => {
-                    result = format!("{}({}[{}:])", go_type, result, offset)
+                    result = render_conversion(go_type, &format!("{}[{}:]", result, offset))
                 }
                 PathSegment::Deref => {
                     if i == last {
@@ -119,16 +116,7 @@ impl AccessPath {
                         result = format!("(*{})", result);
                     }
                 }
-                PathSegment::NewtypeCast {
-                    go_type,
-                    needs_parens,
-                } => {
-                    result = if *needs_parens {
-                        format!("({})({})", go_type, result)
-                    } else {
-                        format!("{}({})", go_type, result)
-                    }
-                }
+                PathSegment::NewtypeCast(go_type) => result = render_conversion(go_type, &result),
                 PathSegment::AssertedAs(ty) => {
                     result = format!("{}.({})", result, ty);
                 }
@@ -154,7 +142,7 @@ impl AccessPath {
                 segment,
                 PathSegment::ArraySliceFrom { .. }
                     | PathSegment::Deref
-                    | PathSegment::NewtypeCast { .. }
+                    | PathSegment::NewtypeCast(_)
                     | PathSegment::AssertedAs(_)
             )
         })
@@ -1252,11 +1240,7 @@ fn collect_newtype_checks(
     };
     let go_underlying = planner.go_type(&underlying_ty);
     collector.packages.extend(go_underlying.requirements());
-    let needs_parens = conversion_needs_parens(&go_underlying.code, &underlying_ty);
-    let field_path = path.push(PathSegment::NewtypeCast {
-        go_type: go_underlying.code,
-        needs_parens,
-    });
+    let field_path = path.push(PathSegment::NewtypeCast(go_underlying.code));
     if let Some(field) = variant.fields.first() {
         collect_checks_and_bindings(
             planner,

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -13,6 +13,7 @@ use crate::Planner;
 use crate::names::packages::PackageRequirements;
 use crate::names::{generics, go_name};
 use crate::patterns::binding_decls::emit_pattern_literal;
+use crate::types::go_type::conversion_needs_parens;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PathSegment {
@@ -116,7 +117,7 @@ impl AccessPath {
                     }
                 }
                 PathSegment::NewtypeCast(ty) => {
-                    result = if ty.starts_with('*') {
+                    result = if conversion_needs_parens(ty) {
                         format!("({})({})", ty, result)
                     } else {
                         format!("{}({})", ty, result)

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -2,6 +2,7 @@ use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::types::go_type::render_conversion;
 use std::fmt::{self, Display, Formatter};
 use syntax::ast::Expression;
 
@@ -111,7 +112,7 @@ impl GoExpression {
     }
 
     pub(crate) fn conversion(go_type: String, value: GoExpression) -> Self {
-        Self::opaque_with_deferred_evaluation(format!("{go_type}({value})"), true)
+        Self::opaque_with_deferred_evaluation(render_conversion(&go_type, value.as_str()), true)
     }
 
     fn parenthesized(value: GoExpression) -> Self {

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -9,6 +9,11 @@ use syntax::ast::ResolvedCallTypeArguments;
 use syntax::program::DefinitionBody;
 use syntax::types::{CompoundKind, FunctionParameter, SimpleKind, Type};
 
+/// Whether a conversion to this Go type misparses without parentheses.
+pub(crate) fn conversion_needs_parens(go_type: &str) -> bool {
+    go_type.starts_with('*') || go_type.starts_with("<-") || go_type.starts_with("func")
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct GoType {
     pub(crate) code: String,

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -9,14 +9,15 @@ use syntax::ast::ResolvedCallTypeArguments;
 use syntax::program::DefinitionBody;
 use syntax::types::{CompoundKind, FunctionParameter, SimpleKind, Type};
 
-/// Whether a conversion to this Go type misparses without parentheses.
-pub(crate) fn conversion_needs_parens(go_type: &str, underlying: &Type) -> bool {
-    go_type.starts_with('*') || go_type.starts_with("<-") || is_function_type(underlying)
-}
-
-fn is_function_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function(_))
-        || matches!(ty, Type::Forall { body, .. } if matches!(body.as_ref(), Type::Function(_)))
+pub(crate) fn render_conversion(go_type: &str, value: &str) -> String {
+    let is_plain_name = go_type
+        .chars()
+        .all(|character| character.is_alphanumeric() || character == '_' || character == '.');
+    if is_plain_name {
+        format!("{}({})", go_type, value)
+    } else {
+        format!("({})({})", go_type, value)
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -10,8 +10,13 @@ use syntax::program::DefinitionBody;
 use syntax::types::{CompoundKind, FunctionParameter, SimpleKind, Type};
 
 /// Whether a conversion to this Go type misparses without parentheses.
-pub(crate) fn conversion_needs_parens(go_type: &str) -> bool {
-    go_type.starts_with('*') || go_type.starts_with("<-") || go_type.starts_with("func")
+pub(crate) fn conversion_needs_parens(go_type: &str, underlying: &Type) -> bool {
+    go_type.starts_with('*') || go_type.starts_with("<-") || is_function_type(underlying)
+}
+
+fn is_function_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function(_))
+        || matches!(ty, Type::Forall { body, .. } if matches!(body.as_ref(), Type::Function(_)))
 }
 
 #[derive(Debug, Clone, Default)]

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -8785,6 +8785,32 @@ fn assert_lowers_to_decomposed_failure_call() {
     );
 }
 
+#[test]
+fn debug_newtype_over_func_leaves_prelude_unimported() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        "struct Cb(fn(int) -> ())\n\nfn main() {\n  let _ = Cb(|n| { let _ = n })\n}",
+    );
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.test.lis",
+        "#[test]\nfn covers() {\n  let n = 1\n  assert n == 1\n}",
+    );
+
+    let go = compile_project_files_with_tests(fs, "github.com/user/p", false, true)
+        .iter()
+        .find(|f| f.name.ends_with("main.go"))
+        .expect("expected a main.go output")
+        .to_go();
+
+    assert!(
+        !go.contains("lisette"),
+        "a func newtype debug method must leave the prelude unimported, got:\n{go}"
+    );
+}
+
 fn compile_test_source(source: &str) -> String {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -14,7 +14,7 @@ type Widget struct {
 }
 
 func (w Widget) MarshalJSON() ([]uint8, error) {
-	return []uint8("\"custom\""), nil
+	return ([]uint8)("\"custom\""), nil
 }
 
 func main() {

--- a/tests/spec/build/snapshots/user_text_marshaler_skips_adapter.snap
+++ b/tests/spec/build/snapshots/user_text_marshaler_skips_adapter.snap
@@ -9,7 +9,7 @@ type Widget struct {
 }
 
 func (w Widget) MarshalText() ([]byte, error) {
-	return []byte("custom"), nil
+	return ([]byte)("custom"), nil
 }
 
 func main() {

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -572,3 +572,14 @@ fn build() -> Holder {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn array_rest_pattern_with_func_elements() {
+    let input = r#"
+fn f(arr: Array<fn(int) -> (), 3>) -> Array<fn(int) -> (), 2> {
+  let [_first, ..rest] = arr
+  rest
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -3960,6 +3960,18 @@ fn main() {
 }
 
 #[test]
+fn cast_to_func_type_parenthesizes() {
+    let input = r#"
+type Handler = fn(int) -> ()
+
+fn test(h: Handler) -> fn(int) -> () {
+  h as fn(int) -> ()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn newtype_over_ref_pointer_cast() {
     let input = r#"
 struct Wrap(Ref<int>)

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -553,6 +553,34 @@ fn test(w: Wrap) -> int {
 }
 
 #[test]
+fn newtype_over_result_less_func_pattern_match() {
+    let input = r#"
+struct Cb(fn(int) -> ())
+
+fn test(c: Cb) {
+  match c {
+    Cb(f) => f(1),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_over_receive_only_channel_pattern_match() {
+    let input = r#"
+struct Ticks(Receiver<int>)
+
+fn test(t: Ticks) -> Receiver<int> {
+  match t {
+    Ticks(r) => r,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn pattern_unicode_escape_conversion() {
     let input = r#"
 fn test(s: string) -> int {

--- a/tests/spec/emit/snapshots/array_let_else_rest_declares_sub_array.snap
+++ b/tests/spec/emit/snapshots/array_let_else_rest_declares_sub_array.snap
@@ -13,6 +13,6 @@ func f(arr [3]int) [2]int {
 	if arr[0] != 0 {
 		return [2]int{9, 9}
 	}
-	rest := [2]int(arr[1:])
+	rest := ([2]int)(arr[1:])
 	return rest
 }

--- a/tests/spec/emit/snapshots/array_rest_pattern_binds_sub_array.snap
+++ b/tests/spec/emit/snapshots/array_rest_pattern_binds_sub_array.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func f(arr [3]int) [2]int {
-	rest := [2]int(arr[1:])
+	rest := ([2]int)(arr[1:])
 	return rest
 }

--- a/tests/spec/emit/snapshots/array_rest_pattern_with_func_elements.snap
+++ b/tests/spec/emit/snapshots/array_rest_pattern_with_func_elements.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f(arr: Array<fn(int) -> (), 3>) -> Array<fn(int) -> (), 2> {
+    let [_first, ..rest] = arr
+    rest
+  }
+---
+package main
+
+func f(arr [3]func(int)) [2]func(int) {
+	rest := ([2]func(int))(arr[1:])
+	return rest
+}

--- a/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
+++ b/tests/spec/emit/snapshots/block_expr_append_ref_newtype.snap
@@ -25,7 +25,7 @@ func get() *Wrap {
 
 func main() {
 	var x []int
-	recv_1 := []int(*get())
+	recv_1 := ([]int)(*get())
 	x = append(recv_1[:len(recv_1):len(recv_1)], 2)
 	_ = x[0]
 }

--- a/tests/spec/emit/snapshots/cast_byte_slice_to_string.snap
+++ b/tests/spec/emit/snapshots/cast_byte_slice_to_string.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func test() string {
-	bytes := []byte("hello")
+	bytes := ([]byte)("hello")
 	return string(bytes)
 }

--- a/tests/spec/emit/snapshots/cast_string_to_byte_slice.snap
+++ b/tests/spec/emit/snapshots/cast_string_to_byte_slice.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func test() []byte {
-	return []byte("hello")
+	return ([]byte)("hello")
 }

--- a/tests/spec/emit/snapshots/cast_to_func_type_parenthesizes.snap
+++ b/tests/spec/emit/snapshots/cast_to_func_type_parenthesizes.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  type Handler = fn(int) -> ()
+  
+  fn test(h: Handler) -> fn(int) -> () {
+    h as fn(int) -> ()
+  }
+---
+package main
+
+type Handler func(int)
+
+func test(h Handler) func(int) {
+	return (func(int))(h)
+}

--- a/tests/spec/emit/snapshots/display_newtype_over_func_parenthesizes.snap
+++ b/tests/spec/emit/snapshots/display_newtype_over_func_parenthesizes.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  #[display]
+  struct Cb(fn(int) -> ())
+---
+package main
+
+import "fmt"
+
+type Cb func(int)
+
+func (c Cb) String() string {
+	return fmt.Sprintf("Cb(%p)", (func(int))(c))
+}
+
+func (c Cb) toString() string {
+	return c.String()
+}

--- a/tests/spec/emit/snapshots/double_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/double_newtype_slice_append.snap
@@ -18,5 +18,5 @@ type B A
 
 func main() {
 	w := B(A([]int{}))
-	w = B(A(append([]int(A(w)), 1)))
+	w = B(A(append(([]int)(A(w)), 1)))
 }

--- a/tests/spec/emit/snapshots/interop_array_return.snap
+++ b/tests/spec/emit/snapshots/interop_array_return.snap
@@ -15,7 +15,7 @@ package main
 import "crypto/sha256"
 
 func main() {
-	data := []byte("hi")
+	data := ([]byte)("hi")
 	hash := sha256.Sum256(data)
 	_ = hash
 }

--- a/tests/spec/emit/snapshots/interop_array_return_to_slice.snap
+++ b/tests/spec/emit/snapshots/interop_array_return_to_slice.snap
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	data := []byte("hi")
+	data := ([]byte)("hi")
 	arr_1 := sha256.Sum256(data)
 	bytes := slices.Clone(arr_1[:])
 	_ = bytes

--- a/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
+++ b/tests/spec/emit/snapshots/map_entry_slice_append_newtype.snap
@@ -18,6 +18,6 @@ func main() {
 	m := make(map[string]Wrap)
 	m["a"] = Wrap([]int{})
 	base_2 := m
-	recv_1 := []int(m["a"])
+	recv_1 := ([]int)(m["a"])
 	base_2["a"] = Wrap(append(recv_1[:len(recv_1):len(recv_1)], 1))
 }

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -26,7 +26,7 @@ func main() {
 		return
 	}
 	ref_3 := r
-	recv_2 := []int(*r)
+	recv_2 := ([]int)(*r)
 	*ref_3 = Wrap(append(recv_2[:len(recv_2):len(recv_2)], 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/newtype_over_func_with_result_field_access.snap
+++ b/tests/spec/emit/snapshots/newtype_over_func_with_result_field_access.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Mapper(fn(int) -> int)
+  
+  fn test(m: Mapper) -> int {
+    m.0(21)
+  }
+---
+package main
+
+type Mapper func(int) int
+
+func test(m Mapper) int {
+	return (func(int) int)(m)(21)
+}

--- a/tests/spec/emit/snapshots/newtype_over_receive_only_channel_field_access.snap
+++ b/tests/spec/emit/snapshots/newtype_over_receive_only_channel_field_access.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Ticks(Receiver<int>)
+  
+  fn test(t: Ticks) -> Receiver<int> {
+    t.0
+  }
+---
+package main
+
+type Ticks <-chan int
+
+func test(t Ticks) <-chan int {
+	return (<-chan int)(t)
+}

--- a/tests/spec/emit/snapshots/newtype_over_receive_only_channel_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_over_receive_only_channel_pattern_match.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Ticks(Receiver<int>)
+  
+  fn test(t: Ticks) -> Receiver<int> {
+    match t {
+      Ticks(r) => r,
+    }
+  }
+---
+package main
+
+type Ticks <-chan int
+
+func test(t Ticks) <-chan int {
+	return (<-chan int)(t)
+}

--- a/tests/spec/emit/snapshots/newtype_over_result_less_func_field_access.snap
+++ b/tests/spec/emit/snapshots/newtype_over_result_less_func_field_access.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Cb(fn(int) -> ())
+  
+  fn test(cb: Cb) {
+    cb.0(1)
+  }
+---
+package main
+
+type Cb func(int)
+
+func test(cb Cb) {
+	(func(int))(cb)(1)
+}

--- a/tests/spec/emit/snapshots/newtype_over_result_less_func_pattern_match.snap
+++ b/tests/spec/emit/snapshots/newtype_over_result_less_func_pattern_match.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  struct Cb(fn(int) -> ())
+  
+  fn test(c: Cb) {
+    match c {
+      Cb(f) => f(1),
+    }
+  }
+---
+package main
+
+type Cb func(int)
+
+func test(c Cb) {
+	(func(int))(c)(1)
+}

--- a/tests/spec/emit/snapshots/newtype_over_type_named_like_func_keyword.snap
+++ b/tests/spec/emit/snapshots/newtype_over_type_named_like_func_keyword.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct funcRegistry { pub n: int }
+  struct Holder(funcRegistry)
+  
+  fn test(h: Holder) -> int {
+    h.0.n
+  }
+---
+package main
+
+type funcRegistry struct {
+	N int
+}
+
+type Holder funcRegistry
+
+func test(h Holder) int {
+	return funcRegistry(h).N
+}

--- a/tests/spec/emit/snapshots/newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/newtype_slice_append.snap
@@ -15,5 +15,5 @@ type Wrap []int
 
 func main() {
 	w := Wrap([]int{1})
-	w = Wrap(append([]int(w), 2))
+	w = Wrap(append(([]int)(w), 2))
 }

--- a/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
+++ b/tests/spec/emit/snapshots/ref_call_newtype_append_no_double_eval.snap
@@ -29,6 +29,6 @@ func get() *Wrap {
 }
 
 func main() {
-	recv_1 := []int(*get())
+	recv_1 := ([]int)(*get())
 	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_append_expr_position.snap
@@ -17,6 +17,6 @@ type Wrap []int
 func main() {
 	w := Wrap([]int{1})
 	r := &w
-	recv_1 := []int(*r)
+	recv_1 := ([]int)(*r)
 	_ = append(recv_1[:len(recv_1):len(recv_1)], 2)
 }

--- a/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/ref_newtype_slice_append.snap
@@ -19,7 +19,7 @@ func main() {
 	w := Wrap([]int{1})
 	r := &w
 	ref_2 := r
-	recv_1 := []int(*r)
+	recv_1 := ([]int)(*r)
 	*ref_2 = Wrap(append(recv_1[:len(recv_1):len(recv_1)], 2))
 	_ = w
 }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2288,6 +2288,15 @@ fn test(t: Ticks) -> Receiver<int> {
 }
 
 #[test]
+fn display_newtype_over_func_parenthesizes() {
+    let input = r#"
+#[display]
+struct Cb(fn(int) -> ())
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn newtype_over_type_named_like_func_keyword() {
     let input = r#"
 struct funcRegistry { pub n: int }

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2252,6 +2252,42 @@ fn test(id: UserId) -> int {
 }
 
 #[test]
+fn newtype_over_result_less_func_field_access() {
+    let input = r#"
+struct Cb(fn(int) -> ())
+
+fn test(cb: Cb) {
+  cb.0(1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_over_func_with_result_field_access() {
+    let input = r#"
+struct Mapper(fn(int) -> int)
+
+fn test(m: Mapper) -> int {
+  m.0(21)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn newtype_over_receive_only_channel_field_access() {
+    let input = r#"
+struct Ticks(Receiver<int>)
+
+fn test(t: Ticks) -> Receiver<int> {
+  t.0
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn newtype_field_autofill_casts() {
     let input = r#"
 struct GameModeParam(string)

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2288,6 +2288,19 @@ fn test(t: Ticks) -> Receiver<int> {
 }
 
 #[test]
+fn newtype_over_type_named_like_func_keyword() {
+    let input = r#"
+struct funcRegistry { pub n: int }
+struct Holder(funcRegistry)
+
+fn test(h: Holder) -> int {
+  h.0.n
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn newtype_field_autofill_casts() {
     let input = r#"
 struct GameModeParam(string)


### PR DESCRIPTION
The compiler emits invalid go in cases where you use a tuple struct wrapping a function. This is present in `*`, `<-`, or `func`, and only `*` was previously gated.

Example:

```rust
import "go:fmt"

struct Cb(fn(int) -> ())

fn main() {
  let cb = Cb(|n| { fmt.Println(n) })
  cb.0(1)
}
```

`lis check` passes. The emitted go does not build:

```go
(func(int) cb)(1)

./main.go:11:13: cb (local variable) is not a type
```
Same bug is present when using a `match`

```rust
import "go:fmt"

struct Cb(fn(int) -> ())

fn main() {
  let cb = Cb(|n| { fmt.Println(n) })
  match cb {
    Cb(f) => f(2),
  }
}
```

The `<-` case fails differently. 

The `<-` binds as a receive operator, so the conversion targets `chan T` instead of `<-chan T`:

```rust
import "go:fmt"
import "go:time"

struct Ticks(Receiver<time.Time>)

fn main() {
  let t = Ticks(time.After(10 * time.Millisecond))
  let r = t.0
  select {
    let _ = r.receive() => fmt.Println("tick"),
  }
}
```

```go
r := <-chan time.Time(t)
```

```
./main.go:12:24: cannot convert t (variable of chan type Ticks) to type chan time.Time
```

To preserve the status-quo emitted go (not adding parens where go does not need them) there is also a check for this in the new `conversion_needs_parens` function.

Also include a small refactor:

Remove the newtype conversion branch in `try_emit_tuple_struct_field_access` as it is unreachable