### PR TITLE
refactor: emit direct nil and error checks when matching Go calls

### DIFF
--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -390,16 +390,22 @@ impl Planner<'_> {
         self.facts.is_nilable_go_type(ok_ty) || peeled.is_slice()
     }
 
+    pub(crate) fn partial_ok_nil_guard(&self, ok_ty: &Type) -> Option<NilGuard> {
+        self.partial_ok_is_nilable(ok_ty).then(|| {
+            if self.facts.as_interface(ok_ty).is_some() {
+                NilGuard::Interface
+            } else {
+                NilGuard::Pointer
+            }
+        })
+    }
+
     pub(crate) fn partial_ok_nil_check(&mut self, ok_ty: &Type, val: &str) -> Option<String> {
-        if !self.partial_ok_is_nilable(ok_ty) {
-            return None;
-        }
-        if self.facts.as_interface(ok_ty).is_some() {
+        let guard = self.partial_ok_nil_guard(ok_ty)?;
+        if guard.is_interface() {
             self.require_stdlib();
-            Some(format!("lisette.IsNilInterface({val})"))
-        } else {
-            Some(format!("{val} == nil"))
         }
+        Some(guard.is_nil(val))
     }
 
     fn go_result_needs_nil_guard(&self, ok_ty: &Type) -> bool {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,5 +1,6 @@
 use crate::Planner;
-use crate::abi::callable::CallableReturnAbi;
+use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
+use crate::calls::comma_ok::CommaOkSource;
 use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind};
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
@@ -18,6 +19,68 @@ pub(super) struct ResultFusePlan<'a> {
     subject: &'a Expression,
     shape: CallableReturnAbi,
     nil_guard: Option<NilGuard>,
+}
+
+pub(super) enum OptionFusePlan<'a> {
+    CommaOk {
+        subject: &'a Expression,
+        source: CommaOkSource,
+    },
+    Nullable {
+        subject: &'a Expression,
+        nil_guard: NilGuard,
+    },
+}
+
+pub(super) struct BoundOption {
+    pub(super) statements: Vec<LoweredStatement>,
+    pub(super) value: Option<String>,
+    pub(super) some_condition: String,
+    pub(super) none_condition: String,
+}
+
+impl OptionFusePlan<'_> {
+    pub(super) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> BoundOption {
+        match self {
+            Self::CommaOk { subject, source } => {
+                let pair = planner.bind_comma_ok_pair(subject, source, slot);
+                let some_condition = planner.pair_success_condition(&pair);
+                let none_condition = planner.pair_failure_condition(&pair);
+                BoundOption {
+                    statements: pair.statements,
+                    value: pair.value,
+                    some_condition,
+                    none_condition,
+                }
+            }
+            Self::Nullable { subject, nil_guard } => {
+                let (mut statements, call) = planner
+                    .lower_call(subject, None, ExpressionContext::value())
+                    .into_parts();
+                let value = match slot {
+                    CommaOkValueSlot::Named(name) => name,
+                    CommaOkValueSlot::Temp | CommaOkValueSlot::Unused => {
+                        let name = planner.fresh_var(Some("ret"));
+                        planner.declare(&name);
+                        name
+                    }
+                };
+                statements.push(LoweredStatement::TempBind {
+                    name: value.clone(),
+                    value: call,
+                });
+                if nil_guard.is_interface() {
+                    planner.require_stdlib();
+                }
+                BoundOption {
+                    statements,
+                    some_condition: nil_guard.non_nil(&value),
+                    none_condition: nil_guard.is_nil(&value),
+                    value: Some(value),
+                }
+            }
+        }
+    }
 }
 
 impl ResultFusePlan<'_> {
@@ -57,6 +120,21 @@ struct ResultArm<'a> {
     is_catch_all: bool,
 }
 
+#[derive(Clone, Copy)]
+enum PartialVariant {
+    Ok,
+    Both,
+    Err,
+}
+
+struct SelectivePartialArms<'a> {
+    variant: PartialVariant,
+    selected: &'a MatchArm,
+    fallback: &'a MatchArm,
+    value_binding: Option<&'a str>,
+    error_binding: Option<&'a str>,
+}
+
 /// How to render the subject declaration line, based on body usage.
 enum SubjectDeclaration {
     /// Identifier path: emit `_ = <var>` when unused, else nothing.
@@ -91,6 +169,11 @@ impl Planner<'_> {
         }
 
         if let Some(fused) = self.lower_fused_partial_match(subject, arms, place) {
+            statements.extend(fused);
+            return LoweredBlock { statements };
+        }
+
+        if let Some(fused) = self.lower_fused_selective_partial_match(subject, arms, place) {
             statements.extend(fused);
             return LoweredBlock { statements };
         }
@@ -253,6 +336,41 @@ impl Planner<'_> {
         })
     }
 
