### PR TITLE
ci: select jobs by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,22 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  changes:
+    name: Changes
+    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+      site: ${{ steps.classify.outputs.site }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - name: Classify the changed paths
+        id: classify
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: scripts/classify-changes.sh >> "$GITHUB_OUTPUT"
+
   pr-title:
     name: PR title
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-') }}
@@ -45,7 +61,8 @@ jobs:
 
   format:
     name: Format
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -57,7 +74,8 @@ jobs:
 
   snapshot-style:
     name: Snapshot style
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -65,7 +83,8 @@ jobs:
 
   clippy:
     name: Clippy
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -77,7 +96,8 @@ jobs:
 
   golangci-lint:
     name: Golangci-lint
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -98,7 +118,8 @@ jobs:
 
   test-suite:
     name: Test suite
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -108,7 +129,8 @@ jobs:
 
   test-unit:
     name: Unit tests
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -119,7 +141,8 @@ jobs:
 
   lsp-test:
     name: LSP tests
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -128,7 +151,8 @@ jobs:
 
   e2e-smoke:
     name: E2E smoke
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -155,7 +179,8 @@ jobs:
 
   stdlib-check:
     name: Stdlib check
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -167,7 +192,8 @@ jobs:
 
   tree-sitter-check:
     name: Tree-sitter check
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -192,7 +218,8 @@ jobs:
 
   ide-extension-version-check:
     name: IDE extension version check
-    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -220,7 +247,8 @@ jobs:
 
   e2e-suite:
     name: E2E suite
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -245,7 +273,8 @@ jobs:
 
   embed-diff:
     name: Embed differential
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -257,7 +286,8 @@ jobs:
 
   prelude-go:
     name: Prelude tests
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -270,7 +300,8 @@ jobs:
 
   shear:
     name: Shear
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -284,7 +315,8 @@ jobs:
 
   deny:
     name: Deny
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -295,3 +327,58 @@ jobs:
         with:
           tool: cargo-deny@0.19.0
       - run: cargo deny check
+
+  site:
+    name: Site build
+    needs: changes
+    if: ${{ needs.changes.outputs.site == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
+  required-checks:
+    name: Required checks
+    needs:
+      - changes
+      - pr-title
+      - format
+      - snapshot-style
+      - clippy
+      - golangci-lint
+      - test-suite
+      - test-unit
+      - lsp-test
+      - e2e-smoke
+      - stdlib-check
+      - tree-sitter-check
+      - ide-extension-version-check
+      - e2e-suite
+      - embed-diff
+      - prelude-go
+      - shear
+      - deny
+      - site
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check every job's result
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          jq -r 'to_entries[] | "  \(.key): \(.value.result)"' <<< "$RESULTS"
+          bad=$(jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key' <<< "$RESULTS")
+          if [ -n "$bad" ]; then
+            echo "::error::Jobs failed or were cancelled: $(tr '\n' ' ' <<< "$bad")"
+            exit 1
+          fi

--- a/scripts/classify-changes.sh
+++ b/scripts/classify-changes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Prints two `key=value` lines for CI to gate jobs on: `code` for anything outside
+# `site/`, `site` for the sources the docs site build reads. Diagnostics go to stderr
+# so the caller can redirect stdout straight into `$GITHUB_OUTPUT`.
+
+EVENT=${EVENT:-pull_request}
+BASE=${BASE:-main}
+
+everything() {
+    echo "code=true"
+    echo "site=true"
+    exit 0
+}
+
+# A push to main has no base to diff against, so it rebuilds everything.
+[[ $EVENT != pull_request ]] && everything
+
+# The CI checkout is shallow and fetches only the merge ref, so it leaves no
+# remote-tracking ref for the base. Fetch one commit and read FETCH_HEAD instead. A
+# full local clone already has the ref, and fetching shallow there would truncate it.
+if git rev-parse --verify -q "origin/$BASE" > /dev/null; then
+    base="origin/$BASE"
+else
+    git fetch --depth=1 origin "$BASE"
+    base=FETCH_HEAD
+fi
+
+changed=$(git diff --name-only "$base..HEAD")
+
+# An empty diff is unexpected, so run everything rather than nothing.
+[[ -z $changed ]] && everything
+
+echo "Changed paths:" >&2
+echo "$changed" >&2
+
+site_sources='^(site/|CHANGELOG\.md$|crates/cli/reference/|crates/cli/src/handlers/learn/|crates/stdlib/prelude\.d\.lis$|editors/vscode/syntaxes/lisette\.tmLanguage\.json$|\.github/workflows/ci\.yml$|scripts/classify-changes\.sh$)'
+
+code=false
+site=false
+grep -qvE '^site/' <<< "$changed" && code=true
+grep -qE "$site_sources" <<< "$changed" && site=true
+
+echo "code=$code"
+echo "site=$site"


### PR DESCRIPTION
A PR now runs only the jobs its changed paths affect. An initial job classifies the diff and conditions subsequent job runs, so a change to the docs site no longer starts 16 Rust + Go jobs. Also adds a check to ensure the docs site builds.
