### PR TITLE
fix: write permission for `&` on call result

### DIFF
--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -349,7 +349,7 @@ impl InferCtx<'_> {
                 } else {
                     coercion = Some(ReceiverCoercion::AutoAddress);
                     if receiver_ty.is_writable() {
-                        self.check_auto_address_mutation(receiver_expression, method_name, span);
+                        self.check_auto_address_mutation(receiver_expression, span);
                     }
                 }
                 // Unify inner types: T with T (from Ref<T>)
@@ -379,28 +379,27 @@ impl InferCtx<'_> {
         coercion
     }
 
-    /// When auto-addressing a receiver (T → Ref<T>), verify the binding
-    /// is declared `let mut`, since the Ref<T> method may mutate it.
-    fn check_auto_address_mutation(
-        &mut self,
-        receiver_expression: &Expression,
-        _method_name: &str,
-        span: &Span,
-    ) {
+    /// An auto-addressed receiver of a writing method must permit the write.
+    fn check_auto_address_mutation(&mut self, receiver_expression: &Expression, span: &Span) {
         let store = self.store;
-        // Ref<T> methods can mutate, require `let mut` on the receiver binding,
-        // unless the receiver chain contains a deref (mutation goes through pointer).
-        let Some(var_name) = receiver_expression.get_var_name() else {
-            return;
-        };
-
-        if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
-            self.facts.mark_alias_mutated(binding_id);
+        if let Some(var_name) = receiver_expression.get_var_name() {
+            if let Some(binding_id) = self.scopes.lookup_binding_id(&var_name) {
+                self.facts.mark_alias_mutated(binding_id);
+            }
+            if self.imports.namespace(&var_name).is_some() {
+                return;
+            }
         }
-        if !self.place_permits_write(receiver_expression)
-            && self.imports.namespace(&var_name).is_none()
-        {
-            self.report_disallowed_mutation(store, &var_name, *span, false, None);
+        match self.classify_write_target(receiver_expression) {
+            super::permission::WriteTarget::Through { governing } if !governing.is_writable() => {
+                self.report_write_through_read_only(receiver_expression, &governing, *span);
+            }
+            super::permission::WriteTarget::Binding { name }
+                if !self.scopes.lookup_mutable(&name) =>
+            {
+                self.report_disallowed_mutation(store, &name, *span, false, None);
+            }
+            _ => {}
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/permission.rs
+++ b/crates/semantics/src/checker/infer/expressions/permission.rs
@@ -555,6 +555,54 @@ impl InferCtx<'_> {
             None => true,
         }
     }
+
+    pub(super) fn report_write_through_read_only(
+        &mut self,
+        target: &Expression,
+        governing: &Type,
+        span: Span,
+    ) {
+        let store = self.store;
+        let root = super::aliasing::place_root_name(target.unwrap_parens());
+        let root_binding = root
+            .as_ref()
+            .and_then(|root| self.scopes.lookup_binding_id(root));
+        let receiver_needs_mut = root.as_deref() == Some("self")
+            && !self
+                .lookup_type(store, "self")
+                .map(|ty| store.peel_alias(&ty.resolve_in(&self.env)))
+                .is_some_and(|ty| ty.is_ref() && ty.is_writable());
+        if receiver_needs_mut {
+            self.report_disallowed_mutation(store, "self", span, false, None);
+        } else if root_binding
+            .and_then(|id| self.binding_inference.get(&id))
+            .and_then(|binding| binding.as_let())
+            .is_some_and(|inference| inference.mutability.was_demoted())
+        {
+            self.report_disallowed_mutation(store, &root.expect("rooted"), span, false, None);
+        } else if let Some(id) = root_binding.filter(|id| {
+            self.binding_inference
+                .get(id)
+                .and_then(|binding| binding.as_loop_element())
+                .is_some_and(|inference| inference.was_demoted)
+        }) {
+            if self.reported_immutable.insert(id) {
+                self.sink.push(diagnostics::infer::loop_binding_read_only(
+                    &root.expect("rooted"),
+                    span,
+                ));
+            }
+        } else if self.report_read_only_write(target) {
+            let context = self.write_context(target);
+            self.sink.push(diagnostics::infer::write_through_read_only(
+                &super::aliasing::render_place(target),
+                &self.write_hop_place(target),
+                &governing.to_string(),
+                span,
+                context,
+            ));
+        }
+    }
 }
 
 impl InferCtx<'_> {

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -192,9 +192,9 @@ impl InferCtx<'_> {
                 .add_overused_reference(span, new_expression.get_var_name());
             resolved_inner
         } else {
-            // The pointer is writable exactly when the place is, and a construction is a fresh cell.
+            // A construction or a call result is a fresh cell that no binding shares.
             let writable = match new_expression.unwrap_parens() {
-                Expression::StructCall { .. } => true,
+                Expression::StructCall { .. } | Expression::Call { .. } => true,
                 other => self.place_permits_write(other),
             };
             Type::qualified_compound(CompoundKind::Ref, vec![inner_ty.clone()], writable)
@@ -478,51 +478,7 @@ impl InferCtx<'_> {
         match self.classify_write_target(&new_target) {
             super::permission::WriteTarget::Through { governing } => {
                 if !governing.is_writable() {
-                    let root = super::aliasing::place_root_name(new_target.unwrap_parens());
-                    let root_binding = root
-                        .as_ref()
-                        .and_then(|root| self.scopes.lookup_binding_id(root));
-                    let receiver_needs_mut = root.as_deref() == Some("self")
-                        && !self
-                            .lookup_type(store, "self")
-                            .map(|ty| store.peel_alias(&ty.resolve_in(&self.env)))
-                            .is_some_and(|ty| ty.is_ref() && ty.is_writable());
-                    if receiver_needs_mut {
-                        self.report_disallowed_mutation(store, "self", span, false, None);
-                    } else if root_binding
-                        .and_then(|id| self.binding_inference.get(&id))
-                        .and_then(|binding| binding.as_let())
-                        .is_some_and(|inference| inference.mutability.was_demoted())
-                    {
-                        self.report_disallowed_mutation(
-                            store,
-                            &root.expect("rooted"),
-                            span,
-                            false,
-                            None,
-                        );
-                    } else if let Some(id) = root_binding.filter(|id| {
-                        self.binding_inference
-                            .get(id)
-                            .and_then(|binding| binding.as_loop_element())
-                            .is_some_and(|inference| inference.was_demoted)
-                    }) {
-                        if self.reported_immutable.insert(id) {
-                            self.sink.push(diagnostics::infer::loop_binding_read_only(
-                                &root.expect("rooted"),
-                                span,
-                            ));
-                        }
-                    } else if self.report_read_only_write(&new_target) {
-                        let context = self.write_context(&new_target);
-                        self.sink.push(diagnostics::infer::write_through_read_only(
-                            &super::aliasing::render_place(&new_target),
-                            &self.write_hop_place(&new_target),
-                            &governing.to_string(),
-                            span,
-                            context,
-                        ));
-                    }
+                    self.report_write_through_read_only(&new_target, &governing, span);
                 }
             }
             super::permission::WriteTarget::Binding { name } => {

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -533,6 +533,82 @@ fn ref_of_immutable_binding_write_refused() {
     .assert_infer_code("write_through_read_only");
 }
 
+#[test]
+fn ref_of_call_result_is_writable() {
+    infer(
+        r#"struct Foo { x: int }
+impl Foo {
+  fn new() -> Foo { Foo { x: 0 } }
+}
+fn bazzle(foo: mut Ref<Foo>) { foo.x = 1 }
+fn main() {
+  bazzle(&Foo.new())
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn ref_of_primitive_call_result_is_writable() {
+    infer(
+        r#"fn make_int() -> int { 5 }
+fn bump(n: mut Ref<int>) { n.* += 1 }
+fn main() {
+  bump(&make_int())
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn call_rooted_receiver_write_refused() {
+    infer(
+        r#"struct Foo { x: int }
+impl Foo {
+  fn bump(self: mut Ref<Foo>) { self.x += 1 }
+}
+fn make_slice() -> Slice<Foo> { [Foo { x: 0 }] }
+fn main() {
+  make_slice()[0].bump()
+}"#,
+    )
+    .assert_infer_code("write_through_read_only");
+}
+
+#[test]
+fn read_only_call_result_receiver_names_the_binding() {
+    infer(
+        r#"struct Foo { x: int }
+impl Foo {
+  fn bump(self: mut Ref<Foo>) { self.x += 1 }
+}
+fn make_slice() -> Slice<Foo> { [Foo { x: 0 }] }
+fn main() {
+  let mut s = make_slice()
+  s[0].bump()
+}"#,
+    )
+    .assert_infer_code("write_through_read_only")
+    .assert_error_contains("`s` is read-only");
+}
+
+#[test]
+fn receiver_on_call_result_accepted() {
+    infer(
+        r#"struct Foo { x: int }
+impl Foo {
+  fn new() -> Foo { Foo { x: 0 } }
+  fn bump(self: mut Ref<Foo>) { self.x += 1 }
+}
+fn make_slice() -> mut Slice<Foo> { [Foo { x: 0 }] }
+fn main() {
+  Foo.new().bump()
+  make_slice()[0].bump()
+}"#,
+    )
+    .assert_no_errors();
+}
+
 // Programs that must stay accepted: false positives the model removes.
 
 #[test]


### PR DESCRIPTION
Fix #1374