### PR TITLE
refactor: suggest import alias in shadowing helptext

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -96,15 +96,38 @@ pub fn duplicate_import_path(path: &str, name_span: Span) -> LisetteDiagnostic {
 pub fn name_shadows_import(name: &str, import_path: &str, name_span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Name shadows import")
         .with_resolve_code("name_shadows_import")
-        .with_span_label(
-            &name_span,
-            format!("conflicts with imported package `{}`", import_path),
-        )
+        .with_span_label(&name_span, format!("conflicts with `{}`", import_path))
         .with_help(format!(
-            "`{}` is already used as a package alias for `{}`. \
-             Rename it or use a different import alias.",
-            name, import_path
+            "`{}` shadows the package alias `{}`. \
+             Rename `{}` or re-alias the package, e.g. `import {} \"{}\"`.",
+            name,
+            import_path,
+            name,
+            suggested_import_alias(import_path, name),
+            import_path
         ))
+}
+
+fn suggested_import_alias(import_path: &str, name: &str) -> String {
+    let path = import_path.strip_prefix("go:").unwrap_or(import_path);
+    let mut alias = match path.rsplit_once('/') {
+        Some((head, last)) => {
+            let parent = head.rsplit_once('/').map_or(head, |(_, parent)| parent);
+            format!("{}_{}", alias_segment(parent), alias_segment(last))
+        }
+        None => format!("{}_pkg", alias_segment(path)),
+    };
+    if alias == name {
+        alias.push_str("_pkg");
+    }
+    alias
+}
+
+fn alias_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
 }
 
 pub fn statement_as_tail(span: Span, expected: &Type) -> LisetteDiagnostic {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -12421,6 +12421,46 @@ fn main() {
 }
 
 #[test]
+fn infer_shadowed_imports_suggest_aliases() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file("lib", "mod.lis", "pub fn hello() -> int { 7 }");
+    let source = r#"
+import "go:image/color"
+import "lib"
+
+fn to_gray(color: color.Color) -> uint8 {
+  let (r, g, b, _) = color.RGBA()
+  ((r/256 + g/256 + b/256) / 3) as uint8
+}
+
+fn lib() {}
+"#;
+    fs.add_file(ENTRY_PACKAGE_ID, "main.lis", source);
+    let result = compile_check(fs);
+    let shadowed: Vec<_> = result
+        .errors()
+        .iter()
+        .filter(|error| error.code_str() == Some("resolve.name_shadows_import"))
+        .collect();
+    assert_eq!(shadowed.len(), 2, "got: {:?}", result.errors());
+
+    let mut output = String::new();
+    for (index, error) in shadowed.iter().enumerate() {
+        if index > 0 {
+            output.push_str("\n---\n\n");
+        }
+        output.push_str(&format_project_diagnostic_for_snapshot(&result, error));
+    }
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        omit_expression => true,
+    }, {
+        insta::assert_snapshot!(output);
+    });
+}
+
+#[test]
 fn infer_builtin_as_value() {
     let input = r#"
 fn main() {

--- a/tests/ui/errors/snapshots/infer_shadowed_imports_suggest_aliases.snap
+++ b/tests/ui/errors/snapshots/infer_shadowed_imports_suggest_aliases.snap
@@ -1,0 +1,23 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Name shadows import
+   ╭─[main.lis:5:12]
+ 4 │ 
+ 5 │ fn to_gray(color: color.Color) -> uint8 {
+   ·            ──┬──
+   ·              ╰── conflicts with `go:image/color`
+ 6 │   let (r, g, b, _) = color.RGBA()
+   ╰────
+  help: `color` shadows the package alias `go:image/color`. Rename `color` or re-alias the package, e.g. `import image_color "go:image/color"` · code: [resolve.name_shadows_import]
+
+---
+
+  ✕ Name shadows import
+    ╭─[main.lis:10:4]
+  9 │ 
+ 10 │ fn lib() {}
+    ·    ─┬─
+    ·     ╰── conflicts with `lib`
+    ╰────
+  help: `lib` shadows the package alias `lib`. Rename `lib` or re-alias the package, e.g. `import lib_pkg "lib"` · code: [resolve.name_shadows_import]


### PR DESCRIPTION
The `name_shadows_import` diagnostic now shows how to re-alias a package.

```
  ✕ Name shadows import
   ╭─[main.lis:5:12]
 4 │ 
 5 │ fn to_gray(color: color.Color) -> uint8 {
   ·            ──┬──
   ·              ╰── conflicts with `go:image/color`
 6 │   let (r, g, b, _) = color.RGBA()
   ╰────
  help: `color` shadows the package alias `go:image/color`. Rename `color` or re-alias the package, e.g. `import image_color "go:image/color"` · code: [resolve.name_shadows_import]
```