### PR TITLE
feat: `Self` as receiver shorthand

### DIFF
--- a/crates/cli/agents_template.md
+++ b/crates/cli/agents_template.md
@@ -6,7 +6,8 @@ Lisette compiles to Go. Rust-like syntax, Go runtime. No ownership, no borrowing
 
 | Rust                      | Lisette                                                          |
 | ------------------------- | ---------------------------------------------------------------- |
-| `&T`, `&mut T`            | `Ref<T>`                                                         |
+| `&T`, `&mut T`            | `Ref<T>`, `mut Ref<T>`                                           |
+| `&self`, `&mut self`      | `self: Ref<Self>`, `self: mut Ref<Self>`                         |
 | `*ptr`                    | `ptr.*`                                                          |
 | `Vec<T>`                  | `Slice<T>`                                                       |
 | `[T; N]`                  | `Array<T, N>`                                                    |
@@ -128,7 +129,7 @@ impl User {
     f"User({self.name})"
   }
 
-  fn set_email(self: Ref<User>, email: string) {
+  fn set_email(self: mut Ref<Self>, email: string) {
     self.email = Some(email)
   }
 }

--- a/crates/cli/reference/methods.md
+++ b/crates/cli/reference/methods.md
@@ -97,7 +97,30 @@ impl Rectangle {
 }
 ```
 
-Calling a method never needs an explicit `&` or `.*`, because Lisette [auto-adds them](/docs/references/#implicit--and--in-method-calls) as needed.
+## `Self`
+
+Instead of spelling out the type, a method may use `Self` for the type being implemented:
+
+```lisette
+struct CoordinatePair<T> {
+  first: T,
+  second: T,
+}
+
+impl<T> CoordinatePair<T> {
+  // !callout[/Self/] `CoordinatePair<T>`
+  fn swap(self: mut Ref<Self>) {
+    let held = self.first
+    self.first = self.second
+    self.second = held
+  }
+
+  // !callout[/Self/] `CoordinatePair<T>`
+  fn swapped(self) -> Self {
+    CoordinatePair { first: self.second, second: self.first }
+  }
+}
+```
 
 ## Associated functions
 

--- a/crates/cli/src/handlers/doc.rs
+++ b/crates/cli/src/handlers/doc.rs
@@ -9,6 +9,7 @@ use stdlib::{
 };
 use syntax::ast::EnumVariant;
 use syntax::ast::{Annotation, Binding, Expression, Generic, Pattern, StructFields, VariantFields};
+use syntax::display::annotation_to_string;
 use syntax::doc::{dedent, drop_callout_lines, split_example};
 use syntax::program::DefinitionBody;
 
@@ -69,66 +70,6 @@ struct GoPackageIndex {
     functions: Vec<FunctionInfo>,
     constants: Vec<ConstInfo>,
     variables: Vec<VarInfo>,
-}
-
-fn annotation_to_string(ann: &Annotation) -> String {
-    match ann {
-        Annotation::Constructor {
-            name,
-            params,
-            writable,
-            ..
-        } => {
-            let rendered = if params.is_empty() {
-                name.to_string()
-            } else {
-                format!(
-                    "{}<{}>",
-                    name,
-                    params
-                        .iter()
-                        .map(annotation_to_string)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
-            if *writable {
-                format!("mut {}", rendered)
-            } else {
-                rendered
-            }
-        }
-        Annotation::Function {
-            params,
-            return_type,
-            ..
-        } => {
-            let params_str = params
-                .iter()
-                .map(annotation_to_string)
-                .collect::<Vec<_>>()
-                .join(", ");
-            let ret = annotation_to_string(return_type);
-            if ret == "Unit" || ret == "()" {
-                format!("fn({})", params_str)
-            } else {
-                format!("fn({}) -> {}", params_str, ret)
-            }
-        }
-        Annotation::Tuple { elements, .. } => {
-            let inner = elements
-                .iter()
-                .map(annotation_to_string)
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("({})", inner)
-        }
-        Annotation::Constant { value, text, .. } => {
-            text.clone().unwrap_or_else(|| value.to_string())
-        }
-        Annotation::Unknown => "Unknown".to_string(),
-        Annotation::Opaque { .. } => String::new(),
-    }
 }
 
 fn generics_to_string(generics: &[Generic]) -> String {

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -3,7 +3,7 @@ use crate::pattern;
 use std::fmt::Display;
 use std::mem;
 use syntax::ast::{Annotation, BinaryOperator, BindingKind, Span};
-use syntax::types::{SimpleKind, Type};
+use syntax::types::{SELF_TYPE_NAME, SimpleKind, Type};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MismatchedTailKind {
@@ -168,16 +168,40 @@ pub fn invalid_map_initialization(key: &Type, value: &Type, span: Span) -> Liset
         ))
 }
 
-pub fn self_type_not_supported(span: Span, impl_receiver: Option<&str>) -> LisetteDiagnostic {
-    let name_span = Span::new(span.file_id, span.byte_offset, 4); // "Self" is 4 chars
-    let help = match impl_receiver {
-        Some(name) => format!("Replace `Self` with `{}`.", name),
-        None => "Use a type parameter instead, e.g. `interface Comparable<T> { fn compare(other: T) -> int }`".to_string(),
-    };
+pub fn self_type_not_supported(span: Span) -> LisetteDiagnostic {
+    let name_span = Span::new(span.file_id, span.byte_offset, SELF_TYPE_NAME.len() as u32);
     LisetteDiagnostic::error("Use of `Self` type")
         .with_resolve_code("self_type_not_supported")
-        .with_span_label(&name_span, "invalid type")
-        .with_help(help)
+        .with_span_label(&name_span, "disallowed")
+        .with_help(
+            "`Self` is only allowed inside an `impl` block. \
+             Use a type parameter instead, e.g. \
+             `interface Comparable<T> { fn compare(other: T) -> int }`",
+        )
+}
+
+pub fn self_type_with_arguments(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Type arguments on `Self`")
+        .with_resolve_code("self_type_with_arguments")
+        .with_span_label(&span, "invalid")
+        .with_help(format!("Use bare `Self`, which already means `{target}`"))
+}
+
+pub fn self_type_as_impl_target(span: Span) -> LisetteDiagnostic {
+    let name_span = Span::new(span.file_id, span.byte_offset, SELF_TYPE_NAME.len() as u32);
+    LisetteDiagnostic::error("Use of `Self` type")
+        .with_resolve_code("self_type_as_impl_target")
+        .with_span_label(&name_span, "disallowed")
+        .with_help("Rename this type. `Self` is reserved for the type of an `impl` block.")
+}
+
+pub fn self_type_is_reserved(kind: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Reserved type name")
+        .with_resolve_code("self_type_is_reserved")
+        .with_span_label(&span, "reserved")
+        .with_help(format!(
+            "Rename this {kind}. `Self` is reserved for the type of an `impl` block"
+        ))
 }
 
 pub fn self_in_interface_method(span: Span) -> LisetteDiagnostic {
@@ -607,14 +631,23 @@ pub fn loop_binding_read_only(variable_name: &str, span: Span) -> LisetteDiagnos
         ))
 }
 
-pub fn mut_without_effect(target: &str, span: Span) -> LisetteDiagnostic {
+pub fn mut_without_effect(written: &str, span: Span) -> LisetteDiagnostic {
     LisetteDiagnostic::error("`mut` has no effect")
         .with_infer_code("mut_without_effect")
-        .with_span_label(&span, format!("`{target}` cannot carry write permission"))
-        .with_help(
-            "Only `Slice`, `Map`, `Ref`, and `Unknown` can carry write permission, \
-             directly or through their contents. Remove `mut`",
-        )
+        .with_span_label(&span, "invalid")
+        .with_help(format!(
+            "Use `mut Ref<{written}>` for a writable pointer, or remove `mut` for a copy"
+        ))
+}
+
+pub fn mut_on_impl_target(target: &str, span: Span) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("`mut` has no effect")
+        .with_infer_code("mut_on_impl_target")
+        .with_span_label(&span, "invalid")
+        .with_help(format!(
+            "Remove `mut`. An `impl` block names the type being implemented, \
+             and each method decides its own receiver, as in `self: mut Ref<{target}>`"
+        ))
 }
 
 pub fn mut_under_read_only_wrapper(

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -48,6 +48,7 @@ use syntax::ast::Span;
 use syntax::doc::to_markdown;
 use syntax::program::File;
 use syntax::types;
+use syntax::types::SELF_TYPE_NAME;
 
 pub use crate::state::{Backend, SharedState};
 
@@ -828,6 +829,12 @@ impl Backend {
             return Ok(None);
         }
 
+        if new_name == SELF_TYPE_NAME && names_a_type(&snapshot, definition_span) {
+            return Err(validation::rename_error(format!(
+                "'{SELF_TYPE_NAME}' is reserved for the type of an `impl` block"
+            )));
+        }
+
         let Some(definition_source) = snapshot.source(definition_span.file_id) else {
             return Ok(None);
         };
@@ -1184,9 +1191,30 @@ fn general_completions(
     }
 
     const PRELUDE_TYPES: &[&str] = &[
-        "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64",
-        "float32", "float64", "string", "bool", "rune", "byte", "Option", "Result", "Slice", "Map",
-        "Channel", "Array",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+        "string",
+        "bool",
+        "rune",
+        "byte",
+        "Option",
+        "Result",
+        "Slice",
+        "Map",
+        "Channel",
+        "Array",
+        "Ref",
+        SELF_TYPE_NAME,
     ];
     for ty in PRELUDE_TYPES {
         items.push(CompletionItem {
@@ -1276,6 +1304,23 @@ fn trailing_segment_span(usage_span: Span, snapshot: &AnalysisSnapshot) -> Span 
         }
         None => usage_span,
     }
+}
+
+fn names_a_type(snapshot: &AnalysisSnapshot, definition_span: Span) -> bool {
+    let Some(file) = snapshot.files().get(&definition_span.file_id) else {
+        return false;
+    };
+    let Some(expression) = find_expression_at(&file.items, definition_span.byte_offset) else {
+        return false;
+    };
+    matches!(
+        expression,
+        Expression::Struct { name_span, .. }
+            | Expression::Enum { name_span, .. }
+            | Expression::Interface { name_span, .. }
+            | Expression::TypeAlias { name_span, .. }
+        if *name_span == definition_span
+    )
 }
 
 fn usage_locations(

--- a/crates/lsp/tests/lsp.rs
+++ b/crates/lsp/tests/lsp.rs
@@ -757,6 +757,33 @@ fn rename_rejects_keywords() {
 }
 
 #[test]
+fn rename_rejects_self_as_a_type_name() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(TEST_URI, "struct Counter { value: int }\n");
+
+    let error = client.try_rename(TEST_URI, 0, 7, "Self").unwrap_err();
+    assert_eq!(error, "'Self' is reserved for the type of an `impl` block");
+
+    client.shutdown();
+}
+
+#[test]
+fn rename_allows_self_as_an_enum_variant() {
+    let mut client = TestClient::new();
+    client.initialize();
+    client.open(
+        TEST_URI,
+        "enum Target { First, Other }\nfn main() { let _ = Target.First }\n",
+    );
+
+    let edit = client.rename(TEST_URI, 0, 14, "Self");
+    assert!(edit.is_some());
+
+    client.shutdown();
+}
+
+#[test]
 fn rename_function() {
     let mut client = TestClient::new();
     client.initialize();

--- a/crates/semantics/src/checker/registration/convert.rs
+++ b/crates/semantics/src/checker/registration/convert.rs
@@ -6,10 +6,11 @@ use crate::checker::infer::expressions::comparison::{
 use std::mem;
 use syntax::EcoString;
 use syntax::ast::{Annotation, Generic, Span, VariantFields};
+use syntax::display::annotation_to_string;
 use syntax::program::{AliasKind, ConstantValue, DefinitionBody};
 use syntax::types::{
-    FunctionParameter, SimpleKind, Symbol, Type, build_named_substitution_map, substitute,
-    unqualified_name,
+    FunctionParameter, SELF_TYPE_NAME, SimpleKind, Symbol, Type, build_named_substitution_map,
+    substitute, unqualified_name,
 };
 
 use crate::checker::TaskState;
@@ -77,6 +78,20 @@ impl TypeArgumentChecks {
 }
 
 #[derive(Clone, Copy)]
+struct WriteQualifierSite<'a> {
+    report: Option<&'a Annotation>,
+    contents_span: Span,
+    read_only_wrapper: Option<ReadOnlyWrapper>,
+}
+
+fn written_without_mut(annotation: &Annotation) -> String {
+    let written = annotation_to_string(annotation);
+    written
+        .strip_prefix("mut ")
+        .map_or(written.clone(), str::to_owned)
+}
+
+#[derive(Clone, Copy)]
 struct ReadOnlyWrapper {
     name: &'static str,
     name_span: Span,
@@ -88,6 +103,7 @@ struct ConvertMode {
     type_argument_checks: TypeArgumentChecks,
     position: TypePosition,
     read_only_wrapper: Option<ReadOnlyWrapper>,
+    is_impl_target: bool,
 }
 
 impl ConvertMode {
@@ -97,6 +113,7 @@ impl ConvertMode {
             type_argument_checks: self.type_argument_checks.nested(),
             position: TypePosition::Value,
             read_only_wrapper: self.read_only_wrapper,
+            is_impl_target: false,
         }
     }
 }
@@ -129,6 +146,7 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::Deferred,
                 position: TypePosition::Bound,
                 read_only_wrapper: None,
+                is_impl_target: false,
             },
         )
     }
@@ -148,6 +166,7 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
                 read_only_wrapper: None,
+                is_impl_target: false,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -168,6 +187,7 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::All,
                 position: TypePosition::Value,
                 read_only_wrapper: None,
+                is_impl_target: false,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -188,6 +208,7 @@ impl TaskState {
                 type_argument_checks: TypeArgumentChecks::Descendants,
                 position: TypePosition::Value,
                 read_only_wrapper: None,
+                is_impl_target: true,
             },
         );
         store.normalized_annotation_type(&ty)
@@ -292,6 +313,7 @@ impl TaskState {
             type_argument_checks,
             position,
             read_only_wrapper,
+            is_impl_target,
         } = mode;
 
         if type_name == "VarArgs" && !variadic_allowed {
@@ -300,6 +322,41 @@ impl TaskState {
                     annotation_span,
                 ));
             return Type::Error;
+        }
+
+        if type_name == SELF_TYPE_NAME {
+            if is_impl_target {
+                self.sink.push(diagnostics::infer::self_type_as_impl_target(
+                    annotation_span,
+                ));
+                return Type::Error;
+            }
+            let Some(target) = self.scopes.impl_receiver_type().cloned() else {
+                self.sink
+                    .push(diagnostics::infer::self_type_not_supported(annotation_span));
+                return Type::Error;
+            };
+            if !params.is_empty() {
+                self.sink.push(diagnostics::infer::self_type_with_arguments(
+                    &target.stringify(),
+                    annotation_span,
+                ));
+                return Type::Error;
+            }
+            if !writable {
+                return target;
+            }
+            let qualified_name = target.get_qualified_id().unwrap_or_default().to_string();
+            return self.apply_write_qualifier(
+                store,
+                &qualified_name,
+                target.make_writable(),
+                WriteQualifierSite {
+                    report: Some(annotation),
+                    contents_span,
+                    read_only_wrapper,
+                },
+            );
         }
 
         // Unit is internal: `()` desugars to Constructor { name: "Unit" }.
@@ -321,8 +378,8 @@ impl TaskState {
             }
             if writable {
                 self.sink.push(diagnostics::infer::mut_without_effect(
-                    type_name,
-                    annotation_span,
+                    &written_without_mut(annotation),
+                    contents_span,
                 ));
             }
             return Type::Parameter(type_name.into());
@@ -332,8 +389,8 @@ impl TaskState {
         if type_name == "Array" {
             if writable {
                 self.sink.push(diagnostics::infer::mut_without_effect(
-                    type_name,
-                    annotation_span,
+                    &written_without_mut(annotation),
+                    contents_span,
                 ));
             }
             return self.convert_array_annotation(store, params, annotation_span, span, mode);
@@ -342,14 +399,7 @@ impl TaskState {
         let Some((qualified_name, ty)) =
             self.resolve_type_with_arity(store, type_name, params.len())
         else {
-            if type_name == "Self" {
-                let receiver = self.scopes.impl_receiver_type().map(|ty| ty.stringify());
-                self.sink.push(diagnostics::infer::self_type_not_supported(
-                    annotation_span,
-                    receiver.as_deref(),
-                ));
-            } else if let Some((kind, help)) = self.classify_unregistered_variant(store, type_name)
-            {
+            if let Some((kind, help)) = self.classify_unregistered_variant(store, type_name) {
                 self.sink.push(diagnostics::infer::value_in_type_position(
                     type_name,
                     kind,
@@ -471,23 +521,46 @@ impl TaskState {
             self.check_map_key_comparable(store, key_ty, annotation_span);
         }
 
-        if writable && !writable_qualifier_has_effect(store, &qualified_name, &resolved_ty) {
-            self.sink.push(diagnostics::infer::mut_without_effect(
-                type_name,
-                annotation_span,
-            ));
-            return resolved_ty.shallow_demoted();
+        if !writable {
+            return resolved_ty;
         }
-        if writable && let Some(wrapper) = read_only_wrapper {
+        self.apply_write_qualifier(
+            store,
+            &qualified_name,
+            resolved_ty,
+            WriteQualifierSite {
+                report: (!is_impl_target).then_some(annotation),
+                contents_span,
+                read_only_wrapper,
+            },
+        )
+    }
+
+    fn apply_write_qualifier(
+        &mut self,
+        store: &Store,
+        qualified_name: &str,
+        writable_ty: Type,
+        site: WriteQualifierSite<'_>,
+    ) -> Type {
+        if !writable_qualifier_has_effect(store, qualified_name, &writable_ty) {
+            if let Some(annotation) = site.report {
+                self.sink.push(diagnostics::infer::mut_without_effect(
+                    &written_without_mut(annotation),
+                    site.contents_span,
+                ));
+            }
+            return writable_ty.shallow_demoted();
+        }
+        if let Some(wrapper) = site.read_only_wrapper {
             self.sink
                 .push(diagnostics::infer::mut_under_read_only_wrapper(
                     wrapper.name,
                     wrapper.name_span,
-                    contents_span,
+                    site.contents_span,
                 ));
         }
-
-        resolved_ty
+        writable_ty
     }
 
     fn convert_array_annotation(

--- a/crates/semantics/src/checker/registration/declarations.rs
+++ b/crates/semantics/src/checker/registration/declarations.rs
@@ -1,6 +1,7 @@
 use super::*;
 use syntax::program::ValueKind;
 use syntax::types::CompoundKind;
+use syntax::types::SELF_TYPE_NAME;
 use syntax::types::SimpleKind;
 
 impl TaskState {
@@ -244,6 +245,30 @@ impl TaskState {
         self.register_type_bodies(store, items);
     }
 
+    fn reject_reserved_type_names(&mut self, items: &[Expression]) {
+        for item in items {
+            let (kind, name, name_span) = match item {
+                Expression::Struct {
+                    name, name_span, ..
+                } => ("struct", name, name_span),
+                Expression::Enum {
+                    name, name_span, ..
+                } => ("enum", name, name_span),
+                Expression::Interface {
+                    name, name_span, ..
+                } => ("interface", name, name_span),
+                Expression::TypeAlias {
+                    name, name_span, ..
+                } => ("alias", name, name_span),
+                _ => continue,
+            };
+            if name == SELF_TYPE_NAME {
+                self.sink
+                    .push(diagnostics::infer::self_type_is_reserved(kind, *name_span));
+            }
+        }
+    }
+
     pub(super) fn register_type_aliases(&mut self, store: &mut Store, items: &mut [Expression]) {
         for item in items {
             if matches!(item, Expression::TypeAlias { .. }) {
@@ -253,6 +278,7 @@ impl TaskState {
     }
 
     pub(super) fn register_type_bodies(&mut self, store: &mut Store, items: &mut [Expression]) {
+        self.reject_reserved_type_names(items);
         self.check_go_hints_in_items(items);
         for item in items {
             match item {

--- a/crates/semantics/src/checker/registration/methods.rs
+++ b/crates/semantics/src/checker/registration/methods.rs
@@ -4,6 +4,7 @@ use ecow::EcoString;
 use syntax::ast::{
     Annotation, Expression, Generic, Pattern, Span, Visibility as SyntacticVisibility,
 };
+use syntax::display::annotation_to_string;
 use syntax::program::MethodOrigin;
 use syntax::program::ValueKind;
 use syntax::program::{
@@ -195,6 +196,9 @@ impl TaskState {
             receiver_ty: &resolved.receiver_ty,
         };
 
+        self.scopes
+            .set_impl_receiver_type(resolved.receiver_ty.clone());
+
         // Static methods land in the parent scope, since this impl's generics scope drops here.
         let mut static_methods: Vec<(String, Type)> = Vec::new();
         for function in functions {
@@ -214,14 +218,18 @@ impl TaskState {
 
     fn reject_writable_impl_target(&mut self, annotation: &Annotation) {
         if let Annotation::Constructor {
-            name,
             writable: true,
+            mut_span,
             span,
             ..
         } = annotation
         {
-            self.sink
-                .push(diagnostics::infer::mut_without_effect(name, *span));
+            let labelled = mut_span.map_or(*span, |mut_span| mut_span.merge(*span));
+            let written = annotation_to_string(annotation);
+            self.sink.push(diagnostics::infer::mut_on_impl_target(
+                written.strip_prefix("mut ").unwrap_or(&written),
+                labelled,
+            ));
         }
     }
 

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::ast::Annotation;
 use crate::program::is_internal_package_id;
 use crate::types::SimpleKind;
 use crate::types::{GO_IMPORT_PREFIX, Symbol, Type};
@@ -182,5 +183,68 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (types, _generics) = Self::remove_vars(&[self]);
         write!(f, "{}", types[0].stringify())
+    }
+}
+
+pub fn annotation_to_string(ann: &Annotation) -> String {
+    match ann {
+        Annotation::Constructor {
+            name,
+            params,
+            writable,
+            ..
+        } => {
+            let rendered = if params.is_empty() {
+                name.to_string()
+            } else {
+                format!(
+                    "{}<{}>",
+                    name,
+                    params
+                        .iter()
+                        .map(annotation_to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            if *writable {
+                format!("mut {}", rendered)
+            } else {
+                rendered
+            }
+        }
+        Annotation::Function {
+            params,
+            return_type,
+            ..
+        } => {
+            let params_str = params
+                .iter()
+                .map(annotation_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if matches!(return_type.as_ref(), Annotation::Unknown) {
+                return format!("fn({})", params_str);
+            }
+            let ret = annotation_to_string(return_type);
+            if ret == "Unit" || ret == "()" {
+                format!("fn({})", params_str)
+            } else {
+                format!("fn({}) -> {}", params_str, ret)
+            }
+        }
+        Annotation::Tuple { elements, .. } => {
+            let inner = elements
+                .iter()
+                .map(annotation_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({})", inner)
+        }
+        Annotation::Constant { value, text, .. } => {
+            text.clone().unwrap_or_else(|| value.to_string())
+        }
+        Annotation::Unknown => "Unknown".to_string(),
+        Annotation::Opaque { .. } => String::new(),
     }
 }

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -2,7 +2,7 @@ pub mod ast;
 pub mod attributes;
 pub mod containment;
 pub mod dependency_block;
-mod display;
+pub mod display;
 pub mod doc;
 pub mod go_names;
 pub mod go_platform;

--- a/crates/syntax/src/types.rs
+++ b/crates/syntax/src/types.rs
@@ -153,6 +153,8 @@ pub fn unqualified_name(id: &str) -> &str {
 
 pub const GO_IMPORT_PREFIX: &str = "go:";
 
+pub const SELF_TYPE_NAME: &str = "Self";
+
 /// Resolve the package of a qualified ID. For `go:` IDs containing `/`,
 /// does a longest-prefix match against known packages to disambiguate paths
 /// whose package segment contains dots (e.g. `gopkg.in/yaml.v3`). Otherwise

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -2473,3 +2473,105 @@ fn test() -> int {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn self_type_in_every_impl_position() {
+    let input = r#"
+struct Pair<T> {
+  first: T,
+  second: T,
+}
+
+impl<T> Pair<T> {
+  fn head(self) -> T {
+    self.first
+  }
+
+  fn peek(self: Ref<Self>) -> T {
+    self.second
+  }
+
+  fn swap(self: mut Ref<Self>) {
+    let held = self.first
+    self.first = self.second
+    self.second = held
+  }
+
+  fn twin(self, other: Self) -> Self {
+    other
+  }
+
+  fn boxed(self) -> Option<Self> {
+    Some(self)
+  }
+
+  fn local(self) -> T {
+    let copy: Self = self
+    copy.first
+  }
+}
+
+fn run() {
+  let mut p = Pair { first: 1, second: 2 }
+  p.swap()
+  let _ = p.head()
+  let _ = p.peek()
+  let _ = p.twin(p)
+  let _ = p.boxed()
+  let _ = p.local()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn self_type_does_not_capture_method_generics() {
+    let input = r#"
+struct Box<T> {
+  value: T,
+}
+
+impl<T> Box<T> {
+  fn map<U>(self, f: fn(T) -> U) -> Box<U> {
+    Box { value: f(self.value) }
+  }
+
+  fn same(self) -> Self {
+    self
+  }
+}
+
+fn run() {
+  let b = Box { value: 1 }
+  let _ = b.same()
+  let _ = b.map(|n| n == 1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn self_type_matches_the_spelled_out_receiver() {
+    let input = r#"
+struct Counter {
+  value: int,
+}
+
+impl Counter {
+  fn spelled(self: mut Ref<Counter>) {
+    self.value += 1
+  }
+
+  fn shorthand(self: mut Ref<Self>) {
+    self.value += 1
+  }
+}
+
+fn run() {
+  let mut c = Counter { value: 0 }
+  c.spelled()
+  c.shorthand()
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/self_type_does_not_capture_method_generics.snap
+++ b/tests/spec/emit/snapshots/self_type_does_not_capture_method_generics.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Box<T> {
+    value: T,
+  }
+  
+  impl<T> Box<T> {
+    fn map<U>(self, f: fn(T) -> U) -> Box<U> {
+      Box { value: f(self.value) }
+    }
+  
+    fn same(self) -> Self {
+      self
+    }
+  }
+  
+  fn run() {
+    let b = Box { value: 1 }
+    let _ = b.same()
+    let _ = b.map(|n| n == 1)
+  }
+---
+package main
+
+type Box[T any] struct {
+	value T
+}
+
+func Box_map[T any, U any](self Box[T], f func(T) U) Box[U] {
+	return Box[U]{value: f(self.value)}
+}
+
+func (b Box[T]) same() Box[T] {
+	return b
+}
+
+func run() {
+	b := Box[int]{value: 1}
+	_ = b.same()
+	_ = Box_map(b, func(n int) bool {
+		return n == 1
+	})
+}

--- a/tests/spec/emit/snapshots/self_type_in_every_impl_position.snap
+++ b/tests/spec/emit/snapshots/self_type_in_every_impl_position.snap
@@ -1,0 +1,94 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Pair<T> {
+    first: T,
+    second: T,
+  }
+  
+  impl<T> Pair<T> {
+    fn head(self) -> T {
+      self.first
+    }
+  
+    fn peek(self: Ref<Self>) -> T {
+      self.second
+    }
+  
+    fn swap(self: mut Ref<Self>) {
+      let held = self.first
+      self.first = self.second
+      self.second = held
+    }
+  
+    fn twin(self, other: Self) -> Self {
+      other
+    }
+  
+    fn boxed(self) -> Option<Self> {
+      Some(self)
+    }
+  
+    fn local(self) -> T {
+      let copy: Self = self
+      copy.first
+    }
+  }
+  
+  fn run() {
+    let mut p = Pair { first: 1, second: 2 }
+    p.swap()
+    let _ = p.head()
+    let _ = p.peek()
+    let _ = p.twin(p)
+    let _ = p.boxed()
+    let _ = p.local()
+  }
+---
+package main
+
+type Pair[T any] struct {
+	first  T
+	second T
+}
+
+func (p Pair[T]) head() T {
+	return p.first
+}
+
+func (p *Pair[T]) peek() T {
+	return p.second
+}
+
+func (p *Pair[T]) swap() {
+	held := p.first
+	p.first = p.second
+	p.second = held
+}
+
+func (p Pair[T]) twin(other Pair[T]) Pair[T] {
+	return other
+}
+
+func (p Pair[T]) boxed() (Pair[T], bool) {
+	return p, true
+}
+
+func (p Pair[T]) local() T {
+	copy_ := p
+	return copy_.first
+}
+
+func run() {
+	p := Pair[int]{
+		first:  1,
+		second: 2,
+	}
+	p.swap()
+	_ = p.head()
+	_ = p.peek()
+	_ = p.twin(p)
+	p.boxed()
+	_ = p.local()
+}

--- a/tests/spec/emit/snapshots/self_type_matches_the_spelled_out_receiver.snap
+++ b/tests/spec/emit/snapshots/self_type_matches_the_spelled_out_receiver.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  struct Counter {
+    value: int,
+  }
+  
+  impl Counter {
+    fn spelled(self: mut Ref<Counter>) {
+      self.value += 1
+    }
+  
+    fn shorthand(self: mut Ref<Self>) {
+      self.value += 1
+    }
+  }
+  
+  fn run() {
+    let mut c = Counter { value: 0 }
+    c.spelled()
+    c.shorthand()
+  }
+---
+package main
+
+type Counter struct {
+	value int
+}
+
+func (c *Counter) spelled() {
+	c.value++
+}
+
+func (c *Counter) shorthand() {
+	c.value++
+}
+
+func run() {
+	c := Counter{value: 0}
+	c.spelled()
+	c.shorthand()
+}

--- a/tests/spec/infer/write_permission.rs
+++ b/tests/spec/infer/write_permission.rs
@@ -1584,7 +1584,7 @@ impl mut Batch {
   }
 }"#,
     )
-    .assert_infer_code("mut_without_effect");
+    .assert_infer_code("mut_on_impl_target");
 }
 
 #[test]

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -11406,14 +11406,27 @@ interface Greeter {
 }
 
 #[test]
-fn infer_self_type_in_impl_block() {
+fn infer_self_type_outside_impl_block() {
     let input = r#"
-struct DiffReporter {
-  pub diffs: Slice<string>,
+struct Counter {
+  value: int,
 }
-impl DiffReporter {
-  pub fn PushStep(self: Ref<Self>, step: string) {
-    let _ = step
+fn peek(c: Self) -> int {
+  c.value
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_with_type_arguments() {
+    let input = r#"
+struct Stack<T> {
+  pub items: Slice<T>,
+}
+impl<T> Stack<T> {
+  pub fn Peek(self: Ref<Self<int>>) -> T {
+    self.items[0]
   }
 }
 "#;
@@ -11421,14 +11434,62 @@ impl DiffReporter {
 }
 
 #[test]
-fn infer_self_type_in_generic_impl_block() {
+fn infer_self_type_with_type_arguments_on_non_generic_impl() {
     let input = r#"
-struct Stack<T> {
-  pub items: Slice<T>,
+struct Counter {
+  value: int,
 }
-impl<T> Stack<T> {
-  pub fn Peek(self: Ref<Self>) -> T {
-    self.items[0]
+impl Counter {
+  fn peek(self: Ref<Self<int>>) -> int {
+    self.value
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_as_impl_target() {
+    let input = r#"
+struct Counter {
+  value: int,
+}
+impl Self {
+  fn peek(self) -> int {
+    self.value
+  }
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_as_declared_name() {
+    let input = r#"
+struct Self {
+  value: int,
+}
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_self_type_as_declared_alias_name() {
+    let input = r#"
+type Self = int
+"#;
+    assert_infer_error_snapshot!(input);
+}
+
+#[test]
+fn infer_mut_on_self_receiver() {
+    let input = r#"
+struct Counter {
+  value: int,
+}
+impl Counter {
+  fn peek(self: mut Self) -> int {
+    self.value
   }
 }
 "#;

--- a/tests/ui/errors/snapshots/infer_mut_on_self_receiver.snap
+++ b/tests/ui/errors/snapshots/infer_mut_on_self_receiver.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ `mut` has no effect
+   ╭─[test.lis:6:17]
+ 5 │ impl Counter {
+ 6 │   fn peek(self: mut Self) -> int {
+   ·                 ────┬───
+   ·                     ╰── invalid
+ 7 │     self.value
+   ╰────
+  help: Use `mut Ref<Self>` for a writable pointer, or remove `mut` for a copy · code: [infer.mut_without_effect]

--- a/tests/ui/errors/snapshots/infer_self_type_as_declared_alias_name.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_as_declared_alias_name.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Reserved type name
+   ╭─[test.lis:2:6]
+ 1 │ 
+ 2 │ type Self = int
+   ·      ──┬─
+   ·        ╰── reserved
+   ╰────
+  help: Rename this alias. `Self` is reserved for the type of an `impl` block · code: [resolve.self_type_is_reserved]

--- a/tests/ui/errors/snapshots/infer_self_type_as_declared_name.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_as_declared_name.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Reserved type name
+   ╭─[test.lis:2:8]
+ 1 │ 
+ 2 │ struct Self {
+   ·        ──┬─
+   ·          ╰── reserved
+ 3 │   value: int,
+   ╰────
+  help: Rename this struct. `Self` is reserved for the type of an `impl` block · code: [resolve.self_type_is_reserved]

--- a/tests/ui/errors/snapshots/infer_self_type_as_impl_target.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_as_impl_target.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Use of `Self` type
+   ╭─[test.lis:5:6]
+ 4 │ }
+ 5 │ impl Self {
+   ·      ──┬─
+   ·        ╰── disallowed
+ 6 │   fn peek(self) -> int {
+   ╰────
+  help: Rename this type. `Self` is reserved for the type of an `impl` block · code: [resolve.self_type_as_impl_target]

--- a/tests/ui/errors/snapshots/infer_self_type_outside_impl_block.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_outside_impl_block.snap
@@ -2,11 +2,11 @@
 source: tests/ui/errors/mod.rs
 ---
   ✕ Use of `Self` type
-   ╭─[test.lis:3:21]
- 2 │ interface Comparable {
- 3 │   fn compare(other: Self) -> int
-   ·                     ──┬─
-   ·                       ╰── disallowed
+   ╭─[test.lis:5:12]
  4 │ }
+ 5 │ fn peek(c: Self) -> int {
+   ·            ──┬─
+   ·              ╰── disallowed
+ 6 │   c.value
    ╰────
   help: `Self` is only allowed inside an `impl` block. Use a type parameter instead, e.g. `interface Comparable<T> { fn compare(other: T) -> int }` · code: [resolve.self_type_not_supported]

--- a/tests/ui/errors/snapshots/infer_self_type_with_type_arguments.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_with_type_arguments.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type arguments on `Self`
+   ╭─[test.lis:6:25]
+ 5 │ impl<T> Stack<T> {
+ 6 │   pub fn Peek(self: Ref<Self<int>>) -> T {
+   ·                         ────┬────
+   ·                             ╰── invalid
+ 7 │     self.items[0]
+   ╰────
+  help: Use bare `Self`, which already means `Stack<T>` · code: [resolve.self_type_with_arguments]

--- a/tests/ui/errors/snapshots/infer_self_type_with_type_arguments_on_non_generic_impl.snap
+++ b/tests/ui/errors/snapshots/infer_self_type_with_type_arguments_on_non_generic_impl.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Type arguments on `Self`
+   ╭─[test.lis:6:21]
+ 5 │ impl Counter {
+ 6 │   fn peek(self: Ref<Self<int>>) -> int {
+   ·                     ────┬────
+   ·                         ╰── invalid
+ 7 │     self.value
+   ╰────
+  help: Use bare `Self`, which already means `Counter` · code: [resolve.self_type_with_arguments]


### PR DESCRIPTION
Adds `Self` as a name for the type targeted by an `impl` block so a method need not repeat it.

```rs
struct CoordinatePair<T> {
  first: T,
  second: T,
}

impl<T> CoordinatePair<T> {
  fn swap(self: mut Ref<Self>) {
    let held = self.first
    self.first = self.second
    self.second = held
  }

  fn swapped(self) -> Self {
    CoordinatePair { first: self.second, second: self.first }
  }
}
```

`Self` works in every type position inside the block, not only the receiver, and it carries the same type args the block declares.

Close #1344