### PR TITLE
feat: `Array.from` for slice-to-array conversion

### DIFF
--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -597,13 +597,37 @@ fn build_prelude_index() -> PreludeIndex {
     if let Some(array) = index.types.iter_mut().find(|t| t.name == "Array") {
         array.generics.push("N".to_string());
         array.definition = "type Array<T, N>".to_string();
-        array.methods.insert(
-            0,
-            MethodInfo {
-                name: "new".to_string(),
-                signature: "fn new() -> Array<T, N>".to_string(),
-                doc: Some("Creates an array of `N` zero values.".to_string()),
-            },
+        // `site/scripts/build-prelude.mjs` mirrors these two. Update both.
+        array.methods.splice(
+            0..0,
+            [
+                MethodInfo {
+                    name: "new".to_string(),
+                    signature: "fn new() -> Array<T, N>".to_string(),
+                    doc: Some(
+                        "Creates an array of `N` zero values.\n\
+                         \n\
+                         Example:\n  \
+                         // !callout-right `[0, 0, 0]`\n  \
+                         let scores = Array.new<int, 3>()"
+                            .to_string(),
+                    ),
+                },
+                MethodInfo {
+                    name: "from".to_string(),
+                    signature: "fn from(slice: Slice<T>) -> Option<Array<T, N>>".to_string(),
+                    doc: Some(
+                        "Copies a `Slice` into a new `Array`, or returns `None` when the \
+                         `Slice` does not hold exactly `N` elements.\n\
+                         \n\
+                         Example:\n  \
+                         let parts = [1, 2, 3]\n  \
+                         // !callout[/from/] `Some([1, 2, 3])`, or `None` on a length mismatch\n  \
+                         let fixed: Option<Array<int, 3>> = Array.from(parts)"
+                            .to_string(),
+                    ),
+                },
+            ],
         );
     }
     index.types.push(TypeInfo {
@@ -2018,7 +2042,7 @@ mod tests {
     }
 
     #[test]
-    fn prelude_documents_array_new() {
+    fn prelude_documents_array_inline_constructors() {
         let index = build_prelude_index();
         let array = index
             .types
@@ -2030,6 +2054,14 @@ mod tests {
         assert_eq!(new.name, "new");
         assert_eq!(new.signature, "fn new() -> Array<T, N>");
         assert!(new.doc.is_some());
+
+        let from = array.methods.get(1).expect("`Array` has a second method");
+        assert_eq!(from.name, "from");
+        assert_eq!(
+            from.signature,
+            "fn from(slice: Slice<T>) -> Option<Array<T, N>>"
+        );
+        assert!(from.doc.is_some());
     }
 
     #[test]

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -4422,6 +4422,19 @@ pub fn ref_qualifier(member: &str, span: Span) -> LisetteDiagnostic {
         .with_help("To take a reference, use `&value`")
 }
 
+pub fn unknown_native_static(type_name: &str, member: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`{type_name}` has no `{member}`"))
+        .with_infer_code("unknown_native_static")
+        .with_span_label(
+            &span,
+            format!("no static method `{member}` on `{type_name}`"),
+        )
+        .with_help(format!(
+            "A native type offers only its own constructors and methods. \
+             Run `lis doc {type_name}` to list them"
+        ))
+}
+
 pub fn control_flow_in_expression(keyword: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!(
         "`{}` cannot be used in expression position",
@@ -4580,6 +4593,19 @@ pub fn array_new_cannot_infer_size(span: Span) -> LisetteDiagnostic {
         .with_help("Write the type arguments, e.g. `Array.new<int, 3>()`, or annotate the binding")
 }
 
+pub fn array_from_cannot_infer_size(span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Cannot infer the array element type and length")
+        .with_infer_code("array_from_cannot_infer_size")
+        .with_span_label(
+            &span,
+            "`Array.from` needs an element type and a length here",
+        )
+        .with_help(
+            "Write the type arguments, e.g. `Array.from<int, 3>(xs)`, or annotate the binding \
+             as `Option<Array<int, 3>>`",
+        )
+}
+
 pub fn array_new_no_zero(element: &dyn Display, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error(format!("`{element}` has no zero value"))
         .with_infer_code("array_new_no_zero")
@@ -4653,6 +4679,13 @@ pub fn array_new_takes_no_arguments(actual: usize, span: Span) -> LisetteDiagnos
         .with_infer_code("array_new_takes_no_arguments")
         .with_span_label(&span, format!("found {actual} argument(s)"))
         .with_help("The element type and length are type arguments: `Array.new<int, 3>()`")
+}
+
+pub fn array_from_takes_one_argument(actual: usize, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`Array.from` takes exactly one value argument")
+        .with_infer_code("array_from_takes_one_argument")
+        .with_span_label(&span, format!("found {actual} argument(s)"))
+        .with_help("Pass the source slice: `Array.from<int, 3>(xs)`")
 }
 
 pub fn spread_on_non_variadic(span: Span) -> LisetteDiagnostic {

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -14,6 +14,7 @@ use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments, StructFields};
@@ -271,8 +272,46 @@ impl<'a> Planner<'a> {
                     None
                 }
             }
+            (NativeGoType::Array, "from") => self.try_lower_array_from(ctx),
             _ => None,
         }
+    }
+
+    /// Lower `Array.from<T, N>(slice)` to a length-guarded comma-ok pair.
+    fn try_lower_array_from(&mut self, ctx: &NativeCallContext) -> Option<ValuePlan> {
+        // A comma-ok context passes no `call_ty`, so fall back to the callee.
+        let callee_ty = ctx.function.get_type();
+        let returned = callee_ty
+            .as_function_type()
+            .map(|f| f.return_type.as_ref())
+            .or(ctx.call_ty)?;
+        let option_ty = self.facts.peel_alias(returned);
+        let inner = option_ty.get_type_params()?.first()?;
+        let Type::Array { length, element } = self.facts.peel_alias(inner) else {
+            return None;
+        };
+        let argument = ctx.args.first()?;
+
+        let element_go = self.use_go_type(&element);
+        let array_go = format!("[{length}]{element_go}");
+
+        let staged = self.stage_operand(argument, ExpressionContext::value());
+        let argument_effect = staged.evaluation.effect;
+        let (setup, source) = staged.into_parts();
+
+        // A function element makes `[N]func(...)(s)` parse as a type.
+        let conversion = render_conversion(&array_go, "s");
+        let value = GoExpression::opaque(format!(
+            "func(s []{element_go}) ({array_go}, bool) {{ \
+             if len(s) != {length} {{ return {array_go}{{}}, false }}; \
+             return {conversion}, true }}({source})"
+        ));
+
+        Some(ValuePlan::observable_call(
+            setup,
+            value,
+            self.native_constructor_effect(ctx, argument_effect),
+        ))
     }
 
     fn try_lower_map_from_pairs(&mut self, ctx: &NativeCallContext) -> Option<ValuePlan> {

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -413,14 +413,22 @@ pub(crate) fn get_type_completions(
     snapshot: &AnalysisSnapshot,
     current_package: &str,
 ) -> Vec<CompletionItem> {
-    // `Array.new` is an inline builtin constructor, not a prelude definition.
+    // Inline builtin constructors, not prelude definitions.
     if type_id == "prelude.Array" {
-        return vec![CompletionItem {
-            label: "new".to_string(),
-            kind: Some(CompletionItemKind::METHOD),
-            detail: Some("fn() -> Array<T, N>".to_string()),
-            ..Default::default()
-        }];
+        return vec![
+            CompletionItem {
+                label: "new".to_string(),
+                kind: Some(CompletionItemKind::METHOD),
+                detail: Some("fn() -> Array<T, N>".to_string()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "from".to_string(),
+                kind: Some(CompletionItemKind::METHOD),
+                detail: Some("fn(Slice<T>) -> Option<Array<T, N>>".to_string()),
+                ..Default::default()
+            },
+        ];
     }
 
     let target = alias_target(type_id, snapshot);

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -1915,7 +1915,7 @@ fn main() {
 }
 
 #[test]
-fn completion_array_type_dot_offers_new() {
+fn completion_array_type_dot_offers_constructors() {
     let mut client = TestClient::new();
     client.initialize();
 
@@ -1932,6 +1932,10 @@ fn main() {
     assert!(
         labels.iter().any(|l| l == "new"),
         "Array type dot should offer 'new', got: {labels:?}"
+    );
+    assert!(
+        labels.iter().any(|l| l == "from"),
+        "Array type dot should offer 'from', got: {labels:?}"
     );
 
     client.shutdown();

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -28,6 +28,14 @@ struct TypeConversionCall {
     span: Span,
 }
 
+struct ArrayFromCall {
+    callee_span: Span,
+    args: Vec<Expression>,
+    spread: Option<Box<Expression>>,
+    type_args: Vec<Annotation>,
+    span: Span,
+}
+
 struct PseudoConstructorCall {
     expression: Box<Expression>,
     args: Vec<Expression>,
@@ -119,9 +127,22 @@ impl InferCtx<'_> {
         let type_args = type_arguments.into_annotations();
         let callee_path = expression.unwrap_parens().as_dotted_path();
 
-        // `Array.new` has no prelude signature (no const generics), so resolve inline.
+        // `Array.new` and `Array.from` have no prelude signature (no const
+        // generics), so resolve them inline.
         if callee_path.as_deref() == Some("Array.new") {
             return self.infer_array_new_call(&expression, args, type_args, span, expected_ty);
+        }
+        if callee_path.as_deref() == Some("Array.from") {
+            return self.infer_array_from_call(
+                ArrayFromCall {
+                    callee_span: expression.get_span(),
+                    args,
+                    spread,
+                    type_args,
+                    span,
+                },
+                expected_ty,
+            );
         }
 
         let pseudo_constructor_diagnostic = match callee_path.as_deref() {
@@ -684,6 +705,104 @@ impl InferCtx<'_> {
             ty: array_ty,
             span,
             call_kind: CallKind::NativeConstructor(NativeTypeKind::Array),
+        }
+    }
+
+    fn infer_array_from_call(&mut self, call: ArrayFromCall, expected_ty: &Type) -> Expression {
+        let ArrayFromCall {
+            callee_span,
+            args,
+            spread,
+            type_args,
+            span,
+        } = call;
+        let store = self.store;
+
+        let resolved = if type_args.is_empty() {
+            match self.expected_array_shape(expected_ty) {
+                Some(shape) => Some(shape),
+                None => {
+                    self.sink
+                        .push(diagnostics::infer::array_from_cannot_infer_size(span));
+                    None
+                }
+            }
+        } else if type_args.len() == 2 {
+            let elem = self.convert_to_type(store, &type_args[0], &span);
+            self.resolve_array_size(store, &type_args[1])
+                .map(|length| (elem, length))
+        } else {
+            self.sink
+                .push(diagnostics::infer::array_type_arity(type_args.len(), span));
+            None
+        };
+
+        if let Some(spread_expr) = spread {
+            self.sink.push(diagnostics::infer::spread_on_non_variadic(
+                spread_expr.get_span(),
+            ));
+            self.with_value_context(|s| s.infer_expression(*spread_expr, &Type::Error));
+        } else if args.len() != 1 {
+            self.sink
+                .push(diagnostics::infer::array_from_takes_one_argument(
+                    args.len(),
+                    span,
+                ));
+        }
+
+        let element_ty = resolved.as_ref().map(|(elem, _)| elem.clone());
+        let new_args: Vec<Expression> = args
+            .into_iter()
+            .enumerate()
+            .map(|(index, arg)| {
+                let want = match (index, &element_ty) {
+                    (0, Some(elem)) => self.type_slice(elem.clone()),
+                    _ => self.new_type_var(),
+                };
+                self.with_value_context(|s| s.infer_expression(arg, &want))
+            })
+            .collect();
+
+        let call_ty = match resolved {
+            Some((elem, len)) => {
+                let array_ty = self.type_array(len, elem);
+                self.type_option(store, array_ty)
+            }
+            None => Type::Error,
+        };
+
+        self.unify(expected_ty, &call_ty, &span);
+
+        let callee_ty = Type::function(Vec::new(), Vec::new(), Box::new(call_ty.clone()));
+        let callee_expression = Expression::Identifier {
+            value: "Array.from".into(),
+            ty: callee_ty,
+            span: callee_span,
+            resolution: IdentifierResolution::Unresolved,
+        };
+
+        Expression::Call {
+            expression: callee_expression.into(),
+            args: new_args,
+            spread: None,
+            type_arguments: CallTypeArguments::checked_without_types(type_args),
+            ty: call_ty,
+            span,
+            call_kind: CallKind::NativeConstructor(NativeTypeKind::Array),
+        }
+    }
+
+    /// The `(element, length)` an expected `Option<Array<T, N>>` asks for.
+    fn expected_array_shape(&self, expected_ty: &Type) -> Option<(Type, u64)> {
+        let store = self.store;
+        let peeled = store.peel_alias(&expected_ty.resolve_in(&self.env));
+        if !peeled.is_option() {
+            return None;
+        }
+        let inner = peeled.get_type_params()?.first()?;
+        match store.peel_alias(&inner.resolve_in(&self.env)) {
+            Type::Array { length, element } => Some((element.as_ref().clone(), length)),
+            _ => None,
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/qualified_path.rs
+++ b/crates/semantics/src/checker/infer/expressions/qualified_path.rs
@@ -1,6 +1,6 @@
 use ecow::EcoString;
 use syntax::ast::{Expression, IdentifierResolution, Span};
-use syntax::program::{DefinitionBody, DotAccessResolution};
+use syntax::program::{DefinitionBody, DotAccessResolution, NativeTypeKind};
 use syntax::types::{Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
@@ -58,6 +58,17 @@ impl InferCtx<'_> {
                     &member,
                     expression.get_span(),
                 ));
+            } else if let Some(native) = qualified_root
+                .strip_prefix("prelude.")
+                .filter(|name| NativeTypeKind::from_name(name).is_some())
+            {
+                let path = format!("{native}.{member}");
+                self.sink
+                    .push(if NativeTypeKind::from_constructor_path(&path).is_some() {
+                        diagnostics::infer::native_constructor_value(&path, span)
+                    } else {
+                        diagnostics::infer::unknown_native_static(native, &member, span)
+                    });
             } else {
                 let target = store.peel_alias(&def.ty);
                 let type_name = if let Type::Nominal { id, .. } = &target {

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -919,6 +919,12 @@ impl InferCtx<'_> {
             );
         }
 
+        if slice_to_array_help_applies(expected, actual) {
+            return format!(
+                "Copy the elements with `Array.from(...)`, which yields `Option<{expected_name}>`, or change the receiving type to `{actual_name}`"
+            );
+        }
+
         if actual.wraps("Slice", expected) {
             return "Index into the slice, e.g. `items[0]`".to_string();
         }
@@ -1123,6 +1129,19 @@ fn array_to_slice_help_applies(expected: &Type, actual: &Type) -> bool {
         return false;
     };
     expected_element == element.as_ref()
+}
+
+fn slice_to_array_help_applies(expected: &Type, actual: &Type) -> bool {
+    let Type::Array { element, .. } = expected else {
+        return false;
+    };
+    if !actual.is_slice() {
+        return false;
+    }
+    actual
+        .get_type_params()
+        .and_then(|params| params.first())
+        .is_some_and(|actual_element| actual_element == element.as_ref())
 }
 
 fn are_go_type_aliases(a: &str, b: &str) -> bool {

--- a/crates/syntax/src/program/resolution.rs
+++ b/crates/syntax/src/program/resolution.rs
@@ -247,6 +247,7 @@ impl NativeTypeKind {
             "Channel.new" | "Channel.buffered" => Some(Self::Channel),
             "Map.new" => Some(Self::Map),
             "Slice.new" | "Slice.make" => Some(Self::Slice),
+            "Array.new" | "Array.from" => Some(Self::Array),
             _ => None,
         }
     }

--- a/site/scripts/build-prelude.mjs
+++ b/site/scripts/build-prelude.mjs
@@ -482,7 +482,37 @@ const checkCoverage = (items, pages) => {
   if (missing.length) throw new Error(`prelude: no page covers: ${missing.join(", ")}`);
 };
 
+const INLINE_ARRAY_CONSTRUCTORS = [
+  {
+    name: "new",
+    signature: "fn new() -> Array<T, N>",
+    doc: {
+      text: "Creates an array of `N` zero values.",
+      example: ["// !callout-right `[0, 0, 0]`", "let scores = Array.new<int, 3>()"].join("\n"),
+    },
+  },
+  {
+    name: "from",
+    signature: "fn from(slice: Slice<T>) -> Option<Array<T, N>>",
+    doc: {
+      text:
+        "Copies a `Slice` into a new `Array`, or returns `None` when the `Slice` does not hold " +
+        "exactly `N` elements.",
+      example: [
+        "let parts = [1, 2, 3]",
+        "// !callout[/from/] `Some([1, 2, 3])`, or `None` on a length mismatch",
+        "let fixed: Option<Array<int, 3>> = Array.from(parts)",
+      ].join("\n"),
+    },
+  },
+].map((member) => ({ ...member, implementation: "impl<T> Array<T>", availableOn: null }));
+
 const items = new Map(parse(readFileSync(SOURCE, "utf8")));
+
+const array = items.get("Array");
+if (!array) throw new Error("prelude: Array is missing, so its constructors have no owner");
+array.members.unshift(...INLINE_ARRAY_CONSTRUCTORS);
+
 checkCoverage(items, PAGES);
 
 // Removed wholesale, so a page dropped from PAGES leaves no orphan behind.

--- a/site/src/content/docs/intro/safety.md
+++ b/site/src/content/docs/intro/safety.md
@@ -295,6 +295,28 @@ fn get_request_id(ctx: context.Context) -> Option<string> {
 
 📚 See [Unknown](/docs/prelude/types/#unknown)
 
+### Panicking conversions
+
+Go converts a slice to a fixed-size array without a length check, and panics when the slice is too short.
+
+```go file="addr.go"
+func addr(b []byte) [4]byte {
+    // !callout-error-right panic: cannot convert slice with length 2 to array with length 4
+    return [4]byte(b)
+}
+```
+
+In Lisette, `Array.from` reports the length mismatch as `None`.
+
+```lisette file="addr.lis"
+fn addr(b: Slice<byte>) -> Option<Array<byte, 4>> {
+  // !callout[/from/] `Some([1, 2, 3, 4])`, or `None` unless `b` holds exactly 4
+  Array.from(b)
+}
+```
+
+📚 See [Array](/docs/prelude/array/)
+
 ## Unintended writes
 
 ### Silent mutation

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -112,6 +112,8 @@ struct Mixer {
   pub lanes: Array<int, LANE_COUNT>
 }
 
+enum Colour { Red, Green }
+
 #[test]
 fn array_size_from_constant() {
   let mixer = Mixer { lanes: Array.new<int, LANE_COUNT>() }
@@ -190,6 +192,65 @@ fn array_mutation_through_ref() {
 fn array_new_fills_option_with_none() {
   let a = Array.new<Option<int>, 2>()
   assert a[0].unwrap_or(-99) == -99
+}
+
+#[test]
+fn array_from_matches_exact_length() {
+  let exact: Option<Array<int, 3>> = Array.from([1, 2, 3])
+  let head = if let Some(a) = exact { a[0] + a[2] } else { -1 }
+  assert head == 4
+  let short: Option<Array<int, 3>> = Array.from([1, 2])
+  assert short.is_none()
+  let long: Option<Array<int, 3>> = Array.from([1, 2, 3, 4])
+  assert long.is_none()
+}
+
+#[test]
+fn array_from_copies_the_source() {
+  let mut source = [1, 2, 3]
+  let copied = Array.from<int, 3>(source)
+  source[0] = 99
+  let first = if let Some(a) = copied { a[0] } else { -1 }
+  assert first == 1
+}
+
+#[test]
+fn array_from_builds_an_element_without_a_zero() {
+  let mut colours = Slice.new<Colour>()
+  colours = colours.append(Colour.Red)
+  colours = colours.append(Colour.Green)
+  let matched = if let Some(a) = Array.from<Colour, 2>(colours) {
+    a[0] == Colour.Red && a[1] == Colour.Green
+  } else {
+    false
+  }
+  assert matched
+}
+
+#[test]
+fn array_from_function_element() {
+  let fs: Slice<fn(int) -> int> = [|x| x + 1, |y| y * 2]
+  let called = if let Some(a) = Array.from<fn(int) -> int, 2>(fs) {
+    a[0](10) + a[1](10)
+  } else {
+    -1
+  }
+  assert called == 31
+}
+
+#[test]
+fn array_from_zero_length_accepts_only_an_empty_slice() {
+  let empty: Option<Array<int, 0>> = Array.from(Slice.new<int>())
+  assert empty.is_some()
+  let filled: Option<Array<int, 0>> = Array.from([1])
+  assert filled.is_none()
+}
+
+#[test]
+fn array_from_named_constant_size() {
+  let lanes: Option<Array<int, LANE_COUNT>> = Array.from([4, 5, 6])
+  let size = if let Some(a) = lanes { a.length() } else { -1 }
+  assert size == 3
 }
 
 #[test]

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -744,3 +744,127 @@ fn f() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn array_from_turbofish() {
+    let input = r#"
+fn make(xs: Slice<int>) -> Option<Array<int, 3>> {
+  Array.from<int, 3>(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_from_annotation() {
+    let input = r#"
+fn make(xs: Slice<int>) -> Option<Array<int, 3>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_zero_length() {
+    let input = r#"
+fn make(xs: Slice<int>) -> Option<Array<int, 0>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_element_without_zero() {
+    let input = r#"
+enum Colour { Red, Green }
+
+fn make(xs: Slice<Colour>) -> Option<Array<Colour, 2>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_function_element_parenthesizes_the_conversion() {
+    let input = r#"
+fn make(xs: Slice<fn(int) -> int>) -> Option<Array<fn(int) -> int, 2>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_option_element() {
+    let input = r#"
+fn make(xs: Slice<Option<int>>) -> Option<Array<Option<int>, 2>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_in_match_binds_comma_ok_pair() {
+    let input = r#"
+fn first(xs: Slice<int>) -> int {
+  match Array.from<int, 3>(xs) {
+    Some(a) => a[0],
+    None => 0,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_propagates_with_question_mark() {
+    let input = r#"
+fn first(xs: Slice<int>) -> Option<int> {
+  let a = Array.from<int, 3>(xs)?
+  Some(a[0])
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_stages_an_effectful_argument() {
+    let input = r#"
+fn grow(seen: mut Slice<int>) -> Slice<int> {
+  seen.append(1)
+}
+
+fn f(seen: mut Slice<int>) -> Option<Array<int, 1>> {
+  Array.from(grow(seen))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_named_constant_size() {
+    let input = r#"
+const SIZE = 3
+
+fn make(xs: Slice<int>) -> Option<Array<int, SIZE>> {
+  Array.from(xs)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_from_slice_alias_argument() {
+    let input = r#"
+type Buffer = Slice<byte>
+
+fn head(b: Buffer) -> Option<Array<byte, 2>> {
+  Array.from(b[0..2])
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/array_from_element_without_zero.snap
+++ b/tests/spec/emit/snapshots/array_from_element_without_zero.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour { Red, Green }
+  
+  fn make(xs: Slice<Colour>) -> Option<Array<Colour, 2>> {
+    Array.from(xs)
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+type ColourTag int
+
+const (
+	ColourRed ColourTag = iota
+	ColourGreen
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+func make_(xs []Colour) ([2]Colour, bool) {
+	return func(s []Colour) ([2]Colour, bool) {
+		if len(s) != 2 {
+			return [2]Colour{}, false
+		}
+		return ([2]Colour)(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_from_annotation.snap
+++ b/tests/spec/emit/snapshots/array_from_from_annotation.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make(xs: Slice<int>) -> Option<Array<int, 3>> {
+    Array.from(xs)
+  }
+---
+package main
+
+func make_(xs []int) ([3]int, bool) {
+	return func(s []int) ([3]int, bool) {
+		if len(s) != 3 {
+			return [3]int{}, false
+		}
+		return ([3]int)(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_function_element_parenthesizes_the_conversion.snap
+++ b/tests/spec/emit/snapshots/array_from_function_element_parenthesizes_the_conversion.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make(xs: Slice<fn(int) -> int>) -> Option<Array<fn(int) -> int, 2>> {
+    Array.from(xs)
+  }
+---
+package main
+
+func make_(xs []func(int) int) ([2]func(int) int, bool) {
+	return func(s []func(int) int) ([2]func(int) int, bool) {
+		if len(s) != 2 {
+			return [2]func(int) int{}, false
+		}
+		return ([2]func(int) int)(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
+++ b/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn first(xs: Slice<int>) -> int {
+    match Array.from<int, 3>(xs) {
+      Some(a) => a[0],
+      None => 0,
+    }
+  }
+---
+package main
+
+func first(xs []int) int {
+	ret_1, ok_2 := func(s []int) ([3]int, bool) {
+		if len(s) != 3 {
+			return [3]int{}, false
+		}
+		return ([3]int)(s), true
+	}(xs)
+	if ok_2 {
+		a := ret_1
+		return a[0]
+	} else {
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/array_from_named_constant_size.snap
+++ b/tests/spec/emit/snapshots/array_from_named_constant_size.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  const SIZE = 3
+  
+  fn make(xs: Slice<int>) -> Option<Array<int, SIZE>> {
+    Array.from(xs)
+  }
+---
+package main
+
+const Size int = 3
+
+func make_(xs []int) ([3]int, bool) {
+	return func(s []int) ([3]int, bool) {
+		if len(s) != 3 {
+			return [3]int{}, false
+		}
+		return ([3]int)(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_option_element.snap
+++ b/tests/spec/emit/snapshots/array_from_option_element.snap
@@ -1,0 +1,20 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make(xs: Slice<Option<int>>) -> Option<Array<Option<int>, 2>> {
+    Array.from(xs)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func make_(xs []lisette.Option[int]) ([2]lisette.Option[int], bool) {
+	return func(s []lisette.Option[int]) ([2]lisette.Option[int], bool) {
+		if len(s) != 2 {
+			return [2]lisette.Option[int]{}, false
+		}
+		return ([2]lisette.Option[int])(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_propagates_with_question_mark.snap
+++ b/tests/spec/emit/snapshots/array_from_propagates_with_question_mark.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn first(xs: Slice<int>) -> Option<int> {
+    let a = Array.from<int, 3>(xs)?
+    Some(a[0])
+  }
+---
+package main
+
+func first(xs []int) (int, bool) {
+	ret_1, ret_2 := func(s []int) ([3]int, bool) {
+		if len(s) != 3 {
+			return [3]int{}, false
+		}
+		return ([3]int)(s), true
+	}(xs)
+	if !ret_2 {
+		return 0, false
+	}
+	a := ret_1
+	return a[0], true
+}

--- a/tests/spec/emit/snapshots/array_from_slice_alias_argument.snap
+++ b/tests/spec/emit/snapshots/array_from_slice_alias_argument.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  type Buffer = Slice<byte>
+  
+  fn head(b: Buffer) -> Option<Array<byte, 2>> {
+    Array.from(b[0..2])
+  }
+---
+package main
+
+type Buffer = []byte
+
+func head(b Buffer) ([2]byte, bool) {
+	return func(s []byte) ([2]byte, bool) {
+		if len(s) != 2 {
+			return [2]byte{}, false
+		}
+		return ([2]byte)(s), true
+	}(b[0:2:2])
+}

--- a/tests/spec/emit/snapshots/array_from_stages_an_effectful_argument.snap
+++ b/tests/spec/emit/snapshots/array_from_stages_an_effectful_argument.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn grow(seen: mut Slice<int>) -> Slice<int> {
+    seen.append(1)
+  }
+  
+  fn f(seen: mut Slice<int>) -> Option<Array<int, 1>> {
+    Array.from(grow(seen))
+  }
+---
+package main
+
+func grow(seen []int) []int {
+	return append(seen[:len(seen):len(seen)], 1)
+}
+
+func f(seen []int) ([1]int, bool) {
+	return func(s []int) ([1]int, bool) {
+		if len(s) != 1 {
+			return [1]int{}, false
+		}
+		return ([1]int)(s), true
+	}(grow(seen))
+}

--- a/tests/spec/emit/snapshots/array_from_turbofish.snap
+++ b/tests/spec/emit/snapshots/array_from_turbofish.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make(xs: Slice<int>) -> Option<Array<int, 3>> {
+    Array.from<int, 3>(xs)
+  }
+---
+package main
+
+func make_(xs []int) ([3]int, bool) {
+	return func(s []int) ([3]int, bool) {
+		if len(s) != 3 {
+			return [3]int{}, false
+		}
+		return ([3]int)(s), true
+	}(xs)
+}

--- a/tests/spec/emit/snapshots/array_from_zero_length.snap
+++ b/tests/spec/emit/snapshots/array_from_zero_length.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  fn make(xs: Slice<int>) -> Option<Array<int, 0>> {
+    Array.from(xs)
+  }
+---
+package main
+
+func make_(xs []int) ([0]int, bool) {
+	return func(s []int) ([0]int, bool) {
+		if len(s) != 0 {
+			return [0]int{}, false
+		}
+		return ([0]int)(s), true
+	}(xs)
+}

--- a/tests/spec/infer/arrays.rs
+++ b/tests/spec/infer/arrays.rs
@@ -225,6 +225,112 @@ fn array_new_zero_length_zeroless_element_from_annotation_is_ok() {
 }
 
 #[test]
+fn array_from_with_turbofish() {
+    infer("Array.from<int, 3>([1, 2, 3])")
+        .assert_type_struct_generic("Option", vec![array_type(3, int_type())]);
+}
+
+#[test]
+fn array_from_infers_size_from_annotation() {
+    infer("let a: Option<Array<int, 3>> = Array.from([1, 2, 3]); a")
+        .assert_last_type(con_type("Option", vec![array_type(3, int_type())]));
+}
+
+#[test]
+fn array_from_without_size_errors() {
+    infer("Array.from([1, 2, 3])").assert_infer_code("array_from_cannot_infer_size");
+}
+
+#[test]
+fn array_from_bare_array_annotation_does_not_infer_size() {
+    infer("let a: Array<int, 3> = Array.from([1, 2, 3]); a")
+        .assert_infer_code("array_from_cannot_infer_size");
+}
+
+#[test]
+fn array_from_wrong_arity_errors() {
+    infer("Array.from<int>([1, 2, 3])").assert_infer_code("array_type_arity");
+}
+
+#[test]
+fn array_from_non_literal_size_errors() {
+    infer("Array.from<int, int>([1, 2, 3])").assert_infer_code("array_size_not_literal");
+}
+
+#[test]
+fn array_from_without_arguments_errors() {
+    infer("Array.from<int, 3>()").assert_infer_code("array_from_takes_one_argument");
+}
+
+#[test]
+fn array_from_with_extra_argument_errors() {
+    infer("Array.from<int, 3>([1, 2, 3], [4])").assert_infer_code("array_from_takes_one_argument");
+}
+
+#[test]
+fn array_from_rejects_spread() {
+    infer("Array.from<int, 3>([1, 2, 3]...)").assert_infer_code("spread_on_non_variadic");
+}
+
+#[test]
+fn array_from_spread_does_not_also_count_arguments() {
+    infer("Array.from<int, 3>([1, 2, 3]...)")
+        .assert_infer_code_count("array_from_takes_one_argument", 0);
+}
+
+#[test]
+fn array_from_still_resolves_names_inside_a_rejected_spread() {
+    infer("Array.from<int, 3>(missing...)").assert_resolve_code("name_not_found");
+}
+
+#[test]
+fn array_from_rejects_non_slice_argument() {
+    infer("Array.from<int, 3>(\"nope\")").assert_infer_code("type_mismatch");
+}
+
+#[test]
+fn array_from_element_without_zero_is_allowed() {
+    infer("fn f(xs: Slice<Ref<int>>) -> Option<Array<Ref<int>, 2>> { Array.from(xs) }")
+        .assert_no_errors();
+}
+
+#[test]
+fn array_from_zero_length_is_ok() {
+    infer("fn f(xs: Slice<int>) -> Option<Array<int, 0>> { Array.from(xs) }").assert_no_errors();
+}
+
+#[test]
+fn array_from_named_constant_size() {
+    infer("const SIZE = 3\nfn f(xs: Slice<int>) -> Option<Array<int, SIZE>> { Array.from(xs) }")
+        .assert_no_errors();
+}
+
+#[test]
+fn slice_to_array_mismatch_suggests_array_from() {
+    infer("let _a: Array<int, 3> = [1, 2, 3][0..3]").assert_error_contains("`Array.from(...)`");
+}
+
+#[test]
+fn unknown_array_static_is_not_an_alias_error() {
+    infer("Array.zzz([1, 2, 3])").assert_infer_code("unknown_native_static");
+}
+
+#[test]
+fn unknown_slice_static_is_not_an_alias_error() {
+    infer("Slice.zzz([1, 2, 3])").assert_infer_code("unknown_native_static");
+}
+
+#[test]
+fn array_from_as_a_value_is_a_constructor_error() {
+    infer("let f = Array.from; f").assert_infer_code("native_constructor_value");
+}
+
+#[test]
+fn array_new_as_a_value_is_a_constructor_error() {
+    infer("let f = Array.new; f").assert_infer_code("native_constructor_value");
+}
+
+#[test]
 fn array_for_loop_binds_element_type() {
     // `_y: int = x` only type-checks if the loop variable is inferred as `int`.
     infer("let arr: Array<int, 3> = [1, 2, 3]; for x in arr { let _y: int = x }")


### PR DESCRIPTION
Adds `Array.from` to create an `Array<T, N>` from a `Slice<T>`. This succeeds only if the slice holds exactly `N` elements, so `from` returns an `Option`.

Close #1269