### PR TITLE
refactor: fit data structures to access patterns

### DIFF
--- a/bindgen/internal/cli/rust_index.go
+++ b/bindgen/internal/cli/rust_index.go
@@ -15,17 +15,17 @@ use std::sync::LazyLock;
 
 use crate::Target;
 
+type TypedefEntries = &'static [(&'static str, &'static str)];
+type PackageTargets = &'static [(&'static str, &'static str)];
+
 static GO_STDLIB_COMMON: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
     HashMap::from([
 %s    ])
 });
 
 %s
-static GO_STDLIB_PACKAGE_TARGETS: LazyLock<HashMap<&str, &[(&str, &str)]>> =
-    LazyLock::new(|| {
-        HashMap::from([
-%s        ])
-    });
+static GO_STDLIB_PACKAGE_TARGETS: &[(&str, PackageTargets)] = &[
+%s];
 
 pub fn get_go_stdlib_typedef(package: &str, target: Target) -> Option<&'static str> {
     if !is_available_on(package, target) {
@@ -44,7 +44,7 @@ pub fn get_go_stdlib_packages(target: Target) -> Vec<&'static str> {
         .filter(|pkg| is_available_on(pkg, target))
         .collect();
     if let Some(overlay) = overlay_for(target) {
-        packages.extend(overlay.keys().copied());
+        packages.extend(overlay.iter().map(|(package, _)| *package));
     }
     packages.sort();
     packages
@@ -53,11 +53,14 @@ pub fn get_go_stdlib_packages(target: Target) -> Vec<&'static str> {
 pub fn get_go_stdlib_package_targets(
     package: &str,
 ) -> Option<&'static [(&'static str, &'static str)]> {
-    GO_STDLIB_PACKAGE_TARGETS.get(package).copied()
+    GO_STDLIB_PACKAGE_TARGETS
+        .iter()
+        .find(|(candidate, _)| *candidate == package)
+        .map(|(_, targets)| *targets)
 }
 
 fn is_available_on(package: &str, target: Target) -> bool {
-    match GO_STDLIB_PACKAGE_TARGETS.get(package) {
+    match get_go_stdlib_package_targets(package) {
         Some(targets) => targets
             .iter()
             .any(|(goos, goarch)| *goos == target.goos && *goarch == target.goarch),
@@ -66,10 +69,15 @@ fn is_available_on(package: &str, target: Target) -> bool {
 }
 
 fn lookup_in_overlay(target: Target, package: &str) -> Option<&'static str> {
-    overlay_for(target).and_then(|overlay| overlay.get(package).copied())
+    overlay_for(target).and_then(|overlay| {
+        overlay
+            .iter()
+            .find(|(candidate, _)| *candidate == package)
+            .map(|(_, source)| *source)
+    })
 }
 
-fn overlay_for(target: Target) -> Option<&'static HashMap<&'static str, &'static str>> {
+fn overlay_for(target: Target) -> Option<TypedefEntries> {
     match (target.goos, target.goarch) {
 %s        _ => None,
     }
@@ -89,7 +97,7 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 		}
 	}
 	slices.Sort(commonPaths)
-	commonEntries := buildEntries(commonPaths, nil)
+	commonEntries := buildEntries(commonPaths, nil, "        ")
 
 	// Invert variants into per-target entries pointing at canonical files.
 	perTarget := make(map[Target]map[string]Target)
@@ -120,11 +128,11 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 		}
 		slices.Sort(paths)
 		staticName := overlayStaticName(target)
-		fmt.Fprintf(&overlayBlocks, "static %s: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {\n    HashMap::from([\n", staticName)
-		overlayBlocks.WriteString(buildEntries(paths, entries))
-		overlayBlocks.WriteString("    ])\n});\n\n")
+		fmt.Fprintf(&overlayBlocks, "static %s: TypedefEntries = &[\n", staticName)
+		overlayBlocks.WriteString(buildEntries(paths, entries, "    "))
+		overlayBlocks.WriteString("];\n\n")
 
-		fmt.Fprintf(&matchArms, "        (%q, %q) => Some(&%s),\n", target.goos, target.goarch, staticName)
+		fmt.Fprintf(&matchArms, "        (%q, %q) => Some(%s),\n", target.goos, target.goarch, staticName)
 	}
 
 	intendedEntries := buildIntendedEntries(partition, len(targets))
@@ -145,10 +153,10 @@ func generateRustIndexFile(outDir string, partition partitioned, targets []Targe
 	return nil
 }
 
-// buildEntries renders HashMap entries for a typedef map. When `canonical`
+// buildEntries renders entries for a typedef table. When `canonical`
 // is nil, paths point at suffixless files (the common map). Otherwise each
 // entry points at the canonical target's file for that package.
-func buildEntries(pkgPaths []string, canonical map[string]Target) string {
+func buildEntries(pkgPaths []string, canonical map[string]Target, indentation string) string {
 	var b strings.Builder
 	for _, pkgPath := range pkgPaths {
 		suffix := ""
@@ -156,8 +164,8 @@ func buildEntries(pkgPaths []string, canonical map[string]Target) string {
 			suffix = "_" + t.Suffix()
 		}
 		fmt.Fprintf(&b,
-			"        (%q, include_str!(\"../typedefs/%s%s.d.lis\")),\n",
-			pkgPath, pkgPath, suffix,
+			"%s(%q, include_str!(\"../typedefs/%s%s.d.lis\")),\n",
+			indentation, pkgPath, pkgPath, suffix,
 		)
 	}
 	return b.String()
@@ -181,7 +189,7 @@ func buildIntendedEntries(partition partitioned, targetCount int) string {
 			}
 			fmt.Fprintf(&pairs, "(%q, %q)", t.goos, t.goarch)
 		}
-		fmt.Fprintf(&b, "            (%q, &[%s][..]),\n", pkgPath, pairs.String())
+		fmt.Fprintf(&b, "    (%q, &[%s]),\n", pkgPath, pairs.String())
 	}
 	return b.String()
 }

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -367,7 +367,11 @@ pub fn write_go_outputs(dir: &Path, files: &[OutputFile]) -> Result<EmitWriteRes
             });
         }
 
-        let mut imports: Vec<String> = file.imports.iter().map(|(path, _)| path.clone()).collect();
+        let mut imports: Vec<String> = file
+            .imports
+            .iter()
+            .map(|import| import.path.clone())
+            .collect();
         imports.sort();
         imports.dedup();
         new_manifest.push(ManifestEntry {

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -740,11 +740,27 @@ pub fn verify_go_packages(
     }
 }
 
+/// An action from one line of `go test -json` output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GoTestAction {
+    Attr,
+    BuildFail,
+    BuildOutput,
+    Fail,
+    Output,
+    Pass,
+    Run,
+    Skip,
+    #[serde(other)]
+    Other,
+}
+
 /// One line of `go test -json` output (`elapsed` is in seconds).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct GoTestEvent {
-    pub action: String,
+    pub action: GoTestAction,
     #[serde(default)]
     pub package: String,
     pub test: Option<String>,
