### PR TITLE
fix: inaccurate write permission error on struct literals

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -685,6 +685,22 @@ pub enum WriteContext {
         field: String,
         origin: Option<String>,
     },
+    ImmutableBinding(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadOnlyComponent {
+    pub kind: ReadOnlyComponentKind,
+    pub declared: String,
+    pub actual: String,
+    pub span: Span,
+    pub context: Option<WriteContext>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReadOnlyComponentKind {
+    Field(String),
+    Spread(Vec<String>),
 }
 
 #[derive(Debug, Clone)]
@@ -699,7 +715,17 @@ pub struct ElementDeclaration {
 }
 
 pub fn needs_writable_help(expected: &str, actual: &str, context: Option<WriteContext>) -> String {
-    let remedy = match context {
+    let remedy = needs_writable_remedy(expected, actual, context);
+    format!("`{expected}` permits writes, `{actual}` does not. {remedy}")
+}
+
+pub fn needs_writable_remedy(
+    expected: &str,
+    actual: &str,
+    context: Option<WriteContext>,
+) -> String {
+    match context {
+        Some(WriteContext::ImmutableBinding(name)) => format!("Declare `let mut {name}`"),
         Some(WriteContext::Parameter(name)) => {
             format!("Declare the parameter `{name}` as `{expected}`")
         }
@@ -726,8 +752,65 @@ pub fn needs_writable_help(expected: &str, actual: &str, context: Option<WriteCo
             None => format!("`{binding}` binds read-only elements"),
         },
         _ => "Make the value writable where it is created, or pass a `.clone()`".to_string(),
+    }
+}
+
+pub fn read_only_construction(
+    expected: &str,
+    actual: &str,
+    constructed: &str,
+    behind_ref: bool,
+    components: &[ReadOnlyComponent],
+) -> LisetteDiagnostic {
+    let mut diagnostic =
+        LisetteDiagnostic::error("Missing write permission").with_infer_code("needs_writable");
+    let mut fields: Vec<&str> = vec![];
+    let mut remedies: Vec<String> = vec![];
+    for component in components {
+        let ReadOnlyComponent {
+            kind,
+            declared,
+            actual,
+            span,
+            context,
+        } = component;
+        let label = match kind {
+            ReadOnlyComponentKind::Field(name) => {
+                fields.push(name);
+                format!("`{name}` is declared `{declared}`, but receives `{actual}`")
+            }
+            ReadOnlyComponentKind::Spread(supplied) => {
+                fields.extend(supplied.iter().map(String::as_str));
+                let verb = if supplied.len() == 1 { "comes" } else { "come" };
+                format!(
+                    "`{}` {verb} from a read-only `{actual}`",
+                    supplied.join("`, `")
+                )
+            }
+        };
+        diagnostic = diagnostic.with_span_label(span, label);
+        let remedy = needs_writable_remedy(declared, actual, context.clone());
+        if !remedies.contains(&remedy) {
+            remedies.push(remedy);
+        }
+    }
+    let subject = match fields.as_slice() {
+        [field] => format!("`{field}`"),
+        [init @ .., last] => format!("`{}` and `{last}`", init.join("`, `")),
+        [] => unreachable!("a read-only construction names at least one component"),
     };
-    format!("`{expected}` permits writes, `{actual}` does not. {remedy}")
+    let outcome = if behind_ref {
+        format!(
+            "so the new `{constructed}` is read-only. A reference to it is `{actual}` \
+             where `{expected}` is expected."
+        )
+    } else {
+        format!("so the new `{constructed}` is read-only where `{expected}` is expected.")
+    };
+    diagnostic.with_help(format!(
+        "{subject} received less `mut` than declared, {outcome} {}",
+        remedies.join(". ")
+    ))
 }
 
 pub fn write_through_read_only(

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -284,6 +284,8 @@ pub struct InferCtx<'a> {
     pub(super) reported_immutable: FxHashSet<BindingId>,
     pub(super) binding_inference: FxHashMap<BindingId, BindingInference>,
     pub(super) reported_read_only_writes: FxHashSet<(BindingId, String)>,
+    /// By span, for the diagnostic when the construction misses a writable expectation.
+    pub(super) read_only_constructions: FxHashMap<Span, Vec<diagnostics::infer::ReadOnlyComponent>>,
     traversal: TraversalContext,
 }
 
@@ -297,6 +299,7 @@ impl<'a> InferCtx<'a> {
             reported_immutable: FxHashSet::default(),
             binding_inference: FxHashMap::default(),
             reported_read_only_writes: FxHashSet::default(),
+            read_only_constructions: FxHashMap::default(),
             traversal: TraversalContext::default(),
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -13,6 +13,7 @@ use syntax::types::{
 
 use super::super::context::{Expectation, ExpectationRole};
 use super::super::unify::Dispatched;
+use super::permission::{ConstructionGrant, MissingSupply};
 use super::struct_call::same_nominal;
 use crate::checker::infer::InferCtx;
 use crate::checker::scopes::DeferredMapKeyCheck;
@@ -267,7 +268,8 @@ impl InferCtx<'_> {
         });
 
         let return_ty = if call_kind == CallKind::TupleStructConstructor {
-            if self.tuple_struct_construction_grants_write(&parameters, &new_args) {
+            let grant = self.tuple_struct_construction_grants_write(&parameters, &new_args);
+            if self.record_construction_grant(span, grant) {
                 return_ty.resolve_in(&self.env).make_writable()
             } else {
                 return_ty
@@ -437,13 +439,13 @@ impl InferCtx<'_> {
         &self,
         parameters: &[FunctionParameter],
         args: &[Expression],
-    ) -> bool {
+    ) -> ConstructionGrant {
         self.components_grant_write(
             parameters
                 .iter()
                 .enumerate()
-                .map(|(i, param)| (param.ty.resolve_in(&self.env), args.get(i))),
-            false,
+                .map(|(i, param)| (format!(".{i}"), param.ty.resolve_in(&self.env), args.get(i))),
+            MissingSupply::Absent,
         )
     }
 

--- a/crates/semantics/src/checker/infer/expressions/dot_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/dot_access.rs
@@ -1,6 +1,8 @@
 use crate::checker::EnvResolve;
 use ecow::EcoString;
-use syntax::ast::{Expression, IdentifierResolution, Span, StructFields, StructKind};
+use syntax::ast::{
+    Expression, IdentifierResolution, Span, StructFields, StructKind, tuple_field_name,
+};
 use syntax::go_names;
 use syntax::program::{Definition, DefinitionBody, DotAccessResolution, NativeTypeKind};
 use syntax::types::{Symbol, Type, substitute};
@@ -309,7 +311,7 @@ impl InferCtx<'_> {
 
         let field_name = if struct_kind == StructKind::Tuple {
             if let Ok(index) = args.member_name.parse::<usize>() {
-                format!("_{}", index)
+                tuple_field_name(index).to_string()
             } else {
                 args.member_name.to_string()
             }

--- a/crates/semantics/src/checker/infer/expressions/permission.rs
+++ b/crates/semantics/src/checker/infer/expressions/permission.rs
@@ -1,4 +1,7 @@
-use syntax::ast::{BindingId, Expression, Literal, Span, StructFieldDefinition, UnaryOperator};
+use diagnostics::infer::{ReadOnlyComponent, ReadOnlyComponentKind, WriteContext};
+use syntax::ast::{
+    BindingId, Expression, Literal, Span, StructFieldDefinition, UnaryOperator, tuple_field_name,
+};
 use syntax::types::{CompoundKind, Type};
 
 use crate::checker::EnvResolve;
@@ -13,6 +16,19 @@ pub(super) enum WriteTarget {
     Binding { name: String },
     /// Neither a reference nor a binding root.
     Other,
+}
+
+pub(super) enum ConstructionGrant {
+    Writable,
+    /// Empty when no component carries `mut`.
+    ReadOnly(Vec<ReadOnlyComponent>),
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum MissingSupply<'e> {
+    Zero,
+    Spread(&'e Expression),
+    Absent,
 }
 
 impl InferCtx<'_> {
@@ -189,26 +205,105 @@ impl InferCtx<'_> {
     /// Whether every gated component received a value carrying its declared permissions.
     pub(super) fn components_grant_write<'c>(
         &self,
-        components: impl Iterator<Item = (Type, Option<&'c Expression>)>,
-        missing_grants: bool,
-    ) -> bool {
+        components: impl Iterator<Item = (String, Type, Option<&'c Expression>)>,
+        missing: MissingSupply<'_>,
+    ) -> ConstructionGrant {
+        let missing_grants = match missing {
+            MissingSupply::Zero => true,
+            MissingSupply::Spread(base) => self.owner_grants_write(&base.get_type()),
+            MissingSupply::Absent => false,
+        };
         let mut gated = false;
-        for (declared, value) in components {
+        let mut withheld = vec![];
+        let mut unsupplied = vec![];
+        for (name, declared, value) in components {
             if !self.store.demotion_changes(&declared) {
                 continue;
             }
             gated = true;
-            let provides = match value {
+            match value {
                 Some(value) => {
-                    self.value_provides_declared_permissions(&declared, &value.get_type())
+                    let actual = value.get_type();
+                    if !self.value_provides_declared_permissions(&declared, &actual) {
+                        let (declared, actual) =
+                            Type::stringify_pair(&declared, &actual.resolve_in(&self.env));
+                        withheld.push(ReadOnlyComponent {
+                            kind: ReadOnlyComponentKind::Field(name),
+                            declared,
+                            actual,
+                            span: value.get_span(),
+                            context: self.initializer_context(value),
+                        });
+                    }
                 }
-                None => missing_grants,
-            };
-            if !provides {
-                return false;
+                None if !missing_grants => unsupplied.push(name),
+                None => {}
             }
         }
-        gated
+        if gated && withheld.is_empty() && unsupplied.is_empty() {
+            return ConstructionGrant::Writable;
+        }
+        if let MissingSupply::Spread(base) = missing
+            && !unsupplied.is_empty()
+        {
+            let actual = base.get_type().resolve_in(&self.env);
+            let (declared, actual) = Type::stringify_pair(&actual.clone().make_writable(), &actual);
+            withheld.push(ReadOnlyComponent {
+                kind: ReadOnlyComponentKind::Spread(unsupplied),
+                declared,
+                actual,
+                span: base.get_span(),
+                context: self.value_context(base),
+            });
+        }
+        ConstructionGrant::ReadOnly(withheld)
+    }
+
+    /// Returns whether the construction is writable.
+    pub(super) fn record_construction_grant(
+        &mut self,
+        span: Span,
+        grant: ConstructionGrant,
+    ) -> bool {
+        match grant {
+            ConstructionGrant::Writable => {
+                self.read_only_constructions.remove(&span);
+                true
+            }
+            ConstructionGrant::ReadOnly(components) => {
+                if components.is_empty() {
+                    self.read_only_constructions.remove(&span);
+                } else {
+                    self.read_only_constructions.insert(span, components);
+                }
+                false
+            }
+        }
+    }
+
+    fn initializer_context(&self, initializer: &Expression) -> Option<WriteContext> {
+        let initializer = initializer.unwrap_parens();
+        if let Expression::Identifier { value: name, .. } = initializer
+            && let Some(binding_id) = self.scopes.lookup_binding_id(name)
+        {
+            if self
+                .facts
+                .bindings
+                .get(&binding_id)
+                .is_some_and(|binding| binding.kind.is_param())
+            {
+                return Some(WriteContext::Parameter(name.to_string()));
+            }
+            if self
+                .binding_inference
+                .get(&binding_id)
+                .and_then(|binding| binding.as_let())
+                .is_some_and(|inference| inference.mutability.was_demoted())
+            {
+                return Some(WriteContext::ImmutableBinding(name.to_string()));
+            }
+        }
+        self.value_context(initializer)
     }
 
     fn initializer_fits_declared(&mut self, declared: &Type, initializer: &Expression) -> bool {
@@ -339,60 +434,58 @@ impl InferCtx<'_> {
 }
 
 impl InferCtx<'_> {
-    pub(super) fn write_context(
-        &self,
-        target: &Expression,
-    ) -> Option<diagnostics::infer::WriteContext> {
+    pub(super) fn write_context(&self, target: &Expression) -> Option<WriteContext> {
         if let Some(element) = self.element_write_declaration(target) {
-            return Some(diagnostics::infer::WriteContext::Element(element));
+            return Some(WriteContext::Element(element));
         }
         let hop = self.write_hop(target)?;
         self.value_context(hop)
             .or_else(|| self.binding_context(&super::aliasing::place_root_name(target)?))
     }
 
-    pub(super) fn value_context(
-        &self,
-        value: &Expression,
-    ) -> Option<diagnostics::infer::WriteContext> {
+    pub(super) fn value_context(&self, value: &Expression) -> Option<WriteContext> {
         match value.unwrap_parens() {
             Expression::DotAccess {
                 expression: owner,
                 member,
                 ..
-            } => match self.struct_field(owner, member) {
-                Some(field) if !self.store.peel_alias(&field.ty).is_writable() => {
-                    Some(diagnostics::infer::WriteContext::Field(member.to_string()))
+            } => {
+                let field = self.struct_field(owner, member)?;
+                let name = if member.parse::<usize>().is_ok() {
+                    format!(".{member}")
+                } else {
+                    member.to_string()
+                };
+                if !self.store.peel_alias(&field.ty).is_writable() {
+                    Some(WriteContext::Field(name))
+                } else {
+                    Some(WriteContext::ReadOnlyOwner {
+                        owner: super::aliasing::render_place(owner.unwrap_parens()),
+                        field: name,
+                        origin: self.owner_origin(owner),
+                    })
                 }
-                Some(_) => Some(diagnostics::infer::WriteContext::ReadOnlyOwner {
-                    owner: super::aliasing::render_place(owner.unwrap_parens()),
-                    field: member.to_string(),
-                    origin: self.owner_origin(owner),
-                }),
-                None => None,
-            },
+            }
             identifier @ Expression::Identifier { .. } => {
                 self.binding_context(&identifier.get_var_name()?)
             }
             call @ Expression::Call { .. } => {
                 let callee = super::aliasing::render_place(call);
                 let callee = callee.strip_suffix("()")?;
-                Some(diagnostics::infer::WriteContext::CallResult(
-                    callee.to_string(),
-                ))
+                Some(WriteContext::CallResult(callee.to_string()))
             }
             _ => None,
         }
     }
 
-    fn binding_context(&self, name: &str) -> Option<diagnostics::infer::WriteContext> {
+    fn binding_context(&self, name: &str) -> Option<WriteContext> {
         let binding_id = self.scopes.lookup_binding_id(name)?;
         if let Some(inference) = self
             .binding_inference
             .get(&binding_id)
             .and_then(|binding| binding.as_loop_element())
         {
-            return Some(diagnostics::infer::WriteContext::LoopElement {
+            return Some(WriteContext::LoopElement {
                 binding: name.to_string(),
                 collection: inference.collection.clone(),
             });
@@ -404,9 +497,7 @@ impl InferCtx<'_> {
             .map(|binding| binding.kind)?;
         let declared = self.scopes.lookup_value(name)?;
         if kind.is_param() && !self.store.peel_alias(declared).is_writable() {
-            return Some(diagnostics::infer::WriteContext::Parameter(
-                name.to_string(),
-            ));
+            return Some(WriteContext::Parameter(name.to_string()));
         }
         match self
             .binding_inference
@@ -415,22 +506,21 @@ impl InferCtx<'_> {
             .source
             .as_ref()?
         {
-            ValueSource::Place(source) => Some(diagnostics::infer::WriteContext::AliasOf {
+            ValueSource::Place(source) => Some(WriteContext::AliasOf {
                 binding: name.to_string(),
                 source: source.clone(),
             }),
-            ValueSource::Call(callee) => {
-                Some(diagnostics::infer::WriteContext::CallResult(callee.clone()))
-            }
+            ValueSource::Call(callee) => Some(WriteContext::CallResult(callee.clone())),
         }
     }
 
     fn struct_field(&self, owner: &Expression, member: &str) -> Option<&StructFieldDefinition> {
         let owner_ty = self.owner_type(owner)?;
+        let tuple_name = member.parse::<usize>().ok().map(tuple_field_name);
         self.store
             .fields_of(owner_ty.get_qualified_id()?)?
             .iter()
-            .find(|field| field.name == member)
+            .find(|field| field.name == member || tuple_name.as_ref() == Some(&field.name))
     }
 
     /// An argument is classified before it is inferred.

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -197,6 +197,15 @@ impl InferCtx<'_> {
                 Expression::StructCall { .. } | Expression::Call { .. } => true,
                 other => self.place_permits_write(other),
             };
+            let constructed = new_expression.unwrap_parens().get_span();
+            match self.read_only_constructions.remove(&constructed) {
+                Some(components) => {
+                    self.read_only_constructions.insert(span, components);
+                }
+                None => {
+                    self.read_only_constructions.remove(&span);
+                }
+            }
             Type::qualified_compound(CompoundKind::Ref, vec![inner_ty.clone()], writable)
         };
 

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -7,6 +7,7 @@ use syntax::ast::{Expression, Span, StructFieldAssignment, StructFields, StructS
 use syntax::program::{Definition, DefinitionBody};
 use syntax::types::{SubstitutionMap, Type, substitute, unqualified_name};
 
+use super::permission::{ConstructionGrant, MissingSupply};
 use crate::checker::infer::InferCtx;
 use crate::store::Store;
 use crate::zero;
@@ -413,11 +414,12 @@ impl InferCtx<'_> {
             &new_field_assignments,
         );
 
-        let struct_call_ty = if self.construction_grants_write(
+        let grant = self.construction_grants_write(
             struct_fields.iter().map(|f| (&f.name, &f.ty)),
             &new_field_assignments,
             &new_spread,
-        ) {
+        );
+        let struct_call_ty = if self.record_construction_grant(span, grant) {
             struct_call_ty.make_writable()
         } else {
             struct_call_ty
@@ -459,11 +461,11 @@ impl InferCtx<'_> {
         fields: impl Iterator<Item = (&'f EcoString, &'f Type)>,
         assignments: &[StructFieldAssignment],
         spread: &StructSpread,
-    ) -> bool {
-        let missing_grants = match spread {
-            StructSpread::Autofill { .. } => true,
-            StructSpread::From(base) => self.owner_grants_write(&base.get_type()),
-            StructSpread::None => false,
+    ) -> ConstructionGrant {
+        let missing = match spread {
+            StructSpread::Autofill { .. } => MissingSupply::Zero,
+            StructSpread::From(base) => MissingSupply::Spread(base),
+            StructSpread::None => MissingSupply::Absent,
         };
         self.components_grant_write(
             fields.map(|(name, ty)| {
@@ -471,9 +473,9 @@ impl InferCtx<'_> {
                     .iter()
                     .find(|a| &a.name == name)
                     .map(|a| a.value.as_ref());
-                (ty.clone(), value)
+                (name.to_string(), ty.clone(), value)
             }),
-            missing_grants,
+            missing,
         )
     }
 
@@ -558,11 +560,12 @@ impl InferCtx<'_> {
         );
 
         // The same construction grant as struct literals.
-        let enum_ty = if self.construction_grants_write(
+        let grant = self.construction_grants_write(
             variant_fields.iter().map(|f| (&f.name, &f.ty)),
             &new_field_assignments,
             &new_spread,
-        ) {
+        );
+        let enum_ty = if self.record_construction_grant(span, grant) {
             enum_ty.resolve_in(&self.env).make_writable()
         } else {
             enum_ty

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -793,6 +793,15 @@ impl InferCtx<'_> {
             UnifyError::QualifierMismatch => {
                 let concrete_expected = overlay_qualifiers(expected, actual);
                 let (expected_name, actual_name) = Type::stringify_pair(&concrete_expected, actual);
+                if let Some(components) = self.read_only_constructions.get(span) {
+                    return diagnostics::infer::read_only_construction(
+                        &expected_name,
+                        &actual_name,
+                        &actual.strip_refs().to_string(),
+                        actual.is_ref(),
+                        components,
+                    );
+                }
                 let diagnostic = LisetteDiagnostic::error("Missing write permission")
                     .with_infer_code("needs_writable")
                     .with_span_label(

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -631,6 +631,11 @@ impl StructFields {
     }
 }
 
+/// The stored name of the tuple struct field accessed as `.{index}`.
+pub fn tuple_field_name(index: usize) -> EcoString {
+    format!("_{index}").into()
+}
+
 impl Deref for StructFields {
     type Target = [StructFieldDefinition];
 

--- a/crates/syntax/src/parse/definitions.rs
+++ b/crates/syntax/src/parse/definitions.rs
@@ -4,7 +4,7 @@ use super::{ParamMode, Parser};
 use crate::ast::{
     Annotation, Attribute, AttributeArg, ConstInitializer, EnumFieldDefinition, EnumVariant,
     Expression, Generic, ParentInterface, Span, StructFieldDefinition, StructFieldKind,
-    StructFields, VariantFields, Visibility,
+    StructFields, VariantFields, Visibility, tuple_field_name,
 };
 use crate::lex::Token;
 use crate::lex::TokenKind::*;
@@ -481,7 +481,7 @@ impl<'source> Parser<'source> {
 
             fields.push(StructFieldDefinition {
                 doc: None,
-                name: format!("_{}", index).into(),
+                name: tuple_field_name(index),
                 name_span: field_span,
                 annotation,
                 visibility: Visibility::Private,

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -2024,3 +2024,93 @@ fn main() {
     )
     .assert_infer_code_once("write_through_read_only");
 }
+
+#[test]
+fn read_only_construction_behind_ref_names_the_field() {
+    infer(
+        r#"struct Rock { size: int }
+struct Beam { rocks: mut Ref<mut Slice<mut Ref<Rock>>>, hits: int }
+fn make(rocks: mut Ref<Slice<mut Ref<Rock>>>) -> mut Ref<Beam> {
+  &Beam { rocks, hits: 0 }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("`rocks` is declared `mut Ref<mut Slice<mut Ref<Rock>>>`")
+    .assert_error_contains("Declare the parameter `rocks` as `mut Ref<mut Slice<mut Ref<Rock>>>`");
+}
+
+#[test]
+fn read_only_construction_names_every_withholding_field() {
+    infer(
+        r#"struct Pair2 { left: mut Slice<int>, right: mut Slice<int> }
+fn make(a: Slice<int>, b: Slice<int>) -> mut Pair2 {
+  Pair2 { left: a, right: b }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("`left` is declared `mut Slice<int>`, but receives `Slice<int>`")
+    .assert_error_contains("`right` is declared `mut Slice<int>`, but receives `Slice<int>`")
+    .assert_error_contains("`left` and `right` received less `mut` than declared");
+}
+
+#[test]
+fn read_only_construction_names_the_spread_base() {
+    infer(
+        r#"struct Holder { items: mut Slice<int>, name: string }
+fn rename(base: Holder) -> mut Holder {
+  Holder { name: "x", ..base }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("`items` comes from a read-only `Holder`")
+    .assert_error_contains("Declare the parameter `base` as `mut Holder`");
+}
+
+#[test]
+fn read_only_construction_names_the_immutable_binding() {
+    infer(
+        r#"struct Holder { items: mut Slice<int> }
+fn make() -> mut Holder {
+  let a = [1, 2, 3]
+  Holder { items: a }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("Declare `let mut a`");
+}
+
+#[test]
+fn read_only_tuple_construction_names_the_component() {
+    infer(
+        r#"struct Pair(mut Slice<int>, int)
+fn make(view: Slice<int>) -> mut Pair {
+  Pair(view, 0)
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("`.0` is declared `mut Slice<int>`, but receives `Slice<int>`");
+}
+
+#[test]
+fn read_only_variant_construction_names_the_field() {
+    infer(
+        r#"enum Load { Heavy { items: mut Slice<int> }, Empty }
+fn make(view: Slice<int>) -> mut Load {
+  Load.Heavy { items: view }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("`items` is declared `mut Slice<int>`, but receives `Slice<int>`");
+}
+
+#[test]
+fn tuple_component_write_names_the_read_only_owner() {
+    infer(
+        r#"struct Pair(mut Slice<int>, int)
+fn poke(p: Pair) {
+  p.0[0] = 1
+}"#,
+    )
+    .assert_infer_code_once("write_through_read_only")
+    .assert_error_contains("`.0` is declared writable, but `p` is read-only");
+}

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -15626,3 +15626,77 @@ enum TwiceOnOne {
 "#;
     assert_infer_error_snapshot!(input);
 }
+
+#[test]
+fn infer_read_only_construction_behind_ref_names_the_field() {
+    let input = r#"
+struct Rock { size: int }
+
+struct Beam {
+  rocks: mut Ref<mut Slice<mut Ref<Rock>>>,
+  hits: int,
+}
+
+impl Beam {
+  fn new(rocks: mut Ref<Slice<mut Ref<Rock>>>) -> mut Ref<Beam> {
+    &Beam {
+      rocks,
+      hits: 0,
+    }
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_read_only_construction_names_the_spread_base() {
+    let input = r#"
+struct Holder {
+  items: mut Slice<int>,
+  name: string,
+}
+
+fn rename(base: Holder) -> mut Holder {
+  Holder { name: "x", ..base }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_read_only_construction_names_the_immutable_binding() {
+    let input = r#"
+struct Holder { items: mut Slice<int> }
+
+fn make() -> mut Holder {
+  let a = [1, 2, 3]
+  Holder { items: a }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_read_only_tuple_construction_names_the_component() {
+    let input = r#"
+struct Pair(mut Slice<int>, int)
+
+fn make(view: Slice<int>) -> mut Pair {
+  Pair(view, 0)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_tuple_component_write_names_the_read_only_owner() {
+    let input = r#"
+struct Pair(mut Slice<int>, int)
+
+fn poke(p: Pair) {
+  p.0[0] = 1
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}

--- a/tests/ui/errors/snapshots/infer_read_only_construction_behind_ref_names_the_field.snap
+++ b/tests/ui/errors/snapshots/infer_read_only_construction_behind_ref_names_the_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing write permission
+    ╭─[test.lis:12:7]
+ 11 │     &Beam {
+ 12 │       rocks,
+    ·       ──┬──
+    ·         ╰── `rocks` is declared `mut Ref<mut Slice<mut Ref<Rock>>>`, but receives `mut Ref<Slice<Ref<Rock>>>`
+ 13 │       hits: 0,
+    ╰────
+  help: `rocks` received less `mut` than declared, so the new `Beam` is read-only. A reference to it is `mut Ref<Beam>` where `mut Ref<mut Beam>` is expected. Declare the parameter `rocks` as `mut Ref<mut Slice<mut Ref<Rock>>>` · code: [infer.needs_writable]

--- a/tests/ui/errors/snapshots/infer_read_only_construction_names_the_immutable_binding.snap
+++ b/tests/ui/errors/snapshots/infer_read_only_construction_names_the_immutable_binding.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing write permission
+   ╭─[test.lis:6:19]
+ 5 │   let a = [1, 2, 3]
+ 6 │   Holder { items: a }
+   ·                   ┬
+   ·                   ╰── `items` is declared `mut Slice<int>`, but receives `Slice<int>`
+ 7 │ }
+   ╰────
+  help: `items` received less `mut` than declared, so the new `Holder` is read-only where `mut Holder` is expected. Declare `let mut a` · code: [infer.needs_writable]

--- a/tests/ui/errors/snapshots/infer_read_only_construction_names_the_spread_base.snap
+++ b/tests/ui/errors/snapshots/infer_read_only_construction_names_the_spread_base.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing write permission
+   ╭─[test.lis:8:25]
+ 7 │ fn rename(base: Holder) -> mut Holder {
+ 8 │   Holder { name: "x", ..base }
+   ·                         ──┬─
+   ·                           ╰── `items` comes from a read-only `Holder`
+ 9 │ }
+   ╰────
+  help: `items` received less `mut` than declared, so the new `Holder` is read-only where `mut Holder` is expected. Declare the parameter `base` as `mut Holder` · code: [infer.needs_writable]

--- a/tests/ui/errors/snapshots/infer_read_only_tuple_construction_names_the_component.snap
+++ b/tests/ui/errors/snapshots/infer_read_only_tuple_construction_names_the_component.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing write permission
+   ╭─[test.lis:5:8]
+ 4 │ fn make(view: Slice<int>) -> mut Pair {
+ 5 │   Pair(view, 0)
+   ·        ──┬─
+   ·          ╰── `.0` is declared `mut Slice<int>`, but receives `Slice<int>`
+ 6 │ }
+   ╰────
+  help: `.0` received less `mut` than declared, so the new `Pair` is read-only where `mut Pair` is expected. Declare the parameter `view` as `mut Slice<int>` · code: [infer.needs_writable]

--- a/tests/ui/errors/snapshots/infer_tuple_component_write_names_the_read_only_owner.snap
+++ b/tests/ui/errors/snapshots/infer_tuple_component_write_names_the_read_only_owner.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Cannot write to `p.0[0]`
+   ╭─[test.lis:5:3]
+ 4 │ fn poke(p: Pair) {
+ 5 │   p.0[0] = 1
+   ·   ─────┬────
+   ·        ╰── `p.0` is read-only
+ 6 │ }
+   ╰────
+  help: `.0` is declared writable, but `p` is read-only, so its fields are too. Make `p` writable where it is created · code: [infer.write_through_read_only]


### PR DESCRIPTION
The write permission error on a struct literal now names the field that made the struct read-only, and explains how to fix it. Before, it was coarsely reporting the outer types on the whole literal.

```
  ✕ Missing write permission
    ╭─[test.lis:12:7]
 11 │     &Beam {
 12 │       rocks,
    ·       ──┬──
    ·         ╰── `rocks` is declared `mut Ref<mut Slice<mut Ref<Rock>>>`, but receives `mut Ref<Slice<Ref<Rock>>>`
 13 │       hits: 0,
    ╰────
  help: `rocks` received less `mut` than declared, so the new `Beam` is read-only. A reference to it is `mut Ref<Beam>` where `mut Ref<mut Beam>` is expected. Declare the parameter `rocks` as `mut Ref<mut Slice<mut Ref<Rock>>>` · code: [infer.needs_writable]
```

The same applies to enum variant literals, tuple struct calls, and `..spread` bases.

Fix #1381
