### PR TITLE
perf: reduce enum tags from `int` to `uint8`

### DIFF
--- a/crates/emit/src/definitions/enum_layout.rs
+++ b/crates/emit/src/definitions/enum_layout.rs
@@ -84,6 +84,14 @@ impl EnumLayout {
         }
     }
 
+    fn tag_go_type(&self) -> &'static str {
+        if self.variants.len() <= 256 {
+            "uint8"
+        } else {
+            "uint16"
+        }
+    }
+
     /// Declaration order, except that the marked variant takes `0`.
     fn tag_values(&self) -> Vec<usize> {
         let Some(default_index) = self.default_variant.filter(|index| *index != 0) else {
@@ -187,7 +195,7 @@ impl EnumLayout {
     pub(crate) fn emit_definition(&self, generics_string: &str) -> String {
         let mut output = Vec::new();
 
-        output.push(format!("type {} int", self.tag_type));
+        output.push(format!("type {} {}", self.tag_type, self.tag_go_type()));
         if !self.variants.is_empty() {
             output.push("const (".to_string());
 

--- a/prelude/option.go
+++ b/prelude/option.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-type OptionTag int
+type OptionTag uint8
 
 const (
 	OptionNone OptionTag = iota

--- a/prelude/partial.go
+++ b/prelude/partial.go
@@ -2,7 +2,7 @@ package lisette
 
 import "fmt"
 
-type PartialTag int
+type PartialTag uint8
 
 const (
 	PartialOk PartialTag = iota

--- a/prelude/result.go
+++ b/prelude/result.go
@@ -2,7 +2,7 @@ package lisette
 
 import "fmt"
 
-type ResultTag int
+type ResultTag uint8
 
 const (
 	ResultOk ResultTag = iota

--- a/tests/spec/build/snapshots/builtin_named_package_qualifier_consistent_in_match.snap
+++ b/tests/spec/build/snapshots/builtin_named_package_qualifier_consistent_in_match.snap
@@ -36,7 +36,7 @@ func MakeLevelHigh() Level {
 	return Level{Tag: LevelHigh}
 }
 
-type LevelTag int
+type LevelTag uint8
 
 const (
 	LevelLow LevelTag = iota

--- a/tests/spec/build/snapshots/cross_package_enum_and_namespace_alias.snap
+++ b/tests/spec/build/snapshots/cross_package_enum_and_namespace_alias.snap
@@ -21,7 +21,7 @@ func MakeColorRGB() Color {
 	return Color{Tag: ColorRGB}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRGB ColorTag = iota

--- a/tests/spec/build/snapshots/cross_package_enum_construction_uses_import_alias.snap
+++ b/tests/spec/build/snapshots/cross_package_enum_construction_uses_import_alias.snap
@@ -12,7 +12,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/build/snapshots/cross_package_enum_variant_non_t_payload.snap
+++ b/tests/spec/build/snapshots/cross_package_enum_variant_non_t_payload.snap
@@ -12,7 +12,7 @@ func MakeResult2Failure[T any](arg0 string) Result2[T] {
 	return Result2[T]{Tag: Result2Failure, Failure: arg0}
 }
 
-type Result2Tag int
+type Result2Tag uint8
 
 const (
 	Result2Success Result2Tag = iota

--- a/tests/spec/build/snapshots/cross_package_generic_free_function_turbofish.snap
+++ b/tests/spec/build/snapshots/cross_package_generic_free_function_turbofish.snap
@@ -12,7 +12,7 @@ func MakeResult2Err2[T any, E any](arg0 E) Result2[T, E] {
 	return Result2[T, E]{Tag: Result2Err2, Err2: arg0}
 }
 
-type Result2Tag int
+type Result2Tag uint8
 
 const (
 	Result2Ok2 Result2Tag = iota

--- a/tests/spec/build/snapshots/cross_package_generic_return_only_string_vs_int.snap
+++ b/tests/spec/build/snapshots/cross_package_generic_return_only_string_vs_int.snap
@@ -12,7 +12,7 @@ func MakeValidatedInvalid[T any](arg0 string) Validated[T] {
 	return Validated[T]{Tag: ValidatedInvalid, Invalid: arg0}
 }
 
-type ValidatedTag int
+type ValidatedTag uint8
 
 const (
 	ValidatedValid ValidatedTag = iota

--- a/tests/spec/build/snapshots/entry_package_type_alias_cross_package_enum_variant.snap
+++ b/tests/spec/build/snapshots/entry_package_type_alias_cross_package_enum_variant.snap
@@ -25,7 +25,7 @@ func MakeColorNamed(arg0 string) Color {
 	return Color{Tag: ColorNamed, Named: arg0}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRGB ColorTag = iota

--- a/tests/spec/build/snapshots/enum_type_alias_with_import_alias.snap
+++ b/tests/spec/build/snapshots/enum_type_alias_with_import_alias.snap
@@ -8,7 +8,7 @@ func MakeEventClick(arg0 int) Event {
 	return Event{Tag: EventClick, X: arg0}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/build/snapshots/generated_dependencies_stay_with_owning_file.snap
+++ b/tests/spec/build/snapshots/generated_dependencies_stay_with_owning_file.snap
@@ -40,7 +40,7 @@ func MakeMyEnumValue(arg0 f.Foo) MyEnum {
 	return MyEnum{Tag: MyEnumValue, Value: arg0}
 }
 
-type MyEnumTag int
+type MyEnumTag uint8
 
 const (
 	MyEnumEmpty MyEnumTag = iota

--- a/tests/spec/build/snapshots/iterate_enum_export_name_consistency.snap
+++ b/tests/spec/build/snapshots/iterate_enum_export_name_consistency.snap
@@ -12,7 +12,7 @@ func MakeLocalPhaseCheck() LocalPhase {
 	return LocalPhase{Tag: LocalPhaseCheck}
 }
 
-type PublicPhaseTag int
+type PublicPhaseTag uint8
 
 const (
 	PublicPhaseBuild PublicPhaseTag = iota
@@ -28,7 +28,7 @@ func PublicPhase_Variants() []PublicPhase {
 	}
 }
 
-type LocalPhaseTag int
+type LocalPhaseTag uint8
 
 const (
 	LocalPhaseCheck LocalPhaseTag = iota

--- a/tests/spec/build/snapshots/iterate_enum_named_go_keyword.snap
+++ b/tests/spec/build/snapshots/iterate_enum_named_go_keyword.snap
@@ -12,7 +12,7 @@ func Makemap_B() map_ {
 	return map_{Tag: mapB}
 }
 
-type mapTag int
+type mapTag uint8
 
 const (
 	mapA mapTag = iota

--- a/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
+++ b/tests/spec/build/snapshots/json_enum_coexists_with_private_json_function.snap
@@ -14,7 +14,7 @@ func MakeStatusReady() Status {
 	return Status{Tag: StatusReady}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusReady StatusTag = iota

--- a/tests/spec/build/snapshots/local_alias_cross_package_enum_struct_variant_tag.snap
+++ b/tests/spec/build/snapshots/local_alias_cross_package_enum_struct_variant_tag.snap
@@ -8,7 +8,7 @@ func MakeEventClick(arg0 int) Event {
 	return Event{Tag: EventClick, X: arg0}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/build/snapshots/multi_file_package_bootstrap_imports.snap
+++ b/tests/spec/build/snapshots/multi_file_package_bootstrap_imports.snap
@@ -70,7 +70,7 @@ func MakeMyEnumAliased(arg0 g.Widget) MyEnum {
 	return MyEnum{Tag: MyEnumAliased, Aliased: arg0}
 }
 
-type MyEnumTag int
+type MyEnumTag uint8
 
 const (
 	MyEnumSingle MyEnumTag = iota

--- a/tests/spec/build/snapshots/multi_file_package_bootstrap_imports_stdlib.snap
+++ b/tests/spec/build/snapshots/multi_file_package_bootstrap_imports_stdlib.snap
@@ -42,7 +42,7 @@ func MakeMyEnumMaybe(arg0 lisette.Option[foo.Foo]) MyEnum {
 	return MyEnum{Tag: MyEnumMaybe, Maybe: arg0}
 }
 
-type MyEnumTag int
+type MyEnumTag uint8
 
 const (
 	MyEnumMaybe MyEnumTag = iota

--- a/tests/spec/build/snapshots/multipackage_cross_package_enum_usage.snap
+++ b/tests/spec/build/snapshots/multipackage_cross_package_enum_usage.snap
@@ -35,7 +35,7 @@ type Circle struct {
 	Radius float64
 }
 
-type ShapeKindTag int
+type ShapeKindTag uint8
 
 const (
 	ShapeKindCircleKind ShapeKindTag = iota

--- a/tests/spec/build/snapshots/multipackage_enum_constructors_not_leaked.snap
+++ b/tests/spec/build/snapshots/multipackage_enum_constructors_not_leaked.snap
@@ -14,7 +14,7 @@ func MakeColorGreen() Color {
 	return Color{Tag: ColorGreen}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/build/snapshots/multipackage_enum_static_method.snap
+++ b/tests/spec/build/snapshots/multipackage_enum_static_method.snap
@@ -27,7 +27,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/build/snapshots/multipackage_iterate_enum.snap
+++ b/tests/spec/build/snapshots/multipackage_iterate_enum.snap
@@ -30,7 +30,7 @@ func MakeBuildPhaseCodegen() BuildPhase {
 	return BuildPhase{Tag: BuildPhaseCodegen}
 }
 
-type BuildPhaseTag int
+type BuildPhaseTag uint8
 
 const (
 	BuildPhaseValidate BuildPhaseTag = iota

--- a/tests/spec/build/snapshots/multipackage_nested_path_enum_construction.snap
+++ b/tests/spec/build/snapshots/multipackage_nested_path_enum_construction.snap
@@ -26,7 +26,7 @@ func MakeEventReset() Event {
 	return Event{Tag: EventReset}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/build/snapshots/multipackage_type_alias_enum_all_variants.snap
+++ b/tests/spec/build/snapshots/multipackage_type_alias_enum_all_variants.snap
@@ -24,7 +24,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/build/snapshots/multipackage_type_alias_enum_pattern_matching.snap
+++ b/tests/spec/build/snapshots/multipackage_type_alias_enum_pattern_matching.snap
@@ -24,7 +24,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
+++ b/tests/spec/build/snapshots/snake_case_enum_impl_satisfies_comma_ok_go_iface_via_adapter.snap
@@ -13,7 +13,7 @@ func MakeCacheKindMem() CacheKind {
 	return CacheKind{Tag: CacheKindMem}
 }
 
-type CacheKindTag int
+type CacheKindTag uint8
 
 const (
 	CacheKindMem CacheKindTag = iota

--- a/tests/spec/build/snapshots/user_file_named_bootstrap_does_not_collide.snap
+++ b/tests/spec/build/snapshots/user_file_named_bootstrap_does_not_collide.snap
@@ -16,7 +16,7 @@ func main() {
 	_ = MakeAA()
 }
 
-type ATag int
+type ATag uint8
 
 const (
 	AA ATag = iota

--- a/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
+++ b/tests/spec/build/snapshots/user_json_alias_preserved_alongside_generated_import.snap
@@ -15,7 +15,7 @@ func MakeStatusReady() Status {
 	return Status{Tag: StatusReady}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusReady StatusTag = iota

--- a/tests/spec/emit/snapshots/address_of_enum_variant.snap
+++ b/tests/spec/emit/snapshots/address_of_enum_variant.snap
@@ -21,7 +21,7 @@ func MakeListNil() List {
 	return List{Tag: ListNil}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListCons ListTag = iota

--- a/tests/spec/emit/snapshots/aliased_go_import_used_by_enum_layout.snap
+++ b/tests/spec/emit/snapshots/aliased_go_import_used_by_enum_layout.snap
@@ -23,7 +23,7 @@ func MakeEventAfter(arg0 t.Duration) Event {
 	return Event{Tag: EventAfter, Delay: arg0}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventAt EventTag = iota

--- a/tests/spec/emit/snapshots/array_from_element_without_zero.snap
+++ b/tests/spec/emit/snapshots/array_from_element_without_zero.snap
@@ -18,7 +18,7 @@ func MakeColourGreen() Colour {
 	return Colour{Tag: ColourGreen}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed ColourTag = iota

--- a/tests/spec/emit/snapshots/array_new_default_variant_first_uses_go_zero_fill.snap
+++ b/tests/spec/emit/snapshots/array_new_default_variant_first_uses_go_zero_fill.snap
@@ -22,7 +22,7 @@ func MakeColourGreen() Colour {
 	return Colour{Tag: ColourGreen}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed ColourTag = iota

--- a/tests/spec/emit/snapshots/array_new_later_default_variant_uses_go_zero_fill.snap
+++ b/tests/spec/emit/snapshots/array_new_later_default_variant_uses_go_zero_fill.snap
@@ -22,7 +22,7 @@ func MakeColourGreen() Colour {
 	return Colour{Tag: ColourGreen}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed   ColourTag = 1

--- a/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
+++ b/tests/spec/emit/snapshots/as_binding_on_enum_variant.snap
@@ -21,7 +21,7 @@ func MakeStatusBad(arg0 string) Status {
 	return Status{Tag: StatusBad, Bad: arg0}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusGood StatusTag = iota

--- a/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
+++ b/tests/spec/emit/snapshots/boolean_match_assign_collapses_to_condition.snap
@@ -25,7 +25,7 @@ func MakeNodeNull() Node {
 	return Node{Tag: NodeNull}
 }
 
-type NodeTag int
+type NodeTag uint8
 
 const (
 	NodeNumber NodeTag = iota

--- a/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
+++ b/tests/spec/emit/snapshots/call_args_carrier_enum_ref_eval_order.snap
@@ -31,7 +31,7 @@ func MakeCarrierC(arg0 *int) Carrier {
 	return Carrier{Tag: CarrierC, P: arg0}
 }
 
-type CarrierTag int
+type CarrierTag uint8
 
 const (
 	CarrierC CarrierTag = iota

--- a/tests/spec/emit/snapshots/chained_callee_constructor_args_stay_inline.snap
+++ b/tests/spec/emit/snapshots/chained_callee_constructor_args_stay_inline.snap
@@ -35,7 +35,7 @@ type O struct{}
 
 type P int
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/display_enum_synthesizes_to_string.snap
+++ b/tests/spec/emit/snapshots/display_enum_synthesizes_to_string.snap
@@ -17,7 +17,7 @@ func MakeColorGreen() Color {
 	return Color{Tag: ColorGreen}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/doc_comment_on_enum.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_enum.snap
@@ -20,7 +20,7 @@ func MakeStatusComplete() Status {
 }
 
 // Represents the status of a task.
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusPending StatusTag = iota

--- a/tests/spec/emit/snapshots/doc_comment_on_enum_variants.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_enum_variants.snap
@@ -27,7 +27,7 @@ func MakeNetworkResultError(arg0 int) NetworkResult {
 }
 
 // Result of a network operation.
-type NetworkResultTag int
+type NetworkResultTag uint8
 
 const (
 	// The operation succeeded.

--- a/tests/spec/emit/snapshots/enum_contested_field_json_keys_stay_source_spelled.snap
+++ b/tests/spec/emit/snapshots/enum_contested_field_json_keys_stay_source_spelled.snap
@@ -29,7 +29,7 @@ func MakeShapeSquare(arg0 int) Shape {
 	return Shape{Tag: ShapeSquare, SquareW: arg0}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeRect ShapeTag = iota

--- a/tests/spec/emit/snapshots/enum_contested_field_slot_prefixes_only_the_struct_field.snap
+++ b/tests/spec/emit/snapshots/enum_contested_field_slot_prefixes_only_the_struct_field.snap
@@ -24,7 +24,7 @@ func MakeShapeOther(arg0 int) Shape {
 	return Shape{Tag: ShapeOther, OtherCircle: arg0}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/enum_contested_field_slots_are_variant_prefixed.snap
+++ b/tests/spec/emit/snapshots/enum_contested_field_slots_are_variant_prefixed.snap
@@ -24,7 +24,7 @@ func MakeEventHover(arg0 string) Event {
 	return Event{Tag: EventHover, HoverTarget: arg0}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/enum_contested_field_slots_contest_through_normalization.snap
+++ b/tests/spec/emit/snapshots/enum_contested_field_slots_contest_through_normalization.snap
@@ -24,7 +24,7 @@ func MakeEventHover(arg0 string, arg1 string) Event {
 	return Event{Tag: EventHover, HoverFooBar: arg0, HoverX: arg1}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
+++ b/tests/spec/emit/snapshots/enum_marshal_json_method_without_json_attribute.snap
@@ -18,7 +18,7 @@ func MakeStatusReady() Status {
 	return Status{Tag: StatusReady}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusReady StatusTag = iota

--- a/tests/spec/emit/snapshots/enum_struct_variant_named_tag.snap
+++ b/tests/spec/emit/snapshots/enum_struct_variant_named_tag.snap
@@ -22,7 +22,7 @@ func MakeEOther(arg0 int) E {
 	return E{Tag: EOther, X: arg0}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	ETag_ ETag = iota

--- a/tests/spec/emit/snapshots/enum_struct_variant_with_ref_field.snap
+++ b/tests/spec/emit/snapshots/enum_struct_variant_with_ref_field.snap
@@ -23,7 +23,7 @@ func MakeTreeNode(arg0 int, arg1 *Tree, arg2 *Tree) Tree {
 	return Tree{Tag: TreeNode, Value: arg0, Left: arg1, Right: arg2}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/enum_tag_constant_spells_reserved_word.snap
+++ b/tests/spec/emit/snapshots/enum_tag_constant_spells_reserved_word.snap
@@ -31,7 +31,7 @@ func Makemaother() ma {
 	return ma{Tag: maother}
 }
 
-type maTag int
+type maTag uint8
 
 const (
 	make_ maTag = iota

--- a/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
+++ b/tests/spec/emit/snapshots/enum_tuple_variant_with_fn_type.snap
@@ -25,7 +25,7 @@ func MakeTransformApply[T any](arg0 func(T) T) Transform[T] {
 	return Transform[T]{Tag: TransformApply, Apply: arg0}
 }
 
-type TransformTag int
+type TransformTag uint8
 
 const (
 	TransformIdentity TransformTag = iota

--- a/tests/spec/emit/snapshots/enum_uncontested_field_slot_stays_shared.snap
+++ b/tests/spec/emit/snapshots/enum_uncontested_field_slot_stays_shared.snap
@@ -24,7 +24,7 @@ func MakeShapeSquare(arg0 float64) Shape {
 	return Shape{Tag: ShapeSquare, W: arg0}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeRect ShapeTag = iota

--- a/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
+++ b/tests/spec/emit/snapshots/enum_user_pascal_string_method_suppresses_auto_stringer.snap
@@ -28,7 +28,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/enum_user_string_and_go_string_methods.snap
+++ b/tests/spec/emit/snapshots/enum_user_string_and_go_string_methods.snap
@@ -32,7 +32,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/enum_user_string_method_emits_go_string.snap
+++ b/tests/spec/emit/snapshots/enum_user_string_method_emits_go_string.snap
@@ -28,7 +28,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
+++ b/tests/spec/emit/snapshots/enum_variant_construction_simple.snap
@@ -22,7 +22,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -32,7 +32,7 @@ func MakeASTNodeNull() ASTNode {
 	return ASTNode{Tag: ASTNodeNull}
 }
 
-type ASTNodeTag int
+type ASTNodeTag uint8
 
 const (
 	ASTNodeNumber ASTNodeTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_consumes_identifier_base.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_consumes_identifier_base.snap
@@ -22,7 +22,7 @@ func MakeCursorArea(arg0 int, arg1 int) Cursor {
 	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
 }
 
-type CursorTag int
+type CursorTag uint8
 
 const (
 	CursorPoint CursorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_all_fields_assigned_discards_base_call.snap
@@ -27,7 +27,7 @@ func MakeCursorArea(arg0 int, arg1 int) Cursor {
 	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
 }
 
-type CursorTag int
+type CursorTag uint8
 
 const (
 	CursorPoint CursorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_spread_builds_fresh_literal.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_builds_fresh_literal.snap
@@ -22,7 +22,7 @@ func MakeCursorArea(arg0 int, arg1 int) Cursor {
 	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
 }
 
-type CursorTag int
+type CursorTag uint8
 
 const (
 	CursorPoint CursorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/enum_variant_spread_side_effecting_base_evaluated_once.snap
@@ -27,7 +27,7 @@ func MakeCursorArea(arg0 int, arg1 int) Cursor {
 	return Cursor{Tag: CursorArea, Id: arg0, W: arg1}
 }
 
-type CursorTag int
+type CursorTag uint8
 
 const (
 	CursorPoint CursorTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
+++ b/tests/spec/emit/snapshots/enum_variant_with_multiple_fields_pattern.snap
@@ -21,7 +21,7 @@ func MakePairNeither[A any, B any]() Pair[A, B] {
 	return Pair[A, B]{Tag: PairNeither}
 }
 
-type PairTag int
+type PairTag uint8
 
 const (
 	PairBoth PairTag = iota

--- a/tests/spec/emit/snapshots/equality_enum_mixed_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_mixed_variants.snap
@@ -23,7 +23,7 @@ func MakeMessageWrite(arg0 string) Message {
 	return Message{Tag: MessageWrite, Write: arg0}
 }
 
-type MessageTag int
+type MessageTag uint8
 
 const (
 	MessageQuit MessageTag = iota

--- a/tests/spec/emit/snapshots/equality_enum_payload_generic_synthesized_equality.snap
+++ b/tests/spec/emit/snapshots/equality_enum_payload_generic_synthesized_equality.snap
@@ -24,7 +24,7 @@ func (b Box[T]) equals(other Box[T]) bool {
 	return slices.Equal(b.items, other.items)
 }
 
-type WrapTag int
+type WrapTag uint8
 
 const (
 	WrapWrapped WrapTag = iota

--- a/tests/spec/emit/snapshots/equality_enum_payload_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_payload_variants.snap
@@ -18,7 +18,7 @@ func MakeShapeRectangle(arg0 float64, arg1 float64) Shape {
 	return Shape{Tag: ShapeRectangle, Rectangle0: arg0, Rectangle1: arg1}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/equality_enum_slice_payload.snap
+++ b/tests/spec/emit/snapshots/equality_enum_slice_payload.snap
@@ -20,7 +20,7 @@ func MakeEventEmpty() Event {
 	return Event{Tag: EventEmpty}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventTags EventTag = iota

--- a/tests/spec/emit/snapshots/equality_enum_unit_variants.snap
+++ b/tests/spec/emit/snapshots/equality_enum_unit_variants.snap
@@ -19,7 +19,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/equality_generic_enum_custom_equatable_bound.snap
+++ b/tests/spec/emit/snapshots/equality_generic_enum_custom_equatable_bound.snap
@@ -19,7 +19,7 @@ type Equatable[T any] interface {
 	equals(T) bool
 }
 
-type PairTag int
+type PairTag uint8
 
 const (
 	PairBoth PairTag = iota

--- a/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
+++ b/tests/spec/emit/snapshots/equality_indirect_recursive_enum_through_struct.snap
@@ -24,7 +24,7 @@ func MakeTreeNode(arg0 Pair) Tree {
 	return Tree{Tag: TreeNode, Node: &arg0}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
+++ b/tests/spec/emit/snapshots/equality_mutually_recursive_enums_deref_pointer_payloads.snap
@@ -27,7 +27,7 @@ func MakeBY(arg0 A) B {
 	return B{Tag: BY, Y: &arg0}
 }
 
-type ATag int
+type ATag uint8
 
 const (
 	AEnd ATag = iota
@@ -51,7 +51,7 @@ func (a A) equals(other A) bool {
 	}
 }
 
-type BTag int
+type BTag uint8
 
 const (
 	BY BTag = iota

--- a/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
+++ b/tests/spec/emit/snapshots/equality_recursive_enum_derefs_pointer_payload.snap
@@ -18,7 +18,7 @@ func MakeListCons(arg0 int, arg1 List) List {
 	return List{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListNil ListTag = iota

--- a/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
+++ b/tests/spec/emit/snapshots/explicit_ref_enum_field_no_double_deref.snap
@@ -24,7 +24,7 @@ func MakeListNil[T any]() List[T] {
 	return List[T]{Tag: ListNil}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListCons ListTag = iota

--- a/tests/spec/emit/snapshots/first_default_variant_keeps_iota.snap
+++ b/tests/spec/emit/snapshots/first_default_variant_keeps_iota.snap
@@ -22,7 +22,7 @@ func MakeColourGreen() Colour {
 	return Colour{Tag: ColourGreen}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed ColourTag = iota

--- a/tests/spec/emit/snapshots/function_returning_enum_with_variant_arity_is_not_a_constructor.snap
+++ b/tests/spec/emit/snapshots/function_returning_enum_with_variant_arity_is_not_a_constructor.snap
@@ -25,7 +25,7 @@ func MakeIntListCons(arg0 int, arg1 IntList) IntList {
 	return IntList{Tag: IntListCons, Cons0: arg0, Cons1: &arg1}
 }
 
-type IntListTag int
+type IntListTag uint8
 
 const (
 	IntListEmpty IntListTag = iota

--- a/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
+++ b/tests/spec/emit/snapshots/generic_adapter_enum_map_key_requires_payload_comparability.snap
@@ -48,7 +48,7 @@ func MakeMaybeNothing[T any]() Maybe[T] {
 	return Maybe[T]{Tag: MaybeNothing}
 }
 
-type MaybeTag int
+type MaybeTag uint8
 
 const (
 	MaybeJust MaybeTag = iota

--- a/tests/spec/emit/snapshots/generic_constructor_value_type_args.snap
+++ b/tests/spec/emit/snapshots/generic_constructor_value_type_args.snap
@@ -16,7 +16,7 @@ func MakeWrapW[T any](arg0 T) Wrap[T] {
 	return Wrap[T]{Tag: WrapW, W: arg0}
 }
 
-type WrapTag int
+type WrapTag uint8
 
 const (
 	WrapW WrapTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_constructor_with_predeclared_generic_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_enum_constructor_with_predeclared_generic_parameter.snap
@@ -29,7 +29,7 @@ func MakeBoxNone[int_ any]() Box[int_] {
 	return Box[int_]{Tag: BoxNone}
 }
 
-type BoxTag int
+type BoxTag uint8
 
 const (
 	BoxSome BoxTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_param_shadows_package_type.snap
+++ b/tests/spec/emit/snapshots/generic_enum_param_shadows_package_type.snap
@@ -33,7 +33,7 @@ type T struct {
 	v int
 }
 
-type WrapTag int
+type WrapTag uint8
 
 const (
 	WrapEmpty WrapTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_variant_non_t_data_needs_type_arg.snap
+++ b/tests/spec/emit/snapshots/generic_enum_variant_non_t_data_needs_type_arg.snap
@@ -22,7 +22,7 @@ func MakeMyResultFail[T any](arg0 string) MyResult[T] {
 	return MyResult[T]{Tag: MyResultFail, Fail: arg0}
 }
 
-type MyResultTag int
+type MyResultTag uint8
 
 const (
 	MyResultOk MyResultTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -49,7 +49,7 @@ type Displayable interface {
 	display() string
 }
 
-type EitherTag int
+type EitherTag uint8
 
 const (
 	EitherLeft EitherTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_with_map_key_type_parameter.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_map_key_type_parameter.snap
@@ -24,7 +24,7 @@ func MakeContainerIndexed[K comparable, V any](arg0 map[K]V) Container[K, V] {
 	return Container[K, V]{Tag: ContainerIndexed, Indexed: arg0}
 }
 
-type ContainerTag int
+type ContainerTag uint8
 
 const (
 	ContainerEmpty ContainerTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_multiple_variant_fields.snap
@@ -18,7 +18,7 @@ func MakeEitherRight[L any, R any](arg0 R) Either[L, R] {
 	return Either[L, R]{Tag: EitherRight, Right: arg0}
 }
 
-type EitherTag int
+type EitherTag uint8
 
 const (
 	EitherLeft EitherTag = iota

--- a/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_variant_field.snap
@@ -18,7 +18,7 @@ func MakeMyResultFailure[T any]() MyResult[T] {
 	return MyResult[T]{Tag: MyResultFailure}
 }
 
-type MyResultTag int
+type MyResultTag uint8
 
 const (
 	MyResultSuccess MyResultTag = iota

--- a/tests/spec/emit/snapshots/generic_param_shadows_enum_variant_constant_and_constructor.snap
+++ b/tests/spec/emit/snapshots/generic_param_shadows_enum_variant_constant_and_constructor.snap
@@ -41,7 +41,7 @@ func MakeWrapPartial(arg0 int) Wrap {
 	return Wrap{Tag: WrapPartial, Partial: arg0}
 }
 
-type WrapTag int
+type WrapTag uint8
 
 const (
 	WrapEmpty WrapTag = iota

--- a/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
+++ b/tests/spec/emit/snapshots/generic_return_only_type_param_string_vs_int.snap
@@ -33,7 +33,7 @@ func MakeValidatedInvalid[T any](arg0 string) Validated[T] {
 	return Validated[T]{Tag: ValidatedInvalid, Invalid: arg0}
 }
 
-type ValidatedTag int
+type ValidatedTag uint8
 
 const (
 	ValidatedValid ValidatedTag = iota

--- a/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_function_field_or_pattern.snap
@@ -24,7 +24,7 @@ type Handler[T any] struct {
 	callback func(T) int
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
+++ b/tests/spec/emit/snapshots/generic_struct_tuple_field_or_pattern.snap
@@ -26,7 +26,7 @@ type Pair[T any] struct {
 	coords lisette.Tuple2[T, T]
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/if_let_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/if_let_or_pattern_unused_branch_binding.snap
@@ -27,7 +27,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_call.snap
@@ -42,7 +42,7 @@ type MyInt = int
 
 type MyString = string
 
-type EitherTag int
+type EitherTag uint8
 
 const (
 	EitherLeft EitherTag = iota

--- a/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
+++ b/tests/spec/emit/snapshots/impl_concrete_generic_method.snap
@@ -37,7 +37,7 @@ type MyInt = int
 
 type MyString = string
 
-type EitherTag int
+type EitherTag uint8
 
 const (
 	EitherLeft EitherTag = iota

--- a/tests/spec/emit/snapshots/impl_method_map_key_body_uses_declared_enum_bound.snap
+++ b/tests/spec/emit/snapshots/impl_method_map_key_body_uses_declared_enum_bound.snap
@@ -24,7 +24,7 @@ func MakeHolderEmpty[T comparable]() Holder[T] {
 	return Holder[T]{Tag: HolderEmpty}
 }
 
-type HolderTag int
+type HolderTag uint8
 
 const (
 	HolderEmpty HolderTag = iota

--- a/tests/spec/emit/snapshots/iterate_enum_variants.snap
+++ b/tests/spec/emit/snapshots/iterate_enum_variants.snap
@@ -31,7 +31,7 @@ func MakeBuildPhaseCodegen() BuildPhase {
 	return BuildPhase{Tag: BuildPhaseCodegen}
 }
 
-type BuildPhaseTag int
+type BuildPhaseTag uint8
 
 const (
 	BuildPhaseValidate BuildPhaseTag = iota

--- a/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_simple_no_payload.snap
@@ -25,7 +25,7 @@ func MakeStatusSuspended() Status {
 	return Status{Tag: StatusSuspended}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusActive StatusTag = iota

--- a/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_multi_payload.snap
@@ -24,7 +24,7 @@ func MakeShapePoint() Shape {
 	return Shape{Tag: ShapePoint}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeRectangle ShapeTag = iota

--- a/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_single_payload.snap
@@ -29,7 +29,7 @@ func MakeShapeUnknown() Shape {
 	return Shape{Tag: ShapeUnknown}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
+++ b/tests/spec/emit/snapshots/json_enum_with_struct_variant.snap
@@ -24,7 +24,7 @@ func MakeMessageQuit() Message {
 	return Message{Tag: MessageQuit}
 }
 
-type MessageTag int
+type MessageTag uint8
 
 const (
 	MessageMove MessageTag = iota

--- a/tests/spec/emit/snapshots/json_enum_without_variants.snap
+++ b/tests/spec/emit/snapshots/json_enum_without_variants.snap
@@ -12,7 +12,7 @@ import (
 	"fmt"
 )
 
-type NothingTag int
+type NothingTag uint8
 type Nothing struct {
 	Tag NothingTag
 }

--- a/tests/spec/emit/snapshots/later_default_variant_takes_tag_zero.snap
+++ b/tests/spec/emit/snapshots/later_default_variant_takes_tag_zero.snap
@@ -27,7 +27,7 @@ func MakeColourBlue() Colour {
 	return Colour{Tag: ColourBlue}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed   ColourTag = 1

--- a/tests/spec/emit/snapshots/let_else_in_arm_drops_the_test_the_arm_made.snap
+++ b/tests/spec/emit/snapshots/let_else_in_arm_drops_the_test_the_arm_made.snap
@@ -27,7 +27,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/let_else_in_switch_case_drops_the_test_the_case_made.snap
+++ b/tests/spec/emit/snapshots/let_else_in_switch_case_drops_the_test_the_case_made.snap
@@ -33,7 +33,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/let_else_in_the_else_arm_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_in_the_else_arm_keeps_its_test.snap
@@ -27,7 +27,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/let_else_on_another_variant_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_on_another_variant_keeps_its_test.snap
@@ -27,7 +27,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/let_else_on_reassigned_subject_keeps_its_test.snap
+++ b/tests/spec/emit/snapshots/let_else_on_reassigned_subject_keeps_its_test.snap
@@ -29,7 +29,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/let_else_or_pattern.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern.snap
@@ -23,7 +23,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/let_else_or_pattern_dropped_binding_else_leak.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_dropped_binding_else_leak.snap
@@ -31,7 +31,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/let_else_or_pattern_else_scope_shadow.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_else_scope_shadow.snap
@@ -31,7 +31,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/let_else_or_pattern_no_loop_wrapper.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_no_loop_wrapper.snap
@@ -29,7 +29,7 @@ func MakeValC() Val {
 	return Val{Tag: ValC}
 }
 
-type ValTag int
+type ValTag uint8
 
 const (
 	ValA ValTag = iota

--- a/tests/spec/emit/snapshots/let_else_or_pattern_outer_preserved_when_pattern_uses_different_name.snap
+++ b/tests/spec/emit/snapshots/let_else_or_pattern_outer_preserved_when_pattern_uses_different_name.snap
@@ -31,7 +31,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/local_enum_definition_in_function_body.snap
+++ b/tests/spec/emit/snapshots/local_enum_definition_in_function_body.snap
@@ -27,7 +27,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/map_alias_with_comparable_bound_in_enum_variant.snap
+++ b/tests/spec/emit/snapshots/map_alias_with_comparable_bound_in_enum_variant.snap
@@ -21,7 +21,7 @@ func MakeHolderSome[T comparable](arg0 Table[T]) Holder[T] {
 
 type Table[T comparable] = map[T]int
 
-type HolderTag int
+type HolderTag uint8
 
 const (
 	HolderSome HolderTag = iota

--- a/tests/spec/emit/snapshots/match_guard_on_last_tested_enum_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_last_tested_enum_variant.snap
@@ -27,7 +27,7 @@ func MakeShapeTri(arg0 int) Shape {
 	return Shape{Tag: ShapeTri, Tri: arg0}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/match_guard_on_the_only_variant.snap
+++ b/tests/spec/emit/snapshots/match_guard_on_the_only_variant.snap
@@ -17,7 +17,7 @@ func MakeOneOnly(arg0 int) One {
 	return One{Tag: OneOnly, Only: arg0}
 }
 
-type OneTag int
+type OneTag uint8
 
 const (
 	OneOnly OneTag = iota

--- a/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
+++ b/tests/spec/emit/snapshots/match_guard_switch_fallback_value_position.snap
@@ -22,7 +22,7 @@ func MakeDirSouth() Dir {
 	return Dir{Tag: DirSouth}
 }
 
-type DirTag int
+type DirTag uint8
 
 const (
 	DirNorth DirTag = iota

--- a/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
+++ b/tests/spec/emit/snapshots/match_guard_with_or_pattern_bindings.snap
@@ -25,7 +25,7 @@ func MakeEC(arg0 int) E {
 	return E{Tag: EC, C: arg0}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/match_on_aliased_lisette_enum_emits_enum_tag_switch.snap
+++ b/tests/spec/emit/snapshots/match_on_aliased_lisette_enum_emits_enum_tag_switch.snap
@@ -28,7 +28,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/match_on_deref_enum.snap
+++ b/tests/spec/emit/snapshots/match_on_deref_enum.snap
@@ -26,7 +26,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/match_on_enum.snap
+++ b/tests/spec/emit/snapshots/match_on_enum.snap
@@ -26,7 +26,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/match_on_enum_variant_as_subject.snap
+++ b/tests/spec/emit/snapshots/match_on_enum_variant_as_subject.snap
@@ -26,7 +26,7 @@ func MakeDirEast() Dir {
 	return Dir{Tag: DirEast}
 }
 
-type DirTag int
+type DirTag uint8
 
 const (
 	DirNorth DirTag = iota

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_partial_unused_binding.snap
@@ -29,7 +29,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_guard_unused_binding.snap
@@ -25,7 +25,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_partial_unused_binding.snap
@@ -29,7 +29,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/match_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/match_or_pattern_unused_branch_binding.snap
@@ -28,7 +28,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
+++ b/tests/spec/emit/snapshots/match_same_variable_in_enum_with_fields.snap
@@ -33,7 +33,7 @@ func MakeEventKeyPress(arg0 string) Event {
 	return Event{Tag: EventKeyPress, KeyPress: arg0}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
+++ b/tests/spec/emit/snapshots/match_self_enum_data_variant_uses_receiver_name.snap
@@ -26,7 +26,7 @@ func MakeShapeRectangle(arg0 int, arg1 int) Shape {
 	return Shape{Tag: ShapeRectangle, Width: arg0, Height: arg1}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/match_with_wildcard.snap
+++ b/tests/spec/emit/snapshots/match_with_wildcard.snap
@@ -25,7 +25,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/method_call_on_enum_variant.snap
+++ b/tests/spec/emit/snapshots/method_call_on_enum_variant.snap
@@ -32,7 +32,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/or_pattern_enum_variants.snap
+++ b/tests/spec/emit/snapshots/or_pattern_enum_variants.snap
@@ -25,7 +25,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_exhaustive_with_bindings.snap
@@ -28,7 +28,7 @@ func MakeShapeTriangle(arg0 int) Shape {
 	return Shape{Tag: ShapeTriangle, Triangle: arg0}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeCircle ShapeTag = iota

--- a/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
+++ b/tests/spec/emit/snapshots/or_pattern_guard_evaluated_once.snap
@@ -21,7 +21,7 @@ func MakeResErr(arg0 int) Res {
 	return Res{Tag: ResErr, Err: arg0}
 }
 
-type ResTag int
+type ResTag uint8
 
 const (
 	ResOk ResTag = iota

--- a/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_in_while_let_with_bindings.snap
@@ -26,7 +26,7 @@ func MakeEB(arg0 int) E {
 	return E{Tag: EB, B: arg0}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_shadow.snap
@@ -24,7 +24,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/or_pattern_no_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_no_bindings.snap
@@ -29,7 +29,7 @@ func MakeStatusFailed() Status {
 	return Status{Tag: StatusFailed}
 }
 
-type StatusTag int
+type StatusTag uint8
 
 const (
 	StatusPending StatusTag = iota

--- a/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
+++ b/tests/spec/emit/snapshots/or_pattern_with_bindings.snap
@@ -20,7 +20,7 @@ func MakeEB(arg0 int) E {
 	return E{Tag: EB, B: arg0}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_constructor_passed_to_higher_order_function.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_constructor_passed_to_higher_order_function.snap
@@ -25,7 +25,7 @@ func MakeIntListCons(arg0 int, arg1 IntList) IntList {
 	return IntList{Tag: IntListCons, Cons0: arg0, Cons1: &arg1}
 }
 
-type IntListTag int
+type IntListTag uint8
 
 const (
 	IntListEmpty IntListTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_alias.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_alias.snap
@@ -28,7 +28,7 @@ func MakeTreeNode(arg0 P) Tree {
 	return Tree{Tag: TreeNode, Node: &arg0}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_mixed_generic_instantiations.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_mixed_generic_instantiations.snap
@@ -30,7 +30,7 @@ func MakeTreeNode(arg0 Outer) Tree {
 	return Tree{Tag: TreeNode, Node: &arg0}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_indirect_through_struct.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_indirect_through_struct.snap
@@ -33,7 +33,7 @@ func MakeTreeNode(arg0 Pair) Tree {
 	return Tree{Tag: TreeNode, Node: &arg0}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_pattern_match_derefs_pointer.snap
@@ -24,7 +24,7 @@ func MakeListNil() List {
 	return List{Tag: ListNil}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListCons ListTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ptr_temp_var_no_collision.snap
@@ -28,7 +28,7 @@ func MakeNodeBranch(arg0 Node, arg1 Node) Node {
 	return Node{Tag: NodeBranch, Left: &arg0, Right: &arg1}
 }
 
-type NodeTag int
+type NodeTag uint8
 
 const (
 	NodeLeaf NodeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_ref_argument_no_double_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ref_argument_no_double_pointer.snap
@@ -22,7 +22,7 @@ func MakeListNil() List {
 	return List{Tag: ListNil}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListCons ListTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_ref_value_no_double_pointer.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_ref_value_no_double_pointer.snap
@@ -27,7 +27,7 @@ func MakeTreeNode(arg0 *Tree, arg1 *Tree) Tree {
 	return Tree{Tag: TreeNode, Node0: arg0, Node1: arg1}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_struct_variant_pattern.snap
@@ -24,7 +24,7 @@ func MakeTreeNode[T any](arg0 Tree[T], arg1 Tree[T]) Tree[T] {
 	return Tree[T]{Tag: TreeNode, Left: &arg0, Right: &arg1}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_through_array_payload.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_through_array_payload.snap
@@ -28,7 +28,7 @@ func MakeTreeNode(arg0 [2]Tree) Tree {
 	return Tree{Tag: TreeNode, Node: &arg0}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_tree.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tree.snap
@@ -21,7 +21,7 @@ func MakeTreeNode(arg0 Tree, arg1 Tree) Tree {
 	return Tree{Tag: TreeNode, Node0: &arg0, Node1: &arg1}
 }
 
-type TreeTag int
+type TreeTag uint8
 
 const (
 	TreeLeaf TreeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_tuple_ptr_temp_var_no_collision.snap
@@ -28,7 +28,7 @@ func MakeNodeBranch(arg0 Node, arg1 Node) Node {
 	return Node{Tag: NodeBranch, Branch0: &arg0, Branch1: &arg1}
 }
 
-type NodeTag int
+type NodeTag uint8
 
 const (
 	NodeLeaf NodeTag = iota

--- a/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
+++ b/tests/spec/emit/snapshots/recursive_enum_variable_stored_constructor.snap
@@ -23,7 +23,7 @@ func MakeListCons(arg0 int, arg1 List) List {
 	return List{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListNil ListTag = iota

--- a/tests/spec/emit/snapshots/recursive_enums_mutual.snap
+++ b/tests/spec/emit/snapshots/recursive_enums_mutual.snap
@@ -29,7 +29,7 @@ func MakeBY(arg0 A) B {
 	return B{Tag: BY, Y: &arg0}
 }
 
-type ATag int
+type ATag uint8
 
 const (
 	AEnd ATag = iota
@@ -41,7 +41,7 @@ type A struct {
 	X   *B
 }
 
-type BTag int
+type BTag uint8
 
 const (
 	BY BTag = iota

--- a/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_list.snap
@@ -21,7 +21,7 @@ func MakeListCons[T any](arg0 T, arg1 List[T]) List[T] {
 	return List[T]{Tag: ListCons, Cons0: arg0, Cons1: &arg1}
 }
 
-type ListTag int
+type ListTag uint8
 
 const (
 	ListNil ListTag = iota

--- a/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
@@ -33,7 +33,7 @@ func MakeCycleNext[T any](arg0 Link[T]) Cycle[T] {
 	return Cycle[T]{Tag: CycleNext, Next: &arg0}
 }
 
-type CycleTag int
+type CycleTag uint8
 
 const (
 	CycleEnd CycleTag = iota

--- a/tests/spec/emit/snapshots/ref_of_call_nested_enum_constructors.snap
+++ b/tests/spec/emit/snapshots/ref_of_call_nested_enum_constructors.snap
@@ -21,7 +21,7 @@ func MakeExprAdd(arg0 *Expr, arg1 *Expr) Expr {
 	return Expr{Tag: ExprAdd, Add0: arg0, Add1: arg1}
 }
 
-type ExprTag int
+type ExprTag uint8
 
 const (
 	ExprNum ExprTag = iota

--- a/tests/spec/emit/snapshots/simple_enum.snap
+++ b/tests/spec/emit/snapshots/simple_enum.snap
@@ -18,7 +18,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/single_variant_unit_enum.snap
+++ b/tests/spec/emit/snapshots/single_variant_unit_enum.snap
@@ -16,7 +16,7 @@ func MakeMarkerValue() Marker {
 	return Marker{Tag: MarkerValue}
 }
 
-type MarkerTag int
+type MarkerTag uint8
 
 const (
 	MarkerValue MarkerTag = iota

--- a/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
+++ b/tests/spec/emit/snapshots/slice_pattern_rest_or_pattern.snap
@@ -19,7 +19,7 @@ func MakeEB(arg0 []int) E {
 	return E{Tag: EB, B: arg0}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/struct_autofill_enum_struct_variant.snap
+++ b/tests/spec/emit/snapshots/struct_autofill_enum_struct_variant.snap
@@ -21,7 +21,7 @@ func MakeActionStop() Action {
 	return Action{Tag: ActionStop}
 }
 
-type ActionTag int
+type ActionTag uint8
 
 const (
 	ActionMove ActionTag = iota

--- a/tests/spec/emit/snapshots/struct_go_predeclared_type_name_iota_with_enum.snap
+++ b/tests/spec/emit/snapshots/struct_go_predeclared_type_name_iota_with_enum.snap
@@ -39,7 +39,7 @@ type iota_ struct {
 	v int
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/struct_spread_fills_a_default_variant_field.snap
+++ b/tests/spec/emit/snapshots/struct_spread_fills_a_default_variant_field.snap
@@ -27,7 +27,7 @@ func MakeColourGreen() Colour {
 	return Colour{Tag: ColourGreen}
 }
 
-type ColourTag int
+type ColourTag uint8
 
 const (
 	ColourRed   ColourTag = 1

--- a/tests/spec/emit/snapshots/struct_variant_construction.snap
+++ b/tests/spec/emit/snapshots/struct_variant_construction.snap
@@ -16,7 +16,7 @@ func MakeMessageMove(arg0 int, arg1 int) Message {
 	return Message{Tag: MessageMove, X: arg0, Y: arg1}
 }
 
-type MessageTag int
+type MessageTag uint8
 
 const (
 	MessageMove MessageTag = iota

--- a/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_match.snap
@@ -24,7 +24,7 @@ func MakeMessageQuit() Message {
 	return Message{Tag: MessageQuit}
 }
 
-type MessageTag int
+type MessageTag uint8
 
 const (
 	MessageMove MessageTag = iota

--- a/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
+++ b/tests/spec/emit/snapshots/struct_variant_pattern_partial.snap
@@ -18,7 +18,7 @@ func MakeShapeRectangle(arg0 int, arg1 int, arg2 int, arg3 int) Shape {
 	return Shape{Tag: ShapeRectangle, X: arg0, Y: arg1, Width: arg2, Height: arg3}
 }
 
-type ShapeTag int
+type ShapeTag uint8
 
 const (
 	ShapeRectangle ShapeTag = iota

--- a/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
+++ b/tests/spec/emit/snapshots/switch_case_with_remaining_enum_check_routes_to_catchall.snap
@@ -23,7 +23,7 @@ func MakeSideRight() Side {
 	return Side{Tag: SideRight}
 }
 
-type SideTag int
+type SideTag uint8
 
 const (
 	SideLeft SideTag = iota

--- a/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_enum_methods_freshen_receiver_against_type_param.snap
@@ -30,7 +30,7 @@ func MakeBoxFull[b any](arg0 b) Box[b] {
 	return Box[b]{Tag: BoxFull, Full: arg0}
 }
 
-type BoxTag int
+type BoxTag uint8
 
 const (
 	BoxEmpty BoxTag = iota

--- a/tests/spec/emit/snapshots/synthesized_json_freshens_local_against_receiver.snap
+++ b/tests/spec/emit/snapshots/synthesized_json_freshens_local_against_receiver.snap
@@ -25,7 +25,7 @@ func MakeVaultFull(arg0 int, arg1 int) Vault {
 	return Vault{Tag: VaultFull, A: arg0, B: arg1}
 }
 
-type VaultTag int
+type VaultTag uint8
 
 const (
 	VaultFull VaultTag = iota

--- a/tests/spec/emit/snapshots/synthesized_json_freshens_param_against_type_param.snap
+++ b/tests/spec/emit/snapshots/synthesized_json_freshens_param_against_type_param.snap
@@ -31,7 +31,7 @@ func MakeBoxFull[data any](arg0 data) Box[data] {
 	return Box[data]{Tag: BoxFull, Full: arg0}
 }
 
-type BoxTag int
+type BoxTag uint8
 
 const (
 	BoxEmpty BoxTag = iota

--- a/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
+++ b/tests/spec/emit/snapshots/tuple_enum_match_checks_every_element.snap
@@ -41,7 +41,7 @@ func MakeHandRight() Hand {
 	return Hand{Tag: HandRight}
 }
 
-type HandTag int
+type HandTag uint8
 
 const (
 	HandLeft HandTag = iota

--- a/tests/spec/emit/snapshots/tuple_subject_single_variant_enum_reads_its_tag.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_single_variant_enum_reads_its_tag.snap
@@ -17,7 +17,7 @@ func MakeOnlySingle() Only {
 	return Only{Tag: OnlySingle}
 }
 
-type OnlyTag int
+type OnlyTag uint8
 
 const (
 	OnlySingle OnlyTag = iota

--- a/tests/spec/emit/snapshots/tuple_subject_with_a_variant_binding_keeps_its_tuple.snap
+++ b/tests/spec/emit/snapshots/tuple_subject_with_a_variant_binding_keeps_its_tuple.snap
@@ -26,7 +26,7 @@ func MakeEventClose() Event {
 	return Event{Tag: EventClose}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventClick EventTag = iota

--- a/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
+++ b/tests/spec/emit/snapshots/type_alias_enum_unit_variant.snap
@@ -28,7 +28,7 @@ func MakeColorBlue() Color {
 	return Color{Tag: ColorBlue}
 }
 
-type ColorTag int
+type ColorTag uint8
 
 const (
 	ColorRed ColorTag = iota

--- a/tests/spec/emit/snapshots/user_defined_unit_enum.snap
+++ b/tests/spec/emit/snapshots/user_defined_unit_enum.snap
@@ -24,7 +24,7 @@ func MakeTagC() Tag {
 	return Tag{Tag: TagC}
 }
 
-type TagTag int
+type TagTag uint8
 
 const (
 	TagA TagTag = iota

--- a/tests/spec/emit/snapshots/while_let_or_pattern_unused_branch_binding.snap
+++ b/tests/spec/emit/snapshots/while_let_or_pattern_unused_branch_binding.snap
@@ -26,7 +26,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota


### PR DESCRIPTION
Emitted enums, and the prelude `Option`, `Result`, and `Partial` types, now declare their tag as `uint8` instead of `int`. A tag only counts variants, so a fieldless enum shrinks from 8 bytes to 1, while types with wider payloads keep their size. The rare enum with more than 256 variants gets a `uint16` tag.