+    /// Recognize an Option-producing call whose physical Go result can be
+    /// tested directly, without first constructing a tagged Option.
+    pub(super) fn option_fuse_plan<'a>(
+        &self,
+        subject: &'a Expression,
+    ) -> Option<OptionFusePlan<'a>> {
+        if let Some(source) = self.comma_ok_source(subject) {
+            return Some(OptionFusePlan::CommaOk { subject, source });
+        }
+
+        let plan = self.plan_call(subject)?;
+        if !matches!(
+            plan.resolved.abi.result,
+            CallableReturnAbi::Option(OptionReturnAbi::Nullable)
+        ) || self
+            .go_result_layout_bridge(&plan.resolved.abi, &subject.get_type())
+            .is_some()
+            || self
+                .go_return_payload_bridge(&plan.resolved.abi, &subject.get_type())
+                .is_some()
+        {
+            return None;
+        }
+
+        let option_ty = subject.get_type();
+        let nil_guard = if self.is_interface_option(&option_ty) {
+            NilGuard::Interface
+        } else if self.facts.is_nullable_option(&option_ty) {
+            NilGuard::Pointer
+        } else {
+            return None;
+        };
+        Some(OptionFusePlan::Nullable { subject, nil_guard })
+    }
+
     /// Bind `let x = match ...` straight into `x`.
     pub(crate) fn lower_fused_result_match_into(
         &mut self,
@@ -263,6 +381,42 @@ impl Planner<'_> {
             return None;
         };
         self.lower_fused_lowered_match(subject, arms, &PlacePlan::Statement, Some(go_name))
+    }
+
+    /// Bind `let x = match nullable_call() { Some(v) => v, None => diverge }`
+    /// straight into `x` and test the raw Go value for nil.
+    pub(crate) fn lower_fused_option_match_into(
+        &mut self,
+        value: &Expression,
+        go_name: &str,
+    ) -> Option<Vec<LoweredStatement>> {
+        let Expression::Match { subject, arms, .. } = value.unwrap_parens() else {
+            return None;
+        };
+        let fuse = self.option_fuse_plan(subject)?;
+        if !matches!(&fuse, OptionFusePlan::Nullable { .. }) {
+            return None;
+        }
+        let arms = classify_option_arms(arms)?;
+        let payload = arms.some_binding?;
+        if !arms.none_body.get_type().is_never()
+            || arm_body_is_identifier(arms.some_body) != Some(payload)
+            || self.facts.peel_alias(&subject.get_type()).ok_type() != value.get_type()
+        {
+            return None;
+        }
+
+        self.declare(go_name);
+        let bound = fuse.bind(self, CommaOkValueSlot::Named(go_name.to_string()));
+        let fail_body = self.lower_block_as_body(arms.none_body);
+        let mut statements = bound.statements;
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: bound.none_condition,
+            then_body: fail_body,
+            else_arm: ElseArm::None,
+        }));
+        Some(statements)
     }
 
     /// The payload name an arm binds, or `None` when the body never reads it.
@@ -369,7 +523,7 @@ impl Planner<'_> {
             arm_place,
         );
 
