### PR TITLE
fix: tighten `for mut` diagnostics

### DIFF
--- a/crates/cli/reference/control-flow.md
+++ b/crates/cli/reference/control-flow.md
@@ -71,13 +71,42 @@ let value = if let Some(x) = opt {
 Iterates over a collection or range, for its side effects.
 
 ```lisette
+// !callout-above[/item/] an immutable copy of each element
 for item in items {
   fmt.Println(item)
 }
 
-for i in 0..5 {
-  // !callout-right prints `0, 1, 2, 3, 4`
-  fmt.Println(i)
+// !callout-above[/item/] a mutable copy of each element
+for mut item in items {
+  item *= 2
+  fmt.Println(item)
+}
+```
+
+Writing to a mutable copy does not affect the original. To write to the original in the collection, write through the index.
+
+```lisette
+for mut item in items {
+  // !callout-right does not change `items`
+  item *= 2
+  fmt.Println(item)
+}
+
+for i in 0..items.length() {
+  // !callout-right changes `items`
+  items[i] *= 2
+}
+```
+
+If the element is a slice, map or ref, `for mut` allows writing through it.
+
+```lisette
+let mut rows = [[1, 2], [3, 4]]
+
+// !callout-above[/row/] `mut Slice<int>`
+for mut row in rows {
+  // !callout-right changes `rows`
+  row[0] = 99
 }
 ```
 

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -571,8 +571,8 @@ pub fn immutable_loop_binding(
             format!("`{variable_name}` binds a copy of each element"),
         )
         .with_help(format!(
-            "Writes to the loop binding do not reach the collection. \
-             Write through {target} to update it"
+            "Bind with `for mut {variable_name}` to write to the copy, \
+             or write through {target} to update the collection"
         ))
 }
 
@@ -583,12 +583,13 @@ pub fn loop_copy_write(
 ) -> LisetteDiagnostic {
     let help = match collection {
         Some(collection) => format!(
-            "`{variable_name}` is a copy of the element, so the collection keeps its \
-             old value. Write through `{collection}[i]` to update it"
+            "`{variable_name}` is a copy of the element, and the loop body does not read it \
+             after this write, so the collection keeps its old value. \
+             Write through `{collection}[i]` to update it"
         ),
         None => format!(
-            "`{variable_name}` is a copy of the element, so the collection keeps its \
-             old value. Index into the collection to update it"
+            "`{variable_name}` is a copy of the element, and the loop body does not read it \
+             after this write, so the write is lost"
         ),
     };
     LisetteDiagnostic::warn("Write to a loop copy")
@@ -675,6 +676,10 @@ pub enum WriteContext {
         binding: String,
         collection: Option<String>,
     },
+    LoopCopy {
+        binding: String,
+        collection: Option<String>,
+    },
     AliasOf {
         binding: String,
         source: String,
@@ -725,6 +730,19 @@ pub fn needs_writable_help(expected: &str, actual: &str, context: Option<WriteCo
             ),
             None => format!("`{binding}` binds read-only elements"),
         },
+        Some(WriteContext::LoopCopy {
+            binding,
+            collection,
+        }) => match collection {
+            Some(collection) => format!(
+                "`{binding}` binds a copy of each element. Bind with `for mut {binding}` \
+                 to write to the copy, or write through `{collection}[i]` to update the collection"
+            ),
+            None => format!(
+                "`{binding}` binds a copy of each element. Bind with `for mut {binding}` \
+                 to write to the copy"
+            ),
+        },
         _ => "Make the value writable where it is created, or pass a `.clone()`".to_string(),
     };
     format!("`{expected}` permits writes, `{actual}` does not. {remedy}")
