### PR TITLE
feat: diagnostic for `mut` inside a read-only container

### DIFF
--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -617,6 +617,21 @@ pub fn mut_without_effect(target: &str, span: Span) -> LisetteDiagnostic {
         )
 }
 
+pub fn mut_under_read_only_wrapper(
+    wrapper: &str,
+    wrapper_span: Span,
+    contents_span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`mut` has no effect")
+        .with_infer_code("mut_without_effect")
+        .with_span_label(&wrapper_span, "read-only")
+        .with_span_label(&contents_span, "`mut` has no effect")
+        .with_help(format!(
+            "A read-only container makes its contents read-only. \
+             Write `mut` before `{wrapper}`, or remove the inner `mut`"
+        ))
+}
+
 pub fn assert_type_needs_concrete(target: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("Cannot assert to a type parameter")
         .with_infer_code("needs_writable")

--- a/crates/semantics/src/cache/mod.rs
+++ b/crates/semantics/src/cache/mod.rs
@@ -495,6 +495,7 @@ mod tests {
                             name: "Comparable".into(),
                             params: Vec::new(),
                             writable: false,
+                            mut_span: None,
                             span: bound_span,
                         },
                         Type::Nominal {

--- a/crates/semantics/src/cache/types.rs
+++ b/crates/semantics/src/cache/types.rs
@@ -138,9 +138,13 @@ fn remap_annotation(annotation: &mut Annotation, remap: &mut impl FnMut(&mut Spa
             name: _,
             params,
             writable: _,
+            mut_span,
             span,
         } => {
             remap(span);
+            if let Some(mut_span) = mut_span {
+                remap(mut_span);
+            }
             for param in params {
                 remap_annotation(param, remap);
             }
@@ -295,6 +299,7 @@ mod tests {
             name: EcoString::from("Item"),
             params: vec![Annotation::Opaque { span: span() }],
             writable: false,
+            mut_span: None,
             span: span(),
         };
         let mut methods = Methods::default();

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -77,10 +77,17 @@ impl TypeArgumentChecks {
 }
 
 #[derive(Clone, Copy)]
+struct ReadOnlyWrapper {
+    name: &'static str,
+    name_span: Span,
+}
+
+#[derive(Clone, Copy)]
 struct ConvertMode {
     variadic_allowed: bool,
     type_argument_checks: TypeArgumentChecks,
     position: TypePosition,
+    read_only_wrapper: Option<ReadOnlyWrapper>,
 }
 
 impl ConvertMode {
@@ -89,7 +96,17 @@ impl ConvertMode {
             variadic_allowed: false,
             type_argument_checks: self.type_argument_checks.nested(),
             position: TypePosition::Value,
+            read_only_wrapper: self.read_only_wrapper,
         }
+    }
+}
+
+fn read_only_wrapper_name(qualified_name: &str) -> Option<&'static str> {
+    match qualified_name {
+        "prelude.Ref" => Some("Ref"),
+        "prelude.Slice" => Some("Slice"),
+        "prelude.Map" => Some("Map"),
+        _ => None,
     }
 }
 
@@ -111,6 +128,7 @@ impl TaskState {
                 variadic_allowed: false,
                 type_argument_checks: TypeArgumentChecks::Deferred,
                 position: TypePosition::Bound,
+                read_only_wrapper: None,
             },
         )
     }
