### PR TITLE
refactor: parse attributes on enum variants

### DIFF
--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -49,6 +49,13 @@ pub fn iterate_non_unit_variant(attribute_span: &Span, variant_span: &Span) -> L
         .with_help("Remove the payload, or drop `#[iterate]`")
 }
 
+pub fn attribute_not_on_enum_variant(name: &str, attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error(format!("`#[{name}]` not on an enum variant"))
+        .with_attribute_code("attribute_not_on_enum_variant")
+        .with_span_label(attribute_span, "an enum variant does not accept this")
+        .with_help("Move it to the declaration it describes, or remove it")
+}
+
 pub fn iterate_generic_enum(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[iterate]` on generic enum")
         .with_attribute_code("iterate_generic_enum")

--- a/crates/format/src/formatter/top_level_item.rs
+++ b/crates/format/src/formatter/top_level_item.rs
@@ -309,6 +309,11 @@ impl<'a> Formatter<'a> {
     }
 
     fn enum_variant_body(&mut self, variant: &'a EnumVariant) -> Document<'a> {
+        let attributes = self.field_attributes(&variant.attributes);
+        attributes.append(self.enum_variant_declaration(variant))
+    }
+
+    fn enum_variant_declaration(&mut self, variant: &'a EnumVariant) -> Document<'a> {
         let name = Document::string(variant.name.to_string());
         match &variant.fields {
             VariantFields::Unit => name.append(","),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -514,9 +514,8 @@ pub(crate) fn attribute_completions(
 
     let mut items = match enclosing_context(before) {
         EnclosingContext::Struct => collect(attributes_for(AttributeTarget::StructField)),
-        EnclosingContext::Parenthesized | EnclosingContext::Enum | EnclosingContext::Function => {
-            Vec::new()
-        }
+        EnclosingContext::Enum => collect(attributes_for(AttributeTarget::EnumVariant)),
+        EnclosingContext::Parenthesized | EnclosingContext::Function => Vec::new(),
         EnclosingContext::Impl => match following_item(after).item {
             FollowingItem::Target(AttributeTarget::Function) | FollowingItem::Unknown => {
                 collect(attributes_for(AttributeTarget::Method))

--- a/crates/passes/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/passes/src/passes/lints/ast_walk/attributes.rs
@@ -17,12 +17,35 @@ pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
 }
 
 pub fn check_enum_attributes(expression: &Expression, ctx: &NodeCtx) {
-    let Expression::Enum { attributes, .. } = expression else {
+    let Expression::Enum {
+        attributes,
+        variants,
+        ..
+    } = expression
+    else {
         return;
     };
 
     for attribute in attributes {
         check_unknown_attribute(attribute, ctx.sink);
+    }
+
+    for variant in variants {
+        for attribute in &variant.attributes {
+            check_unknown_attribute(attribute, ctx.sink);
+            check_variant_attribute_target(attribute, ctx.sink);
+        }
+    }
+}
+
+fn check_variant_attribute_target(attribute: &Attribute, sink: &LocalSink) {
+    let accepted = attributes::lookup(&attribute.name)
+        .is_some_and(|info| info.applies_to(attributes::AttributeTarget::EnumVariant));
+    if !accepted && attributes::is_known_attribute(&attribute.name) {
+        sink.push(diagnostics::attribute::attribute_not_on_enum_variant(
+            &attribute.name,
+            &attribute.span,
+        ));
     }
 }
 

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -191,11 +191,15 @@ fn remap_methods<'a>(
 fn remap_variant(variant: &mut EnumVariant, remap: &mut impl FnMut(&mut Span)) {
     let EnumVariant {
         doc: _,
+        attributes,
         name: _,
         name_span,
         fields,
     } = variant;
     remap(name_span);
+    for attribute in attributes {
+        remap(&mut attribute.span);
+    }
     match fields {
         VariantFields::Unit => {}
         VariantFields::Tuple(fields) | VariantFields::Struct(fields) => {

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -269,6 +269,7 @@ impl TaskState {
 
         EnumVariant {
             doc: enum_variant.doc.clone(),
+            attributes: enum_variant.attributes.clone(),
             name: enum_variant.name.clone(),
             name_span: enum_variant.name_span,
             fields: new_fields,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -564,6 +564,7 @@ impl<'a> IntoIterator for &'a VariantFields {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnumVariant {
     pub doc: Option<String>,
+    pub attributes: Vec<Attribute>,
     pub name: EcoString,
     pub name_span: Span,
     pub fields: VariantFields,

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -8,6 +8,7 @@ pub enum AttributeTarget {
     Struct,
     StructField,
     Enum,
+    EnumVariant,
     Function,
     Method,
     TypeAlias,
@@ -142,6 +143,10 @@ pub(crate) fn field_attribute_forces_export(attribute: &Attribute) -> bool {
 
 pub fn known_attribute_names() -> Vec<&'static str> {
     ATTRIBUTES.iter().map(|a| a.name).collect()
+}
+
+pub fn lookup(name: &str) -> Option<&'static AttributeInfo> {
+    ATTRIBUTES.iter().find(|a| a.name == name)
 }
 
 pub fn attributes_for(target: AttributeTarget) -> impl Iterator<Item = &'static AttributeInfo> {

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -213,7 +213,9 @@ impl<'source> Parser<'source> {
             let start_position = self.stream.position;
 
             let variant_doc = self.collect_doc_comments().map(|(text, _)| text);
-            if let Some(variant) = self.parse_enum_variant_with_doc(variant_doc) {
+            let variant_attributes = self.parse_attributes();
+            if let Some(variant) = self.parse_enum_variant_with_doc(variant_doc, variant_attributes)
+            {
                 if let Some((_, first_span)) =
                     seen_variants.iter().find(|(n, _)| n == &variant.name)
                 {
@@ -253,7 +255,11 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_enum_variant_with_doc(&mut self, doc: Option<string::String>) -> Option<EnumVariant> {
+    fn parse_enum_variant_with_doc(
+        &mut self,
+        doc: Option<string::String>,
+        attributes: Vec<Attribute>,
+    ) -> Option<EnumVariant> {
         if self.is_not(Identifier) {
             self.track_error(
                 "expected variant name",
@@ -287,6 +293,7 @@ impl<'source> Parser<'source> {
 
         Some(EnumVariant {
             doc,
+            attributes,
             name,
             name_span,
             fields,

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -332,6 +332,11 @@ fn enum_empty() {
 }
 
 #[test]
+fn enum_variant_attribute_moves_to_its_own_line() {
+    assert_format_snapshot!("enum Colour { #[json(\"x\")] Red, Green }");
+}
+
+#[test]
 fn for_loop() {
     assert_format_snapshot!("fn test() { for item in items { process(item) } }");
 }

--- a/tests/spec/format/snapshots/enum_variant_attribute_moves_to_its_own_line.snap
+++ b/tests/spec/format/snapshots/enum_variant_attribute_moves_to_its_own_line.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "enum Colour { #[json(\"x\")] Red, Green }"
+---
+enum Colour {
+  #[json("x")]
+  Red,
+  Green,
+}

--- a/tests/spec/parse/snapshots/enum_adt.snap
+++ b/tests/spec/parse/snapshots/enum_adt.snap
@@ -21,6 +21,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "V4",
                 name_span: Span {
                     file_id: 0,
@@ -114,6 +115,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "V6",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_basic.snap
+++ b/tests/spec/parse/snapshots/enum_basic.snap
@@ -23,6 +23,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Pending",
                 name_span: Span {
                     file_id: 0,
@@ -33,6 +34,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Processing",
                 name_span: Span {
                     file_id: 0,
@@ -43,6 +45,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Complete",
                 name_span: Span {
                     file_id: 0,
@@ -53,6 +56,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Failed",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_mixed_variants.snap
+++ b/tests/spec/parse/snapshots/enum_mixed_variants.snap
@@ -22,6 +22,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Quit",
                 name_span: Span {
                     file_id: 0,
@@ -32,6 +33,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Move",
                 name_span: Span {
                     file_id: 0,
@@ -85,6 +87,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Write",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_struct_variant.snap
+++ b/tests/spec/parse/snapshots/enum_struct_variant.snap
@@ -20,6 +20,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Move",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_struct_variant_empty.snap
+++ b/tests/spec/parse/snapshots/enum_struct_variant_empty.snap
@@ -20,6 +20,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Eof",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_struct_variant_single_field.snap
+++ b/tests/spec/parse/snapshots/enum_struct_variant_single_field.snap
@@ -20,6 +20,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Click",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_trailing_comma.snap
+++ b/tests/spec/parse/snapshots/enum_trailing_comma.snap
@@ -22,6 +22,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Red",
                 name_span: Span {
                     file_id: 0,
@@ -32,6 +33,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Green",
                 name_span: Span {
                     file_id: 0,
@@ -42,6 +44,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Blue",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
+++ b/tests/spec/parse/snapshots/enum_tuple_variant_function_type_field.snap
@@ -20,6 +20,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "V",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_variant_rest_pattern.snap
+++ b/tests/spec/parse/snapshots/enum_variant_rest_pattern.snap
@@ -24,6 +24,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Triangle",
                 name_span: Span {
                     file_id: 0,
@@ -97,6 +98,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Circle",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/enum_with_generics.snap
+++ b/tests/spec/parse/snapshots/enum_with_generics.snap
@@ -42,6 +42,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Ok",
                 name_span: Span {
                     file_id: 0,
@@ -75,6 +76,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Err",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/generic_enum_multiple.snap
+++ b/tests/spec/parse/snapshots/generic_enum_multiple.snap
@@ -42,6 +42,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Ok",
                 name_span: Span {
                     file_id: 0,
@@ -75,6 +76,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Err",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/generic_enum_single.snap
+++ b/tests/spec/parse/snapshots/generic_enum_single.snap
@@ -32,6 +32,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Some",
                 name_span: Span {
                     file_id: 0,
@@ -65,6 +66,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "None",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/match_mixed_patterns.snap
+++ b/tests/spec/parse/snapshots/match_mixed_patterns.snap
@@ -29,6 +29,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Int",
                 name_span: Span {
                     file_id: 0,
@@ -62,6 +63,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Pair",
                 name_span: Span {
                     file_id: 0,
@@ -113,6 +115,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Text",
                 name_span: Span {
                     file_id: 0,
@@ -146,6 +149,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Nothing",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/match_nested_adt_with_wildcards.snap
+++ b/tests/spec/parse/snapshots/match_nested_adt_with_wildcards.snap
@@ -26,6 +26,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Running",
                 name_span: Span {
                     file_id: 0,
@@ -59,6 +60,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Stopped",
                 name_span: Span {
                     file_id: 0,
@@ -69,6 +71,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Error",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/or_pattern_enum_variants.snap
+++ b/tests/spec/parse/snapshots/or_pattern_enum_variants.snap
@@ -24,6 +24,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Red",
                 name_span: Span {
                     file_id: 0,
@@ -34,6 +35,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Green",
                 name_span: Span {
                     file_id: 0,
@@ -44,6 +46,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Blue",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/or_pattern_parenthesized.snap
+++ b/tests/spec/parse/snapshots/or_pattern_parenthesized.snap
@@ -23,6 +23,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Red",
                 name_span: Span {
                     file_id: 0,
@@ -33,6 +34,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Blue",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/pub_enum.snap
+++ b/tests/spec/parse/snapshots/pub_enum.snap
@@ -18,6 +18,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Active",
                 name_span: Span {
                     file_id: 0,
@@ -28,6 +29,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Inactive",
                 name_span: Span {
                     file_id: 0,

--- a/tests/spec/parse/snapshots/writable_qualifier_enum_payload.snap
+++ b/tests/spec/parse/snapshots/writable_qualifier_enum_payload.snap
@@ -18,6 +18,7 @@ description: |
         variants: [
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "Tags",
                 name_span: Span {
                     file_id: 0,
@@ -62,6 +63,7 @@ description: |
             },
             EnumVariant {
                 doc: None,
+                attributes: [],
                 name: "None",
                 name_span: Span {
                     file_id: 0,

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -28794,3 +28794,29 @@ fn main() {
 "#
     );
 }
+
+#[test]
+fn attribute_not_on_enum_variant() {
+    assert_lint_snapshot!(
+        r#"
+enum WithJson {
+  #[json("x")]
+  A,
+  B,
+}
+"#
+    );
+}
+
+#[test]
+fn go_attribute_not_on_enum_variant() {
+    assert_lint_snapshot!(
+        r#"
+enum GoOnVariant {
+  #[go(hidden_embed)]
+  A,
+  B,
+}
+"#
+    );
+}

--- a/tests/ui/lint/snapshots/attribute_not_on_enum_variant.snap
+++ b/tests/ui/lint/snapshots/attribute_not_on_enum_variant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ `#[json]` not on an enum variant
+   ╭─[test.lis:3:3]
+ 2 │ enum WithJson {
+ 3 │   #[json("x")]
+   ·   ──────┬─────
+   ·         ╰── an enum variant does not accept this
+ 4 │   A,
+   ╰────
+  help: Move it to the declaration it describes, or remove it · code: [attribute.attribute_not_on_enum_variant]

--- a/tests/ui/lint/snapshots/go_attribute_not_on_enum_variant.snap
+++ b/tests/ui/lint/snapshots/go_attribute_not_on_enum_variant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ `#[go]` not on an enum variant
+   ╭─[test.lis:3:3]
+ 2 │ enum GoOnVariant {
+ 3 │   #[go(hidden_embed)]
+   ·   ─────────┬─────────
+   ·            ╰── an enum variant does not accept this
+ 4 │   A,
+   ╰────
+  help: Move it to the declaration it describes, or remove it · code: [attribute.attribute_not_on_enum_variant]


### PR DESCRIPTION
Attributes on enum variants are now handled in the parser, formatter, and checker. No attribute targets a variant yet, so every one is rejected by name or by placement.
