### PR TITLE
refactor: flatten tuple payloads in Go function wrappers

### DIFF
--- a/crates/emit/src/abi/callable.rs
+++ b/crates/emit/src/abi/callable.rs
@@ -78,6 +78,39 @@ impl CallableReturnAbi {
                 | Self::Tuple { .. }
         )
     }
+
+    pub(crate) fn payload(&self) -> Option<PayloadLayout> {
+        match self {
+            Self::Result { payload }
+            | Self::Partial { payload }
+            | Self::Option(OptionReturnAbi::CommaOk { payload }) => Some(*payload),
+            Self::Tagged
+            | Self::Direct
+            | Self::BareError
+            | Self::Option(OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_))
+            | Self::Tuple { .. } => None,
+        }
+    }
+
+    pub(crate) fn with_payload(self, payload: PayloadLayout) -> Self {
+        match self {
+            Self::Result { .. } => Self::Result { payload },
+            Self::Partial { .. } => Self::Partial { payload },
+            Self::Option(OptionReturnAbi::CommaOk { .. }) => {
+                Self::Option(OptionReturnAbi::CommaOk { payload })
+            }
+            other => other,
+        }
+    }
+
+    pub(crate) fn has_flattened_payload(&self) -> bool {
+        self.payload().is_some_and(PayloadLayout::is_flattened)
+    }
+
+    pub(crate) fn same_logical_contract(&self, other: &Self) -> bool {
+        self.clone().with_payload(PayloadLayout::Packed)
+            == other.clone().with_payload(PayloadLayout::Packed)
+    }
 }
 
 /// Required conversion between two callable result contracts.

--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -324,7 +324,7 @@ pub(crate) fn resolve_layout_bridge(
             }
         }
         (Function { layout: source, .. }, Function { layout: target, .. })
