### PR TITLE
refactor: simplify binding scopes in `emit` crate

### DIFF
--- a/crates/emit/Cargo.toml
+++ b/crates/emit/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 syntax = { package = "lisette-syntax", version = "=0.12.0", path = "../syntax" }

--- a/crates/emit/src/analyze/facts.rs
+++ b/crates/emit/src/analyze/facts.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ecow::EcoString;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -32,8 +30,8 @@ pub(crate) struct EmitFactsConfig<'a> {
     pub(crate) entry_package_name: &'a str,
     pub(crate) go_module: String,
     pub(crate) emit_tests: bool,
-    pub(crate) line_indexes: Option<Arc<HashMap<u32, LineIndex>>>,
-    pub(crate) globals: Arc<GlobalEmitData>,
+    pub(crate) line_indexes: Option<&'a HashMap<u32, LineIndex>>,
+    pub(crate) globals: &'a GlobalEmitData,
     pub(crate) current_package: PackageId,
 }
 
@@ -49,8 +47,8 @@ pub(crate) struct EmitFacts<'a> {
     entry_package_name: &'a str,
     go_module: String,
     emit_tests: bool,
-    line_indexes: Option<Arc<HashMap<u32, LineIndex>>>,
-    globals: Arc<GlobalEmitData>,
+    line_indexes: Option<&'a HashMap<u32, LineIndex>>,
+    globals: &'a GlobalEmitData,
     current_package: PackageId,
 }
 
@@ -333,7 +331,7 @@ impl<'a> EmitFacts<'a> {
     }
 
     pub(crate) fn line_index(&self, file_id: u32) -> Option<&LineIndex> {
-        self.line_indexes.as_ref()?.get(&file_id)
+        self.line_indexes?.get(&file_id)
     }
 }
 

--- a/crates/emit/src/analyze/queries.rs
+++ b/crates/emit/src/analyze/queries.rs
@@ -2,12 +2,9 @@ use std::rc::Rc;
 
 use crate::Planner;
 use crate::control_flow::fallible;
-use crate::definitions::enum_layout::{EnumLayout, FieldTypeInfo, FieldTypeMap};
-use crate::definitions::structs::is_raw_function_type;
+use crate::definitions::enum_layout::EnumLayout;
 use crate::names::go_name;
-use crate::names::packages::PackageRequirements;
 use syntax::ast::{Generic, Pattern, RestPattern, StructFields};
-use syntax::containment::enum_payload_pointer_wrapped;
 use syntax::go_names;
 use syntax::program::{Definition, DefinitionBody, interface_requirements};
 use syntax::types;
@@ -229,13 +226,13 @@ impl Planner<'_> {
 }
 
 impl Planner<'_> {
-    /// Memoized per file. See the note on `Planner::enum_layouts`.
     pub(crate) fn enum_layout(&self, enum_id: &str) -> Option<Rc<EnumLayout>> {
-        if let Some(layout) = self.enum_layouts.borrow().get(enum_id) {
+        if let Some(layout) = self.namespace.enum_layouts.borrow().get(enum_id) {
             return Some(layout.clone());
         }
         let layout = Rc::new(self.compute_enum_layout(enum_id)?);
-        self.enum_layouts
+        self.namespace
+            .enum_layouts
             .borrow_mut()
             .insert(enum_id.to_string(), layout.clone());
         Some(layout)
@@ -261,39 +258,11 @@ impl Planner<'_> {
             return None;
         }
 
-        let mut field_types = FieldTypeMap::default();
-        let mut requirements = PackageRequirements::default();
-        for (vi, variant) in variants.iter().enumerate() {
-            for (fi, field) in variant.fields.iter().enumerate() {
-                let rendered_type = self.go_type(&field.ty);
-                requirements.extend(rendered_type.requirements());
-                let mut go_type = rendered_type.code;
-                let recursive = enum_payload_pointer_wrapped(enum_id, vi, fi, &field.ty, |id| {
-                    self.facts.definition(id)
-                });
-
-                if recursive {
-                    go_type = format!("*{}", go_type);
-                }
-
-                let is_function = !recursive && is_raw_function_type(&field.ty);
-                field_types.insert(
-                    (vi, fi),
-                    FieldTypeInfo {
-                        go_type,
-                        is_function,
-                        is_recursive: recursive,
-                    },
-                );
-            }
-        }
-
         Some(EnumLayout::new(
+            self,
             enum_id,
             generics,
             variants,
-            &field_types,
-            requirements,
             *default_variant,
         ))
     }
@@ -368,7 +337,7 @@ impl Planner<'_> {
             && let Some(variant_layout) = layout.get_variant(variant)
             && let Some(field) = variant_layout.fields.get(index)
         {
-            return field.is_recursive;
+            return field.is_recursive();
         }
         false
     }

--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -1,10 +1,12 @@
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::definitions::structs::StringFormat;
+use crate::Planner;
+use crate::definitions::structs::{StringFormat, is_raw_function_type};
 use crate::names::go_name;
 use crate::names::packages::PackageRequirements;
 use crate::utils::{synthesized_local_name, synthesized_receiver_name};
 use syntax::ast::{EnumVariant, Generic};
+use syntax::containment::enum_payload_pointer_wrapped;
 
 use syntax::go_names;
 use syntax::go_names::EnumFieldShape;
