### PR TITLE
fix: count wide characters as two columns when formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ name = "lisette-format"
 version = "0.12.0"
 dependencies = [
  "lisette-syntax",
- "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -501,12 +501,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "=0.12.0", path = "../syntax" }
-unicode-segmentation = "1.11"
+unicode-width = "0.2"
 
 [lints]
 workspace = true

--- a/crates/format/src/lindig.rs
+++ b/crates/format/src/lindig.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -11,12 +11,12 @@ enum Mode {
 
 type PendingDocument<'a, 'doc> = (isize, Mode, &'doc Document<'a>);
 
-/// For ASCII the byte length is already the grapheme count.
-fn grapheme_count(text: &str) -> isize {
+/// For ASCII the byte length is already the display width.
+fn display_width(text: &str) -> isize {
     if text.is_ascii() {
         text.len() as isize
     } else {
-        text.graphemes(true).count() as isize
+        text.width() as isize
     }
 }
 
@@ -71,14 +71,14 @@ fn fits<'a, 'doc>(
             }
 
             Document::Text(s) => {
-                current_width += grapheme_count(s);
+                current_width += display_width(s);
             }
 
             Document::VerbatimText(s) => {
                 if s.contains('\n') {
                     return false;
                 }
-                current_width += grapheme_count(s);
+                current_width += display_width(s);
             }
 
             Document::StrictBreak { unbroken, .. } | Document::FlexBreak { unbroken, .. } => {
@@ -173,7 +173,7 @@ fn format<'a, 'doc>(
 
             Document::Text(s) => {
                 write_pending_indent(output, &mut pending_indent);
-                width += grapheme_count(s);
+                width += display_width(s);
                 output.push_str(s);
             }
 
@@ -182,12 +182,12 @@ fn format<'a, 'doc>(
                 let mut segments = s.split('\n');
                 if let Some(first) = segments.next() {
                     output.push_str(first);
-                    width += grapheme_count(first);
+                    width += display_width(first);
                 }
                 for segment in segments {
                     output.push('\n');
                     output.push_str(segment);
-                    width = grapheme_count(segment);
+                    width = display_width(segment);
                 }
             }
 

--- a/playground/wasm/Cargo.lock
+++ b/playground/wasm/Cargo.lock
@@ -136,7 +136,7 @@ name = "lisette-format"
 version = "0.12.0"
 dependencies = [
  "lisette-syntax",
- "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -362,12 +362,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/tests/spec/format/mod.rs
+++ b/tests/spec/format/mod.rs
@@ -754,6 +754,13 @@ fn line_breaking_long_slice() {
 }
 
 #[test]
+fn line_breaking_wide_character_slice() {
+    assert_format_snapshot!(
+        "fn main() {\n  let weekdays = [\"日曜日\", \"月曜日\", \"火曜日\", \"水曜日\", \"木曜日\", \"金曜日\", \"土曜日\"]\n  let ascii = [\"aaaaaaa\", \"bbbbbbb\", \"ccccccc\", \"ddddddd\", \"eeeeeee\", \"fffffff\", \"ggggggg\"]\n}"
+    );
+}
+
+#[test]
 fn line_breaking_long_tuple() {
     assert_format_snapshot!(
         "fn test() { (first_long_element, second_long_element, third_long_element, fourth_long_element, fifth_long_element) }"

--- a/tests/spec/format/snapshots/line_breaking_wide_character_slice.snap
+++ b/tests/spec/format/snapshots/line_breaking_wide_character_slice.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/format/mod.rs
+description: |-
+  fn main() {
+    let weekdays = ["日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"]
+    let ascii = ["aaaaaaa", "bbbbbbb", "ccccccc", "ddddddd", "eeeeeee", "fffffff", "ggggggg"]
+  }
+---
+fn main() {
+  let weekdays = [
+    "日曜日",
+    "月曜日",
+    "火曜日",
+    "水曜日",
+    "木曜日",
+    "金曜日",
+    "土曜日",
+  ]
+  let ascii = [
+    "aaaaaaa",
+    "bbbbbbb",
+    "ccccccc",
+    "ddddddd",
+    "eeeeeee",
+    "fffffff",
+    "ggggggg",
+  ]
+}


### PR DESCRIPTION
`lis format` now measures line width in display columns, so East Asian wide characters, fullwidth forms, and emoji count as two columns. Before, the formatter counted grapheme clusters, so a line of wide characters could pass the 80-column check and still overflow the margin in every editor.

```rs
fn main() {
  let weekdays = [
    "日曜日",
    "月曜日",
    "火曜日",
    "水曜日",
    "木曜日",
    "金曜日",
    "土曜日",
  ]
}
```

This slice used to stay on one line at 87 columns. ASCII-only files are unaffected.
