### PR TITLE
perf: concatenate f-strings whose operands are all strings

### DIFF
--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -331,8 +331,17 @@ fn retired_covers_receiver(target: &Expression, receiver: &Expression) -> bool {
     }
 }
 
+fn is_selector_chain(rendered: &str) -> bool {
+    rendered.split('.').all(go_name::is_plain_identifier)
+}
+
 fn render_inline(template: &str, receiver: &str, args: &[String]) -> String {
-    let mut result = template.replace("{r}", receiver);
+    let receiver = if template.contains("{r}[") && !is_selector_chain(receiver) {
+        format!("({receiver})")
+    } else {
+        receiver.to_string()
+    };
+    let mut result = template.replace("{r}", &receiver);
     for (i, arg) in args.iter().enumerate() {
         result = result.replace(&format!("{{{}}}", i), arg);
     }
@@ -340,7 +349,7 @@ fn render_inline(template: &str, receiver: &str, args: &[String]) -> String {
         result = result.replace("{args}", &args.join(", "));
     }
     if result.contains("{r+args}") {
-        let all = iter::once(receiver.to_string())
+        let all = iter::once(receiver)
             .chain(args.iter().cloned())
             .collect::<Vec<_>>()
             .join(", ");

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -124,12 +124,14 @@ enum FmtArgument {
     Sprint,
 }
 
-fn classify_fmt_argument(expression: &Expression) -> Option<FmtArgument> {
+fn classify_fmt_argument(planner: &Planner, expression: &Expression) -> Option<FmtArgument> {
     match expression.unwrap_parens() {
         Expression::Literal {
-            literal: Literal::FormatString(_),
+            literal: Literal::FormatString(parts),
             ..
-        } => Some(FmtArgument::Sprintf),
+        } => planner
+            .format_string_lowers_to_sprintf(parts)
+            .then_some(FmtArgument::Sprintf),
         Expression::Call {
             expression: callee,
             args,
@@ -167,6 +169,7 @@ impl FmtPrint {
 /// - `fmt.Print{ln}(fmt.Sprintf(...))` → `fmt.Printf(..., "\n")`
 /// - `fmt.Print{ln}(fmt.Sprint(x))` → `fmt.Print{ln}(x)`
 fn collapse_fmt_print(
+    planner: &Planner,
     function_string: &str,
     args: &[Expression],
     args_strings: &[String],
@@ -179,7 +182,7 @@ fn collapse_fmt_print(
         return call_str;
     };
 
-    match classify_fmt_argument(arg_expression) {
+    match classify_fmt_argument(planner, arg_expression) {
         Some(FmtArgument::Sprintf) => {
             let Some(inner) = arg
                 .strip_prefix("fmt.Sprintf(")
@@ -347,7 +350,7 @@ impl<'a> Planner<'a> {
             type_args_string,
             args_strings.join(", ")
         );
-        let call_str = collapse_fmt_print(&function_string, args, &args_strings, call_str);
+        let call_str = collapse_fmt_print(self, &function_string, args, &args_strings, call_str);
         let call_str = match &builtin_conversion {
             Some(go_type) => format!("{go_type}({call_str})"),
             None => call_str,

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -152,7 +152,7 @@ impl Planner<'_> {
             .iter()
             .any(|p| matches!(p, FormatStringPart::Expression(_)));
 
-        let stages: Vec<ValuePlan> = parts
+        let mut stages: Vec<ValuePlan> = parts
             .iter()
             .filter_map(|p| {
                 if let FormatStringPart::Expression(e) = p {
@@ -162,13 +162,45 @@ impl Planner<'_> {
                 }
             })
             .collect();
+        let concatenates = self.format_string_concatenates(parts);
+        if concatenates && stages.len() == 1 && parts.len() == 1 {
+            return stages.pop().expect("one staged operand");
+        }
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "fmtarg");
         let effect = sequenced.effect;
-        let (setup, emitted) = sequenced.into_rendered();
+        let setup = sequenced.setup;
+        let mut values = sequenced.values.into_iter();
+
+        if concatenates {
+            let mut pieces: Vec<GoExpression> = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    FormatStringPart::Text(text) => {
+                        let unescaped = text.replace("{{", "{").replace("}}", "}");
+                        let unescaped = convert_escape_sequences(&unescaped);
+                        if !unescaped.is_empty() {
+                            pieces.push(GoExpression::constant(
+                                format!("\"{}\"", unescaped),
+                                ConstantKind::String,
+                            ));
+                        }
+                    }
+                    FormatStringPart::Expression(_) => pieces.push(
+                        values
+                            .next()
+                            .expect("sequenced count matches expression parts"),
+                    ),
+                }
+            }
+            let mut pieces = pieces.into_iter();
+            let first = pieces.next().expect("an interpolated f-string has a piece");
+            let concatenation =
+                pieces.fold(first, |left, right| GoExpression::binary(left, "+", right));
+            return ValuePlan::computed(setup, concatenation, effect);
+        }
 
         let mut format_string = String::new();
-        let mut args = Vec::with_capacity(emitted.len());
-        let mut emitted = emitted.into_iter();
+        let mut args = Vec::with_capacity(values.len());
 
         for part in parts {
             match part {
@@ -185,9 +217,10 @@ impl Planner<'_> {
                     let peeled = self.facts.peel_alias(&expression.get_type());
                     format_string.push_str(format_verb_for(&peeled));
                     args.push(
-                        emitted
+                        values
                             .next()
-                            .expect("emitted count matches expression parts"),
+                            .expect("sequenced count matches expression parts")
+                            .rendered(),
                     );
                 }
             }
@@ -226,13 +259,28 @@ impl Planner<'_> {
         let has_interpolation = parts
             .iter()
             .any(|p| matches!(p, FormatStringPart::Expression(_)));
-        if !has_interpolation {
+        if !has_interpolation || self.format_string_concatenates(parts) {
             return false;
         }
         let [FormatStringPart::Expression(solo)] = parts else {
             return true;
         };
         format_verb_for(&self.facts.peel_alias(&solo.get_type())) == "%c"
+    }
+
+    fn format_string_concatenates(&self, parts: &[FormatStringPart]) -> bool {
+        let mut operands = parts
+            .iter()
+            .filter_map(|part| match part {
+                FormatStringPart::Expression(expression) => Some(expression),
+                FormatStringPart::Text(_) => None,
+            })
+            .peekable();
+        operands.peek().is_some()
+            && operands.all(|expression| {
+                self.facts.peel_alias(&expression.get_type()).as_simple()
+                    == Some(SimpleKind::String)
+            })
     }
 }
 

--- a/tests/e2e_smoke_project/src/strings.test.lis
+++ b/tests/e2e_smoke_project/src/strings.test.lis
@@ -48,3 +48,54 @@ fn string_runes() {
   let runes = s.runes()
   assert runes.length() == 5 && runes[1] == 'é'
 }
+
+#[test]
+fn fstring_string_operands_concatenate() {
+  let a = "x"
+  let b = "y"
+  assert f"{a}-{b}" == "x-y" && f"{a}{b}" == "xy" && f"{a}" == "x"
+}
+
+#[test]
+fn fstring_text_escapes_next_to_string_operand() {
+  let s = "v"
+  assert f"{{{s}}} 100% \"{s}\"" == "{v} 100% \"v\"" && f"{s}\n".length() == 2
+}
+
+#[test]
+fn fstring_concatenation_as_receiver() {
+  let s = "yz"
+  assert (f"x{s}".byte_at(0) as int) == 120 && f"x{s}".length() == 3
+}
+
+fn first_byte(r: Ref<string>) -> byte { r.byte_at(0) }
+fn first_byte_of_deref(r: Ref<string>) -> byte { f"{r.*}".byte_at(0) }
+
+#[test]
+fn byte_at_through_ref() {
+  let s = "abc"
+  assert (first_byte(&s) as int) == 97 && (first_byte_of_deref(&s) as int) == 97
+}
+
+fn note_word_ok(log: mut Ref<string>, s: string) -> Result<string, error> {
+  log.* += s
+  Ok(s)
+}
+
+fn note_word(log: mut Ref<string>, s: string) -> string {
+  log.* += s
+  s
+}
+
+fn join_words(a: string, b: string) -> string { a + b }
+
+fn note_in_order(log: mut Ref<string>) -> Result<string, error> {
+  Ok(join_words(f"{note_word_ok(log, "one")?}{note_word(log, "two")}", note_word_ok(log, "three")?))
+}
+
+#[test]
+fn fstring_operand_calls_run_in_source_order() {
+  let mut log = ""
+  let joined = note_in_order(&log)
+  assert joined.unwrap_or("") == "onetwothree" && log == "onetwothree"
+}

--- a/tests/spec/build/snapshots/cross_package_bounded_impl_tracks_imports.snap
+++ b/tests/spec/build/snapshots/cross_package_bounded_impl_tracks_imports.snap
@@ -4,17 +4,14 @@ source: tests/spec/build/mod.rs
 // === containers/lib.go ===
 package containers
 
-import (
-	"fmt"
-	"github.com/user/myproject/ifaces"
-)
+import "github.com/user/myproject/ifaces"
 
 type Box[T ifaces.Showable] struct {
 	Value T
 }
 
 func (b Box[T]) Display() string {
-	return fmt.Sprintf("Box(%s)", b.Value.Show())
+	return "Box(" + b.Value.Show() + ")"
 }
 
 

--- a/tests/spec/build/snapshots/enum_layout_import_aliases_belong_to_each_file.snap
+++ b/tests/spec/build/snapshots/enum_layout_import_aliases_belong_to_each_file.snap
@@ -38,7 +38,7 @@ func MakeEventEmpty() Event {
 	return Event{Tag: EventEmpty}
 }
 
-type EventTag int
+type EventTag uint8
 
 const (
 	EventAt EventTag = iota

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
@@ -24,7 +24,7 @@ type Container[T interface {
 
 func (c Container[T]) display() string {
 	fmtarg_1 := c.label
-	return fmt.Sprintf("[%s] %s", fmtarg_1, c.value.PrintVal())
+	return "[" + fmtarg_1 + "] " + c.value.PrintVal()
 }
 
 func (c Container[T]) total() int {

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -37,13 +37,12 @@ func main() {
 package ops
 
 import (
-	"fmt"
 	"github.com/user/myproject/traits"
 	"github.com/user/myproject/types"
 )
 
 func DescribeTaggedPair[A traits.Showable, B traits.Showable](tp types.Tagged[types.Pair[A, B]]) string {
-	return fmt.Sprintf("tagged_pair: %s", tp.Display())
+	return "tagged_pair: " + tp.Display()
 }
 
 
@@ -58,10 +57,7 @@ type Showable interface {
 // === types/lib.go ===
 package types
 
-import (
-	"fmt"
-	"github.com/user/myproject/traits"
-)
+import "github.com/user/myproject/traits"
 
 type Pair[A traits.Showable, B traits.Showable] struct {
 	First  A
@@ -69,11 +65,11 @@ type Pair[A traits.Showable, B traits.Showable] struct {
 }
 
 func (p Pair[A, B]) Show() string {
-	return fmt.Sprintf("(%s, %s)", p.First.Show(), p.Second.Show())
+	return "(" + p.First.Show() + ", " + p.Second.Show() + ")"
 }
 
 func (p Pair[A, B]) Display() string {
-	return fmt.Sprintf("Pair%s", p.Show())
+	return "Pair" + p.Show()
 }
 
 type Tagged[T traits.Showable] struct {
@@ -83,9 +79,9 @@ type Tagged[T traits.Showable] struct {
 
 func (t Tagged[T]) Show() string {
 	fmtarg_1 := t.Label
-	return fmt.Sprintf("[%s] %s", fmtarg_1, t.Value.Show())
+	return "[" + fmtarg_1 + "] " + t.Value.Show()
 }
 
 func (t Tagged[T]) Display() string {
-	return fmt.Sprintf("Tagged%s", t.Show())
+	return "Tagged" + t.Show()
 }

--- a/tests/spec/build/snapshots/pub_interface_method_accessible_cross_package.snap
+++ b/tests/spec/build/snapshots/pub_interface_method_accessible_cross_package.snap
@@ -19,8 +19,6 @@ func main() {
 // === types/lib.go ===
 package types
 
-import "fmt"
-
 type Greetable interface {
 	Greet() string
 }
@@ -30,5 +28,5 @@ type Person struct {
 }
 
 func (p Person) Greet() string {
-	return fmt.Sprintf("Hello, I'm %s", p.Name)
+	return "Hello, I'm " + p.Name
 }

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -5281,3 +5281,192 @@ fn run() -> int {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn format_string_string_operands_concatenate() {
+    let input = r#"
+fn greet(first: string, last: string) -> string {
+  f"Hello, {first} {last}!"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_adjacent_string_operands_concatenate() {
+    let input = r#"
+fn join(a: string, b: string) -> string {
+  f"{a}{b}"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_solo_string_operand_is_the_operand() {
+    let input = r#"
+fn same(name: string) -> string {
+  f"{name}"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_concatenation_keeps_text_escapes() {
+    let input = r#"
+fn wrap(a: string, b: string) -> string {
+  f"{{{a}}} 100% \"{b}\"\n"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_string_alias_operand_concatenates() {
+    let input = r#"
+type Name = string
+
+fn greet(n: Name) -> string {
+  f"hi {n}"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_newtype_over_string_keeps_sprintf() {
+    let input = r#"
+#[display]
+struct Id(string)
+
+fn show(id: Id) -> string {
+  f"id {id}"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_mixed_operands_keep_sprintf() {
+    let input = r#"
+fn count(name: string, n: int) -> string {
+  f"{name} has {n}"
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_concatenation_as_byte_at_receiver_is_parenthesized() {
+    let input = r#"
+fn first(b: string) -> byte {
+  f"x{b}".byte_at(0)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_concatenation_as_length_receiver() {
+    let input = r#"
+fn size(b: string) -> int {
+  f"x{b}".length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_concatenation_operands_keep_evaluation_order() {
+    let input = r#"
+import "go:fmt"
+
+fn first() -> string { fmt.Println("first"); "a" }
+fn second() -> string { fmt.Println("second"); "b" }
+
+fn main() {
+  fmt.Println(f"{first()} and {second()}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn errors_new_string_only_format_string_stays_errors_new() {
+    let input = r#"
+import "go:errors"
+
+fn fail(path: string) -> error {
+  errors.New(f"cannot open {path}")
+}
+
+fn main() {
+  let _ = fail("x")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_string_only_format_string_prints_concatenation() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let name = "Ada"
+  fmt.Println(f"Hello {name}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_concatenation_is_captured_before_later_argument_setup() {
+    let input = r#"
+import "go:fmt"
+
+fn next(s: string) -> Result<string, error> { fmt.Println(s); Ok(s) }
+fn log(s: string) -> string { fmt.Println(s); s }
+fn show(a: string, b: string) -> string { a + b }
+
+fn run() -> Result<string, error> {
+  Ok(show(f"{next("one")?}{log("two")}", next("three")?))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fmt_println_does_not_collapse_concatenation_that_starts_with_sprintf() {
+    let input = r#"
+import "go:fmt"
+
+fn b() -> string { "b" }
+
+fn main() {
+  fmt.Println(f"{fmt.Sprintf("%02d", 1)}{b()}")
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn byte_at_on_ref_receiver_is_parenthesized() {
+    let input = r#"
+fn first(r: Ref<string>) -> byte {
+  r.byte_at(0)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn format_string_solo_deref_operand_as_byte_at_receiver_is_parenthesized() {
+    let input = r#"
+fn first(r: Ref<string>) -> byte {
+  f"{r.*}".byte_at(0)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/byte_at_on_ref_receiver_is_parenthesized.snap
+++ b/tests/spec/emit/snapshots/byte_at_on_ref_receiver_is_parenthesized.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn first(r: Ref<string>) -> byte {
+    r.byte_at(0)
+  }
+---
+package main
+
+func first(r *string) byte {
+	return (*r)[0]
+}

--- a/tests/spec/emit/snapshots/closure_param_shadow_outer_access.snap
+++ b/tests/spec/emit/snapshots/closure_param_shadow_outer_access.snap
@@ -23,5 +23,5 @@ func test() string {
 		return fmt.Sprintf("doubled: %d", x_1)
 	}
 	result := f(5)
-	return fmt.Sprintf("%s and %s", result, x)
+	return result + " and " + x
 }

--- a/tests/spec/emit/snapshots/doc_comment_on_public_function.snap
+++ b/tests/spec/emit/snapshots/doc_comment_on_public_function.snap
@@ -9,9 +9,7 @@ description: |
 ---
 package main
 
-import "fmt"
-
 // A publicly exported function.
 func Greet(name string) string {
-	return fmt.Sprintf("Hello, %s!", name)
+	return "Hello, " + name + "!"
 }

--- a/tests/spec/emit/snapshots/emit_fstring_multiline_text.snap
+++ b/tests/spec/emit/snapshots/emit_fstring_multiline_text.snap
@@ -10,8 +10,6 @@ description: |
 ---
 package main
 
-import "fmt"
-
 func test(name string) string {
-	return fmt.Sprintf("hello\n%s\nworld", name)
+	return "hello\n" + name + "\nworld"
 }

--- a/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
+++ b/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
@@ -25,7 +25,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 )
 
@@ -44,7 +43,7 @@ func main() {
 	}
 	encoded := string(result_3.UnwrapOr([]byte{}))
 	if encoded != "[]" {
-		panic(fmt.Sprintf("expected an explicit empty literal to encode as [], got %s", encoded))
+		panic("expected an explicit empty literal to encode as [], got " + encoded)
 	}
 	payload := Payload{Items: []int{}}
 	ret_4, ret_5 := json.Marshal(payload)
@@ -56,6 +55,6 @@ func main() {
 	}
 	wrapped := string(result_6.UnwrapOr([]byte{}))
 	if wrapped != "{\"Items\":[]}" {
-		panic(fmt.Sprintf("expected an empty slice field to encode as [], got %s", wrapped))
+		panic("expected an empty slice field to encode as [], got " + wrapped)
 	}
 }

--- a/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
+++ b/tests/spec/emit/snapshots/enum_layout_keeps_value_function_and_recursive_fields_distinct.snap
@@ -35,7 +35,7 @@ func MakeNodeChild(arg0 Node) Node {
 	return Node{Tag: NodeChild, Child: &arg0}
 }
 
-type NodeTag int
+type NodeTag uint8
 
 const (
 	NodeValue NodeTag = iota

--- a/tests/spec/emit/snapshots/enum_variant_named_string.snap
+++ b/tests/spec/emit/snapshots/enum_variant_named_string.snap
@@ -51,7 +51,7 @@ func visit(node ASTNode) string {
 	case ASTNodeNumber:
 		return fmt.Sprintf("number:%d", node.Number)
 	case ASTNodeString:
-		return fmt.Sprintf("string:%s", node.ASTNodeString_)
+		return "string:" + node.ASTNodeString_
 	default:
 		return "null"
 	}

--- a/tests/spec/emit/snapshots/errors_new_format_string_collapses_to_errorf.snap
+++ b/tests/spec/emit/snapshots/errors_new_format_string_collapses_to_errorf.snap
@@ -19,10 +19,13 @@ description: |
 ---
 package main
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 func fail(line string) error {
-	return fmt.Errorf("malformed line: %s", line)
+	return errors.New("malformed line: " + line)
 }
 
 func percent(rate int) error {

--- a/tests/spec/emit/snapshots/errors_new_non_sprintf_args_stay.snap
+++ b/tests/spec/emit/snapshots/errors_new_non_sprintf_args_stay.snap
@@ -24,10 +24,7 @@ description: |
 ---
 package main
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
 func plain() error {
 	return errors.New("plain message")
@@ -38,7 +35,7 @@ func noInterpolation() error {
 }
 
 func solo(msg string) error {
-	return errors.New(fmt.Sprint(msg))
+	return errors.New(msg)
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/errors_new_string_only_format_string_stays_errors_new.snap
+++ b/tests/spec/emit/snapshots/errors_new_string_only_format_string_stays_errors_new.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:errors"
+  
+  fn fail(path: string) -> error {
+    errors.New(f"cannot open {path}")
+  }
+  
+  fn main() {
+    let _ = fail("x")
+  }
+---
+package main
+
+import "errors"
+
+func fail(path string) error {
+	return errors.New("cannot open " + path)
+}
+
+func main() {
+	_ = fail("x")
+}

--- a/tests/spec/emit/snapshots/fmt_println_does_not_collapse_concatenation_that_starts_with_sprintf.snap
+++ b/tests/spec/emit/snapshots/fmt_println_does_not_collapse_concatenation_that_starts_with_sprintf.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn b() -> string { "b" }
+  
+  fn main() {
+    fmt.Println(f"{fmt.Sprintf("%02d", 1)}{b()}")
+  }
+---
+package main
+
+import "fmt"
+
+func b() string {
+	return "b"
+}
+
+func main() {
+	fmt.Println(fmt.Sprintf("%02d", 1) + b())
+}

--- a/tests/spec/emit/snapshots/fmt_println_string_only_format_string_prints_concatenation.snap
+++ b/tests/spec/emit/snapshots/fmt_println_string_only_format_string_prints_concatenation.snap
@@ -1,0 +1,19 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let name = "Ada"
+    fmt.Println(f"Hello {name}")
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	name := "Ada"
+	fmt.Println("Hello " + name)
+}

--- a/tests/spec/emit/snapshots/format_string_adjacent_string_operands_concatenate.snap
+++ b/tests/spec/emit/snapshots/format_string_adjacent_string_operands_concatenate.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn join(a: string, b: string) -> string {
+    f"{a}{b}"
+  }
+---
+package main
+
+func join(a, b string) string {
+	return a + b
+}

--- a/tests/spec/emit/snapshots/format_string_concatenation_as_byte_at_receiver_is_parenthesized.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_as_byte_at_receiver_is_parenthesized.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn first(b: string) -> byte {
+    f"x{b}".byte_at(0)
+  }
+---
+package main
+
+func first(b string) byte {
+	return ("x" + b)[0]
+}

--- a/tests/spec/emit/snapshots/format_string_concatenation_as_length_receiver.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_as_length_receiver.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn size(b: string) -> int {
+    f"x{b}".length()
+  }
+---
+package main
+
+func size(b string) int {
+	return len("x" + b)
+}

--- a/tests/spec/emit/snapshots/format_string_concatenation_is_captured_before_later_argument_setup.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_is_captured_before_later_argument_setup.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn next(s: string) -> Result<string, error> { fmt.Println(s); Ok(s) }
+  fn log(s: string) -> string { fmt.Println(s); s }
+  fn show(a: string, b: string) -> string { a + b }
+  
+  fn run() -> Result<string, error> {
+    Ok(show(f"{next("one")?}{log("two")}", next("three")?))
+  }
+---
+package main
+
+import "fmt"
+
+func next(s string) (string, error) {
+	fmt.Println(s)
+	return s, nil
+}
+
+func log(s string) string {
+	fmt.Println(s)
+	return s
+}
+
+func show(a, b string) string {
+	return a + b
+}
+
+func run() (string, error) {
+	ret_1, ret_2 := next("one")
+	if ret_2 != nil {
+		return "", ret_2
+	}
+	arg_5 := ret_1 + log("two")
+	ret_3, ret_4 := next("three")
+	if ret_4 != nil {
+		return "", ret_4
+	}
+	return show(arg_5, ret_3), nil
+}

--- a/tests/spec/emit/snapshots/format_string_concatenation_keeps_text_escapes.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_keeps_text_escapes.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn wrap(a: string, b: string) -> string {
+    f"{{{a}}} 100% \"{b}\"\n"
+  }
+---
+package main
+
+func wrap(a, b string) string {
+	return "{" + a + "} 100% \"" + b + "\"\n"
+}

--- a/tests/spec/emit/snapshots/format_string_concatenation_operands_keep_evaluation_order.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_operands_keep_evaluation_order.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn first() -> string { fmt.Println("first"); "a" }
+  fn second() -> string { fmt.Println("second"); "b" }
+  
+  fn main() {
+    fmt.Println(f"{first()} and {second()}")
+  }
+---
+package main
+
+import "fmt"
+
+func first() string {
+	fmt.Println("first")
+	return "a"
+}
+
+func second() string {
+	fmt.Println("second")
+	return "b"
+}
+
+func main() {
+	fmt.Println(first() + " and " + second())
+}

--- a/tests/spec/emit/snapshots/format_string_guard_keeps_the_jump_target.snap
+++ b/tests/spec/emit/snapshots/format_string_guard_keeps_the_jump_target.snap
@@ -16,10 +16,7 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 func label(_ int) lisette.Result[string, string] {
 	return lisette.MakeResultOk[string, string]("x")
@@ -34,7 +31,7 @@ match_1:
 			if check_2.Tag != lisette.ResultOk {
 				return lisette.MakeResultErr[int, string](check_2.ErrVal)
 			}
-			if fmt.Sprintf("v%s", check_2.OkVal) == "vx" {
+			if "v"+check_2.OkVal == "vx" {
 				out = 1
 				break match_1
 			}

--- a/tests/spec/emit/snapshots/format_string_mixed_operands_keep_sprintf.snap
+++ b/tests/spec/emit/snapshots/format_string_mixed_operands_keep_sprintf.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn count(name: string, n: int) -> string {
+    f"{name} has {n}"
+  }
+---
+package main
+
+import "fmt"
+
+func count(name string, n int) string {
+	return fmt.Sprintf("%s has %d", name, n)
+}

--- a/tests/spec/emit/snapshots/format_string_newtype_over_string_keeps_sprintf.snap
+++ b/tests/spec/emit/snapshots/format_string_newtype_over_string_keeps_sprintf.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  #[display]
+  struct Id(string)
+  
+  fn show(id: Id) -> string {
+    f"id {id}"
+  }
+---
+package main
+
+import "fmt"
+
+type Id string
+
+func (i Id) String() string {
+	return fmt.Sprintf("Id(%v)", string(i))
+}
+
+func (i Id) toString() string {
+	return i.String()
+}
+
+func show(id Id) string {
+	return fmt.Sprintf("id %v", id)
+}

--- a/tests/spec/emit/snapshots/format_string_simple.snap
+++ b/tests/spec/emit/snapshots/format_string_simple.snap
@@ -15,5 +15,5 @@ import "fmt"
 
 func test() {
 	name := "Alice"
-	fmt.Printf("Hello, %s!", name)
+	fmt.Print("Hello, " + name + "!")
 }

--- a/tests/spec/emit/snapshots/format_string_solo_deref_operand_as_byte_at_receiver_is_parenthesized.snap
+++ b/tests/spec/emit/snapshots/format_string_solo_deref_operand_as_byte_at_receiver_is_parenthesized.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn first(r: Ref<string>) -> byte {
+    f"{r.*}".byte_at(0)
+  }
+---
+package main
+
+func first(r *string) byte {
+	return (*r)[0]
+}

--- a/tests/spec/emit/snapshots/format_string_solo_string_operand_is_the_operand.snap
+++ b/tests/spec/emit/snapshots/format_string_solo_string_operand_is_the_operand.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn same(name: string) -> string {
+    f"{name}"
+  }
+---
+package main
+
+func same(name string) string {
+	return name
+}

--- a/tests/spec/emit/snapshots/format_string_string_alias_operand_concatenates.snap
+++ b/tests/spec/emit/snapshots/format_string_string_alias_operand_concatenates.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  type Name = string
+  
+  fn greet(n: Name) -> string {
+    f"hi {n}"
+  }
+---
+package main
+
+type Name = string
+
+func greet(n Name) string {
+	return "hi " + n
+}

--- a/tests/spec/emit/snapshots/format_string_string_operands_concatenate.snap
+++ b/tests/spec/emit/snapshots/format_string_string_operands_concatenate.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  fn greet(first: string, last: string) -> string {
+    f"Hello, {first} {last}!"
+  }
+---
+package main
+
+func greet(first, last string) string {
+	return "Hello, " + first + " " + last + "!"
+}

--- a/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
+++ b/tests/spec/emit/snapshots/generic_enum_with_constrained_impl_make_functions.snap
@@ -35,8 +35,6 @@ description: |
 ---
 package main
 
-import "fmt"
-
 func MakeEitherLeft[L Displayable, R Displayable](arg0 L) Either[L, R] {
 	return Either[L, R]{Tag: EitherLeft, Left: arg0}
 }
@@ -65,10 +63,10 @@ type Either[L Displayable, R Displayable] struct {
 func (e Either[L, R]) display() string {
 	if e.Tag == EitherLeft {
 		s := e.Left.display()
-		return fmt.Sprintf("Left(%s)", s)
+		return "Left(" + s + ")"
 	}
 	s := e.Right.display()
-	return fmt.Sprintf("Right(%s)", s)
+	return "Right(" + s + ")"
 }
 
 type Name struct {

--- a/tests/spec/emit/snapshots/interface_bound_method_call.snap
+++ b/tests/spec/emit/snapshots/interface_bound_method_call.snap
@@ -23,5 +23,5 @@ type Stringer interface {
 
 func printIt[T Stringer](x T) {
 	s := x.stringValue()
-	fmt.Printf("%s\n", s)
+	fmt.Print(s + "\n")
 }

--- a/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_tuple_call_arg.snap
@@ -17,7 +17,6 @@ description: |
 package main
 
 import (
-	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
 	"path"
 )
@@ -27,7 +26,7 @@ func useSplit(f func(string) (string, string), p string) string {
 	tup_3 := lisette.MakeTuple2(ret_1, ret_2)
 	dir := tup_3.First
 	file := tup_3.Second
-	return fmt.Sprintf("%s/%s", dir, file)
+	return dir + "/" + file
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_followed_by_statement.snap
@@ -25,7 +25,7 @@ func test() {
 	if result.Tag == lisette.ResultOk {
 		fmt.Printf("success: %d\n", result.OkVal)
 	} else {
-		fmt.Printf("error: %s\n", result.ErrVal)
+		fmt.Print("error: " + result.ErrVal + "\n")
 	}
 	fmt.Print("done\n")
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_guards.snap
@@ -28,6 +28,6 @@ func test() {
 	case result.Tag == lisette.ResultOk:
 		fmt.Printf("non-positive: %d\n", result.OkVal)
 	default:
-		fmt.Printf("error: %s\n", result.ErrVal)
+		fmt.Print("error: " + result.ErrVal + "\n")
 	}
 }

--- a/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_in_statement_position_with_unit_arms.snap
@@ -24,6 +24,6 @@ func test() {
 	if result.Tag == lisette.ResultOk {
 		fmt.Printf("success: %d\n", result.OkVal)
 	} else {
-		fmt.Printf("error: %s\n", result.ErrVal)
+		fmt.Print("error: " + result.ErrVal + "\n")
 	}
 }

--- a/tests/spec/emit/snapshots/or_pattern_let_else_failure_sees_outer_binding.snap
+++ b/tests/spec/emit/snapshots/or_pattern_let_else_failure_sees_outer_binding.snap
@@ -32,7 +32,7 @@ func MakeEC() E {
 	return E{Tag: EC}
 }
 
-type ETag int
+type ETag uint8
 
 const (
 	EA ETag = iota

--- a/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
@@ -39,17 +39,14 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type ValidationError struct {
 	field string
 }
 
 func (v ValidationError) Error() string {
-	return fmt.Sprintf("%s: required", v.field)
+	return v.field + ": required"
 }
 
 func validate(name string) lisette.Result[string, ValidationError] {

--- a/tests/spec/emit/snapshots/propagate_widens_in_prelude_callback_lambda.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_in_prelude_callback_lambda.snap
@@ -38,17 +38,14 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import lisette "github.com/ivov/lisette/prelude"
 
 type ParseError struct {
 	text string
 }
 
 func (p ParseError) Error() string {
-	return fmt.Sprintf("bad: %s", p.text)
+	return "bad: " + p.text
 }
 
 func parseWord(w string) lisette.Result[int, ParseError] {

--- a/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
@@ -28,14 +28,12 @@ description: |
 ---
 package main
 
-import "fmt"
-
 type FileError struct {
 	path string
 }
 
 func (f *FileError) Error() string {
-	return fmt.Sprintf("cannot open %s", f.path)
+	return "cannot open " + f.path
 }
 
 func readValue() (int, *FileError) {

--- a/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
+++ b/tests/spec/emit/snapshots/ref_bounded_generic_explicit_deref.snap
@@ -23,8 +23,6 @@ description: |
 ---
 package main
 
-import "fmt"
-
 type Greetable interface {
 	greet() string
 }
@@ -34,7 +32,7 @@ type Person struct {
 }
 
 func (p Person) greet() string {
-	return fmt.Sprintf("Hello, %s", p.name)
+	return "Hello, " + p.name
 }
 
 func greetRef[T Greetable](item T) string {

--- a/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
+++ b/tests/spec/emit/snapshots/select_continue_in_loop_needs_label.snap
@@ -63,6 +63,6 @@ loop_1:
 		}
 	}
 	if processed != "10," {
-		panic(fmt.Sprintf("expected 10, got %s", processed))
+		panic("expected 10, got " + processed)
 	}
 }

--- a/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
+++ b/tests/spec/emit/snapshots/select_receive_ok_variable_not_shadowed.snap
@@ -34,7 +34,7 @@ func test() {
 	case val, ok_1 := <-ch:
 		if ok_1 {
 			fmt.Printf("received: %d\n", val)
-			fmt.Printf("ok is: %s\n", ok)
+			fmt.Println("ok is: " + ok)
 		} else {
 			fmt.Println("closed")
 		}


### PR DESCRIPTION
An f-string whose interpolated values are all strings now lowers to `+` concatenation instead of `fmt.Sprintf`. The `fmt` path was boxing each operand and parsing the format string at run time, and it was the only heap escape in typical emitted code.