-        if has_nil_guard && err_used {
+        if has_nil_guard && err_used.into_iter().any(|used| used) {
             self.require_errors();
             let error = bound.status();
             else_body.statements.insert(
@@ -512,14 +666,122 @@ impl Planner<'_> {
         Some(statements)
     }
 
-    /// Fuse the wrap+match into a direct pair test for simple `Some`/`None` arms.
+    /// Fuse a single explicit `Partial` variant plus a wildcard directly
+    /// against the physical `(value, error)` result of the call.
+    fn lower_fused_selective_partial_match(
+        &mut self,
+        subject: &Expression,
+        arms: &[MatchArm],
+        place: &PlacePlan,
+    ) -> Option<Vec<LoweredStatement>> {
+        let plan = self.plan_call(subject)?;
+        // Selective fusion relies on the state mapping of a raw Go
+        // `(value, error)` return. Do not infer that mapping for Lisette
+        // functions merely because they share the same lowered shape.
+        if !matches!(plan.resolved.origin, CallableOrigin::GoInterop)
+            || !self.fusable_partial(subject, &plan)
+        {
+            return None;
+        }
+        let arms = classify_selective_partial_arms(arms)?;
+        let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
+        let nil_guard = self.partial_ok_nil_guard(&ok_ty);
+
+        let value_binding = arms.value_binding.filter(|name| *name != "_");
+        let error_binding = arms.error_binding.filter(|name| *name != "_");
+
+        let (mut statements, call) = self
+            .lower_call(subject, None, ExpressionContext::value())
+            .into_parts();
+
+        // A non-nilable value is always present, so its physical ABI has no
+        // distinct Err state. The wildcard arm is therefore unconditional.
+        if matches!(arms.variant, PartialVariant::Err) && nil_guard.is_none() {
+            statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+            let fallback = self
+                .lower_fused_arm(&[], &arms.fallback.expression, place)
+                .0;
+            statements.extend(fallback.statements);
+            return Some(statements);
+        }
+
+        let condition_needs_value = nil_guard.is_some()
+            && matches!(arms.variant, PartialVariant::Both | PartialVariant::Err);
+        let may_need_value = value_binding.is_some() || condition_needs_value;
+        let value = may_need_value.then(|| {
+            let name = self.fresh_var(Some("ret"));
+            self.declare(&name);
+            name
+        });
+        let error = self.fresh_var(Some("err"));
+        self.declare(&error);
+        let (selected, binding_uses) = self.lower_fused_arm(
+            &[
+                value_binding.zip(value.as_deref()),
+                error_binding.map(|name| (name, error.as_str())),
+            ],
+            &arms.selected.expression,
+            place,
+        );
+        let fallback = self
+            .lower_fused_arm(&[], &arms.fallback.expression, place)
+            .0;
+
+        if selected.renders_empty() && fallback.renders_empty() {
+            statements.push(LoweredStatement::RawGo(format!("{call}\n")));
+            return Some(statements);
+        }
+
+        let value_is_used = binding_uses.first().copied().unwrap_or(false);
+        let result_slots = if condition_needs_value || value_is_used {
+            let value = value.as_deref().expect("value use allocates a result slot");
+            format!("{value}, {error}")
+        } else {
+            format!("_, {error}")
+        };
+        let condition = match arms.variant {
+            PartialVariant::Ok => format!("{error} == nil"),
+            PartialVariant::Both => match nil_guard {
+                Some(guard) => {
+                    if guard.is_interface() {
+                        self.require_stdlib();
+                    }
+                    let value = value.as_deref().expect("nil guard captures the value");
+                    format!("{error} != nil && {}", guard.non_nil(value))
+                }
+                None => format!("{error} != nil"),
+            },
+            PartialVariant::Err => {
+                let guard = nil_guard.expect("non-nilable Err returned above");
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                let value = value.as_deref().expect("nil guard captures the value");
+                format!("{error} != nil && {}", guard.is_nil(value))
+            }
+        };
+        statements.push(LoweredStatement::RawGo(format!(
+            "{result_slots} := {call}\n"
+        )));
+        let selected_diverges = selected.ends_with_diverge();
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition,
+            then_body: selected,
+            else_arm: ElseArm::from_body(fallback, selected_diverges),
+        }));
+        Some(statements)
+    }
+
+    /// Fuse the wrap+match into a direct physical-ABI test for simple
+    /// `Some`/`None` arms.
     fn lower_fused_option_match(
         &mut self,
         subject: &Expression,
         arms: &[MatchArm],
         place: &PlacePlan,
     ) -> Option<Vec<LoweredStatement>> {
-        let source = self.comma_ok_source(subject)?;
+        let fuse = self.option_fuse_plan(subject)?;
         let arms = classify_option_arms(arms)?;
 
         let slot = if arms.some_binding.is_some() {
@@ -527,10 +789,10 @@ impl Planner<'_> {
         } else {
             CommaOkValueSlot::Unused
         };
-        let pair = self.bind_comma_ok_pair(subject, source, slot);
+        let bound = fuse.bind(self, slot);
 
         let (then_body, _) = self.lower_fused_arm(
-            &[arms.some_binding.zip(pair.value.as_deref())],
+            &[arms.some_binding.zip(bound.value.as_deref())],
             arms.some_body,
             place,
         );
@@ -538,9 +800,9 @@ impl Planner<'_> {
 
         let invert = then_body.renders_empty() && !else_body.renders_empty();
         let condition = if invert {
-            self.pair_failure_condition(&pair)
+            bound.none_condition
         } else {
-            self.pair_success_condition(&pair)
+            bound.some_condition
         };
         let plan = if invert {
             IfPlan {
@@ -557,7 +819,7 @@ impl Planner<'_> {
                 else_arm: ElseArm::from_body(else_body, false),
             }
         };
-        let mut statements = pair.statements;
+        let mut statements = bound.statements;
         statements.push(LoweredStatement::If(plan));
         Some(statements)
     }
@@ -567,7 +829,7 @@ impl Planner<'_> {
         bindings: &[Option<(&str, &str)>],
         body: &Expression,
         place: &PlacePlan,
-    ) -> (LoweredBlock, bool) {
+    ) -> (LoweredBlock, Vec<bool>) {
         self.with_binding_frame(|this| {
             let bound: Vec<Option<(String, String)>> = bindings
                 .iter()
@@ -582,19 +844,28 @@ impl Planner<'_> {
             let (body_block, used) =
                 this.capture_go_uses(|this| this.lower_block_to_place(body, place));
             let mut statements = Vec::new();
-            let mut any_referenced = false;
-            for (go_name, value) in bound.iter().flatten() {
-                if !used.contains(go_name) {
+            let binding_uses = bound
+                .iter()
+                .map(|binding| {
+                    binding
+                        .as_ref()
+                        .is_some_and(|(go_name, _)| used.contains(go_name))
+                })
+                .collect::<Vec<_>>();
+            for (binding, is_used) in bound.iter().zip(&binding_uses) {
+                let Some((go_name, value)) = binding else {
+                    continue;
+                };
+                if !is_used {
                     continue;
                 }
                 statements.push(LoweredStatement::TempBind {
                     name: go_name.clone(),
                     value: value.clone(),
                 });
-                any_referenced = true;
             }
             statements.extend(body_block.statements);
-            (LoweredBlock { statements }, any_referenced)
+            (LoweredBlock { statements }, binding_uses)
         })
     }
 
@@ -728,6 +999,49 @@ fn classify_partial_arms(arms: &[MatchArm]) -> Option<(&MatchArm, &MatchArm, &Ma
         *slot = Some(arm);
     }
     Some((ok?, both?, err?))
+}
+
+fn classify_selective_partial_arms(arms: &[MatchArm]) -> Option<SelectivePartialArms<'_>> {
+    if arms.len() != 2 || arms.iter().any(MatchArm::has_guard) {
+        return None;
+    }
+    if !matches!(arms[1].pattern, Pattern::WildCard { .. }) {
+        return None;
+    }
+    let (selected, fallback) = (&arms[0], &arms[1]);
+    let Pattern::EnumVariant {
+        identifier,
+        fields,
+        rest,
+        ..
+    } = &selected.pattern
+    else {
+        return None;
+    };
+    if *rest {
+        return None;
+    }
+    let variant = match identifier.as_str() {
+        "Ok" | "Partial.Ok" if fields.len() == 1 => PartialVariant::Ok,
+        "Both" | "Partial.Both" if fields.len() == 2 => PartialVariant::Both,
+        "Err" | "Partial.Err" if fields.len() == 1 => PartialVariant::Err,
+        _ => return None,
+    };
+    let (value_binding, error_binding) = match variant {
+        PartialVariant::Ok => (Some(simple_payload_binding(selected)?), None),
+        PartialVariant::Both => {
+            let (value, error) = partial_both_bindings(selected)?;
+            (Some(value), Some(error))
+        }
+        PartialVariant::Err => (None, Some(simple_payload_binding(selected)?)),
+    };
+    Some(SelectivePartialArms {
+        variant,
+        selected,
+        fallback,
+        value_binding,
+        error_binding,
+    })
 }
 
 struct OptionArms<'a> {
