### PR TITLE
fix: missing return on guarded match

### DIFF
--- a/crates/cli/src/handlers/test/mod.rs
+++ b/crates/cli/src/handlers/test/mod.rs
@@ -124,7 +124,7 @@ pub fn test(path: Option<String>, go_flags: Vec<String>, selection: TestSelectio
             cli_error!(
                 "Tests could not run",
                 build_error.to_string(),
-                "The generated Go failed to build; run `lis check`"
+                "Review the Go compiler output above"
             );
         } else if !matches!(selection, TestSelection::Filter(_)) && !nothing_executed(&report.rows)
         {

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -1068,7 +1068,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
         for (g, (_condition, indices)) in groups.iter().enumerate() {
             let is_last_group = g == group_count - 1;
-            let collapse_as_catchall = is_last_group && last_is_catchall && indices.len() == 1;
+            let collapse_as_catchall = is_last_group && last_is_catchall;
             self.emit_chain_group(
                 statements,
                 ChainGroup {
@@ -1099,17 +1099,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             conditions,
         } = group;
         if collapse_as_catchall {
-            self.walk(statements, &tests[indices[0]].decision, ctx);
+            self.emit_chain_group_tests(statements, indices, tests, ctx);
             return;
         }
 
         let body = self.with_scope(|this| {
             let mut body: Vec<LoweredStatement> = Vec::new();
-            if bindings_are_hoistable(tests, indices) {
-                this.emit_chain_group_hoisted(&mut body, indices, tests, ctx);
-            } else {
-                this.emit_chain_group_per_test(&mut body, indices, tests, ctx);
-            }
+            this.emit_chain_group_tests(&mut body, indices, tests, ctx);
             body
         });
 
@@ -1126,6 +1122,20 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 else_arm: ElseArm::None,
             })),
             None => statements.push(LoweredStatement::Block(body)),
+        }
+    }
+
+    fn emit_chain_group_tests(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        indices: &[usize],
+        tests: &[ChainTest],
+        ctx: &WalkCtx,
+    ) {
+        if bindings_are_hoistable(tests, indices) {
+            self.emit_chain_group_hoisted(statements, indices, tests, ctx);
+        } else {
+            self.emit_chain_group_per_test(statements, indices, tests, ctx);
         }
     }
 

--- a/tests/spec/emit/control_flow.rs
+++ b/tests/spec/emit/control_flow.rs
@@ -1716,6 +1716,98 @@ fn test() -> int {
 }
 
 #[test]
