### PR TITLE
refactor: bracket missing-arg values at the source

### DIFF
--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -349,7 +349,7 @@ fn parse_new(mut arguments: impl Iterator<Item = String>) -> Result<Command, Par
         Some(name) => Ok(Command::New { name }),
         None => Err(ParseError::MissingArgument {
             command: "new",
-            argument: "name",
+            argument: "<name>",
         }),
     }
 }
@@ -684,7 +684,7 @@ fn parse_add(mut arguments: impl Iterator<Item = String>) -> Result<Command, Par
         }),
         (None, None) => Err(ParseError::MissingArgument {
             command: "add",
-            argument: "dependency",
+            argument: "<dependency>",
         }),
     }
 }
@@ -745,7 +745,7 @@ fn parse_doc(arguments: impl Iterator<Item = String>) -> Result<Command, ParseEr
             Some(q) => Ok(Command::DocSearch { query: q }),
             None => Err(ParseError::MissingArgument {
                 command: "doc",
-                argument: "search query",
+                argument: "<search query>",
             }),
         };
     }
@@ -800,7 +800,7 @@ fn bindgen_target(
     let Some(package) = positional.first() else {
         return Err(ParseError::MissingArgument {
             command: "bindgen",
-            argument: "package",
+            argument: "<package>",
         });
     };
     let extra = positional.get(1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         Err(command::ParseError::MissingArgument { command, argument }) => {
             cli_error!(
                 "Missing argument",
-                format!("`lis {}` requires `<{}>` argument", command, argument),
+                format!("`lis {}` requires `{}`", command, argument),
                 format!("Run `lis help {}` for usage", command)
             );
             process::exit(1);


### PR DESCRIPTION
Every `ParseError::MissingArgument` value now carries its own placeholder, so the printer adds none of its own.