### PR TITLE
fix: pass function values to Go callbacks that return a tuple

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -167,7 +167,7 @@ impl Planner<'_> {
         let Some(target) = target_ty else {
             return emitted;
         };
-        let coercion = CoercionPlan::internal(self, &expression.get_type(), target);
+        let coercion = self.value_slot_coercion(expression, target);
         let (setup, value) = coercion.lower(self, emitted);
         output.push_str(&Renderer.render_setup(&setup));
         value

--- a/crates/emit/src/abi/mod.rs
+++ b/crates/emit/src/abi/mod.rs
@@ -9,6 +9,7 @@ use crate::names::go_name;
 use crate::names::go_name::PRELUDE_ERROR_ID;
 use crate::types::go_type::GoType;
 use callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use coercion::CoercionPlan;
 use layout::SlotOrigin;
 use syntax::ast::{Expression, IdentifierResolution};
 use syntax::types::Type;
@@ -67,6 +68,56 @@ impl Planner<'_> {
     fn is_go_named_function_type(&self, ty: &Type) -> bool {
         matches!(ty.unwrap_forall(), Type::Nominal { id, .. } if go_name::is_go_import(id))
             && self.facts.resolve_to_function_type(ty).is_some()
+    }
+
+    pub(crate) fn emitted_function_origin(
+        &self,
+        value: &Expression,
+        slot_origin: SlotOrigin,
+    ) -> SlotOrigin {
+        if is_closure_literal(value) || self.is_go_callable(value) {
+            slot_origin
+        } else {
+            self.function_type_origin(&value.get_type(), SlotOrigin::Lisette)
+        }
+    }
+
+    /// Non-identity for e.g. a Lisette `fn` bound to a Go-named function type.
+    pub(crate) fn function_slot_bridge(
+        &self,
+        value: &Expression,
+        target_ty: &Type,
+    ) -> CoercionPlan {
+        let slot_origin = self.function_type_origin(target_ty, SlotOrigin::Lisette);
+        let source_origin = self.emitted_function_origin(value, slot_origin);
+        self.function_type_slot_bridge(&value.get_type(), target_ty, source_origin)
+    }
+
+    pub(crate) fn function_type_slot_bridge(
+        &self,
+        value_ty: &Type,
+        target_ty: &Type,
+        source_origin: SlotOrigin,
+    ) -> CoercionPlan {
+        let slot_origin = self.function_type_origin(target_ty, SlotOrigin::Lisette);
+        if !slot_origin.declared_by_go()
+            || self.facts.resolve_to_function_type(value_ty).is_none()
+            || self.facts.resolve_to_function_type(target_ty).is_none()
+        {
+            return CoercionPlan::Identity;
+        }
+        let source = self.value_layout(value_ty, source_origin);
+        let target = self.value_layout(target_ty, slot_origin);
+        CoercionPlan::bridge(self, &source, &target)
+    }
+
+    pub(crate) fn value_slot_coercion(&self, value: &Expression, target_ty: &Type) -> CoercionPlan {
+        let bridge = self.function_slot_bridge(value, target_ty);
+        if bridge.is_identity() {
+            CoercionPlan::internal(self, &value.get_type(), target_ty)
+        } else {
+            bridge
+        }
     }
 
     /// Lowered shape for the slot at `origin`, or `None` to keep it tagged.
@@ -218,6 +269,13 @@ pub(crate) fn is_tagged_shape_fn_value(expression: &Expression) -> bool {
             resolution: IdentifierResolution::Definition(q),
             ..
         } if q.starts_with("prelude.")