@@ -759,6 +777,10 @@ pub fn write_through_read_only(
                 Some(WriteContext::LoopElement { binding, .. }) => format!(
                     "`{binding}` binds read-only elements. \
                      Declare the collection with `let mut`"
+                ),
+                Some(WriteContext::LoopCopy { binding, .. }) => format!(
+                    "`{binding}` binds a copy of each element. Bind with `for mut {binding}` \
+                     to write to the copy"
                 ),
                 Some(WriteContext::AliasOf { binding, source }) => format!(
                     "`{binding}` shares storage with `{source}`, which is read-only. \

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -134,6 +134,13 @@ pub(super) struct LoopElementInference {
     pub(super) was_demoted: bool,
 }
 
+pub(super) struct LoopCopyWrite {
+    pub(super) binding_id: BindingId,
+    pub(super) name: String,
+    pub(super) collection: Option<String>,
+    pub(super) span: Span,
+}
+
 pub(super) enum BindingInference {
     Let(LetInference),
     LoopElement(LoopElementInference),
@@ -283,6 +290,8 @@ pub struct InferCtx<'a> {
     pub(crate) satisfying_stack: FxHashSet<(String, String)>,
     pub(super) reported_immutable: FxHashSet<BindingId>,
     pub(super) binding_inference: FxHashMap<BindingId, BindingInference>,
+    pub(super) loop_element_reads: FxHashMap<BindingId, Vec<Span>>,
+    pub(super) pending_loop_copy_writes: Vec<LoopCopyWrite>,
     pub(super) reported_read_only_writes: FxHashSet<(BindingId, String)>,
     traversal: TraversalContext,
 }
@@ -296,6 +305,8 @@ impl<'a> InferCtx<'a> {
             satisfying_stack: FxHashSet::default(),
             reported_immutable: FxHashSet::default(),
             binding_inference: FxHashMap::default(),
+            loop_element_reads: FxHashMap::default(),
+            pending_loop_copy_writes: Vec::new(),
             reported_read_only_writes: FxHashSet::default(),
             traversal: TraversalContext::default(),
         }

--- a/crates/semantics/src/checker/infer/expressions/loops.rs
+++ b/crates/semantics/src/checker/infer/expressions/loops.rs
@@ -1,10 +1,38 @@
+use std::mem;
+
 use crate::checker::EnvResolve;
-use crate::checker::infer::context::{BindingInference, LoopContext, LoopElementInference};
+use crate::checker::infer::context::{
+    BindingInference, LoopContext, LoopCopyWrite, LoopElementInference,
+};
 use syntax::ast::BindingKind;
-use syntax::ast::{Binding, Expression, Pattern, Span};
+use syntax::ast::{Binding, BindingId, Expression, Pattern, Span};
 use syntax::types::Type;
 
 use crate::checker::infer::InferCtx;
+
+fn collect_nested_loop_and_lambda_spans(
+    expression: &Expression,
+    nested_loops: &mut Vec<Span>,
+    lambdas: &mut Vec<Span>,
+) {
+    match expression {
+        Expression::Loop { span, .. }
+        | Expression::While { span, .. }
+        | Expression::WhileLet { span, .. }
+        | Expression::For { span, .. } => nested_loops.push(*span),
+        Expression::Lambda { span, .. } => lambdas.push(*span),
+        _ => {}
+    }
+    for child in expression.children() {
+        collect_nested_loop_and_lambda_spans(child, nested_loops, lambdas);
+    }
+}
+
+fn span_contains(outer: &Span, inner: &Span) -> bool {
+    outer.file_id == inner.file_id
+        && outer.byte_offset <= inner.byte_offset
+        && inner.end() <= outer.end()
+}
 
 enum IterSeqKind {
     Seq,
@@ -139,6 +167,11 @@ impl InferCtx<'_> {
         }
 
         let mutable = binding.mut_span.is_some();
+        if mutable && !binding.pattern.is_identifier() {
+            self.sink.push(diagnostics::infer::disallowed_mut_use(
+                binding.mut_span.unwrap_or(span),
+            ));
+        }
         let mut demoted_from_writable = false;
         let binding_element_ty = if mutable {
             element_ty.clone()
@@ -159,9 +192,10 @@ impl InferCtx<'_> {
                 BindingKind::Let { mutable },
             );
 
-            if let Some(name) = inferred_pattern.get_identifier()
-                && let Some(binding_id) = this.scopes.lookup_binding_id(&name)
-            {
+            let element_binding_id = inferred_pattern
+                .get_identifier()
+                .and_then(|name| this.scopes.lookup_binding_id(&name));
+            if let Some(binding_id) = element_binding_id {
                 let collection = super::aliasing::place_root_name(new_iterable.unwrap_parens())
                     .map(|root| root.to_string());
                 this.binding_inference.insert(
@@ -197,6 +231,9 @@ impl InferCtx<'_> {
             let new_body = this.with_loop(LoopContext::Statement, |s| {
                 s.infer_expression(*body, &Type::ignored())
             });
+            if let Some(binding_id) = element_binding_id {
+                this.report_dead_loop_copy_writes(binding_id, &new_body);
+            }
             (new_binding, new_body)
         });
 
@@ -205,6 +242,60 @@ impl InferCtx<'_> {
             iterable: new_iterable.into(),
             body: new_body.into(),
             span,
+        }
+    }
+
+    pub(super) fn record_loop_copy_write(&mut self, name: &str, span: Span) {
+        let Some(binding_id) = self.scopes.lookup_binding_id(name) else {
+            return;
+        };
+        let Some(inference) = self
+            .binding_inference
+            .get(&binding_id)
+            .and_then(|binding| binding.as_loop_element())
+        else {
+            return;
+        };
+        self.pending_loop_copy_writes.push(LoopCopyWrite {
+            binding_id,
+            name: name.to_string(),
+            collection: inference.collection.clone(),
+            span,
+        });
+    }
+
+    fn report_dead_loop_copy_writes(&mut self, binding_id: BindingId, body: &Expression) {
+        let (writes, other_writes): (Vec<_>, Vec<_>) =
+            mem::take(&mut self.pending_loop_copy_writes)
+                .into_iter()
+                .partition(|write| write.binding_id == binding_id);
+        self.pending_loop_copy_writes = other_writes;
+        let reads = self
+            .loop_element_reads
+            .remove(&binding_id)
+            .unwrap_or_default();
+        if writes.is_empty() {
+            return;
+        }
+        let mut nested_loops = Vec::new();
+        let mut lambdas = Vec::new();
+        collect_nested_loop_and_lambda_spans(body, &mut nested_loops, &mut lambdas);
+        let observes = |read: &Span, write: &LoopCopyWrite| {
+            read.byte_offset >= write.span.end()
+                || lambdas.iter().any(|lambda| span_contains(lambda, read))
+                || nested_loops.iter().any(|nested_loop| {
+                    span_contains(nested_loop, read) && span_contains(nested_loop, &write.span)
+                })
+        };
+        let dead_write = writes
+            .iter()
+            .find(|write| !reads.iter().any(|read| observes(read, write)));
+        if let Some(write) = dead_write {
+            self.sink.push(diagnostics::infer::loop_copy_write(
+                &write.name,
+                write.collection.as_deref(),
+                write.span,
+            ));
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -394,10 +394,12 @@ impl InferCtx<'_> {
             super::permission::WriteTarget::Through { governing } if !governing.is_writable() => {
                 self.report_write_through_read_only(receiver_expression, &governing, *span);
             }
-            super::permission::WriteTarget::Binding { name }
-                if !self.scopes.lookup_mutable(&name) =>
-            {
-                self.report_disallowed_mutation(store, &name, *span, false, None);
+            super::permission::WriteTarget::Binding { name } => {
+                if self.scopes.lookup_mutable(&name) {
+                    self.record_loop_copy_write(&name, *span);
+                } else {
+                    self.report_disallowed_mutation(store, &name, *span, false, None);
+                }
             }
             _ => {}
         }

--- a/crates/semantics/src/checker/infer/expressions/permission.rs
+++ b/crates/semantics/src/checker/infer/expressions/permission.rs
@@ -381,6 +381,15 @@ impl InferCtx<'_> {
                     callee.to_string(),
                 ))
             }
