### PR TITLE
refactor: simplify state ownership in `semantics`

### DIFF
--- a/crates/semantics/src/analysis/mod.rs
+++ b/crates/semantics/src/analysis/mod.rs
@@ -22,7 +22,6 @@ use crate::cache::{
     go_stdlib::{self, load_cached_go_package},
     hash_package_source_pair, is_cache_disabled, prelude as prelude_cache, try_load_cache,
 };
-use crate::checker::infer::InferCtx;
 use crate::checker::{PredeclaredPackage, RegisteredPackage, TaskOutput, TaskState};
 use crate::diagnostics::{GoImportSite, emit_for_locator_result};
 use crate::facts::Facts;

--- a/crates/semantics/src/analysis/packages.rs
+++ b/crates/semantics/src/analysis/packages.rs
@@ -608,7 +608,7 @@ fn infer_packages(checker: &mut TaskState, store: &mut Store, packages: Vec<Regi
     let inferred_files = if packages.len() < PARALLEL_THRESHOLD {
         let mut inferred_files = Vec::new();
         for package in packages {
-            inferred_files.extend(InferCtx::new(checker, store).infer_package(package));
+            inferred_files.extend(checker.infer_registered_package(store, package));
         }
         inferred_files
     } else {
@@ -619,7 +619,7 @@ fn infer_packages(checker: &mut TaskState, store: &mut Store, packages: Vec<Regi
             .into_par_iter()
             .map(|package| {
                 let mut worker = seed.spawn();
-                let inferred_files = InferCtx::new(&mut worker, store_ref).infer_package(package);
+                let inferred_files = worker.infer_registered_package(store_ref, package);
                 (worker.into_output(), inferred_files)
             })
             .collect();

--- a/crates/semantics/src/checker/infer/context.rs
+++ b/crates/semantics/src/checker/infer/context.rs
@@ -93,8 +93,6 @@ struct TraversalContext {
     qualifier_invariant: bool,
     /// In parameter position an implementation may demand less permission.
     flipped_qualifier_variance: bool,
-    /// A writable receiver's place key, for the enclosing call's aliased-argument check.
-    pending_writable_receiver: Option<String>,
     use_context: UseContext,
     dot_access_base: bool,
     in_pattern: bool,
@@ -132,13 +130,8 @@ pub(super) struct LetInference {
 pub(super) struct LoopElementInference {
     pub(super) collection: Option<String>,
     pub(super) was_demoted: bool,
-}
-
-pub(super) struct LoopCopyWrite {
-    pub(super) binding_id: BindingId,
-    pub(super) name: String,
-    pub(super) collection: Option<String>,
-    pub(super) span: Span,
+    pub(super) reads: Vec<Span>,
+    pub(super) writes: Vec<Span>,
 }
 
 pub(super) enum BindingInference {
@@ -155,6 +148,13 @@ impl BindingInference {
     }
 
     pub(super) fn as_loop_element(&self) -> Option<&LoopElementInference> {
+        match self {
+            Self::LoopElement(inference) => Some(inference),
+            Self::Let(_) => None,
+        }
+    }
+
+    pub(super) fn as_loop_element_mut(&mut self) -> Option<&mut LoopElementInference> {
         match self {
             Self::LoopElement(inference) => Some(inference),
             Self::Let(_) => None,
@@ -277,12 +277,6 @@ pub(super) struct FileChecks {
     pub(super) select_exhaustiveness: Vec<SelectExhaustivenessCheck>,
 }
 
-impl FileChecks {
-    pub(super) fn is_empty(&self) -> bool {
-        self.branch_subsumptions.is_empty() && self.select_exhaustiveness.is_empty()
-    }
-}
-
 pub struct InferCtx<'a> {
     pub(super) state: &'a mut TaskState,
     pub(crate) store: &'a Store,
@@ -290,8 +284,6 @@ pub struct InferCtx<'a> {
     pub(crate) satisfying_stack: FxHashSet<(String, String)>,
     pub(super) reported_immutable: FxHashSet<BindingId>,
     pub(super) binding_inference: FxHashMap<BindingId, BindingInference>,
-    pub(super) loop_element_reads: FxHashMap<BindingId, Vec<Span>>,
-    pub(super) pending_loop_copy_writes: Vec<LoopCopyWrite>,
     pub(super) reported_read_only_writes: FxHashSet<(BindingId, String)>,
     /// By span, for the diagnostic when the construction misses a writable expectation.
     pub(super) read_only_constructions: FxHashMap<Span, Vec<diagnostics::infer::ReadOnlyComponent>>,
@@ -307,8 +299,6 @@ impl<'a> InferCtx<'a> {
             satisfying_stack: FxHashSet::default(),
             reported_immutable: FxHashSet::default(),
             binding_inference: FxHashMap::default(),
-            loop_element_reads: FxHashMap::default(),
-            pending_loop_copy_writes: Vec::new(),
             reported_read_only_writes: FxHashSet::default(),
             read_only_constructions: FxHashMap::default(),
             traversal: TraversalContext::default(),
@@ -401,19 +391,6 @@ impl<'a> InferCtx<'a> {
 
     pub(super) fn with_value_context<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         self.with_use_context(UseContext::Value, f)
-    }
-
-    pub(super) fn with_callee_context<T>(
-        &mut self,
-        f: impl FnOnce(&mut Self) -> T,
-    ) -> (T, Option<String>) {
-        debug_assert!(
-            self.traversal.pending_writable_receiver.is_none(),
-            "a writable receiver must be consumed by its enclosing call"
-        );
-        let result = self.with_use_context(UseContext::Callee, f);
-        let writable_receiver = self.traversal.pending_writable_receiver.take();
-        (result, writable_receiver)
     }
 
     pub(super) fn with_expectation<T>(
@@ -559,14 +536,6 @@ impl<'a> InferCtx<'a> {
         self.traversal.flipped_qualifier_variance
     }
 
-    pub(super) fn stash_writable_receiver(&mut self, place: String) {
-        debug_assert!(
-            self.traversal.pending_writable_receiver.is_none(),
-            "one callee cannot register multiple writable receivers"
-        );
-        self.traversal.pending_writable_receiver = Some(place);
-    }
-
     pub(super) fn in_flipped_qualifier_variance<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         let previous = self.traversal.flipped_qualifier_variance;
         self.traversal.flipped_qualifier_variance = !previous;
@@ -600,6 +569,8 @@ impl DerefMut for InferCtx<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::checker::EnvResolve;
+    use crate::checker::infer::unify::UnifyError;
     use crate::store;
 
     #[test]
@@ -637,5 +608,61 @@ mod tests {
         let diagnostics = task.sink.into_diagnostics();
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].plain_message(), "reported");
+    }
+
+    #[test]
+    fn unification_resolves_bound_variables_before_comparing_either_side() {
+        let mut task = TaskState::for_package(store::ENTRY_PACKAGE_ID);
+        let store = Store::new();
+        let mut ctx = InferCtx::new(&mut task, &store);
+        let a = ctx.new_type_var();
+        let b = ctx.new_type_var();
+        let span = Span::dummy();
+        ctx.try_unify(&a, &b, &span).unwrap();
+        ctx.try_unify(&Type::int(), &b, &span).unwrap();
+
+        assert_eq!(a.resolve_in(&ctx.env), Type::int());
+        assert_eq!(
+            ctx.try_unify(&a, &Type::string(), &span),
+            Err(UnifyError::TypeMismatch)
+        );
+        assert_eq!(
+            ctx.try_unify(&Type::string(), &a, &span),
+            Err(UnifyError::TypeMismatch)
+        );
+    }
+
+    #[test]
+    fn unification_rejects_recursive_bindings_through_variable_chains() {
+        let mut task = TaskState::for_package(store::ENTRY_PACKAGE_ID);
+        let store = Store::new();
+        let mut ctx = InferCtx::new(&mut task, &store);
+        let a = ctx.new_type_var();
+        let b = ctx.new_type_var();
+        let span = Span::dummy();
+        ctx.try_unify(&a, &b, &span).unwrap();
+
+        assert_eq!(
+            ctx.try_unify(&b, &Type::Tuple(vec![a.clone()]), &span),
+            Err(UnifyError::InfiniteType)
+        );
+        assert_eq!(b.resolve_in(&ctx.env), b);
+        assert_eq!(ctx.try_unify(&a, &a, &span), Ok(()));
+    }
+
+    #[test]
+    fn error_unification_reaches_variables_inside_arrays() {
+        let mut task = TaskState::for_package(store::ENTRY_PACKAGE_ID);
+        let store = Store::new();
+        let mut ctx = InferCtx::new(&mut task, &store);
+        let element = ctx.new_type_var();
+        let array = Type::Array {
+            length: 2,
+            element: Box::new(element.clone()),
+        };
+
+        ctx.try_unify(&Type::Error, &array, &Span::dummy()).unwrap();
+
+        assert_eq!(element.resolve_in(&ctx.env), Type::Error);
     }
 }

--- a/crates/semantics/src/checker/infer/expressions/call_effects.rs
+++ b/crates/semantics/src/checker/infer/expressions/call_effects.rs
@@ -1,12 +1,37 @@
 use crate::checker::EnvResolve;
 use syntax::ast::{Expression, Span, StructFields};
-use syntax::program::{CallKind, Definition, DefinitionBody, NativeTypeKind};
+use syntax::program::{CallKind, Definition, DefinitionBody, DotAccessResolution, NativeTypeKind};
 use syntax::types::{FunctionParameter, Symbol, Type, peel_to_range_type};
 
 use crate::checker::infer::InferCtx;
 use syntax::program::AliasKind;
 
 impl InferCtx<'_> {
+    pub(super) fn writable_receiver_place(&mut self, callee: &Expression) -> Option<String> {
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            resolution: DotAccessResolution::InstanceMethod { .. },
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return None;
+        };
+        let receiver_ty = receiver.get_type().resolve_in(&self.env).strip_refs();
+        let store = self.store;
+        let method = self.method_of_type(store, &receiver_ty, member)?;
+        let Type::Function(function) = method.ty.unwrap_forall() else {
+            return None;
+        };
+        if !self
+            .store
+            .parameter_grants_write(&function.params.first()?.ty)
+        {
+            return None;
+        }
+        super::aliasing::place_key(receiver.unwrap_parens())
+    }
+
     pub(super) fn classify_call(&mut self, callee: &Expression) -> CallKind {
         let store = self.store;
         let callee = callee.unwrap_parens();

--- a/crates/semantics/src/checker/infer/expressions/calls.rs
+++ b/crates/semantics/src/checker/infer/expressions/calls.rs
@@ -11,7 +11,7 @@ use syntax::types::{
     unqualified_name,
 };
 
-use super::super::context::{Expectation, ExpectationRole};
+use super::super::context::{Expectation, ExpectationRole, UseContext};
 use super::super::unify::Dispatched;
 use super::permission::{ConstructionGrant, MissingSupply};
 use super::struct_call::same_nominal;
@@ -167,8 +167,10 @@ impl InferCtx<'_> {
         let store = self.store;
         let callee_ty = self.new_type_var();
 
-        let (callee_expression, writable_receiver) =
-            self.with_callee_context(|state| state.infer_expression(*expression, &callee_ty));
+        let callee_expression = self.with_use_context(UseContext::Callee, |state| {
+            state.infer_expression(*expression, &callee_ty)
+        });
+        let writable_receiver = self.writable_receiver_place(&callee_expression);
 
         let forall_ty = self.resolve_callee_forall_type(&callee_expression, &type_args);
         let (callee_ty, type_arguments) =

--- a/crates/semantics/src/checker/infer/expressions/comparison.rs
+++ b/crates/semantics/src/checker/infer/expressions/comparison.rs
@@ -459,21 +459,15 @@ fn bound_satisfies(store: &Store, start: &Type, target: &Type) -> bool {
 }
 
 pub(crate) fn param_is_comparable(scopes: &Scopes, env: &TypeEnv, param_name: &str) -> bool {
-    let mut found = false;
-    scopes.for_each_bound_on_param(param_name, |bound_ty| {
-        if found {
-            return;
-        }
-        if let Some(declared) = bound_ty
+    scopes.bounds_on_param(param_name).iter().any(|bound_ty| {
+        bound_ty
             .resolve_in(env)
             .get_qualified_id()
             .and_then(super::super::unify::BuiltinBound::from_qualified_id)
-            && declared.satisfies(super::super::unify::BuiltinBound::Comparable)
-        {
-            found = true;
-        }
-    });
-    found
+            .is_some_and(|declared| {
+                declared.satisfies(super::super::unify::BuiltinBound::Comparable)
+            })
+    })
 }
 
 fn interface_bound_guarantees_equals(store: &Store, bound: &Type, param_name: &str) -> bool {
@@ -493,16 +487,9 @@ pub(crate) fn param_is_equatable(
     if param_is_comparable(scopes, env, param_name) {
         return true;
     }
-    let mut found = false;
-    scopes.for_each_bound_on_param(param_name, |bound_ty| {
-        if found {
-            return;
-        }
-        if interface_bound_guarantees_equals(store, &bound_ty.resolve_in(env), param_name) {
-            found = true;
-        }
-    });
-    found
+    scopes.bounds_on_param(param_name).iter().any(|bound_ty| {
+        interface_bound_guarantees_equals(store, &bound_ty.resolve_in(env), param_name)
+    })
 }
 
 impl InferCtx<'_> {

--- a/crates/semantics/src/checker/infer/expressions/loops.rs
+++ b/crates/semantics/src/checker/infer/expressions/loops.rs
@@ -1,9 +1,7 @@
 use std::mem;
 
 use crate::checker::EnvResolve;
-use crate::checker::infer::context::{
-    BindingInference, LoopContext, LoopCopyWrite, LoopElementInference,
-};
+use crate::checker::infer::context::{BindingInference, LoopContext, LoopElementInference};
 use syntax::ast::BindingKind;
 use syntax::ast::{Binding, BindingId, Expression, Pattern, Span};
 use syntax::types::Type;
@@ -203,6 +201,8 @@ impl InferCtx<'_> {
                     BindingInference::LoopElement(LoopElementInference {
                         collection,
                         was_demoted: demoted_from_writable,
+                        reads: Vec::new(),
+                        writes: Vec::new(),
                     }),
                 );
             }
@@ -251,51 +251,47 @@ impl InferCtx<'_> {
         };
         let Some(inference) = self
             .binding_inference
-            .get(&binding_id)
-            .and_then(|binding| binding.as_loop_element())
+            .get_mut(&binding_id)
+            .and_then(|binding| binding.as_loop_element_mut())
         else {
             return;
         };
-        self.pending_loop_copy_writes.push(LoopCopyWrite {
-            binding_id,
-            name: name.to_string(),
-            collection: inference.collection.clone(),
-            span,
-        });
+        inference.writes.push(span);
     }
 
     fn report_dead_loop_copy_writes(&mut self, binding_id: BindingId, body: &Expression) {
-        let (writes, other_writes): (Vec<_>, Vec<_>) =
-            mem::take(&mut self.pending_loop_copy_writes)
-                .into_iter()
-                .partition(|write| write.binding_id == binding_id);
-        self.pending_loop_copy_writes = other_writes;
-        let reads = self
-            .loop_element_reads
-            .remove(&binding_id)
-            .unwrap_or_default();
+        let Some(inference) = self
+            .binding_inference
+            .get_mut(&binding_id)
+            .and_then(|binding| binding.as_loop_element_mut())
+        else {
+            return;
+        };
+        let writes = mem::take(&mut inference.writes);
+        let reads = mem::take(&mut inference.reads);
         if writes.is_empty() {
             return;
         }
         let mut nested_loops = Vec::new();
         let mut lambdas = Vec::new();
         collect_nested_loop_and_lambda_spans(body, &mut nested_loops, &mut lambdas);
-        let observes = |read: &Span, write: &LoopCopyWrite| {
-            read.byte_offset >= write.span.end()
+        let observes = |read: &Span, write: &Span| {
+            read.byte_offset >= write.end()
                 || lambdas.iter().any(|lambda| span_contains(lambda, read))
                 || nested_loops.iter().any(|nested_loop| {
-                    span_contains(nested_loop, read) && span_contains(nested_loop, &write.span)
+                    span_contains(nested_loop, read) && span_contains(nested_loop, write)
                 })
         };
         let dead_write = writes
             .iter()
             .find(|write| !reads.iter().any(|read| observes(read, write)));
         if let Some(write) = dead_write {
-            self.sink.push(diagnostics::infer::loop_copy_write(
-                &write.name,
-                write.collection.as_deref(),
-                write.span,
-            ));
+            let diagnostic = diagnostics::infer::loop_copy_write(
+                &self.state.facts.bindings[&binding_id].name,
+                inference.collection.as_deref(),
+                *write,
+            );
+            self.sink.push(diagnostic);
         }
     }
 

--- a/crates/semantics/src/checker/infer/expressions/method_access.rs
+++ b/crates/semantics/src/checker/infer/expressions/method_access.rs
@@ -325,11 +325,6 @@ impl InferCtx<'_> {
 
         if self.store.parameter_grants_write(&receiver_ty) {
             self.mark_place_root_mutated(receiver_expression);
-            if self.is_callee_context()
-                && let Some(place) = super::aliasing::place_key(receiver_expression.unwrap_parens())
-            {
-                self.stash_writable_receiver(place);
-            }
         }
 
         match (receiver_is_ref, actual_is_ref) {

--- a/crates/semantics/src/checker/infer/expressions/primitives.rs
+++ b/crates/semantics/src/checker/infer/expressions/primitives.rs
@@ -260,12 +260,12 @@ impl InferCtx<'_> {
             // Don't mark assignment targets as "used" - only mark actual uses
             if !self.is_assignment_target_context() {
                 self.facts.mark_used(id);
-                if self
+                if let Some(inference) = self
                     .binding_inference
-                    .get(&id)
-                    .is_some_and(|binding| binding.as_loop_element().is_some())
+                    .get_mut(&id)
+                    .and_then(|binding| binding.as_loop_element_mut())
                 {
-                    self.loop_element_reads.entry(id).or_default().push(span);
+                    inference.reads.push(span);
                 }
             }
 

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -369,8 +369,7 @@ impl InferCtx<'_> {
     fn own_candidate(&self, resolved: &Type, method: &str) -> Option<ConformanceCandidate> {
         let id = resolved.get_qualified_id()?;
         if self.store.get_interface(id).is_some() {
-            self.store
-                .get_method_for_type(resolved, &Default::default(), method)?;
+            self.store.get_method_for_type(resolved, method)?;
         } else {
             self.store.get_method(id, method)?;
         }
@@ -412,13 +411,11 @@ impl InferCtx<'_> {
         let Type::Parameter(name) = resolved else {
             return None;
         };
-        let bounds = self.scopes.collect_all_trait_bounds();
         let qualified = self.qualify_name(name);
-        bounds.get(&qualified)?.iter().find_map(|bound| {
+        self.scopes.bounds_on_param(name).iter().find_map(|bound| {
             let interface_ty = self.store.deep_resolve_alias(bound);
             interface_ty.get_qualified_id()?;
-            self.store
-                .get_method_for_type(&interface_ty, &Default::default(), method)?;
+            self.store.get_method_for_type(&interface_ty, method)?;
             Some(ConformanceCandidate::Resolved {
                 depth: 0,
                 owner: qualified.as_eco().clone(),

--- a/crates/semantics/src/checker/infer/mod.rs
+++ b/crates/semantics/src/checker/infer/mod.rs
@@ -33,17 +33,18 @@ impl TaskState {
 
     /// Infer one registered package and install its typed ASTs.
     pub fn infer_package(&mut self, store: &mut Store, package: RegisteredPackage) {
-        let inferred_files = InferCtx::new(self, store).infer_package(package);
+        let inferred_files = self.infer_registered_package(store, package);
         Self::install_inferred_files(store, inferred_files);
     }
-}
 
-impl InferCtx<'_> {
-    pub(crate) fn infer_package(&mut self, package: RegisteredPackage) -> Vec<InferredFile> {
+    pub(crate) fn infer_registered_package(
+        &mut self,
+        store: &Store,
+        package: RegisteredPackage,
+    ) -> Vec<InferredFile> {
         let package_id = package.id;
         let (files, typedefs): (Vec<_>, Vec<_>) = package.files.into_iter().partition(|file| {
-            !self
-                .store
+            !store
                 .get_file(file.id)
                 .expect("registered file must remain in the store")
                 .is_d_lis()
@@ -53,7 +54,7 @@ impl InferCtx<'_> {
 
         let mut inferred: Vec<_> = files
             .into_iter()
-            .map(|file| self.infer_file(&package_id, file))
+            .map(|file| InferCtx::new(self, store).infer_file(&package_id, file))
             .collect();
         inferred.extend(
             typedefs
@@ -65,16 +66,14 @@ impl InferCtx<'_> {
         );
         inferred
     }
+}
 
-    fn infer_file(&mut self, package_id: &str, file: RegistrationFile) -> InferredFile {
-        assert!(
-            self.file_checks.is_empty(),
-            "file checks from the previous file must be resolved"
-        );
+impl InferCtx<'_> {
+    fn infer_file(mut self, package_id: &str, file: RegistrationFile) -> InferredFile {
         let file_id = file.id;
         let imports = file.imports;
 
-        let inferred = self.with_file_context(
+        self.with_file_context(
             FileContext::Standard {
                 package_id,
                 file_id,
@@ -110,12 +109,7 @@ impl InferCtx<'_> {
                     items: frozen_items,
                 }
             },
-        );
-        assert!(
-            self.file_checks.is_empty(),
-            "file checks must be resolved before inference returns"
-        );
-        inferred
+        )
     }
 
     fn check_definition_package_collisions(

--- a/crates/semantics/src/checker/infer/unify.rs
+++ b/crates/semantics/src/checker/infer/unify.rs
@@ -2,11 +2,10 @@ use crate::checker::EnvResolve;
 use Type::{Function, Nominal};
 use diagnostics::LisetteDiagnostic;
 use syntax::ast::Span;
-use syntax::types::{Bound, CompoundKind, Type, TypeVarId};
+use syntax::types::{Bound, CompoundKind, Type};
 
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::context::{Expectation, ExpectationRole};
-use crate::checker::type_env::VarState;
 use syntax::types::FunctionParameter;
 use syntax::types::SimpleKind;
 
@@ -179,8 +178,14 @@ impl InferCtx<'_> {
                 }
             }
 
-            (Type::Var { id, .. }, _) => self.unify_type_variable(*id, &r2, span, false),
-            (_, Type::Var { id, .. }) => self.unify_type_variable(*id, &r1, span, true),
+            // Shallow resolution above leaves only unbound variables here.
+            (Type::Var { id, .. }, other) | (other, Type::Var { id, .. }) => {
+                if self.env.occurs(*id, other) {
+                    return Err(UnifyError::InfiniteType);
+                }
+                self.env.bind(*id, other.clone());
+                Ok(())
+            }
 
             _ if r1_is_unknown && self.is_inside_invariant_position() => {
                 Err(UnifyError::TypeMismatch)
@@ -201,11 +206,11 @@ impl InferCtx<'_> {
             _ if matches!(r1, Type::Never) => Err(UnifyError::TypeMismatch),
 
             _ if matches!(r1, Type::Error) => {
-                self.collapse_vars_to_error(&r2, span);
+                self.collapse_vars_to_error(&r2);
                 Ok(())
             }
             _ if matches!(r2, Type::Error) => {
-                self.collapse_vars_to_error(&r1, span);
+                self.collapse_vars_to_error(&r1);
                 Ok(())
             }
 
@@ -369,61 +374,13 @@ impl InferCtx<'_> {
         }
     }
 
-    fn collapse_vars_to_error(&mut self, ty: &Type, span: &Span) {
+    fn collapse_vars_to_error(&mut self, ty: &Type) {
         let resolved = self.env.shallow_resolve(ty);
-        match resolved {
-            Type::Var { id, .. } => {
-                let _ = self.unify_type_variable(id, &Type::Error, span, false);
-            }
-            Nominal { params, .. } => {
-                for p in params {
-                    self.collapse_vars_to_error(&p, span);
-                }
-            }
-            Function(f) => {
-                for p in &f.params {
-                    self.collapse_vars_to_error(&p.ty, span);
-                }
-                self.collapse_vars_to_error(&f.return_type, span);
-            }
-            Type::Tuple(elems) => {
-                for e in elems {
-                    self.collapse_vars_to_error(&e, span);
-                }
-            }
-            Type::Compound { args, .. } => {
-                for a in args {
-                    self.collapse_vars_to_error(&a, span);
-                }
-            }
-            Type::Forall { body, .. } => {
-                self.collapse_vars_to_error(&body, span);
-            }
-            _ => {}
-        }
-    }
-
-    fn unify_type_variable(
-        &mut self,
-        id: TypeVarId,
-        other_ty: &Type,
-        span: &Span,
-        var_on_right: bool,
-    ) -> Result<(), UnifyError> {
-        match self.env.state(id).clone() {
-            VarState::Bound(ty) => {
-                if var_on_right {
-                    self.try_unify(other_ty, &ty, span)
-                } else {
-                    self.try_unify(&ty, other_ty, span)
-                }
-            }
-            VarState::Unbound => {
-                if self.env.occurs(id, other_ty) {
-                    return Err(UnifyError::InfiniteType);
-                }
-                self.env.bind(id, other_ty.clone());
-                Ok(())
+        if let Type::Var { id, .. } = resolved {
+            self.env.bind(id, Type::Error);
+        } else {
+            for child in resolved.children() {
+                self.collapse_vars_to_error(child);
             }
         }
     }

--- a/crates/semantics/src/checker/infer/validation/const_cycles.rs
+++ b/crates/semantics/src/checker/infer/validation/const_cycles.rs
@@ -3,7 +3,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use ecow::EcoString;
 use syntax::ast::{Expression, IdentifierResolution, Span};
 
-use crate::checker::infer::InferCtx;
+use crate::checker::TaskState;
 
 struct ConstEntry<'a> {
     name: &'a EcoString,
@@ -16,7 +16,7 @@ struct ConstNode<'a> {
     span: Span,
 }
 
-impl InferCtx<'_> {
+impl TaskState {
     pub fn check_const_cycles(&mut self, items_per_file: &[&[Expression]]) {
         let mut consts: Vec<ConstEntry<'_>> = Vec::new();
         for items in items_per_file {

--- a/crates/semantics/src/checker/mod.rs
+++ b/crates/semantics/src/checker/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use registration::PredeclaredPackage;
 pub use registration::RegisteredPackage;
 pub use state::{Cursor, TaskState};
 pub(crate) use state::{InferredFile, TaskOutput};
-pub use type_env::{EnvResolve, TypeEnv, VarState};
+pub use type_env::{EnvResolve, TypeEnv};
 
 impl TaskState {
     fn is_d_lis(&self, store: &Store) -> bool {
@@ -68,8 +68,7 @@ impl TaskState {
 
     pub(crate) fn put_in_scope(&mut self, generics: &[Generic]) {
         for (index, generic) in generics.iter().enumerate() {
-            self.scopes
-                .insert_type_param(self.qualify_name(&generic.name), index);
+            self.scopes.insert_type_param(&generic.name, index);
         }
     }
 
@@ -115,21 +114,16 @@ impl TaskState {
     }
 
     fn parameter_satisfies_bound(&self, parameter: &str, target: infer::BuiltinBound) -> bool {
-        let mut found = false;
-        self.scopes.for_each_bound_on_param(parameter, |bound_ty| {
-            if found {
-                return;
-            }
-            if let Some(declared) = bound_ty
-                .resolve_in(&self.env)
-                .get_qualified_id()
-                .and_then(infer::BuiltinBound::from_qualified_id)
-                && declared.satisfies(target)
-            {
-                found = true;
-            }
-        });
-        found
+        self.scopes
+            .bounds_on_param(parameter)
+            .iter()
+            .any(|bound_ty| {
+                bound_ty
+                    .resolve_in(&self.env)
+                    .get_qualified_id()
+                    .and_then(infer::BuiltinBound::from_qualified_id)
+                    .is_some_and(|declared| declared.satisfies(target))
+            })
     }
 
     fn register_bound_annotation(

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -791,8 +791,7 @@ impl TaskState {
             .collect();
 
         for (i, (name, param_span)) in undeclared.iter().enumerate() {
-            self.scopes
-                .insert_type_param(self.qualify_name(name), generics.len() + i);
+            self.scopes.insert_type_param(name, generics.len() + i);
             self.sink
                 .push(diagnostics::infer::undeclared_impl_type_param(
                     name,

--- a/crates/semantics/src/checker/registration/generic_bounds.rs
+++ b/crates/semantics/src/checker/registration/generic_bounds.rs
@@ -201,11 +201,12 @@ impl TaskState {
         own_generics: &[Generic],
     ) -> Option<Vec<Type>> {
         if self.scopes.lookup_type_param(parameter_name).is_some() {
-            let mut bounds = Vec::new();
-            self.scopes
-                .for_each_bound_on_param(parameter_name, |bound| {
-                    bounds.push(bound.resolve_in(&self.env));
-                });
+            let bounds: Vec<_> = self
+                .scopes
+                .bounds_on_param(parameter_name)
+                .iter()
+                .map(|bound| bound.resolve_in(&self.env))
+                .collect();
             return (!bounds.iter().any(Type::contains_error)).then_some(bounds);
         }
         let generic = own_generics

--- a/crates/semantics/src/checker/resolution.rs
+++ b/crates/semantics/src/checker/resolution.rs
@@ -380,9 +380,12 @@ impl TaskState {
 
     pub(super) fn get_all_methods(&mut self, store: &Store, ty: &Type) -> Methods {
         if let Type::Parameter(name) = ty {
-            let trait_bounds = self.scopes.collect_all_trait_bounds();
-            let qualified_name = self.qualify_name(name);
-            return store.get_methods_from_bounds(&qualified_name, trait_bounds);
+            return self
+                .scopes
+                .bounds_on_param(name)
+                .iter()
+                .flat_map(|bound| store.get_all_methods(bound))
+                .collect();
         }
 
         let resolved = ty.strip_refs().resolve_in(&self.env);
@@ -396,13 +399,11 @@ impl TaskState {
         if let Type::Nominal { id, .. } = &peeled
             && store.get_interface(id).is_some()
         {
-            let empty = HashMap::default();
-            store.get_all_methods(&peeled, &empty)
+            store.get_all_methods(&peeled)
         } else if promotion::has_direct_embed(store, &resolved) {
             promotion::promoted_method_set(store, &resolved)
         } else {
-            let empty = HashMap::default();
-            store.get_all_methods(&resolved, &empty)
+            store.get_all_methods(&resolved)
         }
     }
 
@@ -413,9 +414,12 @@ impl TaskState {
         name: &str,
     ) -> Option<Method> {
         if let Type::Parameter(parameter) = ty {
-            let trait_bounds = self.scopes.collect_all_trait_bounds();
-            let qualified_name = self.qualify_name(parameter);
-            return store.get_method_from_bounds(&qualified_name, trait_bounds, name);
+            return self
+                .scopes
+                .bounds_on_param(parameter)
+                .iter()
+                .rev()
+                .find_map(|bound| store.get_method_for_type(bound, name));
         }
 
         let resolved = ty.strip_refs().resolve_in(&self.env);
@@ -429,13 +433,11 @@ impl TaskState {
         if let Type::Nominal { id, .. } = &peeled
             && store.get_interface(id).is_some()
         {
-            let empty = HashMap::default();
-            store.get_method_for_type(&peeled, &empty, name)
+            store.get_method_for_type(&peeled, name)
         } else if promotion::has_direct_embed(store, &resolved) {
             promotion::promoted_method(store, &resolved, name)
         } else {
-            let empty = HashMap::default();
-            store.get_method_for_type(&resolved, &empty, name)
+            store.get_method_for_type(&resolved, name)
         }
     }
 

--- a/crates/semantics/src/checker/scopes.rs
+++ b/crates/semantics/src/checker/scopes.rs
@@ -1,9 +1,9 @@
 use ecow::EcoString;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::mem;
 use syntax::ast::BindingId;
 use syntax::ast::Span;
-use syntax::types::{Symbol, Type};
+use syntax::types::Type;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TryCarrier {
@@ -93,7 +93,7 @@ struct ScopedValue {
 #[derive(Debug, Clone)]
 struct GenericParameter {
     index: usize,
-    qualified: Symbol,
+    bounds: Vec<Type>,
 }
 
 #[derive(Debug)]
@@ -142,7 +142,6 @@ impl FunctionContext {
 pub struct Scope {
     values: HashMap<String, ScopedValue>,
     generic_parameters: HashMap<String, GenericParameter>,
-    shadowed_trait_bounds: Vec<(Symbol, Vec<Type>)>,
     function: Option<FunctionContext>,
     propagation_context: PropagationContext,
     impl_receiver_type: Option<Type>,
@@ -160,7 +159,6 @@ impl Scope {
         Scope {
             values: HashMap::default(),
             generic_parameters: HashMap::default(),
-            shadowed_trait_bounds: Vec::new(),
             function: None,
             propagation_context: PropagationContext::None,
             impl_receiver_type: None,
@@ -224,7 +222,6 @@ impl Scope {
 
 pub struct Scopes {
     stack: Vec<Scope>,
-    visible_trait_bounds: HashMap<Symbol, Vec<Type>>,
 }
 
 impl Default for Scopes {
@@ -237,7 +234,6 @@ impl Scopes {
     pub(crate) fn new() -> Self {
         Scopes {
             stack: vec![Scope::new()],
-            visible_trait_bounds: HashMap::default(),
         }
     }
 
@@ -257,13 +253,7 @@ impl Scopes {
 
     pub(crate) fn pop(&mut self) {
         assert!(self.stack.len() > 1, "root scope cannot be popped");
-        let scope = self.stack.pop().expect("scope stack must not be empty");
-        for parameter in scope.generic_parameters.values() {
-            self.visible_trait_bounds.remove(&parameter.qualified);
-        }
-        for (qualified, bounds) in scope.shadowed_trait_bounds {
-            self.visible_trait_bounds.insert(qualified, bounds);
-        }
+        self.stack.pop();
     }
 
     /// Look up a value by walking the scope stack from top to bottom.
@@ -359,33 +349,24 @@ impl Scopes {
         })
     }
 
-    pub(crate) fn insert_type_param(&mut self, qualified: Symbol, index: usize) {
-        let name = qualified.last_segment().to_string();
-        let shadowed = self
-            .visible_trait_bounds
-            .keys()
-            .find(|visible| visible.last_segment() == name)
-            .cloned()
-            .and_then(|visible| self.visible_trait_bounds.remove_entry(&visible));
-        if let Some(shadowed) = shadowed {
-            self.current_mut().shadowed_trait_bounds.push(shadowed);
-        }
-        self.current_mut()
-            .generic_parameters
-            .insert(name, GenericParameter { index, qualified });
+    pub(crate) fn insert_type_param(&mut self, name: &str, index: usize) {
+        self.current_mut().generic_parameters.insert(
+            name.to_string(),
+            GenericParameter {
+                index,
+                bounds: Vec::new(),
+            },
+        );
     }
 
     pub(crate) fn insert_trait_bound(&mut self, parameter: &str, bound: Type) {
-        let qualified = self
-            .current()
+        let parameter = self
+            .current_mut()
             .generic_parameters
-            .get(parameter)
-            .expect("a generic parameter must be in scope before recording its bounds")
-            .qualified
-            .clone();
-        let bounds = self.visible_trait_bounds.entry(qualified).or_default();
-        if !bounds.contains(&bound) {
-            bounds.push(bound);
+            .get_mut(parameter)
+            .expect("a generic parameter must be in scope before recording its bounds");
+        if !parameter.bounds.contains(&bound) {
+            parameter.bounds.push(bound);
         }
     }
 
@@ -496,21 +477,23 @@ impl Scopes {
         names
     }
 
-    pub(crate) fn collect_all_trait_bounds(&self) -> &HashMap<Symbol, Vec<Type>> {
-        &self.visible_trait_bounds
+    pub(crate) fn visible_parameter_bounds(&self) -> impl Iterator<Item = (&str, &[Type])> {
+        let mut seen = HashSet::default();
+        self.stack
+            .iter()
+            .rev()
+            .flat_map(|scope| &scope.generic_parameters)
+            .filter(move |(name, _)| seen.insert(name.as_str()))
+            .filter(|(_, parameter)| !parameter.bounds.is_empty())
+            .map(|(name, parameter)| (name.as_str(), parameter.bounds.as_slice()))
     }
 
-    pub(crate) fn for_each_bound_on_param<F: FnMut(&Type)>(&self, param_name: &str, mut visit: F) {
-        for scope in self.stack.iter().rev() {
-            if let Some(parameter) = scope.generic_parameters.get(param_name) {
-                if let Some(bounds) = self.visible_trait_bounds.get(&parameter.qualified) {
-                    for bound in bounds {
-                        visit(bound);
-                    }
-                }
-                return;
-            }
-        }
+    pub(crate) fn bounds_on_param(&self, name: &str) -> &[Type] {
+        self.stack
+            .iter()
+            .rev()
+            .find_map(|scope| scope.generic_parameters.get(name))
+            .map_or(&[], |parameter| parameter.bounds.as_slice())
     }
 
     pub(crate) fn mark_test_handle(&mut self) {
@@ -691,27 +674,60 @@ mod tests {
     #[test]
     fn inner_type_parameter_shadows_outer_bounds_without_declaring_its_own() {
         let mut scopes = Scopes::new();
-        scopes.insert_type_param(Symbol::from_parts("package", "T"), 0);
+        scopes.insert_type_param("T", 0);
         scopes.insert_trait_bound("T", Type::Error);
         scopes.push();
-        scopes.insert_type_param(Symbol::from_parts("package", "T"), 0);
+        scopes.insert_type_param("T", 0);
 
-        let bounds = scopes.collect_all_trait_bounds();
-
-        assert!(bounds.is_empty());
+        assert_eq!(scopes.visible_parameter_bounds().count(), 0);
+        assert!(scopes.bounds_on_param("T").is_empty());
     }
 
     #[test]
     fn popping_type_parameter_scope_restores_outer_bounds() {
         let mut scopes = Scopes::new();
-        let outer = Symbol::from_parts("package", "T");
-        scopes.insert_type_param(outer.clone(), 0);
+        scopes.insert_type_param("T", 0);
         scopes.insert_trait_bound("T", Type::Error);
         scopes.push();
-        scopes.insert_type_param(Symbol::from_parts("package.function", "T"), 0);
+        scopes.insert_type_param("T", 0);
 
         scopes.pop();
 
-        assert_eq!(scopes.collect_all_trait_bounds()[&outer], [Type::Error]);
+        assert_eq!(scopes.bounds_on_param("T"), [Type::Error]);
+    }
+
+    #[test]
+    fn redeclaring_a_parameter_does_not_resurrect_its_bounds_after_pop() {
+        let mut scopes = Scopes::new();
+        scopes.insert_type_param("T", 0);
+        scopes.insert_trait_bound("T", Type::int());
+        scopes.push();
+        scopes.insert_type_param("T", 1);
+        scopes.insert_trait_bound("T", Type::string());
+        scopes.insert_type_param("T", 2);
+        scopes.insert_trait_bound("T", Type::bool());
+
+        scopes.pop();
+
+        assert_eq!(scopes.bounds_on_param("T"), [Type::int()]);
+        assert_eq!(scopes.lookup_type_param("T"), Some(0));
+    }
+
+    #[test]
+    fn visible_bounds_use_the_nearest_parameter_and_keep_unshadowed_parameters() {
+        let mut scopes = Scopes::new();
+        scopes.insert_type_param("T", 0);
+        scopes.insert_trait_bound("T", Type::int());
+        scopes.insert_type_param("U", 1);
+        scopes.insert_trait_bound("U", Type::string());
+        scopes.push();
+        scopes.insert_type_param("T", 0);
+        scopes.insert_trait_bound("T", Type::bool());
+        scopes.insert_trait_bound("T", Type::bool());
+
+        let bounds: HashMap<_, _> = scopes.visible_parameter_bounds().collect();
+
+        assert_eq!(bounds["T"], [Type::bool()]);
+        assert_eq!(bounds["U"], [Type::string()]);
     }
 }

--- a/crates/semantics/src/checker/type_env.rs
+++ b/crates/semantics/src/checker/type_env.rs
@@ -14,7 +14,7 @@ use syntax::types::FunctionParameter;
 use syntax::types::{Bound, Type, TypeVarId};
 
 #[derive(Debug, Clone)]
-pub enum VarState {
+enum VarState {
     Unbound,
     Bound(Type),
 }
@@ -57,10 +57,6 @@ impl TypeEnv {
 
     fn slot(id: TypeVarId) -> usize {
         id.index() as usize
-    }
-
-    pub(crate) fn state(&self, id: TypeVarId) -> &VarState {
-        &self.entries[Self::slot(id)]
     }
 
     pub(crate) fn bind(&mut self, id: TypeVarId, ty: Type) {
@@ -241,15 +237,10 @@ impl TypeEnv {
                     VarState::Bound(bound) => self.occurs(id, bound),
                 }
             }
-            Type::Nominal { params, .. } => params.iter().any(|p| self.occurs(id, p)),
-            Type::Compound { args, .. } => args.iter().any(|a| self.occurs(id, a)),
-            Type::Function(f) => {
-                f.params.iter().any(|p| self.occurs(id, &p.ty)) || self.occurs(id, &f.return_type)
-            }
-            Type::Forall { body, .. } => self.occurs(id, body),
-            Type::Tuple(elements) => elements.iter().any(|e| self.occurs(id, e)),
-            Type::Array { element, .. } => self.occurs(id, element),
-            _ => false,
+            _ => ty
+                .children()
+                .into_iter()
+                .any(|child| self.occurs(id, child)),
         }
     }
 
@@ -341,7 +332,7 @@ mod tests {
         env.end_speculation(inner_speculation, SpeculationOutcome::Commit);
         env.end_speculation(outer_speculation, SpeculationOutcome::Rollback);
 
-        assert!(matches!(env.state(outer), VarState::Unbound));
-        assert!(matches!(env.state(inner), VarState::Unbound));
+        assert_eq!(env.shallow_resolve(&var(outer)), var(outer));
+        assert_eq!(env.shallow_resolve(&var(inner)), var(inner));
     }
 }

--- a/crates/semantics/src/generics.rs
+++ b/crates/semantics/src/generics.rs
@@ -2,11 +2,11 @@ use ecow::EcoString;
 use syntax::ast::Generic;
 use syntax::types::{Symbol, Type, build_substitution_map, substitute, unqualified_name};
 
+use crate::checker::TaskState;
 use crate::checker::infer::BuiltinBound;
 use crate::checker::infer::InferCtx;
 use crate::checker::infer::expressions::comparison;
 use crate::checker::infer::interface::interface_requires_methods;
-use crate::checker::{EnvResolve, TaskState};
 use crate::facts::GenericBoundOrigin;
 use crate::store::Store;
 use std::iter;
@@ -140,9 +140,8 @@ pub fn bound_display_name(store: &Store, bound: &Type) -> EcoString {
 impl TaskState {
     pub(crate) fn visible_parameter_bounds(&self) -> Vec<(EcoString, Vec<Type>)> {
         self.scopes
-            .collect_all_trait_bounds()
-            .iter()
-            .map(|(parameter, bounds)| (parameter.last_segment().into(), bounds.clone()))
+            .visible_parameter_bounds()
+            .map(|(parameter, bounds)| (parameter.into(), bounds.to_vec()))
             .collect()
     }
 
@@ -157,8 +156,9 @@ impl TaskState {
         let mut seen = rustc_hash::FxHashSet::default();
 
         for obligation in obligations {
-            let argument = store.deep_resolve_alias(&obligation.argument.resolve_in(&self.env));
-            let required = store.deep_resolve_alias(&obligation.required.resolve_in(&self.env));
+            // Frozen facts may come from workers with different type-variable tables.
+            let argument = store.deep_resolve_alias(&obligation.argument);
+            let required = store.deep_resolve_alias(&obligation.required);
             let key = (obligation.span, argument.to_string(), required.to_string());
             if !seen.insert(key)
                 || argument.contains_error()
@@ -247,6 +247,8 @@ fn return_type_declares_obligation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::checker::freeze::FreezeFolder;
+    use crate::facts::GenericBoundObligation;
     use syntax::ast::{Annotation, Span};
     use syntax::program::{AliasKind, Definition, DefinitionBody, Visibility};
 
@@ -299,5 +301,47 @@ mod tests {
             nested_type_obligations(&store, &nominal("m.A", vec![Type::Parameter("E".into())]));
 
         assert!(obligations.is_empty());
+    }
+
+    #[test]
+    fn frozen_worker_obligations_do_not_resolve_in_the_coordinators_environment() {
+        let store = Store::new();
+        let mut coordinator = TaskState::for_package("main");
+        let mut worker = coordinator.worker_seed().spawn();
+        let Type::Var { id, .. } = worker.new_type_var() else {
+            unreachable!()
+        };
+        let argument = Type::Var {
+            id,
+            hint: Some("T".into()),
+        };
+        worker
+            .facts
+            .deferred
+            .generic_bounds
+            .push(GenericBoundObligation {
+                argument: argument.clone(),
+                required: nominal("prelude.Comparable", vec![]),
+                span: Span::dummy(),
+                package_id: "worker".into(),
+                param_name: "T".into(),
+                available_bounds: vec![],
+                origin: GenericBoundOrigin::FunctionReference {
+                    name: "identity".into(),
+                },
+            });
+        FreezeFolder::new(&worker.env, &store).freeze_facts(&mut worker.facts);
+
+        let Type::Var { id, .. } = coordinator.new_type_var() else {
+            unreachable!()
+        };
+        coordinator.env.bind(id, Type::int());
+        coordinator.absorb_outputs(vec![worker.into_output()]);
+
+        coordinator.check_post_inference_bounds(&store);
+
+        let obligations = &coordinator.facts.deferred.generic_bounds;
+        assert_eq!(obligations.len(), 1);
+        assert_eq!(obligations[0].argument, argument);
     }
 }

--- a/crates/semantics/src/prelude.rs
+++ b/crates/semantics/src/prelude.rs
@@ -2,7 +2,6 @@ use diagnostics::LocalSink;
 use stdlib::{LIS_PRELUDE_SOURCE, LIS_TEST_PRELUDE_SOURCE};
 use syntax::program::{File, Visibility};
 
-use crate::checker::registration::normalize_registered_component_types;
 use crate::checker::{FileContext, TaskState};
 use crate::store::Store;
 
@@ -17,6 +16,7 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
     let result = syntax::build_ast(LIS_PRELUDE_SOURCE, PRELUDE_FILE_ID);
 
     sink.extend_parse_errors(result.errors);
+    let mut items = result.ast;
 
     store.store_file(File {
         id: PRELUDE_FILE_ID,
@@ -26,31 +26,13 @@ pub fn parse_and_register_prelude(store: &mut Store, sink: &LocalSink) {
         display_path: "prelude.d.lis".to_string(),
         source_path: deps::prelude_typedef_path(),
         source: LIS_PRELUDE_SOURCE.to_string(),
-        items: result.ast,
+        items: items.clone(),
         file_comment: None,
     });
 
     let mut checker = TaskState::for_package(PRELUDE_PACKAGE_ID);
-    let mut package = store
-        .get_package(PRELUDE_PACKAGE_ID)
-        .cloned()
-        .expect("prelude package must exist");
-
     checker.with_file_context_mut(store, FileContext::Prelude, |checker, store| {
-        for file in package.typedef_files() {
-            checker.register_type_names(store, &file.items, &Visibility::Public);
-        }
-
-        for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
-            checker.register_constants(store, &file.items, &Visibility::Public);
-            checker.register_type_definitions(store, &mut file.items);
-        }
-        normalize_registered_component_types(store, PRELUDE_PACKAGE_ID);
-        for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
-            checker.derive_enum_constructor_values(store, &file.items);
-            checker.register_impl_blocks(store, &mut file.items);
-            checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
-        }
+        checker.register_types_and_values(store, &mut items, &Visibility::Public);
         checker.finalize_registration(store);
     });
     sink.extend(checker.sink.into_diagnostics());
@@ -63,6 +45,7 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
     let result = syntax::build_ast(LIS_TEST_PRELUDE_SOURCE, file_id);
 
     sink.extend_parse_errors(result.errors);
+    let mut items = result.ast;
 
     store.add_package(TEST_PRELUDE_PACKAGE_ID);
     store.store_file(File {
@@ -73,34 +56,16 @@ pub fn parse_and_register_test_prelude(store: &mut Store, sink: &LocalSink) {
         display_path: "test_prelude.d.lis".to_string(),
         source_path: None,
         source: LIS_TEST_PRELUDE_SOURCE.to_string(),
-        items: result.ast,
+        items: items.clone(),
         file_comment: None,
     });
 
     let mut checker = TaskState::for_package(TEST_PRELUDE_PACKAGE_ID);
-    let mut package = store
-        .get_package(TEST_PRELUDE_PACKAGE_ID)
-        .cloned()
-        .expect("test_prelude package must exist");
-
     checker.with_file_context_mut(
         store,
         FileContext::TestPrelude { file_id },
         |checker, store| {
-            for file in package.typedef_files() {
-                checker.register_type_names(store, &file.items, &Visibility::Public);
-            }
-
-            for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
-                checker.register_constants(store, &file.items, &Visibility::Public);
-                checker.register_type_definitions(store, &mut file.items);
-            }
-            normalize_registered_component_types(store, TEST_PRELUDE_PACKAGE_ID);
-            for file in package.files.values_mut().filter(|file| file.is_d_lis()) {
-                checker.derive_enum_constructor_values(store, &file.items);
-                checker.register_impl_blocks(store, &mut file.items);
-                checker.register_non_const_values(store, &mut file.items, &Visibility::Public);
-            }
+            checker.register_types_and_values(store, &mut items, &Visibility::Public);
             checker.finalize_registration(store);
         },
     );

--- a/crates/semantics/src/store.rs
+++ b/crates/semantics/src/store.rs
@@ -9,21 +9,19 @@ use syntax::program::{
     TestIndex, UninferredExports, method_for_type, methods_for_type, type_has_any_method,
 };
 use syntax::types;
-use syntax::types::{CompoundKind, SimpleKind, Symbol, Type};
+use syntax::types::{CompoundKind, SimpleKind, Type};
 
 pub use crate::closed_domain::{ClosedDomain, ClosedMember, DomainValue};
 pub use syntax::ENTRY_PACKAGE_ID;
 pub const ENTRY_FILE_ID: u32 = 0;
-// A linear scan wins for small stores by avoiding a second hash lookup.
-const DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD: usize = 16;
 
 #[derive(Clone)]
 pub struct Store {
     /// `Arc` so registration workers share a read view; [`Arc::make_mut`]
     /// writes stay zero-copy while a package has a single owner.
     pub packages: HashMap<String, Arc<Package>>,
-    /// Dense file ID -> owning package ID index, enabled for large stores.
-    file_packages: Option<Arc<Vec<Option<String>>>>,
+    /// Avoids scanning every package on the hot file-lookup path (see #1227).
+    file_packages: HashMap<u32, String>,
     /// Go package ID -> package name from the typedef `// Package:` directive.
     pub go_package_names: HashMap<String, String>,
     /// File ID counter. Starts at 2 because 0 is reserved for entry, 1 for prelude.
@@ -52,7 +50,7 @@ impl Store {
 
         Self {
             packages,
-            file_packages: None,
+            file_packages: HashMap::default(),
             go_package_names: Default::default(),
             next_file_id: 2, // 0 = entrypoint, 1 = prelude
             equality_index: Default::default(),
@@ -102,89 +100,43 @@ impl Store {
     pub fn store_file(&mut self, file: File) {
         let package_id = file.package_id.clone();
         let file_id = file.id;
-
         let package = self
             .get_package_mut(&package_id)
             .expect("package must exist to store file");
         package.files.insert(file_id, file);
-        self.index_file(file_id, package_id);
+        self.file_packages.insert(file_id, package_id);
     }
 
     pub fn get_file(&self, file_id: u32) -> Option<&File> {
-        if let Some(package_id) = self
-            .file_packages
-            .as_deref()
-            .and_then(|packages| packages.get(file_id as usize))
-            .and_then(Option::as_deref)
-            && let Some(file) = self
-                .packages
-                .get(package_id)
-                .and_then(|package| package.get_file(file_id))
-        {
-            return Some(file);
-        }
-        self.packages
-            .values()
-            .find_map(|package| package.get_file(file_id))
+        self.file_packages
+            .get(&file_id)
+            .and_then(|package_id| self.packages.get(package_id))
+            .and_then(|package| package.get_file(file_id))
+            // Public package mutation can bypass the index.
+            .or_else(|| {
+                self.packages
+                    .values()
+                    .find_map(|package| package.get_file(file_id))
+            })
     }
 
     pub(crate) fn get_file_mut(&mut self, file_id: u32) -> Option<&mut File> {
-        if let Some(package_id) = self
-            .file_packages
-            .as_deref()
-            .and_then(|packages| packages.get(file_id as usize))
-            .and_then(Option::as_deref)
+        if let Some(package_id) = self.file_packages.get(&file_id)
             && self
                 .packages
                 .get(package_id)
                 .is_some_and(|package| package.files.contains_key(&file_id))
         {
-            return self
-                .packages
-                .get_mut(package_id)
-                .and_then(|package| Arc::make_mut(package).files.get_mut(&file_id));
-        }
-
-        let package_id = self.packages.iter().find_map(|(package_id, package)| {
-            package
+            return Arc::make_mut(self.packages.get_mut(package_id)?)
                 .files
-                .contains_key(&file_id)
-                .then(|| package_id.clone())
-        })?;
-        let package = Arc::make_mut(self.packages.get_mut(&package_id)?);
-        package.files.get_mut(&file_id)
-    }
-
-    fn index_file(&mut self, file_id: u32, package_id: String) {
-        let Some(file_packages) = self.file_packages.as_mut() else {
-            return;
-        };
-        let index = file_id as usize;
-        let file_packages = Arc::make_mut(file_packages);
-        if file_packages.len() <= index {
-            file_packages.resize_with(index + 1, || None);
-        }
-        file_packages[index] = Some(package_id);
-    }
-
-    fn enable_file_index_if_large(&mut self) {
-        if self.file_packages.is_some()
-            || self.packages.len() < DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD
-        {
-            return;
+                .get_mut(&file_id);
         }
 
-        let mut file_packages = Vec::new();
-        for (package_id, package) in &self.packages {
-            for file_id in package.files.keys().copied() {
-                let index = file_id as usize;
-                if file_packages.len() <= index {
-                    file_packages.resize_with(index + 1, || None);
-                }
-                file_packages[index] = Some(package_id.clone());
-            }
-        }
-        self.file_packages = Some(Arc::new(file_packages));
+        let package = self
+            .packages
+            .values_mut()
+            .find(|package| package.files.contains_key(&file_id))?;
+        Arc::make_mut(package).files.get_mut(&file_id)
     }
 
     pub fn get_package(&self, package_id: &str) -> Option<&Package> {
@@ -209,9 +161,6 @@ impl Store {
 
         self.packages
             .insert(package_id.to_string(), Arc::new(Package::new(package_id)));
-        if self.packages.len() == DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD {
-            self.enable_file_index_if_large();
-        }
     }
 
     pub fn get_package_mut(&mut self, package_id: &str) -> Option<&mut Package> {
@@ -220,20 +169,18 @@ impl Store {
 
     /// Inserts a worker-built package (e.g. cache-decoded).
     pub(crate) fn insert_prebuilt_package(&mut self, package: Package) {
-        if self.file_packages.is_none() {
-            self.packages.insert(package.id.clone(), Arc::new(package));
-            if self.packages.len() == DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD {
-                self.enable_file_index_if_large();
+        if let Some(previous) = self.packages.get(&package.id) {
+            for file_id in previous.files.keys() {
+                self.file_packages.remove(file_id);
             }
-            return;
         }
-
-        let package_id = package.id.clone();
-        let file_ids: Vec<u32> = package.files.keys().copied().collect();
+        self.file_packages.extend(
+            package
+                .files
+                .keys()
+                .map(|&file_id| (file_id, package.id.clone())),
+        );
         self.packages.insert(package.id.clone(), Arc::new(package));
-        for file_id in file_ids {
-            self.index_file(file_id, package_id.clone());
-        }
     }
 
     /// `Arc`-bump snapshot for a registration worker, which inserts its own
@@ -696,52 +643,16 @@ impl Store {
         definition.is_pointer_backed_newtype(|id| self.get_definition(id))
     }
 
-    pub(crate) fn get_all_methods(
-        &self,
-        ty: &Type,
-        trait_bounds: &HashMap<Symbol, Vec<Type>>,
-    ) -> Methods {
-        methods_for_type(ty, trait_bounds, |id| self.get_definition(id))
+    pub(crate) fn get_all_methods(&self, ty: &Type) -> Methods {
+        methods_for_type(ty, &HashMap::default(), |id| self.get_definition(id))
     }
 
-    pub(crate) fn get_method_for_type(
-        &self,
-        ty: &Type,
-        trait_bounds: &HashMap<Symbol, Vec<Type>>,
-        name: &str,
-    ) -> Option<Method> {
-        method_for_type(ty, trait_bounds, |id| self.get_definition(id), name)
+    pub(crate) fn get_method_for_type(&self, ty: &Type, name: &str) -> Option<Method> {
+        method_for_type(ty, &HashMap::default(), |id| self.get_definition(id), name)
     }
 
     pub(crate) fn type_has_any_method(&self, ty: &Type) -> bool {
         type_has_any_method(ty, |id| self.get_definition(id))
-    }
-
-    pub(crate) fn get_method_from_bounds(
-        &self,
-        qualified_name: &str,
-        trait_bounds: &HashMap<Symbol, Vec<Type>>,
-        name: &str,
-    ) -> Option<Method> {
-        trait_bounds
-            .get(qualified_name)?
-            .iter()
-            .filter_map(|interface_ty| self.get_method_for_type(interface_ty, trait_bounds, name))
-            .next_back()
-    }
-
-    pub(crate) fn get_methods_from_bounds(
-        &self,
-        qualified_name: &str,
-        trait_bounds: &HashMap<Symbol, Vec<Type>>,
-    ) -> Methods {
-        if let Some(bound_types) = trait_bounds.get(qualified_name) {
-            return bound_types
-                .iter()
-                .flat_map(|interface_ty| self.get_all_methods(interface_ty, trait_bounds))
-                .collect();
-        }
-        Methods::default()
     }
 }
 
@@ -766,14 +677,45 @@ mod clone_tests {
         cloned.store_file(File::new_cached("m", "cloned.lis", "", "", 42));
 
         assert!(store.get_file(42).is_none());
+        assert!(!store.file_packages.contains_key(&42));
+        assert_eq!(cloned.file_packages[&42], "m");
+    }
+
+    #[test]
+    fn stored_files_are_indexed_without_a_package_threshold_or_dense_ids() {
+        let mut store = Store::new();
+        store.add_package("m");
+
+        for file_id in [42, u32::MAX] {
+            store.store_file(File::new_cached("m", "sample.lis", "", "", file_id));
+
+            assert_eq!(store.file_packages[&file_id], "m");
+            assert_eq!(store.get_file(file_id).unwrap().id, file_id);
+            assert_eq!(store.get_file_mut(file_id).unwrap().id, file_id);
+        }
+        assert_eq!(store.file_packages.len(), 2);
+    }
+
+    #[test]
+    fn registration_view_has_independent_file_ownership() {
+        let mut store = Store::new();
+        store.add_package("m");
+        store.store_file(File::new_cached("m", "original.lis", "", "", 42));
+        let mut view = store.registration_view();
+
+        view.store_file(File::new_cached("m", "worker.lis", "", "", 43));
+
+        assert_eq!(view.file_packages[&42], "m");
+        assert_eq!(view.file_packages[&43], "m");
+        assert_eq!(view.get_file(42).unwrap().name, "original.lis");
+        assert_eq!(view.get_file(43).unwrap().name, "worker.lis");
+        assert!(!store.file_packages.contains_key(&43));
+        assert!(store.get_file(43).is_none());
     }
 
     #[test]
     fn prebuilt_package_files_are_available_by_id() {
         let mut store = Store::new();
-        for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
-            store.add_package(&format!("package{index}"));
-        }
         let mut package = Package::new("cached");
         package
             .files
@@ -781,6 +723,7 @@ mod clone_tests {
 
         store.insert_prebuilt_package(package);
 
+        assert_eq!(store.file_packages[&42], "cached");
         assert_eq!(
             store.get_file(42).map(|file| file.name.as_str()),
             Some("cached.lis")
@@ -800,29 +743,47 @@ mod clone_tests {
     }
 
     #[test]
-    fn stored_files_are_indexed_after_the_threshold() {
+    fn files_added_through_a_package_are_available_by_id() {
         let mut store = Store::new();
-        for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
-            store.add_package(&format!("package{index}"));
-        }
         store.add_package("large");
 
-        store.store_file(File::new_cached("large", "large.lis", "", "", 42));
+        store
+            .get_package_mut("large")
+            .unwrap()
+            .files
+            .insert(42, File::new_cached("large", "large.lis", "", "", 42));
 
         assert_eq!(
             store.get_file(42).map(|file| file.name.as_str()),
             Some("large.lis")
         );
+        assert_eq!(store.get_file_mut(42).unwrap().name, "large.lis");
     }
 
     #[test]
-    fn indexed_files_are_mutable_after_the_threshold() {
+    fn file_lookup_tolerates_ownership_changed_through_public_packages() {
         let mut store = Store::new();
-        for index in 0..DIRECT_FILE_LOOKUP_PACKAGE_THRESHOLD - 3 {
-            store.add_package(&format!("package{index}"));
-        }
+        store.add_package("before");
+        store.add_package("after");
+        store.store_file(File::new_cached("before", "before.lis", "", "", 42));
+
+        store.get_package_mut("before").unwrap().files.remove(&42);
+        store
+            .get_package_mut("after")
+            .unwrap()
+            .files
+            .insert(42, File::new_cached("after", "after.lis", "", "", 42));
+
+        assert_eq!(store.get_file(42).unwrap().package_id, "after");
+        assert_eq!(store.get_file_mut(42).unwrap().package_id, "after");
+    }
+
+    #[test]
+    fn mutating_a_file_detaches_only_its_package() {
+        let mut store = Store::new();
         store.add_package("large");
         store.store_file(File::new_cached("large", "before.lis", "", "", 42));
+        let cloned = store.clone();
 
         store.get_file_mut(42).unwrap().name = "after.lis".to_string();
 
@@ -830,6 +791,30 @@ mod clone_tests {
             store.get_file(42).map(|file| file.name.as_str()),
             Some("after.lis")
         );
+        assert_eq!(cloned.get_file(42).unwrap().name, "before.lis");
+        assert!(Arc::ptr_eq(
+            &store.packages["prelude"],
+            &cloned.packages["prelude"]
+        ));
+    }
+
+    #[test]
+    fn replacing_a_package_replaces_its_file_ownership() {
+        let mut store = Store::new();
+        store.add_package("cached");
+        store.store_file(File::new_cached("cached", "before.lis", "", "", 42));
+        let mut replacement = Package::new("cached");
+        replacement
+            .files
+            .insert(43, File::new_cached("cached", "after.lis", "", "", 43));
+
+        store.insert_prebuilt_package(replacement);
+
+        assert!(!store.file_packages.contains_key(&42));
+        assert_eq!(store.file_packages[&43], "cached");
+        assert!(store.get_file(42).is_none());
+        assert!(store.get_file_mut(42).is_none());
+        assert_eq!(store.get_file(43).unwrap().name, "after.lis");
     }
 }
 
@@ -841,7 +826,7 @@ mod closed_domain_tests {
     };
     use syntax::program::{AliasKind, Attributes, TypeAttribute, Visibility};
     use syntax::program::{ConstantValue, ValueKind};
-    use syntax::types::CompoundKind;
+    use syntax::types::{CompoundKind, Symbol};
 
     fn nominal_int(id: &str) -> Type {
         Type::Nominal {

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -7670,6 +7670,53 @@ fn main() {
 }
 
 #[test]
+fn unresolved_constructor_bounds_are_reported_after_parallel_inference() {
+    let mut fs = MockFileSystem::new();
+    for package in ["first", "second", "third"] {
+        fs.add_file(
+            package,
+            "lib.lis",
+            r#"
+struct Box<E: error> {}
+pub fn run() {
+  let value = Box {}
+  let _ = value
+}
+"#,
+        );
+    }
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        r#"
+import "first"
+import "second"
+import "third"
+fn main() {
+  first.run()
+  second.run()
+  third.run()
+}
+"#,
+    );
+
+    let result = compile_check(fs);
+
+    assert_eq!(
+        result
+            .errors()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code_str() == Some("infer.cannot_infer_struct_type_argument")
+            })
+            .count(),
+        3,
+        "{:?}",
+        result.errors()
+    );
+}
+
+#[test]
 fn ufcs_method_resolves_across_packages_on_parallel_path() {
     let mut fs = MockFileSystem::new();
 

--- a/tests/spec/infer/functions.rs
+++ b/tests/spec/infer/functions.rs
@@ -872,6 +872,43 @@ fn load_simple_package_with_function() {
 }
 
 #[test]
+fn deferred_select_checks_are_completed_for_each_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        "mylib",
+        "first.lis",
+        r#"
+fn first() -> int {
+  let ch = Channel.new<int>()
+  select { let Some(value) = ch.receive() => value }
+}
+"#,
+    );
+    fs.add_file(
+        "mylib",
+        "second.lis",
+        r#"
+fn second() -> bool {
+  let ch = Channel.new<bool>()
+  select { let Some(value) = ch.receive() => value }
+}
+"#,
+    );
+    fs.add_file(
+        "mylib",
+        "third.lis",
+        r#"
+fn third() {
+  let ch = Channel.new<int>()
+  select { let Some(_) = ch.receive() => {} }
+}
+"#,
+    );
+
+    infer_package("mylib", fs).assert_infer_code_count("non_exhaustive_select_expression", 2);
+}
+
+#[test]
 fn package_with_multiple_files() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -735,6 +735,37 @@ fn poke(r: mut Ref<Ref<S3>>) {
 }
 
 #[test]
+fn parenthesized_method_keeps_its_writable_receiver() {
+    infer(
+        r#"fn main() {
+  let mut xs = [1, 2, 3]
+  let _ = (xs.copy_from)(xs)
+}"#,
+    )
+    .assert_infer_code_once("aliased_writable_argument");
+}
+
+#[test]
+fn nested_calls_do_not_supply_the_outer_calls_writable_receiver() {
+    infer(
+        r#"struct Buffer { items: mut Slice<int> }
+impl Buffer {
+  fn read(self, other: Slice<int>) -> int { other.length() }
+  fn update(self: mut Ref<Buffer>, other: Slice<int>) -> Buffer {
+    self.items.copy_from(other)
+    Buffer { items: [1, 2, 3] }
+  }
+}
+fn main() {
+  let mut buffer = Buffer { items: [1, 2, 3] }
+  let xs = [4, 5, 6]
+  let _ = buffer.update(xs).read(xs)
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
 fn receiver_aliased_with_argument_refused() {
     infer(
         r#"fn main() {
@@ -1231,6 +1262,40 @@ fn main() {
 }"#,
     )
     .assert_infer_code_count("loop_copy_write", 0);
+}
+
+#[test]
+fn nested_loop_copy_checks_keep_reads_and_writes_with_their_binding() {
+    infer(
+        r#"fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    x += 1
+    for mut y in xs {
+      y += 1
+    }
+    let _ = x
+  }
+}"#,
+    )
+    .assert_infer_code_once("loop_copy_write");
+}
+
+#[test]
+fn shadowed_loop_bindings_do_not_share_observations() {
+    infer(
+        r#"fn main() {
+  let xs = [1, 2, 3]
+  for mut x in xs {
+    x += 1
+    for mut x in xs {
+      x += 1
+      let _ = x
+    }
+  }
+}"#,
+    )
+    .assert_infer_code_once("loop_copy_write");
 }
 
 #[test]


### PR DESCRIPTION
Replaces state carried across the inference walk with lookups at the point of use, so that generic bounds, loop element observations, and writable receivers no longer need shadow-and-restore lists, temp stashes, or cross-file assertions to stay correct.