+fn match_guard_on_last_tested_result_variant() {
+    let input = r#"
+fn test(r: Result<int, string>, flag: bool) -> int {
+  match r {
+    Ok(_) => 1,
+    Err(_) if flag => 2,
+    Err(_) => 3,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_on_last_tested_option_variant() {
+    let input = r#"
+fn test(o: Option<int>, flag: bool) -> int {
+  match o {
+    Some(_) => 1,
+    None if flag => 2,
+    None => 3,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_on_last_tested_enum_variant() {
+    let input = r#"
+enum Shape { Circle(int), Square(int), Tri(int) }
+
+fn test(s: Shape) -> int {
+  match s {
+    Circle(r) => r,
+    Square(w) => w,
+    Tri(h) if h > 10 => h * 2,
+    Tri(h) => h,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_on_last_tested_variant_with_binding() {
+    let input = r#"
+fn test(r: Result<int, string>) -> string {
+  match r {
+    Ok(_) => "ok",
+    Err(e) if e == "boom" => "boom",
+    Err(e) => e,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_on_the_only_variant() {
+    let input = r#"
+enum One { Only(int) }
+
+fn test(o: One) -> int {
+  match o {
+    Only(n) if n > 0 => n,
+    Only(n) => -n,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_guard_on_last_tested_variant_in_statement_position() {
+    let input = r#"
+fn check(n: int) -> Result<bool, string> { Ok(n > 0) }
+
+fn test(o: Option<int>) -> Result<int, string> {
+  let mut out = 0
+  match o {
+    Some(_) => { out = 1 },
+    None if check(0)? => { out = 2 },
+    None => { out = 3 },
+  }
+  Ok(out)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn or_pattern_literals() {
     let input = r#"
 fn test(x: int) -> string {

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_enum_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_enum_variant.snap
@@ -1,0 +1,57 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  enum Shape { Circle(int), Square(int), Tri(int) }
+  
+  fn test(s: Shape) -> int {
+    match s {
+      Circle(r) => r,
+      Square(w) => w,
+      Tri(h) if h > 10 => h * 2,
+      Tri(h) => h,
+    }
+  }
+---
+package main
+
+func MakeShapeCircle(arg0 int) Shape {
+	return Shape{Tag: ShapeCircle, Circle: arg0}
+}
+
+func MakeShapeSquare(arg0 int) Shape {
+	return Shape{Tag: ShapeSquare, Square: arg0}
+}
+
+func MakeShapeTri(arg0 int) Shape {
+	return Shape{Tag: ShapeTri, Tri: arg0}
+}
+
+type ShapeTag int
+
+const (
+	ShapeCircle ShapeTag = iota
+	ShapeSquare
+	ShapeTri
+)
+
+type Shape struct {
+	Tag    ShapeTag
+	Circle int
+	Square int
+	Tri    int
+}
+
+func test(s Shape) int {
+	if s.Tag == ShapeCircle {
+		return s.Circle
+	}
+	if s.Tag == ShapeSquare {
+		return s.Square
+	}
+	h := s.Tri
+	if h > 10 {
+		return h * 2
+	}
+	return h
+}

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_option_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_option_variant.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(o: Option<int>, flag: bool) -> int {
+    match o {
+      Some(_) => 1,
+      None if flag => 2,
+      None => 3,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(o lisette.Option[int], flag bool) int {
+	if o.Tag == lisette.OptionSome {
+		return 1
+	}
+	if flag {
+		return 2
+	}
+	return 3
+}

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_result_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_result_variant.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(r: Result<int, string>, flag: bool) -> int {
+    match r {
+      Ok(_) => 1,
+      Err(_) if flag => 2,
+      Err(_) => 3,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(r lisette.Result[int, string], flag bool) int {
+	if r.Tag == lisette.ResultOk {
+		return 1
+	}
+	if flag {
+		return 2
+	}
+	return 3
+}

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_variant_in_statement_position.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_variant_in_statement_position.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn check(n: int) -> Result<bool, string> { Ok(n > 0) }
+  
+  fn test(o: Option<int>) -> Result<int, string> {
+    let mut out = 0
+    match o {
+      Some(_) => { out = 1 },
+      None if check(0)? => { out = 2 },
+      None => { out = 3 },
+    }
+    Ok(out)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func check(n int) lisette.Result[bool, string] {
+	return lisette.MakeResultOk[bool, string](n > 0)
+}
+
+func test(o lisette.Option[int]) lisette.Result[int, string] {
+	out := 0
+match_1:
+	for {
+		if o.Tag == lisette.OptionSome {
+			out = 1
+			break match_1
+		}
+		check_2 := check(0)
+		if check_2.Tag != lisette.ResultOk {
+			return lisette.MakeResultErr[int, string](check_2.ErrVal)
+		}
+		if check_2.OkVal {
+			out = 2
+			break match_1
+		}
+		out = 3
+		break match_1
+	}
+	return lisette.MakeResultOk[int, string](out)
+}

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_variant_with_binding.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_variant_with_binding.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  fn test(r: Result<int, string>) -> string {
+    match r {
+      Ok(_) => "ok",
+      Err(e) if e == "boom" => "boom",
+      Err(e) => e,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test(r lisette.Result[int, string]) string {
+	if r.Tag == lisette.ResultOk {
+		return "ok"
+	}
+	e := r.ErrVal
+	if e == "boom" {
+		return "boom"
+	}
+	return e
+}

--- a/tests/spec/emit/snapshots/match_guard_on_the_only_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_the_only_variant.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/control_flow.rs
+description: |
+  
+  enum One { Only(int) }
+  
+  fn test(o: One) -> int {
+    match o {
+      Only(n) if n > 0 => n,
+      Only(n) => -n,
+    }
+  }
+---
+package main
+
+func MakeOneOnly(arg0 int) One {
+	return One{Tag: OneOnly, Only: arg0}
+}
+
+type OneTag int
+
+const (
+	OneOnly OneTag = iota
+)
+
+type One struct {
+	Tag  OneTag
+	Only int
+}
+
+func test(o One) int {
+	n := o.Only
+	if n > 0 {
+		return n
+	}
+	return -n
+}


### PR DESCRIPTION
A `match` in return position, when the last tested variant carried both a guarded arm and an unguarded arm, was emitting invalid Go.

```rs
import "go:fmt"

fn describe(r: Result<int, int>) -> string {
  match r {
    Ok(_) => "ok",
    Err(code) if code >= 500 => "server error",
    Err(_) => "client error",
  }
}

fn main() {
  fmt.Println(describe(Err(503)))
}
```