+            Expression::Reference { expression, .. } => {
+                let name = expression.unwrap_parens().get_var_name()?;
+                let binding_id = self.scopes.lookup_binding_id(&name)?;
+                let inference = self.binding_inference.get(&binding_id)?.as_loop_element()?;
+                Some(diagnostics::infer::WriteContext::LoopCopy {
+                    binding: name.to_string(),
+                    collection: inference.collection.clone(),
+                })
+            }
             _ => None,
         }
     }

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -220,18 +220,8 @@ impl InferCtx<'_> {
                 && let Some(binding_id) = self.scopes.lookup_binding_id(&var_name)
             {
                 self.facts.mark_alias_mutated(binding_id);
-                if ref_ty.is_writable()
-                    && let Some(inference) = self
-                        .binding_inference
-                        .get(&binding_id)
-                        .and_then(|binding| binding.as_loop_element())
-                    && self.reported_immutable.insert(binding_id)
-                {
-                    self.sink.push(diagnostics::infer::loop_copy_write(
-                        &var_name,
-                        inference.collection.as_deref(),
-                        span,
-                    ));
+                if ref_ty.is_writable() && expected_ty.resolve_in(&self.env).is_writable() {
+                    self.record_loop_copy_write(&var_name, span);
                 }
             }
         }
