### PR TITLE
fix: keep untyped literals at their checked type in emitted go

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -19,9 +19,7 @@ use crate::types::native::NativeGoType;
 use syntax::EcoString;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments, StructFields};
 use syntax::program::{CallKind, Definition, DefinitionBody, resolved_definition};
-use syntax::types::{
-    CompoundKind, FunctionParameter, SimpleKind, Type, build_substitution_map, substitute,
-};
+use syntax::types::{CompoundKind, FunctionParameter, Type, build_substitution_map, substitute};
 
 struct TupleStructTarget {
     go_ty: String,
@@ -79,26 +77,6 @@ impl Planner<'_> {
             });
             self.literal_misinfers_type_parameter(arg, param.map(|param| &param.ty))
         })
-    }
-
-    /// True when Go's inference would lose this alias: function aliases (infer
-    /// as `func(...)`) and non-default numeric aliases (untyped literals default
-    /// to `int`/`float64`/`complex128`).
-    pub(crate) fn needs_explicit_args_for_go_inference(&self, ty: &Type) -> bool {
-        if self.is_function_alias(ty) {
-            return true;
-        }
-        let Some(numeric) = self.facts.underlying_numeric_type(ty) else {
-            return false;
-        };
-        let Some(kind) = numeric.as_simple() else {
-            return false;
-        };
-        kind.is_arithmetic()
-            && !matches!(
-                kind,
-                SimpleKind::Int | SimpleKind::Float64 | SimpleKind::Complex128
-            )
     }
 }
 
