### PR TITLE
refactor: tighten diagnostic detection

### DIFF
--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -101,17 +101,6 @@ impl From<ParseError> for LisetteDiagnostic {
             diagnostic = diagnostic.with_code(err.code);
         }
 
-        if let Some(fix) = err.fix {
-            let mut edits = fix
-                .edits
-                .into_iter()
-                .map(|(span, content)| crate::Edit::replacement(span, content));
-            if let Some(first) = edits.next() {
-                diagnostic =
-                    diagnostic.with_fix(crate::Fix::multi(fix.message, first, edits.collect()));
-            }
-        }
-
         diagnostic
     }
 }

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -343,6 +343,7 @@ pub fn name_not_found(
     span: Span,
     available_names: &[String],
     expected_ty: Option<&Type>,
+    qualified: Option<&str>,
     test_fn_name: Option<&str>,
 ) -> LisetteDiagnostic {
     if matches!(variable_name, "nil" | "null" | "Nil" | "undefined") {
@@ -358,6 +359,13 @@ pub fn name_not_found(
             .with_resolve_code("name_not_found")
             .with_span_label(&span, "not a Lisette builtin")
             .with_help(hint);
+    }
+
+    if let Some(qualified) = qualified {
+        return LisetteDiagnostic::error("Name not found")
+            .with_resolve_code("name_not_found")
+            .with_span_label(&span, "not declared or imported")
+            .with_help(format!("Did you mean `{qualified}`?"));
     }
 
     let suggestion = available_names
@@ -453,13 +461,14 @@ pub fn receiver_type_mismatch(
         .with_span_label(
             &span,
             format!(
-                "expected `{}` or `Ref<{}>`, found `{}`",
-                impl_type, impl_type, receiver_type
+                "expected `{}`, `Ref<{}>`, or `mut Ref<{}>`, found `{}`",
+                impl_type, impl_type, impl_type, receiver_type
             ),
         )
         .with_help(format!(
-            "Change the receiver type to `{}` or `Ref<{}>`",
-            impl_type, impl_type
+            "Change the receiver type to `{}` for a copy, `Ref<{}>` to point at it, \
+             or `mut Ref<{}>` to write through it",
+            impl_type, impl_type, impl_type
         ))
 }
 

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -43,6 +43,18 @@ impl InferCtx<'_> {
         if peeled.is_ref() { peeled } else { ty }
     }
 
+    pub(super) fn unify_member_expectation(
+        &mut self,
+        args: &DotAccessResolutionArgs<'_>,
+        method_ty: &Type,
+    ) {
+        if !self.is_callee_context() && NativeTypeKind::from_type(args.expression_ty).is_some() {
+            self.unify(args.expected_ty, &Type::Error, args.span);
+        } else {
+            self.unify(args.expected_ty, method_ty, args.span);
+        }
+    }
+
     pub(super) fn infer_dot_access(
         &mut self,
         expression: Box<Expression>,
@@ -111,6 +123,10 @@ impl InferCtx<'_> {
                     diagnostics::infer::NativeMethodForm::Instance,
                     span,
                 ));
+                if let Type::Var { id, .. } = expected_ty {
+                    self.env.bind(*id, Type::Error);
+                }
+                return args.build_dot_access(Type::Error, DotAccessResolution::Unresolved);
             }
             return expression;
         }

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -90,7 +90,7 @@ impl InferCtx<'_> {
             args.span,
         );
 
