### PR TITLE
perf: skip intermediate copy in `Array.to_slice()` chains

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -6,7 +6,7 @@ use crate::expressions::access::index_access::range_var_bounds;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::plan_variadic_spread;
-use crate::plan::values::{CaptureBoundary, EvaluationEffect, ValuePlan};
+use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
 use crate::utils::reads_mutable_operand;
@@ -308,6 +308,10 @@ fn is_fresh_slice_value(receiver: &Expression) -> bool {
                     _ => false,
                 }
             }
+            CallKind::NativeMethod(NativeTypeKind::Array)
+            | CallKind::NativeMethodIdentifier(NativeTypeKind::Array) => {
+                extract_native_method_name(callee.unwrap_parens()) == "to_slice"
+            }
             _ => false,
         },
         _ => false,
@@ -380,6 +384,56 @@ pub(super) fn try_inline_native_method(
 
 fn is_native_array_method(method: &str) -> bool {
     matches!(method, "to_slice" | "get")
+}
+
+/// Reads the receiver, runs no user code, and returns no view of it.
+fn slice_method_reads_elements_only(method: &str, arity: usize) -> bool {
+    matches!(
+        (method, arity),
+        ("length", 0)
+            | ("is_empty", 0)
+            | ("clone", 0)
+            | ("get", 1)
+            | ("contains", 1)
+            | ("equals", 1)
+            | ("join", 1)
+    )
+}
+
+fn contains_call_expression(expression: &Expression) -> bool {
+    matches!(
+        expression,
+        Expression::Call { .. } | Expression::Task { .. }
+    ) || expression
+        .children()
+        .into_iter()
+        .any(contains_call_expression)
+}
+
+fn array_to_slice_receiver(expression: &Expression) -> Option<&Expression> {
+    let Expression::Call {
+        expression: callee,
+        args,
+        spread,
+        call_kind,
+        ..
+    } = expression.unwrap_parens()
+    else {
+        return None;
+    };
+    if spread.is_some() || extract_native_method_name(callee.unwrap_parens()) != "to_slice" {
+        return None;
+    }
+    match call_kind {
+        CallKind::NativeMethod(NativeTypeKind::Array) if args.is_empty() => {
+            match callee.unwrap_parens() {
+                Expression::DotAccess { expression, .. } => Some(expression),
+                _ => None,
+            }
+        }
+        CallKind::NativeMethodIdentifier(NativeTypeKind::Array) if args.len() == 1 => args.first(),
+        _ => None,
+    }
 }
 
 pub(super) fn native_method_lowers_to_plain_call(
@@ -744,6 +798,65 @@ impl Planner<'_> {
         }
     }
 
