### PR TITLE
refactor: share lowered-return and arg-slot utils in `emit` crate

### DIFF
--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -101,24 +101,11 @@ impl FunctionLayout {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.result.go_type(planner),
             CallableReturnAbi::BareError => planner.go_type(&self.result.logical_type().err_type()),
             CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
-                let payload = self
-                    .payload
-                    .as_deref()
-                    .expect("fallible callable layout has a payload");
-                let payload = payload.go_type(planner);
                 let error = planner.go_type(&self.result.logical_type().err_type());
-                GoType::with_dependencies(
-                    format!("({}, {})", payload.code, error.code),
-                    [&payload, &error],
-                )
+                self.multi_result_go_type(planner, error)
             }
             CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-                let payload = self
-                    .payload
-                    .as_deref()
-                    .expect("option callable layout has a payload");
-                let payload = payload.go_type(planner);
-                GoType::with_dependencies(format!("({}, bool)", payload.code), [&payload])
+                self.multi_result_go_type(planner, GoType::new("bool"))
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable) => self
                 .payload
@@ -149,6 +136,18 @@ impl FunctionLayout {
                 GoType::with_dependencies(code, &elements)
             }
         })
+    }
+
+    fn multi_result_go_type(&self, planner: &Planner<'_>, status: GoType) -> GoType {
+        let payload = self
+            .payload
+            .as_deref()
+            .expect("payload-carrying callable layout has a payload")
+            .go_type(planner);
+        GoType::with_dependencies(
+            format!("({}, {})", payload.code, status.code),
+            [&payload, &status],
+        )
     }
 }
 

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -94,45 +94,46 @@ impl Planner<'_> {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type(&peeled),
             CallableReturnAbi::BareError => self.go_type(&peeled.err_type()),
             CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
-                let ok_go = self.go_type(&peeled.ok_type());
-                let err_go = self.go_type(&peeled.err_type());
-                GoType::with_dependencies(
-                    format!("({}, {})", ok_go.code, err_go.code),
-                    [&ok_go, &err_go],
-                )
+                go_result_list(&[
+                    self.go_type(&peeled.ok_type()),
+                    self.go_type(&peeled.err_type()),
+                ])
             }
             CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-                let inner_go = self.go_type(&peeled.ok_type());
-                GoType::with_dependencies(format!("({}, bool)", inner_go.code), [&inner_go])
+                go_result_list(&[self.go_type(&peeled.ok_type()), GoType::new("bool")])
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_)) => {
                 self.go_type(&peeled.ok_type())
             }
-            CallableReturnAbi::Tuple { .. } => {
-                let elements = tuple_element_types(&peeled);
-                let element_gos: Vec<GoType> = elements
-                    .iter()
-                    .map(|t| {
-                        if self.facts.is_nullable_option(t) {
-                            let inner = self.facts.peel_alias(t).ok_type();
-                            self.go_type(&inner)
-                        } else {
-                            self.go_type(t)
-                        }
-                    })
-                    .collect();
-                let code = format!(
-                    "({})",
-                    element_gos
-                        .iter()
-                        .map(|go| go.code.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                GoType::with_dependencies(code, &element_gos)
-            }
+            CallableReturnAbi::Tuple { .. } => go_result_list(&self.tuple_slot_go_types(&peeled)),
         }
     }