-        self.unify(args.expected_ty, &method_ty, args.span);
+        self.unify_member_expectation(args, &method_ty);
 
         Some(args.build_dot_access(
             method_ty,
@@ -137,7 +137,7 @@ impl InferCtx<'_> {
                 .push(diagnostics::infer::private_method_expression(*args.span));
         }
 
-        self.unify(args.expected_ty, &method_ty, args.span);
+        self.unify_member_expectation(args, &method_ty);
         Some(args.build_dot_access(
             method_ty,
             DotAccessResolution::InstanceMethodValue {
@@ -289,7 +289,7 @@ impl InferCtx<'_> {
         let expression_stripped = args.expression_ty.resolve_in(&self.env).strip_refs();
         self.unify(&receiver_stripped, &expression_stripped, args.span);
 
-        self.unify(args.expected_ty, method_ty, args.span);
+        self.unify_member_expectation(args, method_ty);
 
         let is_pointer_receiver = matches!(method_ty, Type::Function(f) if !f.params.is_empty() && f.params[0].ty.resolve_in(&self.env).is_ref());
         Some(args.build_dot_access(
@@ -514,7 +514,7 @@ impl InferCtx<'_> {
 
         let (method_ty, _) = self.instantiate(&method_ty);
 
-        self.unify(args.expected_ty, &method_ty, args.span);
+        self.unify_member_expectation(args, &method_ty);
 
         let type_package = store.package_for_qualified_name(&id).unwrap_or(&id);
         let is_cross_package = type_package != self.cursor.package_id();

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -812,13 +812,59 @@ impl InferCtx<'_> {
             None
         };
 
+        let qualified = self.qualified_name_suggestion(variable_name, expected_ty);
         let test_fn_name = self.scopes.test_fn_name().map(str::to_string);
         self.sink.push(diagnostics::infer::name_not_found(
             variable_name,
             span,
             &available_names,
             hint_ty.as_ref(),
+            qualified.as_deref(),
             test_fn_name.as_deref(),
         ));
+    }
+
+    fn qualified_name_suggestion(&self, name: &str, expected_ty: &Type) -> Option<String> {
+        self.expected_enum_variant(name, expected_ty)
+            .or_else(|| self.receiver_field(name))
+    }
+
+    fn expected_enum_variant(&self, name: &str, expected_ty: &Type) -> Option<String> {
+        let declared = expected_ty.resolve_in(&self.env);
+        let peeled = self.store.peel_alias(&declared);
+        self.store.variant_of(peeled.get_qualified_id()?, name)?;
+        self.qualified_variant(&declared, name)
+            .or_else(|| self.qualified_variant(&peeled, name))
+    }
+
+    fn qualified_variant(&self, ty: &Type, name: &str) -> Option<String> {
+        let id = ty.get_qualified_id()?;
+        if matches!(
+            self.store.get_definition(id).map(|definition| &definition.body),
+            Some(DefinitionBody::TypeAlias { generics, .. }) if !generics.is_empty()
+        ) {
+            return None;
+        }
+        let local = ty.get_name()?;
+        let package = self.store.package_for_qualified_name(id)?;
+        if package == self.cursor.package_id() || self.imports.unprefixed_imports.contains(package)
+        {
+            return Some(format!("{local}.{name}"));
+        }
+        let (prefix, _) = self
+            .imports
+            .packages()
+            .find(|(_, package_id)| *package_id == package)?;
+        Some(format!("{prefix}.{local}.{name}"))
+    }
+
+    fn receiver_field(&self, name: &str) -> Option<String> {
+        let receiver = self.scopes.lookup_value("self")?.resolve_in(&self.env);
+        let receiver = self.store.peel_alias(&receiver.strip_refs());
+        let fields = self.store.fields_of(receiver.get_qualified_id()?)?;
+        fields
+            .iter()
+            .any(|field| field.name == name)
+            .then(|| format!("self.{name}"))
     }
 }

--- a/crates/syntax/src/parse/error.rs
+++ b/crates/syntax/src/parse/error.rs
@@ -1,19 +1,12 @@
 use crate::ast::Span;
 
 #[derive(Debug, Clone)]
-pub struct ParseFix {
-    pub message: String,
-    pub edits: Vec<(Span, String)>,
-}
-
-#[derive(Debug, Clone)]
 pub struct ParseError {
     pub message: String,
     pub labels: Vec<(Span, String)>,
     pub help: Option<String>,
     pub note: Option<String>,
     pub code: String,
-    pub fix: Option<ParseFix>,
 }
 
 impl ParseError {
@@ -24,13 +17,7 @@ impl ParseError {
             help: None,
             note: None,
             code: String::new(),
-            fix: None,
         }
-    }
-
-    pub(crate) fn with_fix(mut self, fix: ParseFix) -> Self {
-        self.fix = Some(fix);
-        self
     }
 
     pub(crate) fn with_span_label(mut self, span: Span, label: impl Into<String>) -> Self {

--- a/crates/syntax/src/parse/patterns.rs
+++ b/crates/syntax/src/parse/patterns.rs
@@ -1,6 +1,5 @@
 use ecow::EcoString;
 
-use super::error::ParseFix;
 use super::strings::cook_string_contents;
 use super::{MAX_TUPLE_ARITY, ParamMode, ParseError, Parser};
 use crate::ast::{
@@ -9,7 +8,7 @@ use crate::ast::{
 };
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
-use crate::types::Type;
+use crate::types::{CompoundKind, SimpleKind, Type};
 use std::string;
 
 impl<'source> Parser<'source> {
@@ -679,7 +678,7 @@ impl<'source> Parser<'source> {
             && identifier == "self"
             && self.is_not(Colon)
         {
-            self.reject_parameter_marker(marker_span, None);
+            self.reject_self_marker(marker_span);
             return Binding {
                 pattern,
                 annotation: None,
@@ -725,31 +724,39 @@ impl<'source> Parser<'source> {
         annotation: Option<&Annotation>,
     ) {
         let Some(span) = marker_span else { return };
-        let mut error = ParseError::new("Syntax error", span, "`mut` goes on the parameter's type")
+        let refuses_permission = match annotation {
+            Some(Annotation::Constructor { name, .. }) => match CompoundKind::from_name(name) {
+                Some(kind) => !kind.accepts_write_qualifier(),
+                None => SimpleKind::from_name(name).is_some() || name == "Array",
+            },
+            Some(Annotation::Tuple { .. } | Annotation::Function { .. }) => true,
+            _ => false,
+        };
+        let error = if refuses_permission {
+            ParseError::new("Syntax error", span, "parameters are immutable")
+                .with_parse_code("syntax_error")
+                .with_help("Rebind with `let mut` inside the body to mutate a local copy.")
+        } else {
+            ParseError::new("Syntax error", span, "`mut` goes on the parameter's type")
+                .with_parse_code("syntax_error")
+                .with_help(
+                    "Place the permission right before the type, as in `items: mut Slice<int>`, \
+                     or rebind with `let mut` inside the body for a local copy.",
+                )
+        };
+        if !self.too_many_errors() {
+            self.errors.push(error);
+        }
+    }
+
+    fn reject_self_marker(&mut self, marker_span: Option<Span>) {
+        let Some(span) = marker_span else { return };
+        let error = ParseError::new("Syntax error", span, "`mut` goes on the receiver's type")
             .with_parse_code("syntax_error")
             .with_help(
-                "Place the permission right before the type, as in `items: mut Slice<int>`, \
-                 or rebind with `let mut` inside the body for a local copy.",
+                "A writable receiver is `self: mut Ref<T>`, where `T` is the type \
+                 this `impl` targets.",
             );
-        if let Some(Annotation::Constructor {
-            name,
-            span: type_span,
-            writable: false,
-            ..
-        }) = annotation
-            && matches!(name.as_str(), "Slice" | "Map" | "Ref")
-        {
-            error = error.with_fix(ParseFix {
-                message: "Move `mut` into the type".to_string(),
-                edits: vec![
-                    (span, string::String::new()),
-                    (
-                        Span::new(self.file_id, type_span.byte_offset, 0),
-                        "mut ".to_string(),
-                    ),
-                ],
-            });
-        }
         if !self.too_many_errors() {
             self.errors.push(error);
         }

--- a/tests/_harness/lint.rs
+++ b/tests/_harness/lint.rs
@@ -47,23 +47,6 @@ pub fn lint(source: &str) -> Vec<LisetteDiagnostic> {
     diagnostics
 }
 
-pub fn apply_parse_fixes(source: &str) -> String {
-    let result = syntax::build_ast(source, TEST_FILE_ID);
-    let errors_before = result.errors.len();
-    let diagnostics: Vec<LisetteDiagnostic> = result.errors.into_iter().map(Into::into).collect();
-    let fixes: Vec<&Fix> = diagnostics
-        .iter()
-        .filter_map(LisetteDiagnostic::fix)
-        .collect();
-    let fixed = apply_fixes(source, fixes).source;
-
-    let errors_after = syntax::build_ast(&fixed, TEST_FILE_ID).errors.len();
-    if errors_after >= errors_before {
-        panic!("Applied fixes must reduce the parse error count:\n{fixed}");
-    }
-    fixed
-}
-
 pub fn apply_infer_fixes(source: &str) -> String {
     let result = super::infer::infer(source);
     let fixes: Vec<&Fix> = result

--- a/tests/spec/lex/snapshots/doc_comment_four_slashes_is_comment.snap
+++ b/tests/spec/lex/snapshots/doc_comment_four_slashes_is_comment.snap
@@ -35,7 +35,6 @@ LexResult {
             ),
             note: None,
             code: "lex.excess_slashes_in_comment",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/multiline_format_string_interpolation_recovery_no_spurious_unterminated.snap
+++ b/tests/spec/lex/snapshots/multiline_format_string_interpolation_recovery_no_spurious_unterminated.snap
@@ -70,7 +70,6 @@ LexResult {
             ),
             note: None,
             code: "lex.format_string_multiline_interpolation",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_in_fstring_boundary_scanner_alignment.snap
+++ b/tests/spec/lex/snapshots/raw_string_in_fstring_boundary_scanner_alignment.snap
@@ -53,7 +53,6 @@ LexResult {
             ),
             note: None,
             code: "lex.raw_string_in_interpolation",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_in_fstring_interpolation_rejected.snap
+++ b/tests/spec/lex/snapshots/raw_string_in_fstring_interpolation_rejected.snap
@@ -53,7 +53,6 @@ LexResult {
             ),
             note: None,
             code: "lex.raw_string_in_interpolation",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_in_nested_fstring_interpolation_rejected.snap
+++ b/tests/spec/lex/snapshots/raw_string_in_nested_fstring_interpolation_rejected.snap
@@ -77,7 +77,6 @@ LexResult {
             ),
             note: None,
             code: "lex.raw_string_in_interpolation",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_nul_byte_rejected.snap
+++ b/tests/spec/lex/snapshots/raw_string_nul_byte_rejected.snap
@@ -35,7 +35,6 @@ LexResult {
             ),
             note: None,
             code: "lex.disallowed_byte_in_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_unterminated_eof.snap
+++ b/tests/spec/lex/snapshots/raw_string_unterminated_eof.snap
@@ -35,7 +35,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unterminated_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/raw_string_unterminated_eof_after_newline.snap
+++ b/tests/spec/lex/snapshots/raw_string_unterminated_eof_after_newline.snap
@@ -37,7 +37,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unterminated_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
+++ b/tests/spec/lex/snapshots/string_literal_with_special_chars.snap
@@ -35,7 +35,6 @@ LexResult {
             ),
             note: None,
             code: "lex.invalid_escape_sequence",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_fr_in_fstring_interpolation.snap
+++ b/tests/spec/lex/snapshots/unsupported_fr_in_fstring_interpolation.snap
@@ -53,7 +53,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_raw_format_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_hash_delimited_in_fstring_interpolation.snap
+++ b/tests/spec/lex/snapshots/unsupported_hash_delimited_in_fstring_interpolation.snap
@@ -53,7 +53,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_hash_delimited_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_double.snap
+++ b/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_double.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_hash_delimited_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_single.snap
+++ b/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_single.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_hash_delimited_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_suppresses_escape_cascade.snap
+++ b/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_suppresses_escape_cascade.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_hash_delimited_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_with_embedded_quote.snap
+++ b/tests/spec/lex/snapshots/unsupported_hash_delimited_raw_string_with_embedded_quote.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_hash_delimited_raw_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_raw_format_string_fr.snap
+++ b/tests/spec/lex/snapshots/unsupported_raw_format_string_fr.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_raw_format_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_raw_format_string_rf.snap
+++ b/tests/spec/lex/snapshots/unsupported_raw_format_string_rf.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_raw_format_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_raw_format_string_suppresses_inner_cascade.snap
+++ b/tests/spec/lex/snapshots/unsupported_raw_format_string_suppresses_inner_cascade.snap
@@ -29,7 +29,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_raw_format_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/spec/lex/snapshots/unsupported_rf_in_fstring_interpolation.snap
+++ b/tests/spec/lex/snapshots/unsupported_rf_in_fstring_interpolation.snap
@@ -53,7 +53,6 @@ LexResult {
             ),
             note: None,
             code: "lex.unsupported_raw_format_string",
-            fix: None,
         },
     ],
     blank_lines: [],

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -4,7 +4,6 @@ use crate::_harness::formatting::{
     format_diagnostic_for_snapshot, format_project_diagnostic_for_snapshot,
 };
 use crate::_harness::infer::{InferResult, checker_errors, infer, infer_package};
-use crate::_harness::lint::apply_parse_fixes;
 use crate::{
     assert_infer_error_snapshot, assert_lex_error_snapshot,
     assert_multipackage_infer_error_snapshot, assert_parse_error_snapshot,
@@ -945,18 +944,34 @@ fn sort(mut items: Slice<int>) {
 }
 
 #[test]
-fn parse_parameter_mut_fix_moves_marker_into_the_type() {
-    let fixed = apply_parse_fixes(
-        r#"
-fn sort(mut items: Slice<int>, keys: Slice<string>, m: Map<string, int>) {
-  items[0] = 1
+fn parse_parameter_mut_scalar() {
+    let input = r#"
+fn shrink(mut n: int) -> int {
+  n
 }
-"#,
+"#;
+    assert_parse_error_snapshot!(input);
+}
+
+#[test]
+fn parse_parameter_mut_on_a_type_that_refuses_permission() {
+    let result = syntax::build_ast(
+        "fn a(mut value: Array<int, 3>) -> int { value[0] }\n\
+         fn b(mut c: Channel<int>) -> int { 1 }\n\
+         fn c(mut pair: (int, int)) -> int { pair.0 }\n\
+         fn d(mut callback: fn()) -> int { 1 }",
+        0,
     );
-    assert!(
-        fixed.contains("fn sort( items: mut Slice<int>, keys: Slice<string>, m: Map<string, int>)"),
-        "fix must move the marker into the type, leaving its whitespace behind: {fixed}"
-    );
+    let diagnostics: Vec<diagnostics::LisetteDiagnostic> =
+        result.errors.into_iter().map(Into::into).collect();
+    assert_eq!(diagnostics.len(), 4, "each marker must report once");
+    for diagnostic in &diagnostics {
+        let help = diagnostic.plain_help().unwrap_or_default();
+        assert!(
+            help.starts_with("Rebind with"),
+            "a type that refuses permission must not be told to move `mut`, got: {help:?}"
+        );
+    }
 }
 
 #[test]
@@ -971,46 +986,6 @@ impl Counter {
 }
 "#;
     assert_parse_error_snapshot!(input);
-}
-
-#[test]
-fn parse_parameter_mut_fix_preserves_trivia() {
-    let fixed = apply_parse_fixes("fn sort(mut\n  items: Slice<int>) {\n  items[0] = 1\n}");
-    assert!(
-        fixed.contains("fn sort(\n  items: mut Slice<int>)"),
-        "the fix must delete exactly the marker, leaving trivia intact: {fixed}"
-    );
-}
-
-#[test]
-fn parse_parameter_mut_fix_applies_next_to_an_unfixable_marker() {
-    let fixed = apply_parse_fixes(
-        r#"
-fn a(mut xs: Slice<int>) {
-  xs[0] = 0
-}
-
-fn b(mut y: int) -> int {
-  y
-}
-"#,
-    );
-    assert!(
-        fixed.contains("fn a( xs: mut Slice<int>)") && fixed.contains("fn b(mut y: int)"),
-        "the container fix must apply while the scalar keeps its error: {fixed}"
-    );
-}
-
-#[test]
-fn parse_parameter_mut_scalar_gets_no_fix() {
-    let result = syntax::build_ast("fn shrink(mut n: int) -> int {\n  n\n}", 0);
-    let diagnostics: Vec<diagnostics::LisetteDiagnostic> =
-        result.errors.into_iter().map(Into::into).collect();
-    assert!(!diagnostics.is_empty(), "the marker must still error");
-    assert!(
-        diagnostics.iter().all(|d| d.fix().is_none()),
-        "a scalar parameter must not be offered the type-position fix"
-    );
 }
 
 #[test]
@@ -6337,6 +6312,119 @@ fn undeclared_t_outside_a_test_keeps_the_generic_hint() {
 }
 
 #[test]
+fn infer_name_not_found_suggests_the_expected_enum_variant() {
+    let input = r#"
+enum TokenType {
+  EOF, Whitespace
+}
+
+fn next(chr: int) -> TokenType {
+  if chr < 0 {
+    return EOF
+  }
+  TokenType.Whitespace
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_name_not_found_qualifies_an_imported_enum_variant() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("events", "mod.lis", "pub enum Event {\n  Click, Scroll\n}");
+    fs.add_file(
+        "main",
+        "main.lis",
+        "import \"events\"\n\nfn pick(n: int) -> events.Event {\n  if n < 0 {\n    return Click\n  }\n  events.Event.Scroll\n}",
+    );
+    let result = infer_package("main", fs);
+    let diagnostic = result
+        .errors
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.name_not_found"))
+        .expect("expected a name_not_found for `Click`");
+    let help = diagnostic.plain_help().unwrap_or_default();
+    assert!(
+        help.contains("`events.Event.Click`"),
+        "an imported enum must be suggested with its prefix, got: {help:?}"
+    );
+}
+
+#[test]
+fn infer_name_not_found_qualifies_an_aliased_enum_variant() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("events", "mod.lis", "pub enum Event {\n  Click, Scroll\n}");
+    fs.add_file(
+        "api",
+        "mod.lis",
+        "import \"events\"\n\npub type UIEvent = events.Event",
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        "import \"api\"\n\nfn pick(n: int) -> api.UIEvent {\n  if n < 0 {\n    return Click\n  }\n  api.UIEvent.Scroll\n}",
+    );
+    let result = infer_package("main", fs);
+    let diagnostic = result
+        .errors
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.name_not_found"))
+        .expect("expected a name_not_found for `Click`");
+    let help = diagnostic.plain_help().unwrap_or_default();
+    assert!(
+        help.contains("`api.UIEvent.Click`"),
+        "the alias the caller can name must be suggested, got: {help:?}"
+    );
+}
+
+#[test]
+fn infer_name_not_found_skips_a_generic_alias_qualifier() {
+    let result = infer(
+        r#"
+enum Event {
+  Click, Scroll
+}
+
+type Wrapped<T> = Event
+
+fn pick(n: int) -> Wrapped<int> {
+  if n < 0 {
+    return Click
+  }
+  Event.Scroll
+}
+"#,
+    );
+    let diagnostic = result
+        .errors
+        .iter()
+        .find(|d| d.code_str() == Some("resolve.name_not_found"))
+        .expect("expected a name_not_found for `Click`");
+    let help = diagnostic.plain_help().unwrap_or_default();
+    assert!(
+        help.contains("`Event.Click`"),
+        "a generic alias is not a legal qualifier, got: {help:?}"
+    );
+}
+
+#[test]
+fn infer_name_not_found_suggests_the_receiver_field() {
+    let input = r#"
+struct Location {
+  line: int,
+  column: int
+}
+
+impl Location {
+  fn describe(self) -> int {
+    line + column
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn undeclared_handle_in_subtest_suppresses_tail_cascade() {
     let fs = test_attribute_fs(
         "pub fn add(a: int, b: int) -> int { a + b }",
@@ -11446,6 +11534,32 @@ fn main() {
 }
 "#;
     assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_native_method_value_reports_once_per_use() {
+    let result = infer(
+        r#"
+fn take(n: int) -> int { n }
+
+fn main() {
+  let a = 1 + "hi".length
+  let b = take("hi".length)
+  let c = if "hi".length == 1 { 1 } else { 2 }
+  let _ = (a, b, c)
+}
+"#,
+    );
+    let codes: Vec<&str> = result.errors.iter().filter_map(|d| d.code_str()).collect();
+    assert_eq!(
+        codes,
+        vec![
+            "infer.native_method_value",
+            "infer.native_method_value",
+            "infer.native_method_value"
+        ],
+        "each use must report once, got: {codes:?}"
+    );
 }
 
 #[test]

--- a/tests/ui/errors/snapshots/infer_method_without_parens.snap
+++ b/tests/ui/errors/snapshots/infer_method_without_parens.snap
@@ -1,15 +1,12 @@
 ---
 source: tests/ui/errors/mod.rs
 ---
-  ✕ Type mismatch
-   ╭─[test.lis:2:27]
- 1 │ 
+  ✕ Cannot use native method as a value
+   ╭─[test.lis:3:3]
  2 │ fn test(s: Slice<int>) -> int {
-   ·                           ─┬─
-   ·                            ╰── return type declared here
  3 │   s.length
    ·   ────┬───
-   ·       ╰── expected `int`, found `fn () -> int`
+   ·       ╰── native methods must be called directly
  4 │ }
    ╰────
-  help: `test` declares return type `int`, but this tail expression has type `fn () -> int`. Change the value, or declare `-> fn () -> int` · code: [infer.type_mismatch]
+  help: Call it directly: `receiver.length()`. To use it as a value, wrap in a closure: `|args| receiver.length(args)` · code: [infer.native_method_value]

--- a/tests/ui/errors/snapshots/infer_name_not_found_suggests_the_expected_enum_variant.snap
+++ b/tests/ui/errors/snapshots/infer_name_not_found_suggests_the_expected_enum_variant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Name not found
+   ╭─[test.lis:8:12]
+ 7 │   if chr < 0 {
+ 8 │     return EOF
+   ·            ─┬─
+   ·             ╰── not declared or imported
+ 9 │   }
+   ╰────
+  help: Did you mean `TokenType.EOF`? · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_name_not_found_suggests_the_receiver_field.snap
+++ b/tests/ui/errors/snapshots/infer_name_not_found_suggests_the_receiver_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Name not found
+    ╭─[test.lis:9:5]
+  8 │   fn describe(self) -> int {
+  9 │     line + column
+    ·     ──┬─
+    ·       ╰── not declared or imported
+ 10 │   }
+    ╰────
+  help: Did you mean `self.line`? · code: [resolve.name_not_found]

--- a/tests/ui/errors/snapshots/infer_receiver_type_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_receiver_type_mismatch.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  5 │ impl Counter {
  6 │   fn wrong(self: Point) -> int {
    ·                  ──┬──
-   ·                    ╰── expected `Counter` or `Ref<Counter>`, found `Point`
+   ·                    ╰── expected `Counter`, `Ref<Counter>`, or `mut Ref<Counter>`, found `Point`
  7 │     0
    ╰────
-  help: Change the receiver type to `Counter` or `Ref<Counter>` · code: [infer.receiver_type_mismatch]
+  help: Change the receiver type to `Counter` for a copy, `Ref<Counter>` to point at it, or `mut Ref<Counter>` to write through it · code: [infer.receiver_type_mismatch]

--- a/tests/ui/errors/snapshots/parse_parameter_mut_scalar.snap
+++ b/tests/ui/errors/snapshots/parse_parameter_mut_scalar.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Syntax error
+   ╭─[test.lis:2:11]
+ 1 │ 
+ 2 │ fn shrink(mut n: int) -> int {
+   ·           ─┬─
+   ·            ╰── parameters are immutable
+ 3 │   n
+   ╰────
+  help: Rebind with `let mut` inside the body to mutate a local copy · code: [parse.syntax_error]

--- a/tests/ui/errors/snapshots/parse_receiver_mut_marker_rejected.snap
+++ b/tests/ui/errors/snapshots/parse_receiver_mut_marker_rejected.snap
@@ -6,7 +6,7 @@ source: tests/ui/errors/mod.rs
  4 │ impl Counter {
  5 │   fn bump(mut self) {
    ·           ─┬─
-   ·            ╰── `mut` goes on the parameter's type
+   ·            ╰── `mut` goes on the receiver's type
  6 │     let _ = self
    ╰────
-  help: Place the permission right before the type, as in `items: mut Slice<int>`, or rebind with `let mut` inside the body for a local copy · code: [parse.syntax_error]
+  help: A writable receiver is `self: mut Ref<T>`, where `T` is the type this `impl` targets · code: [parse.syntax_error]


### PR DESCRIPTION
Diagnostics now better detect certain scenarios:

- Whether the annotated type can carry `mut` at all.
- Whether an unresolved name is a variant of the expected enum or a field of the receiver.
- A native method used as a value, before unification rather than after, so one error reports once.

Closes #1333
Closes #1334