@@ -889,5 +1203,55 @@ fn ok_arm_payload_is_omitted(arm: &MatchArm, shape: &CallableReturnAbi) -> bool 
         | CallableReturnAbi::Partial { .. }
         | CallableReturnAbi::Option(_)
         | CallableReturnAbi::Tuple { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_selective_partial_arms;
+    use syntax::ast::{ConstructorPatternResolution, Expression, MatchArm, Pattern, Span};
+    use syntax::types::Type;
+
+    fn variant(identifier: &str, fields: Vec<Pattern>) -> Pattern {
+        Pattern::EnumVariant {
+            identifier: identifier.into(),
+            fields,
+            rest: false,
+            resolution: ConstructorPatternResolution::Unresolved,
+            ty: Type::uninferred(),
+            span: Span::dummy(),
+        }
+    }
+
+    fn arm(pattern: Pattern) -> MatchArm {
+        MatchArm {
+            pattern,
+            guard: None,
+            expression: Box::new(Expression::Unit {
+                ty: Type::unit(),
+                span: Span::dummy(),
+            }),
+        }
+    }
+
+    #[test]
+    fn selective_partial_classifier_rejects_nested_payload_pattern() {
+        let arms = [
+            arm(variant(
+                "Partial.Ok",
+                vec![variant(
+                    "Some",
+                    vec![Pattern::Identifier {
+                        identifier: "n".into(),
+                        span: Span::dummy(),
+                    }],
+                )],
+            )),
+            arm(Pattern::WildCard {
+                span: Span::dummy(),
+            }),
+        ];
+
+        assert!(classify_selective_partial_arms(&arms).is_none());
     }
 }

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -5,7 +5,7 @@ use syntax::ast::{Expression, MatchArm, Pattern, Span};
 use syntax::types::Type;
 
 use crate::Planner;
-use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair};
+use crate::calls::comma_ok::CommaOkValueSlot;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::{self, prelude_qualifier, testkit_qualifier};
 use crate::patterns::binding_decls::pattern_binds_name;
@@ -273,17 +273,19 @@ impl Planner<'_> {
             None => CommaOkValueSlot::Unused,
         };
         let bound = fuse.bind(self, slot);
-        Some(self.finish_fused_let_else(bound, binding, else_block))
+        let fail_condition = self.pair_failure_condition(&bound);
+        Some(self.finish_fused_let_else(bound.statements, fail_condition, binding, else_block))
     }
 
-    /// Fuse `let Some(x) = <comma-ok source> else { ... }` into a direct pair test.
+    /// Fuse `let Some(x) = <lowered Option source> else { ... }` into a direct
+    /// physical-ABI test.
     fn lower_fused_option_let_else(
         &mut self,
         pattern: &Pattern,
         scrutinee: &Expression,
         else_block: &Expression,
     ) -> Option<Vec<LoweredStatement>> {
-        let source = self.comma_ok_source(scrutinee)?;
+        let fuse = self.option_fuse_plan(scrutinee)?;
         let field = some_pattern_field(pattern)?;
 
         let binding = self.declare_fused_binding(field);
@@ -291,20 +293,24 @@ impl Planner<'_> {
             Some((_, go_name)) => CommaOkValueSlot::Named(go_name.clone()),
             None => CommaOkValueSlot::Unused,
         };
-        let pair = self.bind_comma_ok_pair(scrutinee, source, slot);
-        Some(self.finish_fused_let_else(pair, binding, else_block))
+        let bound = fuse.bind(self, slot);
+        Some(self.finish_fused_let_else(
+            bound.statements,
+            bound.none_condition,
+            binding,
+            else_block,
+        ))
     }
 
     fn finish_fused_let_else(
         &mut self,
-        pair: LoweredPair,
+        mut statements: Vec<LoweredStatement>,
+        fail_condition: String,
         binding: Option<(String, String)>,
         else_block: &Expression,
     ) -> Vec<LoweredStatement> {
-        let fail_condition = self.pair_failure_condition(&pair);
         // The else block sees the enclosing scope, so it lowers before the binding installs.
         let fail_body = self.lower_block_as_body(else_block);
-        let mut statements = pair.statements;
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
             condition: fail_condition,
@@ -446,14 +452,15 @@ impl Planner<'_> {
         }
     }
 
