### PR TITLE
fix: match arms that spell the same value differently

### DIFF
--- a/crates/passes/src/passes/checks/pattern_analysis/escape.rs
+++ b/crates/passes/src/passes/checks/pattern_analysis/escape.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use syntax::ast::Literal;
-use syntax::lex::string_bytes;
+use syntax::lex::{rune_codepoint, string_bytes};
 
 pub(crate) fn runtime_bytes(literal: &Literal) -> Option<Cow<'_, [u8]>> {
     if let Literal::String { value, raw } = literal {
@@ -10,11 +10,24 @@ pub(crate) fn runtime_bytes(literal: &Literal) -> Option<Cow<'_, [u8]>> {
     }
 }
 
+fn integer_value(literal: &Literal) -> Option<u64> {
+    match literal {
+        Literal::Integer { value, .. } => Some(*value),
+        Literal::Char(text) => rune_codepoint(text).map(u64::from),
+        _ => None,
+    }
+}
+
 pub(crate) fn equals_target(
     candidate: &Literal,
     target: &Literal,
     target_bytes: Option<&[u8]>,
 ) -> bool {
+    if let (Some(candidate_value), Some(target_value)) =
+        (integer_value(candidate), integer_value(target))
+    {
+        return candidate_value == target_value;
+    }
     if let Literal::String { value: cv, raw: cr } = candidate
         && let Literal::String { value: tv, raw: tr } = target
     {
@@ -94,5 +107,53 @@ mod tests {
         let a = s("hello", false);
         let b = s("hello", false);
         assert!(equals_target(&a, &b, None));
+    }
+
+    fn integer(value: u64, text: Option<&str>) -> Literal {
+        Literal::Integer {
+            value,
+            text: text.map(str::to_string),
+        }
+    }
+
+    fn c(text: &str) -> Literal {
+        Literal::Char(text.to_string())
+    }
+
+    #[test]
+    fn integer_spellings_with_same_value_are_equal() {
+        assert!(equal(&integer(1, None), &integer(1, Some("0x1"))));
+        assert!(equal(&integer(1, Some("0b1")), &integer(1, Some("0o1"))));
+        assert!(!equal(&integer(1, None), &integer(2, Some("0x2"))));
+    }
+
+    #[test]
+    fn negative_spellings_with_same_value_are_equal() {
+        let minus_one = 1u64.wrapping_neg();
+        assert!(equal(
+            &integer(minus_one, Some("-1")),
+            &integer(minus_one, Some("-0x1"))
+        ));
+        assert!(!equal(&integer(minus_one, Some("-1")), &integer(1, None)));
+    }
+
+    #[test]
+    fn char_equals_integer_with_its_codepoint() {
+        assert!(equal(&c("a"), &integer(97, None)));
+        assert!(equal(&integer(97, None), &c("a")));
+        assert!(!equal(&c("b"), &integer(97, None)));
+    }
+
+    #[test]
+    fn char_spellings_with_same_codepoint_are_equal() {
+        assert!(equal(&c("a"), &c("\\x61")));
+        assert!(equal(&c("\\n"), &c("\\u{000A}")));
+        assert!(equal(&c("\\n"), &c("\\012")));
+        assert!(!equal(&c("a"), &c("b")));
+    }
+
+    #[test]
+    fn integer_and_string_are_not_equal() {
+        assert!(!equal(&integer(1, None), &s("1", false)));
     }
 }

--- a/tests/spec/pattern_analysis/mod.rs
+++ b/tests/spec/pattern_analysis/mod.rs
@@ -1846,6 +1846,120 @@ fn classify(s: string) -> int {
 }
 
 #[test]
+fn test_redundant_integer_pattern_decimal_vs_hex() {
+    let input = r#"
+fn classify(x: int) -> int {
+  match x {
+    1 => 1,
+    0x1 => 2,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_infer_code_count("redundant_arm", 1);
+}
+
+#[test]
+fn test_redundant_negative_integer_pattern_decimal_vs_hex() {
+    let input = r#"
+fn classify(x: int) -> int {
+  match x {
+    -1 => 1,
+    -0x1 => 2,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_infer_code_count("redundant_arm", 1);
+}
+
+#[test]
+fn test_distinct_integer_spellings_are_not_redundant() {
+    let input = r#"
+fn classify(x: int) -> int {
+  match x {
+    1 => 1,
+    0x2 => 2,
+    -1 => 3,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn test_redundant_rune_pattern_char_vs_integer() {
+    let input = r#"
+fn classify(r: rune) -> int {
+  match r {
+    'a' => 1,
+    97 => 2,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_infer_code_count("redundant_arm", 1);
+}
+
+#[test]
+fn test_redundant_char_pattern_hex_escape_vs_plain() {
+    let input = r#"
+fn classify(r: rune) -> int {
+  match r {
+    'a' => 1,
+    '\x61' => 2,
+    _ => 0,
+  }
+}
+"#;
+    infer(input).assert_infer_code_count("redundant_arm", 1);
+}
+
+const LEVELS_TYPEDEF: &str = r#"
+#[go(closed_domain)]
+pub struct Level(int)
+
+pub const Low: Level = 1
+pub const Medium: Level = 2
+pub const High: Level = 3
+"#;
+
+#[test]
+fn test_redundant_closed_domain_pattern_const_vs_hex() {
+    let input = r#"
+import "go:example.com/levels"
+
+fn classify(l: levels.Level) -> int {
+  match l {
+    levels.Low => 1,
+    0x1 => 2,
+    _ => 0,
+  }
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/levels", LEVELS_TYPEDEF)])
+        .assert_infer_code_count("redundant_arm", 1);
+}
+
+#[test]
+fn test_closed_domain_duplicate_spelling_still_non_exhaustive() {
+    let input = r#"
+import "go:example.com/levels"
+
+fn classify(l: levels.Level) -> int {
+  match l {
+    levels.Low => 1,
+    0x1 => 2,
+    3 => 3,
+  }
+}
+"#;
+    infer_with_go_typedefs(input, &[("go:example.com/levels", LEVELS_TYPEDEF)])
+        .assert_exhaustiveness_error();
+}
+
+#[test]
 fn test_tuple_struct_refutable_field_non_exhaustive() {
     let input = r#"
 struct MP(int, string)


### PR DESCRIPTION
`lis check` now reports a match arm as unreachable when an earlier arm spells the same value differently, such as `1` and `0x1`, or `'a'` and `97` on a `rune`. Before, both arms passed the check and `go build` failed with a duplicate case error.

```rs
fn classify(x: int) -> string {
  match x {
    1 => "one",
    0x1 => "hex one",
    _ => "other",
  }
}
```