+    )
+}
+
+pub(crate) fn is_closure_literal(expression: &Expression) -> bool {
+    matches!(
+        expression.unwrap_parens(),
+        Expression::Lambda { .. } | Expression::Function { .. }
     )
 }
 

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -69,12 +69,14 @@ pub(crate) fn lowered_err_values(
 ) -> Vec<String> {
     match shape {
         CallableReturnAbi::BareError => vec![err_expr.to_string()],
-        CallableReturnAbi::Result { .. } => {
+        CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
             let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-            vec![lowered_zero(planner, &ok_ty), err_expr.to_string()]
+            let mut values = lowered_payload_zeros(planner, shape, &ok_ty);
+            values.push(err_expr.to_string());
+            values
         }
-        CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
-            unreachable!("not reached for shapes with their own emission paths")
+        CallableReturnAbi::Tuple { .. } => {
+            unreachable!("a tuple return has no failure path")
         }
         CallableReturnAbi::Tagged | CallableReturnAbi::Direct | CallableReturnAbi::Option(_) => {
             unreachable!("Option's failure constructor `None` carries no payload")
@@ -83,18 +85,26 @@ pub(crate) fn lowered_err_values(
 }
 
 /// The lowered Go-return values for a success-constructor payload, in the
-/// enclosing function's lowered shape (e.g. `[ok, "nil"]`).
-pub(crate) fn lowered_ok_values(shape: &CallableReturnAbi, ok_expr: &str) -> Vec<String> {
+/// enclosing function's lowered shape (e.g. `[ok, "nil"]`). `payload` holds
+/// the already-lowered payload slots.
+pub(crate) fn lowered_ok_values(
+    shape: &CallableReturnAbi,
+    mut payload: Vec<String>,
+) -> Vec<String> {
     match shape {
         CallableReturnAbi::BareError => vec!["nil".to_string()],
-        CallableReturnAbi::Result { .. } => vec![ok_expr.to_string(), "nil".to_string()],
-        CallableReturnAbi::Partial { .. } | CallableReturnAbi::Tuple { .. } => {
-            unreachable!("not reached for shapes with their own emission paths")
+        CallableReturnAbi::Result { .. } | CallableReturnAbi::Partial { .. } => {
+            payload.push("nil".to_string());
+            payload
         }
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
-            vec![ok_expr.to_string(), "true".to_string()]
+            payload.push("true".to_string());
+            payload
         }
-        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec![ok_expr.to_string()],
+        CallableReturnAbi::Option(OptionReturnAbi::Nullable) => payload,
+        CallableReturnAbi::Tuple { .. } => {
+            unreachable!("a tuple return has its own emission path")
+        }
         CallableReturnAbi::Tagged
         | CallableReturnAbi::Direct
         | CallableReturnAbi::Option(OptionReturnAbi::Sentinel(_)) => {
@@ -113,10 +123,50 @@ pub(crate) fn lowered_none_values(
     match shape {
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. }) => {
             let inner = planner.facts.peel_alias(return_ty).ok_type();
-            vec![lowered_zero(planner, &inner), "false".to_string()]
+            let mut values = lowered_payload_zeros(planner, shape, &inner);
+            values.push("false".to_string());
+            values
         }
         CallableReturnAbi::Option(OptionReturnAbi::Nullable) => vec!["nil".to_string()],
         _ => unreachable!("only Option's `None` lacks a payload"),
+    }
+}
+
+pub(crate) fn lowered_payload_values(
+    planner: &mut Planner,
+    shape: &CallableReturnAbi,
+    payload_ty: &Type,
+    payload_expr: &str,
+) -> (Vec<LoweredStatement>, Vec<String>) {
+    if shape.has_flattened_payload() {
+        let mut statements = Vec::new();
+        let tuple = planner.stable_source(&mut statements, "tup", payload_expr);
+        let (projection, values) = lowered_tuple_values(planner, &tuple, payload_ty);
+        statements.extend(projection);
+        (statements, values)
+    } else {
+        (Vec::new(), vec![payload_expr.to_string()])
+    }
+}
+
+fn lowered_payload_zeros(
+    planner: &mut Planner,
+    shape: &CallableReturnAbi,
+    payload_ty: &Type,
+) -> Vec<String> {
+    if shape.has_flattened_payload() {
+        tuple_element_types(&planner.facts.peel_alias(payload_ty))
+            .iter()
+            .map(|slot_ty| {
+                if planner.facts.is_nullable_option(slot_ty) {
+                    "nil".to_string()
+                } else {
+                    lowered_zero(planner, slot_ty)
+                }
+            })
+            .collect()
+    } else {
+        vec![lowered_zero(planner, payload_ty)]
     }
 }
 
@@ -130,43 +180,56 @@ pub(crate) fn emit_lowered_result_return(
 ) -> Vec<LoweredStatement> {
     planner.require_stdlib();
     let p = result_value;
+    let ok_ty = || planner.facts.peel_alias(return_ty).ok_type();
     match shape {
-        CallableReturnAbi::BareError | CallableReturnAbi::Result { .. } => vec![
-            tag_check(
-                format!("{p}.Tag == {RESULT_OK_TAG}"),
-                Vec::new(),
-                lowered_ok_values(shape, &format!("{p}.OkVal")),
-            ),
-            multi_value_return(lowered_err_values(
-                planner,
-                shape,
-                return_ty,
-                &format!("{p}.ErrVal"),
-            )),
-        ],
-        CallableReturnAbi::Partial { .. } => {
-            let ok_ty = planner.facts.peel_alias(return_ty).ok_type();
-            let zero = lowered_zero(planner, &ok_ty);
+        CallableReturnAbi::BareError | CallableReturnAbi::Result { .. } => {
+            let (ok_setup, ok_payload) =
+                lowered_payload_values(planner, shape, &ok_ty(), &format!("{p}.OkVal"));
             vec![
                 tag_check(
+                    format!("{p}.Tag == {RESULT_OK_TAG}"),
+                    ok_setup,
+                    lowered_ok_values(shape, ok_payload),
+                ),
+                multi_value_return(lowered_err_values(
+                    planner,
+                    shape,
+                    return_ty,
+                    &format!("{p}.ErrVal"),
+                )),
+            ]
+        }
+        CallableReturnAbi::Partial { .. } => {
+            let ok_ty = ok_ty();
+            let ok_access = format!("{p}.OkVal");
+            let (ok_setup, ok_payload) = lowered_payload_values(planner, shape, &ok_ty, &ok_access);
+            let (both_setup, mut both_values) =
+                lowered_payload_values(planner, shape, &ok_ty, &ok_access);
+            both_values.push(format!("{p}.ErrVal"));
+            let mut statements = vec![
+                tag_check(
                     format!("{p}.Tag == {PARTIAL_OK_TAG}"),
-                    Vec::new(),
-                    vec![format!("{p}.OkVal"), "nil".to_string()],
+                    ok_setup,
+                    lowered_ok_values(shape, ok_payload),
                 ),
                 tag_check(
                     format!("{p}.Tag == {PARTIAL_ERR_TAG}"),
                     Vec::new(),
-                    vec![zero, format!("{p}.ErrVal")],
+                    lowered_err_values(planner, shape, return_ty, &format!("{p}.ErrVal")),
                 ),
-                multi_value_return(vec![format!("{p}.OkVal"), format!("{p}.ErrVal")]),
-            ]
+            ];
+            statements.extend(both_setup);
+            statements.push(multi_value_return(both_values));
+            statements
         }
         CallableReturnAbi::Option(OptionReturnAbi::CommaOk { .. } | OptionReturnAbi::Nullable) => {
+            let (some_setup, some_payload) =
+                lowered_payload_values(planner, shape, &ok_ty(), &format!("{p}.SomeVal"));
             vec![
                 tag_check(
                     format!("{p}.Tag == {OPTION_SOME_TAG}"),
-                    Vec::new(),
-                    lowered_ok_values(shape, &format!("{p}.SomeVal")),
+                    some_setup,
+                    lowered_ok_values(shape, some_payload),
                 ),
                 multi_value_return(lowered_none_values(planner, shape, return_ty)),
             ]
@@ -218,7 +281,7 @@ fn lowered_tuple_values(
 }
 
 /// Lower each element of a tuple literal into its lowered return slot.
-fn lowered_tuple_literal_values(
+pub(crate) fn lowered_tuple_literal_values(
     planner: &mut Planner,
     elements: &[Expression],
     tuple_ty: &Type,
@@ -552,15 +615,17 @@ pub(crate) fn lower_arg_to_tagged(
     tagged_var
 }
 
-/// Tail return for `Partial` and `Tuple` ABIs. Returns `true` when this
-/// path handled the emission.
+/// Tail return for packed `Partial` and `Tuple` ABIs. A flattened `Partial`
+/// takes the generic wrapped-return path.
 pub(crate) fn try_emit_lowered_tail_return(
     planner: &mut Planner,
     expression: &Expression,
 ) -> Option<Vec<LoweredStatement>> {
     let shape = planner.return_ctx().lowered_shape()?;
     match shape {
-        CallableReturnAbi::Partial { .. } => Some(emit_lowered_partial_tail(planner, expression)),
+        CallableReturnAbi::Partial {
+            payload: PayloadLayout::Packed,
+        } => Some(emit_lowered_partial_tail(planner, expression)),
         CallableReturnAbi::Tuple { arity, .. } => {
             Some(emit_lowered_tuple_tail(planner, expression, arity))
         }

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1,4 +1,4 @@
-use crate::abi::is_tagged_shape_fn_value;
+use crate::abi::{is_closure_literal, is_tagged_shape_fn_value};
 use crate::calls::dispatch::{
     CallArgShape, all_type_params_inferrable, callee_is_go_builtin, go_builtin_name,
     is_prelude_variant_constructor,
@@ -56,6 +56,7 @@ fn go_builtin_conversion(type_args: &str) -> Option<String> {
 
 struct FnArgShapes {
     param_abi: CallableReturnAbi,
+    param_origin: SlotOrigin,
     arg_fn: Type,
     arg_abi: CallableReturnAbi,
 }
@@ -787,11 +788,15 @@ impl<'a> Planner<'a> {
         param: Option<&CallableParamAbi>,
         suppress: bool,
     ) -> ExpressionContext<'b> {
+        let origin = param.map_or(SlotOrigin::Lisette, |param| {
+            self.function_type_origin(&param.instantiated, param.origin)
+        });
         let flows_to_unknown = param.is_some_and(|param| {
             self.facts
                 .resolves_to_unknown(param.instantiated.unwrap_forall())
         });
         ExpressionContext::value()
+            .with_function_slot_origin(origin)
             .with_forced_tagged_go_function(suppress)
             .with_unknown_argument_target(flows_to_unknown)
     }
@@ -820,17 +825,24 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(param_ty.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_abi = self.callable_return_abi(param_ret);
+        let param_origin = self.function_type_origin(param_ty, SlotOrigin::Lisette);
+        let param_abi = self.slot_return_abi(param_ret, param_origin);
 
         let arg_ty = arg.get_type();
         let arg_fn = self
             .facts
             .resolve_to_function_type(arg_ty.unwrap_forall())?;
         let arg_ret = arg_fn.get_function_ret()?;
-        let arg_abi = self.classify_direct_emission(arg_ret)?;
+        let arg_origin = if is_closure_literal(arg) || self.is_go_callable(arg) {
+            param_origin
+        } else {
+            self.function_type_origin(&arg_ty, SlotOrigin::Lisette)
+        };
+        let arg_abi = self.classify_slot_emission(arg_ret, arg_origin)?;
 
         Some(FnArgShapes {
             param_abi,
+            param_origin,
             arg_fn,
             arg_abi,
         })
@@ -859,10 +871,14 @@ impl<'a> Planner<'a> {
     ) -> Option<ValuePlan> {
         let FnArgShapes {
             param_abi,
+            param_origin,
             arg_fn,
             arg_abi,
         } = self.fn_arg_shapes(arg, generic_param_ty)?;
-        let argument = self.lower_value(arg, ExpressionContext::value());
+        let argument = self.lower_value(
+            arg,
+            ExpressionContext::value().with_function_slot_origin(param_origin),
+        );
         Some(argument.map_rendered_as_computed(|setup, value, _| {
             let mut buffer = String::new();
             let adapted =
@@ -892,7 +908,8 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(variadic_inner.unwrap_forall())?;
         let param_ret = param_fn.get_function_ret()?;
-        let param_abi = self.callable_return_abi(param_ret);
+        let param_origin = self.function_type_origin(&variadic_inner, SlotOrigin::Lisette);
+        let param_abi = self.slot_return_abi(param_ret, param_origin);
 
         let spread_ty = spread.get_type();
         let element_ty = spread_ty.unwrap_forall().inner()?;
@@ -900,7 +917,8 @@ impl<'a> Planner<'a> {
             .facts
             .resolve_to_function_type(element_ty.unwrap_forall())?;
         let arg_ret = arg_fn.get_function_ret()?;
-        let arg_abi = self.classify_direct_emission(arg_ret)?;
+        let arg_origin = self.function_type_origin(&element_ty, SlotOrigin::Lisette);
+        let arg_abi = self.classify_slot_emission(arg_ret, arg_origin)?;
 
         if param_abi == arg_abi {
             return None;
@@ -950,11 +968,15 @@ impl<'a> Planner<'a> {
     }
 
     /// Resolve the source and target callback contracts at a Go call boundary.
+    /// A closure literal compiles to the slot's shape and needs no adapter.
     fn detect_callback_wrapper(
         &self,
         arg: &Expression,
         param: Option<&CallableParamAbi>,
     ) -> Option<(CallableReturnAbi, CallableReturnAbi, AbiTransition)> {
+        if is_closure_literal(arg) {
+            return None;
+        }
         let param = param?;
         let param_fn_ty = self
             .facts
@@ -971,7 +993,7 @@ impl<'a> Planner<'a> {
         let Type::Function(param_f) = &param_fn_ty else {
             return None;
         };
-        let target = self.classify_direct_emission(&param_f.return_type)?;
+        let target = self.classify_slot_emission(&param_f.return_type, param.origin)?;
         let source = if is_tagged_shape_fn_value(arg) {
             CallableReturnAbi::Tagged
         } else {
@@ -1054,8 +1076,17 @@ impl<'a> Planner<'a> {
         }
     }
 
-    fn argument_source_layout(&self, argument: &Expression) -> ValueLayout {
-        self.value_layout(&argument.get_type(), SlotOrigin::Lisette)
+    fn argument_source_layout(
+        &self,
+        argument: &Expression,
+        parameter: &CallableParamAbi,
+    ) -> ValueLayout {
+        let origin = if is_closure_literal(argument) {
+            self.function_type_origin(&parameter.instantiated, parameter.origin)
+        } else {
+            SlotOrigin::Lisette
+        };
+        self.value_layout(&argument.get_type(), origin)
     }
 
     fn argument_needs_slot_bridge(
@@ -1066,7 +1097,7 @@ impl<'a> Planner<'a> {
         let physical_source = self.go_physical_expression_layout(argument);
         let source = physical_source
             .clone()
-            .unwrap_or_else(|| self.argument_source_layout(argument));
+            .unwrap_or_else(|| self.argument_source_layout(argument, parameter));
         let target = self.argument_slot_layout(parameter);
         let can_forward_physical = match (&physical_source, &target) {
             (
@@ -1100,7 +1131,7 @@ impl<'a> Planner<'a> {
         let raw_source = self.go_physical_expression_layout(argument);
         let source = raw_source
             .clone()
-            .unwrap_or_else(|| self.argument_source_layout(argument));
+            .unwrap_or_else(|| self.argument_source_layout(argument, parameter));
         let target = self.argument_slot_layout(parameter);
         let coercion = CoercionPlan::bridge(self, &source, &target);
         let value = if raw_source.is_some() {

--- a/crates/emit/src/context/expression.rs
+++ b/crates/emit/src/context/expression.rs
@@ -1,6 +1,7 @@
 use syntax::ast::Expression;
 use syntax::types::Type;
 
+use crate::abi::layout::SlotOrigin;
 use crate::plan::values::CaptureBoundary;
 
 /// Whether the expression is being emitted as the callee of a call.
@@ -21,11 +22,16 @@ pub(crate) enum SyntaxContext {
     Condition,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FunctionValueAbiTarget {
-    #[default]
-    Natural,
+    Slot(SlotOrigin),
     Tagged,
+}
+
+impl Default for FunctionValueAbiTarget {
+    fn default() -> Self {
+        Self::Slot(SlotOrigin::Lisette)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -77,6 +83,16 @@ impl<'a> ExpressionContext<'a> {
         }
     }
 
+    pub(crate) fn with_function_slot_origin(self, origin: SlotOrigin) -> Self {
+        match self.function_value_abi_target {
+            FunctionValueAbiTarget::Tagged => self,
+            FunctionValueAbiTarget::Slot(_) => Self {
+                function_value_abi_target: FunctionValueAbiTarget::Slot(origin),
+                ..self
+            },
+        }
+    }
+
     pub(crate) fn with_unknown_argument_target(self, flows: bool) -> Self {
         if flows {
             Self {
@@ -110,6 +126,13 @@ impl<'a> ExpressionContext<'a> {
             self.function_value_abi_target,
             FunctionValueAbiTarget::Tagged
         )
+    }
+
+    pub(crate) fn function_slot_origin(self) -> SlotOrigin {
+        match self.function_value_abi_target {
+            FunctionValueAbiTarget::Slot(origin) => origin,
+            FunctionValueAbiTarget::Tagged => SlotOrigin::Lisette,
+        }
     }
 
     pub(crate) fn argument_flows_to_unknown(self) -> bool {

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -534,25 +534,35 @@ impl Planner<'_> {
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
         if let Some(shape) = lowered {
-            let ok_arg = if matches!(shape, CallableReturnAbi::BareError) {
+            let payload = if matches!(shape, CallableReturnAbi::BareError) {
                 if !args.is_empty() {
                     let (setup, _) = self
                         .lower_composite_value(&args[0], ExpressionContext::value())
                         .into_parts();
                     statements.extend(setup);
                 }
-                String::new()
+                Vec::new()
             } else if args.is_empty() {
-                "struct{}{}".to_string()
+                vec!["struct{}{}".to_string()]
+            } else if shape.has_flattened_payload()
+                && let Expression::Tuple { elements, .. } = args[0].unwrap_parens()
+            {
+                let (setup, parts) =
+                    transition::lowered_tuple_literal_values(self, elements, fallible.ok_ty());
+                statements.extend(setup);
+                parts
             } else {
                 let (setup, value) = self
                     .lower_composite_value(&args[0], ExpressionContext::value())
                     .into_parts();
                 statements.extend(setup);
-                value
+                let (projection, parts) =
+                    transition::lowered_payload_values(self, shape, fallible.ok_ty(), &value);
+                statements.extend(projection);
+                parts
             };
             statements.push(transition::multi_value_return(
-                transition::lowered_ok_values(shape, &ok_arg),
+                transition::lowered_ok_values(shape, payload),
             ));
         } else {
             let (setup, arg) = self

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -180,7 +180,7 @@ impl Planner<'_> {
         let return_ctx = if suppress_lowering {
             ReturnContext::Tagged(return_ty.clone())
         } else {
-            self.return_context_for_type(return_ty.clone())
+            self.return_context_for_slot(return_ty.clone(), ctx.function_slot_origin())
         };
         let signature = if has_return {
             match return_ctx.lowered_shape() {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -206,7 +206,12 @@ impl Planner<'_> {
             value = coerced;
         }
         if let Some(field_ty) = field_ty {
-            let coercion = CoercionPlan::internal(self, value_ty, field_ty);
+            let bridge = self.function_type_slot_bridge(value_ty, field_ty, SlotOrigin::Lisette);
+            let coercion = if bridge.is_identity() {
+                CoercionPlan::internal(self, value_ty, field_ty)
+            } else {
+                bridge
+            };
             let (coercion_setup, coerced) = coercion.lower(self, value);
             statements.extend(coercion_setup);
             value = coerced;

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -31,7 +31,8 @@ impl Planner<'_> {
         {
             let abi = &callee.abi.result;
             let matches_slot = self.go_fn_slot_abi(expression, ctx).as_ref() == Some(abi);
-            let target_layout = self.value_layout(&expression.get_type(), SlotOrigin::Lisette);
+            let target_layout =
+                self.value_layout(&expression.get_type(), ctx.function_slot_origin());
             let same_abi = matches_slot
                 && matches!(
                     &target_layout,
@@ -190,7 +191,7 @@ impl Planner<'_> {
         Some(if ctx.forces_tagged_go_function() {
             self.value_return_abi(&f.return_type)
         } else {
-            self.callable_return_abi(&f.return_type)
+            self.slot_return_abi(&f.return_type, ctx.function_slot_origin())
         })
     }
 
@@ -397,7 +398,8 @@ impl Planner<'_> {
         ty: &Type,
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
-        let inner = self.plan_operand(expression, ctx);
+        let slot_origin = self.function_type_origin(ty, SlotOrigin::Lisette);
+        let inner = self.lower_value(expression, ctx.with_function_slot_origin(slot_origin));
 
         if self.facts.is_interface(ty) {
             let source_ty = expression.get_type();
@@ -415,6 +417,17 @@ impl Planner<'_> {
         }
 
         let go_type = self.use_go_type(ty);
+
+        let function_bridge = self.function_slot_bridge(expression, ty);
+        if !function_bridge.is_identity() {
+            return inner
+                .map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
+                    let (bridge_setup, bridged) = function_bridge.lower(self, value);
+                    setup.extend(bridge_setup);
+                    GoExpression::opaque_with_deferred_evaluation(bridged, true)
+                })
+                .conversion(go_type);
+        }
 
         if let Some(source_go_type) = self.shift_pin_go_type(expression, ty) {
             return inner.conversion(source_go_type).conversion(go_type);

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -33,8 +33,10 @@ pub use output::imports;
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
+use abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use abi::catalog::GoAbiCatalog;
+use abi::go_payload_layout;
+use abi::layout::SlotOrigin;
 use analyze::facts::{EmitFactsConfig, is_nullable_option};
 use diagnostics::LisetteDiagnostic;
 use names::go_name::GeneratedPackage;
@@ -127,17 +129,7 @@ pub(crate) fn classify_go_return_type(
     return_ty: &Type,
     go_hints: &[String],
 ) -> Option<CallableReturnAbi> {
-    let payload = || {
-        if return_ty
-            .ok_type()
-            .tuple_arity()
-            .is_some_and(|arity| arity >= 2)
-        {
-            PayloadLayout::Flattened
-        } else {
-            PayloadLayout::Packed
-        }
-    };
+    let payload = || go_payload_layout(return_ty);
     if return_ty.is_partial() {
         return Some(CallableReturnAbi::Partial { payload: payload() });
     }
@@ -261,9 +253,18 @@ impl Planner<'_> {
 
 impl<'a> Planner<'a> {
     fn return_context_for_type(&self, return_ty: Type) -> ReturnContext {
-        let return_ty = self.facts.peel_alias(&return_ty);
-        match self.classify_direct_emission(&return_ty) {
-            Some(shape) => ReturnContext::Lowered { return_ty, shape },
+        self.return_context_for_slot(return_ty, SlotOrigin::Lisette)
+    }
+
+    fn return_context_for_slot(&self, return_ty: Type, origin: SlotOrigin) -> ReturnContext {
+        let peeled = self.facts.peel_alias(&return_ty);
+        match self.classify_slot_emission(&peeled, origin) {
+            Some(shape) => ReturnContext::Lowered {
+                return_ty: peeled,
+                shape,
+            },
+            // A non-container keeps its declared name, so a Go-named
+            // function type still identifies its slot.
             None => ReturnContext::Tagged(return_ty),
         }
     }

--- a/crates/emit/src/plan/calls.rs
+++ b/crates/emit/src/plan/calls.rs
@@ -430,8 +430,9 @@ impl<'a> Planner<'a> {
         }
         let declared_return = declared_type.and_then(|ty| ty.unwrap_forall().get_function_ret());
         let classify_ty = declared_return.unwrap_or(f.return_type.as_ref());
+        let origin = self.function_type_origin(&callee_ty, SlotOrigin::Lisette);
 
-        self.classify_direct_emission(classify_ty)
+        self.classify_slot_emission(classify_ty, origin)
     }
 
     /// Resolve a Go-interop call's strategy.

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -65,7 +65,7 @@ impl Planner<'_> {
             let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
             CoercionPlan::bridge(self, &source_layout, &target_layout)
         } else {
-            CoercionPlan::internal(self, &value.get_type(), &target.get_type())
+            self.value_slot_coercion(value, &target.get_type())
         };
         let value = right_hand_side.map_rendered_as_computed(
             |value_setup, rhs_value, contains_deferred_evaluation| {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -1,6 +1,6 @@
 use crate::Planner;
 use crate::abi::callable::{AbiTransition, CallableReturnAbi};
-use crate::abi::coercion::CoercionPlan;
+use crate::abi::layout::SlotOrigin;
 use crate::calls::go_interop::WrapperTarget;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::Fallible;
@@ -221,10 +221,14 @@ impl Planner<'_> {
             return statements;
         }
 
-        let plan = self.lower_value(value, ExpressionContext::value());
+        let origin = self.function_type_origin(binding_ty, SlotOrigin::Lisette);
+        let plan = self.lower_value(
+            value,
+            ExpressionContext::value().with_function_slot_origin(origin),
+        );
         let constant = plan.expression.constant_kind();
         let (mut statements, value_expression) = plan.into_parts();
-        let coercion = CoercionPlan::internal(self, &value.get_type(), binding_ty);
+        let coercion = self.value_slot_coercion(value, binding_ty);
         let constant_needs_type =
             coercion.is_identity() && self.constant_needs_go_type(constant, binding_ty).is_some();
         let (coercion_setup, value_expression) = coercion.lower(self, value_expression);

--- a/tests/spec/emit/interop_matrix.rs
+++ b/tests/spec/emit/interop_matrix.rs
@@ -3051,3 +3051,150 @@ impl Client {
 "#;
     assert_emit_snapshot_with_go_typedefs!(input, &[("go:example.com/promoted", typedef)]);
 }
+
+#[test]
+fn interop_go_fn_value_with_tuple_error_result_forwards_to_go_callback_param() {
+    let input = r#"
+import "go:bufio"
+import "go:fmt"
+import "go:strings"
+
+fn main() {
+  let mut scanner = bufio.NewScanner(strings.NewReader("one two three"))
+  scanner.Split(bufio.ScanWords)
+  let mut count = 0
+  while scanner.Scan() {
+    count += 1
+  }
+  fmt.Println(count)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_closure_with_tuple_error_result_flattens_for_go_callback_param() {
+    let input = r#"
+import "go:bufio"
+import "go:fmt"
+import "go:strings"
+
+fn main() {
+  let mut forwarded = bufio.NewScanner(strings.NewReader("one two three"))
+  forwarded.Split(|data, at_eof| bufio.ScanWords(data, at_eof))
+  let mut count = 0
+  while forwarded.Scan() {
+    count += 1
+  }
+  fmt.Println(count)
+
+  let mut rebuilt = bufio.NewScanner(strings.NewReader("four five"))
+  rebuilt.Split(|data, at_eof| {
+    let (advance, token) = bufio.ScanWords(data, at_eof)?
+    Ok((advance, token))
+  })
+  let mut words = 0
+  while rebuilt.Scan() {
+    words += 1
+  }
+  fmt.Println(words)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_lisette_fn_value_with_tuple_error_result_adapts_to_go_callback_param() {
+    let input = r#"
+import "go:bufio"
+import "go:fmt"
+import "go:strings"
+
+fn split_words(data: Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+  bufio.ScanWords(data, at_eof)
+}
+
+fn count(input: string, split: bufio.SplitFunc) -> int {
+  let mut scanner = bufio.NewScanner(strings.NewReader(input))
+  scanner.Split(split)
+  let mut n = 0
+  while scanner.Scan() {
+    n += 1
+  }
+  n
+}
+
+fn main() {
+  fmt.Println(count("one two three", split_words))
+  fmt.Println(count("four five", bufio.ScanWords))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_lisette_fn_value_binds_to_annotated_go_fn_type() {
+    let input = r#"
+import "go:bufio"
+
+fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+  bufio.ScanWords(data, at_eof)
+}
+
+fn main() {
+  let annotated: bufio.SplitFunc = split_words
+  let forwarded: bufio.SplitFunc = bufio.ScanWords
+  let literal: bufio.SplitFunc = |data, at_eof| bufio.ScanWords(data, at_eof)
+  let _ = annotated
+  let _ = forwarded
+  let _ = literal
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_lisette_fn_value_casts_to_go_fn_type() {
+    let input = r#"
+import "go:bufio"
+
+fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+  bufio.ScanWords(data, at_eof)
+}
+
+fn main() {
+  let _ = split_words as bufio.SplitFunc
+  let _ = bufio.ScanWords as bufio.SplitFunc
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn interop_lisette_fn_value_reaches_go_fn_type_return_field_and_assignment() {
+    let input = r#"
+import "go:bufio"
+
+struct Splitter {
+  split: bufio.SplitFunc,
+}
+
+fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+  bufio.ScanWords(data, at_eof)
+}
+
+fn pick() -> bufio.SplitFunc {
+  split_words
+}
+
+fn main() {
+  let mut assigned: bufio.SplitFunc = bufio.ScanWords
+  assigned = split_words
+  let holder = Splitter { split: split_words }
+  let _ = pick()
+  let _ = assigned
+  let _ = holder
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/interop_closure_with_tuple_error_result_flattens_for_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_closure_with_tuple_error_result_flattens_for_go_callback_param.snap
@@ -1,0 +1,73 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  import "go:fmt"
+  import "go:strings"
+  
+  fn main() {
+    let mut forwarded = bufio.NewScanner(strings.NewReader("one two three"))
+    forwarded.Split(|data, at_eof| bufio.ScanWords(data, at_eof))
+    let mut count = 0
+    while forwarded.Scan() {
+      count += 1
+    }
+    fmt.Println(count)
+  
+    let mut rebuilt = bufio.NewScanner(strings.NewReader("four five"))
+    rebuilt.Split(|data, at_eof| {
+      let (advance, token) = bufio.ScanWords(data, at_eof)?
+      Ok((advance, token))
+    })
+    let mut words = 0
+    while rebuilt.Scan() {
+      words += 1
+    }
+    fmt.Println(words)
+  }
+---
+package main
+
+import (
+	"bufio"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strings"
+)
+
+func main() {
+	forwarded := bufio.NewScanner(strings.NewReader("one two three"))
+	forwarded.Split(func(data []byte, at_eof bool) (int, []byte, error) {
+		return bufio.ScanWords(data, at_eof)
+	})
+	count := 0
+	for forwarded.Scan() {
+		count++
+	}
+	fmt.Println(count)
+	rebuilt := bufio.NewScanner(strings.NewReader("four five"))
+	rebuilt.Split(func(data []byte, at_eof bool) (int, []byte, error) {
+		ret_1, ret_2, ret_3 := bufio.ScanWords(data, at_eof)
+		tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+		var result_5 lisette.Result[lisette.Tuple2[int, []byte], error]
+		if ret_3 != nil {
+			result_5 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+		} else {
+			result_5 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](tup_4)
+		}
+		check_6 := result_5
+		if check_6.Tag != lisette.ResultOk {
+			return 0, nil, check_6.ErrVal
+		}
+		tmp_7 := check_6.OkVal
+		advance := tmp_7.First
+		token := tmp_7.Second
+		return advance, token, nil
+	})
+	words := 0
+	for rebuilt.Scan() {
+		words++
+	}
+	fmt.Println(words)
+}

--- a/tests/spec/emit/snapshots/interop_go_fn_value_with_tuple_error_result_forwards_to_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_go_fn_value_with_tuple_error_result_forwards_to_go_callback_param.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  import "go:fmt"
+  import "go:strings"
+  
+  fn main() {
+    let mut scanner = bufio.NewScanner(strings.NewReader("one two three"))
+    scanner.Split(bufio.ScanWords)
+    let mut count = 0
+    while scanner.Scan() {
+      count += 1
+    }
+    fmt.Println(count)
+  }
+---
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+func main() {
+	scanner := bufio.NewScanner(strings.NewReader("one two three"))
+	scanner.Split(bufio.ScanWords)
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+	fmt.Println(count)
+}

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_binds_to_annotated_go_fn_type.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_binds_to_annotated_go_fn_type.snap
@@ -1,0 +1,55 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  
+  fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+    bufio.ScanWords(data, at_eof)
+  }
+  
+  fn main() {
+    let annotated: bufio.SplitFunc = split_words
+    let forwarded: bufio.SplitFunc = bufio.ScanWords
+    let literal: bufio.SplitFunc = |data, at_eof| bufio.ScanWords(data, at_eof)
+    let _ = annotated
+    let _ = forwarded
+    let _ = literal
+  }
+---
+package main
+
+import (
+	"bufio"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
+	ret_1, ret_2, ret_3 := bufio.ScanWords(data, at_eof)
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[int, []byte], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+	} else {
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](tup_4)
+	}
+	if result_5.Tag == lisette.ResultOk {
+		return result_5.OkVal, nil
+	}
+	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+}
+
+func main() {
+	cb_1 := splitWords
+	var annotated bufio.SplitFunc = func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_2, ret_3 := cb_1(arg0, arg1)
+		return ret_2.First, ret_2.Second, ret_3
+	}
+	var forwarded bufio.SplitFunc = bufio.ScanWords
+	var literal bufio.SplitFunc = func(data []byte, at_eof bool) (int, []byte, error) {
+		return bufio.ScanWords(data, at_eof)
+	}
+	_ = annotated
+	_ = forwarded
+	_ = literal
+}

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_casts_to_go_fn_type.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_casts_to_go_fn_type.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  
+  fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+    bufio.ScanWords(data, at_eof)
+  }
+  
+  fn main() {
+    let _ = split_words as bufio.SplitFunc
+    let _ = bufio.ScanWords as bufio.SplitFunc
+  }
+---
+package main
+
+import (
+	"bufio"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
+	ret_1, ret_2, ret_3 := bufio.ScanWords(data, at_eof)
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[int, []byte], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+	} else {
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](tup_4)
+	}
+	if result_5.Tag == lisette.ResultOk {
+		return result_5.OkVal, nil
+	}
+	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+}
+
+func main() {
+	cb_1 := splitWords
+	_ = bufio.SplitFunc(func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_2, ret_3 := cb_1(arg0, arg1)
+		return ret_2.First, ret_2.Second, ret_3
+	})
+	_ = bufio.SplitFunc(bufio.ScanWords)
+}

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_reaches_go_fn_type_return_field_and_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_reaches_go_fn_type_return_field_and_assignment.snap
@@ -1,0 +1,77 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  
+  struct Splitter {
+    split: bufio.SplitFunc,
+  }
+  
+  fn split_words(data: mut Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+    bufio.ScanWords(data, at_eof)
+  }
+  
+  fn pick() -> bufio.SplitFunc {
+    split_words
+  }
+  
+  fn main() {
+    let mut assigned: bufio.SplitFunc = bufio.ScanWords
+    assigned = split_words
+    let holder = Splitter { split: split_words }
+    let _ = pick()
+    let _ = assigned
+    let _ = holder
+  }
+---
+package main
+
+import (
+	"bufio"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Splitter struct {
+	split bufio.SplitFunc
+}
+
+func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
+	ret_1, ret_2, ret_3 := bufio.ScanWords(data, at_eof)
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[int, []byte], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+	} else {
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](tup_4)
+	}
+	if result_5.Tag == lisette.ResultOk {
+		return result_5.OkVal, nil
+	}
+	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+}
+
+func pick() bufio.SplitFunc {
+	cb_1 := splitWords
+	return func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_2, ret_3 := cb_1(arg0, arg1)
+		return ret_2.First, ret_2.Second, ret_3
+	}
+}
+
+func main() {
+	var assigned bufio.SplitFunc = bufio.ScanWords
+	cb_1 := splitWords
+	assigned = func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_2, ret_3 := cb_1(arg0, arg1)
+		return ret_2.First, ret_2.Second, ret_3
+	}
+	cb_4 := splitWords
+	holder := Splitter{split: func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_5, ret_6 := cb_4(arg0, arg1)
+		return ret_5.First, ret_5.Second, ret_6
+	}}
+	_ = pick()
+	_ = assigned
+	_ = holder
+}

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_with_tuple_error_result_adapts_to_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_with_tuple_error_result_adapts_to_go_callback_param.snap
@@ -1,0 +1,79 @@
+---
+source: tests/spec/emit/interop_matrix.rs
+description: |
+  
+  import "go:bufio"
+  import "go:fmt"
+  import "go:strings"
+  
+  fn split_words(data: Slice<byte>, at_eof: bool) -> Result<(int, Slice<byte>), error> {
+    bufio.ScanWords(data, at_eof)
+  }
+  
+  fn count(input: string, split: bufio.SplitFunc) -> int {
+    let mut scanner = bufio.NewScanner(strings.NewReader(input))
+    scanner.Split(split)
+    let mut n = 0
+    while scanner.Scan() {
+      n += 1
+    }
+    n
+  }
+  
+  fn main() {
+    fmt.Println(count("one two three", split_words))
+    fmt.Println(count("four five", bufio.ScanWords))
+  }
+---
+package main
+
+import (
+	"bufio"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strings"
+)
+
+func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
+	ret_1, ret_2, ret_3 := bufio.ScanWords(data, at_eof)
+	tup_4 := lisette.MakeTuple2(ret_1, ret_2)
+	var result_5 lisette.Result[lisette.Tuple2[int, []byte], error]
+	if ret_3 != nil {
+		result_5 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+	} else {
+		result_5 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](tup_4)
+	}
+	if result_5.Tag == lisette.ResultOk {
+		return result_5.OkVal, nil
+	}
+	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+}
+
+func count(input string, split bufio.SplitFunc) int {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(split)
+	n := 0
+	for scanner.Scan() {
+		n++
+	}
+	return n
+}
+
+func main() {
+	cb_1 := splitWords
+	fmt.Println(count("one two three", func(arg0 []byte, arg1 bool) (int, []byte, error) {
+		ret_2, ret_3 := cb_1(arg0, arg1)
+		var result_4 lisette.Result[lisette.Tuple2[int, []byte], error]
+		if ret_3 != nil {
+			result_4 = lisette.MakeResultErr[lisette.Tuple2[int, []byte], error](ret_3)
+		} else {
+			result_4 = lisette.MakeResultOk[lisette.Tuple2[int, []byte], error](ret_2)
+		}
+		if result_4.Tag == lisette.ResultOk {
+			tup_5 := result_4.OkVal
+			return tup_5.First, tup_5.Second, nil
+		}
+		return 0, nil, result_4.ErrVal
+	}))
+	fmt.Println(count("four five", bufio.ScanWords))
+}


### PR DESCRIPTION
`bufio.SplitFunc` returns three values in Go, and Lisette's typedef for it is `Result<(int, Slice<byte>), error>`. Emit was reading the result shape off the fn value and ignoring the type receiving it, so passing `bufio.ScanWords` to `scanner.Split` did not compile. A fn value now takes the shape the receiving Go type declares.

```rs
import "go:bufio"
import "go:fmt"
import "go:strings"

fn main() {
  let mut scanner = bufio.NewScanner(strings.NewReader("one two three"))
  scanner.Split(bufio.ScanWords)
  let mut count = 0
  while scanner.Scan() {
    count += 1
  }
  fmt.Println(count)
}
```