-    /// Fuse `while let Some(x) = <comma-ok source>` into a per-iteration pair test.
+    /// Fuse `while let Some(x) = <lowered Option source>` into a per-iteration
+    /// physical-ABI test.
     fn lower_fused_option_while_let(
         &mut self,
         pattern: &Pattern,
         scrutinee: &Expression,
         body: &Expression,
     ) -> Option<LoweredBlock> {
-        let source = self.comma_ok_source(scrutinee)?;
+        let fuse = self.option_fuse_plan(scrutinee)?;
         let field = some_pattern_field(pattern)?;
         let binding = field_binding(field).filter(|b| *b != "_");
 
@@ -462,13 +469,12 @@ impl Planner<'_> {
         } else {
             CommaOkValueSlot::Unused
         };
-        let pair = self.bind_comma_ok_pair(scrutinee, source, slot);
+        let bound = fuse.bind(self, slot);
 
-        let condition = self.pair_failure_condition(&pair);
-        let mut loop_body = pair.statements;
+        let mut loop_body = bound.statements;
         loop_body.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition,
+            condition: bound.none_condition,
             then_body: LoweredBlock {
                 statements: vec![LoweredStatement::Break(
                     self.current_loop_id()
@@ -478,7 +484,7 @@ impl Planner<'_> {
             else_arm: ElseArm::None,
         }));
         let (body_block, _) = self.lower_fused_arm(
-            &[binding.zip(pair.value.as_deref())],
+            &[binding.zip(bound.value.as_deref())],
             body,
             &PlacePlan::Statement,
         );

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -131,10 +131,17 @@ impl Planner<'_> {
                 && !self.scope.is_active_assign_target(&go_identifier)
                 && !self.scope.has_binding_for_go_name(&go_identifier)
                 && value.get_type().demoted() == binding_ty.demoted()
-                && let Some(statements) = self.lower_fused_result_match_into(value, &go_identifier)
             {
-                self.scope.bind(identifier, raw_go_name);
-                return statements;
+                if let Some(statements) = self.lower_fused_result_match_into(value, &go_identifier)
+                {
+                    self.scope.bind(identifier, raw_go_name);
+                    return statements;
+                }
+                if let Some(statements) = self.lower_fused_option_match_into(value, &go_identifier)
+                {
+                    self.scope.bind(identifier, raw_go_name);
+                    return statements;
+                }
             }
             if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
                 let fresh = self.fresh_var(Some(identifier));

--- a/tests/spec/emit/go_interface_adapter.rs
+++ b/tests/spec/emit/go_interface_adapter.rs
@@ -289,6 +289,41 @@ fn main() {
     assert_emit_snapshot_with_go_typedefs!(input, &[]);
 }
 