-            if source.return_abi == target.return_abi =>
+            if source.return_abi.same_logical_contract(&target.return_abi) =>
         {
             LayoutBridge::Function {
                 direction: function_bridge_direction(planner, source, target),

--- a/crates/emit/src/abi/layout.rs
+++ b/crates/emit/src/abi/layout.rs
@@ -38,6 +38,10 @@ impl SlotOrigin {
             self
         }
     }
+
+    pub(crate) fn declared_by_go(self) -> bool {
+        matches!(self, Self::GoParameter | Self::GoReturn | Self::GoField)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -142,12 +146,26 @@ impl FunctionLayout {
         let payload = self
             .payload
             .as_deref()
-            .expect("payload-carrying callable layout has a payload")
-            .go_type(planner);
-        GoType::with_dependencies(
-            format!("({}, {})", payload.code, status.code),
-            [&payload, &status],
-        )
+            .expect("payload-carrying callable layout has a payload");
+        let mut slots: Vec<GoType> = match payload {
+            ValueLayout::Tuple { elements, .. } if self.return_abi.has_flattened_payload() => {
+                elements
+                    .iter()
+                    .map(|element| element.go_type(planner))
+                    .collect()
+            }
+            _ => vec![payload.go_type(planner)],
+        };
+        slots.push(status);
+        let code = format!(
+            "({})",
+            slots
+                .iter()
+                .map(|slot| slot.code.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        GoType::with_dependencies(code, &slots)
     }
 }
 
@@ -400,6 +418,7 @@ impl Planner<'_> {
             return self.value_layout_with_hint(ty, SlotOrigin::Lisette, None);
         }
 
+        let origin = self.function_type_origin(ty, origin);
         let resolved = self.facts.peel_alias(ty);
         if resolved != *ty {
             return ValueLayout::Named {
@@ -578,7 +597,7 @@ impl Planner<'_> {
                     let payload = self
                         .callable_payload_layout(&result_type, origin, declared_result)
                         .map(Box::new);
-                    let return_abi = self.callable_return_abi(&result_type);
+                    let return_abi = self.slot_return_abi(&result_type, origin);
                     return ValueLayout::Function {
                         function_type: ty,
                         layout: FunctionLayout {

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -5,11 +5,26 @@ pub(crate) mod layout;
 pub(crate) mod transition;
 
 use crate::Planner;
+use crate::names::go_name;
 use crate::names::go_name::PRELUDE_ERROR_ID;
 use crate::types::go_type::GoType;
 use callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use layout::SlotOrigin;
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::types::Type;
+
+/// Go spells a tuple payload as one result per element.
+pub(crate) fn go_payload_layout(return_ty: &Type) -> PayloadLayout {
+    if return_ty
+        .ok_type()
+        .tuple_arity()
+        .is_some_and(|arity| arity >= 2)
+    {
+        PayloadLayout::Flattened
+    } else {
+        PayloadLayout::Packed
+    }
+}
 
 impl Planner<'_> {
     /// ABI of a value after it has crossed into Lisette expression space.
@@ -28,6 +43,44 @@ impl Planner<'_> {
     pub(crate) fn callable_return_abi(&self, return_ty: &Type) -> CallableReturnAbi {
         self.classify_direct_emission(return_ty)
             .unwrap_or_else(|| self.value_return_abi(return_ty))
+    }
+
+    pub(crate) fn slot_return_abi(
+        &self,
+        return_ty: &Type,
+        origin: SlotOrigin,
+    ) -> CallableReturnAbi {
+        self.classify_slot_emission(return_ty, origin)
+            .unwrap_or_else(|| self.value_return_abi(return_ty))
+    }
+
+    /// A Go-named function type renders as its Go name, so a value of that
+    /// type has Go's shape in any slot.
+    pub(crate) fn function_type_origin(&self, fn_ty: &Type, origin: SlotOrigin) -> SlotOrigin {
+        if origin.declared_by_go() || !self.is_go_named_function_type(fn_ty) {
+            origin
+        } else {
+            SlotOrigin::GoParameter
+        }
+    }
+
+    fn is_go_named_function_type(&self, ty: &Type) -> bool {
+        matches!(ty.unwrap_forall(), Type::Nominal { id, .. } if go_name::is_go_import(id))
+            && self.facts.resolve_to_function_type(ty).is_some()
+    }
+
+    /// Lowered shape for the slot at `origin`, or `None` to keep it tagged.
+    pub(crate) fn classify_slot_emission(
+        &self,
+        return_ty: &Type,
+        origin: SlotOrigin,
+    ) -> Option<CallableReturnAbi> {
+        let abi = self.classify_direct_emission(return_ty)?;
+        Some(if origin.declared_by_go() && abi.payload().is_some() {
+            abi.with_payload(go_payload_layout(&self.facts.peel_alias(return_ty)))
+        } else {
+            abi
+        })
     }
 
     /// Lowered shape for a Lisette return type, or `None` to keep it tagged.
@@ -93,19 +146,27 @@ impl Planner<'_> {
         match shape {
             CallableReturnAbi::Tagged | CallableReturnAbi::Direct => self.go_type(&peeled),
             CallableReturnAbi::BareError => self.go_type(&peeled.err_type()),
-            CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
-                go_result_list(&[
-                    self.go_type(&peeled.ok_type()),
-                    self.go_type(&peeled.err_type()),
-                ])
+            CallableReturnAbi::Result { payload } | CallableReturnAbi::Partial { payload } => {
+                let mut slots = self.lowered_payload_go_types(&peeled.ok_type(), *payload);
+                slots.push(self.go_type(&peeled.err_type()));
+                go_result_list(&slots)
             }
-            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-                go_result_list(&[self.go_type(&peeled.ok_type()), GoType::new("bool")])
+            CallableReturnAbi::Option(OptionReturnAbi::CommaOk { payload }) => {
+                let mut slots = self.lowered_payload_go_types(&peeled.ok_type(), *payload);
+                slots.push(GoType::new("bool"));
+                go_result_list(&slots)
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable | OptionReturnAbi::Sentinel(_)) => {
                 self.go_type(&peeled.ok_type())
             }
             CallableReturnAbi::Tuple { .. } => go_result_list(&self.tuple_slot_go_types(&peeled)),
+        }
+    }
+
+    fn lowered_payload_go_types(&self, ok_ty: &Type, payload: PayloadLayout) -> Vec<GoType> {
+        match payload {
+            PayloadLayout::Flattened => self.tuple_slot_go_types(&self.facts.peel_alias(ok_ty)),
+            PayloadLayout::Packed => vec![self.go_type(ok_ty)],
         }
     }
 

--- a/crates/emit/src/calls/go_interop/wrappers.rs
+++ b/crates/emit/src/calls/go_interop/wrappers.rs
@@ -12,6 +12,7 @@ use crate::names::go_name;
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement};
 use crate::write_line;
 use syntax::ast::Expression;
+use syntax::parse::TUPLE_FIELDS;
 use syntax::types::{FunctionParameter, Type};
 
 #[derive(Clone, Copy)]
@@ -76,6 +77,14 @@ pub(super) fn leaf_block(sink: &ResolvedSink, value: &str) -> LoweredBlock {
     }
 }
 
+fn tuple_slots(layout: &ValueLayout) -> &[ValueLayout] {
+    match layout {
+        ValueLayout::Tuple { elements, .. } => elements,
+        ValueLayout::Named { underlying, .. } => tuple_slots(underlying),
+        _ => unreachable!("a tuple payload is a tuple layout"),
+    }
+}
+
 impl Planner<'_> {
     pub(crate) fn plan_function_layout_bridge(
         &mut self,
@@ -84,7 +93,7 @@ impl Planner<'_> {
         source: &FunctionLayout,
         target: &FunctionLayout,
     ) -> String {
-        debug_assert_eq!(source.return_abi, target.return_abi);
+        debug_assert!(source.return_abi.same_logical_contract(&target.return_abi));
         let function = self.hoist_tmp_value_statement(statements, "cb", value);
         let mut body = Vec::new();
         let mut parameters = Vec::new();
@@ -140,17 +149,30 @@ impl Planner<'_> {
             CallableReturnAbi::Result { .. }
             | CallableReturnAbi::Partial { .. }
             | CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-                let value = self.fresh_var(Some("ret"));
-                self.declare(&value);
-                let auxiliary = self.fresh_var(Some("ret"));
-                self.declare(&auxiliary);
+                let source_payload = source
+                    .payload
+                    .as_deref()
+                    .expect("lowered callable has a payload layout");
+                let target_payload = target
+                    .payload
+                    .as_deref()
+                    .expect("lowered callable target has a payload layout");
+                let source_flat = source.return_abi.has_flattened_payload();
+                let slot_count = if source_flat {
+                    tuple_slots(source_payload).len()
+                } else {
+                    1
+                };
+                let mut values = self.create_temp_vars("ret", slot_count + 1);
                 statements.push(LoweredStatement::RawGo(format!(
-                    "{value}, {auxiliary} := {call}\n"
+                    "{} := {call}\n",
+                    values.join(", ")
                 )));
+                let auxiliary = values.pop().expect("a lowered callable has a status slot");
 
-                if matches!(source.return_abi, CallableReturnAbi::Partial { .. }) {
+                if matches!(source.return_abi, CallableReturnAbi::Partial { .. }) && !source_flat {
                     let ok_type = source.result.logical_type().ok_type();
-                    if let Some(condition) = self.partial_ok_nil_check(&ok_type, &value) {
+                    if let Some(condition) = self.partial_ok_nil_check(&ok_type, &values[0]) {
                         statements.push(LoweredStatement::If(IfPlan {
                             condition_setup: Vec::new(),
                             condition,
@@ -162,17 +184,15 @@ impl Planner<'_> {
                     }
                 }
 
-                let source_payload = source
-                    .payload
-                    .as_deref()
-                    .expect("lowered callable has a payload layout");
-                let target_payload = target
-                    .payload
-                    .as_deref()
-                    .expect("lowered callable target has a payload layout");
-                let bridge = resolve_layout_bridge(self, source_payload, target_payload);
-                let value = self.plan_layout_bridge(statements, &value, &bridge);
-                statements.push(plain_return(format!("{value}, {auxiliary}")));
+                let mut values = self.bridge_payload_slots(
+                    statements,
+                    values,
+                    source_payload,
+                    target_payload,
+                    target.return_abi.has_flattened_payload(),
+                );
+                values.push(auxiliary);
+                statements.push(plain_return(values.join(", ")));
             }
             CallableReturnAbi::Option(OptionReturnAbi::Nullable) => {
                 let raw = self.hoist_tmp_value_statement(statements, "raw", call);
@@ -233,6 +253,45 @@ impl Planner<'_> {
                     .collect::<Vec<_>>();
                 statements.push(plain_return(values.join(", ")));
             }
+        }
+    }
+
+    /// `values` holds one Go value per source slot: the packed payload, or one
+    /// value per tuple element when the source is flattened.
+    fn bridge_payload_slots(
+        &mut self,
+        statements: &mut Vec<LoweredStatement>,
+        values: Vec<String>,
+        source: &ValueLayout,
+        target: &ValueLayout,
+        target_flat: bool,
+    ) -> Vec<String> {
+        let source_flat = values.len() > 1;
+        if !source_flat && !target_flat {
+            let bridge = resolve_layout_bridge(self, source, target);
+            return vec![self.plan_layout_bridge(statements, &values[0], &bridge)];
+        }
+        let source_slots = tuple_slots(source);
+        let target_slots = tuple_slots(target);
+        let elements: Vec<String> = if source_flat {
+            values
+        } else {
+            (0..source_slots.len())
+                .map(|index| format!("{}.{}", values[0], TUPLE_FIELDS[index]))
+                .collect()
+        };
+        let bridged: Vec<String> = elements
+            .into_iter()
+            .zip(source_slots.iter().zip(target_slots))
+            .map(|(value, (source, target))| {
+                let bridge = resolve_layout_bridge(self, source, target);
+                self.plan_layout_bridge(statements, &value, &bridge)
+            })
+            .collect();
+        if target_flat {
+            bridged
+        } else {
+            vec![self.plan_tuple_from_vars(statements, &bridged, target.logical_type())]
         }
     }
 

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1072,7 +1072,13 @@ impl<'a> Planner<'a> {
             (
                 Some(ValueLayout::Function { layout: source, .. }),
                 ValueLayout::Function { layout: target, .. },
-            ) => source.return_abi == target.return_abi,
+            ) => {
+                // `lower_value` re-encodes a Go function value's return itself.
+                if source.return_abi != target.return_abi {
+                    return false;
+                }
+                true
+            }
             (Some(_), _) => true,
             (None, _) => false,
         };


### PR DESCRIPTION
Generalizes function wrappers over both tuple payload layouts, so one path serves both Go and Lis result shapes.
