### PR TITLE
feat: diagnostic for `fmt.Printf` verb and arg type mismatch

### DIFF
--- a/crates/diagnostics/src/lint.rs
+++ b/crates/diagnostics/src/lint.rs
@@ -1,5 +1,6 @@
 use crate::LisetteDiagnostic;
 use syntax::ast::{DeadCodeCause, Span};
+use syntax::types::SimpleKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IssueKind {
@@ -1430,6 +1431,111 @@ pub enum PrintfOperand {
     Verb(char),
     StarWidth,
     StarPrecision,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrintfClass {
+    Integer,
+    Float,
+    Complex,
+    Boolean,
+    String,
+}
+
+impl PrintfClass {
+    pub fn of(kind: SimpleKind) -> Option<PrintfClass> {
+        Some(match kind {
+            SimpleKind::Int
+            | SimpleKind::Int8
+            | SimpleKind::Int16
+            | SimpleKind::Int32
+            | SimpleKind::Int64
+            | SimpleKind::Uint
+            | SimpleKind::Uint8
+            | SimpleKind::Uint16
+            | SimpleKind::Uint32
+            | SimpleKind::Uint64
+            | SimpleKind::Uintptr
+            | SimpleKind::Byte
+            | SimpleKind::Rune => PrintfClass::Integer,
+            SimpleKind::Float32 | SimpleKind::Float64 => PrintfClass::Float,
+            SimpleKind::Complex64 | SimpleKind::Complex128 => PrintfClass::Complex,
+            SimpleKind::Bool => PrintfClass::Boolean,
+            SimpleKind::String => PrintfClass::String,
+            SimpleKind::Unit => return None,
+        })
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            PrintfClass::Integer => "an integer",
+            PrintfClass::Float => "a float",
+            PrintfClass::Complex => "a complex number",
+            PrintfClass::Boolean => "a boolean",
+            PrintfClass::String => "a string",
+        }
+    }
+
+    fn suggested_verb(self) -> char {
+        match self {
+            PrintfClass::Integer => 'd',
+            PrintfClass::Float | PrintfClass::Complex => 'f',
+            PrintfClass::Boolean => 't',
+            PrintfClass::String => 's',
+        }
+    }
+}
+
+fn printf_classes_phrase(accepted: &[PrintfClass]) -> String {
+    match accepted {
+        [] => "a pointer".to_string(),
+        [only] => only.name().to_string(),
+        [first, second] => format!("{} or {}", first.name(), second.name()),
+        [leading @ .., last] => {
+            let listed: Vec<&str> = leading.iter().map(|class| class.name()).collect();
+            format!("{}, or {}", listed.join(", "), last.name())
+        }
+    }
+}
+
+pub fn printf_verb_type_mismatch(
+    span: &Span,
+    package: &str,
+    function: &str,
+    verb: char,
+    accepted: &[PrintfClass],
+    argument: SimpleKind,
+) -> LisetteDiagnostic {
+    let display_package = package.strip_prefix("go:").unwrap_or(package);
+    let type_name = argument.leaf_name();
+    let needs = printf_classes_phrase(accepted);
+    let suggestion = PrintfClass::of(argument).map_or('v', PrintfClass::suggested_verb);
+
+    LisetteDiagnostic::warn("Format verb mismatch")
+        .with_lint_code("printf_verb_mismatch")
+        .with_span_label(span, format!("`{type_name}` argument for `%{verb}`"))
+        .with_help(format!(
+            "`{display_package}.{function}` formats `%{verb}`, which needs {needs}, but the argument has type `{type_name}`. Use `%{suggestion}`, or convert the argument"
+        ))
+}
+
+pub fn printf_star_type_mismatch(
+    span: &Span,
+    package: &str,
+    function: &str,
+    precision: bool,
+    argument: SimpleKind,
+) -> LisetteDiagnostic {
+    let display_package = package.strip_prefix("go:").unwrap_or(package);
+    let type_name = argument.leaf_name();
+    let part = if precision { "precision" } else { "width" };
+
+    LisetteDiagnostic::warn(format!("Format {part} mismatch"))
+        .with_lint_code("printf_verb_mismatch")
+        .with_span_label(span, format!("`{type_name}` argument for the `*` {part}"))
+        .with_help(format!(
+            "`{display_package}.{function}` takes the `*` {part} from an argument of type `{type_name}`, but a {part} must be an integer. Use a fixed {part}, or convert the argument"
+        ))
 }
 
 pub fn printf_verb_mismatch(

--- a/crates/passes/src/passes/lints/ast_walk/checks/printf_verb_mismatch.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/printf_verb_mismatch.rs
@@ -1,8 +1,9 @@
 use crate::passes::walk::NodeCtx;
-use diagnostics::lint::PrintfOperand;
+use diagnostics::lint::{PrintfClass, PrintfOperand};
 use std::str;
 use syntax::ast::{Expression, Literal};
 use syntax::lex::string_bytes;
+use syntax::types::{SimpleKind, Type};
 
 /// (package_id, function_name, index of the format-string argument)
 const PRINTF_TARGETS: &[(&str, &str, usize)] = &[
@@ -70,12 +71,99 @@ pub fn check_printf_verb_mismatch(expression: &Expression, ctx: &NodeCtx) {
 
     let supplied = args.len() - format_index - 1;
     if operands.len() == supplied {
+        check_operand_types(
+            &operands,
+            &args[format_index + 1..],
+            package_id,
+            function,
+            ctx,
+        );
         return;
     }
 
     ctx.sink.push(diagnostics::lint::printf_verb_mismatch(
         span, package_id, function, &operands, supplied,
     ));
+}
+
+const VERB_CLASSES: &[(char, &[PrintfClass])] = {
+    use PrintfClass::{Boolean, Complex, Float, Integer, String};
+    &[
+        ('v', &[Integer, Float, Complex, Boolean, String]),
+        ('s', &[String]),
+        ('q', &[Integer, String]),
+        ('d', &[Integer]),
+        ('b', &[Integer, Float, Complex]),
+        ('o', &[Integer]),
+        ('O', &[Integer]),
+        ('x', &[Integer, Float, Complex, String]),
+        ('X', &[Integer, Float, Complex, String]),
+        ('c', &[Integer]),
+        ('U', &[Integer]),
+        ('e', &[Float, Complex]),
+        ('E', &[Float, Complex]),
+        ('f', &[Float, Complex]),
+        ('F', &[Float, Complex]),
+        ('g', &[Float, Complex]),
+        ('G', &[Float, Complex]),
+        ('t', &[Boolean]),
+        ('p', &[]),
+    ]
+};
+
+fn check_operand_types(
+    operands: &[PrintfOperand],
+    arguments: &[Expression],
+    package_id: &str,
+    function: &str,
+    ctx: &NodeCtx,
+) {
+    for (operand, argument) in operands.iter().zip(arguments) {
+        match operand {
+            PrintfOperand::Verb(verb) => {
+                let Some((_, accepted)) = VERB_CLASSES.iter().find(|(known, _)| known == verb)
+                else {
+                    continue;
+                };
+                let Some((kind, class)) = primitive_class(argument) else {
+                    continue;
+                };
+                if accepted.contains(&class) {
+                    continue;
+                }
+                ctx.sink.push(diagnostics::lint::printf_verb_type_mismatch(
+                    &argument.get_span(),
+                    package_id,
+                    function,
+                    *verb,
+                    accepted,
+                    kind,
+                ));
+            }
+            PrintfOperand::StarWidth | PrintfOperand::StarPrecision => {
+                let Some((kind, class)) = primitive_class(argument) else {
+                    continue;
+                };
+                if class == PrintfClass::Integer {
+                    continue;
+                }
+                ctx.sink.push(diagnostics::lint::printf_star_type_mismatch(
+                    &argument.get_span(),
+                    package_id,
+                    function,
+                    matches!(operand, PrintfOperand::StarPrecision),
+                    kind,
+                ));
+            }
+        }
+    }
+}
+
+fn primitive_class(argument: &Expression) -> Option<(SimpleKind, PrintfClass)> {
+    let Type::Simple(kind) = argument.get_type() else {
+        return None;
+    };
+    Some((kind, PrintfClass::of(kind)?))
 }
 
 /// The parts of `format` that consume an argument, or `None` for an explicit

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -2081,9 +2081,10 @@ fn main() {
     );
 }
 
+/// Narrowed to one code because `printf_verb_mismatch` reports the `%s` too.
 #[test]
 fn redundant_sprintf_non_string_argument_no_warning() {
-    assert_no_lint_warnings!(
+    let diagnostics = lint(
         r#"
 import "go:fmt"
 
@@ -2091,7 +2092,13 @@ fn main() {
   let n = 42
   let _ = fmt.Sprintf("%s", n)
 }
-"#
+"#,
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code_str() == Some("lint.redundant_sprintf")),
+        "a non-string argument is not a redundant `Sprintf`: {diagnostics:?}"
     );
 }
 
@@ -17426,6 +17433,444 @@ fn main() {
             .any(|d| d.plain_message() == "Missing format arguments"),
         "the lint must not depend on a clean check: {:?}",
         result.lints()
+    );
+}
+
+#[test]
+fn printf_verb_type_integer_verb_with_string_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let name = "alice"
+  fmt.Printf("%d\n", name)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_string_verb_with_float_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let price = 3.14159
+  fmt.Printf("%s\n", price)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_bool_verb_with_integer_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("%t\n", 1)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_rune_verb_with_bool_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("%c\n", true)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_pointer_verb_with_integer_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("%p\n", 1)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_star_width_with_string_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("[%*d]\n", "wide", 1)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_star_precision_with_string_argument() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("[%.*f]\n", "fine", 1.5)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_errorf() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let _ = fmt.Errorf("code %d", "boom")
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_float_verb_names_complex() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("%f\n", "text")
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_uintptr_is_an_integer() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  fmt.Printf("%s\n", os.Stdout.Fd())
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_count_mismatch_wins() {
+    let source = r#"
+import "go:fmt"
+
+fn main() {
+  fmt.Printf("%d %d\n", "a")
+}
+"#;
+    assert_diagnostic_count!(source, 1);
+    assert_lint_snapshot!(source);
+}
+
+/// Every verb and type pair that `go vet` accepts, one call per pair.
+#[test]
+fn printf_verb_type_accepted_pairs_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let v_int: int = 1
+  fmt.Printf("%v\n", v_int)
+  fmt.Printf("%q\n", v_int)
+  fmt.Printf("%d\n", v_int)
+  fmt.Printf("%b\n", v_int)
+  fmt.Printf("%o\n", v_int)
+  fmt.Printf("%O\n", v_int)
+  fmt.Printf("%x\n", v_int)
+  fmt.Printf("%X\n", v_int)
+  fmt.Printf("%c\n", v_int)
+  fmt.Printf("%U\n", v_int)
+  let v_int8: int8 = 1
+  fmt.Printf("%v\n", v_int8)
+  fmt.Printf("%q\n", v_int8)
+  fmt.Printf("%d\n", v_int8)
+  fmt.Printf("%b\n", v_int8)
+  fmt.Printf("%o\n", v_int8)
+  fmt.Printf("%O\n", v_int8)
+  fmt.Printf("%x\n", v_int8)
+  fmt.Printf("%X\n", v_int8)
+  fmt.Printf("%c\n", v_int8)
+  fmt.Printf("%U\n", v_int8)
+  let v_int64: int64 = 1
+  fmt.Printf("%v\n", v_int64)
+  fmt.Printf("%q\n", v_int64)
+  fmt.Printf("%d\n", v_int64)
+  fmt.Printf("%b\n", v_int64)
+  fmt.Printf("%o\n", v_int64)
+  fmt.Printf("%O\n", v_int64)
+  fmt.Printf("%x\n", v_int64)
+  fmt.Printf("%X\n", v_int64)
+  fmt.Printf("%c\n", v_int64)
+  fmt.Printf("%U\n", v_int64)
+  let v_uint: uint = 1
+  fmt.Printf("%v\n", v_uint)
+  fmt.Printf("%q\n", v_uint)
+  fmt.Printf("%d\n", v_uint)
+  fmt.Printf("%b\n", v_uint)
+  fmt.Printf("%o\n", v_uint)
+  fmt.Printf("%O\n", v_uint)
+  fmt.Printf("%x\n", v_uint)
+  fmt.Printf("%X\n", v_uint)
+  fmt.Printf("%c\n", v_uint)
+  fmt.Printf("%U\n", v_uint)
+  let v_byte: byte = 1
+  fmt.Printf("%v\n", v_byte)
+  fmt.Printf("%q\n", v_byte)
+  fmt.Printf("%d\n", v_byte)
+  fmt.Printf("%b\n", v_byte)
+  fmt.Printf("%o\n", v_byte)
+  fmt.Printf("%O\n", v_byte)
+  fmt.Printf("%x\n", v_byte)
+  fmt.Printf("%X\n", v_byte)
+  fmt.Printf("%c\n", v_byte)
+  fmt.Printf("%U\n", v_byte)
+  let v_rune: rune = 'x'
+  fmt.Printf("%v\n", v_rune)
+  fmt.Printf("%q\n", v_rune)
+  fmt.Printf("%d\n", v_rune)
+  fmt.Printf("%b\n", v_rune)
+  fmt.Printf("%o\n", v_rune)
+  fmt.Printf("%O\n", v_rune)
+  fmt.Printf("%x\n", v_rune)
+  fmt.Printf("%X\n", v_rune)
+  fmt.Printf("%c\n", v_rune)
+  fmt.Printf("%U\n", v_rune)
+  let v_float32: float32 = 1.5
+  fmt.Printf("%v\n", v_float32)
+  fmt.Printf("%b\n", v_float32)
+  fmt.Printf("%x\n", v_float32)
+  fmt.Printf("%X\n", v_float32)
+  fmt.Printf("%e\n", v_float32)
+  fmt.Printf("%E\n", v_float32)
+  fmt.Printf("%f\n", v_float32)
+  fmt.Printf("%F\n", v_float32)
+  fmt.Printf("%g\n", v_float32)
+  fmt.Printf("%G\n", v_float32)
+  let v_float64: float64 = 1.5
+  fmt.Printf("%v\n", v_float64)
+  fmt.Printf("%b\n", v_float64)
+  fmt.Printf("%x\n", v_float64)
+  fmt.Printf("%X\n", v_float64)
+  fmt.Printf("%e\n", v_float64)
+  fmt.Printf("%E\n", v_float64)
+  fmt.Printf("%f\n", v_float64)
+  fmt.Printf("%F\n", v_float64)
+  fmt.Printf("%g\n", v_float64)
+  fmt.Printf("%G\n", v_float64)
+  let v_complex128 = 1.0 + 2.0i
+  fmt.Printf("%v\n", v_complex128)
+  fmt.Printf("%b\n", v_complex128)
+  fmt.Printf("%x\n", v_complex128)
+  fmt.Printf("%X\n", v_complex128)
+  fmt.Printf("%e\n", v_complex128)
+  fmt.Printf("%E\n", v_complex128)
+  fmt.Printf("%f\n", v_complex128)
+  fmt.Printf("%F\n", v_complex128)
+  fmt.Printf("%g\n", v_complex128)
+  fmt.Printf("%G\n", v_complex128)
+  let v_bool: bool = true
+  fmt.Printf("%v\n", v_bool)
+  fmt.Printf("%t\n", v_bool)
+  let v_string: string = "s"
+  fmt.Printf("%v\n", v_string)
+  fmt.Printf("%s\n", v_string)
+  fmt.Printf("%q\n", v_string)
+  fmt.Printf("%x\n", v_string)
+  fmt.Printf("%X\n", v_string)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_uintptr_accepted_verb_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  fmt.Printf("%d\n", os.Stdout.Fd())
+}
+"#
+    );
+}
+
+/// A parameter type is the only route: no expression produces a `complex64`.
+#[test]
+fn printf_verb_type_complex64_is_a_complex_number() {
+    assert_lint_snapshot!(
+        r#"
+import "go:fmt"
+
+pub fn show(c: complex64) {
+  fmt.Printf("%d\n", c)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_complex64_accepted_verbs_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+pub fn show(c: complex64) {
+  fmt.Printf("%v\n", c)
+  fmt.Printf("%b\n", c)
+  fmt.Printf("%x\n", c)
+  fmt.Printf("%X\n", c)
+  fmt.Printf("%e\n", c)
+  fmt.Printf("%E\n", c)
+  fmt.Printf("%f\n", c)
+  fmt.Printf("%F\n", c)
+  fmt.Printf("%g\n", c)
+  fmt.Printf("%G\n", c)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_go_stringer_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+import "go:time"
+import "go:os"
+
+fn main() {
+  let d = time.Second
+  let m = os.FileMode(420)
+  fmt.Printf("%s\n", d)
+  fmt.Printf("%d\n", d)
+  fmt.Printf("%s\n", m)
+  fmt.Printf("%d\n", m)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_newtype_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+struct Plain(int)
+
+#[display]
+struct Shown(int)
+
+fn main() {
+  let plain = Plain(1)
+  let shown = Shown(1)
+  fmt.Printf("%d\n", plain)
+  fmt.Printf("%s\n", plain)
+  fmt.Printf("%d\n", shown)
+  fmt.Printf("%s\n", shown)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_alias_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+type Aliased = int
+
+fn main() {
+  let aliased: Aliased = 1
+  fmt.Printf("%d\n", aliased)
+  fmt.Printf("%s\n", aliased)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_error_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+import "go:errors"
+
+fn main() {
+  let err = errors.New("boom")
+  fmt.Printf("%s\n", err)
+  fmt.Printf("%d\n", err)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_generic_parameter_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn show<T>(x: T) {
+  fmt.Printf("%d\n", x)
+}
+
+fn main() {
+  show(1)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_byte_slice_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let bytes: Slice<byte> = [104, 105]
+  fmt.Printf("%s\n", bytes)
+  fmt.Printf("%d\n", bytes)
+}
+"#
+    );
+}
+
+#[test]
+fn printf_verb_type_unknown_verb_no_warning() {
+    assert_no_lint_warnings!(
+        r#"
+import "go:fmt"
+
+fn main() {
+  let _ = fmt.Errorf("wrapped: %w", fmt.Errorf("inner"))
+}
+"#
     );
 }
 

--- a/tests/ui/lint/snapshots/printf_verb_type_bool_verb_with_integer_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_bool_verb_with_integer_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:22]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("%t\n", 1)
+   ·                      ┬
+   ·                      ╰── `int` argument for `%t`
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` formats `%t`, which needs a boolean, but the argument has type `int`. Use `%d`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_complex64_is_a_complex_number.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_complex64_is_a_complex_number.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:22]
+ 4 │ pub fn show(c: complex64) {
+ 5 │   fmt.Printf("%d\n", c)
+   ·                      ┬
+   ·                      ╰── `complex64` argument for `%d`
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` formats `%d`, which needs an integer, but the argument has type `complex64`. Use `%f`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_count_mismatch_wins.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_count_mismatch_wins.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Missing format arguments
+   ╭─[test.lis:5:3]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("%d %d\n", "a")
+   ·   ─────────────┬────────────
+   ·                ╰── 2 verbs, 1 argument
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` has 2 verbs but 1 argument, so `%d` prints as `%!d(MISSING)`. Add the missing argument, remove the verb, or write `%%` for a literal percent sign · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_errorf.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_errorf.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:33]
+ 4 │ fn main() {
+ 5 │   let _ = fmt.Errorf("code %d", "boom")
+   ·                                 ───┬──
+   ·                                    ╰── `string` argument for `%d`
+ 6 │ }
+   ╰────
+  help: `fmt.Errorf` formats `%d`, which needs an integer, but the argument has type `string`. Use `%s`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_float_verb_names_complex.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_float_verb_names_complex.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:22]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("%f\n", "text")
+   ·                      ───┬──
+   ·                         ╰── `string` argument for `%f`
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` formats `%f`, which needs a float or a complex number, but the argument has type `string`. Use `%s`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_integer_verb_with_string_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_integer_verb_with_string_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:6:22]
+ 5 │   let name = "alice"
+ 6 │   fmt.Printf("%d\n", name)
+   ·                      ──┬─
+   ·                        ╰── `string` argument for `%d`
+ 7 │ }
+   ╰────
+  help: `fmt.Printf` formats `%d`, which needs an integer, but the argument has type `string`. Use `%s`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_pointer_verb_with_integer_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_pointer_verb_with_integer_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:22]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("%p\n", 1)
+   ·                      ┬
+   ·                      ╰── `int` argument for `%p`
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` formats `%p`, which needs a pointer, but the argument has type `int`. Use `%d`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_rune_verb_with_bool_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_rune_verb_with_bool_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:5:22]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("%c\n", true)
+   ·                      ──┬─
+   ·                        ╰── `bool` argument for `%c`
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` formats `%c`, which needs an integer, but the argument has type `bool`. Use `%t`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_star_precision_with_string_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_star_precision_with_string_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format precision mismatch
+   ╭─[test.lis:5:26]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("[%.*f]\n", "fine", 1.5)
+   ·                          ───┬──
+   ·                             ╰── `string` argument for the `*` precision
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` takes the `*` precision from an argument of type `string`, but a precision must be an integer. Use a fixed precision, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_star_width_with_string_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_star_width_with_string_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format width mismatch
+   ╭─[test.lis:5:25]
+ 4 │ fn main() {
+ 5 │   fmt.Printf("[%*d]\n", "wide", 1)
+   ·                         ───┬──
+   ·                            ╰── `string` argument for the `*` width
+ 6 │ }
+   ╰────
+  help: `fmt.Printf` takes the `*` width from an argument of type `string`, but a width must be an integer. Use a fixed width, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_string_verb_with_float_argument.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_string_verb_with_float_argument.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:6:22]
+ 5 │   let price = 3.14159
+ 6 │   fmt.Printf("%s\n", price)
+   ·                      ──┬──
+   ·                        ╰── `float64` argument for `%s`
+ 7 │ }
+   ╰────
+  help: `fmt.Printf` formats `%s`, which needs a string, but the argument has type `float64`. Use `%f`, or convert the argument · code: [lint.printf_verb_mismatch]

--- a/tests/ui/lint/snapshots/printf_verb_type_uintptr_is_an_integer.snap
+++ b/tests/ui/lint/snapshots/printf_verb_type_uintptr_is_an_integer.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ▲ Format verb mismatch
+   ╭─[test.lis:6:22]
+ 5 │ fn main() {
+ 6 │   fmt.Printf("%s\n", os.Stdout.Fd())
+   ·                      ───────┬──────
+   ·                             ╰── `uintptr` argument for `%s`
+ 7 │ }
+   ╰────
+  help: `fmt.Printf` formats `%s`, which needs a string, but the argument has type `uintptr`. Use `%d`, or convert the argument · code: [lint.printf_verb_mismatch]


### PR DESCRIPTION
Adds a warning that flags a `fmt.Printf` call whose format verb cannot format the arg it receives, e.g. `%d` receiving a `string`.

```
  ▲ Format verb mismatch
   ╭─[test.lis:6:22]
 5 │   let name = "alice"
 6 │   fmt.Printf("%d\n", name)
   ·                      ──┬─
   ·                        ╰── `string` argument for `%d`
 7 │ }
   ╰────
  help: `fmt.Printf` formats `%d`, which needs an integer, but the argument has type `string`. Use `%s`, or convert the argument · code: [lint.printf_verb_mismatch]
```