### PR TITLE
chore: release Zed extension 0.1.3

### DIFF
--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_lisette"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "zed_lisette"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,14 +1,14 @@
 id = "lisette"
 name = "Lisette"
 description = "Language support for Lisette"
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["Iván Ovejero <ivov.src@gmail.com>"]
 repository = "https://github.com/ivov/lisette"
 
 [grammars.lisette]
 repository = "https://github.com/ivov/lisette"
-rev = "8ba205cc17ec985c2a284cb4c84edd606e964bfb"
+rev = "1a0b3900188babaaf99a918b94a3df1e5066adf0"
 path = "editors/tree-sitter-lisette"
 
 [language_servers.lisette-lsp]


### PR DESCRIPTION
Bumps the Zed extension to 0.1.3 and advances the bundled tree-sitter grammar pin to `1a0b3900`, picking up write permission parsing, shebang lines, file-level comments and some grammar gap fixes.