@@ -839,6 +855,13 @@ mod tests {
 
     fn windows() -> Target {
         Target::new("windows", "amd64")
+    }
+
+    #[test]
+    fn unknown_go_test_action_deserializes_as_other() {
+        let event: GoTestEvent = serde_json::from_str(r#"{"Action":"pause"}"#).unwrap();
+
+        assert_eq!(event.action, GoTestAction::Other);
     }
 
     #[test]

--- a/crates/cli/src/go_cli.rs
+++ b/crates/cli/src/go_cli.rs
@@ -327,6 +327,21 @@ pub struct ManifestEntry {
     pub imports: Vec<String>,
 }
 
+struct StoredManifestEntry {
+    content_hash: u64,
+    imports: Vec<String>,
+}
+
+impl StoredManifestEntry {
+    fn with_name(self, name: String) -> ManifestEntry {
+        ManifestEntry {
+            name,
+            content_hash: self.content_hash,
+            imports: self.imports,
+        }
+    }
+}
+
 pub struct EmitWriteResult {
     pub changed: Vec<PathBuf>,
     pub new_manifest: Vec<ManifestEntry>,
@@ -341,13 +356,13 @@ pub fn write_go_outputs(dir: &Path, files: &[OutputFile]) -> Result<EmitWriteRes
         let go_file_path = dir.join(&file.name);
         let go_code = file.to_go_unformatted();
         let hash = hash_go_code(&go_code);
-        let prior = prior_manifest.remove(&file.name);
+        let prior = prior_manifest.remove_entry(&file.name);
 
-        if let Some(entry) = prior
+        if let Some((name, entry)) = prior
             && entry.content_hash == hash
             && go_file_path.exists()
         {
-            new_manifest.push(entry);
+            new_manifest.push(entry.with_name(name));
             continue;
         }
 
@@ -385,7 +400,7 @@ pub fn write_go_outputs(dir: &Path, files: &[OutputFile]) -> Result<EmitWriteRes
     // Preserve entries for files emit skipped this build but still on disk.
     for (name, entry) in prior_manifest {
         if dir.join(&name).exists() {
-            new_manifest.push(entry);
+            new_manifest.push(entry.with_name(name));
         }
     }
 
@@ -443,7 +458,7 @@ fn hash_go_code(content: &str) -> u64 {
     h
 }
 
-fn read_emit_manifest(dir: &Path) -> HashMap<String, ManifestEntry> {
+fn read_emit_manifest(dir: &Path) -> HashMap<String, StoredManifestEntry> {
     let Ok(content) = fs::read_to_string(emit_manifest_path(dir)) else {
         return Default::default();
     };
@@ -460,8 +475,7 @@ fn read_emit_manifest(dir: &Path) -> HashMap<String, ManifestEntry> {
                 .unwrap_or_default();
             Some((
                 name.to_string(),
-                ManifestEntry {
-                    name: name.to_string(),
+                StoredManifestEntry {
                     content_hash: hash,
                     imports,
                 },

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -623,7 +623,7 @@ fn enrich_with_parent_hint(workspace: &GoWorkspace, path: &str, msg: String) -> 
 
 /// Write `target/go.mod` from the manifest, plus one `extra` dep not yet in it.
 fn write_target_go_mod(setup: &MutationProject, extra: Option<(&str, deps::GoDependency)>) -> bool {
-    let mut go_deps = setup.manifest.go_deps();
+    let mut go_deps = setup.manifest.go_deps().clone();
     if let Some((module, dep)) = extra {
         go_deps.insert(module.to_string(), dep);
     }
@@ -669,7 +669,7 @@ fn strip_replacement_for(go_deps: &mut BTreeMap<String, deps::GoDependency>, pac
 fn setup_project(parsed_dep: ParsedDependency) -> Result<AddPlan, i32> {
     let setup = MutationProject::open()?;
     print_preview_notice("Third-party Go dependencies", true);
-    let mut go_deps = setup.manifest.go_deps();
+    let mut go_deps = setup.manifest.go_deps().clone();
     strip_replacement_for(&mut go_deps, &parsed_dep.requested_package);
     if !write_target_go_mod_from(&setup, go_deps) {
         return Err(1);

--- a/crates/cli/src/handlers/add.rs
+++ b/crates/cli/src/handlers/add.rs
@@ -376,13 +376,10 @@ fn run_add_pipeline(plan: AddPlan) -> i32 {
         deps::ReplacementSource::Local { path } => crate::output::ReplacementLabel::Local { path },
     });
 
-    let edges = module_graph.edges();
-    let versions = module_graph.versions();
     print_add_success(
         &resolved_dep.canonical_module,
         &dep_version,
-        &edges,
-        &versions,
+        &module_graph,
         &upgraded_tuples,
         replacement_label,
     );

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -4,7 +4,7 @@
 //! convergence, replacement-closure reconciliation, and manifest application live here
 //! so neither handler owns them.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::go_cli;
@@ -30,13 +30,32 @@ enum ModuleState {
     /// Known through a typedef import, but not yet exhaustively scanned.
     Discovered {
         version: String,
-        known_dependencies: Vec<String>,
+        known_dependencies: Dependencies,
     },
     /// Scanned at this version. An empty dependency list is a real leaf.
     Expanded {
         version: String,
-        dependencies: Vec<String>,
+        dependencies: Dependencies,
     },
+}
+
+#[derive(Default)]
+struct Dependencies {
+    ordered: Vec<String>,
+    members: HashSet<String>,
+}
+
+impl Dependencies {
+    fn from_ordered(ordered: Vec<String>) -> Self {
+        let members = ordered.iter().cloned().collect();
+        Self { ordered, members }
+    }
+
+    fn insert(&mut self, dependency: String) {
+        if self.members.insert(dependency.clone()) {
+            self.ordered.push(dependency);
+        }
+    }
 }
 
 impl ModuleState {
@@ -50,12 +69,12 @@ impl ModuleState {
         match self {
             Self::Discovered {
                 known_dependencies, ..
-            } => known_dependencies,
-            Self::Expanded { dependencies, .. } => dependencies,
+            } => &known_dependencies.ordered,
+            Self::Expanded { dependencies, .. } => &dependencies.ordered,
         }
     }
 
-    fn dependencies_mut(&mut self) -> &mut Vec<String> {
+    fn dependencies_mut(&mut self) -> &mut Dependencies {
         match self {
             Self::Discovered {
                 known_dependencies, ..
@@ -85,19 +104,18 @@ impl GraphResult {
             .entry(module)
             .or_insert_with(|| ModuleState::Discovered {
                 version,
-                known_dependencies: Vec::new(),
+                known_dependencies: Dependencies::default(),
             });
     }
 
-    fn expand(&mut self, module: String, version: String, mut dependencies: Vec<String>) {
+    fn expand(&mut self, module: String, version: String, dependencies: Vec<String>) {
+        let mut dependencies = Dependencies::from_ordered(dependencies);
         if let Some(ModuleState::Discovered {
             known_dependencies, ..
         }) = self.modules.get(&module)
         {
-            for dependency in known_dependencies {
-                if !dependencies.contains(dependency) {
-                    dependencies.push(dependency.clone());
-                }
+            for dependency in &known_dependencies.ordered {
+                dependencies.insert(dependency.clone());
             }
         }
         self.modules.insert(
@@ -114,7 +132,7 @@ impl GraphResult {
             module,
             ModuleState::Discovered {
                 version,
-                known_dependencies: Vec::new(),
+                known_dependencies: Dependencies::default(),
             },
         );
     }
@@ -125,12 +143,9 @@ impl GraphResult {
             .entry(parent)
             .or_insert_with(|| ModuleState::Discovered {
                 version,
-                known_dependencies: Vec::new(),
+                known_dependencies: Dependencies::default(),
             });
-        let dependencies = state.dependencies_mut();
-        if !dependencies.contains(&dependency) {
-            dependencies.push(dependency);
-        }
+        state.dependencies_mut().insert(dependency);
     }
 
     fn discovered_modules(&self) -> Vec<String> {
@@ -147,21 +162,21 @@ impl GraphResult {
 
     /// Invert `edges` into a `module → parents` map, excluding the added root.
     fn transitive_map(&self, added_module: &str) -> HashMap<String, Vec<String>> {
-        let mut transitives: HashMap<String, Vec<String>> = HashMap::new();
+        let mut transitives: HashMap<String, BTreeSet<String>> = HashMap::new();
         for (parent, state) in &self.modules {
             for child in state.dependencies() {
                 if child != added_module {
-                    let parents = transitives.entry(child.clone()).or_default();
-                    if !parents.contains(parent) {
-                        parents.push(parent.clone());
-                    }
+                    transitives
+                        .entry(child.clone())
+                        .or_default()
+                        .insert(parent.clone());
                 }
             }
         }
-        for parents in transitives.values_mut() {
-            parents.sort();
-        }
         transitives
+            .into_iter()
+            .map(|(module, parents)| (module, parents.into_iter().collect()))
+            .collect()
     }
 }
 
@@ -1473,6 +1488,19 @@ mod tests {
         assert_eq!(
             graph.dependencies("parent").unwrap(),
             ["manifest-child", "typedef-child"]
+        );
+    }
+
+    #[test]
+    fn transitive_parents_remain_sorted_and_unique() {
+        let mut graph = GraphResult::default();
+        graph.record_dependency("z-parent".into(), "v1.0.0".into(), "child".into());
+        graph.record_dependency("a-parent".into(), "v1.0.0".into(), "child".into());
+        graph.record_dependency("a-parent".into(), "v1.0.0".into(), "child".into());
+
+        assert_eq!(
+            graph.transitive_map("root")["child"],
+            ["a-parent", "z-parent"],
         );
     }
 

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -201,9 +201,9 @@ pub(crate) fn reconcile_declared_replacements(
 ) -> Result<(), i32> {
     let replaced_roots: Vec<(String, deps::ReplacementSource)> = manifest
         .go_deps()
-        .into_iter()
+        .iter()
         .filter_map(|(module, dep)| match dep {
-            deps::GoDependency::Replaced { source, .. } => Some((module, source)),
+            deps::GoDependency::Replaced { source, .. } => Some((module.clone(), source.clone())),
             deps::GoDependency::Remote { .. } => None,
         })
         .collect();
@@ -215,7 +215,7 @@ pub(crate) fn reconcile_declared_replacements(
     // Seed every declared dep so MVS picks the versions the real build sees.
     go_cli::invalidate_go_mod_stamp(target_dir);
     let locator = deps::TypedefLocator::new(
-        manifest.go_deps(),
+        manifest.go_deps().clone(),
         Some(project_root.to_path_buf()),
         Target::host(),
     );
@@ -732,9 +732,9 @@ pub(crate) fn declared_replacements(
 ) -> HashMap<String, deps::ReplacementSource> {
     manifest
         .go_deps()
-        .into_iter()
+        .iter()
         .filter_map(|(module, dep)| match dep {
-            deps::GoDependency::Replaced { source, .. } => Some((module, source)),
+            deps::GoDependency::Replaced { source, .. } => Some((module.clone(), source.clone())),
             deps::GoDependency::Remote { .. } => None,
         })
         .collect()

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::go_cli;
-use crate::output::{print_progress, print_warning};
+use crate::output::{DependencyGraph, print_progress, print_warning};
 use crate::workspace::{GoWorkspace, UnresolvedTransitive};
 use crate::{cli_error, error};
 use deps::GoModule;
@@ -141,18 +141,8 @@ impl GraphResult {
             .collect()
     }
 
-    pub(crate) fn versions(&self) -> HashMap<String, String> {
-        self.modules
-            .iter()
-            .map(|(module, state)| (module.clone(), state.version().to_string()))
-            .collect()
-    }
-
-    pub(crate) fn edges(&self) -> HashMap<String, Vec<String>> {
-        self.modules
-            .iter()
-            .map(|(module, state)| (module.clone(), state.dependencies().to_vec()))
-            .collect()
+    fn dependencies(&self, module: &str) -> Option<&[String]> {
+        self.modules.get(module).map(ModuleState::dependencies)
     }
 
     /// Invert `edges` into a `module → parents` map, excluding the added root.
@@ -172,6 +162,16 @@ impl GraphResult {
             parents.sort();
         }
         transitives
+    }
+}
+
+impl DependencyGraph for GraphResult {
+    fn version(&self, module: &str) -> Option<&str> {
+        GraphResult::version(self, module)
+    }
+
+    fn dependencies(&self, module: &str) -> Option<&[String]> {
+        GraphResult::dependencies(self, module)
     }
 }
 
@@ -1470,7 +1470,10 @@ mod tests {
             vec!["manifest-child".to_string()],
         );
 
-        assert_eq!(graph.edges()["parent"], ["manifest-child", "typedef-child"]);
+        assert_eq!(
+            graph.dependencies("parent").unwrap(),
+            ["manifest-child", "typedef-child"]
+        );
     }
 
     #[test]
@@ -1484,6 +1487,6 @@ mod tests {
 
         graph.expand("module".to_string(), "v2.0.0".to_string(), Vec::new());
 
-        assert!(graph.edges()["module"].is_empty());
+        assert!(graph.dependencies("module").unwrap().is_empty());
     }
 }

--- a/crates/cli/src/handlers/script_add.rs
+++ b/crates/cli/src/handlers/script_add.rs
@@ -142,8 +142,7 @@ pub(super) fn run(file: &Path, dep_string: &str) -> i32 {
     print_add_success(
         &resolved.canonical_module,
         &version,
-        &graph.edges(),
-        &graph.versions(),
+        &graph,
         &upgraded_tuples,
         None,
     );

--- a/crates/cli/src/handlers/script_deps.rs
+++ b/crates/cli/src/handlers/script_deps.rs
@@ -28,7 +28,7 @@ pub(crate) fn script_deps(source: &str) -> BTreeMap<String, GoDependency> {
         return BTreeMap::new();
     };
     table
-        .deps
+        .into_dependencies()
         .into_iter()
         .filter(|(module_path, dep)| deps::validate_script_entry(module_path, dep).is_ok())
         .collect()

--- a/crates/cli/src/handlers/script_table.rs
+++ b/crates/cli/src/handlers/script_table.rs
@@ -41,7 +41,7 @@ impl ScriptTable {
 
         let table = deps::parse_dependency_table(&block.text)
             .map_err(|error| format!("Invalid dependency table: {}", error.message))?;
-        for (module_path, dep) in &table.deps {
+        for (module_path, dep) in table.dependencies() {
             deps::validate_script_entry(module_path, dep)?;
         }
 

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -74,8 +74,11 @@ pub fn sync(script: Option<&str>) -> i32 {
     let (prewarm_result, needs_separator) = if !non_blank_imports.is_empty() {
         let target = Target::host();
 
-        let locator =
-            deps::TypedefLocator::new(manifest.go_deps(), Some(project_root.clone()), target);
+        let locator = deps::TypedefLocator::new(
+            manifest.go_deps().clone(),
+            Some(project_root.clone()),
+            target,
+        );
         let go_directive = go_cli::project_go_directive(project_root);
         if let Err(msg) =
             go_cli::write_go_mod(target_dir, &manifest.project.name, &locator, &go_directive)

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use syntax::ast::Span;
 use syntax::program::TestFunction;
 
-use crate::go_cli::GoTestEvent;
+use crate::go_cli::{GoTestAction, GoTestEvent};
 use crate::output::{format_backticks, format_elapsed};
 use diagnostics::LisetteDiagnostic;
 use lisette::pipeline::{Sources, TestIndex};
@@ -349,7 +349,7 @@ pub fn build_report_filtered(
     let mut test_elapsed: f64 = 0.0;
 
     for event in events {
-        if event.action == "attr"
+        if event.action == GoTestAction::Attr
             && let (Some(key), Some(test), Some(value)) =
                 (event.key.as_deref(), &event.test, &event.value)
             && let Some(attribute) = decode_test_attribute(key, value)
@@ -436,8 +436,8 @@ fn handle_package_event(
     packages: &mut HashMap<String, PackageEvents>,
     test_elapsed: &mut f64,
 ) {
-    match event.action.as_str() {
-        "build-output" => {
+    match event.action {
+        GoTestAction::BuildOutput => {
             if let Some(text) = &event.output {
                 build_output.push_str(text);
             }
@@ -448,7 +448,7 @@ fn handle_package_event(
                     .record_build_failure();
             }
         }
-        "build-fail" => {
+        GoTestAction::BuildFail => {
             if let Some(path) = &event.import_path {
                 packages
                     .entry(package_of_import_path(path).to_string())
@@ -456,7 +456,7 @@ fn handle_package_event(
                     .record_build_failure();
             }
         }
-        "output" => {
+        GoTestAction::Output => {
             if let Some(text) = &event.output {
                 packages
                     .entry(event.package.clone())
@@ -465,10 +465,10 @@ fn handle_package_event(
                     .push_str(text);
             }
         }
-        "pass" => {
+        GoTestAction::Pass => {
             *test_elapsed = test_elapsed.max(event.elapsed.unwrap_or(0.0));
         }
-        "fail" => {
+        GoTestAction::Fail => {
             packages
                 .entry(event.package.clone())
                 .or_default()
@@ -480,26 +480,26 @@ fn handle_package_event(
 }
 
 fn handle_test_event(event: &GoTestEvent, state: &mut TestEvents) {
-    match event.action.as_str() {
-        "run" => {
+    match event.action {
+        GoTestAction::Run => {
             state.execution.start();
         }
-        "pass" => {
+        GoTestAction::Pass => {
             state
                 .execution
                 .finish(TerminalStatus::Passed, event.elapsed);
         }
-        "fail" => {
+        GoTestAction::Fail => {
             state
                 .execution
                 .finish(TerminalStatus::Failed, event.elapsed);
         }
-        "skip" => {
+        GoTestAction::Skip => {
             state
                 .execution
                 .finish(TerminalStatus::Skipped, event.elapsed);
         }
-        "output" => {
+        GoTestAction::Output => {
             if let Some(text) = &event.output {
                 state.output.push_str(text);
             }
@@ -1438,7 +1438,7 @@ mod tests {
 
     fn event(action: &str, package: &str, test: Option<&str>, output: Option<&str>) -> GoTestEvent {
         GoTestEvent {
-            action: action.to_string(),
+            action: serde_json::from_value(serde_json::Value::String(action.to_string())).unwrap(),
             package: package.to_string(),
             test: test.map(str::to_string),
             elapsed: Some(0.003),
@@ -1451,7 +1451,7 @@ mod tests {
 
     fn build_output_event(package: &str, output: &str) -> GoTestEvent {
         GoTestEvent {
-            action: "build-output".to_string(),
+            action: GoTestAction::BuildOutput,
             package: String::new(),
             test: None,
             elapsed: None,
@@ -1464,7 +1464,7 @@ mod tests {
 
     fn attr_event(package: &str, test: &str, value: &str) -> GoTestEvent {
         GoTestEvent {
-            action: "attr".to_string(),
+            action: GoTestAction::Attr,
             package: package.to_string(),
             test: Some(test.to_string()),
             elapsed: None,
@@ -1477,7 +1477,7 @@ mod tests {
 
     fn skip_attr_event(package: &str, test: &str, reason: &str) -> GoTestEvent {
         GoTestEvent {
-            action: "attr".to_string(),
+            action: GoTestAction::Attr,
             package: package.to_string(),
             test: Some(test.to_string()),
             elapsed: None,
@@ -1490,7 +1490,7 @@ mod tests {
 
     fn subtest_attr_event(package: &str, test: &str, name: &str) -> GoTestEvent {
         GoTestEvent {
-            action: "attr".to_string(),
+            action: GoTestAction::Attr,
             package: package.to_string(),
             test: Some(test.to_string()),
             elapsed: None,
@@ -1504,7 +1504,7 @@ mod tests {
     fn log_attr_event(package: &str, test: &str, file: u32, value: &str) -> GoTestEvent {
         let record = format!(r#"{{"file":{file},"lo":0,"hi":5,"value":{value:?}}}"#);
         GoTestEvent {
-            action: "attr".to_string(),
+            action: GoTestAction::Attr,
             package: package.to_string(),
             test: Some(test.to_string()),
             elapsed: None,

--- a/crates/cli/src/handlers/test/report.rs
+++ b/crates/cli/src/handlers/test/report.rs
@@ -16,6 +16,7 @@ use std::iter;
 use std::mem;
 
 type TestKey = (String, String);
+type TestEventsByPackage = HashMap<String, HashMap<String, TestEvents>>;
 
 #[derive(Default)]
 enum Execution {
@@ -343,7 +344,7 @@ pub fn build_report_filtered(
     go_module: &str,
     selected: Option<&HashSet<(String, String)>>,
 ) -> Report {
-    let mut tests: HashMap<TestKey, TestEvents> = HashMap::new();
+    let mut tests = TestEventsByPackage::new();
     let mut build_output = String::new();
     let mut packages: HashMap<String, PackageEvents> = HashMap::new();
     let mut test_elapsed: f64 = 0.0;
@@ -355,7 +356,9 @@ pub fn build_report_filtered(
             && let Some(attribute) = decode_test_attribute(key, value)
         {
             tests
-                .entry((event.package.clone(), test.clone()))
+                .entry(event.package.clone())
+                .or_default()
+                .entry(test.clone())
                 .or_default()
                 .record_attribute(attribute);
             continue;
@@ -365,7 +368,9 @@ pub fn build_report_filtered(
             continue;
         };
         let state = tests
-            .entry((event.package.clone(), test.clone()))
+            .entry(event.package.clone())
+            .or_default()
+            .entry(test.clone())
             .or_default();
         handle_test_event(event, state);
     }
@@ -378,7 +383,9 @@ pub fn build_report_filtered(
         {
             continue;
         }
-        let state = tests.get(&key);
+        let state = tests
+            .get(&key.0)
+            .and_then(|package_tests| package_tests.get(&key.1));
         let outcome = state
             .map(TestEvents::outcome)
             .unwrap_or(TestOutcome::Unreached);
@@ -549,35 +556,32 @@ fn decode_hex(hex: &str) -> Option<Vec<u8>> {
         .collect()
 }
 
-fn collect_children(
-    package: &str,
-    parent: &str,
-    tests: &HashMap<TestKey, TestEvents>,
-) -> Vec<TestRow> {
+fn collect_children(package: &str, parent: &str, tests: &TestEventsByPackage) -> Vec<TestRow> {
     let prefix = format!("{parent}/");
-    let real: HashSet<&str> = tests
+    let Some(package_tests) = tests.get(package) else {
+        return Vec::new();
+    };
+    let real: HashSet<&str> = package_tests
         .iter()
-        .filter(|((pkg, name), state)| {
-            pkg == package && name.starts_with(&prefix) && state.execution.was_observed()
-        })
-        .map(|((_, name), _)| name.as_str())
+        .filter(|(name, state)| name.starts_with(&prefix) && state.execution.was_observed())
+        .map(|(name, _)| name.as_str())
         .chain(iter::once(parent))
         .collect();
 
     let mut children_of: HashMap<&str, Vec<&str>> = HashMap::new();
     for full in real.iter().copied().filter(|&full| full != parent) {
-        if let Some(mother) = subtest_parent(package, full, &real, tests) {
+        if let Some(mother) = subtest_parent(full, &real, package_tests) {
             children_of.entry(mother).or_default().push(full);
         }
     }
-    subtest_rows(package, parent, &children_of, tests)
+    subtest_rows(package, parent, &children_of, package_tests)
 }
 
 fn subtest_rows(
     package: &str,
     parent: &str,
     children_of: &HashMap<&str, Vec<&str>>,
-    tests: &HashMap<TestKey, TestEvents>,
+    tests: &HashMap<String, TestEvents>,
 ) -> Vec<TestRow> {
     let mut children = children_of.get(parent).cloned().unwrap_or_default();
     children.sort_unstable();
@@ -585,8 +589,7 @@ fn subtest_rows(
     children
         .into_iter()
         .map(|full| {
-            let key = (package.to_string(), full.to_string());
-            let state = &tests[&key];
+            let state = &tests[full];
             let name = state
                 .subtest_name
                 .as_ref()
@@ -609,14 +612,12 @@ fn subtest_rows(
 }
 
 fn subtest_parent<'a>(
-    package: &str,
     full: &'a str,
     real: &HashSet<&'a str>,
-    tests: &HashMap<TestKey, TestEvents>,
+    tests: &HashMap<String, TestEvents>,
 ) -> Option<&'a str> {
-    let key = (package.to_string(), full.to_string());
     if let Some(original) = tests
-        .get(&key)
+        .get(full)
         .and_then(|state| state.subtest_name.as_ref())
     {
         let own_segments = original.matches('/').count() + 1;

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -2,7 +2,6 @@ use std::io::IsTerminal;
 use std::sync::LazyLock;
 
 use owo_colors::OwoColorize;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
 use std::io;
@@ -278,11 +277,15 @@ pub enum ReplacementLabel<'a> {
     Local { path: &'a str },
 }
 
+pub trait DependencyGraph {
+    fn version(&self, module: &str) -> Option<&str>;
+    fn dependencies(&self, module: &str) -> Option<&[String]>;
+}
+
 pub fn print_add_success(
     module_path: &str,
     version: &str,
-    edges: &HashMap<String, Vec<String>>,
-    versions: &HashMap<String, String>,
+    graph: &impl DependencyGraph,
     upgraded_directs: &[(&str, &str, &str)],
     replacement: Option<ReplacementLabel<'_>>,
 ) {
@@ -335,8 +338,7 @@ pub fn print_add_success(
     }
 
     let mut printer = TreePrinter {
-        edges,
-        versions,
+        graph,
         colored,
         visited: HashSet::new(),
     };
@@ -344,16 +346,15 @@ pub fn print_add_success(
     printer.print_children(module_path, "    ");
 }
 
-struct TreePrinter<'a> {
-    edges: &'a HashMap<String, Vec<String>>,
-    versions: &'a HashMap<String, String>,
+struct TreePrinter<'a, G> {
+    graph: &'a G,
     colored: bool,
     visited: HashSet<String>,
 }
 
-impl TreePrinter<'_> {
+impl<G: DependencyGraph> TreePrinter<'_, G> {
     fn print_children(&mut self, node: &str, prefix: &str) {
-        let Some(children) = self.edges.get(node) else {
+        let Some(children) = self.graph.dependencies(node) else {
             return;
         };
         let mut sorted: Vec<&String> = children.iter().collect();
@@ -366,7 +367,7 @@ impl TreePrinter<'_> {
 
     fn print_node(&mut self, node: &str, prefix: &str, is_last: bool) {
         let branch = if is_last { "└─ " } else { "├─ " };
-        let version = self.versions.get(node).map(String::as_str).unwrap_or("");
+        let version = self.graph.version(node).unwrap_or("");
         let already_seen = !self.visited.insert(node.to_string());
 
         if self.colored {

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -1065,8 +1065,11 @@ impl BindgenSetup for WorkspaceBindgenSetup {
 
         let lock = lock::acquire_target_lock_quiet(&target_dir)?;
 
-        let manifest_locator =
-            TypedefLocator::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
+        let manifest_locator = TypedefLocator::new(
+            manifest.go_deps().clone(),
+            Some(project_root.to_path_buf()),
+            target,
+        );
         let go_directive = go_cli::project_go_directive(project_root);
         go_cli::write_go_mod(
             &target_dir,

--- a/crates/deps/src/dependency_table.rs
+++ b/crates/deps/src/dependency_table.rs
@@ -9,12 +9,34 @@ use toml_edit::de;
 
 #[derive(Debug)]
 pub struct DependencyTable {
-    pub deps: BTreeMap<String, GoDependency>,
-    pub spans: BTreeMap<String, Range<usize>>,
+    entries: BTreeMap<String, DependencyEntry>,
     document: toml_edit::ImDocument<String>,
 }
 
+#[derive(Debug)]
+struct DependencyEntry {
+    dependency: GoDependency,
+    span: Option<Range<usize>>,
+}
+
 impl DependencyTable {
+    pub fn dependencies(&self) -> impl Iterator<Item = (&str, &GoDependency)> {
+        self.entries
+            .iter()
+            .map(|(module_path, entry)| (module_path.as_str(), &entry.dependency))
+    }
+
+    pub fn into_dependencies(self) -> BTreeMap<String, GoDependency> {
+        self.entries
+            .into_iter()
+            .map(|(module_path, entry)| (module_path, entry.dependency))
+            .collect()
+    }
+
+    pub fn dependency_span(&self, module_path: &str) -> Option<&Range<usize>> {
+        self.entries.get(module_path)?.span.as_ref()
+    }
+
     pub fn into_document(self) -> toml_edit::DocumentMut {
         self.document.into_mut()
     }
@@ -54,8 +76,7 @@ pub fn parse_dependency_table(text: &str) -> Result<DependencyTable, TableError>
 
     let Some(dependencies) = document.get(TABLE) else {
         return Ok(DependencyTable {
-            deps: BTreeMap::new(),
-            spans: BTreeMap::new(),
+            entries: BTreeMap::new(),
             document,
         });
     };
@@ -68,16 +89,21 @@ pub fn parse_dependency_table(text: &str) -> Result<DependencyTable, TableError>
         }
     }
 
-    let (deps, spans) = match dependencies.get(GO) {
-        Some(go) => (deserialize_go_table(go)?, entry_spans(go)),
-        None => (BTreeMap::new(), BTreeMap::new()),
+    let entries = match dependencies.get(GO) {
+        Some(go) => {
+            let spans = entry_spans(go);
+            deserialize_go_table(go)?
+                .into_iter()
+                .map(|(module_path, dependency)| {
+                    let span = spans.get(&module_path).cloned();
+                    (module_path, DependencyEntry { dependency, span })
+                })
+                .collect()
+        }
+        None => BTreeMap::new(),
     };
 
-    Ok(DependencyTable {
-        deps,
-        spans,
-        document,
-    })
+    Ok(DependencyTable { entries, document })
 }
 
 pub(crate) fn deserialize_go_table(
@@ -142,7 +168,7 @@ mod tests {
     fn table(text: &str) -> BTreeMap<String, GoDependency> {
         parse_dependency_table(text)
             .unwrap_or_else(|e| panic!("{}", e.message))
-            .deps
+            .into_dependencies()
     }
 
     #[test]
@@ -165,11 +191,11 @@ mod tests {
         let table = parse_dependency_table(text).ok().unwrap();
 
         assert_eq!(
-            &text[table.spans["a.b/c"].clone()],
+            &text[table.dependency_span("a.b/c").unwrap().clone()],
             "\"a.b/c\" = \"v1.0.0\""
         );
         assert_eq!(
-            &text[table.spans["d.e/f"].clone()],
+            &text[table.dependency_span("d.e/f").unwrap().clone()],
             "\"d.e/f\" = { version = \"v2.0.0\" }"
         );
     }

--- a/crates/deps/src/project_manifest.rs
+++ b/crates/deps/src/project_manifest.rs
@@ -14,7 +14,8 @@ use toml_edit::de as toml_de;
 pub struct Manifest {
     pub project: Project,
     toolchain: Option<Toolchain>,
-    dependencies: Option<Dependencies>,
+    #[serde(default)]
+    dependencies: Dependencies,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -28,7 +29,7 @@ pub struct Toolchain {
     pub lis: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Dependencies {
     #[serde(default)]
     pub go: BTreeMap<String, GoDependency>,
@@ -168,11 +169,8 @@ fn split_replacement(replacement: &str) -> Result<(String, String), String> {
 }
 
 impl Manifest {
-    pub fn go_deps(&self) -> BTreeMap<String, GoDependency> {
-        self.dependencies
-            .as_ref()
-            .map(|d| d.go.clone())
-            .unwrap_or_default()
+    pub fn go_deps(&self) -> &BTreeMap<String, GoDependency> {
+        &self.dependencies.go
     }
 }
 
@@ -211,7 +209,7 @@ pub fn parse_manifest(project_root: &Path) -> Result<Manifest, String> {
 /// A dotless path is reported first and by name, since it reads as the Go
 /// standard library rather than as a malformed path.
 fn validate_go_dep_paths(manifest: &Manifest) -> Result<(), String> {
-    for (key, dep) in &manifest.go_deps() {
+    for (key, dep) in manifest.go_deps() {
         if let GoDependency::Replaced { source, .. } = dep {
             if !crate::is_third_party(key) {
                 return Err(match source {
@@ -314,7 +312,7 @@ pub fn check_no_subpackage_deps(manifest: &Manifest) -> Result<(), String> {
         )
     };
 
-    for (key, dep) in &deps {
+    for (key, dep) in deps {
         let Some((parent, parent_dep)) = deps
             .iter()
             .find(|(other, _)| other.as_str() != key.as_str() && is_pkg_under(key, other))

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -282,7 +282,11 @@ impl TypedefLocator {
         check_toolchain_version(&manifest)?;
         check_no_subpackage_deps(&manifest)?;
 
-        let locator = Self::new(manifest.go_deps(), Some(project_root.to_path_buf()), target);
+        let locator = Self::new(
+            manifest.go_deps().clone(),
+            Some(project_root.to_path_buf()),
+            target,
+        );
 
         Ok((manifest, locator))
     }

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -216,7 +216,6 @@ pub trait BindgenSetup: Send + Sync {
 #[derive(Debug, Clone, Default)]
 pub struct TypedefLocator {
     deps: BTreeMap<String, GoDependency>,
-    has_local_replacement: bool,
     project_root: Option<PathBuf>,
     target: Target,
     bindgen: Option<Arc<dyn Bindgen>>,
@@ -230,18 +229,8 @@ impl TypedefLocator {
         project_root: Option<PathBuf>,
         target: Target,
     ) -> Self {
-        let has_local_replacement = deps.values().any(|dep| {
-            matches!(
-                dep,
-                GoDependency::Replaced {
-                    source: ReplacementSource::Local { .. },
-                    ..
-                }
-            )
-        });
         Self {
             deps,
-            has_local_replacement,
             project_root,
             target,
             bindgen: None,
@@ -265,8 +254,16 @@ impl TypedefLocator {
         self.local_stamp
             .get_or_init(|| {
                 let project_root = self.project_root.as_deref()?;
-                self.has_local_replacement
-                    .then(|| local_source::stamp_hash(&self.deps, Some(project_root)))
+                let has_local = self.deps.values().any(|dep| {
+                    matches!(
+                        dep,
+                        GoDependency::Replaced {
+                            source: ReplacementSource::Local { .. },
+                            ..
+                        }
+                    )
+                });
+                has_local.then(|| local_source::stamp_hash(&self.deps, Some(project_root)))
             })
             .as_deref()
     }

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -216,6 +216,7 @@ pub trait BindgenSetup: Send + Sync {
 #[derive(Debug, Clone, Default)]
 pub struct TypedefLocator {
     deps: BTreeMap<String, GoDependency>,
+    has_local_replacement: bool,
     project_root: Option<PathBuf>,
     target: Target,
     bindgen: Option<Arc<dyn Bindgen>>,
@@ -229,8 +230,18 @@ impl TypedefLocator {
         project_root: Option<PathBuf>,
         target: Target,
     ) -> Self {
+        let has_local_replacement = deps.values().any(|dep| {
+            matches!(
+                dep,
+                GoDependency::Replaced {
+                    source: ReplacementSource::Local { .. },
+                    ..
+                }
+            )
+        });
         Self {
             deps,
+            has_local_replacement,
             project_root,
             target,
             bindgen: None,
@@ -254,16 +265,8 @@ impl TypedefLocator {
         self.local_stamp
             .get_or_init(|| {
                 let project_root = self.project_root.as_deref()?;
-                let has_local = self.deps.values().any(|dep| {
-                    matches!(
-                        dep,
-                        GoDependency::Replaced {
-                            source: ReplacementSource::Local { .. },
-                            ..
-                        }
-                    )
-                });
-                has_local.then(|| local_source::stamp_hash(&self.deps, Some(project_root)))
+                self.has_local_replacement
+                    .then(|| local_source::stamp_hash(&self.deps, Some(project_root)))
             })
             .as_deref()
     }

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -15,73 +15,6 @@ enum Severity {
     Advice,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DiagnosticPhase {
-    Lex,
-    Parse,
-    Resolve,
-    Infer,
-    Lint,
-    Attribute,
-    Emit,
-}
-
-impl DiagnosticPhase {
-    fn name(self) -> &'static str {
-        match self {
-            Self::Lex => "lex",
-            Self::Parse => "parse",
-            Self::Resolve => "resolve",
-            Self::Infer => "infer",
-            Self::Lint => "lint",
-            Self::Attribute => "attribute",
-            Self::Emit => "emit",
-        }
-    }
-
-    fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "lex" => Some(Self::Lex),
-            "parse" => Some(Self::Parse),
-            "resolve" => Some(Self::Resolve),
-            "infer" => Some(Self::Infer),
-            "lint" => Some(Self::Lint),
-            "attribute" => Some(Self::Attribute),
-            "emit" => Some(Self::Emit),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct DiagnosticCode {
-    rendered: String,
-    phase: Option<DiagnosticPhase>,
-}
-
-impl DiagnosticCode {
-    fn new(phase: DiagnosticPhase, name: &str) -> Self {
-        Self {
-            rendered: format!("{}.{}", phase.name(), name),
-            phase: Some(phase),
-        }
-    }
-
-    fn from_rendered(rendered: String) -> Self {
-        let phase = rendered
-            .split_once('.')
-            .and_then(|(phase, _)| DiagnosticPhase::from_name(phase));
-        Self { rendered, phase }
-    }
-
-    fn name(&self) -> &str {
-        let Some(phase) = self.phase else {
-            return &self.rendered;
-        };
-        &self.rendered[phase.name().len() + 1..]
-    }
-}
-
 /// Source text with a precomputed line-offset index for O(log n) span lookups.
 #[derive(Clone, Debug)]
 pub struct IndexedSource {
@@ -223,7 +156,7 @@ pub struct LisetteDiagnostic {
     help: Option<String>,
     note: Option<String>,
     severity: Severity,
-    code: Option<DiagnosticCode>,
+    code: Option<String>,
     fix: Option<crate::Fix>,
     file_location: Option<String>,
 }
@@ -352,17 +285,17 @@ impl LisetteDiagnostic {
     }
 
     pub(crate) fn with_parse_code(mut self, code: &str) -> Self {
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Parse, code));
+        self.code = Some(format!("parse.{code}"));
         self
     }
 
     pub fn with_resolve_code(mut self, code: &str) -> Self {
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Resolve, code));
+        self.code = Some(format!("resolve.{code}"));
         self
     }
 
     pub fn with_infer_code(mut self, code: &str) -> Self {
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Infer, code));
+        self.code = Some(format!("infer.{code}"));
         self
     }
 
@@ -373,22 +306,22 @@ impl LisetteDiagnostic {
              use a phase-specific code constructor for errors",
             self.severity,
         );
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Lint, code));
+        self.code = Some(format!("lint.{code}"));
         self
     }
 
     pub(crate) fn with_attribute_code(mut self, code: &str) -> Self {
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Attribute, code));
+        self.code = Some(format!("attribute.{code}"));
         self
     }
 
     pub(crate) fn with_emit_code(mut self, code: &str) -> Self {
-        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Emit, code));
+        self.code = Some(format!("emit.{code}"));
         self
     }
 
     fn with_code(mut self, code: impl Into<String>) -> Self {
-        self.code = Some(DiagnosticCode::from_rendered(code.into()));
+        self.code = Some(code.into());
         self
     }
 
@@ -416,7 +349,7 @@ impl LisetteDiagnostic {
             self.code.is_some(),
         )
         .filter(|text| !text.is_empty());
-        let code = self.code.as_ref().map(|code| code.rendered.as_str());
+        let code = self.code.as_deref();
 
         match (combined, code) {
             (None, None) => (None, None),
@@ -494,14 +427,11 @@ impl LisetteDiagnostic {
     }
 
     pub fn code_str(&self) -> Option<&str> {
-        self.code.as_ref().map(|code| code.rendered.as_str())
+        self.code.as_deref()
     }
 
     pub fn lint_name(&self) -> Option<&str> {
-        self.code
-            .as_ref()
-            .filter(|code| code.phase == Some(DiagnosticPhase::Lint))
-            .map(DiagnosticCode::name)
+        self.code.as_deref()?.strip_prefix("lint.")
     }
 
     pub fn primary_offset(&self) -> usize {
@@ -615,19 +545,5 @@ mod tests {
         assert_eq!(diagnostic.label_file_ids(), vec![3, 7]);
         assert_eq!(diagnostic.frame_labels(3, false).len(), 1);
         assert_eq!(diagnostic.frame_labels(7, false).len(), 1);
-    }
-
-    #[test]
-    fn lint_code_retains_structured_name() {
-        let diagnostic = LisetteDiagnostic::warn("warning").with_lint_code("unused_value");
-
-        assert_eq!(diagnostic.lint_name(), Some("unused_value"));
-    }
-
-    #[test]
-    fn non_lint_code_has_no_lint_name() {
-        let diagnostic = LisetteDiagnostic::error("error").with_infer_code("type_mismatch");
-
-        assert_eq!(diagnostic.lint_name(), None);
     }
 }

--- a/crates/diagnostics/src/diagnostic.rs
+++ b/crates/diagnostics/src/diagnostic.rs
@@ -15,6 +15,73 @@ enum Severity {
     Advice,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticPhase {
+    Lex,
+    Parse,
+    Resolve,
+    Infer,
+    Lint,
+    Attribute,
+    Emit,
+}
+
+impl DiagnosticPhase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Lex => "lex",
+            Self::Parse => "parse",
+            Self::Resolve => "resolve",
+            Self::Infer => "infer",
+            Self::Lint => "lint",
+            Self::Attribute => "attribute",
+            Self::Emit => "emit",
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "lex" => Some(Self::Lex),
+            "parse" => Some(Self::Parse),
+            "resolve" => Some(Self::Resolve),
+            "infer" => Some(Self::Infer),
+            "lint" => Some(Self::Lint),
+            "attribute" => Some(Self::Attribute),
+            "emit" => Some(Self::Emit),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DiagnosticCode {
+    rendered: String,
+    phase: Option<DiagnosticPhase>,
+}
+
+impl DiagnosticCode {
+    fn new(phase: DiagnosticPhase, name: &str) -> Self {
+        Self {
+            rendered: format!("{}.{}", phase.name(), name),
+            phase: Some(phase),
+        }
+    }
+
+    fn from_rendered(rendered: String) -> Self {
+        let phase = rendered
+            .split_once('.')
+            .and_then(|(phase, _)| DiagnosticPhase::from_name(phase));
+        Self { rendered, phase }
+    }
+
+    fn name(&self) -> &str {
+        let Some(phase) = self.phase else {
+            return &self.rendered;
+        };
+        &self.rendered[phase.name().len() + 1..]
+    }
+}
+
 /// Source text with a precomputed line-offset index for O(log n) span lookups.
 #[derive(Clone, Debug)]
 pub struct IndexedSource {
@@ -156,7 +223,7 @@ pub struct LisetteDiagnostic {
     help: Option<String>,
     note: Option<String>,
     severity: Severity,
-    code: Option<String>,
+    code: Option<DiagnosticCode>,
     fix: Option<crate::Fix>,
     file_location: Option<String>,
 }
@@ -285,17 +352,17 @@ impl LisetteDiagnostic {
     }
 
     pub(crate) fn with_parse_code(mut self, code: &str) -> Self {
-        self.code = Some(format!("parse.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Parse, code));
         self
     }
 
     pub fn with_resolve_code(mut self, code: &str) -> Self {
-        self.code = Some(format!("resolve.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Resolve, code));
         self
     }
 
     pub fn with_infer_code(mut self, code: &str) -> Self {
-        self.code = Some(format!("infer.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Infer, code));
         self
     }
 
@@ -306,22 +373,22 @@ impl LisetteDiagnostic {
              use a phase-specific code constructor for errors",
             self.severity,
         );
-        self.code = Some(format!("lint.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Lint, code));
         self
     }
 
     pub(crate) fn with_attribute_code(mut self, code: &str) -> Self {
-        self.code = Some(format!("attribute.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Attribute, code));
         self
     }
 
     pub(crate) fn with_emit_code(mut self, code: &str) -> Self {
-        self.code = Some(format!("emit.{}", code));
+        self.code = Some(DiagnosticCode::new(DiagnosticPhase::Emit, code));
         self
     }
 
     fn with_code(mut self, code: impl Into<String>) -> Self {
-        self.code = Some(code.into());
+        self.code = Some(DiagnosticCode::from_rendered(code.into()));
         self
     }
 
@@ -349,7 +416,7 @@ impl LisetteDiagnostic {
             self.code.is_some(),
         )
         .filter(|text| !text.is_empty());
-        let code = self.code.as_deref();
+        let code = self.code.as_ref().map(|code| code.rendered.as_str());
 
         match (combined, code) {
             (None, None) => (None, None),
@@ -427,11 +494,14 @@ impl LisetteDiagnostic {
     }
 
     pub fn code_str(&self) -> Option<&str> {
-        self.code.as_deref()
+        self.code.as_ref().map(|code| code.rendered.as_str())
     }
 
     pub fn lint_name(&self) -> Option<&str> {
-        self.code.as_deref()?.strip_prefix("lint.")
+        self.code
+            .as_ref()
+            .filter(|code| code.phase == Some(DiagnosticPhase::Lint))
+            .map(DiagnosticCode::name)
     }
 
     pub fn primary_offset(&self) -> usize {
@@ -545,5 +615,19 @@ mod tests {
         assert_eq!(diagnostic.label_file_ids(), vec![3, 7]);
         assert_eq!(diagnostic.frame_labels(3, false).len(), 1);
         assert_eq!(diagnostic.frame_labels(7, false).len(), 1);
+    }
+
+    #[test]
+    fn lint_code_retains_structured_name() {
+        let diagnostic = LisetteDiagnostic::warn("warning").with_lint_code("unused_value");
+
+        assert_eq!(diagnostic.lint_name(), Some("unused_value"));
+    }
+
+    #[test]
+    fn non_lint_code_has_no_lint_name() {
+        let diagnostic = LisetteDiagnostic::error("error").with_infer_code("type_mismatch");
+
+        assert_eq!(diagnostic.lint_name(), None);
     }
 }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -78,7 +78,7 @@ impl<'a> EmitFacts<'a> {
     where
         'a: 'b,
     {
-        types::package_for_qualified_name(id, self.go_package_ids.iter().map(String::as_str))
+        types::package_for_qualified_name(id, |package| self.go_package_ids.contains(package))
     }
 
     pub(crate) fn definition(&self, id: &str) -> Option<&'a Definition> {

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -363,33 +363,13 @@ impl Planner<'_> {
         }
     }
 
-    pub(crate) fn is_enum_field_pointer(&self, ty: &Type, variant: &str, index: usize) -> bool {
+    pub(crate) fn is_enum_field_recursive(&self, ty: &Type, variant: &str, index: usize) -> bool {
         if let Type::Nominal { id, .. } = ty
             && let Some(layout) = self.enum_layout(id.as_ref())
             && let Some(variant_layout) = layout.get_variant(variant)
             && let Some(field) = variant_layout.fields.get(index)
         {
-            return field.go_type.starts_with('*');
-        }
-        false
-    }
-
-    /// True when the field's pointer comes from an explicit `Ref<T>` (not
-    /// from auto-pointer recursion support). User `.*` deref relies on this.
-    pub(crate) fn is_enum_field_source_ref(&self, ty: &Type, variant: &str, index: usize) -> bool {
-        if let Type::Nominal { id, .. } = ty
-            && let Some(Definition {
-                body: DefinitionBody::Enum { variants, .. },
-                ..
-            }) = self.facts.definition(id.as_str())
-        {
-            for v in variants {
-                if v.name == variant
-                    && let Some(field) = v.fields.iter().nth(index)
-                {
-                    return field.ty.is_ref();
-                }
-            }
+            return field.is_recursive;
         }
         false
     }

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -1,4 +1,3 @@
-use rustc_hash::FxHashMap as HashMap;
 use std::rc::Rc;
 
 use crate::Planner;
@@ -386,7 +385,7 @@ impl Planner<'_> {
                 ..
             }) = self.facts.definition(id.as_str())
         {
-            let sub_map: HashMap<_, _> = generics
+            let sub_map: types::SubstitutionMap = generics
                 .iter()
                 .map(|g| g.name.clone())
                 .zip(args.iter().cloned())

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -15,6 +15,7 @@ pub(crate) struct EnumLayout {
     pub(crate) enum_name: String,
     tag_type: String,
     pub(crate) variants: Vec<VariantLayout>,
+    variant_indexes: HashMap<String, usize>,
     pub(crate) generics: Vec<Generic>,
     requirements: PackageRequirements,
     /// Index of the `#[default]` variant, which takes tag `0`.
@@ -27,6 +28,7 @@ pub(crate) struct VariantLayout {
     pub(crate) tag_constant: String,
     is_struct_variant: bool,
     pub(crate) fields: Vec<FieldLayout>,
+    field_indexes: HashMap<String, usize>,
     doc: Option<String>,
 }
 
@@ -61,16 +63,21 @@ impl EnumLayout {
         let tag_type = format!("{}Tag", enum_name);
 
         let slots = go_names::enum_field_slots(&enum_name, variants);
-        let variants = variants
+        let variants: Vec<_> = variants
             .iter()
             .enumerate()
             .map(|(vi, v)| Self::compute_variant_layout(vi, v, &enum_name, &slots[vi], field_types))
             .collect();
+        let mut variant_indexes = HashMap::default();
+        for (index, variant) in variants.iter().enumerate() {
+            variant_indexes.entry(variant.name.clone()).or_insert(index);
+        }
 
         Self {
             enum_name,
             tag_type,
             variants,
+            variant_indexes,
             generics: generics.to_vec(),
             requirements,
             default_variant,
@@ -111,7 +118,7 @@ impl EnumLayout {
         let field_shape =
             go_names::enum_field_shape(&variant.fields).unwrap_or(EnumFieldShape::TupleMultiple);
 
-        let fields = variant
+        let fields: Vec<_> = variant
             .fields
             .iter()
             .enumerate()
@@ -140,27 +147,36 @@ impl EnumLayout {
                 }
             })
             .collect();
+        let mut field_indexes = HashMap::default();
+        for (index, field) in fields.iter().enumerate() {
+            field_indexes
+                .entry(field.source_name.clone())
+                .or_insert(index);
+        }
 
         VariantLayout {
             name: variant.name.to_string(),
             tag_constant,
             is_struct_variant: field_shape == EnumFieldShape::Struct,
             fields,
+            field_indexes,
             doc: variant.doc.clone(),
         }
     }
 
     pub(crate) fn get_variant(&self, name: &str) -> Option<&VariantLayout> {
-        self.variants.iter().find(|v| v.name == name)
+        self.variant_indexes
+            .get(name)
+            .and_then(|index| self.variants.get(*index))
     }
 
     pub(crate) fn struct_field_name(&self, variant_name: &str, field_name: &str) -> Option<String> {
         let variant = self.get_variant(variant_name)?;
         variant
-            .fields
-            .iter()
-            .find(|f| f.source_name == field_name)
-            .map(|f| f.go_name.clone())
+            .field_indexes
+            .get(field_name)
+            .and_then(|index| variant.fields.get(*index))
+            .map(|field| field.go_name.clone())
     }
 
     pub(crate) fn tuple_field_name(&self, variant_name: &str, index: usize) -> Option<String> {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -41,6 +41,18 @@ struct EnumCallContext {
     pointer_fields: HashSet<String>,
 }
 
+struct StructCallField {
+    name: String,
+    value: String,
+    has_observable_evaluation: bool,
+}
+
+impl StructCallField {
+    fn into_pair(self) -> (String, String) {
+        (self.name, self.value)
+    }
+}
+
 impl Planner<'_> {
     /// Plan a struct/enum-variant construction. Value is the Go struct
     /// literal or update.
@@ -67,23 +79,23 @@ impl Planner<'_> {
             .iter()
             .map(|f| self.stage_composite(&f.value, ExpressionContext::value()))
             .collect();
-        let mut field_side_effects: Vec<bool> = stages
+        let field_evaluations: Vec<bool> = stages
             .iter()
             .map(|value| value.evaluation.stability.is_observable())
             .collect();
-        if ctx.enum_ctx.is_some() {
-            field_side_effects.insert(0, false);
-        }
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "field");
         let mut effect = sequenced.effect;
         let fields_contain_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let (mut setup, emitted_values) = sequenced.into_rendered();
 
-        let mut field_names: Vec<String> = Vec::new();
-        let mut field_values: Vec<String> = Vec::new();
-        for (slot, f) in field_assignments.iter().enumerate() {
+        let mut fields =
+            Vec::with_capacity(field_assignments.len() + usize::from(ctx.enum_ctx.is_some()));
+        for ((f, has_observable_evaluation), mut value) in field_assignments
+            .iter()
+            .zip(field_evaluations)
+            .zip(emitted_values)
+        {
             let field_name = self.resolve_struct_call_field_name(&f.name, &ctx);
-            let mut value = emitted_values[slot].clone();
             value = self.wrap_recursive_enum_field(&mut setup, value, f, &ctx);
             let value_ty = f.value.get_type();
             let field_ty = self.lookup_struct_field_ty(ty, &f.name);
@@ -96,15 +108,22 @@ impl Planner<'_> {
                 field_ty.as_ref(),
                 field_layout.as_ref(),
             );
-            field_names.push(field_name);
-            field_values.push(value);
+            fields.push(StructCallField {
+                name: field_name,
+                value,
+                has_observable_evaluation,
+            });
         }
 
-        let mut field_pairs: Vec<(String, String)> =
-            field_names.into_iter().zip(field_values).collect();
-
-        if let Some(tag) = tag_field {
-            field_pairs.insert(0, tag);
+        if let Some((name, value)) = tag_field {
+            fields.insert(
+                0,
+                StructCallField {
+                    name,
+                    value,
+                    has_observable_evaluation: false,
+                },
+            );
         }
 
         let value = match spread {
@@ -123,8 +142,7 @@ impl Planner<'_> {
                 } else {
                     let base_staged = self.stage_operand(base, ExpressionContext::value());
                     effect = effect.combine(base_staged.evaluation.effect);
-                    let field_pairs =
-                        self.hoist_observable_fields(&mut setup, field_pairs, &field_side_effects);
+                    let field_pairs = self.hoist_observable_fields(&mut setup, fields);
                     let (spread_setup, value) = if ctx.enum_ctx.is_some() {
                         self.lower_enum_variant_spread(
                             SpreadInput {
@@ -147,6 +165,8 @@ impl Planner<'_> {
             StructSpread::Autofill { .. } => match self.go_imported_newtype_zero(ty) {
                 Some(zero) => GoExpression::opaque(zero),
                 None => {
+                    let mut field_pairs =
+                        fields.into_iter().map(StructCallField::into_pair).collect();
                     self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
                     GoExpression::composite_literal(
                         emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
@@ -154,10 +174,14 @@ impl Planner<'_> {
                     )
                 }
             },
-            StructSpread::None => GoExpression::composite_literal(
-                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
-                fields_contain_deferred_evaluation,
-            ),
+            StructSpread::None => {
+                let field_pairs: Vec<_> =
+                    fields.into_iter().map(StructCallField::into_pair).collect();
+                GoExpression::composite_literal(
+                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                    fields_contain_deferred_evaluation,
+                )
+            }
         };
 
         ValuePlan::computed(setup, value, effect)
@@ -680,18 +704,16 @@ impl Planner<'_> {
     fn hoist_observable_fields(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        field_pairs: Vec<(String, String)>,
-        field_side_effects: &[bool],
+        fields: Vec<StructCallField>,
     ) -> Vec<(String, String)> {
-        field_pairs
+        fields
             .into_iter()
-            .enumerate()
-            .map(|(i, (name, value))| {
-                if field_side_effects.get(i).copied().unwrap_or(false) {
-                    let temp = self.hoist_tmp_value_statement(statements, "field", &value);
-                    (name, temp)
+            .map(|field| {
+                if field.has_observable_evaluation {
+                    let temp = self.hoist_tmp_value_statement(statements, "field", &field.value);
+                    (field.name, temp)
                 } else {
-                    (name, value)
+                    field.into_pair()
                 }
             })
             .collect()

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -386,13 +386,13 @@ impl<'a> Planner<'a> {
             test_index: config.test_index,
             go_package_names: config.go_package_names,
             go_package_ids: config.go_package_ids,
-            entry_package: config.package_id.to_string(),
+            entry_package: config.package_id.to_string().into(),
             entry_package_name: "main",
             go_module: config.go_module.to_string(),
             emit_tests: false,
             line_indexes,
             globals,
-            current_package: config.package_id.to_string(),
+            current_package: config.package_id.to_string().into(),
         });
         Self::emit_files_with_facts(facts, files, config.package_id)
     }
@@ -744,13 +744,13 @@ fn emit_package<'a>(
         test_index: &analysis.test_index,
         go_package_names: &analysis.go_package_names,
         go_package_ids: &analysis.go_package_ids,
-        entry_package: analysis.entry_package_id.to_string(),
+        entry_package: analysis.entry_package_id.to_string().into(),
         entry_package_name,
         go_module: go_module.to_string(),
         emit_tests: shared_emit_ctx.emit_tests,
         line_indexes: shared_emit_ctx.line_indexes.clone(),
         globals: shared_emit_ctx.globals.clone(),
-        current_package: package_id.to_string(),
+        current_package: package_id.to_string().into(),
     });
     Planner::emit_files_with_facts(facts, files, package_id).map(|mut package_output| {
         if package_id != analysis.entry_package_id.as_str() {

--- a/crates/emit/src/names/generics.rs
+++ b/crates/emit/src/names/generics.rs
@@ -6,9 +6,9 @@ use crate::Planner;
 use crate::names::go_name;
 use syntax::EcoString;
 use syntax::ast::Generic;
-use syntax::types::Type;
+use syntax::types::{SubstitutionMap, Type};
 
-fn build_type_map(generics: &[Generic], type_args: &[Type]) -> HashMap<EcoString, Type> {
+fn build_type_map(generics: &[Generic], type_args: &[Type]) -> SubstitutionMap {
     generics
         .iter()
         .map(|g| g.name.clone())

--- a/crates/emit/src/output/imports.rs
+++ b/crates/emit/src/output/imports.rs
@@ -15,6 +15,8 @@ use super::OutputImport;
 /// one record avoids synchronizing separate lookup and emission collections.
 pub(crate) struct ImportPlan {
     imports: Vec<PlannedImport>,
+    package_aliases: HashMap<String, usize>,
+    alias_packages: HashMap<String, usize>,
 }
 
 struct PlannedImport {
@@ -38,6 +40,8 @@ impl ImportPlan {
         go_package_names: &HashMap<String, String>,
     ) -> Self {
         let mut imports = Vec::new();
+        let mut package_aliases = HashMap::default();
+        let mut alias_packages = HashMap::default();
 
         for import in file.imports() {
             let is_blank = matches!(import.alias, Some(ImportAlias::Blank(_)));
@@ -55,8 +59,14 @@ impl ImportPlan {
                 ImportDisposition::Emit
             };
             let (path, go_alias) = resolve_import(&import, go_module, go_package_names);
+            let package = import.name.to_string();
+            let index = imports.len();
+            if let Some(alias) = &source_alias {
+                package_aliases.insert(package.clone(), index);
+                alias_packages.insert(alias.clone(), index);
+            }
             imports.push(PlannedImport {
-                package: import.name.to_string(),
+                package,
                 source_alias,
                 path,
                 go_alias,
@@ -64,23 +74,23 @@ impl ImportPlan {
             });
         }
 
-        Self { imports }
+        Self {
+            imports,
+            package_aliases,
+            alias_packages,
+        }
     }
 
     pub(crate) fn package_alias(&self, package: &str) -> Option<&str> {
-        self.imports
-            .iter()
-            .rev()
-            .filter(|import| import.package == package)
-            .find_map(|import| import.source_alias.as_deref())
+        self.package_aliases
+            .get(package)
+            .and_then(|index| self.imports[*index].source_alias.as_deref())
     }
 
     pub(crate) fn package_for_alias(&self, alias: &str) -> Option<&str> {
-        self.imports
-            .iter()
-            .rev()
-            .find(|import| import.source_alias.as_deref() == Some(alias))
-            .map(|import| import.package.as_str())
+        self.alias_packages
+            .get(alias)
+            .map(|index| self.imports[*index].package.as_str())
     }
 
     fn into_builder_state(self) -> (HashMap<String, String>, HashMap<String, String>) {
@@ -107,7 +117,7 @@ pub struct ImportBuilder<'a> {
     imports: HashMap<String, String>,
     /// Additional qualifiers requested for a path already present under a
     /// different qualifier.
-    duplicate_imports: Vec<(String, String)>,
+    duplicate_imports: HashSet<(String, String)>,
     dropped_aliases: HashMap<String, String>,
     used_packages: HashSet<String>,
 }
@@ -121,7 +131,7 @@ impl<'a> ImportBuilder<'a> {
             go_package_names,
             go_package_ids,
             imports: HashMap::default(),
-            duplicate_imports: Vec::new(),
+            duplicate_imports: HashSet::default(),
             dropped_aliases: HashMap::default(),
             used_packages: HashSet::default(),
         }
@@ -137,7 +147,7 @@ impl<'a> ImportBuilder<'a> {
             go_package_names,
             go_package_ids,
             imports,
-            duplicate_imports: Vec::new(),
+            duplicate_imports: HashSet::default(),
             dropped_aliases,
             used_packages: HashSet::default(),
         }
@@ -171,16 +181,8 @@ impl<'a> ImportBuilder<'a> {
         match self.imports.get(path) {
             Some(alias) if effective_qualifier(path, alias, self.go_package_ids) == qualifier => {}
             Some(_) => {
-                if !self
-                    .duplicate_imports
-                    .iter()
-                    .any(|(duplicate_path, duplicate_alias)| {
-                        duplicate_path == path && duplicate_alias == qualifier
-                    })
-                {
-                    self.duplicate_imports
-                        .push((path.to_string(), qualifier.to_string()));
-                }
+                self.duplicate_imports
+                    .insert((path.to_string(), qualifier.to_string()));
             }
             None => {
                 let alias = self
@@ -294,5 +296,39 @@ pub(crate) fn format_import(path: &str, alias: &str) -> String {
         }
     } else {
         format!("{alias} \"{path}\"")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntax::FileParseStatus;
+
+    #[test]
+    fn import_plan_indexes_the_last_matching_alias() {
+        let source = r#"
+import early "one"
+import late "one"
+import shared "two"
+import shared "three"
+"#;
+        let parsed = syntax::build_ast(source, 0);
+        assert!(parsed.errors.is_empty());
+        let file = File {
+            id: 0,
+            package_id: "package".to_string(),
+            parse_status: FileParseStatus::Clean,
+            name: "test.lis".to_string(),
+            display_path: "test.lis".to_string(),
+            source_path: None,
+            source: source.to_string(),
+            items: parsed.ast,
+            file_comment: None,
+        };
+
+        let plan = ImportPlan::build(&file, "module", &HashSet::default(), &HashMap::default());
+
+        assert_eq!(plan.package_alias("one"), Some("late"));
+        assert_eq!(plan.package_for_alias("shared"), Some("three"));
     }
 }

--- a/crates/emit/src/output/imports.rs
+++ b/crates/emit/src/output/imports.rs
@@ -9,6 +9,8 @@ use syntax::program::{File, FileImport, PackageId};
 use crate::names::packages::{PackageRequirements, PackageUse};
 use syntax::program;
 
+use super::OutputImport;
+
 /// Source imports resolved once during the plan phase. Keeping each import as
 /// one record avoids synchronizing separate lookup and emission collections.
 pub(crate) struct ImportPlan {
@@ -194,11 +196,19 @@ impl<'a> ImportBuilder<'a> {
         }
     }
 
-    pub fn build(mut self) -> (Vec<(String, String)>, Vec<LisetteDiagnostic>) {
+    pub fn build(mut self) -> (Vec<OutputImport>, Vec<LisetteDiagnostic>) {
         self.imports
             .retain(|path, alias| alias == "_" || self.used_packages.contains(path));
-        let mut entries: Vec<(String, String)> = self.imports.into_iter().collect();
-        entries.extend(self.duplicate_imports);
+        let mut entries: Vec<OutputImport> = self
+            .imports
+            .into_iter()
+            .map(|(path, alias)| OutputImport { path, alias })
+            .collect();
+        entries.extend(
+            self.duplicate_imports
+                .into_iter()
+                .map(|(path, alias)| OutputImport { path, alias }),
+        );
         entries.sort();
         entries.dedup();
         let diagnostics = detect_collisions(&entries, self.go_package_ids);
@@ -207,19 +217,22 @@ impl<'a> ImportBuilder<'a> {
 }
 
 fn detect_collisions(
-    entries: &[(String, String)],
+    entries: &[OutputImport],
     go_package_ids: &HashSet<String>,
 ) -> Vec<LisetteDiagnostic> {
     if entries.len() < 2 {
         return Vec::new();
     }
     let mut groups: HashMap<String, Vec<&str>> = HashMap::default();
-    for (path, alias) in entries {
-        if alias == "_" {
+    for entry in entries {
+        if entry.alias == "_" {
             continue;
         }
-        let qualifier = effective_qualifier(path, alias, go_package_ids);
-        groups.entry(qualifier).or_default().push(path.as_str());
+        let qualifier = effective_qualifier(&entry.path, &entry.alias, go_package_ids);
+        groups
+            .entry(qualifier)
+            .or_default()
+            .push(entry.path.as_str());
     }
     let mut groups: Vec<_> = groups.into_iter().filter(|(_, p)| p.len() > 1).collect();
     groups.sort_by(|a, b| a.0.cmp(&b.0));

--- a/crates/emit/src/output/imports.rs
+++ b/crates/emit/src/output/imports.rs
@@ -157,14 +157,14 @@ impl<'a> ImportBuilder<'a> {
         for package_id in package_ids {
             let qualifier = self
                 .dropped_aliases
-                .get(package_id)
+                .get(package_id.as_str())
                 .or_else(|| {
                     self.go_package_names
                         .get(&format!("{}{package_id}", go_name::GO_IMPORT_PREFIX))
                 })
                 .cloned()
                 .unwrap_or_default();
-            self.require_package_use(&PackageUse::new(package_id.clone(), qualifier));
+            self.require_package_use(&PackageUse::new(package_id.to_string(), qualifier));
         }
     }
 

--- a/crates/emit/src/output/mod.rs
+++ b/crates/emit/src/output/mod.rs
@@ -10,11 +10,15 @@ use crate::expressions::top_items::emit_doc;
 pub struct OutputFile {
     pub name: String,
     pub(crate) source: String,
-    /// `(path, alias)` pairs; a path may appear twice when a generated
-    /// import coexists with a source alias of the same package.
-    pub imports: Vec<(String, String)>,
+    pub imports: Vec<OutputImport>,
     pub package_name: String,
     pub(crate) file_comment: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct OutputImport {
+    pub path: String,
+    pub alias: String,
 }
 
 impl OutputFile {
@@ -40,13 +44,16 @@ impl OutputFile {
 
         match self.imports.as_slice() {
             [] => {}
-            [(path, alias)] => {
-                output.collect(format!("import {}", format_import(path, alias)));
+            [entry] => {
+                output.collect(format!(
+                    "import {}",
+                    format_import(&entry.path, &entry.alias)
+                ));
             }
             entries => {
                 output.collect("import (");
-                for (path, alias) in entries {
-                    output.collect(format_import(path, alias));
+                for entry in entries {
+                    output.collect(format_import(&entry.path, &entry.alias));
                 }
                 output.collect(")");
             }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -991,7 +991,6 @@ fn compute_struct_field_path(
     field: &StructFieldPattern,
     ty: &Type,
     enum_info: Option<&(String, String)>,
-    variant_fields: Option<&[EnumFieldDefinition]>,
 ) -> AccessPath {
     let go_field_name = if let Some((enum_id, variant_name)) = enum_info {
         planner
@@ -1013,17 +1012,11 @@ fn compute_struct_field_path(
     if let Some((_, variant_name)) = enum_info
         && let Some(field_index) =
             planner.get_enum_struct_field_index(ty, variant_name, &field.name)
+        && planner.is_enum_field_recursive(ty, variant_name, field_index)
     {
-        let is_source_ref = variant_fields
-            .and_then(|vf| vf.get(field_index).map(|f| f.ty.is_ref()))
-            .unwrap_or_else(|| planner.is_enum_field_source_ref(ty, variant_name, field_index));
-        let is_auto_pointer =
-            planner.is_enum_field_pointer(ty, variant_name, field_index) && !is_source_ref;
-        if is_auto_pointer {
-            return parent_path
-                .push(PathSegment::Field(go_field_name))
-                .push(PathSegment::Deref);
-        }
+        return parent_path
+            .push(PathSegment::Field(go_field_name))
+            .push(PathSegment::Deref);
     }
 
     parent_path.push(PathSegment::Field(go_field_name))
@@ -1095,17 +1088,13 @@ fn collect_enum_variant_checks(
     let Some(definition) = planner.facts.definition(enum_name) else {
         return;
     };
-    let (variant_fields, field_types): (&[EnumFieldDefinition], Vec<Type>) = match &definition.body
-    {
+    let field_types: Vec<Type> = match &definition.body {
         DefinitionBody::Struct {
             fields, generics, ..
-        } => (
-            &[],
-            fields
-                .iter()
-                .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
-                .collect(),
-        ),
+        } => fields
+            .iter()
+            .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
+            .collect(),
         DefinitionBody::Enum {
             variants, generics, ..
         } => {
@@ -1115,14 +1104,11 @@ fn collect_enum_variant_checks(
             else {
                 return;
             };
-            (
-                variant.fields.as_slice(),
-                variant
-                    .fields
-                    .iter()
-                    .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
-                    .collect(),
-            )
+            variant
+                .fields
+                .iter()
+                .map(|field| generics::resolve_field_type(generics, &params, &field.ty))
+                .collect()
         }
         _ => return,
     };
@@ -1131,7 +1117,6 @@ fn collect_enum_variant_checks(
         identifier,
         fields,
         ty,
-        variant_fields,
         field_types: &field_types,
     };
 
@@ -1260,7 +1245,6 @@ struct EnumVariantData<'a> {
     identifier: &'a str,
     fields: &'a [Pattern],
     ty: &'a Type,
-    variant_fields: &'a [EnumFieldDefinition],
     field_types: &'a [Type],
 }
 
@@ -1307,17 +1291,9 @@ fn collect_tagged_enum_checks(
     for (i, field) in variant.fields.iter().enumerate() {
         let field_name = planner.get_enum_tuple_field_name(variant.ty, variant_name, i);
 
-        let is_source_ref = variant
-            .variant_fields
-            .get(i)
-            .map(|f| f.ty.is_ref())
-            .unwrap_or_else(|| planner.is_enum_field_source_ref(variant.ty, variant_name, i));
-        let is_auto_pointer =
-            planner.is_enum_field_pointer(variant.ty, variant_name, i) && !is_source_ref;
-
         let is_unit = planner.is_enum_field_unit(variant.ty, variant_name, i);
 
-        let field_path = if is_auto_pointer {
+        let field_path = if planner.is_enum_field_recursive(variant.ty, variant_name, i) {
             path.push(PathSegment::Field(field_name))
                 .push(PathSegment::Deref)
         } else {
@@ -1380,17 +1356,10 @@ fn collect_struct_checks(
 
     let (enum_info, child_path) =
         resolve_struct_child_path(planner, path, pattern, path_ty, collector);
-    let variant_fields = record_variant_fields(planner, resolution);
 
     for field in fields {
-        let field_path = compute_struct_field_path(
-            planner,
-            &child_path,
-            field,
-            ty,
-            enum_info.as_ref(),
-            variant_fields,
-        );
+        let field_path =
+            compute_struct_field_path(planner, &child_path, field, ty, enum_info.as_ref());
         let field_ty = record_field_type(planner, resolution, ty, &field.name);
         collect_checks_and_bindings(
             planner,

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -552,7 +552,7 @@ fn try_build_switch(arms: &[ArmInfo]) -> Option<Decision> {
     validate_switch_arms(arms, &kind, &switch_path)?;
 
     let grouped = group_switch_branches(arms, &kind);
-    let branches = build_switch_branches(grouped.order, grouped.by_label, &grouped.fallback);
+    let branches = build_switch_branches(grouped.branches, &grouped.fallback);
 
     let fallback = if grouped.fallback.is_empty() {
         None
@@ -628,14 +628,12 @@ fn validate_switch_arms(
 }
 
 struct GroupedBranches {
-    order: Vec<String>,
-    by_label: HashMap<String, Vec<ArmInfo>>,
+    branches: Vec<(String, Vec<ArmInfo>)>,
     fallback: Vec<ArmInfo>,
 }
 
 fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches {
-    let mut by_label: HashMap<String, Vec<ArmInfo>> = HashMap::default();
-    let mut order: Vec<String> = Vec::new();
+    let mut branches: Vec<(String, Vec<ArmInfo>)> = Vec::new();
     let mut fallback = Vec::new();
 
     for arm in arms {
@@ -666,33 +664,25 @@ fn group_switch_branches(arms: &[ArmInfo], kind: &SwitchKind) -> GroupedBranches
             has_guard: arm.has_guard,
         };
 
-        by_label
-            .entry(case_label.clone())
-            .and_modify(|arms| arms.push(inner_arm.clone()))
-            .or_insert_with(|| {
-                order.push(case_label);
-                vec![inner_arm]
-            });
+        if let Some((_, arms)) = branches.iter_mut().find(|(label, _)| label == &case_label) {
+            arms.push(inner_arm);
+        } else {
+            branches.push((case_label, vec![inner_arm]));
+        }
     }
 
-    GroupedBranches {
-        order,
-        by_label,
-        fallback,
-    }
+    GroupedBranches { branches, fallback }
 }
 
 /// Splice the catchall into any fail-prone case body: Go `switch` cases do not
 /// fall through to `default`, so a failed inner check has nowhere else to go.
 fn build_switch_branches(
-    order: Vec<String>,
-    mut by_label: HashMap<String, Vec<ArmInfo>>,
+    branches: Vec<(String, Vec<ArmInfo>)>,
     fallback_arms: &[ArmInfo],
 ) -> Vec<SwitchBranch> {
-    order
+    branches
         .into_iter()
-        .map(|label| {
-            let inner_arms = by_label.remove(&label).unwrap();
+        .map(|(label, inner_arms)| {
             let any_inner_can_fail = inner_arms
                 .iter()
                 .any(|a| a.has_guard || !a.checks.is_empty());

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -41,15 +41,20 @@ pub(crate) enum BindingValue {
     InlineExpr(InlineExpr),
 }
 
-pub(crate) struct BindingSnapshot(HashMap<String, BindingValue>);
+pub(crate) type BindingUndo = Vec<(String, Option<BindingValue>)>;
+
+pub(crate) struct BindingSnapshot {
+    bindings: HashMap<String, BindingValue>,
+    undo: BindingUndo,
+}
 
 impl BindingSnapshot {
-    pub(crate) fn new(bindings: HashMap<String, BindingValue>) -> Self {
-        Self(bindings)
+    pub(crate) fn new(bindings: HashMap<String, BindingValue>, undo: BindingUndo) -> Self {
+        Self { bindings, undo }
     }
 
-    pub(crate) fn into_inner(self) -> HashMap<String, BindingValue> {
-        self.0
+    pub(crate) fn into_inner(self) -> (HashMap<String, BindingValue>, BindingUndo) {
+        (self.bindings, self.undo)
     }
 }
 

--- a/crates/emit/src/state/file_namespace.rs
+++ b/crates/emit/src/state/file_namespace.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::names::packages::{PackageRequirements, PackageUse};
+use crate::output::OutputImport;
 use crate::output::imports::{ImportBuilder, ImportPlan};
 use diagnostics::LisetteDiagnostic;
 use ecow::EcoString;
@@ -50,7 +51,7 @@ impl FileNamespace {
         self,
         go_package_names: &HashMap<String, String>,
         go_package_ids: &rustc_hash::FxHashSet<String>,
-    ) -> (Vec<(String, String)>, Vec<LisetteDiagnostic>) {
+    ) -> (Vec<OutputImport>, Vec<LisetteDiagnostic>) {
         let mut builder = ImportBuilder::from_plan(self.imports, go_package_names, go_package_ids);
         builder.extend_with_package_uses(&self.requirements);
         builder.build()

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -4,11 +4,13 @@ use std::mem;
 use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::plan::bodies::LoopId;
-use crate::state::bindings::{BindingSnapshot, BindingValue, InlineExpr};
+use crate::state::bindings::{BindingSnapshot, BindingUndo, BindingValue, InlineExpr};
 
 pub(crate) struct ScopeState {
     next_var: usize,
     next_loop_id: u32,
+    bindings: HashMap<String, BindingValue>,
+    bound_go_names: HashMap<String, usize>,
     frames: Vec<ScopeFrame>,
     loop_stack: Vec<LoopContext>,
     return_ctx_stack: Vec<ReturnContext>,
@@ -19,7 +21,8 @@ pub(crate) struct ScopeState {
 }
 
 struct ScopeFrame {
-    bindings: HashMap<String, BindingValue>,
+    binding_undo: BindingUndo,
+    changed_bindings: HashSet<String>,
     declarations: DeclarationScope,
     /// Conditions the branch being lowered has already tested in this scope.
     established: Vec<String>,
@@ -47,8 +50,11 @@ impl ScopeState {
         Self {
             next_var: 0,
             next_loop_id: 0,
+            bindings: HashMap::default(),
+            bound_go_names: HashMap::default(),
             frames: vec![ScopeFrame {
-                bindings: HashMap::default(),
+                binding_undo: Vec::new(),
+                changed_bindings: HashSet::default(),
                 declarations: DeclarationScope::Block(HashMap::default()),
                 established: Vec::new(),
             }],
@@ -97,41 +103,38 @@ impl ScopeState {
         go_name: impl Into<String>,
     ) -> String {
         let go_name = crate::escape_reserved(&go_name.into()).into_owned();
-        self.current_bindings_mut()
-            .insert(lisette_name.into(), BindingValue::GoName(go_name.clone()));
+        self.set_binding(lisette_name.into(), BindingValue::GoName(go_name.clone()));
         go_name
     }
 
     pub(crate) fn bind_inline_expr(&mut self, lisette_name: impl Into<String>, expr: InlineExpr) {
-        self.current_bindings_mut()
-            .insert(lisette_name.into(), BindingValue::InlineExpr(expr));
+        self.set_binding(lisette_name.into(), BindingValue::InlineExpr(expr));
     }
 
     pub(crate) fn bind_value(&mut self, lisette_name: impl Into<String>, value: BindingValue) {
-        self.current_bindings_mut()
-            .insert(lisette_name.into(), value);
+        self.set_binding(lisette_name.into(), value);
     }
 
     pub(crate) fn mark_go_const(&mut self, lisette_name: &str) {
-        let Some(value) = self.current_bindings_mut().get_mut(lisette_name) else {
+        let Some(BindingValue::GoName(name)) = self.bindings.get(lisette_name).cloned() else {
             return;
         };
-        if let BindingValue::GoName(name) = value {
-            let name = mem::take(name);
-            *value = BindingValue::GoConst(name);
-        }
+        self.set_binding(lisette_name.to_string(), BindingValue::GoConst(name));
     }
 
     pub(crate) fn remove_binding(&mut self, lisette_name: &str) {
-        self.current_bindings_mut().remove(lisette_name);
+        self.record_binding_change(lisette_name);
+        if let Some(value) = self.bindings.remove(lisette_name) {
+            self.remove_bound_go_name(&value);
+        }
     }
 
     pub(crate) fn resolve_identifier_binding(&self, lisette_name: &str) -> Option<&BindingValue> {
-        self.current_bindings().get(lisette_name)
+        self.bindings.get(lisette_name)
     }
 
     pub(crate) fn resolve_binding_go_name(&self, lisette_name: &str) -> Option<&str> {
-        self.current_bindings()
+        self.bindings
             .get(lisette_name)
             .and_then(BindingValue::as_go_name)
     }
@@ -139,10 +142,7 @@ impl ScopeState {
     /// Falls back to the keyword-escaped form when the name is unbound or
     /// inline-bound; callers needing a usable local must hoist a fresh temp.
     pub(crate) fn has_binding_for_go_name(&self, go_name: &str) -> bool {
-        self.current_bindings()
-            .values()
-            .filter_map(BindingValue::as_go_name)
-            .any(|candidate| candidate == go_name)
+        self.bound_go_names.contains_key(go_name)
     }
 
     pub(crate) fn push_binding_frame(&mut self) {
@@ -161,17 +161,27 @@ impl ScopeState {
     }
 
     pub(crate) fn binding_snapshot(&self) -> BindingSnapshot {
-        BindingSnapshot::new(self.current_bindings().clone())
+        BindingSnapshot::new(
+            self.bindings.clone(),
+            self.current_frame().binding_undo.clone(),
+        )
     }
 
     pub(crate) fn replace_binding_snapshot(
         &mut self,
         snapshot: BindingSnapshot,
     ) -> BindingSnapshot {
-        BindingSnapshot::new(mem::replace(
-            self.current_bindings_mut(),
-            snapshot.into_inner(),
-        ))
+        let (bindings, undo) = snapshot.into_inner();
+        let previous_bindings = mem::replace(&mut self.bindings, bindings);
+        self.rebuild_bound_go_names();
+        let previous_undo = mem::replace(&mut self.current_frame_mut().binding_undo, undo);
+        self.current_frame_mut().changed_bindings = self
+            .current_frame()
+            .binding_undo
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect();
+        BindingSnapshot::new(previous_bindings, previous_undo)
     }
 
     pub(crate) fn declare_go_name(&mut self, go_name: &str) {
@@ -338,14 +348,25 @@ impl ScopeState {
 
     fn push_frame(&mut self, declarations: DeclarationScope) {
         self.frames.push(ScopeFrame {
-            bindings: self.current_bindings().clone(),
+            binding_undo: Vec::new(),
+            changed_bindings: HashSet::default(),
             declarations,
             established: Vec::new(),
         });
     }
 
     fn pop_frame(&mut self) {
-        pop_keep_base(&mut self.frames);
+        assert!(self.frames.len() > 1, "cannot pop a stack's base frame");
+        let frame = self.frames.pop().expect("scope state retains a base frame");
+        for (name, previous) in frame.binding_undo.into_iter().rev() {
+            if let Some(value) = self.bindings.remove(&name) {
+                self.remove_bound_go_name(&value);
+            }
+            if let Some(value) = previous {
+                self.add_bound_go_name(&value);
+                self.bindings.insert(name, value);
+            }
+        }
     }
 
     fn current_frame(&self) -> &ScopeFrame {
@@ -360,12 +381,51 @@ impl ScopeState {
             .expect("scope state always retains a frame")
     }
 
-    fn current_bindings(&self) -> &HashMap<String, BindingValue> {
-        &self.current_frame().bindings
+    fn set_binding(&mut self, name: String, value: BindingValue) {
+        self.record_binding_change(&name);
+        if let Some(previous) = self.bindings.insert(name, value.clone()) {
+            self.remove_bound_go_name(&previous);
+        }
+        self.add_bound_go_name(&value);
     }
 
-    fn current_bindings_mut(&mut self) -> &mut HashMap<String, BindingValue> {
-        &mut self.current_frame_mut().bindings
+    fn record_binding_change(&mut self, name: &str) {
+        if self.frames.len() == 1 {
+            return;
+        }
+        let previous = self.bindings.get(name).cloned();
+        let frame = self.current_frame_mut();
+        if frame.changed_bindings.insert(name.to_string()) {
+            frame.binding_undo.push((name.to_string(), previous));
+        }
+    }
+
+    fn add_bound_go_name(&mut self, value: &BindingValue) {
+        if let Some(name) = value.as_go_name() {
+            *self.bound_go_names.entry(name.to_string()).or_default() += 1;
+        }
+    }
+
+    fn remove_bound_go_name(&mut self, value: &BindingValue) {
+        let Some(name) = value.as_go_name() else {
+            return;
+        };
+        let Some(count) = self.bound_go_names.get_mut(name) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            self.bound_go_names.remove(name);
+        }
+    }
+
+    fn rebuild_bound_go_names(&mut self) {
+        self.bound_go_names.clear();
+        for value in self.bindings.values() {
+            if let Some(name) = value.as_go_name() {
+                *self.bound_go_names.entry(name.to_string()).or_default() += 1;
+            }
+        }
     }
 
     fn current_declarations(&self) -> &Declarations {
@@ -408,4 +468,56 @@ impl ScopeState {
 fn pop_keep_base<T>(stack: &mut Vec<T>) {
     assert!(stack.len() > 1, "cannot pop a stack's base frame");
     let _ = stack.pop();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exiting_block_restores_shadowed_binding() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "outer");
+        scope.enter_block();
+        scope.bind("value", "inner");
+
+        scope.exit_block();
+
+        assert_eq!(scope.resolve_binding_go_name("value"), Some("outer"));
+    }
+
+    #[test]
+    fn removing_binding_hides_it_until_scope_exit() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "outer");
+        scope.enter_block();
+        scope.remove_binding("value");
+        assert!(scope.resolve_identifier_binding("value").is_none());
+
+        scope.exit_block();
+
+        assert_eq!(scope.resolve_binding_go_name("value"), Some("outer"));
+    }
+
+    #[test]
+    fn replacing_snapshot_can_restore_current_bindings() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "before");
+        let before = scope.binding_snapshot();
+        scope.bind("value", "after");
+
+        let after = scope.replace_binding_snapshot(before);
+        assert_eq!(scope.resolve_binding_go_name("value"), Some("before"));
+        let _ = scope.replace_binding_snapshot(after);
+
+        assert_eq!(scope.resolve_binding_go_name("value"), Some("after"));
+    }
+
+    #[test]
+    fn fresh_name_skips_bound_go_name() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "tmp_1");
+
+        assert_eq!(scope.fresh_go_name(None), "tmp_2");
+    }
 }

--- a/crates/format/src/comments.rs
+++ b/crates/format/src/comments.rs
@@ -270,14 +270,13 @@ impl<'a> Comments<'a> {
     }
 
     pub(crate) fn has_comment_immediately_before(&self, position: u32) -> bool {
-        let Some(comment) = self.line_trivia[self.line_cursor..]
-            .iter()
-            .filter_map(|event| match event {
-                LineTrivia::Comment(comment) if comment.start < position => Some(comment),
-                _ => None,
-            })
-            .next_back()
-        else {
+        let events = &self.line_trivia[self.line_cursor..];
+        let before = events.partition_point(|event| event.start() < position);
+        let comment = events[..before].iter().rev().find_map(|event| match event {
+            LineTrivia::Comment(comment) => Some(comment),
+            _ => None,
+        });
+        let Some(comment) = comment else {
             return false;
         };
         self.source
@@ -456,6 +455,22 @@ mod tests {
 
     fn render(doc: Option<Document<'_>>) -> Option<String> {
         doc.map(|d| d.to_pretty_string(80))
+    }
+
+    #[test]
+    fn immediately_before_ignores_future_comments() {
+        let source = "// old\nmember\n// future\n";
+        let c = comments(source, vec![(0, 6), (14, 23)], Vec::new());
+
+        assert!(c.has_comment_immediately_before(7));
+    }
+
+    #[test]
+    fn immediately_before_rejects_intervening_code() {
+        let source = "// old\nmember\n// future\n";
+        let c = comments(source, vec![(0, 6), (14, 23)], Vec::new());
+
+        assert!(!c.has_comment_immediately_before(14));
     }
 
     #[test]

--- a/crates/format/src/formatter.rs
+++ b/crates/format/src/formatter.rs
@@ -350,7 +350,7 @@ impl<'a> Formatter<'a> {
     fn visibility(vis: Visibility) -> Option<Document<'a>> {
         match vis {
             Visibility::Public => Some(Document::str("pub ")),
-            Visibility::Private => None,
+            Visibility::Private | Visibility::Local => None,
         }
     }
 

--- a/crates/format/src/lindig.rs
+++ b/crates/format/src/lindig.rs
@@ -9,6 +9,8 @@ enum Mode {
     ForcedUnbroken,
 }
 
+type PendingDocument<'a, 'doc> = (isize, Mode, &'doc Document<'a>);
+
 /// For ASCII the byte length is already the grapheme count.
 fn grapheme_count(text: &str) -> isize {
     if text.is_ascii() {
@@ -21,41 +23,51 @@ fn grapheme_count(text: &str) -> isize {
 fn fits<'a, 'doc>(
     limit: isize,
     mut current_width: isize,
-    docs: &mut Vec<(isize, Mode, &'doc Document<'a>)>,
+    docs: &[PendingDocument<'a, 'doc>],
+    first: Option<PendingDocument<'a, 'doc>>,
+    expanded: &mut Vec<PendingDocument<'a, 'doc>>,
 ) -> bool {
+    expanded.clear();
+    expanded.extend(first);
+    let mut remaining = docs.len();
+
     loop {
         if current_width > limit {
             return false;
         }
 
-        let (indent, mode, document) = match docs.pop() {
-            Some(x) => x,
+        let (indent, mode, document) = match expanded.pop() {
+            Some(document) => document,
+            None if remaining > 0 => {
+                remaining -= 1;
+                docs[remaining]
+            }
             None => return true,
         };
 
         match document {
             Document::ForceBroken(doc) => match mode {
-                Mode::ForcedBroken => docs.push((indent, mode, doc)),
+                Mode::ForcedBroken => expanded.push((indent, mode, doc)),
                 _ => return false,
             },
 
             Document::Newline => return true,
 
             Document::Nest(i, doc) => {
-                docs.push((indent + i, mode, doc));
+                expanded.push((indent + i, mode, doc));
             }
 
             Document::NestIfBroken(_, doc) => {
-                docs.push((indent, mode, doc));
+                expanded.push((indent, mode, doc));
             }
 
             Document::Group(doc) => match mode {
-                Mode::Broken => docs.push((indent, Mode::Unbroken, doc)),
-                _ => docs.push((indent, mode, doc)),
+                Mode::Broken => expanded.push((indent, Mode::Unbroken, doc)),
+                _ => expanded.push((indent, mode, doc)),
             },
 
             Document::MeasureFlat(doc) => {
-                docs.push((indent, Mode::ForcedUnbroken, doc));
+                expanded.push((indent, Mode::ForcedUnbroken, doc));
             }
 
             Document::Text(s) => {
@@ -79,18 +91,18 @@ fn fits<'a, 'doc>(
             }
 
             Document::NextBreakFits(doc) => match mode {
-                Mode::ForcedUnbroken => docs.push((indent, mode, doc)),
-                _ => docs.push((indent, Mode::ForcedBroken, doc)),
+                Mode::ForcedUnbroken => expanded.push((indent, mode, doc)),
+                _ => expanded.push((indent, Mode::ForcedBroken, doc)),
             },
 
             Document::NextBreakDoesNotFit(doc) => match mode {
-                Mode::ForcedBroken => docs.push((indent, mode, doc)),
-                _ => docs.push((indent, Mode::ForcedUnbroken, doc)),
+                Mode::ForcedBroken => expanded.push((indent, mode, doc)),
+                _ => expanded.push((indent, Mode::ForcedUnbroken, doc)),
             },
 
             Document::Sequence(vec) => {
                 for doc in vec.iter().rev() {
-                    docs.push((indent, mode, doc));
+                    expanded.push((indent, mode, doc));
                 }
             }
         }
@@ -129,9 +141,7 @@ fn format<'a, 'doc>(
             Document::FlexBreak { broken, unbroken } => {
                 let unbroken_width = width + unbroken.len() as isize;
                 let unbroken_fits = mode == Mode::Unbroken || {
-                    fits_buffer.clear();
-                    fits_buffer.extend_from_slice(&docs);
-                    fits(limit, unbroken_width, &mut fits_buffer)
+                    fits(limit, unbroken_width, &docs, None, &mut fits_buffer)
                 };
                 if unbroken_fits {
                     write_pending_indent(output, &mut pending_indent);
@@ -200,9 +210,13 @@ fn format<'a, 'doc>(
             }
 
             Document::Group(doc) => {
-                fits_buffer.clear();
-                fits_buffer.push((indent, Mode::Unbroken, doc.as_ref()));
-                if fits(limit, width, &mut fits_buffer) {
+                if fits(
+                    limit,
+                    width,
+                    &[],
+                    Some((indent, Mode::Unbroken, doc.as_ref())),
+                    &mut fits_buffer,
+                ) {
                     docs.push((indent, Mode::Unbroken, doc));
                 } else {
                     docs.push((indent, Mode::Broken, doc));
@@ -341,4 +355,22 @@ pub fn strict_break<'a>(broken: &'a str, unbroken: &'a str) -> Document<'a> {
 
 pub fn flex_break<'a>(broken: &'a str, unbroken: &'a str) -> Document<'a> {
     Document::FlexBreak { broken, unbroken }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flex_break_considers_remaining_documents() {
+        let document = concat([
+            Document::str("call("),
+            flex_break("", " "),
+            Document::str("argument"),
+            Document::str(")"),
+        ])
+        .group();
+
+        assert_eq!(document.to_pretty_string(10), "call(\nargument)");
+    }
 }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::{Arc, PoisonError};
 
 use crate::protocol::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use deps::TypedefLocator;
 use diagnostics::LisetteDiagnostic;
@@ -417,12 +417,13 @@ impl SharedState {
     pub(crate) fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
         let uris: Vec<Url> = self.workspace().documents.keys().cloned().collect();
         let mut keys: Vec<AnalysisKey> = Vec::new();
+        let mut seen = FxHashSet::default();
         for uri in uris {
             if self.validate(&uri).is_some() {
                 continue;
             }
             if let Some(key) = self.key_for(&uri)
-                && !keys.contains(&key)
+                && seen.insert(key.clone())
             {
                 keys.push(key);
             }

--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::{Arc, PoisonError};
 
 use crate::protocol::*;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use deps::TypedefLocator;
 use diagnostics::LisetteDiagnostic;
@@ -417,13 +417,12 @@ impl SharedState {
     pub(crate) fn open_document_snapshots(&self) -> Vec<Arc<AnalysisSnapshot>> {
         let uris: Vec<Url> = self.workspace().documents.keys().cloned().collect();
         let mut keys: Vec<AnalysisKey> = Vec::new();
-        let mut seen = FxHashSet::default();
         for uri in uris {
             if self.validate(&uri).is_some() {
                 continue;
             }
             if let Some(key) = self.key_for(&uri)
-                && seen.insert(key.clone())
+                && !keys.contains(&key)
             {
                 keys.push(key);
             }

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -1,5 +1,4 @@
 use crate::protocol::*;
-use rustc_hash::FxHashSet;
 use semantics::checker::promotion::{self, MemberKind};
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::attributes::{AttributeInfo, AttributeTarget, attributes_for};
@@ -365,12 +364,11 @@ pub(crate) fn get_struct_literal_completions(
     let mut items = Vec::new();
     struct_field_completions(type_id, snapshot, same_package, &mut items);
     enum_variant_field_completions(type_id, call_name, snapshot, &mut items);
-    let assigned_names: FxHashSet<&str> = assigned
-        .iter()
-        .filter(|fa| !cursor_on_name(fa, offset))
-        .map(|fa| fa.name.as_str())
-        .collect();
-    items.retain(|item| !assigned_names.contains(item.label.as_str()));
+    items.retain(|item| {
+        !assigned
+            .iter()
+            .any(|fa| fa.name.as_str() == item.label && !cursor_on_name(fa, offset))
+    });
     items
 }
 
@@ -434,7 +432,6 @@ pub(crate) fn get_type_completions(
     let method_id = target.as_deref().unwrap_or(type_id);
 
     let mut items = enum_variant_items(method_id, snapshot).unwrap_or_default();
-    let mut seen: FxHashSet<String> = items.iter().map(|item| item.label.clone()).collect();
 
     let same_package = id_is_in_package(method_id, current_package);
     let method_prefix = format!("{method_id}.");
@@ -443,10 +440,8 @@ pub(crate) fn get_type_completions(
             && !method_name.contains('.')
             && matches!(definition.body, DefinitionBody::Value { .. })
             && (same_package || definition.visibility.is_public())
+            && !items.iter().any(|item| item.label == method_name)
         {
-            if !seen.insert(method_name.to_string()) {
-                continue;
-            }
             items.push(CompletionItem {
                 label: method_name.to_string(),
                 kind: Some(CompletionItemKind::METHOD),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -1,4 +1,5 @@
 use crate::protocol::*;
+use rustc_hash::FxHashSet;
 use semantics::checker::promotion::{self, MemberKind};
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::attributes::{AttributeInfo, AttributeTarget, attributes_for};
@@ -367,11 +368,12 @@ pub(crate) fn get_struct_literal_completions(
     let mut items = Vec::new();
     struct_field_completions(type_id, snapshot, same_package, &mut items);
     enum_variant_field_completions(type_id, call_name, snapshot, &mut items);
-    items.retain(|item| {
-        !assigned
-            .iter()
-            .any(|fa| fa.name.as_str() == item.label && !cursor_on_name(fa, offset))
-    });
+    let assigned_names: FxHashSet<&str> = assigned
+        .iter()
+        .filter(|fa| !cursor_on_name(fa, offset))
+        .map(|fa| fa.name.as_str())
+        .collect();
+    items.retain(|item| !assigned_names.contains(item.label.as_str()));
     items
 }
 
@@ -435,6 +437,7 @@ pub(crate) fn get_type_completions(
     let method_id = target.as_deref().unwrap_or(type_id);
 
     let mut items = enum_variant_items(method_id, snapshot).unwrap_or_default();
+    let mut seen: FxHashSet<String> = items.iter().map(|item| item.label.clone()).collect();
 
     let same_package = id_is_in_package(method_id, current_package);
     let method_prefix = format!("{method_id}.");
@@ -443,8 +446,10 @@ pub(crate) fn get_type_completions(
             && !method_name.contains('.')
             && matches!(definition.body, DefinitionBody::Value { .. })
             && (same_package || definition.visibility.is_public())
-            && !items.iter().any(|i| i.label == method_name)
         {
+            if !seen.insert(method_name.to_string()) {
+                continue;
+            }
             items.push(CompletionItem {
                 label: method_name.to_string(),
                 kind: Some(CompletionItemKind::METHOD),

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -94,10 +94,7 @@ pub(crate) fn resolve_variable_type(
     snapshot: &AnalysisSnapshot,
     indexed: bool,
 ) -> Option<String> {
-    let binding = snapshot
-        .bindings()
-        .values()
-        .find(|b| b.name == var_name && b.span.file_id == file.id && b.span.byte_offset < offset)?;
+    let binding = snapshot.binding_named_before(file.id, var_name, offset)?;
 
     let expression = find_expression_at(&file.items, binding.span.byte_offset)?;
     let borrowed_ty = match expression {

--- a/crates/lsp/src/definition.rs
+++ b/crates/lsp/src/definition.rs
@@ -528,15 +528,8 @@ pub(crate) fn resolve_symbol_definition_span(
     offset: u32,
 ) -> Option<Span> {
     snapshot
-        .bindings()
-        .values()
-        .find_map(|binding| {
-            if binding.span.file_id == file_id && offset_in_span(offset, &binding.span) {
-                Some(binding.span)
-            } else {
-                None
-            }
-        })
+        .binding_at(file_id, offset)
+        .map(|binding| binding.span)
         .or_else(|| {
             let expression = find_expression_at(&file.items, offset)?;
             match expression {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -281,10 +281,8 @@ impl Backend {
 
         let find_binding = || {
             snapshot
-                .bindings()
-                .values()
-                .find(|b| b.span.file_id == file_id && offset_in_span(offset, &b.span))
-                .map(|b| b.span)
+                .binding_at(file_id, offset)
+                .map(|binding| binding.span)
         };
         let binding_or_word_fallback = |resolved: Option<Span>| {
             resolved
@@ -636,11 +634,8 @@ impl Backend {
                 Ok(None)
             };
 
-        for binding in snapshot.bindings().values() {
-            let span = binding.span;
-            if span.file_id == file_id && offset_in_span(offset, &span) {
-                return rename_response(span, &binding.name);
-            }
+        if let Some(binding) = snapshot.binding_at(file_id, offset) {
+            return rename_response(binding.span, &binding.name);
         }
 
         let Some(expression) = find_expression_at(&file.items, offset) else {
@@ -1223,8 +1218,8 @@ fn general_completions(
         }
     }
 
-    for binding in snapshot.bindings().values() {
-        if binding.span.file_id == document.file_id && binding.span.byte_offset < offset {
+    for binding in snapshot.bindings_in_file(document.file_id) {
+        if binding.span.byte_offset < offset {
             items.push(CompletionItem {
                 label: binding.name.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),

--- a/crates/lsp/src/loader.rs
+++ b/crates/lsp/src/loader.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap as HashMap;
 use std::fs::{read_dir, read_to_string};
 use std::path::{Path, PathBuf};
-use std::sync::{PoisonError, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, PoisonError, RwLock, RwLockWriteGuard};
 
 use crate::protocol::Url;
 use semantics::loader::{DiscoveredPackages, FileContent, Files, Loader};
@@ -116,14 +116,41 @@ impl ProjectState {
 
 pub(crate) struct OverlayLoader {
     config: ProjectConfig,
-    overlays: HashMap<(bool, String, String), String>,
+    overlays: Arc<Overlays>,
+}
+
+#[derive(Clone, Default)]
+struct Overlays {
+    production: HashMap<String, HashMap<String, String>>,
+    external_tests: HashMap<String, HashMap<String, String>>,
+}
+
+impl Overlays {
+    fn packages(&self, external_test: bool) -> &HashMap<String, HashMap<String, String>> {
+        if external_test {
+            &self.external_tests
+        } else {
+            &self.production
+        }
+    }
+
+    fn packages_mut(
+        &mut self,
+        external_test: bool,
+    ) -> &mut HashMap<String, HashMap<String, String>> {
+        if external_test {
+            &mut self.external_tests
+        } else {
+            &mut self.production
+        }
+    }
 }
 
 impl OverlayLoader {
     pub(crate) fn new(config: ProjectConfig) -> Self {
         Self {
             config,
-            overlays: HashMap::default(),
+            overlays: Arc::default(),
         }
     }
 
@@ -134,15 +161,22 @@ impl OverlayLoader {
         filename: &str,
         content: String,
     ) {
-        self.overlays.insert(
-            (external_test, package_id.to_string(), filename.to_string()),
-            content,
-        );
+        Arc::make_mut(&mut self.overlays)
+            .packages_mut(external_test)
+            .entry(package_id.to_string())
+            .or_default()
+            .insert(filename.to_string(), content);
     }
 
     pub(crate) fn remove_overlay(&mut self, external_test: bool, package_id: &str, filename: &str) {
-        self.overlays
-            .remove(&(external_test, package_id.to_string(), filename.to_string()));
+        let overlays = Arc::make_mut(&mut self.overlays).packages_mut(external_test);
+        let Some(files) = overlays.get_mut(package_id) else {
+            return;
+        };
+        files.remove(filename);
+        if files.is_empty() {
+            overlays.remove(package_id);
+        }
     }
 
     pub(crate) fn for_analysis(
@@ -161,7 +195,7 @@ impl OverlayLoader {
 
 pub(crate) struct AnalysisLoader {
     config: ProjectConfig,
-    overlays: HashMap<(bool, String, String), String>,
+    overlays: Arc<Overlays>,
     entry_package_path: PathBuf,
     external_test_root: Option<String>,
 }
@@ -216,12 +250,13 @@ impl Loader for AnalysisLoader {
             Some((external, package_id.to_string()))
         };
 
-        if let Some((external_test, overlay_package)) = overlay_key {
-            for ((_, _, filename), content) in
-                self.overlays.iter().filter(|((ext, package, _), _)| {
-                    *ext == external_test && package == &overlay_package
-                })
-            {
+        if let Some((external_test, overlay_package)) = overlay_key
+            && let Some(overlays) = self
+                .overlays
+                .packages(external_test)
+                .get(overlay_package.as_str())
+        {
+            for (filename, content) in overlays {
                 files.insert(
                     filename.clone(),
                     FileContent::new(content.clone(), filename.clone()),
@@ -282,6 +317,11 @@ mod tests {
         );
 
         assert!(project.remove_overlay(&first_uri));
+        assert_eq!(
+            analysis.loader.scan_folder(ENTRY_PACKAGE_ID)["main.lis"].source,
+            "memory",
+            "an active analysis keeps its overlay snapshot",
+        );
         let analysis = project.for_key(&key).unwrap();
         assert_eq!(
             analysis.loader.scan_folder(ENTRY_PACKAGE_ID)["main.lis"].source,

--- a/crates/lsp/src/position.rs
+++ b/crates/lsp/src/position.rs
@@ -3,69 +3,105 @@ use syntax::ast::Span;
 
 pub(crate) struct LineIndex {
     line_starts: Vec<u32>,
-    source: String,
+    encoded_chars: Vec<EncodedChar>,
+    source_len: u32,
+}
+
+struct EncodedChar {
+    byte_start: u32,
+    utf16_start: u32,
+    byte_len: u8,
+    utf16_len: u8,
 }
 
 impl LineIndex {
     pub(crate) fn new(source: &str) -> Self {
         let mut line_starts = vec![0];
-        for (i, c) in source.char_indices() {
+        let mut encoded_chars = Vec::new();
+        let mut utf16_offset = 0;
+        for (byte_start, c) in source.char_indices() {
+            let byte_len = c.len_utf8() as u8;
+            let utf16_len = c.len_utf16() as u8;
+            if byte_len != utf16_len {
+                encoded_chars.push(EncodedChar {
+                    byte_start: byte_start as u32,
+                    utf16_start: utf16_offset,
+                    byte_len,
+                    utf16_len,
+                });
+            }
+            utf16_offset += u32::from(utf16_len);
             if c == '\n' {
-                line_starts.push((i + 1) as u32);
+                line_starts.push(byte_start as u32 + u32::from(byte_len));
+                utf16_offset = 0;
             }
         }
         Self {
             line_starts,
-            source: source.to_string(),
+            encoded_chars,
+            source_len: source.len() as u32,
         }
-    }
-
-    pub(crate) fn source(&self) -> &str {
-        &self.source
     }
 
     pub(crate) fn position_to_offset(&self, position: Position) -> Option<u32> {
-        let line_start = *self.line_starts.get(position.line as usize)?;
+        let line = position.line as usize;
+        let line_start = *self.line_starts.get(line)?;
         let line_end = self
             .line_starts
-            .get(position.line as usize + 1)
+            .get(line + 1)
             .copied()
-            .unwrap_or(self.source.len() as u32);
-
-        let line_text = &self.source[line_start as usize..line_end as usize];
-
-        let mut utf16_offset = 0u32;
-        let mut byte_offset = 0usize;
-
-        for c in line_text.chars() {
-            if utf16_offset >= position.character {
+            .unwrap_or(self.source_len);
+        let encoded_chars = self.encoded_chars_between(line_start, line_end);
+        let encoded_adjustment: u32 = encoded_chars.iter().map(EncodedChar::adjustment).sum();
+        let utf16_len = line_end - line_start - encoded_adjustment;
+        let character = position.character.min(utf16_len);
+        let mut byte_offset = character;
+        for encoded in encoded_chars {
+            if character <= encoded.utf16_start {
                 break;
             }
-            utf16_offset += c.len_utf16() as u32;
-            byte_offset += c.len_utf8();
+            if character < encoded.utf16_start + u32::from(encoded.utf16_len) {
+                return Some(encoded.byte_start + u32::from(encoded.byte_len));
+            }
+            byte_offset += encoded.adjustment();
         }
-
-        Some(line_start + byte_offset as u32)
+        Some(line_start + byte_offset)
     }
 
     pub(crate) fn offset_to_position(&self, offset: u32) -> Position {
         let line = self
             .line_starts
-            .partition_point(|&start| start <= offset)
+            .partition_point(|&line_start| line_start <= offset)
             .saturating_sub(1);
-
-        let line_start = self.line_starts[line] as usize;
-        let offset_usize = offset as usize;
-
-        let end = offset_usize.min(self.source.len());
-        let line_text = &self.source[line_start..end];
-
-        let character: u32 = line_text.chars().map(|c| c.len_utf16() as u32).sum();
+        let line_start = self.line_starts[line];
+        let line_end = self
+            .line_starts
+            .get(line + 1)
+            .copied()
+            .unwrap_or(self.source_len);
+        let end = offset.min(self.source_len);
+        let byte_offset = end.saturating_sub(line_start);
+        let encoded_adjustment: u32 = self
+            .encoded_chars_between(line_start, line_end)
+            .iter()
+            .take_while(|encoded| encoded.byte_start + u32::from(encoded.byte_len) <= end)
+            .map(EncodedChar::adjustment)
+            .sum();
 
         Position {
             line: line as u32,
-            character,
+            character: byte_offset - encoded_adjustment,
         }
+    }
+
+    fn encoded_chars_between(&self, start: u32, end: u32) -> &[EncodedChar] {
+        let first = self
+            .encoded_chars
+            .partition_point(|encoded| encoded.byte_start < start);
+        let last = self
+            .encoded_chars
+            .partition_point(|encoded| encoded.byte_start < end);
+        &self.encoded_chars[first..last]
     }
 
     pub(crate) fn span_to_range(&self, span: Span) -> Range {
@@ -80,5 +116,44 @@ impl LineIndex {
             start: self.offset_to_position(offset as u32),
             end: self.offset_to_position((offset + length) as u32),
         }
+    }
+}
+
+impl EncodedChar {
+    fn adjustment(&self) -> u32 {
+        u32::from(self.byte_len - self.utf16_len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_to_offset_accounts_for_utf16_surrogate_pairs() {
+        let index = LineIndex::new("a😀b");
+
+        assert_eq!(index.position_to_offset(Position::new(0, 3)), Some(5));
+    }
+
+    #[test]
+    fn offset_to_position_accounts_for_utf16_surrogate_pairs() {
+        let index = LineIndex::new("a😀b");
+
+        assert_eq!(index.offset_to_position(5), Position::new(0, 3));
+    }
+
+    #[test]
+    fn conversions_preserve_line_boundaries_and_clamping() {
+        let index = LineIndex::new("ab\nç😀z\n");
+
+        assert_eq!(index.position_to_offset(Position::new(0, 99)), Some(3));
+        assert_eq!(index.position_to_offset(Position::new(1, 1)), Some(5));
+        assert_eq!(index.position_to_offset(Position::new(1, 2)), Some(9));
+        assert_eq!(index.position_to_offset(Position::new(1, 4)), Some(10));
+        assert_eq!(index.offset_to_position(5), Position::new(1, 1));
+        assert_eq!(index.offset_to_position(9), Position::new(1, 3));
+        assert_eq!(index.offset_to_position(11), Position::new(2, 0));
+        assert_eq!(index.offset_to_position(99), Position::new(2, 0));
     }
 }

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 pub(crate) struct AnalysisSnapshot {
     pub(crate) analysis: Analysis,
     sources: HashMap<u32, SnapshotSource>,
+    file_ids_by_uri: HashMap<Url, u32>,
     packages: PackageResolver,
 }
 
@@ -81,9 +82,17 @@ impl AnalysisSnapshot {
             );
         }
 
+        let mut file_ids_by_uri = HashMap::default();
+        for (file_id, source) in &sources {
+            file_ids_by_uri
+                .entry(source.uri.clone())
+                .or_insert(*file_id);
+        }
+
         Self {
             analysis,
             sources,
+            file_ids_by_uri,
             packages,
         }
     }
@@ -93,7 +102,8 @@ impl AnalysisSnapshot {
     }
 
     pub(crate) fn document(&self, uri: &Url) -> Option<SnapshotDocument<'_>> {
-        let (file_id, source) = self.sources.iter().find(|(_, source)| &source.uri == uri)?;
+        let file_id = self.file_ids_by_uri.get(uri)?;
+        let source = self.sources.get(file_id)?;
         Some(SnapshotDocument {
             file_id: *file_id,
             file: self.analysis.emit_input.files.get(file_id)?,

--- a/crates/lsp/src/snapshot.rs
+++ b/crates/lsp/src/snapshot.rs
@@ -10,6 +10,7 @@ use syntax::ast::BindingId;
 use syntax::program::{Definition, File};
 use syntax::types::Symbol;
 
+use crate::analysis::offset_in_span;
 use crate::imports::{Importable, PackageResolver};
 use crate::paths::{ENTRY_PACKAGE_ID, package_file_to_path};
 use crate::position::LineIndex;
@@ -20,6 +21,8 @@ pub(crate) struct AnalysisSnapshot {
     pub(crate) analysis: Analysis,
     sources: HashMap<u32, SnapshotSource>,
     file_ids_by_uri: HashMap<Url, u32>,
+    binding_ids_by_file: HashMap<u32, Vec<BindingId>>,
+    binding_ids_by_file_and_name: HashMap<u32, HashMap<String, Vec<BindingId>>>,
     packages: PackageResolver,
 }
 
@@ -89,10 +92,44 @@ impl AnalysisSnapshot {
                 .or_insert(*file_id);
         }
 
+        let bindings = analysis.bindings();
+        let mut binding_ids_by_file: HashMap<u32, Vec<BindingId>> = HashMap::default();
+        let mut binding_ids_by_file_and_name: HashMap<u32, HashMap<String, Vec<BindingId>>> =
+            HashMap::default();
+        for (&binding_id, binding) in bindings {
+            binding_ids_by_file
+                .entry(binding.span.file_id)
+                .or_default()
+                .push(binding_id);
+            binding_ids_by_file_and_name
+                .entry(binding.span.file_id)
+                .or_default()
+                .entry(binding.name.clone())
+                .or_default()
+                .push(binding_id);
+        }
+        let sort_bindings = |binding_ids: &mut Vec<BindingId>| {
+            binding_ids.sort_unstable_by_key(|binding_id| {
+                let binding = &bindings[binding_id];
+                (
+                    binding.span.byte_offset,
+                    binding.span.byte_length,
+                    *binding_id,
+                )
+            });
+        };
+        binding_ids_by_file.values_mut().for_each(sort_bindings);
+        binding_ids_by_file_and_name
+            .values_mut()
+            .flat_map(HashMap::values_mut)
+            .for_each(sort_bindings);
+
         Self {
             analysis,
             sources,
             file_ids_by_uri,
+            binding_ids_by_file,
+            binding_ids_by_file_and_name,
             packages,
         }
     }
@@ -137,6 +174,39 @@ impl AnalysisSnapshot {
 
     pub(crate) fn bindings(&self) -> &HashMap<BindingId, BindingFact> {
         self.analysis.bindings()
+    }
+
+    pub(crate) fn bindings_in_file(&self, file_id: u32) -> impl Iterator<Item = &BindingFact> {
+        self.binding_ids_by_file
+            .get(&file_id)
+            .into_iter()
+            .flatten()
+            .filter_map(|binding_id| self.bindings().get(binding_id))
+    }
+
+    pub(crate) fn binding_at(&self, file_id: u32, offset: u32) -> Option<&BindingFact> {
+        let binding_ids = self.binding_ids_by_file.get(&file_id)?;
+        let end = binding_ids
+            .partition_point(|binding_id| self.bindings()[binding_id].span.byte_offset <= offset);
+        binding_ids[..end]
+            .iter()
+            .rev()
+            .filter_map(|binding_id| self.bindings().get(binding_id))
+            .find(|binding| offset_in_span(offset, &binding.span))
+    }
+
+    pub(crate) fn binding_named_before(
+        &self,
+        file_id: u32,
+        name: &str,
+        offset: u32,
+    ) -> Option<&BindingFact> {
+        let binding_ids = self.binding_ids_by_file_and_name.get(&file_id)?.get(name)?;
+        let end = binding_ids
+            .partition_point(|binding_id| self.bindings()[binding_id].span.byte_offset < offset);
+        binding_ids[..end]
+            .last()
+            .and_then(|binding_id| self.bindings().get(binding_id))
     }
 
     pub(crate) fn usages(&self) -> &HashSet<Usage> {

--- a/crates/lsp/src/state.rs
+++ b/crates/lsp/src/state.rs
@@ -169,6 +169,7 @@ impl Deref for Backend {
 }
 
 pub(crate) struct DocumentState {
+    content: String,
     line_index: LineIndex,
     version: i32,
     last_usable: Option<Arc<AnalysisSnapshot>>,
@@ -178,6 +179,7 @@ impl DocumentState {
     pub(crate) fn new(content: String, version: i32) -> Self {
         Self {
             line_index: LineIndex::new(&content),
+            content,
             version,
             last_usable: None,
         }
@@ -185,11 +187,12 @@ impl DocumentState {
 
     pub(crate) fn update(&mut self, content: String, version: i32) {
         self.line_index = LineIndex::new(&content);
+        self.content = content;
         self.version = version;
     }
 
     pub(crate) fn content(&self) -> &str {
-        self.line_index.source()
+        &self.content
     }
 
     pub(crate) fn line_index(&self) -> &LineIndex {

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -476,6 +476,23 @@ fn completion_includes_local_bindings() {
 }
 
 #[test]
+fn completion_uses_the_nearest_shadowed_binding() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "struct First { first: int }\nstruct Second { second: int }\nfn main() {\n  let value = First { first: 1 }\n  let value = Second { second: 2 }\n  value.\n}",
+    );
+
+    let response = client.completion(TEST_URI, 5, 8).unwrap();
+    let labels = completion_labels(&response);
+
+    assert_eq!(labels, vec!["second"]);
+
+    client.shutdown();
+}
+
+#[test]
 fn completion_includes_defined_functions() {
     let mut client = TestClient::new();
     client.initialize();

--- a/crates/passes/src/analyze.rs
+++ b/crates/passes/src/analyze.rs
@@ -24,12 +24,28 @@ pub struct Analysis {
     pub unreachable_packages: Vec<String>,
     bindings: HashMap<BindingId, BindingFact>,
     usages: HashSet<Usage>,
-    diagnostics: Vec<LisetteDiagnostic>,
+    errors: Vec<LisetteDiagnostic>,
+    lints: Vec<LisetteDiagnostic>,
+}
+
+#[derive(Clone, Copy)]
+pub struct Diagnostics<'a> {
+    errors: &'a [LisetteDiagnostic],
+    lints: &'a [LisetteDiagnostic],
+}
+
+impl<'a> Diagnostics<'a> {
+    pub fn iter(self) -> impl Iterator<Item = &'a LisetteDiagnostic> {
+        self.errors.iter().chain(self.lints)
+    }
 }
 
 impl Analysis {
-    pub fn diagnostics(&self) -> &[LisetteDiagnostic] {
-        &self.diagnostics
+    pub fn diagnostics(&self) -> Diagnostics<'_> {
+        Diagnostics {
+            errors: &self.errors,
+            lints: &self.lints,
+        }
     }
 
     pub fn bindings(&self) -> &HashMap<BindingId, BindingFact> {
@@ -41,26 +57,22 @@ impl Analysis {
     }
 
     pub fn errors(&self) -> &[LisetteDiagnostic] {
-        &self.diagnostics[..self.error_count()]
+        &self.errors
     }
 
     pub fn lints(&self) -> &[LisetteDiagnostic] {
-        &self.diagnostics[self.error_count()..]
+        &self.lints
     }
 
     pub fn push_error(&mut self, error: LisetteDiagnostic) {
         assert!(error.is_error());
-        let index = self.error_count();
-        self.diagnostics.insert(index, error);
+        self.errors.push(error);
     }
 
     pub fn take_diagnostics(&mut self) -> Vec<LisetteDiagnostic> {
-        mem::take(&mut self.diagnostics)
-    }
-
-    fn error_count(&self) -> usize {
-        self.diagnostics
-            .partition_point(LisetteDiagnostic::is_error)
+        let mut diagnostics = mem::take(&mut self.errors);
+        diagnostics.append(&mut self.lints);
+        diagnostics
     }
 
     pub fn failed(&self) -> bool {
@@ -224,6 +236,7 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         files.extend(package.files);
     }
 
+    let (errors, lints) = classify_diagnostics(all_diagnostics);
     Analysis {
         emit_input: EmitInput {
             files,
@@ -241,16 +254,17 @@ pub fn analyze(input: AnalyzeInput) -> Analysis {
         unreachable_packages,
         bindings,
         usages,
-        diagnostics: order_diagnostics_by_severity(all_diagnostics),
+        errors,
+        lints,
     }
 }
 
-fn order_diagnostics_by_severity(diagnostics: Vec<LisetteDiagnostic>) -> Vec<LisetteDiagnostic> {
-    let (mut errors, lints): (Vec<_>, Vec<_>) = diagnostics
+fn classify_diagnostics(
+    diagnostics: Vec<LisetteDiagnostic>,
+) -> (Vec<LisetteDiagnostic>, Vec<LisetteDiagnostic>) {
+    diagnostics
         .into_iter()
-        .partition(LisetteDiagnostic::is_error);
-    errors.extend(lints);
-    errors
+        .partition(LisetteDiagnostic::is_error)
 }
 
 #[cfg(test)]
@@ -262,14 +276,15 @@ mod tests {
 
     #[test]
     fn analysis_classifies_diagnostics_by_severity() {
-        let diagnostics = order_diagnostics_by_severity(vec![
+        let (errors, lints) = classify_diagnostics(vec![
             LisetteDiagnostic::warn("warning"),
             LisetteDiagnostic::error("error"),
             LisetteDiagnostic::info("info"),
         ]);
 
-        let messages = diagnostics
+        let messages = errors
             .iter()
+            .chain(&lints)
             .map(LisetteDiagnostic::plain_message)
             .collect::<Vec<_>>();
         assert_eq!(messages, vec!["error", "warning", "info"]);

--- a/crates/passes/src/passes/checks/always_true_disjunction.rs
+++ b/crates/passes/src/passes/checks/always_true_disjunction.rs
@@ -84,7 +84,10 @@ fn collect_disjuncts<'a>(
 }
 
 enum Constraint {
-    Bounded { low: Bound, high: Bound },
+    Bounded {
+        low: Option<Bound>,
+        high: Option<Bound>,
+    },
     Excluded(i128),
 }
 
@@ -104,25 +107,25 @@ fn falsifying_constraint(
     // Each arm negates its comparison: `x < b` is false exactly when `x >= b`.
     let constraint = match operator {
         LessThan => Constraint::Bounded {
-            low: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
             high: None,
         },
         LessThanOrEqual => Constraint::Bounded {
-            low: Some((bound, false)),
+            low: Some(Bound::new(bound, false)),
             high: None,
         },
         GreaterThan => Constraint::Bounded {
             low: None,
-            high: Some((bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         GreaterThanOrEqual => Constraint::Bounded {
             low: None,
-            high: Some((bound, false)),
+            high: Some(Bound::new(bound, false)),
         },
         Equal => Constraint::Excluded(bound),
         NotEqual => Constraint::Bounded {
-            low: Some((bound, true)),
-            high: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         _ => return None,
     };
@@ -134,8 +137,8 @@ fn falsifying_constraint(
 /// operand type's range: values outside the domain cannot falsify anything.
 struct FalseSet<'a> {
     operand: &'a Expression,
-    low: (i128, bool),
-    high: (i128, bool),
+    low: Bound,
+    high: Bound,
     excluded: Vec<i128>,
 }
 
@@ -143,8 +146,8 @@ impl<'a> FalseSet<'a> {
     fn new(operand: &'a Expression, (min, max): (i128, i128)) -> Self {
         FalseSet {
             operand,
-            low: (min, true),
-            high: (max, true),
+            low: Bound::new(min, true),
+            high: Bound::new(max, true),
             excluded: Vec::new(),
         }
     }
@@ -161,17 +164,15 @@ impl<'a> FalseSet<'a> {
 
     // Integer operands, so exclusive bounds shrink to the nearest integer.
     fn is_empty(&self) -> bool {
-        let (low_value, low_inclusive) = self.low;
-        let (high_value, high_inclusive) = self.high;
-        let low = if low_inclusive {
-            low_value
+        let low = if self.low.inclusive {
+            self.low.value
         } else {
-            low_value + 1
+            self.low.value + 1
         };
-        let high = if high_inclusive {
-            high_value
+        let high = if self.high.inclusive {
+            self.high.value
         } else {
-            high_value - 1
+            self.high.value - 1
         };
         if low > high {
             return true;

--- a/crates/passes/src/passes/checks/impossible_comparison.rs
+++ b/crates/passes/src/passes/checks/impossible_comparison.rs
@@ -88,7 +88,10 @@ fn collect_conjuncts<'a>(
 }
 
 enum Constraint {
-    Bounded { low: Bound, high: Bound },
+    Bounded {
+        low: Option<Bound>,
+        high: Option<Bound>,
+    },
     Excluded(i128),
 }
 
@@ -101,23 +104,23 @@ fn comparison_constraint(expression: &Expression) -> Option<(&Expression, Constr
     let constraint = match operator {
         LessThan => Constraint::Bounded {
             low: None,
-            high: Some((bound, false)),
+            high: Some(Bound::new(bound, false)),
         },
         LessThanOrEqual => Constraint::Bounded {
             low: None,
-            high: Some((bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         GreaterThan => Constraint::Bounded {
-            low: Some((bound, false)),
+            low: Some(Bound::new(bound, false)),
             high: None,
         },
         GreaterThanOrEqual => Constraint::Bounded {
-            low: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
             high: None,
         },
         Equal => Constraint::Bounded {
-            low: Some((bound, true)),
-            high: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         NotEqual => Constraint::Excluded(bound),
         _ => return None,
@@ -129,8 +132,8 @@ fn comparison_constraint(expression: &Expression) -> Option<(&Expression, Constr
 /// The integer constraints on one operand, accumulated across the chain.
 struct Group<'a> {
     operand: &'a Expression,
-    low: Bound,
-    high: Bound,
+    low: Option<Bound>,
+    high: Option<Bound>,
     excluded: Vec<i128>,
 }
 
@@ -157,16 +160,15 @@ impl<'a> Group<'a> {
     // Bounds are a continuous interval: `x > 0 && x < 1` (empty only for
     // integers) is deliberately not flagged, since it holds for `float64`.
     fn is_unsatisfiable(&self) -> bool {
-        let (Some((low, low_inclusive)), Some((high, high_inclusive))) = (self.low, self.high)
-        else {
+        let (Some(low), Some(high)) = (self.low, self.high) else {
             return false;
         };
-        if low > high {
+        if low.value > high.value {
             return true;
         }
-        if low == high {
+        if low.value == high.value {
             // Single point `low`: empty if either side excludes it or a `!=` rules it out.
-            return !(low_inclusive && high_inclusive) || self.excluded.contains(&low);
+            return !(low.inclusive && high.inclusive) || self.excluded.contains(&low.value);
         }
         false
     }

--- a/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/inhabitance.rs
@@ -16,47 +16,12 @@ enum InhabitanceState {
 
 #[derive(Default)]
 pub struct InhabitanceCache {
-    states: HashMap<String, InhabitanceState>,
+    states: HashMap<Type, InhabitanceState>,
 }
 
 impl InhabitanceCache {
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-fn type_key(ty: &Type) -> String {
-    match ty {
-        Type::Never => "Never".to_string(),
-        Type::Nominal { id, params, .. } => {
-            if params.is_empty() {
-                id.to_string()
-            } else {
-                let param_keys: Vec<String> = params.iter().map(type_key).collect();
-                format!("{}<{}>", id, param_keys.join(", "))
-            }
-        }
-        Type::Tuple(elements) => {
-            let elem_keys: Vec<String> = elements.iter().map(type_key).collect();
-            format!("({})", elem_keys.join(", "))
-        }
-        Type::Array { length, element } => format!("[{}]{}", length, type_key(element)),
-        Type::Function(_) => "fn".to_string(),
-        Type::Var { .. } | Type::Uninferred | Type::Ignored | Type::Parameter(_) | Type::Error => {
-            "param".to_string()
-        }
-        Type::Forall { body, .. } => type_key(body),
-        Type::ImportNamespace(m) => format!("<import:{}>", m),
-        Type::ReceiverPlaceholder => "<receiver>".to_string(),
-        Type::Simple(kind) => kind.leaf_name().to_string(),
-        Type::Compound { kind, args, .. } => {
-            if args.is_empty() {
-                kind.leaf_name().to_string()
-            } else {
-                let arg_keys: Vec<String> = args.iter().map(type_key).collect();
-                format!("{}<{}>", kind.leaf_name(), arg_keys.join(", "))
-            }
-        }
     }
 }
 
@@ -72,16 +37,14 @@ pub fn is_inhabited(ty: &Type, store: &Store, cache: &mut InhabitanceCache) -> b
         return elements.iter().all(|e| is_inhabited(e, store, cache));
     }
 
-    let key = type_key(ty);
-
-    if let Some(state) = cache.states.get(&key) {
+    if let Some(state) = cache.states.get(ty) {
         return match state {
             InhabitanceState::Visiting | InhabitanceState::Inhabited => true,
             InhabitanceState::Uninhabited => false,
         };
     }
 
-    cache.states.insert(key.clone(), InhabitanceState::Visiting);
+    cache.states.insert(ty.clone(), InhabitanceState::Visiting);
 
     let result = match ty {
         Type::Nominal { id, params, .. } => check_constructor_inhabited(id, params, store, cache),
@@ -95,7 +58,7 @@ pub fn is_inhabited(ty: &Type, store: &Store, cache: &mut InhabitanceCache) -> b
     } else {
         InhabitanceState::Uninhabited
     };
-    cache.states.insert(key, final_state);
+    cache.states.insert(ty.clone(), final_state);
 
     result
 }

--- a/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/normalize.rs
@@ -12,16 +12,16 @@ use super::inhabitance::{InhabitanceCache, is_inhabited, is_variant_inhabited};
 use super::types::Row;
 use super::types::*;
 
-fn make_type_key(name: &str, type_args: &[Type]) -> String {
+fn make_type_key(name: &str, type_args: &[Type]) -> TypeName {
     if type_args.is_empty() {
-        name.to_string()
+        name.into()
     } else {
         let args = type_args
             .iter()
             .map(|t| t.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        format!("{}<{}>", name, args)
+        format!("{}<{}>", name, args).into()
     }
 }
 
@@ -67,7 +67,7 @@ fn try_normalize_interface_implementer(
 
     let interface_type_name = make_type_key(interface_id, interface_params);
     let struct_ctor = Constructor {
-        tag_id: struct_name.to_string(),
+        tag_id: struct_name.into(),
         arity,
     };
 
@@ -75,11 +75,11 @@ fn try_normalize_interface_implementer(
         let mut found = false;
         let mut unknown_pos = union.len();
         for (i, c) in union.iter().enumerate() {
-            if c.tag_id == struct_name {
+            if c.tag_id.as_str() == struct_name {
                 found = true;
                 break;
             }
-            if c.tag_id == INTERFACE_UNKNOWN_TAG {
+            if c.tag_id.as_str() == INTERFACE_UNKNOWN_TAG {
                 unknown_pos = i;
             }
         }
@@ -92,7 +92,7 @@ fn try_normalize_interface_implementer(
             vec![
                 struct_ctor,
                 Constructor {
-                    tag_id: INTERFACE_UNKNOWN_TAG.to_string(),
+                    tag_id: INTERFACE_UNKNOWN_TAG.into(),
                     arity: 0,
                 },
             ],
@@ -101,7 +101,7 @@ fn try_normalize_interface_implementer(
 
     Some(NormalizedPattern::Constructor {
         type_name: interface_type_name,
-        tag: struct_name.to_string(),
+        tag: struct_name.into(),
         args,
     })
 }
@@ -287,7 +287,7 @@ fn normalize_enum_variant_pattern(
                     .iter()
                     .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, cache))
                     .map(|v| Constructor {
-                        tag_id: format!("{}.{}", enum_name, v.name),
+                        tag_id: format!("{}.{}", enum_name, v.name).into(),
                         arity: v.fields.len(),
                     })
                     .collect(),
@@ -304,7 +304,7 @@ fn normalize_enum_variant_pattern(
                 ) =>
                 {
                     vec![Constructor {
-                        tag_id: tag.clone(),
+                        tag_id: tag.clone().into(),
                         arity: struct_fields.len(),
                     }]
                 }
@@ -313,7 +313,7 @@ fn normalize_enum_variant_pattern(
 
             NormalizedPattern::Constructor {
                 type_name,
-                tag,
+                tag: tag.into(),
                 args: patterns,
             }
         }
@@ -367,7 +367,7 @@ fn normalize_record_pattern(
                     .iter()
                     .filter(|v| is_variant_inhabited(v, &type_args, generics, ctx.store, cache))
                     .map(|v| Constructor {
-                        tag_id: format!("{}.{}", enum_name, v.name),
+                        tag_id: format!("{}.{}", enum_name, v.name).into(),
                         arity: v.fields.len(),
                     })
                     .collect()
@@ -377,7 +377,7 @@ fn normalize_record_pattern(
 
             NormalizedPattern::Constructor {
                 type_name,
-                tag,
+                tag: tag.into(),
                 args: patterns,
             }
         }
@@ -427,7 +427,7 @@ fn normalize_record_pattern(
                     cache,
                 ) {
                     vec![Constructor {
-                        tag_id: struct_name.to_string(),
+                        tag_id: struct_name.as_str().into(),
                         arity: struct_fields.len(),
                     }]
                 } else {
@@ -437,7 +437,7 @@ fn normalize_record_pattern(
 
             NormalizedPattern::Constructor {
                 type_name,
-                tag: struct_name.to_string(),
+                tag: struct_name.as_str().into(),
                 args: patterns,
             }
         }
@@ -482,9 +482,13 @@ fn find_variant<'a>(variants: &'a [EnumVariant], variant_name: &str) -> Option<&
         .find(|variant| variant.name == unqualified_name(variant_name))
 }
 
-fn register_union(unions: &mut UnionTable, type_name: &str, alternatives: impl FnOnce() -> Union) {
+fn register_union(
+    unions: &mut UnionTable,
+    type_name: &TypeName,
+    alternatives: impl FnOnce() -> Union,
+) {
     if unions.get(type_name).is_none() {
-        unions.insert(type_name.to_string(), alternatives());
+        unions.insert(type_name.clone(), alternatives());
     }
 }
 
@@ -499,13 +503,13 @@ fn normalize_slice(
     let type_name = make_type_key("Slice", slice::from_ref(element_type));
     register_union(unions, &type_name, || {
         let mut constructors = vec![Constructor {
-            tag_id: "EmptySlice".to_string(),
+            tag_id: "EmptySlice".into(),
             arity: 0,
         }];
 
         if is_inhabited(element_type, ctx.store, cache) {
             constructors.push(Constructor {
-                tag_id: "NonEmptySlice".to_string(),
+                tag_id: "NonEmptySlice".into(),
                 arity: 2, // head and tail
             });
         }
@@ -520,7 +524,7 @@ fn normalize_slice(
     if prefix.is_empty() && !has_rest {
         return NormalizedPattern::Constructor {
             type_name,
-            tag: "EmptySlice".to_string(),
+            tag: "EmptySlice".into(),
             args: vec![],
         };
     }
@@ -530,7 +534,7 @@ fn normalize_slice(
     } else {
         NormalizedPattern::Constructor {
             type_name: type_name.clone(),
-            tag: "EmptySlice".to_string(),
+            tag: "EmptySlice".into(),
             args: vec![],
         }
     };
@@ -541,7 +545,7 @@ fn normalize_slice(
         let head = normalize_pattern(element, unions, &element_ctx, cache);
         result = NormalizedPattern::Constructor {
             type_name: type_name.clone(),
-            tag: "NonEmptySlice".to_string(),
+            tag: "NonEmptySlice".into(),
             args: vec![head, result],
         };
     }
@@ -556,11 +560,11 @@ fn normalize_tuple(
     cache: &mut InhabitanceCache,
 ) -> NormalizedPattern {
     let arity = elements.len();
-    let type_name = format!("Tuple{}", arity);
+    let type_name: TypeName = format!("Tuple{}", arity).into();
 
     register_union(unions, &type_name, || {
         vec![Constructor {
-            tag_id: type_name.clone(),
+            tag_id: type_name.as_str().into(),
             arity,
         }]
     });
@@ -581,7 +585,7 @@ fn normalize_tuple(
 
     NormalizedPattern::Constructor {
         type_name: type_name.clone(),
-        tag: type_name,
+        tag: type_name.as_str().into(),
         args: patterns,
     }
 }
@@ -599,13 +603,13 @@ fn normalize_array(
     if length == 0 {
         register_union(unions, &type_name, || {
             vec![Constructor {
-                tag_id: "ArrayNil".to_string(),
+                tag_id: "ArrayNil".into(),
                 arity: 0,
             }]
         });
         return NormalizedPattern::Constructor {
             type_name,
-            tag: "ArrayNil".to_string(),
+            tag: "ArrayNil".into(),
             args: vec![],
         };
     }
@@ -613,7 +617,7 @@ fn normalize_array(
     register_union(unions, &type_name, || {
         if is_inhabited(element_type, ctx.store, cache) {
             vec![Constructor {
-                tag_id: "ArrayCons".to_string(),
+                tag_id: "ArrayCons".into(),
                 arity: 2,
             }]
         } else {
@@ -631,17 +635,17 @@ fn normalize_array(
 
     NormalizedPattern::Constructor {
         type_name,
-        tag: "ArrayCons".to_string(),
+        tag: "ArrayCons".into(),
         args: vec![head, tail],
     }
 }
 
 fn normalize_boolean(boolean: bool, unions: &mut UnionTable) -> NormalizedPattern {
-    let type_name = "Bool".to_string();
+    let type_name: TypeName = "Bool".into();
 
     register_union(unions, &type_name, || {
         let make_alt = |b: bool| Constructor {
-            tag_id: b.to_string(),
+            tag_id: b.to_string().into(),
             arity: 0,
         };
 
@@ -650,7 +654,7 @@ fn normalize_boolean(boolean: bool, unions: &mut UnionTable) -> NormalizedPatter
 
     NormalizedPattern::Constructor {
         type_name,
-        tag: boolean.to_string(),
+        tag: boolean.to_string().into(),
         args: vec![],
     }
 }

--- a/crates/passes/src/passes/checks/pattern_analysis/pattern_matrix.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/pattern_matrix.rs
@@ -14,7 +14,7 @@ pub enum ScrutineeSignature {
     WildcardsOrLiterals,
 }
 
-pub fn specialize_by_constructor(rows: &[Row], tag_id: &str, arity: usize) -> Vec<Row> {
+pub fn specialize_by_constructor(rows: &[Row], tag_id: &TagId, arity: usize) -> Vec<Row> {
     rows.iter()
         .filter_map(|row| {
             let first = row.first()?;

--- a/crates/passes/src/passes/checks/pattern_analysis/types.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/types.rs
@@ -1,9 +1,65 @@
 use rustc_hash::FxHashMap as HashMap;
+use std::ops::Deref;
 
 use syntax::ast::Literal;
 
-pub type TagId = String;
-pub type TypeName = String;
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TagId(String);
+
+impl TagId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for TagId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for TagId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for TagId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypeName(String);
+
+impl TypeName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for TypeName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for TypeName {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for TypeName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
 
 pub type Row = Vec<NormalizedPattern>;
 

--- a/crates/passes/src/passes/checks/pattern_analysis/witness.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/witness.rs
@@ -113,12 +113,12 @@ fn format_array_pattern(
 
     loop {
         match current {
-            NormalizedPattern::Constructor { tag, .. } if tag == "ArrayNil" => break,
+            NormalizedPattern::Constructor { tag, .. } if tag.as_str() == "ArrayNil" => break,
             NormalizedPattern::Constructor {
                 tag,
                 args,
                 type_name,
-            } if tag == "ArrayCons" && args.len() >= 2 => {
+            } if tag.as_str() == "ArrayCons" && args.len() >= 2 => {
                 elements.push(format_element(&args[0]));
                 if matches!(args[1], NormalizedPattern::Wildcard) {
                     ends_with_rest = array_tail_length(type_name) > 0;
@@ -186,10 +186,10 @@ fn format_slice_pattern(pattern: &NormalizedPattern) -> String {
 
     loop {
         match current {
-            NormalizedPattern::Constructor { tag, .. } if tag == "EmptySlice" => {
+            NormalizedPattern::Constructor { tag, .. } if tag.as_str() == "EmptySlice" => {
                 break;
             }
-            NormalizedPattern::Constructor { tag, args, .. } if tag == "NonEmptySlice" => {
+            NormalizedPattern::Constructor { tag, args, .. } if tag.as_str() == "NonEmptySlice" => {
                 if args.len() >= 2 {
                     elements.push(format_witness(&args[0]));
                     current = &args[1];
@@ -222,10 +222,10 @@ fn format_slice_pattern_for_display(pattern: &NormalizedPattern) -> String {
 
     loop {
         match current {
-            NormalizedPattern::Constructor { tag, .. } if tag == "EmptySlice" => {
+            NormalizedPattern::Constructor { tag, .. } if tag.as_str() == "EmptySlice" => {
                 break;
             }
-            NormalizedPattern::Constructor { tag, args, .. } if tag == "NonEmptySlice" => {
+            NormalizedPattern::Constructor { tag, args, .. } if tag.as_str() == "NonEmptySlice" => {
                 if args.len() >= 2 {
                     elements.push(format_pattern(&args[0]));
                     current = &args[1];

--- a/crates/passes/src/passes/comparison.rs
+++ b/crates/passes/src/passes/comparison.rs
@@ -2,8 +2,17 @@ use semantics::store::Store;
 use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
 use syntax::types::SimpleKind;
 
-/// A value bound: `(value, inclusive)`, or `None` for an open side.
-pub(crate) type Bound = Option<(i128, bool)>;
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Bound {
+    pub(crate) value: i128,
+    pub(crate) inclusive: bool,
+}
+
+impl Bound {
+    pub(crate) fn new(value: i128, inclusive: bool) -> Self {
+        Self { value, inclusive }
+    }
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MaskOp {
@@ -339,16 +348,20 @@ pub(crate) fn prelude_min_max(expression: &Expression) -> Option<MinMaxCall<'_>>
 
 /// The more restrictive of two bounds; `first_wins(a, b)` is true when `a`'s
 /// value is tighter. At equal values the bound stays inclusive only if both were.
-pub(crate) fn tighter(a: Bound, b: Bound, first_wins: impl Fn(i128, i128) -> bool) -> Bound {
+pub(crate) fn tighter(
+    a: Option<Bound>,
+    b: Option<Bound>,
+    first_wins: impl Fn(i128, i128) -> bool,
+) -> Option<Bound> {
     match (a, b) {
         (None, other) | (other, None) => other,
-        (Some((av, ai)), Some((bv, bi))) => {
-            if av == bv {
-                Some((av, ai && bi))
-            } else if first_wins(av, bv) {
-                Some((av, ai))
+        (Some(a), Some(b)) => {
+            if a.value == b.value {
+                Some(Bound::new(a.value, a.inclusive && b.inclusive))
+            } else if first_wins(a.value, b.value) {
+                Some(a)
             } else {
-                Some((bv, bi))
+                Some(b)
             }
         }
     }

--- a/crates/passes/src/passes/lints/ast_walk/checks/redundant_comparison.rs
+++ b/crates/passes/src/passes/lints/ast_walk/checks/redundant_comparison.rs
@@ -59,8 +59,8 @@ pub fn check_redundant_comparison(expression: &Expression, ctx: &NodeCtx) {
 
 #[derive(Clone, Copy)]
 struct Interval {
-    low: Bound,
-    high: Bound,
+    low: Option<Bound>,
+    high: Option<Bound>,
 }
 
 /// The interval a `variable OP literal` comparison constrains its operand to,
@@ -72,23 +72,23 @@ fn comparison_interval(expression: &Expression) -> Option<(&Expression, Interval
     let interval = match operator {
         LessThan => Interval {
             low: None,
-            high: Some((bound, false)),
+            high: Some(Bound::new(bound, false)),
         },
         LessThanOrEqual => Interval {
             low: None,
-            high: Some((bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         GreaterThan => Interval {
-            low: Some((bound, false)),
+            low: Some(Bound::new(bound, false)),
             high: None,
         },
         GreaterThanOrEqual => Interval {
-            low: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
             high: None,
         },
         Equal => Interval {
-            low: Some((bound, true)),
-            high: Some((bound, true)),
+            low: Some(Bound::new(bound, true)),
+            high: Some(Bound::new(bound, true)),
         },
         _ => return None,
     };

--- a/crates/passes/src/passes/lints/from_facts.rs
+++ b/crates/passes/src/passes/lints/from_facts.rs
@@ -225,12 +225,12 @@ fn push_suppressible(
         .iter()
         .filter_map(LisetteDiagnostic::file_id)
         .collect();
-    let allows: Vec<_> = store
+    let allows: super::suppression::AllowIndex = store
         .packages
         .values()
         .flat_map(|package| package.source_files())
         .filter(|file| reported.contains(&file.id))
-        .flat_map(|file| super::suppression::collect_function_allows(&file.items))
+        .map(|file| super::suppression::collect_function_allows(&file.items))
         .collect();
     out.extend(super::suppression::filter_allowed(produced, &allows));
 }

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -152,16 +152,15 @@ fn run_ref_lints(
         }
     }
 
-    for ((method_package_id, method_name), satisfactions) in &facts.interface_satisfied_methods {
-        if method_package_id != &package.id {
-            continue;
-        }
-        if method_name == "equals" {
-            for impl_type_name in satisfactions.impl_type_names() {
-                graph.mark_as_used(PackageItemId::equals_method(impl_type_name));
+    if let Some(methods) = facts.interface_satisfied_methods.get(&package.id) {
+        for (method_name, satisfactions) in methods {
+            if method_name == "equals" {
+                for impl_type_name in satisfactions.impl_type_names() {
+                    graph.mark_as_used(PackageItemId::equals_method(impl_type_name));
+                }
+            } else {
+                graph.mark_as_used(PackageItemId::new(method_name));
             }
-        } else {
-            graph.mark_as_used(PackageItemId::new(method_name));
         }
     }
 

--- a/crates/passes/src/passes/lints/ref_graph/mod.rs
+++ b/crates/passes/src/passes/lints/ref_graph/mod.rs
@@ -115,9 +115,9 @@ fn apply_ref_lints(
     }
     let mut diagnostics = result.diagnostics;
     if !diagnostics.is_empty() {
-        let allows: Vec<_> = package
+        let allows: super::suppression::AllowIndex = package
             .source_files()
-            .flat_map(|file| super::suppression::collect_declaration_allows(&file.items))
+            .map(|file| super::suppression::collect_declaration_allows(&file.items))
             .collect();
         diagnostics = super::suppression::filter_unused_allowed(diagnostics, &allows);
     }

--- a/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
+++ b/crates/passes/src/passes/lints/ref_graph/reference_graph.rs
@@ -5,6 +5,7 @@ use syntax::ast::Span;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PackageItemId {
     Definition(EcoString),
+    EqualityMethod(EcoString),
     Import { file_id: u32, alias: EcoString },
 }
 
@@ -21,13 +22,13 @@ impl PackageItemId {
     }
 
     pub fn equals_method(type_name: &str) -> Self {
-        Self::Definition(format!("{type_name}#equals").into())
+        Self::EqualityMethod(type_name.into())
     }
 
     fn import_alias(&self) -> Option<&str> {
         match self {
             Self::Import { alias, .. } => Some(alias),
-            Self::Definition(_) => None,
+            Self::Definition(_) | Self::EqualityMethod(_) => None,
         }
     }
 
@@ -285,5 +286,13 @@ mod tests {
         graph.mark_enum_variant_used(variant);
 
         assert_eq!(graph.unused_members().count(), 0);
+    }
+
+    #[test]
+    fn equality_method_identity_does_not_collide_with_definition_names() {
+        assert_ne!(
+            PackageItemId::equals_method("Thing"),
+            PackageItemId::new("Thing#equals"),
+        );
     }
 }

--- a/crates/passes/src/passes/lints/ref_graph/visibility_constraints.rs
+++ b/crates/passes/src/passes/lints/ref_graph/visibility_constraints.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use diagnostics::LisetteDiagnostic;
 use syntax::ast::{Annotation, Expression, Span};
@@ -11,17 +11,20 @@ pub fn check_visibility_constraints(
     files: &HashMap<u32, File>,
     diagnostics: &mut Vec<LisetteDiagnostic>,
 ) {
-    for (qualified_name, definition) in &package.definitions {
-        if definition.visibility != Visibility::Public {
-            continue;
-        }
-
-        let item_name = qualified_name
-            .split('.')
-            .next_back()
-            .unwrap_or(qualified_name);
-
-        let annotation = find_function_annotation(files, item_name);
+    let public_definitions: Vec<_> = package
+        .definitions
+        .iter()
+        .filter(|(_, definition)| definition.visibility == Visibility::Public)
+        .collect();
+    let function_annotations = index_function_annotations(
+        files,
+        public_definitions
+            .iter()
+            .map(|(qualified_name, _)| item_name(qualified_name)),
+    );
+    for (qualified_name, definition) in public_definitions {
+        let item_name = item_name(qualified_name);
+        let annotation = function_annotations.get(item_name).copied();
 
         let mut ctx = LeakCtx {
             package,
@@ -29,11 +32,26 @@ pub fn check_visibility_constraints(
             fallback_span: definition.name_span,
             diagnostics,
         };
-        ctx.check(&definition.ty, annotation.as_ref());
+        ctx.check(&definition.ty, annotation);
     }
 }
 
-fn find_function_annotation(files: &HashMap<u32, File>, name: &str) -> Option<Annotation> {
+fn item_name(qualified_name: &str) -> &str {
+    qualified_name
+        .split('.')
+        .next_back()
+        .unwrap_or(qualified_name)
+}
+
+fn index_function_annotations<'files, 'names>(
+    files: &'files HashMap<u32, File>,
+    names: impl IntoIterator<Item = &'names str>,
+) -> HashMap<&'files str, &'files Annotation> {
+    let mut annotations = HashMap::default();
+    let mut pending: HashSet<&str> = names.into_iter().collect();
+    if pending.is_empty() {
+        return annotations;
+    }
     for file in files.values() {
         for item in &file.items {
             if let Expression::Function {
@@ -41,13 +59,16 @@ fn find_function_annotation(files: &HashMap<u32, File>, name: &str) -> Option<An
                 return_annotation,
                 ..
             } = item
-                && fn_name == name
+                && pending.remove(fn_name.as_str())
             {
-                return Some(return_annotation.clone());
+                annotations.insert(fn_name.as_str(), return_annotation);
+                if pending.is_empty() {
+                    return annotations;
+                }
             }
         }
     }
-    None
+    annotations
 }
 
 struct LeakCtx<'a> {

--- a/crates/passes/src/passes/lints/suppression.rs
+++ b/crates/passes/src/passes/lints/suppression.rs
@@ -1,29 +1,64 @@
+use std::borrow::Borrow;
+
+use ecow::EcoString;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
 use crate::passes::walk::visit_ast;
 use diagnostics::LisetteDiagnostic;
 use syntax::ast::{AttributeArg, Expression, Span};
 
-const SUPPRESSIBLE_UNUSED_LINTS: &[&str] = &[
-    "unused_function",
-    "unused_type",
-    "unused_struct_field",
-    "unused_enum_variant",
-];
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct LintName(EcoString);
 
-pub(super) fn collect_function_allows(items: &[Expression]) -> Vec<(Span, Vec<String>)> {
+impl Borrow<str> for LintName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+struct Allow {
+    span: Span,
+    lints: HashSet<LintName>,
+}
+
+#[derive(Default)]
+pub(super) struct AllowIndex {
+    by_file: HashMap<u32, Vec<Allow>>,
+}
+
+impl Extend<AllowIndex> for AllowIndex {
+    fn extend<T: IntoIterator<Item = AllowIndex>>(&mut self, iter: T) {
+        for index in iter {
+            for (file_id, mut allows) in index.by_file {
+                self.by_file.entry(file_id).or_default().append(&mut allows);
+            }
+        }
+    }
+}
+
+impl FromIterator<AllowIndex> for AllowIndex {
+    fn from_iter<T: IntoIterator<Item = AllowIndex>>(iter: T) -> Self {
+        let mut combined = Self::default();
+        combined.extend(iter);
+        combined
+    }
+}
+
+pub(super) fn collect_function_allows(items: &[Expression]) -> AllowIndex {
     collect_allows(items, |expression| {
         matches!(expression, Expression::Function { .. })
     })
 }
 
-pub(super) fn collect_declaration_allows(items: &[Expression]) -> Vec<(Span, Vec<String>)> {
+pub(super) fn collect_declaration_allows(items: &[Expression]) -> AllowIndex {
     collect_allows(items, |_| true)
 }
 
 fn collect_allows(
     items: &[Expression],
     mut include: impl FnMut(&Expression) -> bool,
-) -> Vec<(Span, Vec<String>)> {
-    let mut out = Vec::new();
+) -> AllowIndex {
+    let mut out = AllowIndex::default();
     visit_ast(
         items,
         &mut |expression, _| {
@@ -32,7 +67,11 @@ fn collect_allows(
             }
             let flags = allow_flags(expression);
             if !flags.is_empty() {
-                out.push((expression.get_span(), flags));
+                let span = expression.get_span();
+                out.by_file
+                    .entry(span.file_id)
+                    .or_default()
+                    .push(Allow { span, lints: flags });
             }
         },
         &mut |_, _| {},
@@ -40,20 +79,20 @@ fn collect_allows(
     out
 }
 
-fn allow_flags(expression: &Expression) -> Vec<String> {
+fn allow_flags(expression: &Expression) -> HashSet<LintName> {
     let attributes = match expression {
         Expression::Function { attributes, .. }
         | Expression::Struct { attributes, .. }
         | Expression::Enum { attributes, .. }
         | Expression::TypeAlias { attributes, .. } => attributes,
-        _ => return Vec::new(),
+        _ => return HashSet::default(),
     };
     attributes
         .iter()
         .filter(|attribute| attribute.name == "allow")
         .flat_map(|attribute| {
             attribute.args.iter().filter_map(|arg| match arg {
-                AttributeArg::Flag(name) => Some(name.clone()),
+                AttributeArg::Flag(name) => Some(LintName(name.as_str().into())),
                 _ => None,
             })
         })
@@ -63,82 +102,91 @@ fn allow_flags(expression: &Expression) -> Vec<String> {
 /// Drop any AST-walk lint named in an enclosing `#[allow(...)]`.
 pub(super) fn filter_allowed(
     diagnostics: Vec<LisetteDiagnostic>,
-    allows: &[(Span, Vec<String>)],
+    allows: &AllowIndex,
 ) -> Vec<LisetteDiagnostic> {
     diagnostics
         .into_iter()
-        .filter(|diagnostic| !is_allowed(diagnostic, allows, None))
+        .filter(|diagnostic| !is_allowed(diagnostic, allows, false))
         .collect()
 }
 
 pub(super) fn filter_unused_allowed(
     diagnostics: Vec<LisetteDiagnostic>,
-    allows: &[(Span, Vec<String>)],
+    allows: &AllowIndex,
 ) -> Vec<LisetteDiagnostic> {
     diagnostics
         .into_iter()
-        .filter(|diagnostic| !is_allowed(diagnostic, allows, Some(SUPPRESSIBLE_UNUSED_LINTS)))
+        .filter(|diagnostic| !is_allowed(diagnostic, allows, true))
         .collect()
 }
 
-fn is_allowed(
-    diagnostic: &LisetteDiagnostic,
-    allows: &[(Span, Vec<String>)],
-    restrict_to: Option<&[&str]>,
-) -> bool {
+fn is_allowed(diagnostic: &LisetteDiagnostic, allows: &AllowIndex, unused_only: bool) -> bool {
     let Some(lint_name) = diagnostic.lint_name() else {
         return false;
     };
-    if let Some(restrict_to) = restrict_to
-        && !restrict_to.contains(&lint_name)
-    {
+    if unused_only && !is_suppressible_unused_lint(lint_name) {
         return false;
     }
     let Some(point) = diagnostic.location_offset() else {
         return false;
     };
     let point = point as u32;
-    let file_id = diagnostic.file_id();
-    allows.iter().any(|(span, flags)| {
-        Some(span.file_id) == file_id
-            && span.byte_offset <= point
-            && point < span.end()
-            && flags.iter().any(|flag| flag == lint_name)
+    let Some(file_id) = diagnostic.file_id() else {
+        return false;
+    };
+    allows.by_file.get(&file_id).is_some_and(|file_allows| {
+        file_allows.iter().any(|allow| {
+            allow.span.byte_offset <= point
+                && point < allow.span.end()
+                && allow.lints.contains(lint_name)
+        })
     })
+}
+
+fn is_suppressible_unused_lint(lint_name: &str) -> bool {
+    matches!(
+        lint_name,
+        "unused_function" | "unused_type" | "unused_struct_field" | "unused_enum_variant"
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn allow(file_id: u32, name: &str) -> (Span, Vec<String>) {
-        (Span::new(file_id, 0, 100), vec![name.to_string()])
+    fn allow(file_id: u32, name: &str) -> AllowIndex {
+        let span = Span::new(file_id, 0, 100);
+        let mut lints = HashSet::default();
+        lints.insert(LintName(name.into()));
+        let mut by_file = HashMap::default();
+        by_file.insert(file_id, vec![Allow { span, lints }]);
+        AllowIndex { by_file }
     }
 
     #[test]
     fn allow_suppresses_matching_lint_in_same_file() {
-        let allows = [allow(0, "unused_function")];
+        let allows = allow(0, "unused_function");
         let diagnostic = diagnostics::lint::unused_function(&Span::new(0, 10, 5));
         assert!(filter_allowed(vec![diagnostic], &allows).is_empty());
     }
 
     #[test]
     fn allow_does_not_suppress_overlapping_offset_in_another_file() {
-        let allows = [allow(0, "unused_function")];
+        let allows = allow(0, "unused_function");
         let diagnostic = diagnostics::lint::unused_function(&Span::new(1, 10, 5));
         assert_eq!(filter_allowed(vec![diagnostic], &allows).len(), 1);
     }
 
     #[test]
     fn allow_is_specific_to_the_named_lint() {
-        let allows = [allow(0, "unused_type")];
+        let allows = allow(0, "unused_type");
         let diagnostic = diagnostics::lint::unused_function(&Span::new(0, 10, 5));
         assert_eq!(filter_allowed(vec![diagnostic], &allows).len(), 1);
     }
 
     #[test]
     fn unused_filter_ignores_lints_outside_the_whitelist() {
-        let allows = [allow(0, "internal_type_leak")];
+        let allows = allow(0, "internal_type_leak");
         let diagnostic =
             diagnostics::lint::private_type_in_public_api(Some(&Span::new(0, 10, 5)), "T", "f");
         assert_eq!(filter_unused_allowed(vec![diagnostic], &allows).len(), 1);
@@ -146,7 +194,7 @@ mod tests {
 
     #[test]
     fn unused_filter_suppresses_whitelisted_lint() {
-        let allows = [allow(0, "unused_function")];
+        let allows = allow(0, "unused_function");
         let diagnostic = diagnostics::lint::unused_function(&Span::new(0, 10, 5));
         assert!(filter_unused_allowed(vec![diagnostic], &allows).is_empty());
     }
@@ -155,8 +203,8 @@ mod tests {
     fn function_allows_ignore_struct_and_enum_declarations() {
         let source = "#[allow(unused_type)]\nstruct Foo { x: int }\n";
         let items = parse_items(source);
-        assert!(collect_function_allows(&items).is_empty());
-        assert_eq!(collect_declaration_allows(&items).len(), 1);
+        assert!(collect_function_allows(&items).by_file.is_empty());
+        assert_eq!(collect_declaration_allows(&items).by_file.len(), 1);
     }
 
     fn parse_items(source: &str) -> Vec<Expression> {

--- a/crates/semantics/src/analysis/entry.rs
+++ b/crates/semantics/src/analysis/entry.rs
@@ -144,25 +144,39 @@ pub(super) fn compute_roots(
     match project_kind {
         ProjectKind::Binary => {
             let mut additional = match compile_phase {
-                CompilePhase::Check => discovered.production_packages().cloned().collect(),
+                CompilePhase::Check => discovered
+                    .production_packages()
+                    .map(|package_id| package_id.as_str().into())
+                    .collect(),
                 CompilePhase::Emit | CompilePhase::Test => Vec::new(),
             };
             if include_test_roots {
-                additional.extend(discovered.test_roots().cloned());
+                additional.extend(
+                    discovered
+                        .test_roots()
+                        .map(|package_id| package_id.as_str().into()),
+                );
             }
             Roots {
-                primary: vec![entry_package],
+                primary: vec![entry_package.into()],
                 additional,
             }
         }
         ProjectKind::Library => {
             let mut additional = Vec::new();
             if include_test_roots {
-                additional.extend(discovered.test_roots().cloned());
+                additional.extend(
+                    discovered
+                        .test_roots()
+                        .map(|package_id| package_id.as_str().into()),
+                );
             }
-            additional.push(entry_package);
+            additional.push(entry_package.into());
             Roots {
-                primary: discovered.production_packages().cloned().collect(),
+                primary: discovered
+                    .production_packages()
+                    .map(|package_id| package_id.as_str().into())
+                    .collect(),
                 additional,
             }
         }

--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -395,8 +395,14 @@ pub fn run_inference(input: AnalyzeInput) -> InferenceOutput {
     let package_output = infer_all_packages(
         &mut store,
         PackageInferenceInput {
-            order,
-            files,
+            order: order
+                .into_iter()
+                .map(|package_id| package_id.to_string())
+                .collect(),
+            files: files
+                .into_iter()
+                .map(|(package_id, files)| (package_id.to_string(), files))
+                .collect(),
             dependencies,
             sink,
             compile_phase: input.compile_phase,

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -175,19 +175,20 @@ pub(crate) fn compute_package_hash(production_hash: u64, dep_hashes: &HashMap<St
     hasher.finish()
 }
 
-pub(crate) fn get_dependency_package_hashes<'a>(
-    dependencies: impl IntoIterator<Item = &'a String>,
+pub(crate) fn get_dependency_package_hashes<'a, T: AsRef<str> + ?Sized + 'a>(
+    dependencies: impl IntoIterator<Item = &'a T>,
     package_hashes: &HashMap<String, u64>,
 ) -> HashMap<String, u64> {
     dependencies
         .into_iter()
         .map(|dep_id| {
+            let dep_id = dep_id.as_ref();
             let hash = if dep_id.starts_with("go:") || dep_id == "prelude" {
                 STDLIB_HASH
             } else {
                 *package_hashes.get(dep_id).unwrap_or(&0)
             };
-            (dep_id.clone(), hash)
+            (dep_id.to_string(), hash)
         })
         .collect()
 }

--- a/crates/semantics/src/checker/infer/expressions/call_effects.rs
+++ b/crates/semantics/src/checker/infer/expressions/call_effects.rs
@@ -7,7 +7,7 @@ use crate::checker::infer::InferCtx;
 use syntax::program::AliasKind;
 
 impl InferCtx<'_> {
-    pub(super) fn classify_call(&self, callee: &Expression) -> CallKind {
+    pub(super) fn classify_call(&mut self, callee: &Expression) -> CallKind {
         let store = self.store;
         let callee = callee.unwrap_parens();
         match callee {
@@ -83,7 +83,7 @@ impl InferCtx<'_> {
 
     /// Classify `Type.method(receiver, args)` as `ReceiverMethodUfcs`.
     /// Uses scope-aware name resolution instead of the old suffix-matching heuristic.
-    pub(super) fn try_classify_receiver_ufcs(&self, value: &str) -> Option<CallKind> {
+    pub(super) fn try_classify_receiver_ufcs(&mut self, value: &str) -> Option<CallKind> {
         let store = self.store;
         let last_dot = value.rfind('.')?;
         let method = &value[last_dot + 1..];

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -404,7 +404,7 @@ impl InferCtx<'_> {
     }
 
     fn constructor_call_grants_write(
-        &self,
+        &mut self,
         callee: &Expression,
         parameters: &[FunctionParameter],
     ) -> bool {

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -77,7 +77,7 @@ fn check_not_comparable_impl(
     env: &TypeEnv,
     store: &Store,
     ty: &Type,
-    visiting: &mut HashSet<String>,
+    visiting: &mut HashSet<Type>,
     definite_only: bool,
     comparable_parameter: &mut dyn FnMut(&str) -> bool,
 ) -> Option<&'static str> {
@@ -136,8 +136,7 @@ fn check_not_comparable_impl(
             return Some(RECURSIVE_TYPES);
         }
 
-        let type_key = format!("{ty:?}");
-        if !visiting.insert(type_key.clone()) {
+        if !visiting.insert(ty.clone()) {
             return Some(RECURSIVE_TYPES);
         }
 
@@ -199,7 +198,7 @@ fn check_not_comparable_impl(
             _ => {}
         }
 
-        visiting.remove(&type_key);
+        visiting.remove(ty);
     }
 
     if let Type::Tuple(elems) = ty {
@@ -274,7 +273,7 @@ fn reaches_definition(
     store: &Store,
     ty: &Type,
     target: &str,
-    visited: &mut HashSet<String>,
+    visited: &mut HashSet<Type>,
     depth: usize,
 ) -> bool {
     if depth > REACHES_DEPTH_LIMIT {
@@ -286,7 +285,7 @@ fn reaches_definition(
             if id.as_str() == target {
                 return true;
             }
-            if !visited.insert(format!("{resolved:?}")) {
+            if !visited.insert(resolved.clone()) {
                 return false;
             }
             let field_types: Vec<(Type, &[Generic])> =

--- a/crates/semantics/src/checker/infer/expressions/patterns.rs
+++ b/crates/semantics/src/checker/infer/expressions/patterns.rs
@@ -460,7 +460,7 @@ impl InferCtx<'_> {
     }
 
     fn resolve_pattern_constructor(
-        &self,
+        &mut self,
         identifier: &str,
         expected_ty: &Type,
         is_bare_name: bool,
@@ -468,10 +468,11 @@ impl InferCtx<'_> {
         if let Some(ty) = self.resolve_variant_type(identifier, expected_ty) {
             return Some(ty);
         }
+        let accepts_struct = !is_bare_name && self.scrutinee_is_interface(expected_ty);
         let definition = self.resolve_struct_definition(identifier)?;
         if let Some(constructor_ty) = definition.constructor_type() {
             Some(constructor_ty)
-        } else if !is_bare_name && self.scrutinee_is_interface(expected_ty) {
+        } else if accepts_struct {
             Some(definition.ty.clone())
         } else {
             None
@@ -484,7 +485,7 @@ impl InferCtx<'_> {
         store.is_interface(&resolved)
     }
 
-    fn resolve_variant_type(&self, identifier: &str, expected_ty: &Type) -> Option<Type> {
+    fn resolve_variant_type(&mut self, identifier: &str, expected_ty: &Type) -> Option<Type> {
         let store = self.store;
         // A bare name is a variant of the scrutinee's enum, if any.
         if !identifier.contains('.') {
@@ -507,7 +508,7 @@ impl InferCtx<'_> {
             .flatten()
     }
 
-    fn resolve_struct_definition(&self, identifier: &str) -> Option<&Definition> {
+    fn resolve_struct_definition(&mut self, identifier: &str) -> Option<&Definition> {
         let store = self.store;
         let qualified_name = self.lookup_qualified_name(store, identifier)?;
         let definition = store.get_definition(&qualified_name)?;

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -390,7 +390,7 @@ impl InferCtx<'_> {
         }
     }
 
-    pub(super) fn enum_of_variant(&self, store: &Store, value: &str) -> Option<EcoString> {
+    pub(super) fn enum_of_variant(&mut self, store: &Store, value: &str) -> Option<EcoString> {
         let (type_part, variant_name) = value.rsplit_once('.')?;
         let qualified = self.lookup_qualified_name(store, type_part)?;
         store

--- a/crates/semantics/src/checker/infer/expressions/struct_call.rs
+++ b/crates/semantics/src/checker/infer/expressions/struct_call.rs
@@ -167,7 +167,7 @@ impl InferCtx<'_> {
     }
 
     /// Resolve a `type Alias = Struct` name to its underlying struct.
-    fn as_alias_struct(&self, store: &Store, name: &str) -> Option<ResolvedStruct> {
+    fn as_alias_struct(&mut self, store: &Store, name: &str) -> Option<ResolvedStruct> {
         let qualified_name = self.lookup_qualified_name(store, name)?;
         let Definition {
             ty: alias_ty,

--- a/crates/semantics/src/checker/promotion.rs
+++ b/crates/semantics/src/checker/promotion.rs
@@ -162,7 +162,7 @@ where
     F: Copy + Fn(&str) -> Option<&'d Definition>,
 {
     let mut visited: Vec<Entry> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::default();
+    let mut seen: HashSet<Type> = HashSet::default();
 
     let Some(root) = nominal_entry(outer.clone(), 0, false, false, lookup) else {
         return visited;
@@ -175,7 +175,7 @@ where
 
         for entry in &current {
             // Seen at a shallower depth: shadows here, and breaks cycles.
-            if !seen.insert(type_key(&entry.ty)) {
+            if !seen.insert(entry.ty.clone()) {
                 continue;
             }
             visited.push(entry.clone());
@@ -386,29 +386,16 @@ where
 /// one path so its members resolve as ambiguous.
 fn consolidate(list: Vec<Entry>) -> Vec<Entry> {
     let mut result: Vec<Entry> = Vec::with_capacity(list.len());
-    let mut index_of: HashMap<String, usize> = HashMap::default();
+    let mut index_of: HashMap<Type, usize> = HashMap::default();
     for entry in list {
-        let key = type_key(&entry.ty);
-        if let Some(&i) = index_of.get(&key) {
+        if let Some(&i) = index_of.get(&entry.ty) {
             result[i].multiples = true;
         } else {
-            index_of.insert(key, result.len());
+            index_of.insert(entry.ty.clone(), result.len());
             result.push(entry);
         }
     }
     result
-}
-
-/// Type identity for `seen`/`multiples`: qualified id plus any type arguments.
-fn type_key(ty: &Type) -> String {
-    match ty {
-        Type::Nominal { id, params, .. } if params.is_empty() => id.as_str().to_string(),
-        Type::Nominal { id, params, .. } => {
-            let args: Vec<String> = params.iter().map(type_key).collect();
-            format!("{}<{}>", id, args.join(","))
-        }
-        other => other.to_string(),
-    }
 }
 
 /// Strip one `Ref`, reporting whether it was present (a pointer edge).

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -608,7 +608,7 @@ impl TaskState {
 
     /// Classifies `Enum.Variant` in type position before its constructor value exists.
     fn classify_unregistered_variant(
-        &self,
+        &mut self,
         store: &Store,
         type_name: &str,
     ) -> Option<(&'static str, Option<String>)> {

--- a/crates/semantics/src/checker/registration/display.rs
+++ b/crates/semantics/src/checker/registration/display.rs
@@ -74,7 +74,7 @@ impl TaskState {
         let Some(generics) = type_generics(definition) else {
             return;
         };
-        let visibility = definition.visibility.clone();
+        let visibility = definition.visibility;
         let name_span = definition.name_span;
 
         if let Some(user_ty) = definition

--- a/crates/semantics/src/checker/registration/equality.rs
+++ b/crates/semantics/src/checker/registration/equality.rs
@@ -277,7 +277,7 @@ impl TaskState {
         let Some(generics) = type_generics(definition) else {
             return;
         };
-        let visibility = definition.visibility.clone();
+        let visibility = definition.visibility;
         let name_span = definition.name_span;
 
         let receiver_ty = match scheme {

--- a/crates/semantics/src/checker/registration/iterate.rs
+++ b/crates/semantics/src/checker/registration/iterate.rs
@@ -59,7 +59,7 @@ impl TaskState {
         let (has_instance_variants, visibility) = match store.get_definition(qualified.as_str()) {
             Some(definition) => (
                 matches!(&definition.body, DefinitionBody::Enum { methods, .. } if methods.contains_key("variants")),
-                definition.visibility.clone(),
+                definition.visibility,
             ),
             None => (false, Visibility::Private),
         };

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -416,7 +416,7 @@ impl TaskState {
             let method = Method {
                 source_name: fn_name.clone(),
                 ty: method_ty.clone(),
-                visibility: fn_visibility.clone(),
+                visibility: fn_visibility,
                 origin: MethodOrigin::Declared,
                 name_span: Some(*fn_name_span),
                 doc: fn_doc.clone(),
@@ -445,7 +445,7 @@ impl TaskState {
             package.definitions.insert(
                 package_qualified_name,
                 Definition {
-                    visibility: fn_visibility.clone(),
+                    visibility: fn_visibility,
                     ty: method_ty,
                     name_span: Some(*fn_name_span),
                     doc: fn_doc,
@@ -485,7 +485,7 @@ impl TaskState {
             .current_package(&*store)
             .definitions
             .get(qualified_name.as_str())
-            .map(|definition| definition.visibility.clone())
+            .map(|definition| definition.visibility)
             .unwrap_or(Visibility::Private);
         let (generics, new_parents, methods) = self.with_scope(|this| {
             this.put_in_scope(generics);
@@ -571,7 +571,7 @@ impl TaskState {
                         Method {
                             source_name: method_name.clone(),
                             ty: fn_ty,
-                            visibility: visibility.clone(),
+                            visibility,
                             origin: MethodOrigin::Declared,
                             name_span: Some(*method_name_span),
                             doc: fn_doc,
@@ -606,7 +606,7 @@ impl TaskState {
         package.definitions.insert(
             qualified_name.clone(),
             Definition {
-                visibility: visibility.clone(),
+                visibility,
                 ty: interface_ty,
                 name_span: Some(*name_span),
                 doc: doc.clone(),

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -1,6 +1,5 @@
 use crate::checker::EnvResolve;
 use rustc_hash::{FxHashMap, FxHashSet};
-use syntax::ast;
 use syntax::ast::{
     EnumFieldDefinition, EnumVariant, Expression, Generic, Span, StructFieldDefinition,
     StructFields, VariantFields,
@@ -66,7 +65,7 @@ impl TaskState {
             .current_package(&*store)
             .definitions
             .get(qualified_name.as_str())
-            .map(|definition| definition.visibility.clone())
+            .map(|definition| definition.visibility)
             .unwrap_or(Visibility::Private);
 
         if self.is_lis(&*store) && self.type_definition_exists(&*store, &qualified_name) {
@@ -115,7 +114,7 @@ impl TaskState {
             else {
                 continue;
             };
-            let visibility = definition.visibility.clone();
+            let visibility = definition.visibility;
             let generics = generics.clone();
             let variants = variants.clone();
             let Some(enum_ty) = store.get_type(&qualified_name).cloned() else {
@@ -167,7 +166,7 @@ impl TaskState {
                 variant_definitions
             {
                 let definition = Definition {
-                    visibility: visibility.clone(),
+                    visibility,
                     ty: variant_ty,
                     name_span: Some(variant_name_span),
                     doc: variant_doc,
@@ -429,7 +428,7 @@ impl TaskState {
             .current_package(&*store)
             .definitions
             .get(qualified_name.as_str())
-            .map(|definition| definition.visibility.clone())
+            .map(|definition| definition.visibility)
             .unwrap_or(Visibility::Private);
 
         if self.is_lis(&*store) && self.type_definition_exists(&*store, &qualified_name) {
@@ -613,7 +612,7 @@ impl TaskState {
                 .current_package(&*store)
                 .definitions
                 .get(qualified_name.as_str())
-                .map(|definition| definition.visibility.clone())
+                .map(|definition| definition.visibility)
                 .unwrap_or(Visibility::Private);
 
             let alias_ty = if name == "Never" && generics.is_empty() {
@@ -720,7 +719,7 @@ impl TaskState {
             .current_package(&*store)
             .definitions
             .get(qualified_name.as_str())
-            .map(|definition| definition.visibility.clone())
+            .map(|definition| definition.visibility)
             .unwrap_or(Visibility::Private);
 
         if self.is_lis(&*store) && self.type_definition_exists(&*store, &qualified_name) {
@@ -907,7 +906,7 @@ fn is_pointer_backed_newtype(store: &Store, ty: &Type) -> bool {
 }
 
 // Mirror the written type's own visibility: peel storage (`Option`/`Ref`), not aliases.
-fn embed_field_visibility(store: &Store, field_ty: &Type) -> ast::Visibility {
+fn embed_field_visibility(store: &Store, field_ty: &Type) -> Visibility {
     let mut target = field_ty.clone();
     while target.is_option() || target.is_ref() {
         let Some(inner) = target.inner() else { break };
@@ -916,8 +915,8 @@ fn embed_field_visibility(store: &Store, field_ty: &Type) -> ast::Visibility {
     let public = matches!(&target, Type::Nominal { id, .. }
         if store.get_definition(id.as_str()).is_some_and(|d| d.visibility.is_public()));
     if public {
-        ast::Visibility::Public
+        Visibility::Public
     } else {
-        ast::Visibility::Private
+        Visibility::Private
     }
 }

--- a/crates/semantics/src/checker/registration/types.rs
+++ b/crates/semantics/src/checker/registration/types.rs
@@ -19,6 +19,13 @@ use super::enum_variant_constructor_type;
 use crate::checker::TaskState;
 use crate::store::Store;
 
+struct EnumFieldSlot<'a> {
+    variant_name: &'a str,
+    field_name: &'a str,
+    shape: EnumFieldShape,
+    field_type: &'a Type,
+}
+
 impl TaskState {
     pub(super) fn populate_enum(&mut self, store: &mut Store, expression: &mut Expression) {
         let Expression::Enum {
@@ -195,9 +202,7 @@ impl TaskState {
 
         let slots = go_names::enum_field_slots(name, variants);
 
-        // (variant_name, field_name, field shape, type, span)
-        let mut seen: FxHashMap<String, (&str, &str, EnumFieldShape, &Type, Span)> =
-            FxHashMap::default();
+        let mut seen: FxHashMap<String, EnumFieldSlot<'_>> = FxHashMap::default();
 
         for (vi, variant) in variants.iter().enumerate() {
             let Some(field_shape) = go_names::enum_field_shape(&variant.fields) else {
@@ -214,15 +219,20 @@ impl TaskState {
                 } else {
                     variant.name_span
                 };
-                let Some(&(v_a, f_a, shape_a, ty_a, _)) = seen.get(&go_name) else {
+                let Some(previous) = seen.get(&go_name) else {
                     seen.insert(
                         go_name,
-                        (&variant.name, &field.name, field_shape, &field.ty, span),
+                        EnumFieldSlot {
+                            variant_name: &variant.name,
+                            field_name: &field.name,
+                            shape: field_shape,
+                            field_type: &field.ty,
+                        },
                     );
                     continue;
                 };
 
-                let ty_a_resolved = ty_a.resolve_in(&self.env);
+                let ty_a_resolved = previous.field_type.resolve_in(&self.env);
                 if matches!(ty_a_resolved, Type::Error)
                     || matches!(resolved, Type::Error)
                     || ty_a_resolved == resolved
@@ -230,10 +240,10 @@ impl TaskState {
                     continue;
                 }
 
-                let loc_a = if shape_a == EnumFieldShape::Struct {
-                    format!("{}.{}.{}", name, v_a, f_a)
+                let loc_a = if previous.shape == EnumFieldShape::Struct {
+                    format!("{}.{}.{}", name, previous.variant_name, previous.field_name)
                 } else {
-                    format!("{}.{}", name, v_a)
+                    format!("{}.{}", name, previous.variant_name)
                 };
                 let loc_b = if field_shape == EnumFieldShape::Struct {
                     format!("{}.{}.{}", name, variant.name, field.name)

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -382,7 +382,7 @@ impl TaskState {
         if let Type::Parameter(name) = ty {
             let trait_bounds = self.scopes.collect_all_trait_bounds();
             let qualified_name = self.qualify_name(name);
-            return store.get_methods_from_bounds(&qualified_name, &trait_bounds);
+            return store.get_methods_from_bounds(&qualified_name, trait_bounds);
         }
 
         let resolved = ty.strip_refs().resolve_in(&self.env);
@@ -415,7 +415,7 @@ impl TaskState {
         if let Type::Parameter(parameter) = ty {
             let trait_bounds = self.scopes.collect_all_trait_bounds();
             let qualified_name = self.qualify_name(parameter);
-            return store.get_method_from_bounds(&qualified_name, &trait_bounds, name);
+            return store.get_method_from_bounds(&qualified_name, trait_bounds, name);
         }
 
         let resolved = ty.strip_refs().resolve_in(&self.env);

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -7,6 +7,7 @@ pub(super) struct ImportState {
     pub(super) prefixed: HashMap<String, PrefixedImport>,
     /// Packages whose exports are available without prefix (current package and prelude)
     pub(super) unprefixed_imports: HashSet<String>,
+    imported_resolutions: HashMap<EcoString, HashMap<EcoString, Option<Symbol>>>,
 }
 
 #[derive(Debug)]
@@ -79,46 +80,61 @@ impl TaskState {
     /// for nested definitions (e.g., `package_id.Weekday.Sunday`) preferring top-level
     /// over nested when both share the same simple name.
     pub(super) fn resolve_in_imported_package<'m>(
-        &self,
+        &mut self,
         store: &Store,
         package: &'m Package,
         simple_name: &str,
     ) -> Option<(String, &'m Definition)> {
-        let package_prefix = format!("{}.", package.id);
+        if let Some(cached) = self
+            .imports
+            .imported_resolutions
+            .get(package.id.as_str())
+            .and_then(|resolutions| resolutions.get(simple_name))
+        {
+            let qualified_name = cached.as_ref()?;
+            let definition = package.definitions.get(qualified_name)?;
+            return Some((qualified_name.to_string(), definition));
+        }
 
         // Direct match: package_id.simple_name
-        let direct = format!("{}{}", package_prefix, simple_name);
-        if let Some(definition) = package.definitions.get(direct.as_str())
+        let direct = Symbol::from_parts(&package.id, simple_name);
+        let package_prefix = format!("{}.", package.id);
+        let resolved = if let Some(definition) = package.definitions.get(direct.as_str())
             && definition.visibility.is_public()
             && !store.is_test_definition(definition)
         {
-            return Some((direct, definition));
-        }
+            Some(direct)
+        } else {
+            let suffix = format!(".{}", simple_name);
+            package
+                .definitions
+                .iter()
+                .find(|(qualified_name, definition)| {
+                    qualified_name.ends_with(suffix.as_str())
+                        && qualified_name.starts_with(package_prefix.as_str())
+                        && definition.visibility.is_public()
+                        && !store.is_test_definition(definition)
+                        && qualified_name[package_prefix.len()..].contains('.')
+                })
+                .map(|(qualified_name, _)| qualified_name.clone())
+        };
 
-        // Nested match: find a public definition whose simple name matches,
-        // e.g., package_id.EnumType.VariantName where simple_name = "VariantName".
-        // Skip if a top-level definition with the same simple name exists
-        // (handles transitive import collisions like go:net/http).
-        let suffix = format!(".{}", simple_name);
-        for (qn, definition) in &package.definitions {
-            if qn.ends_with(suffix.as_str())
-                && qn.starts_with(package_prefix.as_str())
-                && definition.visibility.is_public()
-                && !store.is_test_definition(definition)
-            {
-                let rest = &qn[package_prefix.len()..];
-                // Only match if it's nested (contains a dot), direct was tried above
-                if rest.contains('.') {
-                    return Some((qn.to_string(), definition));
-                }
-            }
-        }
-
-        None
+        let result = resolved.as_ref().and_then(|qualified_name| {
+            package
+                .definitions
+                .get(qualified_name)
+                .map(|definition| (qualified_name.to_string(), definition))
+        });
+        self.imports
+            .imported_resolutions
+            .entry(package.id.as_str().into())
+            .or_default()
+            .insert(simple_name.into(), resolved);
+        result
     }
 
     pub(super) fn lookup_qualified_name(
-        &self,
+        &mut self,
         store: &Store,
         type_name: &str,
     ) -> Option<EcoString> {
@@ -126,7 +142,7 @@ impl TaskState {
     }
 
     pub(super) fn lookup_qualified_name_in_type_position(
-        &self,
+        &mut self,
         store: &Store,
         type_name: &str,
     ) -> Option<EcoString> {
@@ -153,7 +169,7 @@ impl TaskState {
     }
 
     pub(super) fn lookup_qualified_name_in_scope(
-        &self,
+        &mut self,
         store: &Store,
         type_name: &str,
         prefer_type: bool,
@@ -211,7 +227,7 @@ impl TaskState {
         store.is_const(qualified_name)
     }
 
-    pub(super) fn is_const_var(&self, store: &Store, var_name: &str) -> bool {
+    pub(super) fn is_const_var(&mut self, store: &Store, var_name: &str) -> bool {
         if self.scopes.lookup_value(var_name).is_some() {
             return self.scopes.lookup_const(var_name);
         }
@@ -263,7 +279,7 @@ impl TaskState {
         definition.ty.clone()
     }
 
-    pub(super) fn lookup_type(&self, store: &Store, value_name: &str) -> Option<Type> {
+    pub(super) fn lookup_type(&mut self, store: &Store, value_name: &str) -> Option<Type> {
         if let Some(ty) = self.scopes.lookup_value(value_name) {
             return Some(ty.clone());
         }
@@ -273,8 +289,10 @@ impl TaskState {
         }
 
         if let Some((prefix, rest)) = value_name.split_once('.')
-            && let Some(package_id) = self.imports.package_id(prefix)
-            && let Some(imported_package) = store.get_package(package_id)
+            && let Some(imported_package) = self
+                .imports
+                .package_id(prefix)
+                .and_then(|package_id| store.get_package(package_id))
         {
             if let Some((_, definition)) =
                 self.resolve_in_imported_package(store, imported_package, rest)
@@ -282,7 +300,7 @@ impl TaskState {
                 return Some(self.resolve_definition_value_type(store, definition));
             }
             if let Some((owner, method)) = rest.rsplit_once('.') {
-                let owner = Symbol::from_parts(package_id, owner);
+                let owner = Symbol::from_parts(&imported_package.id, owner);
                 if let Some(method) = store.get_method(&owner, method) {
                     return Some(method.ty.clone());
                 }

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -562,14 +562,14 @@ mod tests {
         let mut scopes = Scopes::new();
         scopes
             .current_mut()
-            .insert_binding("value".into(), Type::Error, 1, true);
+            .insert_binding("value".into(), Type::Error, BindingId::new(1), true);
 
         scopes.push();
         scopes
             .current_mut()
-            .insert_binding("value".into(), Type::Error, 2, false);
+            .insert_binding("value".into(), Type::Error, BindingId::new(2), false);
 
-        assert_eq!(scopes.lookup_binding_id("value"), Some(2));
+        assert_eq!(scopes.lookup_binding_id("value"), Some(BindingId::new(2)));
         assert!(!scopes.lookup_mutable("value"));
         assert!(!scopes.lookup_const("value"));
 
@@ -587,7 +587,7 @@ mod tests {
         let mut scopes = Scopes::new();
         scopes
             .current_mut()
-            .insert_binding("value".into(), Type::Error, 1, true);
+            .insert_binding("value".into(), Type::Error, BindingId::new(1), true);
 
         scopes.push();
         scopes.set_fn_return_type(Type::Error);

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -94,7 +94,6 @@ struct ScopedValue {
 struct GenericParameter {
     index: usize,
     qualified: Symbol,
-    bounds: Vec<Type>,
 }
 
 #[derive(Debug)]
@@ -143,6 +142,7 @@ impl FunctionContext {
 pub struct Scope {
     values: HashMap<String, ScopedValue>,
     generic_parameters: HashMap<String, GenericParameter>,
+    shadowed_trait_bounds: Vec<(Symbol, Vec<Type>)>,
     function: Option<FunctionContext>,
     propagation_context: PropagationContext,
     impl_receiver_type: Option<Type>,
@@ -160,6 +160,7 @@ impl Scope {
         Scope {
             values: HashMap::default(),
             generic_parameters: HashMap::default(),
+            shadowed_trait_bounds: Vec::new(),
             function: None,
             propagation_context: PropagationContext::None,
             impl_receiver_type: None,
@@ -223,6 +224,7 @@ impl Scope {
 
 pub struct Scopes {
     stack: Vec<Scope>,
+    visible_trait_bounds: HashMap<Symbol, Vec<Type>>,
 }
 
 impl Default for Scopes {
@@ -235,6 +237,7 @@ impl Scopes {
     pub(crate) fn new() -> Self {
         Scopes {
             stack: vec![Scope::new()],
+            visible_trait_bounds: HashMap::default(),
         }
     }
 
@@ -254,7 +257,13 @@ impl Scopes {
 
     pub(crate) fn pop(&mut self) {
         assert!(self.stack.len() > 1, "root scope cannot be popped");
-        self.stack.pop();
+        let scope = self.stack.pop().expect("scope stack must not be empty");
+        for parameter in scope.generic_parameters.values() {
+            self.visible_trait_bounds.remove(&parameter.qualified);
+        }
+        for (qualified, bounds) in scope.shadowed_trait_bounds {
+            self.visible_trait_bounds.insert(qualified, bounds);
+        }
     }
 
     /// Look up a value by walking the scope stack from top to bottom.
@@ -352,23 +361,29 @@ impl Scopes {
 
     pub(crate) fn insert_type_param(&mut self, qualified: Symbol, index: usize) {
         let name = qualified.last_segment().to_string();
-        self.current_mut().generic_parameters.insert(
-            name,
-            GenericParameter {
-                index,
-                qualified,
-                bounds: Vec::new(),
-            },
-        );
+        let shadowed = self
+            .visible_trait_bounds
+            .keys()
+            .find(|visible| visible.last_segment() == name)
+            .cloned()
+            .and_then(|visible| self.visible_trait_bounds.remove_entry(&visible));
+        if let Some(shadowed) = shadowed {
+            self.current_mut().shadowed_trait_bounds.push(shadowed);
+        }
+        self.current_mut()
+            .generic_parameters
+            .insert(name, GenericParameter { index, qualified });
     }
 
     pub(crate) fn insert_trait_bound(&mut self, parameter: &str, bound: Type) {
-        let bounds = &mut self
-            .current_mut()
+        let qualified = self
+            .current()
             .generic_parameters
-            .get_mut(parameter)
+            .get(parameter)
             .expect("a generic parameter must be in scope before recording its bounds")
-            .bounds;
+            .qualified
+            .clone();
+        let bounds = self.visible_trait_bounds.entry(qualified).or_default();
         if !bounds.contains(&bound) {
             bounds.push(bound);
         }
@@ -481,29 +496,17 @@ impl Scopes {
         names
     }
 
-    pub(crate) fn collect_all_trait_bounds(&self) -> HashMap<Symbol, Vec<Type>> {
-        let mut all_bounds: HashMap<Symbol, Vec<Type>> = HashMap::default();
-        // Walk from bottom to top so inner scopes override outer
-        for scope in &self.stack {
-            all_bounds.retain(|parameter, _| {
-                !scope
-                    .generic_parameters
-                    .contains_key(parameter.last_segment())
-            });
-            for parameter in scope.generic_parameters.values() {
-                if !parameter.bounds.is_empty() {
-                    all_bounds.insert(parameter.qualified.clone(), parameter.bounds.clone());
-                }
-            }
-        }
-        all_bounds
+    pub(crate) fn collect_all_trait_bounds(&self) -> &HashMap<Symbol, Vec<Type>> {
+        &self.visible_trait_bounds
     }
 
     pub(crate) fn for_each_bound_on_param<F: FnMut(&Type)>(&self, param_name: &str, mut visit: F) {
         for scope in self.stack.iter().rev() {
             if let Some(parameter) = scope.generic_parameters.get(param_name) {
-                for bound in &parameter.bounds {
-                    visit(bound);
+                if let Some(bounds) = self.visible_trait_bounds.get(&parameter.qualified) {
+                    for bound in bounds {
+                        visit(bound);
+                    }
                 }
                 return;
             }
@@ -696,5 +699,19 @@ mod tests {
         let bounds = scopes.collect_all_trait_bounds();
 
         assert!(bounds.is_empty());
+    }
+
+    #[test]
+    fn popping_type_parameter_scope_restores_outer_bounds() {
+        let mut scopes = Scopes::new();
+        let outer = Symbol::from_parts("package", "T");
+        scopes.insert_type_param(outer.clone(), 0);
+        scopes.insert_trait_bound("T", Type::Error);
+        scopes.push();
+        scopes.insert_type_param(Symbol::from_parts("package.function", "T"), 0);
+
+        scopes.pop();
+
+        assert_eq!(scopes.collect_all_trait_bounds()[&outer], [Type::Error]);
     }
 }

--- a/crates/semantics/src/checker/state.rs
+++ b/crates/semantics/src/checker/state.rs
@@ -274,7 +274,7 @@ impl TaskState {
 
                 (substitute(body, &map), map)
             }
-            _ => (ty.clone(), HashMap::default()),
+            _ => (ty.clone(), SubstitutionMap::default()),
         }
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -39,7 +39,7 @@ pub struct Facts {
     pub always_failing_try_blocks: Vec<Span>,
     pub expression_only_fstrings: Vec<ExpressionOnlyFstringFact>,
     pub unprefixed_fstrings: Vec<UnprefixedFstringFact>,
-    pub interface_satisfied_methods: HashMap<(String, String), InterfaceSatisfactions>,
+    pub interface_satisfied_methods: HashMap<String, HashMap<String, InterfaceSatisfactions>>,
 
     pub(crate) deferred: DeferredChecks,
 
@@ -324,7 +324,9 @@ impl Facts {
         spelling_pinned: bool,
     ) {
         self.interface_satisfied_methods
-            .entry((package_id, method_name))
+            .entry(package_id)
+            .or_default()
+            .entry(method_name)
             .or_default()
             .record(impl_type_name, spelling_pinned);
     }
@@ -338,7 +340,8 @@ impl Facts {
         type_name: &str,
     ) -> bool {
         self.interface_satisfied_methods
-            .get(&(package_id.to_string(), method_name.to_string()))
+            .get(package_id)
+            .and_then(|methods| methods.get(method_name))
             .is_some_and(|satisfactions| satisfactions.spelling_pinned(type_name))
     }
 
@@ -379,11 +382,17 @@ impl Facts {
 
         self.usages.extend(usages);
 
-        for (key, satisfactions) in interface_satisfied_methods {
-            self.interface_satisfied_methods
-                .entry(key)
-                .or_default()
-                .merge(satisfactions);
+        for (package_id, methods) in interface_satisfied_methods {
+            let existing_methods = self
+                .interface_satisfied_methods
+                .entry(package_id)
+                .or_default();
+            for (method_name, satisfactions) in methods {
+                existing_methods
+                    .entry(method_name)
+                    .or_default()
+                    .merge(satisfactions);
+            }
         }
     }
 }
@@ -589,19 +598,10 @@ mod tests {
         b.mark_method_used_for_interface("m".into(), "g".into(), "C".into(), true);
 
         a.merge(b);
-        assert_eq!(a.interface_satisfied_methods.len(), 2);
-        assert_eq!(
-            a.interface_satisfied_methods[&("m".into(), "f".into())]
-                .impl_type_names()
-                .count(),
-            2
-        );
-        assert_eq!(
-            a.interface_satisfied_methods[&("m".into(), "g".into())]
-                .impl_type_names()
-                .count(),
-            1
-        );
+        let methods = &a.interface_satisfied_methods["m"];
+        assert_eq!(methods.len(), 2);
+        assert_eq!(methods["f"].impl_type_names().count(), 2);
+        assert_eq!(methods["g"].impl_type_names().count(), 1);
         assert!(a.method_spelling_pinned_by_interface("m", "f", "A"));
     }
 }

--- a/crates/semantics/src/facts.rs
+++ b/crates/semantics/src/facts.rs
@@ -18,11 +18,11 @@ impl BindingIdAllocator {
     }
 
     fn reserve(&self) -> BindingId {
-        self.next.fetch_add(1, Ordering::Relaxed)
+        BindingId::new(self.next.fetch_add(1, Ordering::Relaxed))
     }
 
     fn snapshot(&self) -> BindingId {
-        self.next.load(Ordering::Relaxed)
+        BindingId::new(self.next.load(Ordering::Relaxed))
     }
 }
 

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -141,8 +141,8 @@ impl TaskState {
     pub(crate) fn visible_parameter_bounds(&self) -> Vec<(EcoString, Vec<Type>)> {
         self.scopes
             .collect_all_trait_bounds()
-            .into_iter()
-            .map(|(parameter, bounds)| (parameter.last_segment().into(), bounds))
+            .iter()
+            .map(|(parameter, bounds)| (parameter.last_segment().into(), bounds.clone()))
             .collect()
     }
 

--- a/crates/semantics/src/package_graph/kahn.rs
+++ b/crates/semantics/src/package_graph/kahn.rs
@@ -1,3 +1,5 @@
+use std::collections::BinaryHeap;
+
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use syntax::ast::Span;
@@ -23,13 +25,11 @@ pub fn topological_sort(edges: &DependencyGraph) -> (Vec<PackageId>, Vec<Cycle>)
         }
     }
 
-    let mut queue: Vec<_> = in_degree
+    let mut queue: BinaryHeap<_> = in_degree
         .iter()
         .filter(|&(_, deg)| *deg == 0)
         .map(|(id, _)| id.clone())
         .collect();
-
-    queue.sort();
 
     while let Some(package) = queue.pop() {
         order.push(package.clone());
@@ -39,7 +39,6 @@ pub fn topological_sort(edges: &DependencyGraph) -> (Vec<PackageId>, Vec<Cycle>)
                 *degree -= 1;
                 if *degree == 0 {
                     queue.push(import.clone());
-                    queue.sort();
                 }
             }
         }

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -673,7 +673,7 @@ pub(crate) fn check_dependency_blocks(
             }
         };
 
-        for (module_path, dep) in &table.deps {
+        for (module_path, dep) in table.dependencies() {
             if let Err(message) = deps::validate_script_entry(module_path, dep) {
                 let span = entry_span(first, &table, module_path, *file_id);
                 sink.push(diagnostics::package_graph::invalid_dependency_table(
@@ -690,7 +690,7 @@ fn entry_span(
     module_path: &str,
     file_id: u32,
 ) -> Span {
-    match table.spans.get(module_path) {
+    match table.dependency_span(module_path) {
         Some(range) => block.map_span(range.clone(), file_id),
         None => block.span,
     }

--- a/crates/semantics/src/package_graph/mod.rs
+++ b/crates/semantics/src/package_graph/mod.rs
@@ -12,14 +12,13 @@ use crate::loader as semantics_loader;
 use crate::loader::Loader;
 use crate::store::{ENTRY_PACKAGE_ID, Store};
 use diagnostics::LocalSink;
+use std::hash::Hash;
 use std::mem;
 use syntax::dependency_block;
 use syntax::dependency_block::DependencyBlock;
 use syntax::imports::scan_imports;
 use syntax::program;
-use syntax::program::FileImport;
-
-pub type PackageId = String;
+use syntax::program::{FileImport, PackageId};
 
 pub fn root_import_target(name: &str, importer: &str, kind: ProjectKind) -> Option<&'static str> {
     (name == semantics_loader::ROOT_IMPORT
@@ -156,8 +155,11 @@ impl DependencyGraph {
     }
 }
 
-impl From<HashMap<PackageId, HashSet<PackageId>>> for DependencyGraph {
-    fn from(edges: HashMap<PackageId, HashSet<PackageId>>) -> Self {
+impl<T> From<HashMap<T, HashSet<T>>> for DependencyGraph
+where
+    T: Eq + Hash + Into<PackageId>,
+{
+    fn from(edges: HashMap<T, HashSet<T>>) -> Self {
         Self {
             edges: edges
                 .into_iter()
@@ -166,7 +168,7 @@ impl From<HashMap<PackageId, HashSet<PackageId>>> for DependencyGraph {
                         .into_iter()
                         .map(|dependency| {
                             (
-                                dependency,
+                                dependency.into(),
                                 Dependency {
                                     kind: DependencyKind::Production,
                                     usage: ImportUse::Referenced,
@@ -175,7 +177,7 @@ impl From<HashMap<PackageId, HashSet<PackageId>>> for DependencyGraph {
                             )
                         })
                         .collect();
-                    (package_id, dependencies)
+                    (package_id.into(), dependencies)
                 })
                 .collect(),
         }
@@ -783,7 +785,7 @@ fn process_file_imports(
                             span: file_import.name_span,
                         };
                         imports
-                            .entry(entry.to_string())
+                            .entry(entry.into())
                             .and_modify(|existing: &mut Dependency| existing.merge(dependency))
                             .or_insert(dependency);
                     }
@@ -842,7 +844,7 @@ fn process_file_imports(
                 }
             };
             if ok {
-                imports.insert(file_import.name.to_string(), pending);
+                imports.insert(file_import.name.to_string().into(), pending);
             }
             continue;
         }
@@ -885,7 +887,7 @@ fn process_file_imports(
             span: file_import.name_span,
         };
         imports
-            .entry(file_import.name.to_string())
+            .entry(file_import.name.to_string().into())
             .and_modify(|existing: &mut Dependency| existing.merge(dependency))
             .or_insert(dependency);
     }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -271,19 +271,9 @@ impl Store {
     }
 
     pub fn package_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
-        if !qualified_name.starts_with(types::GO_IMPORT_PREFIX) || !qualified_name.contains('/') {
-            return qualified_name.split_once('.').map(|(package, _)| package);
-        }
-
-        let mut end = qualified_name.len();
-        while let Some(separator) = qualified_name[..end].rfind('.') {
-            let candidate = &qualified_name[..separator];
-            if self.packages.contains_key(candidate) {
-                return Some(candidate);
-            }
-            end = separator;
-        }
-        None
+        types::package_for_qualified_name(qualified_name, |package| {
+            self.packages.contains_key(package)
+        })
     }
 
     pub(crate) fn is_const(&self, qualified_name: &str) -> bool {

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -822,7 +822,6 @@ mod clone_tests {
 #[cfg(test)]
 mod closed_domain_tests {
     use super::*;
-    use syntax::ast;
     use syntax::ast::{
         Annotation, Generic, Span, StructFieldDefinition, StructFieldKind, StructFields,
     };
@@ -868,7 +867,7 @@ mod closed_domain_tests {
                     name: "0".into(),
                     name_span: Span::dummy(),
                     annotation: Annotation::Unknown,
-                    visibility: ast::Visibility::Private,
+                    visibility: Visibility::Private,
                     ty: Type::Simple(SimpleKind::Int),
                     kind: StructFieldKind::Named { attributes: vec![] },
                 }]),
@@ -1098,7 +1097,7 @@ mod closed_domain_tests {
                         name: "0".into(),
                         name_span: Span::dummy(),
                         annotation: Annotation::Unknown,
-                        visibility: ast::Visibility::Private,
+                        visibility: Visibility::Private,
                         ty: field_ty,
                         kind: StructFieldKind::Named { attributes: vec![] },
                     }]),
@@ -1194,7 +1193,7 @@ mod closed_domain_tests {
                         name: "0".into(),
                         name_span: Span::dummy(),
                         annotation: Annotation::Unknown,
-                        visibility: ast::Visibility::Private,
+                        visibility: Visibility::Private,
                         ty: nominal_int("m.Items"),
                         kind: StructFieldKind::Named { attributes: vec![] },
                     }]),

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -129,6 +129,22 @@ impl Store {
     }
 
     pub(crate) fn get_file_mut(&mut self, file_id: u32) -> Option<&mut File> {
+        if let Some(package_id) = self
+            .file_packages
+            .as_deref()
+            .and_then(|packages| packages.get(file_id as usize))
+            .and_then(Option::as_deref)
+            && self
+                .packages
+                .get(package_id)
+                .is_some_and(|package| package.files.contains_key(&file_id))
+        {
+            return self
+                .packages
+                .get_mut(package_id)
+                .and_then(|package| Arc::make_mut(package).files.get_mut(&file_id));
+        }
+
         let package_id = self.packages.iter().find_map(|(package_id, package)| {
             package
                 .files
@@ -782,6 +798,23 @@ mod clone_tests {
         assert_eq!(
             store.get_file(42).map(|file| file.name.as_str()),
             Some("large.lis")
+        );
+    }
+
+    #[test]
+    fn indexed_files_are_mutable_after_the_threshold() {
+        let mut store = Store::new();
+        for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
+            store.add_package(&format!("package{index}"));
+        }
+        store.add_package("large");
+        store.store_file(File::new_cached("large", "before.lis", "", "", 42));
+
+        store.get_file_mut(42).unwrap().name = "after.lis".to_string();
+
+        assert_eq!(
+            store.get_file(42).map(|file| file.name.as_str()),
+            Some("after.lis")
         );
     }
 }

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -271,7 +271,19 @@ impl Store {
     }
 
     pub fn package_for_qualified_name<'a>(&'a self, qualified_name: &'a str) -> Option<&'a str> {
-        types::package_for_qualified_name(qualified_name, self.packages.keys().map(String::as_str))
+        if !qualified_name.starts_with(types::GO_IMPORT_PREFIX) || !qualified_name.contains('/') {
+            return qualified_name.split_once('.').map(|(package, _)| package);
+        }
+
+        let mut end = qualified_name.len();
+        while let Some(separator) = qualified_name[..end].rfind('.') {
+            let candidate = &qualified_name[..separator];
+            if self.packages.contains_key(candidate) {
+                return Some(candidate);
+            }
+            end = separator;
+        }
+        None
     }
 
     pub(crate) fn is_const(&self, qualified_name: &str) -> bool {
@@ -782,6 +794,18 @@ mod clone_tests {
         assert_eq!(
             store.get_file(42).map(|file| file.name.as_str()),
             Some("cached.lis")
+        );
+    }
+
+    #[test]
+    fn qualified_go_name_uses_longest_registered_package_prefix() {
+        let mut store = Store::new();
+        store.add_package("go:gopkg.in/yaml");
+        store.add_package("go:gopkg.in/yaml.v3");
+
+        assert_eq!(
+            store.package_for_qualified_name("go:gopkg.in/yaml.v3.Node"),
+            Some("go:gopkg.in/yaml.v3"),
         );
     }
 

--- a/crates/stdlib/src/go_modules.rs
+++ b/crates/stdlib/src/go_modules.rs
@@ -5,6 +5,9 @@ use std::sync::LazyLock;
 
 use crate::Target;
 
+type TypedefEntries = &'static [(&'static str, &'static str)];
+type PackageTargets = &'static [(&'static str, &'static str)];
+
 static GO_STDLIB_COMMON: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
     HashMap::from([
         ("archive/tar", include_str!("../typedefs/archive/tar.d.lis")),
@@ -400,125 +403,111 @@ static GO_STDLIB_COMMON: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
     ])
 });
 
-static GO_STDLIB_LINUX_AMD64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_linux_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_linux_amd64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_linux_amd64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_LINUX_AMD64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_linux_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_linux_amd64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_linux_amd64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_LINUX_ARM64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_linux_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_linux_arm64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_linux_arm64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_LINUX_ARM64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_linux_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_linux_arm64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_linux_arm64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_DARWIN_AMD64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_darwin_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_darwin_amd64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_darwin_amd64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_DARWIN_AMD64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_darwin_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_darwin_amd64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_darwin_amd64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_DARWIN_ARM64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_darwin_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_darwin_arm64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_darwin_arm64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_DARWIN_ARM64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_darwin_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_linux_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_darwin_arm64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_darwin_arm64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_WINDOWS_AMD64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_windows_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_windows_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_windows_amd64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_windows_amd64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_WINDOWS_AMD64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_windows_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_windows_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_windows_amd64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_windows_amd64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_WINDOWS_ARM64: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
-    HashMap::from([
-        ("os", include_str!("../typedefs/os_windows_amd64.d.lis")),
-        (
-            "path/filepath",
-            include_str!("../typedefs/path/filepath_windows_amd64.d.lis"),
-        ),
-        (
-            "runtime",
-            include_str!("../typedefs/runtime_windows_arm64.d.lis"),
-        ),
-        (
-            "syscall",
-            include_str!("../typedefs/syscall_windows_amd64.d.lis"),
-        ),
-    ])
-});
+static GO_STDLIB_WINDOWS_ARM64: TypedefEntries = &[
+    ("os", include_str!("../typedefs/os_windows_amd64.d.lis")),
+    (
+        "path/filepath",
+        include_str!("../typedefs/path/filepath_windows_amd64.d.lis"),
+    ),
+    (
+        "runtime",
+        include_str!("../typedefs/runtime_windows_arm64.d.lis"),
+    ),
+    (
+        "syscall",
+        include_str!("../typedefs/syscall_windows_amd64.d.lis"),
+    ),
+];
 
-static GO_STDLIB_PACKAGE_TARGETS: LazyLock<HashMap<&str, &[(&str, &str)]>> = LazyLock::new(|| {
-    HashMap::from([(
-        "log/syslog",
-        &[
-            ("linux", "amd64"),
-            ("linux", "arm64"),
-            ("darwin", "amd64"),
-            ("darwin", "arm64"),
-        ][..],
-    )])
-});
+static GO_STDLIB_PACKAGE_TARGETS: &[(&str, PackageTargets)] = &[(
+    "log/syslog",
+    &[
+        ("linux", "amd64"),
+        ("linux", "arm64"),
+        ("darwin", "amd64"),
+        ("darwin", "arm64"),
+    ],
+)];
 
 pub fn get_go_stdlib_typedef(package: &str, target: Target) -> Option<&'static str> {
     if !is_available_on(package, target) {
@@ -537,7 +526,7 @@ pub fn get_go_stdlib_packages(target: Target) -> Vec<&'static str> {
         .filter(|pkg| is_available_on(pkg, target))
         .collect();
     if let Some(overlay) = overlay_for(target) {
-        packages.extend(overlay.keys().copied());
+        packages.extend(overlay.iter().map(|(package, _)| *package));
     }
     packages.sort();
     packages
@@ -546,11 +535,14 @@ pub fn get_go_stdlib_packages(target: Target) -> Vec<&'static str> {
 pub fn get_go_stdlib_package_targets(
     package: &str,
 ) -> Option<&'static [(&'static str, &'static str)]> {
-    GO_STDLIB_PACKAGE_TARGETS.get(package).copied()
+    GO_STDLIB_PACKAGE_TARGETS
+        .iter()
+        .find(|(candidate, _)| *candidate == package)
+        .map(|(_, targets)| *targets)
 }
 
 fn is_available_on(package: &str, target: Target) -> bool {
-    match GO_STDLIB_PACKAGE_TARGETS.get(package) {
+    match get_go_stdlib_package_targets(package) {
         Some(targets) => targets
             .iter()
             .any(|(goos, goarch)| *goos == target.goos && *goarch == target.goarch),
@@ -559,17 +551,22 @@ fn is_available_on(package: &str, target: Target) -> bool {
 }
 
 fn lookup_in_overlay(target: Target, package: &str) -> Option<&'static str> {
-    overlay_for(target).and_then(|overlay| overlay.get(package).copied())
+    overlay_for(target).and_then(|overlay| {
+        overlay
+            .iter()
+            .find(|(candidate, _)| *candidate == package)
+            .map(|(_, source)| *source)
+    })
 }
 
-fn overlay_for(target: Target) -> Option<&'static HashMap<&'static str, &'static str>> {
+fn overlay_for(target: Target) -> Option<TypedefEntries> {
     match (target.goos, target.goarch) {
-        ("linux", "amd64") => Some(&GO_STDLIB_LINUX_AMD64),
-        ("linux", "arm64") => Some(&GO_STDLIB_LINUX_ARM64),
-        ("darwin", "amd64") => Some(&GO_STDLIB_DARWIN_AMD64),
-        ("darwin", "arm64") => Some(&GO_STDLIB_DARWIN_ARM64),
-        ("windows", "amd64") => Some(&GO_STDLIB_WINDOWS_AMD64),
-        ("windows", "arm64") => Some(&GO_STDLIB_WINDOWS_ARM64),
+        ("linux", "amd64") => Some(GO_STDLIB_LINUX_AMD64),
+        ("linux", "arm64") => Some(GO_STDLIB_LINUX_ARM64),
+        ("darwin", "amd64") => Some(GO_STDLIB_DARWIN_AMD64),
+        ("darwin", "arm64") => Some(GO_STDLIB_DARWIN_ARM64),
+        ("windows", "amd64") => Some(GO_STDLIB_WINDOWS_AMD64),
+        ("windows", "arm64") => Some(GO_STDLIB_WINDOWS_ARM64),
         _ => None,
     }
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -2490,6 +2490,7 @@ pub struct ParentInterface {
 pub enum Visibility {
     Public,
     Private,
+    Local,
 }
 
 impl Visibility {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -59,7 +59,20 @@ impl fmt::Debug for Binding {
     }
 }
 
-pub type BindingId = u32;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct BindingId(u32);
+
+impl BindingId {
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdentifierResolution {

--- a/crates/syntax/src/containment.rs
+++ b/crates/syntax/src/containment.rs
@@ -21,12 +21,13 @@ where
     F: Fn(&str) -> Option<&'d Definition>,
 {
     let severed = HashSet::default();
+    let mut wrap_checking = HashSet::default();
     ContainmentWalk {
         lookup: &lookup,
         enum_payloads: EnumPayloads::Traverse,
         severed: &severed,
     }
-    .payload_pointer_wrapped(enum_id, variant, field, payload, &HashSet::default())
+    .payload_pointer_wrapped(enum_id, variant, field, payload, &mut wrap_checking)
 }
 
 pub fn definition_contains_by_value<'d, F>(
@@ -39,6 +40,7 @@ pub fn definition_contains_by_value<'d, F>(
 where
     F: Fn(&str) -> Option<&'d Definition>,
 {
+    let mut wrap_checking = HashSet::default();
     ContainmentWalk {
         lookup: &lookup,
         enum_payloads,
@@ -48,7 +50,7 @@ where
         current_id,
         target_id,
         &mut HashSet::default(),
-        &HashSet::default(),
+        &mut wrap_checking,
     )
 }
 
@@ -64,7 +66,7 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         ty: &Type,
         target_id: &str,
         visited: &mut HashSet<String>,
-        wrap_checking: &HashSet<(String, usize, usize)>,
+        wrap_checking: &mut HashSet<(String, usize, usize)>,
     ) -> bool {
         let peeled = peel_alias(ty, self.lookup);
         match &peeled {
@@ -106,7 +108,7 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         current_id: &str,
         target_id: &str,
         visited: &mut HashSet<String>,
-        wrap_checking: &HashSet<(String, usize, usize)>,
+        wrap_checking: &mut HashSet<(String, usize, usize)>,
     ) -> bool {
         if self.severed.contains(current_id) {
             return false;
@@ -135,7 +137,7 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         id: &str,
         position: usize,
         checking: &mut HashSet<(String, usize)>,
-        wrap_checking: &HashSet<(String, usize, usize)>,
+        wrap_checking: &mut HashSet<(String, usize, usize)>,
     ) -> bool {
         if !checking.insert((id.to_string(), position)) {
             return false;
@@ -204,21 +206,21 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         variant: usize,
         field: usize,
         payload: &Type,
-        wrap_checking: &HashSet<(String, usize, usize)>,
+        wrap_checking: &mut HashSet<(String, usize, usize)>,
     ) -> bool {
         let key = (enum_id.to_string(), variant, field);
-        if wrap_checking.contains(&key) {
+        if !wrap_checking.insert(key.clone()) {
             return false;
         }
-        let mut nested_checking = wrap_checking.clone();
-        nested_checking.insert(key);
         let severed = HashSet::default();
-        ContainmentWalk {
+        let wrapped = ContainmentWalk {
             lookup: self.lookup,
             enum_payloads: EnumPayloads::Traverse,
             severed: &severed,
         }
-        .type_contains(payload, enum_id, &mut HashSet::default(), &nested_checking)
+        .type_contains(payload, enum_id, &mut HashSet::default(), wrap_checking);
+        wrap_checking.remove(&key);
+        wrapped
     }
 
     fn parameter_stored_inline(
@@ -226,7 +228,7 @@ impl<'d, F: Fn(&str) -> Option<&'d Definition>> ContainmentWalk<'_, F> {
         ty: &Type,
         parameter: &str,
         checking: &mut HashSet<(String, usize)>,
-        wrap_checking: &HashSet<(String, usize, usize)>,
+        wrap_checking: &mut HashSet<(String, usize, usize)>,
     ) -> bool {
         match ty {
             Type::Parameter(name) => name == parameter,

--- a/crates/syntax/src/go_names.rs
+++ b/crates/syntax/src/go_names.rs
@@ -302,6 +302,14 @@ pub fn conformance_method_if_public<'a>(
     select_by_emitted_name(methods, interface_id, method_name, candidate, true)
 }
 
+struct EmittedMethodMatch<'a> {
+    depth: usize,
+    exact: bool,
+    owner: Option<EcoString>,
+    name: &'a EcoString,
+    ty: &'a Type,
+}
+
 fn select_by_emitted_name<'a>(
     methods: &'a Methods,
     interface_id: &str,
@@ -314,7 +322,7 @@ fn select_by_emitted_name<'a>(
     } else {
         Cow::Owned(snake_to_camel(method_name))
     };
-    let mut matches: Vec<(usize, bool, Option<EcoString>, &EcoString, &Type)> = Vec::new();
+    let mut matches = Vec::new();
     for (name, method) in methods {
         let ty = &method.ty;
         let exported = method.visibility.is_public();
@@ -341,17 +349,26 @@ fn select_by_emitted_name<'a>(
         if !exact && emitted != *want {
             continue;
         }
-        matches.push((depth, exact, owner, name, ty));
+        matches.push(EmittedMethodMatch {
+            depth,
+            exact,
+            owner,
+            name,
+            ty,
+        });
     }
-    let depth = matches.iter().map(|m| m.0).min()?;
-    matches.retain(|m| m.0 == depth);
-    if matches.iter().any(|m| m.2 != matches[0].2) {
+    let depth = matches.iter().map(|candidate| candidate.depth).min()?;
+    matches.retain(|candidate| candidate.depth == depth);
+    if matches
+        .iter()
+        .any(|candidate| candidate.owner.as_ref() != matches[0].owner.as_ref())
+    {
         return None;
     }
     matches
         .into_iter()
-        .min_by_key(|(_, exact, _, name, _)| (!exact, (*name).clone()))
-        .map(|(_, _, _, name, ty)| (name, ty))
+        .min_by_key(|candidate| (!candidate.exact, candidate.name.clone()))
+        .map(|candidate| (candidate.name, candidate.ty))
 }
 
 pub fn is_builtin_enum_member(go_name: &str) -> bool {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -37,7 +37,37 @@ pub enum TypeAttribute {
     HiddenFields,
 }
 
-pub type Attributes = HashSet<TypeAttribute>;
+impl TypeAttribute {
+    const fn mask(self) -> u8 {
+        match self {
+            Self::Display => 1 << 0,
+            Self::ClosedDomain => 1 << 1,
+            Self::AnonStruct => 1 << 2,
+            Self::HiddenEmbed => 1 << 3,
+            Self::Serialized => 1 << 4,
+            Self::ZeroSafe => 1 << 5,
+            Self::ZeroUnsafe => 1 << 6,
+            Self::HiddenFields => 1 << 7,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Attributes(u8);
+
+impl Attributes {
+    pub fn insert(&mut self, attribute: TypeAttribute) -> bool {
+        let mask = attribute.mask();
+        let was_absent = self.0 & mask == 0;
+        self.0 |= mask;
+        was_absent
+    }
+
+    pub fn contains(&self, attribute: &TypeAttribute) -> bool {
+        self.0 & attribute.mask() != 0
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -880,6 +910,31 @@ pub struct Interface {
 mod tests {
     use super::*;
     use crate::types::Symbol;
+
+    #[test]
+    fn attributes_track_independent_flags() {
+        let mut attributes = Attributes::default();
+
+        attributes.insert(TypeAttribute::Display);
+        attributes.insert(TypeAttribute::Serialized);
+
+        assert_eq!(
+            [
+                attributes.contains(&TypeAttribute::Display),
+                attributes.contains(&TypeAttribute::Serialized),
+                attributes.contains(&TypeAttribute::HiddenFields),
+            ],
+            [true, true, false]
+        );
+    }
+
+    #[test]
+    fn inserting_an_existing_attribute_reports_it_present() {
+        let mut attributes = Attributes::default();
+
+        assert!(attributes.insert(TypeAttribute::Display));
+        assert!(!attributes.insert(TypeAttribute::Display));
+    }
 
     fn generic(name: &str) -> Generic {
         Generic::new(name, vec![], Span::dummy())

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -568,7 +568,7 @@ where
         interface_ty: &Type,
         parent_of: Option<&Symbol>,
         lookup: F,
-        visited: &mut HashSet<String>,
+        visited: &mut HashSet<Type>,
         visiting: &mut HashSet<Symbol>,
         instances: &mut Vec<InterfaceInstance>,
     ) where
@@ -578,9 +578,7 @@ where
         let Type::Nominal { id, params, .. } = &resolved else {
             return;
         };
-        // `Display` intentionally omits package qualification, so it cannot
-        // distinguish same-named interfaces from different packages.
-        if !visited.insert(format!("{resolved:?}")) || !visiting.insert(id.clone()) {
+        if !visited.insert(resolved.clone()) || !visiting.insert(id.clone()) {
             return;
         }
         let Some(Definition {

--- a/crates/syntax/src/program/definition.rs
+++ b/crates/syntax/src/program/definition.rs
@@ -4,6 +4,7 @@ use ecow::EcoString;
 
 use crate::ast::{
     Annotation, EnumVariant, Generic, Literal, Span, StructFieldDefinition, StructFields,
+    Visibility,
 };
 use crate::types;
 use crate::types::{
@@ -881,20 +882,6 @@ fn method_lookup_key(ty: &Type) -> Option<Symbol> {
         Type::Simple(kind) => Some(Symbol::from_parts("prelude", kind.leaf_name())),
         Type::Array { .. } => Some(Symbol::from_parts("prelude", "Array")),
         _ => None,
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Visibility {
-    Public,
-    Private,
-    Local,
-}
-
-impl Visibility {
-    pub fn is_public(&self) -> bool {
-        matches!(self, Visibility::Public)
     }
 }
 

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -105,12 +105,10 @@ impl TestFunction {
 #[derive(Debug, Clone, Default)]
 pub struct TestIndex {
     tests: Vec<TestFunction>,
-    qualified_names: HashSet<Symbol>,
 }
 
 impl TestIndex {
     pub fn push(&mut self, test: TestFunction) {
-        self.qualified_names.insert(test.qualified_name.clone());
         self.tests.push(test);
     }
 
@@ -119,7 +117,9 @@ impl TestIndex {
     }
 
     pub fn contains_qualified(&self, qualified_name: &str) -> bool {
-        self.qualified_names.contains(qualified_name)
+        self.tests
+            .iter()
+            .any(|test| test.qualified_name == qualified_name)
     }
 }
 

--- a/crates/syntax/src/program/emit_input.rs
+++ b/crates/syntax/src/program/emit_input.rs
@@ -105,10 +105,12 @@ impl TestFunction {
 #[derive(Debug, Clone, Default)]
 pub struct TestIndex {
     tests: Vec<TestFunction>,
+    qualified_names: HashSet<Symbol>,
 }
 
 impl TestIndex {
     pub fn push(&mut self, test: TestFunction) {
+        self.qualified_names.insert(test.qualified_name.clone());
         self.tests.push(test);
     }
 
@@ -117,9 +119,7 @@ impl TestIndex {
     }
 
     pub fn contains_qualified(&self, qualified_name: &str) -> bool {
-        self.tests
-            .iter()
-            .any(|test| test.qualified_name == qualified_name)
+        self.qualified_names.contains(qualified_name)
     }
 }
 

--- a/crates/syntax/src/program/mod.rs
+++ b/crates/syntax/src/program/mod.rs
@@ -4,9 +4,10 @@ mod file;
 mod package;
 mod resolution;
 
+pub use crate::ast::Visibility;
 pub use definition::{
     AliasKind, Attributes, ConstantValue, Definition, DefinitionBody, Interface, InterfaceInstance,
-    InterfaceRequirement, Method, MethodOrigin, Methods, TypeAttribute, ValueKind, Visibility,
+    InterfaceRequirement, Method, MethodOrigin, Methods, TypeAttribute, ValueKind,
     interface_declares_any_method, interface_instances, interface_requirements, method_for_type,
     methods_for_type, type_has_any_method,
 };

--- a/crates/syntax/src/program/package.rs
+++ b/crates/syntax/src/program/package.rs
@@ -1,11 +1,71 @@
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
 
 use super::file::File;
 use super::{Definition, Visibility};
 use crate::types::Symbol;
 
-pub type PackageId = String;
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PackageId(String);
+
+impl PackageId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for PackageId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for PackageId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl Borrow<str> for PackageId {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for PackageId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for PackageId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for PackageId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl PartialEq<str> for PackageId {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for PackageId {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
 
 pub fn is_internal_package_id(id: &str) -> bool {
     id == "prelude" || id == "**test_prelude" || id == "**nominal" || id.starts_with("go:")

--- a/crates/syntax/src/program/package.rs
+++ b/crates/syntax/src/program/package.rs
@@ -1,8 +1,8 @@
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::definition::{Definition, Visibility};
 use super::file::File;
+use super::{Definition, Visibility};
 use crate::types::Symbol;
 
 pub type PackageId = String;

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -154,27 +154,27 @@ pub fn unqualified_name(id: &str) -> &str {
 pub const GO_IMPORT_PREFIX: &str = "go:";
 
 /// Resolve the package of a qualified ID. For `go:` IDs containing `/`,
-/// does a longest-prefix match against `package_ids` to disambiguate paths
+/// does a longest-prefix match against known packages to disambiguate paths
 /// whose package segment contains dots (e.g. `gopkg.in/yaml.v3`). Otherwise
 /// splits on the first dot. Returns `None` when the id has no dot and is
 /// not a registered `go:` package.
-pub fn package_for_qualified_name<'a, I>(id: &'a str, package_ids: I) -> Option<&'a str>
-where
-    I: IntoIterator<Item = &'a str>,
-{
+pub fn package_for_qualified_name(
+    id: &str,
+    mut contains_package: impl FnMut(&str) -> bool,
+) -> Option<&str> {
     if !id.starts_with(GO_IMPORT_PREFIX) || !id.contains('/') {
         return id.split_once('.').map(|(m, _)| m);
     }
-    let mut best: Option<&str> = None;
-    for package_id in package_ids {
-        if id.starts_with(package_id)
-            && id.as_bytes().get(package_id.len()) == Some(&b'.')
-            && best.is_none_or(|prev| package_id.len() > prev.len())
-        {
-            best = Some(package_id);
+
+    let mut end = id.len();
+    while let Some(separator) = id[..end].rfind('.') {
+        let candidate = &id[..separator];
+        if contains_package(candidate) {
+            return Some(candidate);
         }
+        end = separator;
     }
-    best
+    None
 }
 
 fn is_range_type_name(name: &str) -> bool {

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1,5 +1,6 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::Borrow;
+use std::mem;
 use std::sync::Arc;
 
 use ecow::EcoString;
@@ -193,8 +194,47 @@ where
         .then_some(peeled)
 }
 
-/// type param name -> type variable
-pub type SubstitutionMap = HashMap<EcoString, Type>;
+/// Type parameter name -> concrete type.
+#[derive(Debug, Clone, Default)]
+pub struct SubstitutionMap(Vec<(EcoString, Type)>);
+
+impl SubstitutionMap {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn get(&self, name: &EcoString) -> Option<&Type> {
+        self.0
+            .iter()
+            .find_map(|(candidate, ty)| (candidate == name).then_some(ty))
+    }
+
+    pub fn insert(&mut self, name: EcoString, ty: Type) -> Option<Type> {
+        if let Some((_, existing)) = self.0.iter_mut().find(|(candidate, _)| candidate == &name) {
+            return Some(mem::replace(existing, ty));
+        }
+        self.0.push((name, ty));
+        None
+    }
+
+    fn keys(&self) -> impl Iterator<Item = &EcoString> {
+        self.0.iter().map(|(name, _)| name)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&EcoString, &Type)> {
+        self.0.iter().map(|(name, ty)| (name, ty))
+    }
+}
+
+impl FromIterator<(EcoString, Type)> for SubstitutionMap {
+    fn from_iter<T: IntoIterator<Item = (EcoString, Type)>>(iter: T) -> Self {
+        let mut map = Self::default();
+        for (name, ty) in iter {
+            map.insert(name, ty);
+        }
+        map
+    }
+}
 
 /// Build a substitution map from a list of generics and their type arguments,
 /// pairing each generic's name with the type at the same position.
@@ -228,7 +268,7 @@ pub fn type_args_match_params<'a>(
             .all(|(arg, param)| matches!(arg, Type::Parameter(name) if name == param))
 }
 
-pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
+pub fn substitute(ty: &Type, map: &SubstitutionMap) -> Type {
     if map.is_empty() {
         return ty.clone();
     }
@@ -262,7 +302,7 @@ pub fn substitute(ty: &Type, map: &HashMap<EcoString, Type>) -> Type {
         Type::Forall { vars, body } => {
             let has_overlap = map.keys().any(|k| vars.contains(k));
             let substituted_body = if has_overlap {
-                let filtered_map: HashMap<EcoString, Type> = map
+                let filtered_map: SubstitutionMap = map
                     .iter()
                     .filter(|(k, _)| !vars.contains(*k))
                     .map(|(k, v)| (k.clone(), v.clone()))

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -1,5 +1,6 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
 use std::mem;
 use std::sync::Arc;
 
@@ -642,6 +643,65 @@ impl PartialEq for Type {
                 },
             ) => k1 == k2 && a1 == a2 && w1 == w2,
             _ => false,
+        }
+    }
+}
+
+impl Eq for Type {}
+
+impl Hash for Type {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        mem::discriminant(self).hash(state);
+        match self {
+            Type::Simple(kind) => kind.hash(state),
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            } => {
+                kind.hash(state);
+                args.hash(state);
+                writable.hash(state);
+            }
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            } => {
+                id.hash(state);
+                params.hash(state);
+                writable.hash(state);
+            }
+            Type::ImportNamespace(package_id) => package_id.hash(state),
+            Type::Function(function) => {
+                function.params.len().hash(state);
+                for parameter in &function.params {
+                    parameter.ty.hash(state);
+                }
+                function.bounds.len().hash(state);
+                for bound in &function.bounds {
+                    bound.param_name.hash(state);
+                    bound.generic.hash(state);
+                    bound.ty.hash(state);
+                }
+                function.return_type.hash(state);
+            }
+            Type::Var { id, .. } => id.hash(state),
+            Type::Forall { vars, body } => {
+                vars.hash(state);
+                body.hash(state);
+            }
+            Type::Parameter(name) => name.hash(state),
+            Type::Tuple(elements) => elements.hash(state),
+            Type::Array { length, element } => {
+                length.hash(state);
+                element.hash(state);
+            }
+            Type::Uninferred
+            | Type::Ignored
+            | Type::Never
+            | Type::Error
+            | Type::ReceiverPlaceholder => {}
         }
     }
 }
@@ -2172,7 +2232,15 @@ fn alpha_index(idx: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
     use std::iter;
+
+    fn hash(ty: &Type) -> u64 {
+        let mut state = DefaultHasher::new();
+        ty.hash(&mut state);
+        state.finish()
+    }
 
     #[test]
     fn error_type_equals_itself() {
@@ -2206,6 +2274,36 @@ mod tests {
 
         assert_eq!(named, differently_named);
         assert_eq!(named, unnamed);
+    }
+
+    #[test]
+    fn equal_function_types_have_equal_hashes() {
+        let named = Type::function(
+            vec![FunctionParameter::named(Type::int(), Some("width".into()))],
+            vec![],
+            Box::new(Type::bool()),
+        );
+        let unnamed = Type::function(
+            vec![FunctionParameter::new(Type::int())],
+            vec![],
+            Box::new(Type::bool()),
+        );
+
+        assert_eq!(hash(&named), hash(&unnamed));
+    }
+
+    #[test]
+    fn equal_type_variables_have_equal_hashes() {
+        let named = Type::Var {
+            id: TypeVarId::new(1),
+            hint: Some("value".into()),
+        };
+        let unnamed = Type::Var {
+            id: TypeVarId::new(1),
+            hint: None,
+        };
+
+        assert_eq!(hash(&named), hash(&unnamed));
     }
 
     #[test]

--- a/tests/_harness/infer.rs
+++ b/tests/_harness/infer.rs
@@ -66,9 +66,12 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
 
     let locator = deps::TypedefLocator::default();
     let discovered = fs.discover_packages();
-    let additional = discovered.test_roots().cloned().collect();
+    let additional = discovered
+        .test_roots()
+        .map(|package_id| package_id.as_str().into())
+        .collect();
     let roots = Roots {
-        primary: vec![package_name.to_string()],
+        primary: vec![package_name.into()],
         additional,
     };
     let mut graph_result = build_package_graph(
@@ -96,7 +99,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
                     file
                 })
                 .collect();
-            (package_id, files)
+            (package_id.to_string(), files)
         })
         .collect();
 
@@ -128,7 +131,7 @@ pub fn infer_package(package_name: &str, fs: MockFileSystem) -> InferResult {
                 continue;
             }
 
-            let files = parsed.remove(&package_id).unwrap_or_default();
+            let files = parsed.remove(package_id.as_str()).unwrap_or_default();
 
             store.store_package(&package_id, files);
             let package = checker.register_package(&mut store, &package_id);

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -6750,7 +6750,7 @@ fn go_import_collision_flags_shared_last_segment() {
     builder.extend_with_packages(
         &["database/sql", "entgo.io/ent/dialect/sql"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect(),
     );
 
@@ -6784,7 +6784,7 @@ fn go_import_collision_silent_when_aliases_differ() {
     builder.extend_with_packages(
         &["database/sql", "entgo.io/ent/dialect/sql"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect(),
     );
 
@@ -6810,7 +6810,7 @@ fn go_import_collision_silent_for_distinct_versioned_packages() {
     builder.extend_with_packages(
         &["github.com/pion/sdp/v3", "github.com/pion/dtls/v3"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect(),
     );
 
@@ -6832,7 +6832,7 @@ fn go_import_collision_flags_local_packages_sharing_last_segment() {
     builder.extend_with_packages(
         &["myproject/api/v2", "myproject/admin/v2"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect(),
     );
 
@@ -6858,7 +6858,7 @@ fn go_import_under_project_package_resolves_by_package_not_version() {
     builder.extend_with_packages(
         &["myproject/plugins/v2", "myproject/api/v2"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect(),
     );
 

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -29,7 +29,7 @@ fn default_resolver() -> deps::TypedefLocator {
 
 fn roots(entry: &str) -> Roots {
     Roots {
-        primary: vec![entry.to_string()],
+        primary: vec![entry.into()],
         additional: vec![],
     }
 }
@@ -565,8 +565,8 @@ fn additional_roots_widen_graph_but_not_reachable_set() {
     let result = build_package_graph(
         &mut store,
         Roots {
-            primary: vec!["main".to_string()],
-            additional: vec!["orphan".to_string()],
+            primary: vec!["main".into()],
+            additional: vec!["orphan".into()],
         },
         graph_options(&fs, &sink, &default_resolver(), &PROJECT_SCOPE),
     );
@@ -613,7 +613,7 @@ fn zero_primary_roots_begins_with_additional() {
         &mut store,
         Roots {
             primary: vec![],
-            additional: vec!["lib".to_string()],
+            additional: vec!["lib".into()],
         },
         graph_options(&fs, &sink, &default_resolver(), &PROJECT_SCOPE),
     );

--- a/tests/spec/graph/mod.rs
+++ b/tests/spec/graph/mod.rs
@@ -102,6 +102,22 @@ fn kahn_diamond_dependency() {
 }
 
 #[test]
+fn kahn_ready_package_order_is_stable() {
+    let mut edges = HashMap::default();
+    edges.insert(
+        "a".to_string(),
+        HashSet::from_iter(["b".to_string(), "c".to_string()]),
+    );
+    edges.insert("b".to_string(), HashSet::from_iter(["d".to_string()]));
+    edges.insert("c".to_string(), HashSet::from_iter(["d".to_string()]));
+    edges.insert("d".to_string(), HashSet::default());
+
+    let (order, _) = topological_sort(&DependencyGraph::from(edges));
+
+    assert_eq!(order, ["d", "b", "c", "a"]);
+}
+
+#[test]
 fn kahn_simple_cycle() {
     let mut edges = HashMap::default();
     edges.insert("a".to_string(), HashSet::from_iter(["b".to_string()]));

--- a/tests/spec/representation.rs
+++ b/tests/spec/representation.rs
@@ -1,7 +1,7 @@
 use crate::_harness::infer;
 use syntax::ast::{
-    Annotation, BinaryOperator, CallTypeArguments, ConstructorPatternResolution, Expression,
-    IfLetAlternative, Pattern, SelectArm, Span, StructFieldKind, StructFields,
+    Annotation, BinaryOperator, BindingId, CallTypeArguments, ConstructorPatternResolution,
+    Expression, IfLetAlternative, Pattern, SelectArm, Span, StructFieldKind, StructFields,
 };
 use syntax::lex::Lexer;
 use syntax::parse::Parser;
@@ -68,11 +68,14 @@ fn function_parameter_metadata_survives_type_substitution() {
 #[test]
 fn alias_mutation_is_not_downgraded_by_a_direct_mark() {
     let mut mutations = MutationInfo::default();
-    mutations.record(7, BindingMutation::ThroughAlias);
-    mutations.record(7, BindingMutation::Direct);
+    mutations.record(BindingId::new(7), BindingMutation::ThroughAlias);
+    mutations.record(BindingId::new(7), BindingMutation::Direct);
 
-    assert_eq!(mutations.mutation(7), Some(BindingMutation::ThroughAlias));
-    assert_eq!(mutations.mutation(8), None);
+    assert_eq!(
+        mutations.mutation(BindingId::new(7)),
+        Some(BindingMutation::ThroughAlias),
+    );
+    assert_eq!(mutations.mutation(BindingId::new(8)), None);
 }
 
 #[test]


### PR DESCRIPTION
Replaces various containers, keys, and tuples with a shape closer to the data has, e.g. sets and maps where vecs were scanned, named records where tuples were read by position, newtypes for `BindingId` and `PackageId`, and `Type` as a hash key instead of rendered strings.