@@ -37,36 +39,45 @@ pub(crate) struct FieldLayout {
     pub(crate) source_name: String,
     pub(crate) go_name: String,
     pub(crate) go_type: String,
-    is_function: bool,
-    pub(crate) is_recursive: bool,
+    kind: FieldKind,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct FieldTypeInfo {
-    pub(crate) go_type: String,
-    pub(crate) is_function: bool,
-    pub(crate) is_recursive: bool,
+#[derive(Debug, Clone, Copy)]
+enum FieldKind {
+    Value,
+    Function,
+    Recursive,
 }
 
-pub(crate) type FieldTypeMap = HashMap<(usize, usize), FieldTypeInfo>;
+impl FieldLayout {
+    fn is_function(&self) -> bool {
+        matches!(self.kind, FieldKind::Function)
+    }
+
+    pub(crate) fn is_recursive(&self) -> bool {
+        matches!(self.kind, FieldKind::Recursive)
+    }
+}
 
 impl EnumLayout {
     pub(crate) fn new(
+        planner: &Planner,
         enum_id: &str,
         generics: &[Generic],
         variants: &[EnumVariant],
-        field_types: &FieldTypeMap,
-        requirements: PackageRequirements,
         default_variant: Option<usize>,
     ) -> Self {
         let enum_name = go_name::unqualified_name(enum_id).to_string();
         let tag_type = format!("{}Tag", enum_name);
 
+        let mut requirements = PackageRequirements::default();
         let slots = go_names::enum_field_slots(&enum_name, variants);
         let variants: Vec<_> = variants
             .iter()
             .enumerate()
-            .map(|(vi, v)| Self::compute_variant_layout(vi, v, &enum_name, &slots[vi], field_types))
+            .map(|(vi, v)| {
+                Self::compute_variant_layout(planner, vi, v, enum_id, &slots[vi], &mut requirements)
+            })
             .collect();
         let mut variant_indexes = HashMap::default();
         for (index, variant) in variants.iter().enumerate() {
@@ -107,12 +118,14 @@ impl EnumLayout {
     }
 
     fn compute_variant_layout(
+        planner: &Planner,
         variant_index: usize,
         variant: &EnumVariant,
-        enum_name: &str,
+        enum_id: &str,
         slots: &[String],
-        field_types: &FieldTypeMap,
+        requirements: &mut PackageRequirements,
     ) -> VariantLayout {
+        let enum_name = go_name::unqualified_name(enum_id);
         let tag_constant = go_name::enum_tag_constant(enum_name, &variant.name);
 
         let field_shape =
@@ -131,19 +144,25 @@ impl EnumLayout {
 
                 let go_name = slots[fi].clone();
 
-                let info = field_types.get(&(variant_index, fi));
-                let go_type = info
-                    .map(|i| i.go_type.clone())
-                    .unwrap_or_else(|| "any".to_string());
-                let is_function = info.is_some_and(|i| i.is_function);
-                let is_recursive = info.is_some_and(|i| i.is_recursive);
+                let rendered = planner.go_type(&field.ty);
+                requirements.extend(rendered.requirements());
+                let recursive =
+                    enum_payload_pointer_wrapped(enum_id, variant_index, fi, &field.ty, |id| {
+                        planner.facts.definition(id)
+                    });
+                let (go_type, kind) = if recursive {
+                    (format!("*{}", rendered.code), FieldKind::Recursive)
+                } else if is_raw_function_type(&field.ty) {
+                    (rendered.code, FieldKind::Function)
+                } else {
+                    (rendered.code, FieldKind::Value)
+                };
 
                 FieldLayout {
                     source_name,
                     go_name,
                     go_type,
-                    is_function,
-                    is_recursive,
+                    kind,
                 }
             })
             .collect();
@@ -287,20 +306,20 @@ impl EnumLayout {
         let args: Vec<String> = variant
             .fields
             .iter()
-            .map(|f| format.argument(format!("{receiver}.{}", f.go_name), f.is_function))
+            .map(|f| format.argument(format!("{receiver}.{}", f.go_name), f.is_function()))
             .collect();
         let (open, close, placeholders) = if variant.is_struct_variant {
             let parts: Vec<String> = variant
                 .fields
                 .iter()
-                .map(|f| format!("{}: {}", f.source_name, format.verb(f.is_function)))
+                .map(|f| format!("{}: {}", f.source_name, format.verb(f.is_function())))
                 .collect();
             (" { ", " }", parts.join(", "))
         } else {
             let parts: Vec<&str> = variant
                 .fields
                 .iter()
-                .map(|f| format.verb(f.is_function))
+                .map(|f| format.verb(f.is_function()))
                 .collect();
             ("(", ")", parts.join(", "))
         };
@@ -319,7 +338,7 @@ impl EnumLayout {
         self.variants
             .iter()
             .flat_map(|v| v.fields.iter())
-            .any(|f| !f.is_function)
+            .any(|f| !f.is_function())
     }
 
     pub(crate) fn emit_variants_function(&self, fn_name: &str) -> String {

--- a/crates/emit/src/definitions/enums.rs
+++ b/crates/emit/src/definitions/enums.rs
@@ -150,7 +150,7 @@ impl Planner<'_> {
                 .map(|(sem_field, layout_field)| {
                     let mut lhs = format!("{receiver}.{}", layout_field.go_name);
                     let mut rhs = format!("{other}.{}", layout_field.go_name);
-                    if layout_field.is_recursive {
+                    if layout_field.is_recursive() {
                         lhs = format!("(*{lhs})");
                         rhs = format!("(*{rhs})");
                     }
@@ -215,7 +215,7 @@ impl Planner<'_> {
             .enumerate()
             .map(|(index, field)| {
                 let argument = format!("arg{}", index);
-                if field.is_recursive {
+                if field.is_recursive() {
                     let pointee = field.go_type.trim_start_matches('*');
                     let param = format!("{} {}", argument, pointee);
                     let field_assignment = format!("{}: &{}", field.go_name, argument);

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -645,7 +645,7 @@ impl Planner<'_> {
                 variant
                     .fields
                     .iter()
-                    .filter(|f| f.is_recursive)
+                    .filter(|f| f.is_recursive())
                     .map(|f| f.source_name.clone())
                     .collect()
             } else {

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -32,10 +32,6 @@ pub use output::OutputFile;
 pub use output::imports;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::cell::RefCell;
-use std::mem;
-use std::rc::Rc;
-use std::sync::Arc;
 
 use abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use abi::catalog::GoAbiCatalog;
@@ -46,7 +42,6 @@ use names::packages::{PackageRequirements, PackageUse};
 use plan::PackagePlan;
 use plan::bodies::{LoopId, LoweredBlock, LoweredStatement};
 use state::adapter_registry::AdapterRegistry;
-use state::bindings::BindingSnapshot;
 use state::file_namespace::FileNamespace;
 use state::package_state::{FunctionEmissionContext, PackageState};
 use state::scope::ScopeState;
@@ -203,9 +198,6 @@ pub struct Planner<'a> {
     scope: ScopeState,
     adapter_registry: AdapterRegistry,
     namespace: FileNamespace,
-    /// Keep this memo. Layout queries run per field access, and each recompute
-    /// renders every field type again (5.8x slower on a 40-variant enum).
-    enum_layouts: RefCell<HashMap<String, Rc<EnumLayout>>>,
 }
 
 impl Planner<'_> {
@@ -292,24 +284,22 @@ impl<'a> Planner<'a> {
         options: EmitOptions,
     ) -> Result<Vec<OutputFile>, Vec<LisetteDiagnostic>> {
         let line_indexes = options.sourcemap.then(|| {
-            Arc::new(
-                analysis
-                    .files
-                    .iter()
-                    .map(|(file_id, file)| {
-                        (
-                            *file_id,
-                            LineIndex::from_source(file.display_path.clone(), &file.source),
-                        )
-                    })
-                    .collect(),
-            )
+            analysis
+                .files
+                .iter()
+                .map(|(file_id, file)| {
+                    (
+                        *file_id,
+                        LineIndex::from_source(file.display_path.clone(), &file.source),
+                    )
+                })
+                .collect()
         });
 
         let shared = SharedEmitContext {
             emit_tests: options.emit_tests,
             line_indexes,
-            globals: Arc::new(GlobalEmitData::compute(&analysis.definitions)),
+            globals: GlobalEmitData::compute(&analysis.definitions),
         };
 
         let mut files_by_package: HashMap<&str, Vec<&File>> = HashMap::default();
@@ -372,12 +362,12 @@ impl<'a> Planner<'a> {
         files: &[&File],
     ) -> Result<Vec<OutputFile>, Vec<LisetteDiagnostic>> {
         let line_indexes = source.map(|src| {
-            Arc::new(HashMap::from_iter([(
+            HashMap::from_iter([(
                 0u32,
                 LineIndex::from_source("src/test.lis".to_string(), src),
-            )]))
+            )])
         });
-        let globals = Arc::new(GlobalEmitData::compute(config.definitions));
+        let globals = GlobalEmitData::compute(config.definitions);
         let facts = EmitFacts::new(EmitFactsConfig {
             definitions: config.definitions,
             unused: config.unused,
@@ -390,11 +380,11 @@ impl<'a> Planner<'a> {
             entry_package_name: "main",
             go_module: config.go_module.to_string(),
             emit_tests: false,
-            line_indexes,
-            globals,
+            line_indexes: line_indexes.as_ref(),
+            globals: &globals,
             current_package: config.package_id.to_string().into(),
         });
-        Self::emit_files_with_facts(facts, files, config.package_id)
+        Planner::emit_files_with_facts(facts, files)
     }
 
     fn new(facts: EmitFacts<'a>, first_file: &File) -> Self {
@@ -411,7 +401,6 @@ impl<'a> Planner<'a> {
             scope: ScopeState::new(),
             adapter_registry: AdapterRegistry::default(),
             namespace,
-            enum_layouts: RefCell::default(),
         }
     }
 
@@ -570,17 +559,6 @@ impl<'a> Planner<'a> {
         result
     }
 
-    fn with_binding_snapshot<R>(
-        &mut self,
-        snapshot: BindingSnapshot,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        let current = self.scope.replace_binding_snapshot(snapshot);
-        let result = f(self);
-        let _ = self.scope.replace_binding_snapshot(current);
-        result
-    }
-
     fn capture_go_uses<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> (R, HashSet<String>) {
         self.scope.enter_use_region();
         let result = f(self);
@@ -614,20 +592,15 @@ impl<'a> Planner<'a> {
     fn emit_files_with_facts(
         facts: EmitFacts<'a>,
         files: &[&File],
-        package_id: &str,
     ) -> Result<Vec<OutputFile>, Vec<LisetteDiagnostic>> {
         let Some(first_file) = files.first() else {
             return Ok(Vec::new());
         };
-        Self::new(facts, first_file).emit_files(files, package_id)
+        Self::new(facts, first_file).emit_files(files)
     }
 
-    fn emit_files(
-        mut self,
-        files: &[&File],
-        package_id: &str,
-    ) -> Result<Vec<OutputFile>, Vec<LisetteDiagnostic>> {
-        let plan = self.build_package_plan(files, package_id);
+    fn emit_files(mut self, files: &[&File]) -> Result<Vec<OutputFile>, Vec<LisetteDiagnostic>> {
+        let plan = self.build_package_plan(files);
         self.render_package_plan(files, plan)
     }
 
@@ -643,46 +616,26 @@ impl<'a> Planner<'a> {
         let mut output_files = Vec::new();
         let mut all_diagnostics = collision_diagnostics;
 
-        let (last_file, preceding_files) = files
-            .split_last()
-            .expect("a planner is created only for a nonempty file set");
-        for (i, file) in preceding_files.iter().enumerate() {
-            let rendered_source = self.render_file_source(file);
-            let next_namespace = FileNamespace::build(
-                files[i + 1],
+        for file in files {
+            self.namespace = FileNamespace::build(
+                file,
                 self.facts.go_module(),
                 self.facts.unused_imports_for_current_package(),
                 self.facts.go_package_names(),
             );
-            // Layouts render Go types against the current file's import aliases.
-            self.enum_layouts.get_mut().clear();
-            let namespace = mem::replace(&mut self.namespace, next_namespace);
-            let (imports, mut diagnostics) =
-                namespace.finish(self.facts.go_package_names(), self.facts.go_package_ids());
+            let source = self.render_file_source(file);
+            let (imports, mut diagnostics) = self
+                .namespace
+                .finish(self.facts.go_package_names(), self.facts.go_package_ids());
             all_diagnostics.append(&mut diagnostics);
             output_files.push(OutputFile {
                 name: file.go_filename(),
                 imports,
-                source: rendered_source,
+                source,
                 package_name: package_name.clone(),
                 file_comment: file.file_comment.clone(),
             });
         }
-
-        let rendered_source = self.render_file_source(last_file);
-        let Planner {
-            facts, namespace, ..
-        } = self;
-        let (imports, mut diagnostics) =
-            namespace.finish(facts.go_package_names(), facts.go_package_ids());
-        all_diagnostics.append(&mut diagnostics);
-        output_files.push(OutputFile {
-            name: last_file.go_filename(),
-            imports,
-            source: rendered_source,
-            package_name,
-            file_comment: last_file.file_comment.clone(),
-        });
 
         if all_diagnostics.is_empty() {
             Ok(output_files)
@@ -724,8 +677,8 @@ impl<'a> Planner<'a> {
 /// Emit state built once in [`Planner::emit`] and shared by every package worker.
 struct SharedEmitContext {
     emit_tests: bool,
-    line_indexes: Option<Arc<HashMap<u32, LineIndex>>>,
-    globals: Arc<GlobalEmitData>,
+    line_indexes: Option<HashMap<u32, LineIndex>>,
+    globals: GlobalEmitData,
 }
 
 fn emit_package<'a>(
@@ -748,11 +701,11 @@ fn emit_package<'a>(
         entry_package_name,
         go_module: go_module.to_string(),
         emit_tests: shared_emit_ctx.emit_tests,
-        line_indexes: shared_emit_ctx.line_indexes.clone(),
-        globals: shared_emit_ctx.globals.clone(),
+        line_indexes: shared_emit_ctx.line_indexes.as_ref(),
+        globals: &shared_emit_ctx.globals,
         current_package: package_id.to_string().into(),
     });
-    Planner::emit_files_with_facts(facts, files, package_id).map(|mut package_output| {
+    Planner::emit_files_with_facts(facts, files).map(|mut package_output| {
         if package_id != analysis.entry_package_id.as_str() {
             for file in &mut package_output {
                 file.name = format!("{}/{}", package_id, file.name);

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -1,12 +1,12 @@
 use crate::Planner;
-use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate, region_blocks_inline};
+use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
 use crate::patterns::decision_tree::{
     Check, PatternBinding, PatternInfo, SubjectRoot, render_condition,
 };
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::placement::simple_assign;
 use crate::plan::values::ValuePlan;
-use crate::state::bindings::{BindingValue, InlineExpr};
+use crate::state::bindings::InlineExpr;
 use std::borrow::Cow;
 use syntax::ast::Expression;
 
@@ -106,17 +106,14 @@ pub(crate) fn compose_refutable_condition(
     }
 }
 
-/// Push one `name := subject.path` per binding. Inlined bindings produce no
-/// statement; their overlay pairs are returned for `drop_inline_overlays`.
+/// Push one `name := subject.path` per binding. Inlined bindings produce no statement.
 pub(crate) fn tree_binding_statements(
     planner: &mut Planner,
     statements: &mut Vec<LoweredStatement>,
     bindings: &[PatternBinding],
     subject_var: &str,
     consumers: &[&Expression],
-    inline_blockers: &[&Expression],
-) -> Vec<(String, Option<BindingValue>)> {
-    let mut installed_inlines = Vec::new();
+) {
     for binding in bindings {
         let Some(ref go_name) = binding.go_name else {
             planner.scope.bind(&binding.lisette_name, "");
@@ -125,13 +122,7 @@ pub(crate) fn tree_binding_statements(
 
         let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
 
-        if analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline
-            && !region_blocks_inline(inline_blockers.iter().copied(), &binding.lisette_name)
-        {
-            let previous = planner
-                .scope
-                .resolve_identifier_binding(&binding.lisette_name)
-                .cloned();
+        if analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline {
             let safe_text = binding
                 .path
                 .render_composable(SubjectRoot::Var(subject_var));
@@ -143,7 +134,6 @@ pub(crate) fn tree_binding_statements(
                     binding.path.contains_deferred_evaluation(),
                 ),
             );
-            installed_inlines.push((binding.lisette_name.clone(), previous));
             continue;
         }
 
@@ -169,26 +159,6 @@ pub(crate) fn tree_binding_statements(
             value: access_expression,
         });
     }
-    installed_inlines
-}
-
-pub(crate) fn drop_inline_overlays(
-    planner: &mut Planner,
-    installed: &[(String, Option<BindingValue>)],
-) {
-    for (name, previous) in installed {
-        match previous {
-            Some(value @ (BindingValue::GoName(_) | BindingValue::GoConst(_))) => {
-                planner.scope.bind_value(name.as_str(), value.clone());
-            }
-            Some(BindingValue::InlineExpr(expr)) => {
-                planner.scope.bind_inline_expr(name.as_str(), expr.clone());
-            }
-            None => {
-                planner.scope.remove_binding(name);
-            }
-        }
-    }
 }
 
 pub(crate) fn with_tree_bindings<R>(
@@ -199,11 +169,10 @@ pub(crate) fn with_tree_bindings<R>(
     body: &Expression,
     f: impl FnOnce(&mut Planner, &mut Vec<LoweredStatement>) -> R,
 ) -> R {
-    let overlays =
-        tree_binding_statements(planner, statements, bindings, subject_var, &[body], &[]);
-    let result = f(planner, statements);
-    drop_inline_overlays(planner, &overlays);
-    result
+    planner.with_binding_frame(|planner| {
+        tree_binding_statements(planner, statements, bindings, subject_var, &[body]);
+        f(planner, statements)
+    })
 }
 
 /// Push `name = subject.path` leaves for or-pattern alternatives whose

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -94,10 +94,10 @@ impl ResolvedSubject {
     }
 }
 
-struct LetElseAlternatives<'s> {
-    collected: Vec<PatternInfo>,
-    hoisted: Vec<(Cow<'s, str>, Option<String>)>,
-    irrefutable_index: Option<usize>,
+struct RefutableAlternative<'s> {
+    info: PatternInfo,
+    subject: Cow<'s, str>,
+    ok_var: Option<String>,
 }
 
 impl Planner<'_> {
@@ -158,7 +158,7 @@ impl Planner<'_> {
         let (body, used) = self.capture_go_uses(|this| {
             let mut body = Vec::new();
             let effective = apply_root_assertion(this, &mut body, &info, resolved.var());
-            tree_binding_statements(this, &mut body, &info.bindings, &effective, &[], &[]);
+            tree_binding_statements(this, &mut body, &info.bindings, &effective, &[]);
             body
         });
         let body_block = LoweredBlock { statements: body };
@@ -410,14 +410,7 @@ impl Planner<'_> {
         let then_body = self.with_scope(|this| {
             let mut then_body: Vec<LoweredStatement> = Vec::new();
             if !matches!(pattern, Pattern::Or { .. }) {
-                tree_binding_statements(
-                    this,
-                    &mut then_body,
-                    &info.bindings,
-                    &effective,
-                    &[body],
-                    &[],
-                );
+                tree_binding_statements(this, &mut then_body, &info.bindings, &effective, &[body]);
             }
             then_body.extend(this.lower_block_as_body(body).statements);
             then_body
@@ -561,7 +554,6 @@ impl Planner<'_> {
                 &info.bindings,
                 &effective_subject,
                 &[],
-                &[],
             );
             return statements;
         }
@@ -596,7 +588,6 @@ impl Planner<'_> {
             &info.bindings,
             &effective_subject,
             &[],
-            &[],
         );
         statements
     }
@@ -616,102 +607,70 @@ impl Planner<'_> {
         let Pattern::Or { patterns, .. } = pattern else {
             unreachable!("lower_let_else_or_pattern requires an Or pattern");
         };
-        let pre_let_snapshot = self.scope.binding_snapshot();
-        let mut statements = Vec::new();
-        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty);
-
-        let mut asserts = Vec::new();
-        let alts =
-            self.collect_let_else_alternatives(&mut asserts, patterns, subject_ty, subject_var);
-
-        statements.extend(asserts);
-
-        let chain_len = alts.irrefutable_index.unwrap_or(alts.collected.len());
-
-        // An irrefutable first alternative always matches: no chain, just its
-        // assignments.
-        if chain_len == 0 {
-            let (effective, _) = &alts.hoisted[0];
-            tree_assignment_statements(
-                self,
-                &mut statements,
-                &alts.collected[0].bindings,
-                effective,
-            );
-            return statements;
-        }
-
-        // Forward pass (preserves scope-op order): condition plus assignment
-        // block per chain alternative.
-        let mut pieces: Vec<(String, LoweredBlock)> = Vec::with_capacity(chain_len);
-        for (i, info) in alts.collected.iter().take(chain_len).enumerate() {
-            let (effective, ok_var) = &alts.hoisted[i];
-            if !info.checks.is_empty() {
-                self.scope.record_go_use(effective.as_ref());
-            }
-            let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
-            let mut assigns = Vec::new();
-            tree_assignment_statements(self, &mut assigns, &info.bindings, effective);
-            pieces.push((
-                condition,
-                LoweredBlock {
-                    statements: assigns,
-                },
-            ));
-        }
-
-        // Terminal `else`: the irrefutable alternative's assignments, or the
-        // lowered `else` block (with the or-pattern bindings out of scope).
-        let terminal = match alts.irrefutable_index {
-            Some(index) => {
-                let (effective, _) = &alts.hoisted[index];
-                let mut assigns = Vec::new();
-                tree_assignment_statements(
-                    self,
-                    &mut assigns,
-                    &alts.collected[index].bindings,
-                    effective,
-                );
-                LoweredBlock {
-                    statements: assigns,
-                }
-            }
-            None => self.with_binding_snapshot(pre_let_snapshot, |this| {
-                this.lower_refutable_fail(fail, subject_var)
-            }),
-        };
-
-        statements.push(assemble_if_else_chain(pieces, terminal));
-        statements
-    }
-
-    fn collect_let_else_alternatives<'s>(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        patterns: &[Pattern],
-        subject_ty: &Type,
-        subject_var: &'s str,
-    ) -> LetElseAlternatives<'s> {
-        let collected: Vec<PatternInfo> = patterns
+        let infos: Vec<_> = patterns
             .iter()
             .map(|alt| decision_tree::collect_pattern_info(self, alt, subject_ty))
             .collect();
-        for info in &collected {
-            self.require_packages(&info.packages);
-        }
-        let hoisted: Vec<(Cow<'s, str>, Option<String>)> = collected
+        let failure = infos
             .iter()
-            .map(|info| apply_refutable_root_assertion(self, statements, info, subject_var))
-            .collect();
-        let irrefutable_index = collected
-            .iter()
-            .zip(hoisted.iter())
-            .position(|(info, (_, ok_var))| info.checks.is_empty() && ok_var.is_none());
-        LetElseAlternatives {
-            collected,
-            hoisted,
-            irrefutable_index,
+            .all(|info| !info.checks.is_empty() || info.root_assertion.is_some())
+            .then(|| self.lower_refutable_fail(fail, subject_var));
+
+        let mut statements = Vec::new();
+        self.lower_binding_declarations_with_type(&mut statements, pattern, binding_ty);
+        let alternatives = self.prepare_refutable_alternatives(&mut statements, infos, subject_var);
+        let mut pieces = Vec::new();
+        for alternative in alternatives {
+            let RefutableAlternative {
+                info,
+                subject,
+                ok_var,
+            } = alternative;
+            let mut assigns = Vec::new();
+            tree_assignment_statements(self, &mut assigns, &info.bindings, &subject);
+            let body = LoweredBlock {
+                statements: assigns,
+            };
+            if info.checks.is_empty() && ok_var.is_none() {
+                if pieces.is_empty() {
+                    statements.extend(body.statements);
+                } else {
+                    statements.push(assemble_if_else_chain(pieces, body));
+                }
+                return statements;
+            }
+            if !info.checks.is_empty() {
+                self.scope.record_go_use(&subject);
+            }
+            let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, &subject);
+            pieces.push((condition, body));
         }
+        statements.push(assemble_if_else_chain(
+            pieces,
+            failure.expect("all alternatives are refutable"),
+        ));
+        statements
+    }
+
+    fn prepare_refutable_alternatives<'s>(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        infos: Vec<PatternInfo>,
+        subject: &'s str,
+    ) -> Vec<RefutableAlternative<'s>> {
+        infos
+            .into_iter()
+            .map(|info| {
+                self.require_packages(&info.packages);
+                let (subject, ok_var) =
+                    apply_refutable_root_assertion(self, statements, &info, subject);
+                RefutableAlternative {
+                    info,
+                    subject,
+                    ok_var,
+                }
+            })
+            .collect()
     }
 
     /// Lower a binding or-pattern while-let body into `statements`: per-
@@ -732,10 +691,6 @@ impl Planner<'_> {
             .iter()
             .map(|alt| decision_tree::collect_pattern_info(self, alt, subject_ty))
             .collect();
-        for info in &alternatives {
-            self.require_packages(&info.packages);
-        }
-
         let unused_names: rustc_hash::FxHashSet<String> = alternatives
             .iter()
             .flat_map(|info| info.bindings.iter())
@@ -750,15 +705,17 @@ impl Planner<'_> {
             }
         }
 
-        let hoisted: Vec<_> = alternatives
-            .iter()
-            .map(|info| apply_refutable_root_assertion(self, statements, info, subject_var))
-            .collect();
-
-        let mut pieces: Vec<(String, LoweredBlock)> = Vec::with_capacity(alternatives.len());
-        for (i, info) in alternatives.iter().enumerate() {
-            let (effective, ok_var) = &hoisted[i];
-            let condition = compose_refutable_condition(ok_var.as_deref(), &info.checks, effective);
+        let alternatives =
+            self.prepare_refutable_alternatives(statements, alternatives, subject_var);
+        let mut pieces = Vec::with_capacity(alternatives.len());
+        for alternative in alternatives {
+            let RefutableAlternative {
+                info,
+                subject: effective,
+                ok_var,
+            } = alternative;
+            let condition =
+                compose_refutable_condition(ok_var.as_deref(), &info.checks, &effective);
 
             let branch = self.with_scope(|this| {
                 let mut branch = Vec::new();
@@ -766,7 +723,7 @@ impl Planner<'_> {
                     this,
                     &mut branch,
                     &info.bindings,
-                    effective,
+                    &effective,
                     body,
                     |this, branch| {
                         branch.extend(this.lower_block_as_body(body).statements);

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -5,7 +5,7 @@ use crate::Planner;
 use crate::analyze::inline_uses::{InlineDecision, analyze_inline_candidate};
 use crate::context::expression::ExpressionContext;
 use crate::patterns::binding_decls::{is_catchall_pattern, is_unconditional_catchall};
-use crate::patterns::binding_emit::{drop_inline_overlays, tree_binding_statements};
+use crate::patterns::binding_emit::tree_binding_statements;
 use crate::patterns::decision_tree::{
     ChainTest, Decision, PatternBinding, SubjectRoot, SwitchBranch,
     SwitchKind as PatternSwitchKind, SwitchShape, compile_expanded_arms, decision_is_exhaustive,
@@ -16,7 +16,7 @@ use crate::plan::bodies::{
     SwitchCasePlan, SwitchKind, SwitchStatementPlan,
 };
 use crate::plan::placement::unreachable_panic_if_needed;
-use crate::state::bindings::{BindingValue, InlineExpr};
+use crate::state::bindings::InlineExpr;
 use crate::utils::wrap_if_struct_literal;
 
 struct FlatCase<'d> {
@@ -239,6 +239,13 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         result
     }
 
+    fn with_binding_frame<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.planner.scope.push_binding_frame();
+        let result = f(self);
+        self.planner.scope.pop_binding_frame();
+        result
+    }
+
     fn with_optional_scope<R>(&mut self, scoped: bool, f: impl FnOnce(&mut Self) -> R) -> R {
         if scoped { self.with_scope(f) } else { f(self) }
     }
@@ -257,7 +264,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
 
         let (inner, needs_block) = self.with_scope(|this| {
             let mut inner: Vec<LoweredStatement> = Vec::new();
-            this.with_bindings(&mut inner, bindings, &[arm_body], None, |this, inner| {
+            this.with_bindings(&mut inner, bindings, &[arm_body], |this, inner| {
                 this.emit_arm_body(inner, arm_index, place)
             });
             let needs_block =
@@ -301,13 +308,9 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 bindings,
             } => {
                 let arm_body = &*self.arms[*arm_index].expression;
-                self.with_bindings(
-                    statements,
-                    bindings,
-                    &[arm_body],
-                    None,
-                    |this, statements| this.emit_arm_body(statements, *arm_index, place),
-                );
+                self.with_bindings(statements, bindings, &[arm_body], |this, statements| {
+                    this.emit_arm_body(statements, *arm_index, place)
+                });
             }
             Decision::Chain { tests, fallback } => {
                 self.lower_chain_branch(statements, tests, fallback, place);
@@ -621,9 +624,10 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         arm_index: usize,
         bindings: &[PatternBinding],
     ) -> Option<String> {
-        let overlays = self.install_path_overlays(bindings);
-        let lowered = self.lower_guard_condition(arm_index);
-        drop_inline_overlays(self.planner, &overlays);
+        let lowered = self.with_binding_frame(|this| {
+            this.install_path_overlays(bindings);
+            this.lower_guard_condition(arm_index)
+        });
         let (setup, condition) = lowered?;
         if !setup.is_empty() {
             return None;
@@ -639,20 +643,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         })
     }
 
-    fn install_path_overlays(
-        &mut self,
-        bindings: &[PatternBinding],
-    ) -> Vec<(String, Option<BindingValue>)> {
-        let mut overlays = Vec::with_capacity(bindings.len());
+    fn install_path_overlays(&mut self, bindings: &[PatternBinding]) {
         for binding in bindings {
             if binding.go_name.is_none() {
                 continue;
             }
-            let previous = self
-                .planner
-                .scope
-                .resolve_identifier_binding(&binding.lisette_name)
-                .cloned();
             let text = binding.path.render_composable(self.subject.root());
             self.planner.scope.bind_inline_expr(
                 &binding.lisette_name,
@@ -662,9 +657,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                     binding.path.contains_deferred_evaluation(),
                 ),
             );
-            overlays.push((binding.lisette_name.clone(), previous));
         }
-        overlays
     }
 
     fn lower_flat_case_body(&mut self, case: &FlatCase, place: &PlacePlan) -> LoweredBlock {
@@ -685,7 +678,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 })
                 .cloned()
                 .collect();
-            this.with_bindings(&mut body, &bindings, &[arm_body], None, |this, body| {
+            this.with_bindings(&mut body, &bindings, &[arm_body], |this, body| {
                 this.walk(body, case.decision, &ctx);
             });
             LoweredBlock { statements: body }
@@ -702,7 +695,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 let arm_body = &*self.arms[*arm_index].expression;
                 let leaf = self.with_optional_scope(wrap, |this| {
                     let mut leaf: Vec<LoweredStatement> = Vec::new();
-                    this.with_bindings(&mut leaf, bindings, &[arm_body], None, |this, leaf| {
+                    this.with_bindings(&mut leaf, bindings, &[arm_body], |this, leaf| {
                         let mut body_statements: Vec<LoweredStatement> = Vec::new();
                         this.emit_arm_body(&mut body_statements, *arm_index, ctx.arm_place);
                         let body_diverges = capture_diverge(body_statements, leaf);
@@ -878,7 +871,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 &mut guard_statements,
                 bindings,
                 &guard_consumers,
-                Some(failure),
                 |this, _| {
                     let (condition_setup, condition) = this.lower_guard_condition(arm_index)?;
                     let then_body = this.with_scope(|this| {
@@ -1171,7 +1163,6 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 statements,
                 decision_top_bindings(&tests[ref_index].decision),
                 &consumers,
-                None,
                 |this, statements| {
                     this.emit_chain_group_bodies(statements, indices, tests, ctx);
                 },
@@ -1249,57 +1240,25 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
         }
     }
 
-    /// Returns the overlay pairs installed for inline substitutions; pass to
-    /// `drop_inline_overlays` to roll them back.
-    fn emit_bindings(
-        &mut self,
-        statements: &mut Vec<LoweredStatement>,
-        bindings: &[PatternBinding],
-        consumers: &[&Expression],
-        failure_blocker: Option<&Decision>,
-    ) -> Vec<(String, Option<BindingValue>)> {
-        let failure_trees: Vec<&Expression> = match failure_blocker {
-            Some(failure) => {
-                let mut reached: Vec<usize> = Vec::new();
-                collect_reachable_arms(failure, &mut reached);
-                let mut trees: Vec<&Expression> = Vec::with_capacity(reached.len() * 2);
-                for index in reached {
-                    let arm = &self.arms[index];
-                    if let Some(guard) = arm.guard.as_ref() {
-                        trees.push(guard);
-                    }
-                    trees.push(&arm.expression);
-                }
-                trees
-            }
-            None => Vec::new(),
-        };
-
-        if bindings.is_empty() {
-            return Vec::new();
-        }
-        tree_binding_statements(
-            self.planner,
-            statements,
-            bindings,
-            self.subject.var(),
-            consumers,
-            &failure_trees,
-        )
-    }
-
     fn with_bindings<R>(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         bindings: &[PatternBinding],
         consumers: &[&Expression],
-        failure_blocker: Option<&Decision>,
         f: impl FnOnce(&mut Self, &mut Vec<LoweredStatement>) -> R,
     ) -> R {
-        let overlays = self.emit_bindings(statements, bindings, consumers, failure_blocker);
-        let result = f(self, statements);
-        drop_inline_overlays(self.planner, &overlays);
-        result
+        self.with_binding_frame(|this| {
+            if !bindings.is_empty() {
+                tree_binding_statements(
+                    this.planner,
+                    statements,
+                    bindings,
+                    this.subject.var(),
+                    consumers,
+                );
+            }
+            f(this, statements)
+        })
     }
 
     fn emit_arm_body(
@@ -1400,45 +1359,6 @@ fn decision_top_bindings(decision: &Decision) -> &[PatternBinding] {
     match decision {
         Decision::Guard { bindings, .. } | Decision::Success { bindings, .. } => bindings,
         _ => &[],
-    }
-}
-
-fn collect_reachable_arms(decision: &Decision, out: &mut Vec<usize>) {
-    match decision {
-        Decision::Success { arm_index, .. } => {
-            if !out.contains(arm_index) {
-                out.push(*arm_index);
-            }
-        }
-        Decision::Guard {
-            arm_index,
-            success,
-            failure,
-            ..
-        } => {
-            if !out.contains(arm_index) {
-                out.push(*arm_index);
-            }
-            collect_reachable_arms(success, out);
-            collect_reachable_arms(failure, out);
-        }
-        Decision::Switch {
-            branches, fallback, ..
-        } => {
-            for branch in branches {
-                collect_reachable_arms(&branch.decision, out);
-            }
-            if let Some(fallback) = fallback.as_deref() {
-                collect_reachable_arms(fallback, out);
-            }
-        }
-        Decision::Chain { tests, fallback } => {
-            for test in tests {
-                collect_reachable_arms(&test.decision, out);
-            }
-            collect_reachable_arms(fallback, out);
-        }
-        Decision::Unreachable => {}
     }
 }
 

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -16,13 +16,13 @@ pub(crate) struct PackagePlan {
 
 impl Planner<'_> {
     /// Resolve package-wide names and collisions before any item is rendered.
-    pub(crate) fn build_package_plan(&mut self, files: &[&File], package_id: &str) -> PackagePlan {
-        debug_assert_eq!(self.facts.current_package(), package_id);
+    pub(crate) fn build_package_plan(&mut self, files: &[&File]) -> PackagePlan {
         self.collect_escape_remap(files);
         self.derive_package_go_consts(files);
         self.collect_generic_renames(files);
         let collision_diagnostics = self.detect_name_collisions(files);
 
+        let package_id = self.facts.current_package();
         let package_name = if self.facts.is_entry_package(package_id) {
             self.facts.entry_package_name().to_string()
         } else {

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -1,5 +1,3 @@
-use rustc_hash::FxHashMap as HashMap;
-
 #[derive(Clone, Debug)]
 pub(crate) struct InlineExpr {
     text: String,
@@ -39,23 +37,6 @@ pub(crate) enum BindingValue {
     GoName(String),
     GoConst(String),
     InlineExpr(InlineExpr),
-}
-
-pub(crate) type BindingUndo = Vec<(String, Option<BindingValue>)>;
-
-pub(crate) struct BindingSnapshot {
-    bindings: HashMap<String, BindingValue>,
-    undo: BindingUndo,
-}
-
-impl BindingSnapshot {
-    pub(crate) fn new(bindings: HashMap<String, BindingValue>, undo: BindingUndo) -> Self {
-        Self { bindings, undo }
-    }
-
-    pub(crate) fn into_inner(self) -> (HashMap<String, BindingValue>, BindingUndo) {
-        (self.bindings, self.undo)
-    }
 }
 
 impl BindingValue {

--- a/crates/emit/src/state/file_namespace.rs
+++ b/crates/emit/src/state/file_namespace.rs
@@ -1,4 +1,8 @@
 use rustc_hash::FxHashMap as HashMap;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::EnumLayout;
 
 use crate::names::packages::{PackageRequirements, PackageUse};
 use crate::output::OutputImport;
@@ -10,6 +14,8 @@ use syntax::program::File;
 pub(crate) struct FileNamespace {
     imports: ImportPlan,
     requirements: PackageRequirements,
+    /// Keep this memo. Recomputing a layout per field access was 5.8x slower.
+    pub(crate) enum_layouts: RefCell<HashMap<String, Rc<EnumLayout>>>,
 }
 
 impl FileNamespace {
@@ -22,6 +28,7 @@ impl FileNamespace {
         Self {
             imports: ImportPlan::build(file, go_module, unused_imports, go_package_names),
             requirements: PackageRequirements::default(),
+            enum_layouts: RefCell::default(),
         }
     }
 

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -1,16 +1,13 @@
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::mem;
 
 use crate::ReturnContext;
 use crate::context::lowering::LoopContext;
 use crate::plan::bodies::LoopId;
-use crate::state::bindings::{BindingSnapshot, BindingUndo, BindingValue, InlineExpr};
+use crate::state::bindings::{BindingValue, InlineExpr};
 
 pub(crate) struct ScopeState {
     next_var: usize,
     next_loop_id: u32,
-    bindings: HashMap<String, BindingValue>,
-    bound_go_names: HashMap<String, usize>,
     frames: Vec<ScopeFrame>,
     loop_stack: Vec<LoopContext>,
     return_ctx_stack: Vec<ReturnContext>,
@@ -21,8 +18,7 @@ pub(crate) struct ScopeState {
 }
 
 struct ScopeFrame {
-    binding_undo: BindingUndo,
-    changed_bindings: HashSet<String>,
+    bindings: HashMap<String, BindingValue>,
     declarations: DeclarationScope,
     /// Conditions the branch being lowered has already tested in this scope.
     established: Vec<String>,
@@ -50,11 +46,8 @@ impl ScopeState {
         Self {
             next_var: 0,
             next_loop_id: 0,
-            bindings: HashMap::default(),
-            bound_go_names: HashMap::default(),
             frames: vec![ScopeFrame {
-                binding_undo: Vec::new(),
-                changed_bindings: HashSet::default(),
+                bindings: HashMap::default(),
                 declarations: DeclarationScope::Block(HashMap::default()),
                 established: Vec::new(),
             }],
@@ -111,38 +104,34 @@ impl ScopeState {
         self.set_binding(lisette_name.into(), BindingValue::InlineExpr(expr));
     }
 
-    pub(crate) fn bind_value(&mut self, lisette_name: impl Into<String>, value: BindingValue) {
-        self.set_binding(lisette_name.into(), value);
-    }
-
     pub(crate) fn mark_go_const(&mut self, lisette_name: &str) {
-        let Some(BindingValue::GoName(name)) = self.bindings.get(lisette_name).cloned() else {
+        let Some(BindingValue::GoName(name)) =
+            self.resolve_identifier_binding(lisette_name).cloned()
+        else {
             return;
         };
         self.set_binding(lisette_name.to_string(), BindingValue::GoConst(name));
     }
 
-    pub(crate) fn remove_binding(&mut self, lisette_name: &str) {
-        self.record_binding_change(lisette_name);
-        if let Some(value) = self.bindings.remove(lisette_name) {
-            self.remove_bound_go_name(&value);
-        }
-    }
-
     pub(crate) fn resolve_identifier_binding(&self, lisette_name: &str) -> Option<&BindingValue> {
-        self.bindings.get(lisette_name)
+        self.frames
+            .iter()
+            .rev()
+            .find_map(|frame| frame.bindings.get(lisette_name))
     }
 
     pub(crate) fn resolve_binding_go_name(&self, lisette_name: &str) -> Option<&str> {
-        self.bindings
-            .get(lisette_name)
+        self.resolve_identifier_binding(lisette_name)
             .and_then(BindingValue::as_go_name)
     }
 
-    /// Falls back to the keyword-escaped form when the name is unbound or
-    /// inline-bound; callers needing a usable local must hoist a fresh temp.
     pub(crate) fn has_binding_for_go_name(&self, go_name: &str) -> bool {
-        self.bound_go_names.contains_key(go_name)
+        self.frames.iter().any(|frame| {
+            frame.bindings.iter().any(|(source_name, value)| {
+                value.as_go_name() == Some(go_name)
+                    && self.resolve_binding_go_name(source_name) == Some(go_name)
+            })
+        })
     }
 
     pub(crate) fn push_binding_frame(&mut self) {
@@ -158,30 +147,6 @@ impl ScopeState {
             "a binding frame must be pushed before it is popped"
         );
         self.pop_frame();
-    }
-
-    pub(crate) fn binding_snapshot(&self) -> BindingSnapshot {
-        BindingSnapshot::new(
-            self.bindings.clone(),
-            self.current_frame().binding_undo.clone(),
-        )
-    }
-
-    pub(crate) fn replace_binding_snapshot(
-        &mut self,
-        snapshot: BindingSnapshot,
-    ) -> BindingSnapshot {
-        let (bindings, undo) = snapshot.into_inner();
-        let previous_bindings = mem::replace(&mut self.bindings, bindings);
-        self.rebuild_bound_go_names();
-        let previous_undo = mem::replace(&mut self.current_frame_mut().binding_undo, undo);
-        self.current_frame_mut().changed_bindings = self
-            .current_frame()
-            .binding_undo
-            .iter()
-            .map(|(name, _)| name.clone())
-            .collect();
-        BindingSnapshot::new(previous_bindings, previous_undo)
     }
 
     pub(crate) fn declare_go_name(&mut self, go_name: &str) {
@@ -348,8 +313,7 @@ impl ScopeState {
 
     fn push_frame(&mut self, declarations: DeclarationScope) {
         self.frames.push(ScopeFrame {
-            binding_undo: Vec::new(),
-            changed_bindings: HashSet::default(),
+            bindings: HashMap::default(),
             declarations,
             established: Vec::new(),
         });
@@ -357,16 +321,7 @@ impl ScopeState {
 
     fn pop_frame(&mut self) {
         assert!(self.frames.len() > 1, "cannot pop a stack's base frame");
-        let frame = self.frames.pop().expect("scope state retains a base frame");
-        for (name, previous) in frame.binding_undo.into_iter().rev() {
-            if let Some(value) = self.bindings.remove(&name) {
-                self.remove_bound_go_name(&value);
-            }
-            if let Some(value) = previous {
-                self.add_bound_go_name(&value);
-                self.bindings.insert(name, value);
-            }
-        }
+        self.frames.pop();
     }
 
     fn current_frame(&self) -> &ScopeFrame {
@@ -382,50 +337,7 @@ impl ScopeState {
     }
 
     fn set_binding(&mut self, name: String, value: BindingValue) {
-        self.record_binding_change(&name);
-        if let Some(previous) = self.bindings.insert(name, value.clone()) {
-            self.remove_bound_go_name(&previous);
-        }
-        self.add_bound_go_name(&value);
-    }
-
-    fn record_binding_change(&mut self, name: &str) {
-        if self.frames.len() == 1 {
-            return;
-        }
-        let previous = self.bindings.get(name).cloned();
-        let frame = self.current_frame_mut();
-        if frame.changed_bindings.insert(name.to_string()) {
-            frame.binding_undo.push((name.to_string(), previous));
-        }
-    }
-
-    fn add_bound_go_name(&mut self, value: &BindingValue) {
-        if let Some(name) = value.as_go_name() {
-            *self.bound_go_names.entry(name.to_string()).or_default() += 1;
-        }
-    }
-
-    fn remove_bound_go_name(&mut self, value: &BindingValue) {
-        let Some(name) = value.as_go_name() else {
-            return;
-        };
-        let Some(count) = self.bound_go_names.get_mut(name) else {
-            return;
-        };
-        *count -= 1;
-        if *count == 0 {
-            self.bound_go_names.remove(name);
-        }
-    }
-
-    fn rebuild_bound_go_names(&mut self) {
-        self.bound_go_names.clear();
-        for value in self.bindings.values() {
-            if let Some(name) = value.as_go_name() {
-                *self.bound_go_names.entry(name.to_string()).or_default() += 1;
-            }
-        }
+        self.current_frame_mut().bindings.insert(name, value);
     }
 
     fn current_declarations(&self) -> &Declarations {
@@ -487,37 +399,66 @@ mod tests {
     }
 
     #[test]
-    fn removing_binding_hides_it_until_scope_exit() {
-        let mut scope = ScopeState::new();
-        scope.bind("value", "outer");
-        scope.enter_block();
-        scope.remove_binding("value");
-        assert!(scope.resolve_identifier_binding("value").is_none());
-
-        scope.exit_block();
-
-        assert_eq!(scope.resolve_binding_go_name("value"), Some("outer"));
-    }
-
-    #[test]
-    fn replacing_snapshot_can_restore_current_bindings() {
-        let mut scope = ScopeState::new();
-        scope.bind("value", "before");
-        let before = scope.binding_snapshot();
-        scope.bind("value", "after");
-
-        let after = scope.replace_binding_snapshot(before);
-        assert_eq!(scope.resolve_binding_go_name("value"), Some("before"));
-        let _ = scope.replace_binding_snapshot(after);
-
-        assert_eq!(scope.resolve_binding_go_name("value"), Some("after"));
-    }
-
-    #[test]
     fn fresh_name_skips_bound_go_name() {
         let mut scope = ScopeState::new();
         scope.bind("value", "tmp_1");
 
         assert_eq!(scope.fresh_go_name(None), "tmp_2");
+    }
+
+    #[test]
+    fn nested_bindings_restore_names_constants_and_inline_expressions() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "outer");
+        scope.mark_go_const("value");
+        scope.push_binding_frame();
+        scope.bind_inline_expr(
+            "value",
+            InlineExpr::new("pair.F0", vec!["pair".into()], false),
+        );
+        scope.enter_block();
+        scope.bind("value", "inner");
+        scope.bind("value", "rebound");
+        scope.exit_block();
+        assert!(matches!(
+            scope.resolve_identifier_binding("value"),
+            Some(BindingValue::InlineExpr(expr)) if expr.as_str() == "pair.F0"
+        ));
+        scope.pop_binding_frame();
+        assert!(matches!(
+            scope.resolve_identifier_binding("value"),
+            Some(BindingValue::GoConst(name)) if name == "outer"
+        ));
+    }
+
+    #[test]
+    fn binding_frames_restore_all_bindings_but_keep_go_declarations() {
+        let mut scope = ScopeState::new();
+        scope.bind("value", "outer");
+        scope.push_binding_frame();
+        scope.bind("value", "inner");
+        scope.bind("new", "local");
+        scope.declare_go_name("local");
+        scope.pop_binding_frame();
+
+        assert_eq!(scope.resolve_binding_go_name("value"), Some("outer"));
+        assert!(scope.resolve_identifier_binding("new").is_none());
+        assert!(!scope.has_binding_for_go_name("inner"));
+        assert!(scope.is_go_name_declared("local"));
+    }
+
+    #[test]
+    fn bound_go_names_follow_visible_bindings_including_aliases() {
+        let mut scope = ScopeState::new();
+        scope.bind("first", "shared");
+        scope.bind("second", "shared");
+        scope.enter_block();
+        scope.bind("first", "inner");
+        assert!(scope.has_binding_for_go_name("shared"));
+        scope.bind_inline_expr("second", InlineExpr::new("pair.F0", vec![], false));
+        assert!(!scope.has_binding_for_go_name("shared"));
+        scope.exit_block();
+        assert!(scope.has_binding_for_go_name("shared"));
+        assert!(!scope.has_binding_for_go_name("inner"));
     }
 }

--- a/tests/spec/build/mod.rs
+++ b/tests/spec/build/mod.rs
@@ -10,6 +10,48 @@ use semantics::CompilePhase;
 use semantics::store::ENTRY_PACKAGE_ID;
 
 #[test]
+fn enum_layout_import_aliases_belong_to_each_file() {
+    let mut fs = MockFileSystem::new();
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "types.lis",
+        r#"
+import clock "go:time"
+
+enum Event { At(clock.Time), Empty }
+
+fn first(event: Event) -> Option<clock.Time> {
+  match event {
+    Event.At(value) => Some(value),
+    Event.Empty => None,
+  }
+}
+"#,
+    );
+    fs.add_file(
+        ENTRY_PACKAGE_ID,
+        "main.lis",
+        r#"
+import timer "go:time"
+import "go:fmt"
+
+fn second(event: Event) -> Option<timer.Time> {
+  match event {
+    Event.At(value) => Some(value),
+    Event.Empty => None,
+  }
+}
+
+fn main() {
+  let event = Event.At(timer.Now())
+  fmt.Println(first(event), second(event))
+}
+"#,
+    );
+    assert_build_snapshot!(fs, "github.com/user/myproject");
+}
+
+#[test]
 fn unnecessary_mut_holds_while_permission_errors_stand() {
     let mut fs = MockFileSystem::new();
     fs.add_file(

--- a/tests/spec/build/snapshots/enum_layout_import_aliases_belong_to_each_file.snap
+++ b/tests/spec/build/snapshots/enum_layout_import_aliases_belong_to_each_file.snap
@@ -1,0 +1,58 @@
+---
+source: tests/spec/build/mod.rs
+---
+// === main.go ===
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	timer "time"
+)
+
+func second(event Event) (timer.Time, bool) {
+	if event.Tag == EventAt {
+		return event.At, true
+	}
+	return *new(timer.Time), false
+}
+
+func main() {
+	event := MakeEventAt(timer.Now())
+	option_1 := lisette.OptionFromCommaOk[timer.Time](first(event))
+	option_2 := lisette.OptionFromCommaOk[timer.Time](second(event))
+	fmt.Println(option_1, option_2)
+}
+
+
+// === types.go ===
+package main
+
+import clock "time"
+
+func MakeEventAt(arg0 clock.Time) Event {
+	return Event{Tag: EventAt, At: arg0}
+}
+
+func MakeEventEmpty() Event {
+	return Event{Tag: EventEmpty}
+}
+
+type EventTag int
+
+const (
+	EventAt EventTag = iota
+	EventEmpty
+)
+
+type Event struct {
+	Tag EventTag
+	At  clock.Time
+}
+
+func first(event Event) (clock.Time, bool) {
+	if event.Tag == EventAt {
+		return event.At, true
+	}
+	return *new(clock.Time), false
+}

--- a/tests/spec/emit/patterns.rs
+++ b/tests/spec/emit/patterns.rs
@@ -2,6 +2,48 @@ use crate::assert_emit_snapshot;
 use crate::assert_emit_snapshot_with_go_typedefs;
 
 #[test]
+fn or_pattern_let_else_failure_sees_outer_binding() {
+    let input = r#"
+enum E { A(int), B(int), C }
+
+fn read(e: E) -> int {
+  let value = 40
+  let E.A(value) | E.B(value) = e else {
+    let fallback = value + 2
+    return fallback
+  }
+  value
+}
+
+fn main() {
+  if read(E.C) != 42 { panic("failure must see the outer value") }
+  if read(E.B(7)) != 7 { panic("success must see the new value") }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn guarded_pattern_restores_outer_binding_for_fallback() {
+    let input = r#"
+fn read(option: Option<int>) -> string {
+  let value = "outer"
+  match option {
+    Some(value) if value > 0 => if value == 7 { "seven" } else { "positive" },
+    _ => value,
+  }
+}
+
+fn main() {
+  if read(Some(-1)) != "outer" { panic("guard failure must restore the outer value") }
+  if read(Some(7)) != "seven" { panic("guard success must see the pattern value") }
+  if read(None) != "outer" { panic("fallback must see the outer value") }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_pattern_in_match() {
     let input = r#"
 struct Pair(int, int)

--- a/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
+++ b/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
@@ -1,0 +1,73 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  enum Node {
+    Value(int),
+    Callback(fn() -> int),
+    Child(Node),
+  }
+  
+  fn read(node: Node) -> int {
+    match node {
+      Node.Value(value) => value,
+      Node.Callback(call) => call(),
+      Node.Child(child) => read(child),
+    }
+  }
+  
+  fn main() {
+    if read(Node.Child(Node.Callback(|| 7))) != 7 { panic("wrong field layout") }
+    if read(Node.Value(3)) != 3 { panic("wrong value field") }
+  }
+---
+package main
+
+func MakeNodeValue(arg0 int) Node {
+	return Node{Tag: NodeValue, Value: arg0}
+}
+
+func MakeNodeCallback(arg0 func() int) Node {
+	return Node{Tag: NodeCallback, Callback: arg0}
+}
+
+func MakeNodeChild(arg0 Node) Node {
+	return Node{Tag: NodeChild, Child: &arg0}
+}
+
+type NodeTag int
+
+const (
+	NodeValue NodeTag = iota
+	NodeCallback
+	NodeChild
+)
+
+type Node struct {
+	Tag      NodeTag
+	Value    int
+	Callback func() int
+	Child    *Node
+}
+
+func read(node Node) int {
+	switch node.Tag {
+	case NodeValue:
+		return node.Value
+	case NodeCallback:
+		return node.Callback()
+	default:
+		return read((*node.Child))
+	}
+}
+
+func main() {
+	if read(MakeNodeChild(MakeNodeCallback(func() int {
+		return 7
+	}))) != 7 {
+		panic("wrong field layout")
+	}
+	if read(MakeNodeValue(3)) != 3 {
+		panic("wrong value field")
+	}
+}

--- a/tests/spec/emit/snapshots/guarded_pattern_restores_outer_binding_for_fallback.snap
+++ b/tests/spec/emit/snapshots/guarded_pattern_restores_outer_binding_for_fallback.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  fn read(option: Option<int>) -> string {
+    let value = "outer"
+    match option {
+      Some(value) if value > 0 => if value == 7 { "seven" } else { "positive" },
+      _ => value,
+    }
+  }
+  
+  fn main() {
+    if read(Some(-1)) != "outer" { panic("guard failure must restore the outer value") }
+    if read(Some(7)) != "seven" { panic("guard success must see the pattern value") }
+    if read(None) != "outer" { panic("fallback must see the outer value") }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func read(option lisette.Option[int]) string {
+	value := "outer"
+	if option.Tag == lisette.OptionSome {
+		value_1 := option.SomeVal
+		if value_1 > 0 {
+			if value_1 == 7 {
+				return "seven"
+			}
+			return "positive"
+		}
+	}
+	{
+		return value
+	}
+}
+
+func main() {
+	if read(lisette.MakeOptionSome(-1)) != "outer" {
+		panic("guard failure must restore the outer value")
+	}
+	if read(lisette.MakeOptionSome(7)) != "seven" {
+		panic("guard success must see the pattern value")
+	}
+	if read(lisette.MakeOptionNone[int]()) != "outer" {
+		panic("fallback must see the outer value")
+	}
+}

--- a/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_go_builtin_name_escaped_with_guards.snap
@@ -19,8 +19,7 @@ func categorize(items []int) string {
 	if len_ == 0 {
 		return "empty"
 	}
-	n := len_
-	if n == 1 {
+	if len_ == 1 {
 		return "single"
 	}
 	if len_ <= 3 {

--- a/tests/spec/emit/snapshots/match_guard_on_struct.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_struct.snap
@@ -21,9 +21,7 @@ type Point struct {
 
 func test(p Point) string {
 	{
-		x := p.x
-		y := p.y
-		if x == y {
+		if p.x == p.y {
 			return "diagonal"
 		}
 	}

--- a/tests/spec/emit/snapshots/match_guard_tuple.snap
+++ b/tests/spec/emit/snapshots/match_guard_tuple.snap
@@ -16,9 +16,7 @@ import lisette "github.com/ivov/lisette/prelude"
 
 func test(pair lisette.Tuple2[int, int]) string {
 	{
-		x := pair.First
-		y := pair.Second
-		if x == y {
+		if pair.First == pair.Second {
 			return "equal"
 		}
 	}

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -36,8 +36,7 @@ type Res struct {
 
 func test(r Res, threshold int) int {
 	if r.Tag == ResOk {
-		x := r.Ok
-		if x > threshold {
+		if r.Ok > threshold {
 			return 100
 		}
 	}

--- a/tests/spec/emit/snapshots/or_pattern_let_else_failure_sees_outer_binding.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_failure_sees_outer_binding.snap
@@ -1,0 +1,70 @@
+---
+source: tests/spec/emit/patterns.rs
+description: |
+  
+  enum E { A(int), B(int), C }
+  
+  fn read(e: E) -> int {
+    let value = 40
+    let E.A(value) | E.B(value) = e else {
+      let fallback = value + 2
+      return fallback
+    }
+    value
+  }
+  
+  fn main() {
+    if read(E.C) != 42 { panic("failure must see the outer value") }
+    if read(E.B(7)) != 7 { panic("success must see the new value") }
+  }
+---
+package main
+
+func MakeEA(arg0 int) E {
+	return E{Tag: EA, A: arg0}
+}
+
+func MakeEB(arg0 int) E {
+	return E{Tag: EB, B: arg0}
+}
+
+func MakeEC() E {
+	return E{Tag: EC}
+}
+
+type ETag int
+
+const (
+	EA ETag = iota
+	EB
+	EC
+)
+
+type E struct {
+	Tag ETag
+	A   int
+	B   int
+}
+
+func read(e E) int {
+	value := 40
+	var value_1 int
+	if e.Tag == EA {
+		value_1 = e.A
+	} else if e.Tag == EB {
+		value_1 = e.B
+	} else {
+		fallback := value + 2
+		return fallback
+	}
+	return value_1
+}
+
+func main() {
+	if read(MakeEC()) != 42 {
+		panic("failure must see the outer value")
+	}
+	if read(MakeEB(7)) != 7 {
+		panic("success must see the new value")
+	}
+}

--- a/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
+++ b/tests/spec/emit/snapshots/tuple_struct_match_guard.snap
@@ -21,9 +21,8 @@ type Point struct {
 func test(p Point) int {
 	{
 		x := p.F0
-		y := p.F1
 		if x > 0 {
-			return x + y
+			return x + p.F1
 		}
 	}
 	{

--- a/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_four_guarded_arms_same_type.snap
@@ -21,16 +21,13 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		if x > 1000 {
+		if e.X > 1000 {
 			return 4
 		}
-		x_1 := e.X
-		if x_1 > 100 {
+		if e.X > 100 {
 			return 3
 		}
-		x_2 := e.X
-		if x_2 > 50 {
+		if e.X > 50 {
 			return 2
 		}
 		if e.X > 0 {

--- a/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
+++ b/tests/spec/emit/snapshots/type_switch_three_guarded_arms_same_type.snap
@@ -20,12 +20,10 @@ import "example.com/events"
 func handle(e events.Event) int {
 	switch e := e.(type) {
 	case events.Click:
-		x := e.X
-		if x > 100 {
+		if e.X > 100 {
 			return 3
 		}
-		x_1 := e.X
-		if x_1 > 50 {
+		if e.X > 50 {
 			return 2
 		}
 		if e.X > 0 {

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -3032,6 +3032,31 @@ fn test() -> Tree {
 }
 
 #[test]
+fn enum_layout_keeps_value_function_and_recursive_fields_distinct() {
+    let input = r#"
+enum Node {
+  Value(int),
+  Callback(fn() -> int),
+  Child(Node),
+}
+
+fn read(node: Node) -> int {
+  match node {
+    Node.Value(value) => value,
+    Node.Callback(call) => call(),
+    Node.Child(child) => read(child),
+  }
+}
+
+fn main() {
+  if read(Node.Child(Node.Callback(|| 7))) != 7 { panic("wrong field layout") }
+  if read(Node.Value(3)) != 3 { panic("wrong value field") }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_function_vs_constructor() {
     let input = r#"
 struct Point(int, int)


### PR DESCRIPTION
Gives each scope frame its own binding map. This way, match arms, guards, and `let else` alternatives no longer need to undo lists, snapshots, or overlay rollbacks to restore the outer bndings.