+
+    fn tuple_slot_go_types(&self, tuple_ty: &Type) -> Vec<GoType> {
+        tuple_element_types(tuple_ty)
+            .iter()
+            .map(|t| {
+                if self.facts.is_nullable_option(t) {
+                    let inner = self.facts.peel_alias(t).ok_type();
+                    self.go_type(&inner)
+                } else {
+                    self.go_type(t)
+                }
+            })
+            .collect()
+    }
+}
+
+fn go_result_list(slots: &[GoType]) -> GoType {
+    let code = format!(
+        "({})",
+        slots
+            .iter()
+            .map(|slot| slot.code.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    GoType::with_dependencies(code, slots)
 }
 
 pub(crate) fn tuple_element_types(ty: &Type) -> Vec<Type> {

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -171,8 +171,8 @@ pub(crate) fn emit_lowered_result_return(
                 multi_value_return(lowered_none_values(planner, shape, return_ty)),
             ]
         }
-        CallableReturnAbi::Tuple { arity, .. } => {
-            emit_lowered_tuple_return(planner, result_value, return_ty, *arity)
+        CallableReturnAbi::Tuple { .. } => {
+            emit_lowered_tuple_return(planner, result_value, return_ty)
         }
         CallableReturnAbi::Tagged
         | CallableReturnAbi::Direct
@@ -182,39 +182,63 @@ pub(crate) fn emit_lowered_result_return(
     }
 }
 
-/// `Tuple` shape return: project each tuple field, unwrapping any
-/// nullable-Option slot to its bare Go nilable.
 fn emit_lowered_tuple_return(
     planner: &mut Planner,
     result_value: &str,
     return_ty: &Type,
-    arity: usize,
 ) -> Vec<LoweredStatement> {
-    let peeled = planner.facts.peel_alias(return_ty);
-    let slot_tys = tuple_element_types(&peeled);
-    let any_nullable = slot_tys.iter().any(|t| planner.facts.is_nullable_option(t));
-    if !any_nullable {
-        let fields: Vec<String> = (0..arity)
-            .map(|i| format!("{}.{}", result_value, TUPLE_FIELDS[i]))
-            .collect();
-        return vec![multi_value_return(fields)];
-    }
-    let mut statements = Vec::new();
-    let fields: Vec<String> = (0..arity)
-        .map(|i| {
-            let raw = format!("{}.{}", result_value, TUPLE_FIELDS[i]);
-            slot_tys
-                .get(i)
-                .filter(|t| planner.facts.is_nullable_option(t))
-                .map(|t| {
-                    let inner = planner.use_go_type(&t.ok_type());
-                    planner.plan_option_projection(&mut statements, &raw, "unwrap", &inner, false)
-                })
-                .unwrap_or(raw)
-        })
-        .collect();
+    let (mut statements, fields) = lowered_tuple_values(planner, result_value, return_ty);
     statements.push(multi_value_return(fields));
     statements
+}
+
+/// Project each field of a lowered tuple value, unwrapping any
+/// nullable-Option slot to its bare Go nilable.
+fn lowered_tuple_values(
+    planner: &mut Planner,
+    tuple_value: &str,
+    tuple_ty: &Type,
+) -> (Vec<LoweredStatement>, Vec<String>) {
+    let slot_tys = tuple_element_types(&planner.facts.peel_alias(tuple_ty));
+    let mut statements = Vec::new();
+    let fields = slot_tys
+        .iter()
+        .enumerate()
+        .map(|(i, slot_ty)| {
+            let raw = format!("{}.{}", tuple_value, TUPLE_FIELDS[i]);
+            if planner.facts.is_nullable_option(slot_ty) {
+                let inner = planner.use_go_type(&slot_ty.ok_type());
+                planner.plan_option_projection(&mut statements, &raw, "unwrap", &inner, false)
+            } else {
+                raw
+            }
+        })
+        .collect();
+    (statements, fields)
+}
+
+/// Lower each element of a tuple literal into its lowered return slot.
+fn lowered_tuple_literal_values(
+    planner: &mut Planner,
+    elements: &[Expression],
+    tuple_ty: &Type,
+) -> (Vec<LoweredStatement>, Vec<String>) {
+    let slot_tys = tuple_element_types(&planner.facts.peel_alias(tuple_ty));
+    let stages: Vec<ValuePlan> = elements
+        .iter()
+        .enumerate()
+        .map(|(i, e)| match slot_tys.get(i) {
+            Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
+                lower_nullable_slot_value(planner, e, slot_ty)
+            }
+            _ => planner.lower_composite_value(e, ExpressionContext::value()),
+        })
+        .collect();
+    let (mut statements, parts) = planner
+        .sequence_values(stages, CaptureBoundary::SiblingSequence, "ret")
+        .into_rendered();
+    let parts = planner.coerce_elements_to_slots(&mut statements, elements, parts, &slot_tys);
+    (statements, parts)
 }
 
 impl Planner<'_> {
@@ -528,7 +552,7 @@ pub(crate) fn lower_arg_to_tagged(
     tagged_var
 }
 
-/// Tail return for `PartialTuple` and `Tuple` ABIs. Returns `true` when this
+/// Tail return for `Partial` and `Tuple` ABIs. Returns `true` when this
 /// path handled the emission.
 pub(crate) fn try_emit_lowered_tail_return(
     planner: &mut Planner,
@@ -570,30 +594,15 @@ fn emit_lowered_tuple_tail(
     arity: usize,
 ) -> Vec<LoweredStatement> {
     use Expression;
+    let return_ty = planner.return_ctx().expect_ty();
     if let Expression::Tuple { elements, .. } = expression
         && elements.len() == arity
     {
-        let return_ty = planner.return_ctx().expect_ty();
-        let slot_tys = tuple_element_types(&planner.facts.peel_alias(&return_ty));
-        let stages: Vec<ValuePlan> = elements
-            .iter()
-            .enumerate()
-            .map(|(i, e)| match slot_tys.get(i) {
-                Some(slot_ty) if planner.facts.is_nullable_option(slot_ty) => {
-                    lower_nullable_slot_value(planner, e, slot_ty)
-                }
-                _ => planner.lower_composite_value(e, ExpressionContext::value()),
-            })
-            .collect();
-        let (mut statements, parts) = planner
-            .sequence_values(stages, CaptureBoundary::SiblingSequence, "ret")
-            .into_rendered();
-        let parts = planner.coerce_elements_to_slots(&mut statements, elements, parts, &slot_tys);
+        let (mut statements, parts) = lowered_tuple_literal_values(planner, elements, &return_ty);
         statements.push(multi_value_return(parts));
         return statements;
     }
 
-    let return_ty = planner.return_ctx().expect_ty();
     lowered_tail_fallback(
         planner,
         expression,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -54,6 +54,12 @@ fn go_builtin_conversion(type_args: &str) -> Option<String> {
     (!inner.is_empty() && !inner.contains(',')).then(|| inner.to_string())
 }
 
+struct FnArgShapes {
+    param_abi: CallableReturnAbi,
+    arg_fn: Type,
+    arg_abi: CallableReturnAbi,
+}
+
 struct CallArgsContext<'plan, 'facts> {
     plan: &'plan CallPlan<'facts>,
     /// Suppresses the Go-fn identity short-circuit on fn-typed params
@@ -611,16 +617,14 @@ impl<'a> Planner<'a> {
             ArgumentPlan::TaggedGoLowering => {
                 let target =
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
-                let arg_ctx = direct_arg_emit_ctx(&self.facts, Some(target), true);
+                let arg_ctx = self.direct_arg_emit_ctx(param, true);
                 let argument = self.lower_composite_value(arg, arg_ctx);
                 argument.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
                     let lowered = self.emit_lower_arg_to_tagged(setup, &value, target);
                     GoExpression::opaque_with_deferred_evaluation(lowered, true)
                 })
             }
-            ArgumentPlan::Direct => {
-                self.lower_direct_arg(arg, ctx, effective_param_ty, declared_param_ty)
-            }
+            ArgumentPlan::Direct => self.lower_direct_arg(arg, ctx, param, declared_param_ty),
         }
     }
 
@@ -636,8 +640,7 @@ impl<'a> Planner<'a> {
         let effective_param_ty = param.map(|param| &param.instantiated);
         let declared_param_ty = param.and_then(|param| param.declared.as_ref());
         if matches!(callee.origin, CallableOrigin::GoInterop)
-            && let Some((source, target, transition)) =
-                self.detect_callback_wrapper(arg, effective_param_ty)
+            && let Some((source, target, transition)) = self.detect_callback_wrapper(arg, param)
         {
             return ArgumentPlan::GoCallbackAdapter {
                 source,
@@ -755,16 +758,16 @@ impl<'a> Planner<'a> {
         &mut self,
         arg: &Expression,
         ctx: &CallArgsContext<'_, '_>,
-        effective_param_ty: Option<&Type>,
+        param: Option<&CallableParamAbi>,
         declared_param_ty: Option<&Type>,
     ) -> ValuePlan {
         let suppress = would_suppress_tagged_go(&ctx.plan.resolved, declared_param_ty);
-        let mut arg_ctx = direct_arg_emit_ctx(&self.facts, effective_param_ty, suppress);
+        let mut arg_ctx = self.direct_arg_emit_ctx(param, suppress);
         if let Some(retired) = ctx.retired_receiver {
             arg_ctx = arg_ctx.with_retired_receiver(retired);
         }
         let argument = self.lower_composite_value(arg, arg_ctx);
-        let Some(target) = effective_param_ty else {
+        let Some(target) = param.map(|param| &param.instantiated) else {
             return argument;
         };
         let coercion = CoercionPlan::internal(self, &arg.get_type(), target);
@@ -776,6 +779,21 @@ impl<'a> Planner<'a> {
             setup.extend(coercion_setup);
             GoExpression::opaque_with_deferred_evaluation(coerced, contains_deferred_evaluation)
         })
+    }
+
+    /// Context for a `Direct` or `TaggedGoLowering` argument.
+    fn direct_arg_emit_ctx<'b>(
+        &self,
+        param: Option<&CallableParamAbi>,
+        suppress: bool,
+    ) -> ExpressionContext<'b> {
+        let flows_to_unknown = param.is_some_and(|param| {
+            self.facts
+                .resolves_to_unknown(param.instantiated.unwrap_forall())
+        });
+        ExpressionContext::value()
+            .with_forced_tagged_go_function(suppress)
+            .with_unknown_argument_target(flows_to_unknown)
     }
 
     /// Adapt a lowered-return fn arg when its shape disagrees with the
@@ -791,11 +809,7 @@ impl<'a> Planner<'a> {
 
     /// Detect whether `arg`'s fn-shape disagrees with the callee's generic
     /// param shape (Lisette callback adapter trigger). Pure detection.
-    fn fn_arg_shapes(
-        &self,
-        arg: &Expression,
-        raw_param_ty: &Type,
-    ) -> Option<(CallableReturnAbi, Type, CallableReturnAbi)> {
+    fn fn_arg_shapes(&self, arg: &Expression, raw_param_ty: &Type) -> Option<FnArgShapes> {
         let variadic_inner = if raw_param_ty.get_name() == Some("VarArgs") {
             raw_param_ty.inner()
         } else {
@@ -815,7 +829,11 @@ impl<'a> Planner<'a> {
         let arg_ret = arg_fn.get_function_ret()?;
         let arg_abi = self.classify_direct_emission(arg_ret)?;
 
-        Some((param_abi, arg_fn, arg_abi))
+        Some(FnArgShapes {
+            param_abi,
+            arg_fn,
+            arg_abi,
+        })
     }
 
     fn detect_lowered_fn_arg_shape(
@@ -827,8 +845,8 @@ impl<'a> Planner<'a> {
             return None;
         }
         let raw_param_ty = generic_param_ty?;
-        let (param_abi, _arg_fn, arg_abi) = self.fn_arg_shapes(arg, raw_param_ty)?;
-        if param_abi == arg_abi {
+        let shapes = self.fn_arg_shapes(arg, raw_param_ty)?;
+        if shapes.param_abi == shapes.arg_abi {
             return None;
         }
         Some(())
@@ -839,7 +857,11 @@ impl<'a> Planner<'a> {
         arg: &Expression,
         generic_param_ty: &Type,
     ) -> Option<ValuePlan> {
-        let (param_abi, arg_fn, arg_abi) = self.fn_arg_shapes(arg, generic_param_ty)?;
+        let FnArgShapes {
+            param_abi,
+            arg_fn,
+            arg_abi,
+        } = self.fn_arg_shapes(arg, generic_param_ty)?;
         let argument = self.lower_value(arg, ExpressionContext::value());
         Some(argument.map_rendered_as_computed(|setup, value, _| {
             let mut buffer = String::new();
@@ -931,13 +953,12 @@ impl<'a> Planner<'a> {
     fn detect_callback_wrapper(
         &self,
         arg: &Expression,
-        effective_param_ty: Option<&Type>,
+        param: Option<&CallableParamAbi>,
     ) -> Option<(CallableReturnAbi, CallableReturnAbi, AbiTransition)> {
-        let param_fn_ty = effective_param_ty
-            .and_then(|param_ty| {
-                self.facts
-                    .resolve_to_function_type(param_ty.unwrap_forall())
-            })
+        let param = param?;
+        let param_fn_ty = self
+            .facts
+            .resolve_to_function_type(param.instantiated.unwrap_forall())
             .filter(|fn_ty| {
                 let Type::Function(f) = fn_ty else {
                     return false;
@@ -1033,6 +1054,10 @@ impl<'a> Planner<'a> {
         }
     }
 
+    fn argument_source_layout(&self, argument: &Expression) -> ValueLayout {
+        self.value_layout(&argument.get_type(), SlotOrigin::Lisette)
+    }
+
     fn argument_needs_slot_bridge(
         &self,
         argument: &Expression,
@@ -1041,7 +1066,7 @@ impl<'a> Planner<'a> {
         let physical_source = self.go_physical_expression_layout(argument);
         let source = physical_source
             .clone()
-            .unwrap_or_else(|| self.value_layout(&argument.get_type(), SlotOrigin::Lisette));
+            .unwrap_or_else(|| self.argument_source_layout(argument));
         let target = self.argument_slot_layout(parameter);
         let can_forward_physical = match (&physical_source, &target) {
             (
@@ -1069,7 +1094,7 @@ impl<'a> Planner<'a> {
         let raw_source = self.go_physical_expression_layout(argument);
         let source = raw_source
             .clone()
-            .unwrap_or_else(|| self.value_layout(&argument.get_type(), SlotOrigin::Lisette));
+            .unwrap_or_else(|| self.argument_source_layout(argument));
         let target = self.argument_slot_layout(parameter);
         let coercion = CoercionPlan::bridge(self, &source, &target);
         let value = if raw_source.is_some() {
@@ -1195,18 +1220,4 @@ fn spread_needs_any_wrap(
 fn would_suppress_tagged_go(callee: &ResolvedCallee<'_>, declared_param_ty: Option<&Type>) -> bool {
     let unwrapped = declared_param_ty.map(|p| p.unwrap_forall());
     callee.is_prelude_dispatch && unwrapped.is_some_and(|p| matches!(p, Type::Function(_)))
-}
-
-/// Compute the `ExpressionContext` for emitting a Direct or TaggedGoLowering
-/// argument's underlying value via `emit_composite_value`.
-fn direct_arg_emit_ctx<'b>(
-    facts: &crate::EmitFacts<'_>,
-    effective_param_ty: Option<&'b Type>,
-    suppress: bool,
-) -> ExpressionContext<'b> {
-    let unwrapped = effective_param_ty.map(|p| p.unwrap_forall());
-    let flows_to_unknown = unwrapped.is_some_and(|ty| facts.resolves_to_unknown(ty));
-    ExpressionContext::value()
-        .with_forced_tagged_go_function(suppress)
-        .with_unknown_argument_target(flows_to_unknown)
 }


### PR DESCRIPTION
Extracts the shared utils for lowered-return rendering and arg-slot planning in the `emit` crate.