@@ -642,7 +620,7 @@ impl<'a> Planner<'a> {
             let any_needs_explicit = vars.iter().any(|v| {
                 mapping
                     .get(v.as_str())
-                    .is_some_and(|t| self.needs_explicit_args_for_go_inference(t))
+                    .is_some_and(|t| self.is_function_alias(t))
             });
             if !any_needs_explicit {
                 return None;

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -68,6 +68,19 @@ pub(crate) fn all_type_params_inferrable(
 }
 
 impl Planner<'_> {
+    /// True when no argument gives Go the right type. A builtin's arguments
+    /// share one type parameter, so one typed argument settles the call.
+    fn builtin_literal_misinfers(&self, params: &[FunctionParameter], args: &[Expression]) -> bool {
+        args.iter().enumerate().all(|(index, arg)| {
+            let param = params.get(index).or_else(|| {
+                params
+                    .last()
+                    .filter(|p| p.ty.is_native(CompoundKind::VarArgs))
+            });
+            self.literal_misinfers_type_parameter(arg, param.map(|param| &param.ty))
+        })
+    }
+
     /// True when Go's inference would lose this alias: function aliases (infer
     /// as `func(...)`) and non-default numeric aliases (untyped literals default
     /// to `int`/`float64`/`complex128`).
@@ -607,6 +620,7 @@ impl<'a> Planner<'a> {
         function: &Expression,
         declared: Option<&Type>,
         arg_shape: CallArgShape,
+        args: &[Expression],
     ) -> Option<String> {
         let Type::Forall { vars, body } = declared? else {
             return None;
@@ -621,7 +635,10 @@ impl<'a> Planner<'a> {
         let mut mapping: HashMap<String, Type> = HashMap::default();
         extract_type_mapping(body, &instantiated_ty, &mut mapping);
 
-        if all_inferrable {
+        // A builtin takes no type argument, so this becomes the conversion.
+        let builtin_needs_conversion =
+            callee_is_go_builtin(function) && self.builtin_literal_misinfers(generic_params, args);
+        if all_inferrable && !builtin_needs_conversion {
             let any_needs_explicit = vars.iter().any(|v| {
                 mapping
                     .get(v.as_str())

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -640,14 +640,16 @@ impl<'a> Planner<'a> {
         let Expression::Literal { literal, ty, .. } = unwrap_unary_negation(arg) else {
             return false;
         };
-        // `string`, `bool` and imaginary always default to the type they fill.
         let default = match literal {
             Literal::Integer { .. } => SimpleKind::Int,
             Literal::Float { .. } => SimpleKind::Float64,
+            Literal::Imaginary(_) => SimpleKind::Complex128,
             Literal::Char(_) => SimpleKind::Rune,
+            Literal::Boolean(_) => SimpleKind::Bool,
+            Literal::String { .. } => SimpleKind::String,
             _ => return false,
         };
-        self.facts.underlying_simple_kind(ty) != Some(default)
+        self.facts.peel_alias(ty).as_simple() != Some(default)
     }
 
     /// The type to convert a misinferring literal to. A variadic slot renders

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -17,9 +17,13 @@ use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee}
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
-use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
+use crate::types::go_type::render_conversion;
+use crate::utils::{
+    reads_mutable_operand, reads_unsequenced_mutable_operand, unwrap_unary_negation,
+};
 use crate::write_line;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
+use syntax::types::SimpleKind;
 use syntax::types::Type;
 
 struct CallTypeArgsRequest<'e, 'c> {
@@ -28,6 +32,7 @@ struct CallTypeArgsRequest<'e, 'c> {
     type_args: ResolvedCallTypeArguments<'e>,
     call_ty: Option<&'e Type>,
     arg_shape: CallArgShape,
+    args: &'e [Expression],
     ctx: ExpressionContext<'e>,
 }
 
@@ -40,6 +45,10 @@ struct CallArgsContext<'plan, 'facts> {
     combine_variadic: Option<VariadicCombine>,
     capture_boundary: CaptureBoundary,
     retired_receiver: Option<&'plan Expression>,
+    /// A builtin wraps the whole call, so its arguments must not also convert.
+    callee_is_builtin: bool,
+    /// Pinned type arguments type every literal, leaving nothing to infer.
+    callee_pins_type_args: bool,
 }
 
 /// Escape-aware close-quote search; plain `find` would collide with `\"` inside the literal.
@@ -245,6 +254,7 @@ impl<'a> Planner<'a> {
                 value_count: args.len(),
                 has_spread: spread.is_some(),
             },
+            args,
             ctx: expression_ctx,
         });
         // A Go builtin takes no type argument, so the instantiated type it would
@@ -271,6 +281,8 @@ impl<'a> Planner<'a> {
                 && self.callee_lowers_to_type_construction(function))
             .then(|| expression_ctx.retired_receiver())
             .flatten(),
+            callee_is_builtin: callee_is_go_builtin(function),
+            callee_pins_type_args: !type_args_string.is_empty(),
         };
         let sequenced_args = self.emit_call_args(args, &args_ctx);
         let args_effect = sequenced_args.effect;
@@ -430,6 +442,7 @@ impl<'a> Planner<'a> {
             type_args,
             call_ty,
             arg_shape,
+            args,
             ctx,
         } = request;
         if callee_curries_receiver(callee) {
@@ -452,7 +465,7 @@ impl<'a> Planner<'a> {
 
         if type_args_string.is_empty()
             && let Some(inferred) =
-                self.infer_return_only_type_args(function, callee.declared_type(), arg_shape)
+                self.infer_return_only_type_args(function, callee.declared_type(), arg_shape, args)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t).unwrap_or(inferred),
@@ -614,6 +627,41 @@ impl<'a> Planner<'a> {
         ArgumentPlan::Direct
     }
 
+    /// True when Go would read this literal at another type than its slot:
+    /// `1` filling a `T` bound to `float64` is a Go `int`.
+    pub(super) fn literal_misinfers_type_parameter(
+        &self,
+        arg: &Expression,
+        declared_param_ty: Option<&Type>,
+    ) -> bool {
+        if !declared_param_ty.is_some_and(Type::contains_type_parameter) {
+            return false;
+        }
+        let Expression::Literal { literal, ty, .. } = unwrap_unary_negation(arg) else {
+            return false;
+        };
+        // `string`, `bool` and imaginary always default to the type they fill.
+        let default = match literal {
+            Literal::Integer { .. } => SimpleKind::Int,
+            Literal::Float { .. } => SimpleKind::Float64,
+            Literal::Char(_) => SimpleKind::Rune,
+            _ => return false,
+        };
+        self.facts.underlying_simple_kind(ty) != Some(default)
+    }
+
+    /// The type to convert a misinferring literal to. A variadic slot renders
+    /// as `...T`, so this targets the element type.
+    pub(super) fn literal_pinning_go_type(
+        &mut self,
+        arg: &Expression,
+        declared_param_ty: Option<&Type>,
+        target: &Type,
+    ) -> Option<String> {
+        self.literal_misinfers_type_parameter(arg, declared_param_ty)
+            .then(|| self.use_go_type(&varargs_inner_or_self(target)))
+    }
+
     fn lower_direct_arg(
         &mut self,
         arg: &Expression,
@@ -622,13 +670,14 @@ impl<'a> Planner<'a> {
         declared_param_ty: Option<&Type>,
     ) -> ValuePlan {
         let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
+        let call_carries_type = ctx.callee_is_builtin || ctx.callee_pins_type_args;
         let mut arg_ctx = direct_arg_emit_ctx(&self.facts, effective_param_ty, suppress);
         if let Some(retired) = ctx.retired_receiver {
             arg_ctx = arg_ctx.with_retired_receiver(retired);
         }
         let argument = self.lower_composite_value(arg, arg_ctx);
         argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
-            let final_value = match effective_param_ty {
+            let mut final_value = match effective_param_ty {
                 Some(target) => {
                     let coercion = CoercionPlan::internal(self, &arg.get_type(), target);
                     let (coercion_setup, coerced) = coercion.lower(self, value);
@@ -637,6 +686,12 @@ impl<'a> Planner<'a> {
                 }
                 None => value,
             };
+            if let Some(target) = effective_param_ty
+                && !call_carries_type
+                && let Some(go_type) = self.literal_pinning_go_type(arg, declared_param_ty, target)
+            {
+                final_value = render_conversion(&go_type, &final_value);
+            }
             GoExpression::opaque_with_deferred_evaluation(final_value, contains_deferred_evaluation)
         })
     }

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -11,6 +11,7 @@ use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, ResolvedCallee};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::program::ReceiverCoercion;
@@ -257,7 +258,19 @@ impl Planner<'_> {
         if let Some(value) = self.try_adapt_lowered_fn_arg_shape(arg, Some(declared)) {
             return value;
         }
-        self.stage_composite(arg, ExpressionContext::value())
+        let staged = self.stage_composite(arg, ExpressionContext::value());
+        let Some(target) = formal_param else {
+            return staged;
+        };
+        let Some(go_type) = self.literal_pinning_go_type(arg, Some(declared), target) else {
+            return staged;
+        };
+        staged.map_rendered(|_setup, value, deferred| {
+            GoExpression::opaque_with_deferred_evaluation(
+                render_conversion(&go_type, &value),
+                deferred,
+            )
+        })
     }
 
     fn build_ufcs_qualified_call(

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -403,18 +403,13 @@ impl Planner<'_> {
             (Type::Nominal { id, params, .. }, _) => {
                 self.lisette_zero_nominal(ty, id.as_str(), params)
             }
-            (Type::Tuple(_), ValueLayout::Tuple { elements, .. }) => {
+            (Type::Tuple(slots), ValueLayout::Tuple { elements, .. }) => {
                 let parts: Vec<String> = elements
                     .iter()
-                    .map(|element| self.lisette_zero_self_typed(element.logical_type()))
+                    .map(|element| self.lisette_zero(element.logical_type()))
                     .collect();
-                self.require_stdlib();
-                format!(
-                    "{}.MakeTuple{}({})",
-                    go_name::GO_STDLIB_PKG,
-                    parts.len(),
-                    parts.join(", ")
-                )
+                let callee = self.make_tuple_callee(slots, parts.len());
+                format!("{}({})", callee, parts.join(", "))
             }
             (
                 Type::Array { .. },
@@ -424,16 +419,6 @@ impl Planner<'_> {
             ) => self.array_zero(*length, element.logical_type()).rendered(),
             _ => format!("{}{{}}", self.use_go_type(ty)),
         }
-    }
-
-    /// `lisette_zero` where Go infers from the value. Only a bare `0` needs it.
-    fn lisette_zero_self_typed(&mut self, ty: &Type) -> String {
-        let rendered = self.lisette_zero(ty);
-        if rendered != "0" || self.facts.underlying_simple_kind(ty) == Some(SimpleKind::Int) {
-            return rendered;
-        }
-        let go_type = self.use_go_type(ty);
-        render_conversion(&go_type, &rendered)
     }
 
     fn lisette_zero_nominal(&mut self, ty: &Type, id: &str, params: &[Type]) -> String {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -406,7 +406,7 @@ impl Planner<'_> {
             (Type::Tuple(_), ValueLayout::Tuple { elements, .. }) => {
                 let parts: Vec<String> = elements
                     .iter()
-                    .map(|element| self.lisette_zero(element.logical_type()))
+                    .map(|element| self.lisette_zero_self_typed(element.logical_type()))
                     .collect();
                 self.require_stdlib();
                 format!(
@@ -424,6 +424,16 @@ impl Planner<'_> {
             ) => self.array_zero(*length, element.logical_type()).rendered(),
             _ => format!("{}{{}}", self.use_go_type(ty)),
         }
+    }
+
+    /// `lisette_zero` where Go infers from the value. Only a bare `0` needs it.
+    fn lisette_zero_self_typed(&mut self, ty: &Type) -> String {
+        let rendered = self.lisette_zero(ty);
+        if rendered != "0" || self.facts.underlying_simple_kind(ty) == Some(SimpleKind::Int) {
+            return rendered;
+        }
+        let go_type = self.use_go_type(ty);
+        render_conversion(&go_type, &rendered)
     }
 
     fn lisette_zero_nominal(&mut self, ty: &Type, id: &str, params: &[Type]) -> String {

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -156,7 +156,7 @@ impl Planner<'_> {
                 .all(|ret| fn_params.iter().any(|param| param.ty.contains_type(ret)));
         let parameters_support_go_inference = fn_params
             .iter()
-            .all(|param| !self.needs_explicit_args_for_go_inference(&param.ty));
+            .all(|param| !self.is_function_alias(&param.ty));
         let inferred_at_call_site =
             ctx.is_callee() && return_params_are_inferrable && parameters_support_go_inference;
         if inferred_at_call_site {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -12,7 +12,8 @@ use crate::plan::placement::{
     collapse_boolean_branch_assign, collapse_declare_assign, expression_contains_binding,
     is_unit_call, rebind_trailing_temp, requires_temp_var,
 };
-use syntax::ast::{Binding, Expression, Literal, Pattern, UnaryOperator};
+use crate::utils::unwrap_unary_negation;
+use syntax::ast::{Binding, Expression, Literal, Pattern};
 use syntax::types::Type;
 
 #[derive(Clone, Copy)]
@@ -49,18 +50,6 @@ fn needs_explicit_type_declaration(
             _ => false,
         },
         _ => false,
-    }
-}
-
-fn unwrap_unary_negation(expression: &Expression) -> &Expression {
-    match expression {
-        Expression::Unary {
-            operator: UnaryOperator::Negative,
-            expression,
-            ..
-        } => expression.as_ref(),
-        Expression::Paren { expression, .. } => unwrap_unary_negation(expression),
-        _ => expression,
     }
 }
 

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -95,6 +95,18 @@ pub(crate) fn group_params(params: &[(String, String)]) -> String {
     parts.join(", ")
 }
 
+pub(crate) fn unwrap_unary_negation(expression: &Expression) -> &Expression {
+    match expression {
+        Expression::Unary {
+            operator: UnaryOperator::Negative,
+            expression,
+            ..
+        } => unwrap_unary_negation(expression),
+        Expression::Paren { expression, .. } => unwrap_unary_negation(expression),
+        _ => expression,
+    }
+}
+
 fn is_scalar_literal(expression: &Expression) -> bool {
     matches!(
         expression.unwrap_parens(),

--- a/tests/e2e_smoke_project/src/builtins.test.lis
+++ b/tests/e2e_smoke_project/src/builtins.test.lis
@@ -9,6 +9,17 @@ fn builtin_max_int() {
 }
 
 #[test]
+#[allow(float_cmp)]
+fn builtin_min_keeps_a_literal_at_its_annotated_type() {
+  // As `int` these divide to 0, and go reports nothing.
+  let two: float64 = min(1, 2)
+  assert two / 4.0 == 0.25
+
+  let three: float64 = min(1, 2, 3)
+  assert three / 4.0 == 0.25
+}
+
+#[test]
 fn builtin_min_string() {
   assert min("banana", "apple") == "apple"
 }

--- a/tests/e2e_smoke_project/src/generics.test.lis
+++ b/tests/e2e_smoke_project/src/generics.test.lis
@@ -173,6 +173,23 @@ fn paren_negated_literal_times_aliased() {
 
 struct Box<T> { value: T }
 
+#[test]
+fn generic_call_keeps_a_literal_at_its_annotated_type() {
+  // Inferring `int` here would make the division integer division.
+  let widened: float64 = echo_value(1)
+  assert widened / 2.0 > 0.4
+
+  let narrow: float32 = echo_value(3)
+  assert narrow > 2.5
+}
+
+#[test]
+fn tuple_field_autofill_keeps_its_element_types() {
+  let p = Measurement { .. }
+  assert p.reading.0 == 0
+  assert p.reading.1 < 0.5
+}
+
 impl<T> Box<T> {
   fn get(self: Box<T>) -> T {
     self.value
@@ -203,3 +220,9 @@ fn make_duo<A, B>(a: A, b: B) -> Duo<A, B> {
 struct Ticket(int)
 
 struct Toggle(bool)
+
+struct Measurement { reading: (int, float64) }
+
+fn echo_value<T>(value: T) -> T {
+  value
+}

--- a/tests/e2e_smoke_project/src/generics.test.lis
+++ b/tests/e2e_smoke_project/src/generics.test.lis
@@ -190,6 +190,16 @@ fn tuple_field_autofill_keeps_its_element_types() {
   assert p.reading.1 < 0.5
 }
 
+#[test]
+fn generic_call_keeps_a_literal_at_its_newtype() {
+  let toggle: Toggle = echo_value(true)
+  let label: Label = echo_value("on")
+  let ticket: Ticket = echo_value(7)
+  assert toggle.0
+  assert label.0 == "on"
+  assert ticket.0 == 7
+}
+
 impl<T> Box<T> {
   fn get(self: Box<T>) -> T {
     self.value
@@ -220,6 +230,8 @@ fn make_duo<A, B>(a: A, b: B) -> Duo<A, B> {
 struct Ticket(int)
 
 struct Toggle(bool)
+
+struct Label(string)
 
 struct Measurement { reading: (int, float64) }
 

--- a/tests/e2e_smoke_project/src/options_results.test.lis
+++ b/tests/e2e_smoke_project/src/options_results.test.lis
@@ -2,6 +2,21 @@ import "go:fmt"
 import "go:errors"
 
 #[test]
+#[allow(float_cmp)]
+fn option_some_keeps_a_literal_at_its_annotated_type() {
+  // `Some(1)` inferring `Option[int]` fails to compile at the call below.
+  let widened: Option<float64> = Some(1)
+  assert halved_option(widened) == 0.25
+}
+
+fn halved_option(value: Option<float64>) -> float64 {
+  match value {
+    Some(v) => v / 4.0,
+    None => 0.0,
+  }
+}
+
+#[test]
 fn option_some() {
   let x = Some(42)
   let result = x.unwrap_or(0)

--- a/tests/e2e_smoke_project/src/options_results.test.lis
+++ b/tests/e2e_smoke_project/src/options_results.test.lis
@@ -17,6 +17,18 @@ fn halved_option(value: Option<float64>) -> float64 {
 }
 
 #[test]
+fn option_some_keeps_a_literal_at_its_newtype() {
+  let armed: Option<Armed> = Some(true)
+  let rank: Option<Rank> = Some(3)
+  assert armed.unwrap_or(Armed(false)).0
+  assert rank.unwrap_or(Rank(0)).0 == 3
+}
+
+struct Armed(bool)
+
+struct Rank(int)
+
+#[test]
 fn option_some() {
   let x = Some(42)
   let result = x.unwrap_or(0)

--- a/tests/spec/build/snapshots/adapted_numeric_literal_through_generic_constructor_compiles.snap
+++ b/tests/spec/build/snapshots/adapted_numeric_literal_through_generic_constructor_compiles.snap
@@ -11,9 +11,9 @@ import (
 
 func main() {
 	xs := []lisette.Option[int32]{
-		lisette.MakeOptionSome[int32](1),
+		lisette.MakeOptionSome(int32(1)),
 		lisette.MakeOptionNone[int32](),
-		lisette.MakeOptionSome[int32](3),
+		lisette.MakeOptionSome(int32(3)),
 	}
 	counts := make(map[int32]string)
 	counts[7] = "seven"

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1772,6 +1772,69 @@ fn test() {
 }
 
 #[test]
+fn generic_call_types_a_literal_of_another_default() {
+    let input = r#"
+fn ident<T>(v: T) -> T { v }
+
+fn test() -> float64 {
+  let widened: float64 = ident(1)
+  let already: float64 = ident(1.5)
+  let narrow: float32 = ident(2)
+  widened / already + narrow as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_call_types_a_negated_literal() {
+    let input = r#"
+fn ident<T>(v: T) -> T { v }
+
+fn test() -> float64 {
+  let parenthesized: float64 = -(1)
+  let negated: float64 = ident(-(1))
+  parenthesized / 2.0 + negated / 2.0
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn method_call_types_a_literal_of_another_default() {
+    let input = r#"
+struct Box { label: string }
+
+impl Box {
+  fn scale<T>(self, v: T) -> T { v }
+}
+
+fn test() -> byte {
+  let b = Box { label: "x" }
+  let widened: float32 = b.scale(1)
+  let letter: byte = b.scale('a')
+  letter + widened as byte
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generic_call_leaves_a_literal_in_a_concrete_slot_alone() {
+    let input = r#"
+fn scaled<T>(v: T, _factor: float64) -> T { v }
+fn work() -> Result<int, error> { Ok(1) }
+
+fn test() -> int {
+  let r = work()
+  let t: (Result<int, error>, int) = (scaled(r, 1), 0)
+  t.1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn parenthesized_local_generic_return_only_type_args() {
     let input = r#"
 fn make<T>() -> Slice<T> {

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1835,6 +1835,29 @@ fn test() -> int {
 }
 
 #[test]
+fn generic_call_types_a_literal_into_a_newtype() {
+    let input = r#"
+struct Flag(bool)
+struct Label(string)
+struct Ticket(int)
+struct Weight(float64)
+struct Letter(rune)
+
+fn ident<T>(v: T) -> T { v }
+
+fn test() -> Flag {
+  let label: Label = ident("x")
+  let ticket: Ticket = ident(1)
+  let weight: Weight = ident(1.5)
+  let letter: Letter = ident('a')
+  let _ = (label, ticket, weight, letter)
+  ident(true)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn parenthesized_local_generic_return_only_type_args() {
     let input = r#"
 fn make<T>() -> Slice<T> {

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -1371,6 +1371,43 @@ fn test() -> float64 {
 }
 
 #[test]
+fn builtin_min_types_a_literal_of_another_default() {
+    let input = r#"
+fn test() -> float64 {
+  let two: float64 = min(1, 2)
+  let three: float64 = min(1, 2, 3)
+  let narrow: float32 = min(1, 2)
+  two / three + narrow as float64
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn builtin_min_types_a_character_literal_into_an_int_slot() {
+    let input = r#"
+fn test() -> int {
+  let letter: int = min('a', 'b')
+  letter
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+/// One argument Go can already type settles the call, so no wrap is emitted.
+#[test]
+fn builtin_max_leaves_go_inference_alone_when_an_operand_types_it() {
+    let input = r#"
+fn test(measured: float64) -> float64 {
+  let promoted: float64 = max(1, 2.5)
+  let from_operand: float64 = max(1, measured)
+  promoted + from_operand
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn builtin_min_strings() {
     let input = r#"
 fn test() -> string {

--- a/tests/spec/emit/prelude.rs
+++ b/tests/spec/emit/prelude.rs
@@ -1408,6 +1408,21 @@ fn test(measured: float64) -> float64 {
 }
 
 #[test]
+fn builtin_min_types_a_literal_into_a_newtype() {
+    let input = r#"
+struct Ticket(int)
+struct Label(string)
+
+fn test() -> Ticket {
+  let label: Label = max("a", "b")
+  let _ = label
+  min(1, 2)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn builtin_min_strings() {
     let input = r#"
 fn test() -> string {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -31,6 +31,35 @@ fn test() -> Option<int> {
 }
 
 #[test]
+fn option_some_types_a_literal_of_another_default() {
+    let input = r#"
+fn halved(value: Option<float64>) -> float64 {
+  match value {
+    Some(v) => v / 4.0,
+    None => 0.0,
+  }
+}
+
+fn test() -> float64 {
+  let widened: Option<float64> = Some(1)
+  halved(widened)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn result_ok_types_a_literal_of_another_default() {
+    let input = r#"
+fn test() -> Result<float64, error> {
+  let widened: Result<float64, error> = Ok(1)
+  widened
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn option_none_construction() {
     let input = r#"
 fn test() -> Option<int> {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -60,6 +60,21 @@ fn test() -> Result<float64, error> {
 }
 
 #[test]
+fn option_some_types_a_literal_into_a_newtype() {
+    let input = r#"
+struct Flag(bool)
+struct Ticket(int)
+
+fn test() -> (Option<Flag>, Option<Ticket>) {
+  let armed: Option<Flag> = Some(true)
+  let ticket: Option<Ticket> = Some(1)
+  (armed, ticket)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn option_none_construction() {
     let input = r#"
 fn test() -> Option<int> {

--- a/tests/spec/emit/snapshots/builtin_max_leaves_go_inference_alone_when_an_operand_types_it.snap
+++ b/tests/spec/emit/snapshots/builtin_max_leaves_go_inference_alone_when_an_operand_types_it.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test(measured: float64) -> float64 {
+    let promoted: float64 = max(1, 2.5)
+    let from_operand: float64 = max(1, measured)
+    promoted + from_operand
+  }
+---
+package main
+
+func test(measured float64) float64 {
+	promoted := max(1, 2.5)
+	from_operand := max(1, measured)
+	return promoted + from_operand
+}

--- a/tests/spec/emit/snapshots/builtin_min_max_sized_integers.snap
+++ b/tests/spec/emit/snapshots/builtin_min_max_sized_integers.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func test(a, b byte, c, d rune) rune {
-	_ = byte(min(a, b))
-	return rune(max(c, d))
+	_ = min(a, b)
+	return max(c, d)
 }

--- a/tests/spec/emit/snapshots/builtin_min_named_go_type.snap
+++ b/tests/spec/emit/snapshots/builtin_min_named_go_type.snap
@@ -13,5 +13,5 @@ package main
 import "time"
 
 func test(a, b time.Duration) time.Duration {
-	return time.Duration(min(a, b))
+	return min(a, b)
 }

--- a/tests/spec/emit/snapshots/builtin_min_types_a_character_literal_into_an_int_slot.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_character_literal_into_an_int_slot.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> int {
+    let letter: int = min('a', 'b')
+    letter
+  }
+---
+package main
+
+func test() int {
+	letter := int(min('a', 'b'))
+	return letter
+}

--- a/tests/spec/emit/snapshots/builtin_min_types_a_literal_into_a_newtype.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_literal_into_a_newtype.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  struct Ticket(int)
+  struct Label(string)
+  
+  fn test() -> Ticket {
+    let label: Label = max("a", "b")
+    let _ = label
+    min(1, 2)
+  }
+---
+package main
+
+type Ticket int
+
+type Label string
+
+func test() Ticket {
+	label := Label(max("a", "b"))
+	_ = label
+	return Ticket(min(1, 2))
+}

--- a/tests/spec/emit/snapshots/builtin_min_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_literal_of_another_default.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/prelude.rs
+description: |
+  
+  fn test() -> float64 {
+    let two: float64 = min(1, 2)
+    let three: float64 = min(1, 2, 3)
+    let narrow: float32 = min(1, 2)
+    two / three + narrow as float64
+  }
+---
+package main
+
+func test() float64 {
+	two := float64(min(1, 2))
+	three := float64(min(1, 2, 3))
+	narrow := float32(min(1, 2))
+	return two/three + float64(narrow)
+}

--- a/tests/spec/emit/snapshots/generic_call_leaves_a_literal_in_a_concrete_slot_alone.snap
+++ b/tests/spec/emit/snapshots/generic_call_leaves_a_literal_in_a_concrete_slot_alone.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn scaled<T>(v: T, _factor: float64) -> T { v }
+  fn work() -> Result<int, error> { Ok(1) }
+  
+  fn test() -> int {
+    let r = work()
+    let t: (Result<int, error>, int) = (scaled(r, 1), 0)
+    t.1
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func scaled[T any](v T, _ float64) T {
+	return v
+}
+
+func work() (int, error) {
+	return 1, nil
+}
+
+func test() int {
+	ret_1, ret_2 := work()
+	var r lisette.Result[int, error]
+	if ret_2 != nil {
+		r = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		r = lisette.MakeResultOk[int, error](ret_1)
+	}
+	t := lisette.MakeTuple2[lisette.Result[int, error], int](scaled(r, 1), 0)
+	return t.Second
+}

--- a/tests/spec/emit/snapshots/generic_call_types_a_literal_into_a_newtype.snap
+++ b/tests/spec/emit/snapshots/generic_call_types_a_literal_into_a_newtype.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Flag(bool)
+  struct Label(string)
+  struct Ticket(int)
+  struct Weight(float64)
+  struct Letter(rune)
+  
+  fn ident<T>(v: T) -> T { v }
+  
+  fn test() -> Flag {
+    let label: Label = ident("x")
+    let ticket: Ticket = ident(1)
+    let weight: Weight = ident(1.5)
+    let letter: Letter = ident('a')
+    let _ = (label, ticket, weight, letter)
+    ident(true)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Flag bool
+
+type Label string
+
+type Ticket int
+
+type Weight float64
+
+type Letter rune
+
+func ident[T any](v T) T {
+	return v
+}
+
+func test() Flag {
+	label := ident(Label("x"))
+	ticket := ident(Ticket(1))
+	weight := ident(Weight(1.5))
+	letter := ident(Letter('a'))
+	_ = lisette.MakeTuple4[Label, Ticket, Weight, Letter](label, ticket, weight, letter)
+	return ident(Flag(true))
+}

--- a/tests/spec/emit/snapshots/generic_call_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/generic_call_types_a_literal_of_another_default.snap
@@ -20,6 +20,6 @@ func ident[T any](v T) T {
 func test() float64 {
 	widened := ident(float64(1))
 	already := ident(1.5)
-	narrow := ident[float32](2)
+	narrow := ident(float32(2))
 	return widened/already + float64(narrow)
 }

--- a/tests/spec/emit/snapshots/generic_call_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/generic_call_types_a_literal_of_another_default.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn ident<T>(v: T) -> T { v }
+  
+  fn test() -> float64 {
+    let widened: float64 = ident(1)
+    let already: float64 = ident(1.5)
+    let narrow: float32 = ident(2)
+    widened / already + narrow as float64
+  }
+---
+package main
+
+func ident[T any](v T) T {
+	return v
+}
+
+func test() float64 {
+	widened := ident(float64(1))
+	already := ident(1.5)
+	narrow := ident[float32](2)
+	return widened/already + float64(narrow)
+}

--- a/tests/spec/emit/snapshots/generic_call_types_a_negated_literal.snap
+++ b/tests/spec/emit/snapshots/generic_call_types_a_negated_literal.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn ident<T>(v: T) -> T { v }
+  
+  fn test() -> float64 {
+    let parenthesized: float64 = -(1)
+    let negated: float64 = ident(-(1))
+    parenthesized / 2.0 + negated / 2.0
+  }
+---
+package main
+
+func ident[T any](v T) T {
+	return v
+}
+
+func test() float64 {
+	var parenthesized float64 = -(1)
+	negated := ident(float64(-(1)))
+	return parenthesized/2.0 + negated/2.0
+}

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	b := aws.ListInput{}
-	opt_1 := lisette.MakeOptionSome[int32](5)
+	opt_1 := lisette.MakeOptionSome(int32(5))
 	var ptr_2 *int32
 	if opt_1.Tag == lisette.OptionSome {
 		ptr_2 = &opt_1.SomeVal

--- a/tests/spec/emit/snapshots/method_call_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/method_call_types_a_literal_of_another_default.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Box { label: string }
+  
+  impl Box {
+    fn scale<T>(self, v: T) -> T { v }
+  }
+  
+  fn test() -> byte {
+    let b = Box { label: "x" }
+    let widened: float32 = b.scale(1)
+    let letter: byte = b.scale('a')
+    letter + widened as byte
+  }
+---
+package main
+
+type Box struct {
+	label string
+}
+
+func Box_scale[T any](_ Box, v T) T {
+	return v
+}
+
+func test() byte {
+	b := Box{label: "x"}
+	widened := Box_scale(b, float32(1))
+	letter := Box_scale(b, byte('a'))
+	return letter + byte(widened)
+}

--- a/tests/spec/emit/snapshots/option_some_types_a_literal_into_a_newtype.snap
+++ b/tests/spec/emit/snapshots/option_some_types_a_literal_into_a_newtype.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct Flag(bool)
+  struct Ticket(int)
+  
+  fn test() -> (Option<Flag>, Option<Ticket>) {
+    let armed: Option<Flag> = Some(true)
+    let ticket: Option<Ticket> = Some(1)
+    (armed, ticket)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Flag bool
+
+type Ticket int
+
+func test() (lisette.Option[Flag], lisette.Option[Ticket]) {
+	armed := lisette.MakeOptionSome(Flag(true))
+	ticket := lisette.MakeOptionSome(Ticket(1))
+	return armed, ticket
+}

--- a/tests/spec/emit/snapshots/option_some_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/option_some_types_a_literal_of_another_default.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn halved(value: Option<float64>) -> float64 {
+    match value {
+      Some(v) => v / 4.0,
+      None => 0.0,
+    }
+  }
+  
+  fn test() -> float64 {
+    let widened: Option<float64> = Some(1)
+    halved(widened)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func halved(value lisette.Option[float64]) float64 {
+	if value.Tag == lisette.OptionSome {
+		return value.SomeVal / 4.0
+	}
+	return 0.0
+}
+
+func test() float64 {
+	widened := lisette.MakeOptionSome(float64(1))
+	return halved(widened)
+}

--- a/tests/spec/emit/snapshots/result_ok_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/result_ok_types_a_literal_of_another_default.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn test() -> Result<float64, error> {
+    let widened: Result<float64, error> = Ok(1)
+    widened
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test() (float64, error) {
+	widened := lisette.MakeResultOk[float64, error](1)
+	v_1 := widened
+	if v_1.Tag == lisette.ResultOk {
+		return v_1.OkVal, nil
+	}
+	return 0.0, v_1.ErrVal
+}

--- a/tests/spec/emit/snapshots/tuple_field_autofill_uses_constructor.snap
+++ b/tests/spec/emit/snapshots/tuple_field_autofill_uses_constructor.snap
@@ -22,7 +22,7 @@ type Probe struct {
 
 func make_() Probe {
 	return Probe{
-		Pair:   lisette.MakeTuple2(0, ""),
-		Nested: lisette.MakeTuple2(lisette.MakeOptionNone[int](), lisette.MakeTuple2(0, 0)),
+		Pair:   lisette.MakeTuple2[int, string](0, ""),
+		Nested: lisette.MakeTuple2[lisette.Option[int], lisette.Tuple2[int, int]](lisette.MakeOptionNone[int](), lisette.MakeTuple2[int, int](0, 0)),
 	}
 }

--- a/tests/spec/emit/snapshots/tuple_field_autofill_zeros_carry_their_element_types.snap
+++ b/tests/spec/emit/snapshots/tuple_field_autofill_zeros_carry_their_element_types.snap
@@ -49,14 +49,14 @@ type Probe struct {
 
 func make_() Probe {
 	return Probe{
-		Plain:        lisette.MakeTuple2(0, ""),
-		Floaty:       lisette.MakeTuple2(0, float64(0)),
-		Small:        lisette.MakeTuple2(float32(0), uint8(0)),
-		Bytes:        lisette.MakeTuple2(byte(0), ""),
-		Aliased:      lisette.MakeTuple2(Meters(0), 0),
-		AliasOfInt:   lisette.MakeTuple2(0, ""),
-		Newtype:      lisette.MakeTuple2(Ticket(0), 0),
-		NewtypeFloat: lisette.MakeTuple2(Weight(0), 0),
-		Nested:       lisette.MakeTuple2(0, lisette.MakeTuple2(0, float64(0))),
+		Plain:        lisette.MakeTuple2[int, string](0, ""),
+		Floaty:       lisette.MakeTuple2[int, float64](0, 0),
+		Small:        lisette.MakeTuple2[float32, uint8](0, 0),
+		Bytes:        lisette.MakeTuple2[byte, string](0, ""),
+		Aliased:      lisette.MakeTuple2[Meters, int](0, 0),
+		AliasOfInt:   lisette.MakeTuple2[Count, string](0, ""),
+		Newtype:      lisette.MakeTuple2[Ticket, int](Ticket(0), 0),
+		NewtypeFloat: lisette.MakeTuple2[Weight, int](Weight(0), 0),
+		Nested:       lisette.MakeTuple2[int, lisette.Tuple2[int, float64]](0, lisette.MakeTuple2[int, float64](0, 0)),
 	}
 }

--- a/tests/spec/emit/snapshots/tuple_field_autofill_zeros_carry_their_element_types.snap
+++ b/tests/spec/emit/snapshots/tuple_field_autofill_zeros_carry_their_element_types.snap
@@ -1,0 +1,62 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  type Meters = float64
+  type Count = int
+  struct Ticket(int)
+  struct Weight(float64)
+  
+  struct Probe {
+    pub plain: (int, string),
+    pub floaty: (int, float64),
+    pub small: (float32, uint8),
+    pub bytes: (byte, string),
+    pub aliased: (Meters, int),
+    pub alias_of_int: (Count, string),
+    pub newtype: (Ticket, int),
+    pub newtype_float: (Weight, int),
+    pub nested: (int, (int, float64)),
+  }
+  
+  fn make() -> Probe {
+    Probe { .. }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Meters = float64
+
+type Count = int
+
+type Ticket int
+
+type Weight float64
+
+type Probe struct {
+	Plain        lisette.Tuple2[int, string]
+	Floaty       lisette.Tuple2[int, float64]
+	Small        lisette.Tuple2[float32, uint8]
+	Bytes        lisette.Tuple2[byte, string]
+	Aliased      lisette.Tuple2[Meters, int]
+	AliasOfInt   lisette.Tuple2[Count, string]
+	Newtype      lisette.Tuple2[Ticket, int]
+	NewtypeFloat lisette.Tuple2[Weight, int]
+	Nested       lisette.Tuple2[int, lisette.Tuple2[int, float64]]
+}
+
+func make_() Probe {
+	return Probe{
+		Plain:        lisette.MakeTuple2(0, ""),
+		Floaty:       lisette.MakeTuple2(0, float64(0)),
+		Small:        lisette.MakeTuple2(float32(0), uint8(0)),
+		Bytes:        lisette.MakeTuple2(byte(0), ""),
+		Aliased:      lisette.MakeTuple2(Meters(0), 0),
+		AliasOfInt:   lisette.MakeTuple2(0, ""),
+		Newtype:      lisette.MakeTuple2(Ticket(0), 0),
+		NewtypeFloat: lisette.MakeTuple2(Weight(0), 0),
+		Nested:       lisette.MakeTuple2(0, lisette.MakeTuple2(0, float64(0))),
+	}
+}

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2365,6 +2365,33 @@ fn make() -> Probe {
 }
 
 #[test]
+fn tuple_field_autofill_zeros_carry_their_element_types() {
+    let input = r#"
+type Meters = float64
+type Count = int
+struct Ticket(int)
+struct Weight(float64)
+
+struct Probe {
+  pub plain: (int, string),
+  pub floaty: (int, float64),
+  pub small: (float32, uint8),
+  pub bytes: (byte, string),
+  pub aliased: (Meters, int),
+  pub alias_of_int: (Count, string),
+  pub newtype: (Ticket, int),
+  pub newtype_float: (Weight, int),
+  pub nested: (int, (int, float64)),
+}
+
+fn make() -> Probe {
+  Probe { .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_multi_field_def() {
     let input = r#"
 struct Point(int, int)


### PR DESCRIPTION
The compiler does not produce the correct type cast (on the go side), when given a type. The emitted code is correct in both in lis and go, but fails logically (produces a wrong result).

A dumbed-down example. No errors, but silently a wrong result.

```rust
let smallest: float64 = min(3, 10)
let half = smallest / 2.0
fmt.Println(half) // expected 1.5, but got 1
```

I found this issue is present in at least the following cases:

```rust
struct Config { size: (int, float64) }

impl Box {
  fn scale<T>(self, v: T) -> T { v }
}

fn ident<T>(v: T) -> T { v }

                                    expected               currently
let c = Config { .. }               Tuple2[int, float64]   Tuple2[int, int]
let x: float64 = ident(1)           float64                int
let n: float32 = -(1)               float32                int
let m: float32 = b.scale(3)         float32                int
let l: byte = b.scale('a')          byte                   rune
let a: float64 = min(3, 10)         float64                int
let o: Option<float64> = Some(1)    Option[float64]        Option[int]
```