+    /// Stage `to_slice()` as `arr[:]` when the consumer cannot observe the skipped clone.
+    fn try_stage_to_slice_view(
+        &mut self,
+        ctx: &NativeCallContext,
+        receiver_expression: &Expression,
+        arguments: &[Expression],
+    ) -> Option<ValuePlan> {
+        if !matches!(ctx.native_type, NativeGoType::Slice) {
+            return None;
+        }
+        if !matches!(
+            ctx.capture_boundary,
+            CaptureBoundary::SiblingSequence | CaptureBoundary::AssignmentRightHandSide
+        ) {
+            return None;
+        }
+        if ctx.spread.is_some()
+            || !slice_method_reads_elements_only(ctx.method, arguments.len())
+            || arguments.iter().any(contains_call_expression)
+        {
+            return None;
+        }
+        let array = array_to_slice_receiver(receiver_expression)?;
+        if !matches!(
+            self.facts.strip_and_peel(&array.get_type()),
+            Type::Array { .. }
+        ) {
+            return None;
+        }
+        if matches!(ctx.method, "contains" | "equals") {
+            let element = self
+                .facts
+                .strip_and_peel(&receiver_expression.get_type())
+                .inner()?;
+            if self.needs_custom_equality(&element, &[]) {
+                return None;
+            }
+        }
+        Some(self.stage_array_view(array))
+    }
+
+    fn stage_array_view(&mut self, array: &Expression) -> ValuePlan {
+        let mut staged = self.stage_operand(array, ExpressionContext::value());
+        if array.get_type().is_ref() {
+            staged = staged.unary("*");
+        }
+        if !self.receiver_is_addressable(array) {
+            self.pin_staged(&mut staged, "arr");
+        }
+        staged.map_rendered_as_observable_computed(|_setup, rendered, deferred| {
+            let base = if rendered.starts_with('*') {
+                format!("({rendered})")
+            } else {
+                rendered
+            };
+            GoExpression::opaque_with_deferred_evaluation(format!("{base}[:]"), deferred)
+        })
+    }
+
     fn stage_native_method(
         &mut self,
         ctx: &NativeCallContext,
@@ -751,14 +864,29 @@ impl Planner<'_> {
     ) -> StagedNativeMethod {
         let (receiver, mut stages) = match (form, ctx.function) {
             (NativeMethodForm::Dot, Expression::DotAccess { expression, .. }) => {
-                let mut stages = vec![self.stage_operand(expression, ExpressionContext::value())];
+                let receiver_stage = self
+                    .try_stage_to_slice_view(ctx, expression, ctx.args)
+                    .unwrap_or_else(|| self.stage_operand(expression, ExpressionContext::value()));
+                let mut stages = vec![receiver_stage];
                 stages.extend(self.stage_native_method_args(ctx.function, ctx.args));
                 (expression.as_ref(), stages)
             }
-            (NativeMethodForm::Identifier, _) => (
-                &ctx.args[0],
-                self.stage_native_method_args(ctx.function, ctx.args),
-            ),
+            (NativeMethodForm::Identifier, _) => {
+                let receiver = &ctx.args[0];
+                let stages = match self.try_stage_to_slice_view(ctx, receiver, &ctx.args[1..]) {
+                    Some(view) => {
+                        let mut stages = vec![view];
+                        stages.extend(self.stage_native_method_args_from(
+                            ctx.function,
+                            ctx.args,
+                            1,
+                        ));
+                        stages
+                    }
+                    None => self.stage_native_method_args(ctx.function, ctx.args),
+                };
+                (receiver, stages)
+            }
             (NativeMethodForm::Dot, _) => unreachable!("dot form requires dot access"),
         };
         let spread_stage = ctx

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -264,9 +264,19 @@ impl Planner<'_> {
         function: &Expression,
         args: &[Expression],
     ) -> Vec<ValuePlan> {
+        self.stage_native_method_args_from(function, args, 0)
+    }
+
+    pub(crate) fn stage_native_method_args_from(
+        &mut self,
+        function: &Expression,
+        args: &[Expression],
+        start_index: usize,
+    ) -> Vec<ValuePlan> {
         let params = self.resolve_callable_params(function, args.len());
         args.iter()
             .enumerate()
+            .skip(start_index)
             .map(|(i, arg)| {
                 let param = params.get(i).or_else(|| {
                     params

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -622,7 +622,10 @@ impl Planner<'_> {
             );
         }
 
-        let plan = self.lower_value(expression, ExpressionContext::value());
+        let plan = self.lower_value(
+            expression,
+            ExpressionContext::value().with_capture_boundary(CaptureBoundary::DirectDelayedCall),
+        );
         if needs_iife_for_async(expression, plan.evaluation.form) {
             let capture_boundary = if keyword == "defer" {
                 CaptureBoundary::DeferSite

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -242,6 +242,7 @@ impl EvaluationEffect {
 pub(crate) enum CaptureBoundary {
     #[default]
     SiblingSequence,
+    DirectDelayedCall,
     DeferSite,
     TaskSite,
     LoopLifetime,
@@ -250,7 +251,10 @@ pub(crate) enum CaptureBoundary {
 
 impl CaptureBoundary {
     pub(crate) fn requires_value_capture(self, stability: Stability) -> bool {
-        !matches!(self, CaptureBoundary::SiblingSequence) && stability.is_observable()
+        !matches!(
+            self,
+            CaptureBoundary::SiblingSequence | CaptureBoundary::DirectDelayedCall
+        ) && stability.is_observable()
     }
 }
 

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -149,6 +149,29 @@ fn array_for_loop_and_to_slice() {
 }
 
 #[test]
+fn array_to_slice_chain_reads() {
+  let a: Array<int, 3> = [1, 2, 3]
+  assert a.to_slice().contains(2)
+  assert a.to_slice().equals([1, 2, 3])
+  assert a.to_slice().get(1).unwrap_or(-1) == 2
+  assert !a.to_slice().is_empty()
+  assert a.to_slice().clone().length() == 3
+  let names: Array<string, 2> = ["a", "b"]
+  assert names.to_slice().join("-") == "a-b"
+}
+
+#[test]
+fn array_to_slice_copies_before_arguments_run() {
+  let mut a: Array<int, 3> = [1, 2, 3]
+  let bump = || {
+    a[0] = 99
+    return 99
+  }
+  assert !a.to_slice().contains(bump())
+  assert a[0] == 99
+}
+
+#[test]
 fn array_direct_mutation() {
   let mut a: Array<int, 3> = [1, 2, 3]
   a[0] = 9

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -583,3 +583,164 @@ fn f(arr: Array<fn(int) -> (), 3>) -> Array<fn(int) -> (), 2> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn array_to_slice_chain_skips_copy_for_reading_methods() {
+    let input = r#"
+fn reads(arr: Array<int, 3>) -> (bool, bool, Option<int>, int, bool) {
+  let hit = arr.to_slice().contains(2)
+  let same = arr.to_slice().equals([1, 2, 3])
+  let second = arr.to_slice().get(1)
+  let n = arr.to_slice().length()
+  let blank = arr.to_slice().is_empty()
+  (hit, same, second, n, blank)
+}
+
+fn copies(arr: Array<int, 3>, names: Array<string, 2>) -> (Slice<int>, string) {
+  let copy = arr.to_slice().clone()
+  let line = names.to_slice().join("-")
+  (copy, line)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_skip_identifier_form() {
+    let input = r#"
+fn f(arr: Array<int, 3>) -> bool {
+  Slice.contains(Array.to_slice(arr), 2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_skip_negated_is_empty() {
+    let input = r#"
+fn f(arr: Array<int, 3>) -> bool {
+  !arr.to_slice().is_empty()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_skip_through_alias_and_ref() {
+    let input = r#"
+type Addr = Array<byte, 4>
+
+fn alias_receiver(a: Addr) -> bool {
+  a.to_slice().contains(2)
+}
+
+fn ref_receiver(a: Ref<Array<int, 3>>) -> bool {
+  a.to_slice().contains(2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_skip_hoists_unaddressable_receiver() {
+    let input = r#"
+fn make_arr() -> Array<int, 3> {
+  [7, 8, 9]
+}
+
+fn f() -> bool {
+  make_arr().to_slice().contains(8)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_keeps_copy_when_argument_calls() {
+    let input = r#"
+fn f() -> bool {
+  let mut arr: Array<int, 3> = [1, 2, 3]
+  let bump = || {
+    arr[0] = 99
+    return 99
+  }
+  arr.to_slice().contains(bump())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_keeps_copy_for_custom_equality() {
+    let input = r#"
+struct Point {
+  x: int,
+}
+
+impl Point {
+  fn equals(self, other: Point) -> bool {
+    self.x == other.x
+  }
+}
+
+fn user_equals(pts: Array<Point, 2>, want: Point) -> bool {
+  pts.to_slice().contains(want)
+}
+
+fn nested_containers(rows: Array<Slice<int>, 2>, want: Slice<int>) -> bool {
+  rows.to_slice().contains(want)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_keeps_copy_for_excluded_methods() {
+    let input = r#"
+fn f(arr: Array<int, 3>) -> (Slice<int>, int, int, Slice<int>, Slice<int>) {
+  let doubled = arr.to_slice().map(|x| x * 2)
+  let stomped = arr.to_slice().copy_from([7, 8])
+  let room = arr.to_slice().capacity()
+  let grown = arr.to_slice().reserve(10)
+  let extended = arr.to_slice().append(4)
+  (doubled, stomped, room, grown, extended)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_keeps_copy_when_deferred_directly() {
+    let input = r#"
+fn f() {
+  let mut arr: Array<int, 3> = [1, 2, 3]
+  defer arr.to_slice().contains(2)
+  task arr.to_slice().contains(3)
+  arr[0] = 99
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_to_slice_chain_skips_copy_in_async_arguments_and_blocks() {
+    let input = r#"
+fn consume(hit: bool) {
+  let _ = hit
+}
+
+fn f() {
+  let mut arr: Array<int, 3> = [1, 2, 3]
+  defer consume(arr.to_slice().contains(2))
+  task consume(arr.to_slice().contains(3))
+  defer {
+    consume(arr.to_slice().contains(2))
+  }
+  task {
+    consume(arr.to_slice().contains(3))
+  }
+  arr[0] = 99
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_custom_equality.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_custom_equality.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  struct Point {
+    x: int,
+  }
+  
+  impl Point {
+    fn equals(self, other: Point) -> bool {
+      self.x == other.x
+    }
+  }
+  
+  fn user_equals(pts: Array<Point, 2>, want: Point) -> bool {
+    pts.to_slice().contains(want)
+  }
+  
+  fn nested_containers(rows: Array<Slice<int>, 2>, want: Slice<int>) -> bool {
+    rows.to_slice().contains(want)
+  }
+---
+package main
+
+import "slices"
+
+type Point struct {
+	x int
+}
+
+func (p Point) equals(other Point) bool {
+	return p.x == other.x
+}
+
+func userEquals(pts [2]Point, want Point) bool {
+	want_1 := want
+	return slices.ContainsFunc(slices.Clone(pts[:]), func(e_2 Point) bool { return e_2.equals(want_1) })
+}
+
+func nestedContainers(rows [2][]int, want []int) bool {
+	want_1 := want
+	return slices.ContainsFunc(slices.Clone(rows[:]), func(e_2 []int) bool { return slices.Equal(e_2, want_1) })
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_excluded_methods.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_excluded_methods.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f(arr: Array<int, 3>) -> (Slice<int>, int, int, Slice<int>, Slice<int>) {
+    let doubled = arr.to_slice().map(|x| x * 2)
+    let stomped = arr.to_slice().copy_from([7, 8])
+    let room = arr.to_slice().capacity()
+    let grown = arr.to_slice().reserve(10)
+    let extended = arr.to_slice().append(4)
+    (doubled, stomped, room, grown, extended)
+  }
+---
+package main
+
+import "slices"
+
+func f(arr [3]int) ([]int, int, int, []int, []int) {
+	src_1 := slices.Clone(arr[:])
+	result_2 := make([]int, len(src_1))
+	for i_3, x := range src_1 {
+		result_2[i_3] = x * 2
+	}
+	doubled := result_2
+	stomped := copy(slices.Clone(arr[:]), []int{7, 8})
+	room := cap(slices.Clone(arr[:]))
+	grown := slices.Grow(slices.Clone(arr[:]), 10)
+	extended := append(slices.Clone(arr[:]), 4)
+	return doubled, stomped, room, grown, extended
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_when_argument_calls.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_when_argument_calls.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f() -> bool {
+    let mut arr: Array<int, 3> = [1, 2, 3]
+    let bump = || {
+      arr[0] = 99
+      return 99
+    }
+    arr.to_slice().contains(bump())
+  }
+---
+package main
+
+import "slices"
+
+func f() bool {
+	arr := [3]int{1, 2, 3}
+	bump := func() int {
+		arr[0] = 99
+		return 99
+	}
+	return slices.Contains(slices.Clone(arr[:]), bump())
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_when_deferred_directly.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_when_deferred_directly.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f() {
+    let mut arr: Array<int, 3> = [1, 2, 3]
+    defer arr.to_slice().contains(2)
+    task arr.to_slice().contains(3)
+    arr[0] = 99
+  }
+---
+package main
+
+import "slices"
+
+func f() {
+	arr := [3]int{1, 2, 3}
+	defer slices.Contains(slices.Clone(arr[:]), 2)
+	go slices.Contains(slices.Clone(arr[:]), 3)
+	arr[0] = 99
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skip_hoists_unaddressable_receiver.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skip_hoists_unaddressable_receiver.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make_arr() -> Array<int, 3> {
+    [7, 8, 9]
+  }
+  
+  fn f() -> bool {
+    make_arr().to_slice().contains(8)
+  }
+---
+package main
+
+import "slices"
+
+func makeArr() [3]int {
+	return [3]int{7, 8, 9}
+}
+
+func f() bool {
+	arr_1 := makeArr()
+	return slices.Contains(arr_1[:], 8)
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skip_identifier_form.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skip_identifier_form.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f(arr: Array<int, 3>) -> bool {
+    Slice.contains(Array.to_slice(arr), 2)
+  }
+---
+package main
+
+import "slices"
+
+func f(arr [3]int) bool {
+	return slices.Contains(arr[:], 2)
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skip_negated_is_empty.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skip_negated_is_empty.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn f(arr: Array<int, 3>) -> bool {
+    !arr.to_slice().is_empty()
+  }
+---
+package main
+
+func f(arr [3]int) bool {
+	return len(arr[:]) != 0
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skip_through_alias_and_ref.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skip_through_alias_and_ref.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  type Addr = Array<byte, 4>
+  
+  fn alias_receiver(a: Addr) -> bool {
+    a.to_slice().contains(2)
+  }
+  
+  fn ref_receiver(a: Ref<Array<int, 3>>) -> bool {
+    a.to_slice().contains(2)
+  }
+---
+package main
+
+import "slices"
+
+type Addr = [4]byte
+
+func aliasReceiver(a Addr) bool {
+	return slices.Contains(a[:], 2)
+}
+
+func refReceiver(a *[3]int) bool {
+	return slices.Contains((*a)[:], 2)
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skips_copy_for_reading_methods.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skips_copy_for_reading_methods.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn reads(arr: Array<int, 3>) -> (bool, bool, Option<int>, int, bool) {
+    let hit = arr.to_slice().contains(2)
+    let same = arr.to_slice().equals([1, 2, 3])
+    let second = arr.to_slice().get(1)
+    let n = arr.to_slice().length()
+    let blank = arr.to_slice().is_empty()
+    (hit, same, second, n, blank)
+  }
+  
+  fn copies(arr: Array<int, 3>, names: Array<string, 2>) -> (Slice<int>, string) {
+    let copy = arr.to_slice().clone()
+    let line = names.to_slice().join("-")
+    (copy, line)
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"slices"
+	"strings"
+)
+
+func reads(arr [3]int) (bool, bool, lisette.Option[int], int, bool) {
+	hit := slices.Contains(arr[:], 2)
+	same := slices.Equal(arr[:], []int{1, 2, 3})
+	second := lisette.SliceGet(arr[:], 1)
+	n := len(arr[:])
+	blank := len(arr[:]) == 0
+	return hit, same, second, n, blank
+}
+
+func copies(arr [3]int, names [2]string) ([]int, string) {
+	copy_ := slices.Clone(arr[:])
+	line := strings.Join(names[:], "-")
+	return copy_, line
+}

--- a/tests/spec/emit/snapshots/array_to_slice_chain_skips_copy_in_async_arguments_and_blocks.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_skips_copy_in_async_arguments_and_blocks.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn consume(hit: bool) {
+    let _ = hit
+  }
+  
+  fn f() {
+    let mut arr: Array<int, 3> = [1, 2, 3]
+    defer consume(arr.to_slice().contains(2))
+    task consume(arr.to_slice().contains(3))
+    defer {
+      consume(arr.to_slice().contains(2))
+    }
+    task {
+      consume(arr.to_slice().contains(3))
+    }
+    arr[0] = 99
+  }
+---
+package main
+
+import "slices"
+
+func consume(hit bool) {
+	_ = hit
+}
+
+func f() {
+	arr := [3]int{1, 2, 3}
+	defer consume(slices.Contains(arr[:], 2))
+	go consume(slices.Contains(arr[:], 3))
+	defer func() {
+		consume(slices.Contains(arr[:], 2))
+	}()
+	go func() {
+		consume(slices.Contains(arr[:], 3))
+	}()
+	arr[0] = 99
+}


### PR DESCRIPTION
`Array.to_slice()` no longer copies when its result immediately feeds a method that only reads it.

```rs
pub fn has_two(arr: Array<int, 3>) -> bool {
  arr.to_slice().contains(2)
}
```

```go
func HasTwo(arr [3]int) bool {
	return slices.Contains(arr[:], 2)
}
```

We keep copying whenever the copy can be observed: a method that runs user code such as `map`, an element type with its own `equals`, an arg holding a call, and a chain that `defer` or `task` runs directly.

Relates to #1269