### PR TITLE
fix: preserve return-less function types when formatting

### DIFF
--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -539,10 +539,15 @@ impl<'a> Formatter<'a> {
                 ..
             } => {
                 let param_docs: Vec<_> = params.iter().map(Self::annotation).collect();
+                let return_doc = if return_type.is_unknown() {
+                    Document::Sequence(vec![])
+                } else {
+                    Document::str(" -> ").append(Self::annotation(return_type))
+                };
                 Document::str("fn(")
                     .append(join(param_docs, Document::str(", ")))
-                    .append(") -> ")
-                    .append(Self::annotation(return_type))
+                    .append(")")
+                    .append(return_doc)
             }
             Annotation::Unknown => Document::str("_"),
             Annotation::Tuple { elements, .. } => {

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -1402,6 +1402,21 @@ fn type_alias_function() {
 }
 
 #[test]
+fn type_alias_function_without_return() {
+    assert_format_snapshot!("type Handler = fn(int, string)");
+}
+
+#[test]
+fn function_type_param_without_return() {
+    assert_format_snapshot!("fn a(f: fn(int)) {}");
+}
+
+#[test]
+fn function_type_param_with_unit_return() {
+    assert_format_snapshot!("fn a(f: fn(int) -> ()) {}");
+}
+
+#[test]
 fn type_alias_opaque() {
     assert_format_snapshot!("type   Point");
 }

--- a/tests/spec/format/snapshots/function_type_param_with_unit_return.snap
+++ b/tests/spec/format/snapshots/function_type_param_with_unit_return.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn a(f: fn(int) -> ()) {}"
+---
+fn a(f: fn(int) -> ()) {}

--- a/tests/spec/format/snapshots/function_type_param_without_return.snap
+++ b/tests/spec/format/snapshots/function_type_param_without_return.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "fn a(f: fn(int)) {}"
+---
+fn a(f: fn(int)) {}

--- a/tests/spec/format/snapshots/type_alias_function_without_return.snap
+++ b/tests/spec/format/snapshots/type_alias_function_without_return.snap
@@ -1,0 +1,5 @@
+---
+source: tests/spec/format/mod.rs
+description: "type Handler = fn(int, string)"
+---
+type Handler = fn(int, string)


### PR DESCRIPTION
`lis format` no longer rewrites a function type written without a return. `fn(int)` was incorrectly becoming `fn(int) -> _`. `lis format` now leaves this unchanged. An explicit `-> ()` is unaffected.