### PR TITLE
refactor: align function cast diagnostics with assignment

### DIFF
--- a/crates/semantics/src/checker/infer/validation/casts.rs
+++ b/crates/semantics/src/checker/infer/validation/casts.rs
@@ -17,6 +17,8 @@ impl InferCtx<'_> {
     ///   including types with numeric underlying types (e.g., `struct Duration(int64)`).
     /// - rune -> string (UTF-8 encodes the codepoint)
     /// - string <-> Slice<byte> / Slice<rune>
+    /// - Function type -> function type under the assignment rule: a parameter
+    ///   may demand less permission than the target promises, never more.
     ///
     /// Explicitly blocked:
     /// - rune -> byte/uint8 (rune is int32 and may not fit in a byte)
@@ -33,6 +35,16 @@ impl InferCtx<'_> {
         let store = self.store;
         let raw_source_resolved = raw_source_ty.resolve_in(&self.env);
         let raw_target_resolved = raw_target_ty.resolve_in(&self.env);
+        let source_is_function = store
+            .resolve_to_function_type(&raw_source_resolved)
+            .is_some();
+        let target_is_function = store
+            .resolve_to_function_type(&raw_target_resolved)
+            .is_some();
+        if source_is_function && target_is_function {
+            self.unify(&raw_target_resolved, &raw_source_resolved, &span);
+            return;
+        }
         if !self.cast_keeps_permission(&raw_source_resolved, &raw_target_resolved) {
             self.sink.push(diagnostics::infer::cast_grants_permission(
                 &raw_source_resolved.to_string(),

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -9442,6 +9442,57 @@ fn test() -> int {
 }
 
 #[test]
+fn infer_cast_fn_reader_to_writer_type() {
+    let input = r#"
+struct Node { value: int }
+
+type Handler = fn(mut Ref<Node>)
+
+fn read_only(n: Ref<Node>) { let _ = n.value }
+
+fn test() {
+  let handler = read_only as Handler
+  let mut node = Node { value: 1 }
+  handler(&node)
+}
+"#;
+    infer(input).assert_no_errors();
+}
+
+#[test]
+fn infer_cast_fn_writer_to_reader_type() {
+    let input = r#"
+struct Node { value: int }
+
+type Handler = fn(Ref<Node>)
+
+fn writer(n: mut Ref<Node>) { n.value = 2 }
+
+fn test() {
+  let handler = writer as Handler
+  let node = Node { value: 1 }
+  handler(&node)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_cast_fn_parameter_count_mismatch() {
+    let input = r#"
+type Handler = fn(int)
+
+fn pair(a: int, b: int) { let _ = a + b }
+
+fn test() {
+  let handler = pair as Handler
+  handler(1)
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
 fn infer_invalid_cast_complex_to_int() {
     let input = r#"
 fn test() -> int {

--- a/tests/ui/errors/snapshots/infer_cast_fn_parameter_count_mismatch.snap
+++ b/tests/ui/errors/snapshots/infer_cast_fn_parameter_count_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type mismatch
+   ╭─[test.lis:7:17]
+ 6 │ fn test() {
+ 7 │   let handler = pair as Handler
+   ·                 ───────┬───────
+   ·                        ╰── expected `Handler`, found `fn (int, int) -> ()`
+ 8 │   handler(1)
+   ╰────
+  help: The function types must have the same number of parameters · code: [infer.type_mismatch]

--- a/tests/ui/errors/snapshots/infer_cast_fn_writer_to_reader_type.snap
+++ b/tests/ui/errors/snapshots/infer_cast_fn_writer_to_reader_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Missing write permission
+    ╭─[test.lis:9:17]
+  8 │ fn test() {
+  9 │   let handler = writer as Handler
+    ·                 ────────┬────────
+    ·                         ╰── expected `Handler`, found `fn (mut Ref<Node>) -> ()`
+ 10 │   let node = Node { value: 1 }
+    ╰────
+  help: A function value may demand less permission than its type promises, never more. Match `mut` on each differing parameter, or expect `fn (mut Ref<Node>) -> ()` instead · code: [infer.needs_writable]


### PR DESCRIPTION
A cast between two function types now goes through the same permission check as assignment, so the unsafe direction reports `needs_writable` instead of a generic invalid conversion.