### PR TITLE
feat: `#[default]` for enum zero values

### DIFF
--- a/crates/cli/reference/attributes.md
+++ b/crates/cli/reference/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: "Attributes"
-description: "Serialization and custom tags, iteration, display, equality, lint suppression"
+description: "Serialization and custom tags, iteration, display, equality, default variants, lint suppression"
 ---
 
 Attributes attach metadata or behavior to declarations.
@@ -332,6 +332,55 @@ let b = Batch { item: Order { id: 1, tags: ["a"] } }
 
 // !callout-right `true`
 a.equals(b)
+```
+
+## `#[default]`
+
+Out of the box, an enum has no zero value.
+
+```lisette
+enum Status {
+  Active,
+  Paused,
+  Stopped,
+}
+
+// !callout-error-right error: `Status` has no zero value
+let queue = Slice.make<Status>(2)
+// !callout-error-right error: `Status` has no zero value
+let slots = Array.new<Status, 3>()
+```
+
+Place `#[default]` on an enum variant to make it the zero value.
+
+```lisette
+enum Status {
+  Active,
+  Paused,
+  #[default]
+  Stopped,
+}
+
+// !callout-right `[Stopped, Stopped]`
+let queue = Slice.make<Status>(2)
+// !callout-right `[Stopped, Stopped, Stopped]`
+let slots = Array.new<Status, 3>()
+```
+
+An enum's default appears wherever a zero value is expected.
+
+```lisette
+struct Job {
+  pub name: string,
+  pub status: Status,
+}
+
+// !callout[/job/] `job.status` is `Status.Stopped`
+let job = Job { name: "build", .. }
+
+let by_name = Map.new<string, Status>()
+// !callout[/missing/] `Status.Stopped`
+let missing = by_name["absent"]
 ```
 
 ## `#[allow]`

--- a/crates/diagnostics/src/attribute.rs
+++ b/crates/diagnostics/src/attribute.rs
@@ -56,6 +56,45 @@ pub fn attribute_not_on_enum_variant(name: &str, attribute_span: &Span) -> Liset
         .with_help("Move it to the declaration it describes, or remove it")
 }
 