@@ -129,6 +147,7 @@ impl TaskState {
                 variadic_allowed: false,
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
+                read_only_wrapper: None,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -148,6 +167,7 @@ impl TaskState {
                 variadic_allowed: true,
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
+                read_only_wrapper: None,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -167,6 +187,7 @@ impl TaskState {
                 variadic_allowed: false,
                 type_argument_checks: TypeArgumentChecks::Descendants,
                 position: TypePosition::Value,
+                read_only_wrapper: None,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -198,6 +219,7 @@ impl TaskState {
                             span,
                             ConvertMode {
                                 variadic_allowed: index == last_param,
+                                read_only_wrapper: None,
                                 ..mode.nested()
                             },
                         )
@@ -255,6 +277,7 @@ impl TaskState {
             name: type_name,
             params,
             writable,
+            mut_span,
             span: annotation_span,
         } = annotation
         else {
@@ -262,10 +285,13 @@ impl TaskState {
         };
         let writable = *writable;
         let annotation_span = *annotation_span;
+        let contents_span =
+            mut_span.map_or(annotation_span, |mut_span| mut_span.merge(annotation_span));
         let ConvertMode {
             variadic_allowed,
             type_argument_checks,
             position,
+            read_only_wrapper,
         } = mode;
 
         if type_name == "VarArgs" && !variadic_allowed {
@@ -375,9 +401,24 @@ impl TaskState {
         // demote writable type arguments.
         let body = if writable { body.make_writable() } else { body };
 
+        let argument_mode = ConvertMode {
+            read_only_wrapper: read_only_wrapper.or_else(|| {
+                read_only_wrapper_name(&qualified_name)
+                    .filter(|_| !writable)
+                    .map(|name| ReadOnlyWrapper {
+                        name,
+                        name_span: Span::new(
+                            annotation_span.file_id,
+                            annotation_span.byte_offset,
+                            type_name.len() as u32,
+                        ),
+                    })
+            }),
+            ..mode.nested()
+        };
         let concrete_args: Vec<Type> = params
             .iter()
-            .map(|arg| self.convert_to_type_mode(store, arg, span, mode.nested()))
+            .map(|arg| self.convert_to_type_mode(store, arg, span, argument_mode))
             .collect();
 
         if generics.len() != params.len() {
@@ -436,6 +477,14 @@ impl TaskState {
                 annotation_span,
             ));
             return resolved_ty.shallow_demoted();
+        }
+        if writable && let Some(wrapper) = read_only_wrapper {
+            self.sink
+                .push(diagnostics::infer::mut_under_read_only_wrapper(
+                    wrapper.name,
+                    wrapper.name_span,
+                    contents_span,
+                ));
         }
 
         resolved_ty

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -928,6 +928,7 @@ pub enum Annotation {
         name: EcoString,
         params: Vec<Self>,
         writable: bool,
+        mut_span: Option<Span>,
         span: Span,
     },
     Function {
@@ -959,6 +960,7 @@ impl fmt::Debug for Annotation {
                 name,
                 params,
                 writable,
+                mut_span: _,
                 span,
             } => {
                 let mut s = f.debug_struct("Constructor");
@@ -1001,6 +1003,7 @@ impl Annotation {
             name: "Unit".into(),
             params: vec![],
             writable: false,
+            mut_span: None,
             span: Span::dummy(),
         }
     }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -23,7 +23,7 @@ pub type AstBuildResult = parse::ParseResult;
 #[cfg(target_pointer_width = "64")]
 mod size_assertions {
     use std::mem::size_of;
-    const _: () = assert!(size_of::<super::ast::Expression>() == 304);
+    const _: () = assert!(size_of::<super::ast::Expression>() == 320);
     const _: () = assert!(size_of::<super::ast::Pattern>() == 160);
     const _: () = assert!(size_of::<super::types::Type>() == 48);
     const _: () = assert!(size_of::<super::ast::Span>() == 12);

--- a/crates/syntax/src/parse/annotations.rs
+++ b/crates/syntax/src/parse/annotations.rs
@@ -78,6 +78,7 @@ impl<'source> Parser<'source> {
                         name: "Slice".into(),
                         params: vec![],
                         writable: false,
+                        mut_span: None,
                         span: error_span,
                     };
                 }
@@ -87,6 +88,7 @@ impl<'source> Parser<'source> {
                     name: "".into(),
                     params: vec![],
                     writable: false,
+                    mut_span: None,
                     span,
                 }
             }
@@ -108,6 +110,7 @@ impl<'source> Parser<'source> {
 
     fn parse_writable_annotation(&mut self) -> Annotation {
         let mut_token = self.current_token();
+        let mut_span = Span::new(self.file_id, mut_token.byte_offset, mut_token.byte_length);
         self.next();
         while self.is(Mut) {
             self.track_error("duplicate `mut` qualifier", "Write `mut` once.");
@@ -119,16 +122,18 @@ impl<'source> Parser<'source> {
                 name,
                 params,
                 writable: _,
+                mut_span: _,
                 span,
             } => Annotation::Constructor {
                 name,
                 params,
                 writable: true,
+                mut_span: Some(mut_span),
                 span,
             },
             other => {
                 self.track_error_at(
-                    Span::new(self.file_id, mut_token.byte_offset, mut_token.byte_length),
+                    mut_span,
                     "`mut` does not apply to this type",
                     "Write `mut` on the reference type it protects, as in `mut Slice<int>`. \
                      A tuple or function type cannot carry it.",
@@ -170,6 +175,7 @@ impl<'source> Parser<'source> {
                 name,
                 params: type_params,
                 writable: false,
+                mut_span: None,
                 span: self.span_from_offset(start.byte_offset),
             };
         }
@@ -182,6 +188,7 @@ impl<'source> Parser<'source> {
             name,
             params: vec![],
             writable: false,
+            mut_span: None,
             span: self.span_from_offset(start.byte_offset),
         }
     }
@@ -242,6 +249,7 @@ impl<'source> Parser<'source> {
             name,
             params: type_params,
             writable: false,
+            mut_span: None,
             span: self.span_from_offset(start.byte_offset),
         }
     }

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -1386,6 +1386,92 @@ fn mut_on_scalar_let_refused() {
 }
 
 #[test]
+fn mut_under_read_only_ref_refused() {
+    infer(
+        r#"fn main() {
+  let xs = [1, 2]
+  let r: Ref<mut Slice<int>> = &xs
+  let _ = r
+}"#,
+    )
+    .assert_infer_code("mut_without_effect");
+}
+
+#[test]
+fn mut_under_read_only_slice_field_refused() {
+    infer(
+        r#"struct P { x: int }
+
+struct Holder {
+  items: Slice<mut Ref<P>>,
+}"#,
+    )
+    .assert_infer_code("mut_without_effect");
+}
+
+#[test]
+fn mut_under_read_only_map_value_refused() {
+    infer(
+        r#"fn take(by_name: Map<string, mut Slice<int>>) {
+  let _ = by_name
+}"#,
+    )
+    .assert_infer_code("mut_without_effect");
+}
+
+#[test]
+fn mut_under_read_only_ref_through_option_refused() {
+    infer(
+        r#"fn take(maybe: Ref<Option<mut Slice<int>>>) {
+  let _ = maybe
+}"#,
+    )
+    .assert_infer_code("mut_without_effect");
+}
+
+#[test]
+fn mut_under_read_only_ref_reports_each_layer() {
+    infer(
+        r#"struct P { x: int }
+
+fn take(items: Ref<mut Slice<mut Ref<P>>>) {
+  let _ = items
+}"#,
+    )
+    .assert_infer_code_count("mut_without_effect", 2);
+}
+
+#[test]
+fn mut_under_writable_ref_accepted() {
+    infer(
+        r#"fn take(items: mut Ref<mut Slice<int>>) {
+  let _ = items
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_in_function_parameter_under_read_only_ref_accepted() {
+    infer(
+        r#"fn take(callback: Ref<fn(mut Slice<int>) -> ()>) {
+  let _ = callback
+}"#,
+    )
+    .assert_no_errors();
+}
+
+#[test]
+fn mut_in_function_result_under_read_only_ref_refused() {
+    infer(
+        r#"fn take(factory: Ref<fn() -> mut Slice<int>>) {
+  let _ = factory
+}"#,
+    )
+    .assert_infer_code("mut_without_effect");
+}
+
+#[test]
 fn mut_on_impl_target_refused() {
     infer(
         r#"struct Batch {

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -15650,7 +15650,7 @@ struct Beam {
 }
 
 impl Beam {
-  fn new(rocks: mut Ref<Slice<mut Ref<Rock>>>) -> mut Ref<Beam> {
+  fn new(rocks: mut Ref<Slice<Ref<Rock>>>) -> mut Ref<Beam> {
     &Beam {
       rocks,
       hits: 0,
@@ -15708,6 +15708,30 @@ struct Pair(mut Slice<int>, int)
 
 fn poke(p: Pair) {
   p.0[0] = 1
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_under_read_only_ref_names_the_wrapper() {
+    let input = r#"
+fn main() {
+  let xs = [1, 2]
+  let r: Ref<mut Slice<int>> = &xs
+  let _ = r
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_under_read_only_ref_inner_layer_names_the_outer_wrapper() {
+    let input = r#"
+struct P { x: int }
+
+fn take(items: Ref<mut Slice<mut Ref<P>>>) {
+  let _ = items
 }
 "#;
     assert_infer_error_snapshot!(input);

--- a/tests/ui/errors/snapshots/infer_mut_under_read_only_ref_inner_layer_names_the_outer_wrapper.snap
+++ b/tests/ui/errors/snapshots/infer_mut_under_read_only_ref_inner_layer_names_the_outer_wrapper.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `mut` has no effect
+   ╭─[test.lis:4:16]
+ 3 │ 
+ 4 │ fn take(items: Ref<mut Slice<mut Ref<P>>>) {
+   ·                ─┬─           ─────┬────
+   ·                 │                 ╰── `mut` has no effect
+   ·                 ╰── read-only
+ 5 │   let _ = items
+   ╰────
+  help: A read-only container makes its contents read-only. Write `mut` before `Ref`, or remove the inner `mut` · code: [infer.mut_without_effect]

--- a/tests/ui/errors/snapshots/infer_mut_under_read_only_ref_names_the_wrapper.snap
+++ b/tests/ui/errors/snapshots/infer_mut_under_read_only_ref_names_the_wrapper.snap
@@ -1,0 +1,13 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `mut` has no effect
+   ╭─[test.lis:4:10]
+ 3 │   let xs = [1, 2]
+ 4 │   let r: Ref<mut Slice<int>> = &xs
+   ·          ─┬─ ───────┬──────
+   ·           │         ╰── `mut` has no effect
+   ·           ╰── read-only
+ 5 │   let _ = r
+   ╰────
+  help: A read-only container makes its contents read-only. Write `mut` before `Ref`, or remove the inner `mut` · code: [infer.mut_without_effect]


### PR DESCRIPTION
Adds a diagnostic for a `mut` written inside a read-only `Ref`, `Slice`, or `Map`.

```
  ✕ `mut` has no effect
   ╭─[src/main.lis:5:10]
 4 │   let xs = [1, 2]
 5 │   let r: Ref<mut Slice<int>> = &xs
   ·          ─┬─ ───────┬──────
   ·           │         ╰── `mut` has no effect
   ·           ╰── read-only
 6 │   fmt.Println(r)
   ╰────
  help: A read-only container makes its contents read-only. Write `mut` before `Ref`, or remove 
        the inner `mut` · code: [infer.mut_without_effect]
```


