### PR TITLE
refactor: unify literal typing where Go infers a type

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -65,21 +65,6 @@ pub(crate) fn all_type_params_inferrable(
     })
 }
 
-impl Planner<'_> {
-    /// True when no argument gives Go the right type. A builtin's arguments
-    /// share one type parameter, so one typed argument settles the call.
-    fn builtin_literal_misinfers(&self, params: &[FunctionParameter], args: &[Expression]) -> bool {
-        args.iter().enumerate().all(|(index, arg)| {
-            let param = params.get(index).or_else(|| {
-                params
-                    .last()
-                    .filter(|p| p.ty.is_native(CompoundKind::VarArgs))
-            });
-            self.literal_misinfers_type_parameter(arg, param.map(|param| &param.ty))
-        })
-    }
-}
-
 fn extract_return_type_param(function: &Expression) -> Option<Type> {
     let ty = function.get_type();
     let f = ty.as_function_type()?;
@@ -598,7 +583,6 @@ impl<'a> Planner<'a> {
         function: &Expression,
         declared: Option<&Type>,
         arg_shape: CallArgShape,
-        args: &[Expression],
     ) -> Option<String> {
         let Type::Forall { vars, body } = declared? else {
             return None;
@@ -613,10 +597,7 @@ impl<'a> Planner<'a> {
         let mut mapping: HashMap<String, Type> = HashMap::default();
         extract_type_mapping(body, &instantiated_ty, &mut mapping);
 
-        // A builtin takes no type argument, so this becomes the conversion.
-        let builtin_needs_conversion =
-            callee_is_go_builtin(function) && self.builtin_literal_misinfers(generic_params, args);
-        if all_inferrable && !builtin_needs_conversion {
+        if all_inferrable {
             let any_needs_explicit = vars.iter().any(|v| {
                 mapping
                     .get(v.as_str())
@@ -829,7 +810,13 @@ fn extract_receiver_ufcs_method(function: &Expression) -> String {
 }
 
 pub(super) fn callee_is_go_builtin(callee: &Expression) -> bool {
-    resolved_definition(callee).is_some_and(go_name::is_prelude_go_builtin)
+    go_builtin_name(callee).is_some()
+}
+
+pub(super) fn go_builtin_name(callee: &Expression) -> Option<&str> {
+    resolved_definition(callee)
+        .filter(|qualified| go_name::is_prelude_go_builtin(qualified))
+        .and_then(|qualified| qualified.strip_prefix("prelude."))
 }
 
 pub(super) fn is_prelude_variant_constructor(callee: &Expression) -> bool {

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1,7 +1,10 @@
 use crate::abi::is_tagged_shape_fn_value;
 use crate::calls::dispatch::{
-    CallArgShape, all_type_params_inferrable, callee_is_go_builtin, is_prelude_variant_constructor,
+    CallArgShape, all_type_params_inferrable, callee_is_go_builtin, go_builtin_name,
+    is_prelude_variant_constructor,
 };
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use syntax::EcoString;
 use syntax::types::FunctionParameter;
 
 use crate::Planner;
@@ -15,15 +18,11 @@ use crate::names::generics::extract_type_mapping;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
 use crate::plan::values::{
-    CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
+    CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
-use crate::types::go_type::render_conversion;
-use crate::utils::{
-    reads_mutable_operand, reads_unsequenced_mutable_operand, unwrap_unary_negation,
-};
+use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
-use syntax::types::SimpleKind;
 use syntax::types::Type;
 
 struct CallTypeArgsRequest<'e, 'c> {
@@ -32,8 +31,27 @@ struct CallTypeArgsRequest<'e, 'c> {
     type_args: ResolvedCallTypeArguments<'e>,
     call_ty: Option<&'e Type>,
     arg_shape: CallArgShape,
-    args: &'e [Expression],
     ctx: ExpressionContext<'e>,
+}
+
+fn builtin_constant(builtin: &str, values: &[GoExpression]) -> Option<ConstantKind> {
+    let mut kinds = values.iter().map(GoExpression::constant_kind);
+    let first = kinds.next()??;
+    let joined = kinds.try_fold(first, |joined, kind| {
+        let kind = kind?;
+        joined.join(kind).or((joined == kind).then_some(kind))
+    })?;
+    match builtin {
+        "min" | "max" => Some(joined),
+        "complex" => Some(ConstantKind::Complex),
+        "real" | "imag" => Some(ConstantKind::Float),
+        _ => None,
+    }
+}
+
+fn go_builtin_conversion(type_args: &str) -> Option<String> {
+    let inner = type_args.strip_prefix('[')?.strip_suffix(']')?;
+    (!inner.is_empty() && !inner.contains(',')).then(|| inner.to_string())
 }
 
 struct CallArgsContext<'plan, 'facts> {
@@ -45,10 +63,33 @@ struct CallArgsContext<'plan, 'facts> {
     combine_variadic: Option<VariadicCombine>,
     capture_boundary: CaptureBoundary,
     retired_receiver: Option<&'plan Expression>,
-    /// A builtin wraps the whole call, so its arguments must not also convert.
     callee_is_builtin: bool,
-    /// Pinned type arguments type every literal, leaving nothing to infer.
     callee_pins_type_args: bool,
+    receiver_binding: Option<(Type, Type)>,
+}
+
+fn receiver_type_binding(
+    callee_expression: &Expression,
+    callee: &ResolvedCallee<'_>,
+) -> Option<(Type, Type)> {
+    if callee.receiver_offset != 1 {
+        return None;
+    }
+    let Expression::DotAccess {
+        expression: receiver,
+        ..
+    } = callee_expression.unwrap_parens()
+    else {
+        return None;
+    };
+    let declared = callee
+        .declared_type()?
+        .unwrap_forall()
+        .get_function_params()?
+        .first()?
+        .ty
+        .clone();
+    Some((declared, receiver.get_type().strip_refs()))
 }
 
 /// Escape-aware close-quote search; plain `find` would collide with `\"` inside the literal.
@@ -254,11 +295,8 @@ impl<'a> Planner<'a> {
                 value_count: args.len(),
                 has_spread: spread.is_some(),
             },
-            args,
             ctx: expression_ctx,
         });
-        // A Go builtin takes no type argument, so the instantiated type it would
-        // have pinned becomes a conversion around the call instead.
         let builtin_conversion = callee_is_go_builtin(function)
             .then(|| go_builtin_conversion(&type_args_string))
             .flatten();
@@ -283,9 +321,13 @@ impl<'a> Planner<'a> {
             .flatten(),
             callee_is_builtin: callee_is_go_builtin(function),
             callee_pins_type_args: !type_args_string.is_empty(),
+            receiver_binding: receiver_type_binding(function, &call_plan.resolved),
         };
         let sequenced_args = self.emit_call_args(args, &args_ctx);
         let args_effect = sequenced_args.effect;
+        let constant_result = go_builtin_name(function)
+            .filter(|_| builtin_conversion.is_none())
+            .and_then(|builtin| builtin_constant(builtin, &sequenced_args.values));
         let (args_setup, args_strings) = sequenced_args.into_rendered();
 
         let delayed_after_arg_setup = !args_setup.is_empty() && reads_mutable_operand(function);
@@ -316,18 +358,12 @@ impl<'a> Planner<'a> {
         let effect = self
             .regular_call_effect(function, args_effect)
             .combine(callee_effect);
+        let expression = GoExpression::opaque_with_deferred_evaluation(call_str, true)
+            .with_constant(constant_result);
         if self.callee_lowers_to_type_construction(function) {
-            ValuePlan::computed(
-                setup,
-                GoExpression::opaque_with_deferred_evaluation(call_str, true),
-                effect,
-            )
+            ValuePlan::computed(setup, expression, effect)
         } else {
-            ValuePlan::plain_call(
-                setup,
-                GoExpression::opaque_with_deferred_evaluation(call_str, true),
-                effect,
-            )
+            ValuePlan::plain_call(setup, expression, effect)
         }
     }
 
@@ -442,7 +478,6 @@ impl<'a> Planner<'a> {
             type_args,
             call_ty,
             arg_shape,
-            args,
             ctx,
         } = request;
         if callee_curries_receiver(callee) {
@@ -465,7 +500,7 @@ impl<'a> Planner<'a> {
 
         if type_args_string.is_empty()
             && let Some(inferred) =
-                self.infer_return_only_type_args(function, callee.declared_type(), arg_shape, args)
+                self.infer_return_only_type_args(function, callee.declared_type(), arg_shape)
         {
             type_args_string = match slot_ty {
                 Some(t) => self.prelude_container_type_args(t).unwrap_or(inferred),
@@ -492,11 +527,12 @@ impl<'a> Planner<'a> {
         args: &[Expression],
         ctx: &CallArgsContext<'_, '_>,
     ) -> SequencedValues {
-        let mut stages: Vec<ValuePlan> = args
+        let stages: Vec<ValuePlan> = args
             .iter()
             .enumerate()
             .map(|(i, arg)| self.lower_call_arg(arg, i, ctx))
             .collect();
+        let mut stages = self.type_constant_arguments(stages, ctx);
 
         if let Some(spread) = ctx.spread
             && let Some(stage) =
@@ -627,41 +663,90 @@ impl<'a> Planner<'a> {
         ArgumentPlan::Direct
     }
 
-    /// True when Go would read this literal at another type than its slot:
-    /// `1` filling a `T` bound to `float64` is a Go `int`.
-    pub(super) fn literal_misinfers_type_parameter(
-        &self,
-        arg: &Expression,
-        declared_param_ty: Option<&Type>,
-    ) -> bool {
-        if !declared_param_ty.is_some_and(Type::contains_type_parameter) {
-            return false;
+    pub(super) fn convert_inferred_constants(
+        &mut self,
+        stages: Vec<ValuePlan>,
+        slots: &[Option<(&Type, &Type)>],
+        convertible: &[bool],
+        vars: &[EcoString],
+        receiver: Option<(&Type, &Type)>,
+    ) -> Vec<ValuePlan> {
+        let mut bound: HashSet<String> = HashSet::default();
+        if let Some((declared, instantiated)) = receiver {
+            let mut mapping: HashMap<String, Type> = HashMap::default();
+            extract_type_mapping(declared, instantiated, &mut mapping);
+            bound.extend(mapping.into_keys());
         }
-        let Expression::Literal { literal, ty, .. } = unwrap_unary_negation(arg) else {
-            return false;
-        };
-        let default = match literal {
-            Literal::Integer { .. } => SimpleKind::Int,
-            Literal::Float { .. } => SimpleKind::Float64,
-            Literal::Imaginary(_) => SimpleKind::Complex128,
-            Literal::Char(_) => SimpleKind::Rune,
-            Literal::Boolean(_) => SimpleKind::Bool,
-            Literal::String { .. } => SimpleKind::String,
-            _ => return false,
-        };
-        self.facts.peel_alias(ty).as_simple() != Some(default)
+        for (stage, slot) in stages.iter().zip(slots) {
+            if stage.expression.constant_kind().is_some() {
+                continue;
+            }
+            if let Some((declared, instantiated)) = slot {
+                let mut mapping: HashMap<String, Type> = HashMap::default();
+                extract_type_mapping(declared, instantiated, &mut mapping);
+                bound.extend(mapping.into_keys());
+            }
+        }
+        stages
+            .into_iter()
+            .zip(slots)
+            .zip(convertible)
+            .map(|((stage, slot), convertible)| {
+                let Some((declared, instantiated)) = slot else {
+                    return stage;
+                };
+                let constant = stage.expression.constant_kind();
+                if !convertible || constant.is_none() {
+                    return stage;
+                }
+                let mut mapping: HashMap<String, Type> = HashMap::default();
+                extract_type_mapping(declared, instantiated, &mut mapping);
+                let inferred = mapping.keys().any(|name| {
+                    (vars.is_empty() || vars.iter().any(|var| var == name)) && !bound.contains(name)
+                });
+                if !inferred {
+                    return stage;
+                }
+                let slot_ty = varargs_inner_or_self(instantiated);
+                match self.constant_needs_go_type(constant, &slot_ty) {
+                    Some(go_type) => stage.conversion(go_type),
+                    None => stage,
+                }
+            })
+            .collect()
     }
 
-    /// The type to convert a misinferring literal to. A variadic slot renders
-    /// as `...T`, so this targets the element type.
-    pub(super) fn literal_pinning_go_type(
+    fn type_constant_arguments(
         &mut self,
-        arg: &Expression,
-        declared_param_ty: Option<&Type>,
-        target: &Type,
-    ) -> Option<String> {
-        self.literal_misinfers_type_parameter(arg, declared_param_ty)
-            .then(|| self.use_go_type(&varargs_inner_or_self(target)))
+        stages: Vec<ValuePlan>,
+        ctx: &CallArgsContext<'_, '_>,
+    ) -> Vec<ValuePlan> {
+        if ctx.callee_is_builtin || ctx.callee_pins_type_args {
+            return stages;
+        }
+        let abi = &ctx.plan.resolved.abi;
+        let vars: Vec<EcoString> = match ctx.plan.resolved.declared_type() {
+            Some(Type::Forall { vars, .. }) => vars.clone(),
+            _ => Vec::new(),
+        };
+        let slots: Vec<Option<(&Type, &Type)>> = (0..stages.len())
+            .map(|index| {
+                abi.param(index).and_then(|param| {
+                    param
+                        .declared
+                        .as_ref()
+                        .map(|declared| (declared, &param.instantiated))
+                })
+            })
+            .collect();
+        let convertible: Vec<bool> = (0..stages.len())
+            .map(|index| matches!(ctx.plan.arguments.get(index), Some(ArgumentPlan::Direct)))
+            .collect();
+        let receiver = ctx
+            .receiver_binding
+            .as_ref()
+            .map(|(declared, instantiated)| (declared, instantiated));
+        self.convert_inferred_constants(stages, &slots, &convertible, &vars, receiver)
     }
 
     fn lower_direct_arg(
@@ -672,29 +757,22 @@ impl<'a> Planner<'a> {
         declared_param_ty: Option<&Type>,
     ) -> ValuePlan {
         let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
-        let call_carries_type = ctx.callee_is_builtin || ctx.callee_pins_type_args;
         let mut arg_ctx = direct_arg_emit_ctx(&self.facts, effective_param_ty, suppress);
         if let Some(retired) = ctx.retired_receiver {
             arg_ctx = arg_ctx.with_retired_receiver(retired);
         }
         let argument = self.lower_composite_value(arg, arg_ctx);
+        let Some(target) = effective_param_ty else {
+            return argument;
+        };
+        let coercion = CoercionPlan::internal(self, &arg.get_type(), target);
+        if coercion.is_identity() {
+            return argument;
+        }
         argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
-            let mut final_value = match effective_param_ty {
-                Some(target) => {
-                    let coercion = CoercionPlan::internal(self, &arg.get_type(), target);
-                    let (coercion_setup, coerced) = coercion.lower(self, value);
-                    setup.extend(coercion_setup);
-                    coerced
-                }
-                None => value,
-            };
-            if let Some(target) = effective_param_ty
-                && !call_carries_type
-                && let Some(go_type) = self.literal_pinning_go_type(arg, declared_param_ty, target)
-            {
-                final_value = render_conversion(&go_type, &final_value);
-            }
-            GoExpression::opaque_with_deferred_evaluation(final_value, contains_deferred_evaluation)
+            let (coercion_setup, coerced) = coercion.lower(self, value);
+            setup.extend(coercion_setup);
+            GoExpression::opaque_with_deferred_evaluation(coerced, contains_deferred_evaluation)
         })
     }
 
@@ -1067,11 +1145,6 @@ impl<'a> Planner<'a> {
 
 /// The single Go type inside a rendered `[T]` list, which becomes a conversion
 /// around a builtin call. `None` for an empty or multi-parameter list.
-fn go_builtin_conversion(type_args: &str) -> Option<String> {
-    let inner = type_args.strip_prefix('[')?.strip_suffix(']')?;
-    (!inner.is_empty() && !inner.contains(',')).then(|| inner.to_string())
-}
-
 fn callee_curries_receiver(callee: &ResolvedCallee<'_>) -> bool {
     let Some(Type::Forall { body, .. }) = callee.declared_type() else {
         return false;

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -11,8 +11,8 @@ use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, ResolvedCallee};
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
-use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
+use syntax::EcoString;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::program::ReceiverCoercion;
 use syntax::types::Type;
@@ -215,6 +215,46 @@ impl Planner<'_> {
                 param.map(|param| &param.instantiated),
             ));
         }
+        let vars: Vec<EcoString> = match callee.declared_type() {
+            Some(Type::Forall { vars, .. }) if !callee.is_prelude_dispatch => vars.clone(),
+            _ => Vec::new(),
+        };
+        let receiver_instantiated = receiver.get_type().strip_refs();
+        let receiver_declared = (!callee.is_prelude_dispatch && callee.receiver_offset == 1)
+            .then(|| {
+                callee
+                    .declared_type()
+                    .and_then(|ty| ty.unwrap_forall().get_function_params())
+                    .and_then(|params| params.first())
+                    .map(|param| &param.ty)
+            })
+            .flatten();
+        let receiver_binding = receiver_declared.map(|declared| (declared, &receiver_instantiated));
+        let mut slots: Vec<Option<(&Type, &Type)>> = vec![None];
+        let mut convertible = vec![false];
+        for index in 0..args.len() {
+            let param = callee.abi.param(index);
+            slots.push(
+                (!callee.is_prelude_dispatch)
+                    .then(|| {
+                        param.and_then(|param| {
+                            param
+                                .declared
+                                .as_ref()
+                                .map(|declared| (declared, &param.instantiated))
+                        })
+                    })
+                    .flatten(),
+            );
+            convertible.push(true);
+        }
+        let all_stages = self.convert_inferred_constants(
+            all_stages,
+            &slots,
+            &convertible,
+            &vars,
+            receiver_binding,
+        );
         let combine = plan_variadic_spread(&self.facts, function, spread).map(|p| p.combine(1));
 
         let sequenced = self.sequence_args_with_spread_adapter_values(
@@ -258,19 +298,7 @@ impl Planner<'_> {
         if let Some(value) = self.try_adapt_lowered_fn_arg_shape(arg, Some(declared)) {
             return value;
         }
-        let staged = self.stage_composite(arg, ExpressionContext::value());
-        let Some(target) = formal_param else {
-            return staged;
-        };
-        let Some(go_type) = self.literal_pinning_go_type(arg, Some(declared), target) else {
-            return staged;
-        };
-        staged.map_rendered(|_setup, value, deferred| {
-            GoExpression::opaque_with_deferred_evaluation(
-                render_conversion(&go_type, &value),
-                deferred,
-            )
-        })
+        self.stage_composite(arg, ExpressionContext::value())
     }
 
     fn build_ufcs_qualified_call(

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -3,47 +3,79 @@ use std::fmt::Write;
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::context::expression::ExpressionContext;
-use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::values::{
+    CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
+};
 use syntax::ast::{Expression, FormatStringPart, Literal};
 use syntax::types::{SimpleKind, Type};
 
 impl Planner<'_> {
     pub(super) fn emit_literal(&mut self, literal: &Literal, ty: &Type) -> ValuePlan {
-        let value = match literal {
-            Literal::Integer { value, text } => match text {
-                Some(original) => original.clone(),
-                None => value.to_string(),
-            },
-            Literal::Float { value, text } => match text {
-                Some(t) => t.clone(),
-                None => {
-                    let s = value.to_string();
-                    if s.contains('.') || s.contains('e') || s.contains('E') {
-                        s
-                    } else {
-                        format!("{}.0", s)
+        let (value, kind) = match literal {
+            Literal::Integer { value, text } => {
+                let rendered = match text {
+                    Some(original) => original.clone(),
+                    None => value.to_string(),
+                };
+                (rendered, ConstantKind::Int)
+            }
+            Literal::Float { value, text } => {
+                let rendered = match text {
+                    Some(t) => t.clone(),
+                    None => {
+                        let s = value.to_string();
+                        if s.contains('.') || s.contains('e') || s.contains('E') {
+                            s
+                        } else {
+                            format!("{}.0", s)
+                        }
                     }
-                }
-            },
+                };
+                (rendered, ConstantKind::Float)
+            }
             Literal::Imaginary(coef) => {
-                if *coef == coef.trunc() && coef.abs() < 1e15 {
+                let rendered = if *coef == coef.trunc() && coef.abs() < 1e15 {
                     format!("{}i", *coef as i64)
                 } else {
                     format!("{}i", coef)
-                }
+                };
+                (rendered, ConstantKind::Complex)
             }
-            Literal::Boolean(b) => b.to_string(),
-            Literal::String { value, raw: false } => {
-                format!("\"{}\"", convert_escape_sequences(value))
-            }
-            Literal::String { value, raw: true } => emit_raw_string(value),
-            Literal::Char(c) => {
-                format!("'{}'", convert_escape_sequences(c))
-            }
+            Literal::Boolean(b) => (b.to_string(), ConstantKind::Bool),
+            Literal::String { value, raw: false } => (
+                format!("\"{}\"", convert_escape_sequences(value)),
+                ConstantKind::String,
+            ),
+            Literal::String { value, raw: true } => (emit_raw_string(value), ConstantKind::String),
+            Literal::Char(c) => (
+                format!("'{}'", convert_escape_sequences(c)),
+                ConstantKind::Rune,
+            ),
             Literal::FormatString(parts) => return self.emit_format_string(parts),
             Literal::Slice(elements) => return self.emit_slice_literal(elements, ty),
         };
-        ValuePlan::literal(value)
+        ValuePlan::constant(value, kind)
+    }
+
+    pub(crate) fn constant_needs_go_type(
+        &mut self,
+        constant: Option<ConstantKind>,
+        slot_ty: &Type,
+    ) -> Option<String> {
+        let kind = constant?;
+        if self.facts.is_interface_or_unknown(slot_ty) {
+            return None;
+        }
+        let peeled = self.facts.peel_alias(slot_ty);
+        match &peeled {
+            Type::Simple(_) => {}
+            Type::Nominal { params, .. } if params.is_empty() => {}
+            _ => return None,
+        }
+        if peeled.as_simple() == Some(kind.default_kind()) {
+            return None;
+        }
+        Some(self.use_go_type(slot_ty))
     }
 
     fn emit_slice_literal(&mut self, elements: &[Expression], ty: &Type) -> ValuePlan {

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -4,7 +4,9 @@ use crate::analyze::facts::EmitFacts;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::values::{
+    CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
+};
 use syntax::ast::{BinaryOperator, Expression, Literal, UnaryOperator};
 use syntax::program::DefinitionBody;
 use syntax::types::Type;
@@ -199,7 +201,7 @@ impl Planner<'_> {
                 ..
             } = expression
         {
-            return ValuePlan::literal("-9223372036854775808".to_string());
+            return ValuePlan::constant("-9223372036854775808".to_string(), ConstantKind::Int);
         }
 
         if matches!(operator, UnaryOperator::Not) {

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -627,13 +627,19 @@ impl Planner<'_> {
         literals: LiteralInlining,
         names_inline: bool,
     ) -> Option<String> {
-        let go_type = self.use_go_type(&expression.get_type());
+        let expression_ty = expression.get_type();
+        let go_type = self.use_go_type(&expression_ty);
         let inlines = plan.setup.is_empty()
             && match plan.evaluation.form {
                 OperandForm::Name => names_inline,
+                OperandForm::Call => false,
                 _ => {
+                    let constant = plan.expression.constant_kind();
                     matches!(literals, LiteralInlining::Allowed)
-                        && constant_default_go_type(expression) == Some(go_type.as_str())
+                        && constant.is_some()
+                        && self
+                            .constant_needs_go_type(constant, &expression_ty)
+                            .is_none()
                 }
             };
         (!inlines).then_some(go_type)
@@ -647,6 +653,7 @@ impl Planner<'_> {
         temp_type: Option<String>,
         statements: &mut Vec<LoweredStatement>,
     ) -> AssertOperand {
+        let constant = plan.expression.constant_kind();
         let (setup, value) = plan.into_parts();
         statements.extend(setup);
         let Some(go_type) = temp_type else {
@@ -661,18 +668,23 @@ impl Planner<'_> {
         self.scope.bind(name.clone(), name.clone());
         // Under `:=` a Go constant may take its own default type, so a large
         // `uint64` literal would come back as an overflowing `int`.
-        statements.push(if self.is_go_constant_expression(expression) {
-            LoweredStatement::VarDecl {
-                name: name.clone(),
-                go_type,
-                value: Some(value),
-            }
-        } else {
-            LoweredStatement::TempBind {
-                name: name.clone(),
-                value,
-            }
-        });
+        let constant_needs_type = self
+            .constant_needs_go_type(constant, &expression.get_type())
+            .is_some();
+        statements.push(
+            if constant_needs_type || self.is_go_constant_expression(expression) {
+                LoweredStatement::VarDecl {
+                    name: name.clone(),
+                    go_type,
+                    value: Some(value),
+                }
+            } else {
+                LoweredStatement::TempBind {
+                    name: name.clone(),
+                    value,
+                }
+            },
+        );
         AssertOperand {
             expression: temp_identifier(&name, expression),
             rendered: name,
@@ -1128,27 +1140,6 @@ struct AssertOperand {
 enum LiteralInlining {
     Allowed,
     Denied,
-}
-
-/// The Go type an operand takes on its own when it emits as an untyped
-/// constant. `None` for anything typed, or whose default is not knowable here.
-fn constant_default_go_type(expression: &Expression) -> Option<&'static str> {
-    match expression {
-        Expression::Paren { expression, .. }
-        | Expression::Unary {
-            operator: UnaryOperator::Negative,
-            expression,
-            ..
-        } => constant_default_go_type(expression),
-        Expression::Literal { literal, .. } => match literal {
-            Literal::Integer { .. } => Some("int"),
-            Literal::Float { .. } => Some("float64"),
-            Literal::String { .. } => Some("string"),
-            Literal::Boolean(_) => Some("bool"),
-            _ => None,
-        },
-        _ => None,
-    }
 }
 
 fn paired_operands(lhs: &str, rhs: &str) -> String {

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -5,6 +5,7 @@ use crate::plan::bodies::LoweredStatement;
 use crate::types::go_type::render_conversion;
 use std::fmt::{self, Display, Formatter};
 use syntax::ast::Expression;
+use syntax::types::SimpleKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OperandForm {
@@ -14,12 +15,70 @@ pub(crate) enum OperandForm {
     Other,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ConstantKind {
+    Int,
+    Rune,
+    Float,
+    Complex,
+    Bool,
+    String,
+}
+
+impl ConstantKind {
+    pub(crate) fn default_kind(self) -> SimpleKind {
+        match self {
+            Self::Int => SimpleKind::Int,
+            Self::Rune => SimpleKind::Rune,
+            Self::Float => SimpleKind::Float64,
+            Self::Complex => SimpleKind::Complex128,
+            Self::Bool => SimpleKind::Bool,
+            Self::String => SimpleKind::String,
+        }
+    }
+
+    fn is_numeric(self) -> bool {
+        matches!(self, Self::Int | Self::Rune | Self::Float | Self::Complex)
+    }
+
+    pub(crate) fn join(self, other: Self) -> Option<Self> {
+        (self.is_numeric() && other.is_numeric()).then(|| self.max(other))
+    }
+}
+
+fn binary_constant(
+    left: Option<ConstantKind>,
+    operator: &str,
+    right: Option<ConstantKind>,
+) -> Option<ConstantKind> {
+    let (left, right) = (left?, right?);
+    match operator {
+        "==" | "!=" | "<" | "<=" | ">" | ">=" | "&&" | "||" => Some(ConstantKind::Bool),
+        "<<" | ">>" => left.is_numeric().then_some(left),
+        "+" if left == ConstantKind::String && right == ConstantKind::String => {
+            Some(ConstantKind::String)
+        }
+        "+" | "-" | "*" | "/" | "%" | "&" | "|" | "^" | "&^" => left.join(right),
+        _ => None,
+    }
+}
+
+fn unary_constant(operator: &str, value: Option<ConstantKind>) -> Option<ConstantKind> {
+    let value = value?;
+    match operator {
+        "-" | "+" | "^" => value.is_numeric().then_some(value),
+        "!" => (value == ConstantKind::Bool).then_some(value),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GoExpression {
     rendered: String,
     contains_deferred_evaluation: bool,
     composite_literal: bool,
     syntax_form: OperandForm,
+    constant: Option<ConstantKind>,
 }
 
 impl GoExpression {
@@ -34,7 +93,21 @@ impl GoExpression {
             contains_deferred_evaluation,
             composite_literal,
             syntax_form,
+            constant: None,
         }
+    }
+
+    pub(crate) fn constant(rendered: String, kind: ConstantKind) -> Self {
+        Self::literal(rendered).with_constant(Some(kind))
+    }
+
+    pub(crate) fn with_constant(mut self, constant: Option<ConstantKind>) -> Self {
+        self.constant = constant;
+        self
+    }
+
+    pub(crate) fn constant_kind(&self) -> Option<ConstantKind> {
+        self.constant
     }
 
     pub(crate) fn name(value: String) -> Self {
@@ -95,10 +168,12 @@ impl GoExpression {
 
     fn render_binary(left: Self, operator: String, right: Self, separator: &str) -> Self {
         let deferred = left.contains_deferred_evaluation() || right.contains_deferred_evaluation();
+        let constant = binary_constant(left.constant, &operator, right.constant);
         Self::opaque_with_deferred_evaluation(
             format!("{left}{separator}{operator}{separator}{right}"),
             deferred,
         )
+        .with_constant(constant)
     }
 
     pub(crate) fn selector(base: GoExpression, field: String) -> Self {
@@ -116,12 +191,15 @@ impl GoExpression {
     }
 
     fn parenthesized(value: GoExpression) -> Self {
-        Self::opaque_with_deferred_evaluation(format!("({value})"), true)
+        let constant = value.constant;
+        Self::opaque_with_deferred_evaluation(format!("({value})"), true).with_constant(constant)
     }
 
     fn unary(operator: &str, value: GoExpression) -> Self {
         let deferred = value.contains_deferred_evaluation();
+        let constant = unary_constant(operator, value.constant);
         Self::opaque_with_deferred_evaluation(render_unary(operator, &value.rendered()), deferred)
+            .with_constant(constant)
     }
 
     pub(crate) fn slice(
@@ -346,10 +424,10 @@ impl ValuePlan {
         }
     }
 
-    pub(crate) fn literal(rendered: String) -> Self {
+    pub(crate) fn constant(rendered: String, kind: ConstantKind) -> Self {
         Self::from_facts(
             Vec::new(),
-            GoExpression::literal(rendered),
+            GoExpression::constant(rendered, kind),
             EvaluationFacts::literal(),
         )
     }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -12,8 +12,7 @@ use crate::plan::placement::{
     collapse_boolean_branch_assign, collapse_declare_assign, expression_contains_binding,
     is_unit_call, rebind_trailing_temp, requires_temp_var,
 };
-use crate::utils::unwrap_unary_negation;
-use syntax::ast::{Binding, Expression, Literal, Pattern};
+use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
 
 #[derive(Clone, Copy)]
@@ -41,16 +40,7 @@ fn needs_explicit_type_declaration(
             return true;
         }
     }
-    match unwrap_unary_negation(value) {
-        Expression::Literal { literal, .. } => match literal {
-            Literal::Integer { .. } => !matches!(binding_ty.get_name(), Some("int") | None),
-            Literal::Float { .. } => !matches!(binding_ty.get_name(), Some("float64") | None),
-            Literal::String { .. } => !matches!(binding_ty.get_name(), Some("string") | None),
-            Literal::Boolean(_) => !matches!(binding_ty.get_name(), Some("bool") | None),
-            _ => false,
-        },
-        _ => false,
-    }
+    false
 }
 
 /// Pick the Go type for a `let` binding's `var X T` temp. Diverging values
@@ -231,10 +221,12 @@ impl Planner<'_> {
             return statements;
         }
 
-        let (mut statements, value_expression) = self
-            .lower_value(value, ExpressionContext::value())
-            .into_parts();
+        let plan = self.lower_value(value, ExpressionContext::value());
+        let constant = plan.expression.constant_kind();
+        let (mut statements, value_expression) = plan.into_parts();
         let coercion = CoercionPlan::internal(self, &value.get_type(), binding_ty);
+        let constant_needs_type =
+            coercion.is_identity() && self.constant_needs_go_type(constant, binding_ty).is_some();
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
         statements.extend(coercion_setup);
 
@@ -249,7 +241,7 @@ impl Planner<'_> {
             bound
         };
 
-        if needs_explicit_type_declaration(self, value, binding_ty) {
+        if constant_needs_type || needs_explicit_type_declaration(self, value, binding_ty) {
             let var_ty = self.use_go_type(binding_ty);
             statements.push(LoweredStatement::VarDecl {
                 name: go_identifier,

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -95,18 +95,6 @@ pub(crate) fn group_params(params: &[(String, String)]) -> String {
     parts.join(", ")
 }
 
-pub(crate) fn unwrap_unary_negation(expression: &Expression) -> &Expression {
-    match expression {
-        Expression::Unary {
-            operator: UnaryOperator::Negative,
-            expression,
-            ..
-        } => unwrap_unary_negation(expression),
-        Expression::Paren { expression, .. } => unwrap_unary_negation(expression),
-        _ => expression,
-    }
-}
-
 fn is_scalar_literal(expression: &Expression) -> bool {
     matches!(
         expression.unwrap_parens(),

--- a/tests/e2e_smoke_project/src/bindings.test.lis
+++ b/tests/e2e_smoke_project/src/bindings.test.lis
@@ -1,4 +1,16 @@
 #[test]
+fn let_keeps_a_character_literal_at_its_annotated_type() {
+  let b: byte = 'a'
+  let i: int = 'a'
+  assert byte_value(b) == 97
+  assert int_value(i) == 97
+}
+
+fn byte_value(b: byte) -> byte { b }
+
+fn int_value(i: int) -> int { i }
+
+#[test]
 fn if_let_some() {
   let opt = Some(42)
   let result = if let Some(x) = opt { x } else { 0 }

--- a/tests/e2e_smoke_project/src/options_results.test.lis
+++ b/tests/e2e_smoke_project/src/options_results.test.lis
@@ -24,6 +24,13 @@ fn option_some_keeps_a_literal_at_its_newtype() {
   assert rank.unwrap_or(Rank(0)).0 == 3
 }
 
+#[test]
+#[allow(float_cmp)]
+fn option_some_keeps_a_constant_builtin_result_at_its_type() {
+  let widened: Option<float64> = Some(min(1, 2))
+  assert halved_option(widened) == 0.25
+}
+
 struct Armed(bool)
 
 struct Rank(int)

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -1858,6 +1858,45 @@ fn test() -> Flag {
 }
 
 #[test]
+fn generic_call_leaves_a_constant_alone_when_a_typed_sibling_binds_the_parameter() {
+    let input = r#"
+fn pick<T>(_a: T, b: T) -> T { b }
+fn ident<T>(v: T) -> T { v }
+
+fn test(w: int64, f: float64) -> float64 {
+  let a: int64 = pick(w, 1)
+  let b: float64 = pick(1, f)
+  let c: float64 = pick(1, 2)
+  let d: float64 = ident(min(1, 2))
+  let _ = a
+  b + c + d
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn method_call_leaves_a_constant_alone_when_the_receiver_binds_the_parameter() {
+    let input = r#"
+struct Wrapper<T> { value: T }
+
+impl<T> Wrapper<T> {
+  fn replace(self, v: T) -> Wrapper<T> { Wrapper { value: v } }
+  fn with<U>(self, u: U) -> U { u }
+}
+
+fn test() -> float32 {
+  let w: Wrapper<float64> = Wrapper { value: 1 }
+  let r = w.replace(2)
+  let u: float32 = w.with(3)
+  let _ = r
+  u
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn parenthesized_local_generic_return_only_type_args() {
     let input = r#"
 fn make<T>() -> Slice<T> {

--- a/tests/spec/emit/literals.rs
+++ b/tests/spec/emit/literals.rs
@@ -1,6 +1,22 @@
 use crate::assert_emit_snapshot;
 
 #[test]
+fn let_binding_types_a_character_literal_into_a_byte() {
+    let input = r#"
+fn takes_byte(b: byte) -> byte { b }
+
+fn test() -> byte {
+  let b: byte = 'a'
+  let i: int = 'a'
+  let r: rune = 'a'
+  let _ = (i, r)
+  takes_byte(b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn integer_literal() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -75,6 +75,17 @@ fn test() -> (Option<Flag>, Option<Ticket>) {
 }
 
 #[test]
+fn option_some_types_a_constant_builtin_result() {
+    let input = r#"
+fn test() -> Option<float64> {
+  let widened: Option<float64> = Some(min(1, 2))
+  widened
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn option_none_construction() {
     let input = r#"
 fn test() -> Option<int> {

--- a/tests/spec/emit/snapshots/builtin_min_types_a_character_literal_into_an_int_slot.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_character_literal_into_an_int_slot.snap
@@ -10,6 +10,6 @@ description: |
 package main
 
 func test() int {
-	letter := int(min('a', 'b'))
+	var letter int = min('a', 'b')
 	return letter
 }

--- a/tests/spec/emit/snapshots/builtin_min_types_a_literal_into_a_newtype.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_literal_into_a_newtype.snap
@@ -18,7 +18,7 @@ type Ticket int
 type Label string
 
 func test() Ticket {
-	label := Label(max("a", "b"))
+	var label Label = max("a", "b")
 	_ = label
-	return Ticket(min(1, 2))
+	return min(1, 2)
 }

--- a/tests/spec/emit/snapshots/builtin_min_types_a_literal_of_another_default.snap
+++ b/tests/spec/emit/snapshots/builtin_min_types_a_literal_of_another_default.snap
@@ -12,8 +12,8 @@ description: |
 package main
 
 func test() float64 {
-	two := float64(min(1, 2))
-	three := float64(min(1, 2, 3))
-	narrow := float32(min(1, 2))
+	var two float64 = min(1, 2)
+	var three float64 = min(1, 2, 3)
+	var narrow float32 = min(1, 2)
 	return two/three + float64(narrow)
 }

--- a/tests/spec/emit/snapshots/generic_call_leaves_a_constant_alone_when_a_typed_sibling_binds_the_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_call_leaves_a_constant_alone_when_a_typed_sibling_binds_the_parameter.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn pick<T>(_a: T, b: T) -> T { b }
+  fn ident<T>(v: T) -> T { v }
+  
+  fn test(w: int64, f: float64) -> float64 {
+    let a: int64 = pick(w, 1)
+    let b: float64 = pick(1, f)
+    let c: float64 = pick(1, 2)
+    let d: float64 = ident(min(1, 2))
+    let _ = a
+    b + c + d
+  }
+---
+package main
+
+func pick[T any](_, b T) T {
+	return b
+}
+
+func ident[T any](v T) T {
+	return v
+}
+
+func test(w int64, f float64) float64 {
+	a := pick(w, 1)
+	b := pick(1, f)
+	c := pick(float64(1), float64(2))
+	d := ident(float64(min(1, 2)))
+	_ = a
+	return b + c + d
+}

--- a/tests/spec/emit/snapshots/let_binding_types_a_character_literal_into_a_byte.snap
+++ b/tests/spec/emit/snapshots/let_binding_types_a_character_literal_into_a_byte.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/literals.rs
+description: |
+  
+  fn takes_byte(b: byte) -> byte { b }
+  
+  fn test() -> byte {
+    let b: byte = 'a'
+    let i: int = 'a'
+    let r: rune = 'a'
+    let _ = (i, r)
+    takes_byte(b)
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func takesByte(b byte) byte {
+	return b
+}
+
+func test() byte {
+	var b byte = 'a'
+	var i int = 'a'
+	r := 'a'
+	_ = lisette.MakeTuple2[int, rune](i, r)
+	return takesByte(b)
+}

--- a/tests/spec/emit/snapshots/method_call_leaves_a_constant_alone_when_the_receiver_binds_the_parameter.snap
+++ b/tests/spec/emit/snapshots/method_call_leaves_a_constant_alone_when_the_receiver_binds_the_parameter.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Wrapper<T> { value: T }
+  
+  impl<T> Wrapper<T> {
+    fn replace(self, v: T) -> Wrapper<T> { Wrapper { value: v } }
+    fn with<U>(self, u: U) -> U { u }
+  }
+  
+  fn test() -> float32 {
+    let w: Wrapper<float64> = Wrapper { value: 1 }
+    let r = w.replace(2)
+    let u: float32 = w.with(3)
+    let _ = r
+    u
+  }
+---
+package main
+
+type Wrapper[T any] struct {
+	value T
+}
+
+func (w Wrapper[T]) replace(v T) Wrapper[T] {
+	return Wrapper[T]{value: v}
+}
+
+func Wrapper_with[T any, U any](_ Wrapper[T], u U) U {
+	return u
+}
+
+func test() float32 {
+	w := Wrapper[float64]{value: 1}
+	r := w.replace(2)
+	u := Wrapper_with(w, float32(3))
+	_ = r
+	return u
+}

--- a/tests/spec/emit/snapshots/option_some_types_a_constant_builtin_result.snap
+++ b/tests/spec/emit/snapshots/option_some_types_a_constant_builtin_result.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn test() -> Option<float64> {
+    let widened: Option<float64> = Some(min(1, 2))
+    widened
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func test() (float64, bool) {
+	widened := lisette.MakeOptionSome(float64(min(1, 2)))
+	v_1 := widened
+	if v_1.Tag == lisette.OptionSome {
+		return v_1.SomeVal, true
+	}
+	return 0.0, false
+}


### PR DESCRIPTION
Replaces the five separate rules that decided a literal's Go type in emitted code with a single rule at the positions where Go infers a type.

Follow-up to #1387