+pub fn default_not_on_enum_variant(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[default]` not on an enum variant")
+        .with_attribute_code("default_not_on_enum_variant")
+        .with_span_label(attribute_span, "expected on a variant")
+        .with_help("Place `#[default]` on the variant that is the enum's zero value")
+}
+
+pub fn default_variant_in_typedef(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[default]` in a typedef")
+        .with_attribute_code("default_variant_in_typedef")
+        .with_span_label(
+            attribute_span,
+            "a generated declaration cannot claim a zero",
+        )
+        .with_help("A Go type's zero value comes from Go, so Lisette does not choose one")
+}
+
+pub fn default_variant_with_payload(variant_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[default]` on a variant with a payload")
+        .with_attribute_code("default_variant_with_payload")
+        .with_span_label(variant_span, "this variant has a payload")
+        .with_help("`#[default]` is allowed only on a payload-less variant")
+}
+
+pub fn duplicate_default_variant(attribute_span: &Span, first_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Duplicate default variants")
+        .with_attribute_code("duplicate_default_variant")
+        .with_span_label(first_span, "first")
+        .with_span_label(attribute_span, "second")
+        .with_help("Mark a single variant with `#[default]`")
+}
+
+pub fn default_takes_no_arguments(attribute_span: &Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`#[default]` takes no arguments")
+        .with_attribute_code("default_takes_no_arguments")
+        .with_span_label(attribute_span, "disallowed")
+        .with_help("Write `#[default]` without passing any arguments")
+}
+
 pub fn iterate_generic_enum(attribute_span: &Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`#[iterate]` on generic enum")
         .with_attribute_code("iterate_generic_enum")

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -244,9 +244,13 @@ impl Planner<'_> {
 
     fn compute_enum_layout(&self, enum_id: &str) -> Option<EnumLayout> {
         let Definition {
-            body: DefinitionBody::Enum {
-                generics, variants, ..
-            },
+            body:
+                DefinitionBody::Enum {
+                    generics,
+                    variants,
+                    default_variant,
+                    ..
+                },
             ..
         } = self.facts.definition(enum_id)?
         else {
@@ -291,6 +295,7 @@ impl Planner<'_> {
             variants,
             &field_types,
             requirements,
+            *default_variant,
         ))
     }
 

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -17,6 +17,8 @@ pub(crate) struct EnumLayout {
     pub(crate) variants: Vec<VariantLayout>,
     pub(crate) generics: Vec<Generic>,
     requirements: PackageRequirements,
+    /// Index of the `#[default]` variant, which takes tag `0`.
+    default_variant: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +55,7 @@ impl EnumLayout {
         variants: &[EnumVariant],
         field_types: &FieldTypeMap,
         requirements: PackageRequirements,
+        default_variant: Option<usize>,
     ) -> Self {
         let enum_name = go_name::unqualified_name(enum_id).to_string();
         let tag_type = format!("{}Tag", enum_name);
@@ -70,7 +73,26 @@ impl EnumLayout {
             variants,
             generics: generics.to_vec(),
             requirements,
+            default_variant,
         }
+    }
+
+    /// Declaration order, except that the marked variant takes `0`.
+    fn tag_values(&self) -> Vec<usize> {
+        let Some(default_index) = self.default_variant.filter(|index| *index != 0) else {
+            return (0..self.variants.len()).collect();
+        };
+        let mut next = 1;
+        (0..self.variants.len())
+            .map(|index| {
+                if index == default_index {
+                    return 0;
+                }
+                let value = next;
+                next += 1;
+                value
+            })
+            .collect()
     }
 
     pub(crate) fn requirements(&self) -> &PackageRequirements {
@@ -153,6 +175,9 @@ impl EnumLayout {
         if !self.variants.is_empty() {
             output.push("const (".to_string());
 
+            let renumbered = self.default_variant.is_some_and(|index| index != 0);
+            let values = self.tag_values();
+
             for (i, variant) in self.variants.iter().enumerate() {
                 if let Some(doc) = &variant.doc {
                     for line in doc.lines() {
@@ -160,7 +185,12 @@ impl EnumLayout {
                     }
                 }
 
-                if i == 0 {
+                if renumbered {
+                    output.push(format!(
+                        "{} {} = {}",
+                        variant.tag_constant, self.tag_type, values[i]
+                    ));
+                } else if i == 0 {
                     output.push(format!("{} {} = iota", variant.tag_constant, self.tag_type));
                 } else {
                     output.push(variant.tag_constant.clone());

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -495,6 +495,13 @@ impl Planner<'_> {
             } => true,
             Type::Array { element, .. } => self.element_go_zero_ok(element),
             Type::Tuple(elements) => elements.iter().all(|e| self.element_go_zero_ok(e)),
+            Type::Nominal { id, .. } => matches!(
+                &self.facts.definition(id.as_str()).map(|d| &d.body),
+                Some(DefinitionBody::Enum {
+                    default_variant: Some(_),
+                    ..
+                })
+            ),
             _ => false,
         }
     }

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -908,9 +908,9 @@ mod attribute_completion_tests {
     }
 
     #[test]
-    fn enum_variant_position_offers_nothing() {
+    fn enum_variant_position_offers_default() {
         let labels = labels_at("enum E {\n  #[|\n  A\n}", false).unwrap();
-        assert!(labels.is_empty());
+        assert_eq!(labels, vec!["default".to_string()]);
     }
 
     #[test]

--- a/crates/passes/src/passes/lints/ast_walk/attributes.rs
+++ b/crates/passes/src/passes/lints/ast_walk/attributes.rs
@@ -7,13 +7,16 @@ use syntax::attributes::is_serialization_key;
 
 pub fn check_attributes(expression: &Expression, ctx: &NodeCtx) {
     let attributes = match expression {
-        Expression::Function { attributes, .. } => attributes,
+        Expression::Function { attributes, .. } | Expression::TypeAlias { attributes, .. } => {
+            attributes
+        }
         _ => return,
     };
 
     for attribute in attributes {
         check_unknown_attribute(attribute, ctx.sink);
     }
+    check_misplaced_default(attributes, ctx.sink);
 }
 
 pub fn check_enum_attributes(expression: &Expression, ctx: &NodeCtx) {
@@ -29,6 +32,7 @@ pub fn check_enum_attributes(expression: &Expression, ctx: &NodeCtx) {
     for attribute in attributes {
         check_unknown_attribute(attribute, ctx.sink);
     }
+    check_misplaced_default(attributes, ctx.sink);
 
     for variant in variants {
         for attribute in &variant.attributes {
@@ -44,6 +48,14 @@ fn check_variant_attribute_target(attribute: &Attribute, sink: &LocalSink) {
     if !accepted && attributes::is_known_attribute(&attribute.name) {
         sink.push(diagnostics::attribute::attribute_not_on_enum_variant(
             &attribute.name,
+            &attribute.span,
+        ));
+    }
+}
+
+pub fn check_misplaced_default(attributes: &[Attribute], sink: &LocalSink) {
+    for attribute in attributes.iter().filter(|a| a.name == "default") {
+        sink.push(diagnostics::attribute::default_not_on_enum_variant(
             &attribute.span,
         ));
     }
@@ -65,6 +77,7 @@ pub fn check_struct_attributes(expression: &Expression, ctx: &NodeCtx) {
         check_unknown_tag_options(attribute, sink);
         check_conflicting_case_transforms(attribute, sink);
     }
+    check_misplaced_default(struct_attributes, sink);
 
     let struct_keys: HashSet<&str> = struct_attributes
         .iter()
@@ -132,6 +145,7 @@ fn check_field_attributes(
         // Check for raw tags that should use predefined aliases
         check_tag_with_alias(attribute, sink);
     }
+    check_misplaced_default(field.attributes(), sink);
 }
 
 /// Gets the effective key for an attribute (for deduplication).

--- a/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/replaceable_with_autofill.rs
@@ -1,7 +1,7 @@
 use diagnostics::{Edit, Fix};
 use rustc_hash::FxHashSet as HashSet;
 use syntax::ast::{Expression, Literal, Span, StructFieldAssignment, StructSpread};
-use syntax::program::DefinitionBody;
+use syntax::program::{DefinitionBody, DotAccessResolution};
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
 use super::helpers::replacement_drops_comment;
@@ -29,7 +29,7 @@ pub fn check_replaceable_with_autofill(expression: &Expression, ctx: &NodeCtx) {
 
     let zero_count = field_assignments
         .iter()
-        .filter(|f| is_obvious_zero(&f.value))
+        .filter(|f| is_obvious_zero(&f.value, ctx.store))
         .count();
     if zero_count < ZERO_FIELD_THRESHOLD {
         return;
@@ -45,7 +45,7 @@ pub fn check_replaceable_with_autofill(expression: &Expression, ctx: &NodeCtx) {
         return;
     }
 
-    let kept = render_kept_fields(ctx.source(), field_assignments);
+    let kept = render_kept_fields(ctx.source(), field_assignments, ctx.store);
     let owner_span = Span::new(span.file_id, span.byte_offset, name.len() as u32);
     let replacement = if kept.is_empty() {
         format!("{name} {{ .. }}")
@@ -62,10 +62,10 @@ pub fn check_replaceable_with_autofill(expression: &Expression, ctx: &NodeCtx) {
     ctx.sink.push(diagnostic);
 }
 
-fn render_kept_fields(source: &str, fields: &[StructFieldAssignment]) -> String {
+fn render_kept_fields(source: &str, fields: &[StructFieldAssignment], store: &Store) -> String {
     fields
         .iter()
-        .filter(|f| !is_obvious_zero(&f.value))
+        .filter(|f| !is_obvious_zero(&f.value, store))
         .map(|f| {
             let value_span = f.value.get_span();
             let start = f.name_span.byte_offset as usize;
@@ -79,7 +79,7 @@ fn render_kept_fields(source: &str, fields: &[StructFieldAssignment]) -> String 
         .join(", ")
 }
 
-fn is_obvious_zero(value: &Expression) -> bool {
+fn is_obvious_zero(value: &Expression, store: &Store) -> bool {
     match value {
         Expression::Literal { literal, .. } => match literal {
             Literal::Integer { value, .. } => *value == 0,
@@ -89,8 +89,29 @@ fn is_obvious_zero(value: &Expression) -> bool {
             _ => false,
         },
         Expression::Identifier { value, .. } => value.as_str() == "None",
+        Expression::DotAccess { resolution, .. } => is_default_variant(resolution, store),
         _ => false,
     }
+}
+
+fn is_default_variant(resolution: &DotAccessResolution, store: &Store) -> bool {
+    let DotAccessResolution::EnumVariant { definition } = resolution else {
+        return false;
+    };
+    let Some((enum_id, variant_name)) = definition.as_str().rsplit_once('.') else {
+        return false;
+    };
+    let Some(DefinitionBody::Enum {
+        variants,
+        default_variant: Some(index),
+        ..
+    }) = store.get_definition(enum_id).map(|d| &d.body)
+    else {
+        return false;
+    };
+    variants
+        .get(*index)
+        .is_some_and(|variant| variant.name == variant_name)
 }
 
 fn is_go_imported(ty: &Type) -> bool {
@@ -150,7 +171,7 @@ fn post_rewrite_unspecified_fields(
 ) -> Option<Vec<OmittedField>> {
     let kept: HashSet<&str> = field_assignments
         .iter()
-        .filter(|f| !is_obvious_zero(&f.value))
+        .filter(|f| !is_obvious_zero(&f.value, store))
         .map(|f| f.name.as_str())
         .collect();
     fields_filtered(store, ty, name, &kept)

--- a/crates/passes/src/passes/lints/ast_walk/mod.rs
+++ b/crates/passes/src/passes/lints/ast_walk/mod.rs
@@ -163,7 +163,7 @@ fn run_expression_checks(expression: &Expression, ctx: &mut NodeCtx<'_>, role: F
         (check_duplicate_cutset, &[Call]),
         (check_struct_attributes, &[Struct]),
         (check_ineffective_omitempty, &[Struct]),
-        (check_attributes, &[Function]),
+        (check_attributes, &[Function, TypeAlias]),
         (check_enum_attributes, &[Enum]),
         (check_duplicate_logical_operand, &[Binary]),
         (check_negated_logical_operand, &[Binary]),

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -93,6 +93,7 @@ fn remap_definition_spans(definition: &mut Definition, remap: &mut impl FnMut(&m
             variants,
             methods,
             attributes: _,
+            default_variant: _,
         } => {
             remap_generics(generics, remap);
             for variant in variants {

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -53,6 +53,8 @@ impl TaskState {
 
         self.check_enum_field_slot_collisions(name, &new_variants);
 
+        let default_variant = self.resolve_default_variant(&*store, &new_variants);
+
         let visibility = self
             .current_package(&*store)
             .definitions
@@ -80,6 +82,7 @@ impl TaskState {
                     variants: new_variants,
                     methods: Methods::default(),
                     attributes,
+                    default_variant,
                 },
             },
         );
@@ -247,6 +250,53 @@ impl TaskState {
                 ));
             }
         }
+    }
+
+    fn resolve_default_variant(
+        &mut self,
+        store: &Store,
+        variants: &[EnumVariant],
+    ) -> Option<usize> {
+        let in_typedef = self.is_d_lis(store);
+        let mut marked: Option<(usize, Span)> = None;
+        for (index, variant) in variants.iter().enumerate() {
+            for attribute in variant
+                .attributes
+                .iter()
+                .filter(|attribute| attribute.name == "default")
+            {
+                if !attribute.args.is_empty() {
+                    self.sink
+                        .push(diagnostics::attribute::default_takes_no_arguments(
+                            &attribute.span,
+                        ));
+                }
+                if in_typedef {
+                    self.sink
+                        .push(diagnostics::attribute::default_variant_in_typedef(
+                            &attribute.span,
+                        ));
+                    continue;
+                }
+                if let Some((_, first_span)) = marked {
+                    self.sink
+                        .push(diagnostics::attribute::duplicate_default_variant(
+                            &attribute.span,
+                            &first_span,
+                        ));
+                    continue;
+                }
+                if !matches!(variant.fields, VariantFields::Unit) {
+                    self.sink
+                        .push(diagnostics::attribute::default_variant_with_payload(
+                            &variant.name_span,
+                        ));
+                    continue;
+                }
+                marked = Some((index, attribute.span));
+            }
+        }
+        marked.map(|(index, _)| index)
     }
 
     fn resolve_enum_variant_fields(

--- a/crates/semantics/src/zero.rs
+++ b/crates/semantics/src/zero.rs
@@ -295,8 +295,10 @@ impl ZeroWalk<'_> {
                     .expect("transparent alias has a target");
                 self.walk(&resolved)
             }
-            // Enums and other definitions have no zero unless we add a designated
-            // default-variant mechanism later.
+            DefinitionBody::Enum {
+                default_variant: Some(_),
+                ..
+            } => Ok(()),
             _ => Err(NoZero {
                 chain: vec![],
                 reason: NoZeroReason::NoZeroForType,

--- a/crates/syntax/src/attributes.rs
+++ b/crates/syntax/src/attributes.rs
@@ -113,6 +113,11 @@ pub const ATTRIBUTES: &[AttributeInfo] = &[
         detail: "mark a test function",
         targets: &[Function],
     },
+    AttributeInfo {
+        name: "default",
+        detail: "mark the variant that is the enum's zero value",
+        targets: &[EnumVariant],
+    },
 ];
 
 /// `go` is accepted but absent from [`ATTRIBUTES`] (the Go-interop rail).

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -92,6 +92,8 @@ pub enum DefinitionBody {
         variants: Vec<EnumVariant>,
         methods: Methods,
         attributes: Attributes,
+        /// Index into `variants`, if the enum marks one.
+        default_variant: Option<usize>,
     },
     Struct {
         generics: Vec<Generic>,

--- a/tests/e2e_smoke_project/src/collections.test.lis
+++ b/tests/e2e_smoke_project/src/collections.test.lis
@@ -253,6 +253,73 @@ fn array_from_named_constant_size() {
   assert size == 3
 }
 
+enum Shade {
+  #[default]
+  Pale,
+  Deep,
+}
+
+enum LaterDefault {
+  First,
+  #[default]
+  Second,
+}
+
+struct Wall {
+  pub name: string,
+  pub shade: Shade,
+}
+
+struct LaterBox {
+  pub mode: LaterDefault,
+}
+
+#[test]
+fn default_variant_zero_fills_an_array() {
+  let mut a = Array.new<Shade, 3>()
+  assert a[0] == Shade.Pale && a[2] == Shade.Pale
+  a[1] = Shade.Deep
+  assert a[1] == Shade.Deep
+}
+
+#[test]
+fn default_variant_zero_fills_a_slice() {
+  let s = Slice.make<Shade>(2)
+  assert s.length() == 2 && s[1] == Shade.Pale
+}
+
+#[test]
+fn default_variant_fills_a_struct_spread() {
+  let wall = Wall { name: "hall", .. }
+  assert wall.shade == Shade.Pale
+}
+
+#[test]
+fn default_variant_after_the_first_is_used() {
+  let mut a = Array.new<LaterDefault, 2>()
+  assert a[0] == LaterDefault.Second && a[1] == LaterDefault.Second
+  a[0] = LaterDefault.First
+  assert a[0] == LaterDefault.First
+}
+
+#[test]
+fn default_variant_answers_a_missing_map_key() {
+  let shades = Map.new<string, Shade>()
+  assert shades["absent"] == Shade.Pale
+}
+
+#[test]
+fn later_default_variant_answers_a_missing_map_key() {
+  let modes = Map.new<string, LaterDefault>()
+  assert modes["absent"] == LaterDefault.Second
+}
+
+#[test]
+fn later_default_variant_reaches_through_a_struct() {
+  let boxes = Map.new<string, LaterBox>()
+  assert boxes["absent"].mode == LaterDefault.Second
+}
+
 #[test]
 fn array_alias_at_use_sites() {
   let x: Vec3 = [1, 2, 3]

--- a/tests/spec/emit/arrays.rs
+++ b/tests/spec/emit/arrays.rs
@@ -868,3 +868,91 @@ fn head(b: Buffer) -> Option<Array<byte, 2>> {
 "#;
     assert_emit_snapshot!(input);
 }
+
+// A `#[default]` variant takes Go tag `0`, so Go's own zero is that variant.
+
+#[test]
+fn array_new_default_variant_first_uses_go_zero_fill() {
+    let input = r#"
+enum Colour {
+  #[default]
+  Red,
+  Green,
+}
+
+fn swatch() -> Array<Colour, 3> {
+  Array.new<Colour, 3>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn array_new_later_default_variant_uses_go_zero_fill() {
+    let input = r#"
+enum Colour {
+  Red,
+  #[default]
+  Green,
+}
+
+fn swatch() -> Array<Colour, 3> {
+  Array.new<Colour, 3>()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_spread_fills_a_default_variant_field() {
+    let input = r#"
+enum Colour {
+  Red,
+  #[default]
+  Green,
+}
+
+struct Paint {
+  name: string,
+  shade: Colour,
+}
+
+fn blank() -> Paint {
+  Paint { name: "a", .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn later_default_variant_takes_tag_zero() {
+    let input = r#"
+enum Colour {
+  Red,
+  #[default]
+  Green,
+  Blue,
+}
+
+fn lookup(m: Map<string, Colour>) -> Colour {
+  m["a"]
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn first_default_variant_keeps_iota() {
+    let input = r#"
+enum Colour {
+  #[default]
+  Red,
+  Green,
+}
+
+fn lookup(m: Map<string, Colour>) -> Colour {
+  m["a"]
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/array_new_default_variant_first_uses_go_zero_fill.snap
+++ b/tests/spec/emit/snapshots/array_new_default_variant_first_uses_go_zero_fill.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour {
+    #[default]
+    Red,
+    Green,
+  }
+  
+  fn swatch() -> Array<Colour, 3> {
+    Array.new<Colour, 3>()
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+type ColourTag int
+
+const (
+	ColourRed ColourTag = iota
+	ColourGreen
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+func swatch() [3]Colour {
+	return [3]Colour{}
+}

--- a/tests/spec/emit/snapshots/array_new_later_default_variant_uses_go_zero_fill.snap
+++ b/tests/spec/emit/snapshots/array_new_later_default_variant_uses_go_zero_fill.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour {
+    Red,
+    #[default]
+    Green,
+  }
+  
+  fn swatch() -> Array<Colour, 3> {
+    Array.new<Colour, 3>()
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+type ColourTag int
+
+const (
+	ColourRed   ColourTag = 1
+	ColourGreen ColourTag = 0
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+func swatch() [3]Colour {
+	return [3]Colour{}
+}

--- a/tests/spec/emit/snapshots/first_default_variant_keeps_iota.snap
+++ b/tests/spec/emit/snapshots/first_default_variant_keeps_iota.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour {
+    #[default]
+    Red,
+    Green,
+  }
+  
+  fn lookup(m: Map<string, Colour>) -> Colour {
+    m["a"]
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+type ColourTag int
+
+const (
+	ColourRed ColourTag = iota
+	ColourGreen
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+func lookup(m map[string]Colour) Colour {
+	return m["a"]
+}

--- a/tests/spec/emit/snapshots/later_default_variant_takes_tag_zero.snap
+++ b/tests/spec/emit/snapshots/later_default_variant_takes_tag_zero.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour {
+    Red,
+    #[default]
+    Green,
+    Blue,
+  }
+  
+  fn lookup(m: Map<string, Colour>) -> Colour {
+    m["a"]
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+func MakeColourBlue() Colour {
+	return Colour{Tag: ColourBlue}
+}
+
+type ColourTag int
+
+const (
+	ColourRed   ColourTag = 1
+	ColourGreen ColourTag = 0
+	ColourBlue  ColourTag = 2
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+func lookup(m map[string]Colour) Colour {
+	return m["a"]
+}

--- a/tests/spec/emit/snapshots/struct_spread_fills_a_default_variant_field.snap
+++ b/tests/spec/emit/snapshots/struct_spread_fills_a_default_variant_field.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/arrays.rs
+description: |
+  
+  enum Colour {
+    Red,
+    #[default]
+    Green,
+  }
+  
+  struct Paint {
+    name: string,
+    shade: Colour,
+  }
+  
+  fn blank() -> Paint {
+    Paint { name: "a", .. }
+  }
+---
+package main
+
+func MakeColourRed() Colour {
+	return Colour{Tag: ColourRed}
+}
+
+func MakeColourGreen() Colour {
+	return Colour{Tag: ColourGreen}
+}
+
+type ColourTag int
+
+const (
+	ColourRed   ColourTag = 1
+	ColourGreen ColourTag = 0
+)
+
+type Colour struct {
+	Tag ColourTag
+}
+
+type Paint struct {
+	name  string
+	shade Colour
+}
+
+func blank() Paint {
+	return Paint{
+		name:  "a",
+		shade: Colour{},
+	}
+}

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -337,6 +337,18 @@ fn enum_variant_attribute_moves_to_its_own_line() {
 }
 
 #[test]
+fn enum_default_variant_moves_to_its_own_line() {
+    assert_format_snapshot!("enum Colour { #[default] Red, Green }");
+}
+
+#[test]
+fn enum_default_variant_keeps_its_doc_comment() {
+    assert_format_snapshot!(
+        "enum Colour {\n  /// The zero value.\n  #[default]\n  Red,\n  Green,\n}"
+    );
+}
+
+#[test]
 fn for_loop() {
     assert_format_snapshot!("fn test() { for item in items { process(item) } }");
 }

--- a/tests/spec/format/snapshots/enum_default_variant_keeps_its_doc_comment.snap
+++ b/tests/spec/format/snapshots/enum_default_variant_keeps_its_doc_comment.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  enum Colour {
+    /// The zero value.
+    #[default]
+    Red,
+    Green,
+  }
+---
+enum Colour {
+  /// The zero value.
+  #[default]
+  Red,
+  Green,
+}

--- a/tests/spec/format/snapshots/enum_default_variant_moves_to_its_own_line.snap
+++ b/tests/spec/format/snapshots/enum_default_variant_moves_to_its_own_line.snap
@@ -1,0 +1,9 @@
+---
+source: tests/spec/format/mod.rs
+description: "enum Colour { #[default] Red, Green }"
+---
+enum Colour {
+  #[default]
+  Red,
+  Green,
+}

--- a/tests/spec/infer/arrays.rs
+++ b/tests/spec/infer/arrays.rs
@@ -855,3 +855,67 @@ fn array_size_rejects_a_test_only_constant_from_a_production_file() {
     );
     infer_package("main", fs).assert_infer_code("array_size_unknown_constant");
 }
+
+#[test]
+fn array_new_default_variant_enum_is_zeroable() {
+    infer("enum Colour { #[default] Red, Green }\nfn f() { let _ = Array.new<Colour, 3>() }")
+        .assert_no_errors();
+}
+
+#[test]
+fn array_new_enum_without_default_still_errors() {
+    infer("enum Colour { Red, Green }\nfn f() { let _ = Array.new<Colour, 3>() }")
+        .assert_infer_code("array_new_no_zero");
+}
+
+#[test]
+fn slice_make_default_variant_enum_is_zeroable() {
+    infer("enum Colour { #[default] Red, Green }\nfn f() { let _ = Slice.make<Colour>(3) }")
+        .assert_no_errors();
+}
+
+#[test]
+fn struct_spread_fills_default_variant_field() {
+    infer(
+        "enum Colour { #[default] Red, Green }\nstruct Paint { name: string, shade: Colour }\nfn f() { let _ = Paint { name: \"a\", .. } }",
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn map_read_of_default_variant_enum_is_allowed() {
+    infer(
+        "enum Colour { #[default] Red, Green }\nfn f(m: Map<string, Colour>) -> Colour { m[\"a\"] }",
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn default_variant_reaches_through_a_struct_field() {
+    infer(
+        "enum Colour { #[default] Red, Green }\nstruct Paint { shade: Colour }\nfn f() { let _ = Array.new<Paint, 2>() }",
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn generic_enum_may_mark_a_payload_less_variant() {
+    infer("enum Cached<T> { #[default] Miss, Hit(T) }\nfn f() { let _ = Array.new<Cached<int>, 2>() }")
+        .assert_no_errors();
+}
+
+#[test]
+fn default_variant_in_typedef_is_rejected() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "gen",
+        "gen.d.lis",
+        "pub enum Mode { #[default] Fast, Slow }\n",
+    );
+    fs.add_file(
+        "main",
+        "main.lis",
+        "import \"gen\"\nfn f() { let _ = gen.Mode.Fast }\n",
+    );
+    infer_package("main", fs).assert_error_contains("#[default]` in a typedef");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -15576,3 +15576,53 @@ fn main() {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn default_variant_with_payload() {
+    let input = r#"
+enum Payload {
+  #[default]
+  Full(int),
+  Empty,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn duplicate_default_variant() {
+    let input = r#"
+enum Twice {
+  #[default]
+  A,
+  #[default]
+  B,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn default_takes_no_arguments() {
+    let input = r#"
+enum Args {
+  #[default(extra)]
+  A,
+  B,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn duplicate_default_on_one_variant() {
+    let input = r#"
+enum TwiceOnOne {
+  #[default]
+  #[default]
+  A,
+  B,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/default_takes_no_arguments.snap
+++ b/tests/ui/errors/snapshots/default_takes_no_arguments.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `#[default]` takes no arguments
+   ╭─[test.lis:3:3]
+ 2 │ enum Args {
+ 3 │   #[default(extra)]
+   ·   ────────┬────────
+   ·           ╰── disallowed
+ 4 │   A,
+   ╰────
+  help: Write `#[default]` without passing any arguments · code: [attribute.default_takes_no_arguments]

--- a/tests/ui/errors/snapshots/default_variant_with_payload.snap
+++ b/tests/ui/errors/snapshots/default_variant_with_payload.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `#[default]` on a variant with a payload
+   ╭─[test.lis:4:3]
+ 3 │   #[default]
+ 4 │   Full(int),
+   ·   ──┬─
+   ·     ╰── this variant has a payload
+ 5 │   Empty,
+   ╰────
+  help: `#[default]` is allowed only on a payload-less variant · code: [attribute.default_variant_with_payload]

--- a/tests/ui/errors/snapshots/duplicate_default_on_one_variant.snap
+++ b/tests/ui/errors/snapshots/duplicate_default_on_one_variant.snap
@@ -1,0 +1,15 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Duplicate default variants
+   ╭─[test.lis:3:3]
+ 2 │ enum TwiceOnOne {
+ 3 │   #[default]
+   ·   ─────┬────
+   ·        ╰── first
+ 4 │   #[default]
+   ·   ─────┬────
+   ·        ╰── second
+ 5 │   A,
+   ╰────
+  help: Mark a single variant with `#[default]` · code: [attribute.duplicate_default_variant]

--- a/tests/ui/errors/snapshots/duplicate_default_variant.snap
+++ b/tests/ui/errors/snapshots/duplicate_default_variant.snap
@@ -1,0 +1,16 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Duplicate default variants
+   ╭─[test.lis:3:3]
+ 2 │ enum Twice {
+ 3 │   #[default]
+   ·   ─────┬────
+   ·        ╰── first
+ 4 │   A,
+ 5 │   #[default]
+   ·   ─────┬────
+   ·        ╰── second
+ 6 │   B,
+   ╰────
+  help: Mark a single variant with `#[default]` · code: [attribute.duplicate_default_variant]

--- a/tests/ui/lint/mod.rs
+++ b/tests/ui/lint/mod.rs
@@ -28796,6 +28796,19 @@ fn main() {
 }
 
 #[test]
+fn default_not_on_enum_variant() {
+    assert_lint_snapshot!(
+        r#"
+#[default]
+enum OnEnum {
+  A,
+  B,
+}
+"#
+    );
+}
+
+#[test]
 fn attribute_not_on_enum_variant() {
     assert_lint_snapshot!(
         r#"
@@ -28804,6 +28817,28 @@ enum WithJson {
   A,
   B,
 }
+"#
+    );
+}
+
+#[test]
+fn default_on_struct_field() {
+    assert_lint_snapshot!(
+        r#"
+struct OnField {
+  #[default]
+  pub a: int,
+}
+"#
+    );
+}
+
+#[test]
+fn default_on_type_alias() {
+    assert_lint_snapshot!(
+        r#"
+#[default]
+type Alias = int
 "#
     );
 }

--- a/tests/ui/lint/snapshots/default_not_on_enum_variant.snap
+++ b/tests/ui/lint/snapshots/default_not_on_enum_variant.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ `#[default]` not on an enum variant
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[default]
+   · ─────┬────
+   ·      ╰── expected on a variant
+ 3 │ enum OnEnum {
+   ╰────
+  help: Place `#[default]` on the variant that is the enum's zero value · code: [attribute.default_not_on_enum_variant]

--- a/tests/ui/lint/snapshots/default_on_struct_field.snap
+++ b/tests/ui/lint/snapshots/default_on_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ `#[default]` not on an enum variant
+   ╭─[test.lis:3:3]
+ 2 │ struct OnField {
+ 3 │   #[default]
+   ·   ─────┬────
+   ·        ╰── expected on a variant
+ 4 │   pub a: int,
+   ╰────
+  help: Place `#[default]` on the variant that is the enum's zero value · code: [attribute.default_not_on_enum_variant]

--- a/tests/ui/lint/snapshots/default_on_type_alias.snap
+++ b/tests/ui/lint/snapshots/default_on_type_alias.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/lint/mod.rs
+---
+  ✕ `#[default]` not on an enum variant
+   ╭─[test.lis:2:1]
+ 1 │ 
+ 2 │ #[default]
+   · ─────┬────
+   ·      ╰── expected on a variant
+ 3 │ type Alias = int
+   ╰────
+  help: Place `#[default]` on the variant that is the enum's zero value · code: [attribute.default_not_on_enum_variant]

--- a/tests/ui/lint/snapshots/unknown_attribute.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ pub struct User {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]`, `#[default]` · code: [lint.unknown_attribute]

--- a/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
+++ b/tests/ui/lint/snapshots/unknown_attribute_on_enum.snap
@@ -9,4 +9,4 @@ source: tests/ui/lint/mod.rs
    ·    ╰── not recognized
  3 │ enum Color {
    ╰────
-  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]` · code: [lint.unknown_attribute]
+  help: `foo` is not a recognized attribute. Known attributes: `#[json]`, `#[xml]`, `#[yaml]`, `#[toml]`, `#[db]`, `#[bson]`, `#[mapstructure]`, `#[msgpack]`, `#[tag]`, `#[allow]`, `#[iterate]`, `#[display]`, `#[equality]`, `#[test]`, `#[default]` · code: [lint.unknown_attribute]


### PR DESCRIPTION
An enum has no zero value, so `Array.new`, `Slice.make`, a `..` struct spread, etc. all reject enums. This PR adds `#[default]` to mark one variant as the enum's zero value.

```rs
enum Status {
  Active,
  Paused,
  #[default]
  Stopped,
}

struct Job {
  pub name: string,
  pub status: Status,
}

let slots = Array.new<Status, 3>()   // [Stopped, Stopped, Stopped]
let job = Job { name: "build", .. }  // job.status is Stopped
```

Close #1269
