### PR TITLE
fix: wrap `slices` index returns with `Option`

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -89,6 +89,7 @@
           "Index", "IndexAny", "IndexByte", "IndexRune",
           "LastIndex", "LastIndexAny", "LastIndexByte"
         ],
+        "slices": ["Index", "IndexFunc"],
         "strings": [
           "Index", "IndexAny", "IndexByte", "IndexFunc", "IndexRune",
           "LastIndex", "LastIndexAny", "LastIndexByte", "LastIndexFunc"

--- a/crates/stdlib/typedefs/slices.d.lis
+++ b/crates/stdlib/typedefs/slices.d.lis
@@ -167,12 +167,14 @@ pub fn Grow<E>(s: Slice<E>, n: int) -> Slice<E>
 /// Index returns the index of the first occurrence of v in s,
 /// or -1 if not present.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn Index<E: Comparable>(s: Slice<E>, v: E) -> int
+#[go(sentinel_minus_one)]
+pub fn Index<E: Comparable>(s: Slice<E>, v: E) -> Option<int>
 
 /// IndexFunc returns the first index i satisfying f(s[i]),
 /// or -1 if none do.
 #[go(collapsed_type_params, "Slice<E>, E")]
-pub fn IndexFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> int
+#[go(sentinel_minus_one)]
+pub fn IndexFunc<E>(s: Slice<E>, f: fn(E) -> bool) -> Option<int>
 
 /// Insert inserts the values v... into s at index i,
 /// returning the modified slice.


### PR DESCRIPTION
`slices.Index` and `slices.IndexFunc` now bind as `Option<int>`, reflecting the `-1` that Go returns when the value is absent.

```rs
import "go:slices"

fn describe(xs: Slice<int>, want: int) -> string {
  match slices.Index(xs, want) {
    Some(i) => f"found {want} at {i}",
    None => f"{want} is absent",
  }
}
```