### PR TITLE
ci: build Intel Mac binary on Apple Silicon runner

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,3 +19,6 @@ create-release = false
 github-attestations = true
 install-updater = false
 features = ["self-upgrade"]
+
+[dist.github-custom-runners]
+x86_64-apple-darwin = "macos-14"


### PR DESCRIPTION
Builds the `x86_64-apple-darwin` release binary on the `macos-14` Apple Silicon runner instead of `macos-15-intel`, which should roughly halve release runs. A `dist` maintainer [recommends it](https://github.com/axodotdev/cargo-dist/issues/864#issuecomment-2010696229) for exactly this case. `dist` itself runs `rustup target add` before the build.