### PR TITLE
fix: newtype field access through type alias

### DIFF
--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -277,25 +277,15 @@ impl Planner<'_> {
         }
     }
 
-    /// Emit a newtype cast like `MyType(inner)` for single-field tuple struct access.
-    /// Returns None if the struct shape doesn't match (no single field, non-struct type).
+    /// Emit `.0` on a newtype as a Go conversion to the field type, `int(n)`.
+    /// Peels type aliases, so `.0` through `type Alias = New` also converts.
+    /// Returns None when the type is not a newtype.
     fn try_emit_newtype_cast(
         &mut self,
         expression_ty: &Type,
         expression_string: &str,
     ) -> Option<String> {
-        let deref_ty = expression_ty.strip_refs();
-        let Type::Nominal { id, .. } = &deref_ty else {
-            return None;
-        };
-        let Some(Definition {
-            body: DefinitionBody::Struct { fields, .. },
-            ..
-        }) = self.facts.definition(id.as_str())
-        else {
-            return None;
-        };
-        let field_ty = fields.first()?.ty.clone();
+        let field_ty = self.get_newtype_underlying(expression_ty)?;
         let go_type = self.use_go_type(&field_ty);
         let operand = if expression_ty.is_ref() {
             format!("*{}", expression_string)

--- a/tests/e2e_smoke_project/src/structs.test.lis
+++ b/tests/e2e_smoke_project/src/structs.test.lis
@@ -41,6 +41,13 @@ fn tuple_struct_single() {
 }
 
 #[test]
+fn tuple_struct_single_through_alias() {
+  let id: UserIdAlias = UserId(42)
+  let result = id.0
+  assert result == 42
+}
+
+#[test]
 fn tuple_struct_multi() {
   let p = Point2D(10, 20)
   let result = p.0 + p.1
@@ -373,6 +380,8 @@ enum Cursor {
 }
 
 struct UserId(int)
+
+type UserIdAlias = UserId
 
 struct Point2D(int, int)
 

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -415,6 +415,30 @@ fn test() -> int {
 }
 
 #[test]
+fn newtype_field_access_through_alias() {
+    let input = r#"
+import "go:fmt"
+
+struct Flag(bool)
+struct Ticket(int)
+type FlagAlias = Flag
+type TicketAlias = Ticket
+type Deep = TicketAlias
+
+fn read(x: FlagAlias) -> bool { x.0 }
+fn deep(t: Deep) -> int { t.0 }
+
+fn main() {
+  let f: FlagAlias = Flag(true)
+  let t: TicketAlias = Ticket(3)
+  let o: Option<FlagAlias> = Some(Flag(false))
+  fmt.Println(f.0, t.0, read(f), deep(t), o.unwrap_or(Flag(true)).0)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_field_assignment() {
     let input = r#"
 fn test() -> int {

--- a/tests/spec/emit/snapshots/newtype_field_access_through_alias.snap
+++ b/tests/spec/emit/snapshots/newtype_field_access_through_alias.snap
@@ -1,0 +1,55 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Flag(bool)
+  struct Ticket(int)
+  type FlagAlias = Flag
+  type TicketAlias = Ticket
+  type Deep = TicketAlias
+  
+  fn read(x: FlagAlias) -> bool { x.0 }
+  fn deep(t: Deep) -> int { t.0 }
+  
+  fn main() {
+    let f: FlagAlias = Flag(true)
+    let t: TicketAlias = Ticket(3)
+    let o: Option<FlagAlias> = Some(Flag(false))
+    fmt.Println(f.0, t.0, read(f), deep(t), o.unwrap_or(Flag(true)).0)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Flag bool
+
+type Ticket int
+
+type FlagAlias = Flag
+
+type TicketAlias = Ticket
+
+type Deep = TicketAlias
+
+func read(x FlagAlias) bool {
+	return bool(x)
+}
+
+func deep(t Deep) int {
+	return int(t)
+}
+
+func main() {
+	f := Flag(true)
+	t := Ticket(3)
+	o := lisette.MakeOptionSome(Flag(false))
+	arg_1 := bool(f)
+	arg_2 := int(t)
+	fmt.Println(arg_1, arg_2, read(f), deep(t), bool(o.UnwrapOr(Flag(true))))
+}


### PR DESCRIPTION
Reading `.0` on a newtype through a type alias now compiles.

```rs
import "go:fmt"

struct Flag(bool)
type FlagAlias = Flag

fn read(f: FlagAlias) -> bool {
  f.0
}

fn main() {
  fmt.Println(read(Flag(true)))
}
```