+#[test]
+fn nullable_match_destination_preserves_interface_adapter() {
+    let input = r#"
+struct Thing {}
+
+interface Opt {
+  fn find() -> Option<mut Ref<Thing>>
+}
+
+struct Bar<T> {
+  x: Option<T>,
+}
+
+impl<T> Bar<T> {
+  fn find(self) -> Option<T> { self.x }
+}
+
+fn maybe_bar(bar: mut Ref<Bar<mut Ref<Thing>>>) -> Option<mut Ref<Bar<mut Ref<Thing>>>> {
+  Some(bar)
+}
+
+fn main() {
+  let mut bar = Bar { x: Some(&Thing {}) }
+  let opt: Opt = match maybe_bar(&bar) {
+    Some(found) => found,
+    None => { return },
+  }
+  if let Some(thing) = opt.find() {
+    let _ = thing
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
 // Coverage for scenario 9: match arm value. Each arm produces a
 // concrete and the match's result type is a Go interface.
 #[test]

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -1133,6 +1133,35 @@ fn main() {
 }
 
 #[test]
+fn fused_nullable_pointer_match_binds_destination() {
+    let input = r#"
+import "go:flag"
+
+fn main() {
+  let found = match flag.Lookup("verbose") {
+    Some(f) => f,
+    None => { return }
+  }
+  let _ = found.Name
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_nullable_pointer_let_else() {
+    let input = r#"
+import "go:flag"
+
+fn main() {
+  let Some(found) = flag.Lookup("verbose") else { return }
+  let _ = found.Name
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn interop_typed_nil_interface_result_return() {
     let input = r#"
 import "go:fmt"
@@ -2421,6 +2450,60 @@ fn main() {
 "#;
     let typedef = r#"
 pub fn Read() -> Partial<Slice<Option<string>>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn fused_selective_partial_err_checks_nilable_value() {
+    let input = r#"
+import "go:fmt"
+import "go:example.com/aws"
+
+fn main() {
+  match aws.Read() {
+    Partial.Err(e) => fmt.Println("err", e),
+    _ => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Read() -> Partial<Slice<byte>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn selective_partial_err_sentinel_falls_back_to_tagged_match() {
+    let input = r#"
+import "go:example.com/aws"
+import "go:io"
+
+fn main() {
+  match aws.Read() {
+    Partial.Err(io.EOF) => panic("empty"),
+    _ => {},
+  }
+}
+"#;
+    let typedef = r#"
+pub fn Read() -> Partial<Slice<byte>, error>
+"#;
+    assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
+}
+
+#[test]
+fn selective_partial_empty_interface_arms_do_not_import_prelude() {
+    let input = r#"
+import "go:example.com/aws"
+
+fn main() {
+  if let Partial.Err(_) = aws.Read() {}
+}
+"#;
+    let typedef = r#"
+pub interface Item {}
+pub fn Read() -> Partial<Item, error>
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/aws", typedef)]);
 }

--- a/tests/spec/emit/partial.rs
+++ b/tests/spec/emit/partial.rs
@@ -119,6 +119,92 @@ fn write_all(file: Ref<os.File>) {
 }
 
 #[test]
+fn fused_selective_partial_both_omits_unused_named_value() {
+    let input = r#"
+import "go:os"
+
+fn write(file: Ref<os.File>) -> Option<error> {
+  if let Partial.Both(written, err) = file.Write(['h', 'i']) {
+    return Some(err)
+  }
+  None
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn impossible_selective_partial_err_keeps_call() {
+    let input = r#"
+import "go:os"
+
+fn write(file: Ref<os.File>) {
+  if let Partial.Err(err) = file.Write(['h', 'i']) {
+    panic(err.Error())
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selective_partial_with_empty_arms_keeps_call() {
+    let input = r#"
+import "go:os"
+
+fn write(file: Ref<os.File>) {
+  if let Partial.Both(_, _) = file.Write(['h', 'i']) {}
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selective_partial_literal_payload_falls_back_to_tagged_match() {
+    let input = r#"
+import "go:os"
+
+fn write(file: Ref<os.File>) {
+  match file.Write(['h', 'i']) {
+    Partial.Ok(0) => panic("wrote nothing"),
+    _ => {},
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selective_partial_ok_wildcard_does_not_bind_nilable_value() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  if let Partial.Ok(_) = os.ReadDir(".") {
+    fmt.Println("ok")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn selective_partial_ok_unused_name_does_not_bind_nilable_value() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  if let Partial.Ok(entries) = os.ReadDir(".") {
+    fmt.Println("ok")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn fused_partial_match_on_lowered_call() {
     let input = r#"
 import "go:errors"

--- a/tests/spec/emit/snapshots/fused_nullable_pointer_let_else.snap
+++ b/tests/spec/emit/snapshots/fused_nullable_pointer_let_else.snap
@@ -1,0 +1,22 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:flag"
+  
+  fn main() {
+    let Some(found) = flag.Lookup("verbose") else { return }
+    let _ = found.Name
+  }
+---
+package main
+
+import "flag"
+
+func main() {
+	found := flag.Lookup("verbose")
+	if found == nil {
+		return
+	}
+	_ = found.Name
+}

--- a/tests/spec/emit/snapshots/fused_nullable_pointer_match_binds_destination.snap
+++ b/tests/spec/emit/snapshots/fused_nullable_pointer_match_binds_destination.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:flag"
+  
+  fn main() {
+    let found = match flag.Lookup("verbose") {
+      Some(f) => f,
+      None => { return }
+    }
+    let _ = found.Name
+  }
+---
+package main
+
+import "flag"
+
+func main() {
+	found := flag.Lookup("verbose")
+	if found == nil {
+		return
+	}
+	_ = found.Name
+}

--- a/tests/spec/emit/snapshots/fused_selective_partial_both_omits_unused_named_value.snap
+++ b/tests/spec/emit/snapshots/fused_selective_partial_both_omits_unused_named_value.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:os"
+  
+  fn write(file: Ref<os.File>) -> Option<error> {
+    if let Partial.Both(written, err) = file.Write(['h', 'i']) {
+      return Some(err)
+    }
+    None
+  }
+---
+package main
+
+import "os"
+
+func write(file *os.File) error {
+	_, err_2 := file.Write([]byte{'h', 'i'})
+	if err_2 != nil {
+		err := err_2
+		return err
+	}
+	return nil
+}

--- a/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
+++ b/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:fmt"
+  import "go:example.com/aws"
+  
+  fn main() {
+    match aws.Read() {
+      Partial.Err(e) => fmt.Println("err", e),
+      _ => {},
+    }
+  }
+---
+package main
+
+import (
+	"example.com/aws"
+	"fmt"
+)
+
+func main() {
+	ret_1, err_2 := aws.Read()
+	if err_2 != nil && ret_1 == nil {
+		e := err_2
+		fmt.Println("err", e)
+	}
+}

--- a/tests/spec/emit/snapshots/impossible_selective_partial_err_keeps_call.snap
+++ b/tests/spec/emit/snapshots/impossible_selective_partial_err_keeps_call.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:os"
+  
+  fn write(file: Ref<os.File>) {
+    if let Partial.Err(err) = file.Write(['h', 'i']) {
+      panic(err.Error())
+    }
+  }
+---
+package main
+
+import "os"
+
+func write(file *os.File) {
+	file.Write([]byte{'h', 'i'})
+}

--- a/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
@@ -19,9 +19,9 @@ import (
 )
 
 func main() {
-	raw_1 := reg.Events()
-	option_2 := lisette.OptionFromNilable[chan int](raw_1, raw_1 == nil)
-	if option_2.Tag == lisette.OptionSome {
-		_ = lisette.ChannelReceive(option_2.SomeVal)
+	ret_1 := reg.Events()
+	if ret_1 != nil {
+		ch := ret_1
+		_ = lisette.ChannelReceive(ch)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_map_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_map_return.snap
@@ -13,15 +13,12 @@ description: |
 ---
 package main
 
-import (
-	"example.com/reg"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/reg"
 
 func main() {
-	raw_1 := reg.Registry(true)
-	option_2 := lisette.OptionFromNilable[map[string]int](raw_1, raw_1 == nil)
-	if option_2.Tag == lisette.OptionSome {
-		_ = len(option_2.SomeVal)
+	ret_1 := reg.Registry(true)
+	if ret_1 != nil {
+		m := ret_1
+		_ = len(m)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
@@ -13,15 +13,12 @@ description: |
 ---
 package main
 
-import (
-	"example.com/reg"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/reg"
 
 func main() {
-	raw_1 := reg.Lookup()
-	option_2 := lisette.OptionFromNilable[reg.Index](raw_1, raw_1 == nil)
-	if option_2.Tag == lisette.OptionSome {
-		_ = option_2.SomeVal
+	ret_1 := reg.Lookup()
+	if ret_1 != nil {
+		idx := ret_1
+		_ = idx
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
@@ -18,18 +18,15 @@ description: |
 ---
 package main
 
-import (
-	"flag"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "flag"
 
 func apply(f func(string) *flag.Flag, name string) bool {
-	raw_1 := f(name)
-	option_2 := lisette.OptionFromNilable[*flag.Flag](raw_1, raw_1 == nil)
-	if option_2.Tag == lisette.OptionSome {
+	ret_1 := f(name)
+	if ret_1 != nil {
 		return true
+	} else {
+		return false
 	}
-	return false
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -21,10 +21,10 @@ import (
 )
 
 func main() {
-	raw_1 := evts.Peek()
-	option_2 := lisette.OptionFromNilable[evts.Msg](raw_1, lisette.IsNilInterface(raw_1))
-	if option_2.Tag == lisette.OptionSome {
-		fmt.Println(option_2.SomeVal)
+	ret_1 := evts.Peek()
+	if !lisette.IsNilInterface(ret_1) {
+		e := ret_1
+		fmt.Println(e)
 	} else {
 		fmt.Println("none")
 	}

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_single_return.snap
@@ -23,10 +23,10 @@ import (
 
 func main() {
 	ctx := context.Background()
-	raw_1 := ctx.Err()
-	option_2 := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
-	if option_2.Tag == lisette.OptionSome {
-		fmt.Println(option_2.SomeVal.Error())
+	ret_1 := ctx.Err()
+	if !lisette.IsNilInterface(ret_1) {
+		e := ret_1
+		fmt.Println(e.Error())
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
+++ b/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
@@ -56,10 +56,10 @@ func (b Bar[T]) find() (T, bool) {
 }
 
 func useOpt(o Opt) {
-	raw_1 := o.find()
-	option_2 := lisette.OptionFromNilable[*Thing](raw_1, raw_1 == nil)
-	if option_2.Tag == lisette.OptionSome {
-		_ = option_2.SomeVal
+	ret_1 := o.find()
+	if ret_1 != nil {
+		t := ret_1
+		_ = t
 	}
 }
 

--- a/tests/spec/emit/snapshots/nullable_match_destination_preserves_interface_adapter.snap
+++ b/tests/spec/emit/snapshots/nullable_match_destination_preserves_interface_adapter.snap
@@ -1,0 +1,93 @@
+---
+source: tests/spec/emit/go_interface_adapter.rs
+description: |
+  
+  struct Thing {}
+  
+  interface Opt {
+    fn find() -> Option<mut Ref<Thing>>
+  }
+  
+  struct Bar<T> {
+    x: Option<T>,
+  }
+  
+  impl<T> Bar<T> {
+    fn find(self) -> Option<T> { self.x }
+  }
+  
+  fn maybe_bar(bar: mut Ref<Bar<mut Ref<Thing>>>) -> Option<mut Ref<Bar<mut Ref<Thing>>>> {
+    Some(bar)
+  }
+  
+  fn main() {
+    let mut bar = Bar { x: Some(&Thing {}) }
+    let opt: Opt = match maybe_bar(&bar) {
+      Some(found) => found,
+      None => { return },
+    }
+    if let Some(thing) = opt.find() {
+      let _ = thing
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Thing struct{}
+
+type Opt interface {
+	find() *Thing
+}
+
+type Bar[T any] struct {
+	x lisette.Option[T]
+}
+
+func (b Bar[T]) find() (T, bool) {
+	v_1 := b.x
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return *new(T), false
+}
+
+func maybeBar(bar *Bar[*Thing]) *Bar[*Thing] {
+	return bar
+}
+
+func main() {
+	bar := Bar[*Thing]{x: lisette.MakeOptionSome(&Thing{})}
+	var opt Opt
+	ret_1 := maybeBar(&bar)
+	if ret_1 != nil {
+		found := ret_1
+		opt = _lisAdapter_Bar_Opt_0{inner: found}
+	} else {
+		return
+	}
+	ret_5 := opt.find()
+	if ret_5 != nil {
+		thing := ret_5
+		_ = thing
+	}
+}
+
+type _lisAdapter_Bar_Opt_0 struct {
+	inner *Bar[*Thing]
+}
+
+func (a _lisAdapter_Bar_Opt_0) find() *Thing {
+	ret_2, ret_3 := a.inner.find()
+	var option_4 lisette.Option[*Thing]
+	if ret_3 && ret_2 != nil {
+		option_4 = lisette.MakeOptionSome[*Thing](ret_2)
+	} else {
+		option_4 = lisette.MakeOptionNone[*Thing]()
+	}
+	if option_4.Tag == lisette.OptionSome {
+		return option_4.SomeVal
+	}
+	return nil
+}

--- a/tests/spec/emit/snapshots/selective_partial_empty_interface_arms_do_not_import_prelude.snap
+++ b/tests/spec/emit/snapshots/selective_partial_empty_interface_arms_do_not_import_prelude.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/aws"
+  
+  fn main() {
+    if let Partial.Err(_) = aws.Read() {}
+  }
+---
+package main
+
+import "example.com/aws"
+
+func main() {
+	aws.Read()
+}

--- a/tests/spec/emit/snapshots/selective_partial_err_sentinel_falls_back_to_tagged_match.snap
+++ b/tests/spec/emit/snapshots/selective_partial_err_sentinel_falls_back_to_tagged_match.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:example.com/aws"
+  import "go:io"
+  
+  fn main() {
+    match aws.Read() {
+      Partial.Err(io.EOF) => panic("empty"),
+      _ => {},
+    }
+  }
+---
+package main
+
+import (
+	"example.com/aws"
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+)
+
+func main() {
+	ret_1, ret_2 := aws.Read()
+	var result_3 lisette.Partial[[]byte, error]
+	if ret_2 != nil {
+		if ret_1 == nil {
+			result_3 = lisette.MakePartialErr[[]byte, error](ret_2)
+		} else {
+			result_3 = lisette.MakePartialBoth[[]byte, error](ret_1, ret_2)
+		}
+	} else {
+		result_3 = lisette.MakePartialOk[[]byte, error](ret_1)
+	}
+	if result_3.Tag == lisette.PartialErr {
+		if result_3.ErrVal == io.EOF {
+			panic("empty")
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/selective_partial_literal_payload_falls_back_to_tagged_match.snap
+++ b/tests/spec/emit/snapshots/selective_partial_literal_payload_falls_back_to_tagged_match.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:os"
+  
+  fn write(file: Ref<os.File>) {
+    match file.Write(['h', 'i']) {
+      Partial.Ok(0) => panic("wrote nothing"),
+      _ => {},
+    }
+  }
+---
+package main
+
+import (
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func write(file *os.File) {
+	ret_1, ret_2 := file.Write([]byte{'h', 'i'})
+	var result_3 lisette.Partial[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakePartialBoth[int, error](ret_1, ret_2)
+	} else {
+		result_3 = lisette.MakePartialOk[int, error](ret_1)
+	}
+	if result_3.Tag == lisette.PartialOk {
+		if result_3.OkVal == 0 {
+			panic("wrote nothing")
+		}
+	}
+}

--- a/tests/spec/emit/snapshots/selective_partial_ok_unused_name_does_not_bind_nilable_value.snap
+++ b/tests/spec/emit/snapshots/selective_partial_ok_unused_name_does_not_bind_nilable_value.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    if let Partial.Ok(entries) = os.ReadDir(".") {
+      fmt.Println("ok")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	_, err_2 := os.ReadDir(".")
+	if err_2 == nil {
+		fmt.Println("ok")
+	}
+}

--- a/tests/spec/emit/snapshots/selective_partial_ok_wildcard_does_not_bind_nilable_value.snap
+++ b/tests/spec/emit/snapshots/selective_partial_ok_wildcard_does_not_bind_nilable_value.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    if let Partial.Ok(_) = os.ReadDir(".") {
+      fmt.Println("ok")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	_, err_1 := os.ReadDir(".")
+	if err_1 == nil {
+		fmt.Println("ok")
+	}
+}

--- a/tests/spec/emit/snapshots/selective_partial_with_empty_arms_keeps_call.snap
+++ b/tests/spec/emit/snapshots/selective_partial_with_empty_arms_keeps_call.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/partial.rs
+description: |
+  
+  import "go:os"
+  
+  fn write(file: Ref<os.File>) {
+    if let Partial.Both(_, _) = file.Write(['h', 'i']) {}
+  }
+---
+package main
+
+import "os"
+
+func write(file *os.File) {
+	file.Write([]byte{'h', 'i'})
+}


### PR DESCRIPTION
Matching on an `Option` built from a nullable Go return now lowers to a direct nil check, instead of wrapping the value into a tagged `lisette.Option` and testing its tag.

Before:

```go
func main() {
	ctx := context.Background()
	raw_1 := ctx.Err()
	option_2 := lisette.OptionFromNilable[error](raw_1, lisette.IsNilInterface(raw_1))
	if option_2.Tag == lisette.OptionSome {
		fmt.Println(option_2.SomeVal.Error())
	} else {
		fmt.Println("no error")
	}
}
```

After:

```go
func main() {
	ctx := context.Background()
	ret_1 := ctx.Err()
	if !lisette.IsNilInterface(ret_1) {
		e := ret_1
		fmt.Println(e.Error())
	} else {
		fmt.Println("no error")
	}
}
```

Relates to #1284