@@ -261,6 +251,13 @@ impl InferCtx<'_> {
             // Don't mark assignment targets as "used" - only mark actual uses
             if !self.is_assignment_target_context() {
                 self.facts.mark_used(id);
+                if self
+                    .binding_inference
+                    .get(&id)
+                    .is_some_and(|binding| binding.as_loop_element().is_some())
+                {
+                    self.loop_element_reads.entry(id).or_default().push(span);
+                }
             }
 
             if let Some(binding_fact) = self.facts.bindings.get(&id) {
@@ -485,18 +482,8 @@ impl InferCtx<'_> {
                 if !self.scopes.lookup_mutable(&name) && self.imports.namespace(&name).is_none() {
                     let rhs_is_ref = store.peel_alias(&value_ty.resolve_in(&self.env)).is_ref();
                     self.report_disallowed_mutation(store, &name, span, rhs_is_ref, None);
-                } else if let Some(id) = self.scopes.lookup_binding_id(&name)
-                    && let Some(inference) = self
-                        .binding_inference
-                        .get(&id)
-                        .and_then(|binding| binding.as_loop_element())
-                    && self.reported_immutable.insert(id)
-                {
-                    self.sink.push(diagnostics::infer::loop_copy_write(
-                        &name,
-                        inference.collection.as_deref(),
-                        span,
-                    ));
+                } else {
+                    self.record_loop_copy_write(&name, span);
                 }
             }
             super::permission::WriteTarget::Other => {}

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -1137,6 +1137,159 @@ fn scan(todos: Slice<Todo>) {
 }
 
 #[test]
+fn loop_copy_read_after_write_does_not_warn() {
+    infer(
+        r#"fn show(n: int) {}
+fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    x += 1
+    show(x)
+  }
+}"#,
+    )
+    .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn loop_copy_write_after_last_read_warns() {
+    infer(
+        r#"fn show(n: int) {}
+fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    show(x)
+    x += 1
+  }
+}"#,
+    )
+    .assert_infer_code_once("loop_copy_write");
+}
+
+#[test]
+fn loop_copy_method_call_warns() {
+    infer(
+        r#"struct Todo { done: bool }
+impl Todo {
+  fn finish(self: mut Ref<Todo>) { self.done = true }
+}
+fn main() {
+  let todos = [Todo { done: false }]
+  for mut todo in todos { todo.finish() }
+}"#,
+    )
+    .assert_infer_code_once("loop_copy_write");
+}
+
+#[test]
+fn loop_copy_method_call_read_after_does_not_warn() {
+    infer(
+        r#"struct Todo { done: bool }
+impl Todo {
+  fn finish(self: mut Ref<Todo>) { self.done = true }
+}
+fn show(todo: Todo) {}
+fn main() {
+  let todos = [Todo { done: false }]
+  for mut todo in todos {
+    todo.finish()
+    show(todo)
+  }
+}"#,
+    )
+    .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn loop_copy_read_only_reference_after_write_does_not_warn() {
+    infer(
+        r#"struct Todo { done: bool }
+fn show(todo: Ref<Todo>) {}
+fn main() {
+  let todos = [Todo { done: false }]
+  for mut todo in todos {
+    todo.done = true
+    show(&todo)
+  }
+}"#,
+    )
+    .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn loop_copy_write_in_nested_loop_read_before_does_not_warn() {
+    infer(
+        r#"fn show(n: int) {}
+fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    for _ in 0..2 {
+      show(x)
+      x += 1
+    }
+  }
+}"#,
+    )
+    .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn loop_copy_write_captured_by_lambda_does_not_warn() {
+    infer(
+        r#"fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    let show = || x
+    x += 1
+    let _ = show()
+  }
+}"#,
+    )
+    .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn immutable_loop_binding_suggests_for_mut() {
+    infer(
+        r#"fn main() {
+  let xs = [1, 2, 3]
+  for x in xs {
+    x += 1
+  }
+}"#,
+    )
+    .assert_infer_code_once("immutable")
+    .assert_error_contains("for mut x");
+}
+
+#[test]
+fn writable_reference_to_immutable_loop_binding_suggests_for_mut() {
+    infer(
+        r#"struct Todo { done: bool }
+fn finish(todo: mut Ref<Todo>) { todo.*.done = true }
+fn main() {
+  let todos = [Todo { done: false }]
+  for todo in todos { finish(&todo) }
+}"#,
+    )
+    .assert_infer_code_once("needs_writable")
+    .assert_error_contains("for mut todo");
+}
+
+#[test]
+fn for_mut_with_destructuring_refused() {
+    infer(
+        r#"fn main() {
+  let pairs = [(1, 2), (3, 4)]
+  for mut (a, b) in pairs {
+    let _ = a + b
+  }
+}"#,
+    )
+    .assert_infer_code_once("mut_not_allowed");
+}
+
+#[test]
 fn mut_on_scalar_refused() {
     infer(
         r#"fn double(n: mut int) -> int {


### PR DESCRIPTION
- The error on a write to a plain loop binding now mentions `for mut`.
- "Write to a loop copy" now fires only when nothing reads the copy after the write.
- The `for` docs section documents `for mut`.
