### PR TITLE
feat: idiomatic Go for error variables of fallible Go calls

### DIFF
--- a/crates/emit/src/analyze/collectors.rs
+++ b/crates/emit/src/analyze/collectors.rs
@@ -111,17 +111,16 @@ impl Planner<'_> {
             return;
         }
 
-        let reserved = self.package_block_names(files);
+        let mut taken = self.package.package_block_names().clone();
         let mut colliding: Vec<&EcoString> = generic_names
             .iter()
-            .filter(|name| reserved.contains(go_name::escape_type_name(name).as_ref()))
+            .filter(|name| taken.contains(go_name::escape_type_name(name).as_ref()))
             .collect();
         if colliding.is_empty() {
             return;
         }
         colliding.sort();
 
-        let mut taken = reserved;
         taken.extend(generic_names.iter().map(EcoString::to_string));
 
         for name in colliding {

--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -3,8 +3,10 @@ use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi, PayloadLayout};
 use crate::calls::dispatch::extract_native_method_name;
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
+use crate::escape_reserved;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::CallableOrigin;
+use crate::state::scope::PairStatusKind;
 use crate::types::native::NativeGoType;
 use syntax::ast::Expression;
 use syntax::types::Type;
@@ -64,6 +66,7 @@ pub(crate) struct LoweredPair {
     status: String,
     success: PairSuccess,
     nil_guard: Option<NilGuard>,
+    initializer: Option<String>,
 }
 
 impl LoweredPair {
@@ -159,6 +162,7 @@ impl Planner<'_> {
             PairKind::CommaOk {
                 nil_guard: source.nil_guard,
             },
+            None,
         )
     }
 
@@ -168,13 +172,21 @@ impl Planner<'_> {
         expression: String,
         slot: CommaOkValueSlot,
         kind: PairKind,
+        status_hint: Option<&str>,
     ) -> LoweredPair {
-        let (carries_value, nil_guard, success, hint) = match kind {
-            PairKind::CommaOk { nil_guard } => (true, nil_guard, PairSuccess::Truthy, "ok"),
+        let (carries_value, nil_guard, success, status_kind) = match kind {
+            PairKind::CommaOk { nil_guard } => {
+                (true, nil_guard, PairSuccess::Truthy, PairStatusKind::Ok)
+            }
             PairKind::Error {
                 carries_value,
                 nil_guard,
-            } => (carries_value, nil_guard, PairSuccess::Nil, "err"),
+            } => (
+                carries_value,
+                nil_guard,
+                PairSuccess::Nil,
+                PairStatusKind::Error,
+            ),
         };
         let value = carries_value
             .then(|| match slot {
@@ -183,29 +195,59 @@ impl Planner<'_> {
                 CommaOkValueSlot::Unused => nil_guard.map(|_| self.fresh_pair_value()),
             })
             .flatten();
-        let status = self.fresh_var(Some(hint));
-        self.declare(&status);
+        let opens_if = value.is_none();
+        let status = self.pair_status(status_hint, status_kind, opens_if);
         let binding = match (carries_value, value.as_deref()) {
             (true, Some(value)) => format!("{value}, {status}"),
             (true, None) => format!("_, {status}"),
             (false, _) => status.clone(),
         };
-        statements.push(LoweredStatement::RawGo(format!(
-            "{binding} := {expression}\n"
-        )));
+        let line = format!("{binding} := {expression}");
+        let initializer = if opens_if {
+            Some(line)
+        } else {
+            statements.push(LoweredStatement::RawGo(format!("{line}\n")));
+            None
+        };
         LoweredPair {
             statements,
             value,
             status,
             success,
             nil_guard,
+            initializer,
         }
     }
 
-    fn fresh_pair_value(&mut self) -> String {
+    pub(crate) fn fresh_pair_value(&mut self) -> String {
         let v = self.fresh_var(Some("ret"));
         self.declare(&v);
         v
+    }
+
+    /// Fresh within a Go block; nested blocks may shadow outer statuses.
+    pub(crate) fn pair_status(
+        &mut self,
+        hint: Option<&str>,
+        kind: PairStatusKind,
+        opens_if: bool,
+    ) -> String {
+        let candidate = escape_reserved(hint.unwrap_or(match kind {
+            PairStatusKind::Error => "err",
+            PairStatusKind::Ok => "ok",
+        }));
+        let taken = (!opens_if && self.scope.current_block_declares(&candidate))
+            || self.scope.has_binding_for_go_name(&candidate)
+            || self.package.is_package_block_name(&candidate);
+        let name = if taken {
+            self.fresh_var(Some(&candidate))
+        } else {
+            candidate.into_owned()
+        };
+        if !opens_if {
+            self.declare(&name);
+        }
+        name
     }
 
     pub(crate) fn pair_success_condition(&mut self, pair: &LoweredPair) -> String {
@@ -223,23 +265,29 @@ impl Planner<'_> {
             (PairSuccess::Nil, true) => format!("{} == nil", pair.status),
             (PairSuccess::Nil, false) => format!("{} != nil", pair.status),
         };
-        let Some(guard) = pair.nil_guard else {
-            return status;
+        let condition = match pair.nil_guard {
+            None => status,
+            Some(guard) => {
+                if guard.is_interface() {
+                    self.require_stdlib();
+                }
+                let value = pair
+                    .value
+                    .as_deref()
+                    .expect("nil guard requires the value var");
+                let nil_condition = if success {
+                    guard.non_nil(value)
+                } else {
+                    guard.is_nil(value)
+                };
+                let operator = if success { "&&" } else { "||" };
+                format!("{status} {operator} {nil_condition}")
+            }
         };
-        if guard.is_interface() {
-            self.require_stdlib();
+        match &pair.initializer {
+            Some(initializer) => format!("{initializer}; {condition}"),
+            None => condition,
         }
-        let value = pair
-            .value
-            .as_deref()
-            .expect("nil guard requires the value var");
-        let nil_condition = if success {
-            guard.non_nil(value)
-        } else {
-            guard.is_nil(value)
-        };
-        let operator = if success { "&&" } else { "||" };
-        format!("{status} {operator} {nil_condition}")
     }
 
     /// Lower the pair-producing Go expression.

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -224,7 +224,7 @@ impl Planner<'_> {
             None => match self.go_name_for_binding(pattern) {
                 Some(name) => {
                     let escaped = go_name::escape_reserved(&name).into_owned();
-                    if self.is_declared(&escaped) {
+                    if self.shadows_declaration(&escaped) {
                         self.fresh_var(Some(&name))
                     } else {
                         escaped

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -8,6 +8,7 @@ use crate::control_flow::fallible::{ConstructorKind, Fallible, FalliblePlanner};
 use crate::definitions::functions::is_go_never;
 use crate::plan::bodies::{AssignForm, LoweredBlock, LoweredStatement, PlacePlan, ReturnForm};
 use crate::plan::values::{GoExpression, ValuePlan};
+use crate::state::scope::PairStatusKind;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -223,27 +224,42 @@ impl Planner<'_> {
             return None;
         }
 
-        let want_value = !matches!(result_var_name, Some("_"));
-        let value_var = (has_value_slot && (want_value || nil_guard.is_some())).then(|| {
-            let v = self.fresh_var(Some("ret"));
-            self.declare(&v);
-            v
-        });
-        let outcome_var = self.fresh_var(Some("ret"));
-        self.declare(&outcome_var);
-
         let (mut statements, call_str) = self
             .lower_call(expression, None, ExpressionContext::value())
             .into_parts();
-        let bind_line = if has_value_slot {
-            match &value_var {
-                Some(v) => format!("{}, {} := {}\n", v, outcome_var, call_str),
-                None => format!("_, {} := {}\n", outcome_var, call_str),
-            }
+        let want_value = !matches!(result_var_name, Some("_"));
+        let let_slot = result_var_name.filter(|name| {
+            has_value_slot && *name != "_" && payload_bridge.is_none() && !self.is_declared(name)
+        });
+        let value_var =
+            (has_value_slot && (want_value || nil_guard.is_some())).then(|| match let_slot {
+                Some(name) => {
+                    self.declare(name);
+                    name.to_string()
+                }
+                None => self.fresh_pair_value(),
+            });
+        let status_kind = if comma_ok {
+            PairStatusKind::Ok
         } else {
-            format!("{} := {}\n", outcome_var, call_str)
+            PairStatusKind::Error
         };
-        statements.push(LoweredStatement::RawGo(bind_line));
+        let outcome_var = self.pair_status(None, status_kind, value_var.is_none());
+        let bind_line = match &value_var {
+            Some(value) => format!("{value}, {outcome_var} := {call_str}"),
+            None if has_value_slot => format!("_, {outcome_var} := {call_str}"),
+            None => format!("{outcome_var} := {call_str}"),
+        };
+        let initializer = if value_var.is_some() {
+            statements.push(LoweredStatement::RawGo(format!("{bind_line}\n")));
+            None
+        } else {
+            Some(bind_line)
+        };
+        let open_if = |condition: String| match &initializer {
+            Some(initializer) => format!("{initializer}; {condition}"),
+            None => condition,
+        };
 
         if comma_ok {
             let failure_condition = match nil_guard {
@@ -261,7 +277,7 @@ impl Planner<'_> {
             let (failure_setup, failure_values) =
                 self.propagate_failure_values(fallible, &outcome_var);
             statements.push(transition::tag_check(
-                failure_condition,
+                open_if(failure_condition),
                 failure_setup,
                 failure_values,
             ));
@@ -269,7 +285,7 @@ impl Planner<'_> {
             let (failure_setup, failure_values) =
                 self.propagate_failure_values(fallible, &outcome_var);
             statements.push(transition::tag_check(
-                format!("{} != nil", outcome_var),
+                open_if(format!("{} != nil", outcome_var)),
                 failure_setup,
                 failure_values,
             ));
@@ -299,6 +315,7 @@ impl Planner<'_> {
         let value = match result_var_name {
             None => ok_value.unwrap_or_else(|| "struct{}{}".to_string()),
             Some("_") => "_".to_string(),
+            Some(name) if let_slot.is_some() => name.to_string(),
             Some(name) => {
                 let v = ok_value.unwrap_or_else(|| "struct{}{}".to_string());
                 statements.push(self.bind_propagate_ok(name, &v));

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -220,7 +220,7 @@ impl Planner<'_> {
     }
 
     fn fresh_ok_var(&mut self) -> String {
-        if self.scope.has_binding_for_go_name("ok") || self.is_declared("ok") {
+        if self.scope.has_binding_for_go_name("ok") || self.shadows_declaration("ok") {
             self.fresh_var(Some("ok"))
         } else {
             "ok".to_string()

--- a/crates/emit/src/definitions/functions.rs
+++ b/crates/emit/src/definitions/functions.rs
@@ -242,7 +242,7 @@ impl Planner<'_> {
     /// Bind and declare a parameter; freshens the Go name on collision.
     fn declare_param(&mut self, lisette_name: &str, raw_go_name: impl Into<String>) -> String {
         let go_id = self.scope.bind(lisette_name, raw_go_name);
-        let go_id = if self.is_declared(&go_id) {
+        let go_id = if self.shadows_declaration(&go_id) {
             let fresh = self.fresh_var(Some(lisette_name));
             self.scope.bind(lisette_name, fresh)
         } else {
@@ -435,8 +435,9 @@ impl Planner<'_> {
         let ty_string = self.use_go_type(actual_ty);
         let mut receiver_var = receiver_name(&ty_string);
 
-        let taken =
-            |this: &Self, name: &String| param_names.contains(name) || this.is_declared(name);
+        let taken = |this: &Self, name: &String| {
+            param_names.contains(name) || this.shadows_declaration(name)
+        };
         if taken(self, &receiver_var) {
             receiver_var = format!("{}{}", receiver_var, receiver_var);
             let mut counter = 2;

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -464,6 +464,10 @@ impl<'a> Planner<'a> {
         self.scope.is_go_name_declared(go_name)
     }
 
+    fn shadows_declaration(&self, go_name: &str) -> bool {
+        self.is_declared(go_name) || self.package.is_package_block_name(go_name)
+    }
+
     /// Whether an enclosing branch already tested this exact condition.
     fn is_condition_established(&self, condition: &str) -> bool {
         self.scope.is_condition_established(condition)
@@ -568,7 +572,12 @@ impl<'a> Planner<'a> {
     }
 
     fn fresh_var(&mut self, hint: Option<&str>) -> String {
-        self.scope.fresh_go_name(hint)
+        loop {
+            let name = self.scope.fresh_go_name(hint);
+            if !self.package.is_package_block_name(&name) {
+                return name;
+            }
+        }
     }
 
     fn current_function_context(&self) -> Option<&FunctionEmissionContext> {

--- a/crates/emit/src/patterns/binding_decls.rs
+++ b/crates/emit/src/patterns/binding_decls.rs
@@ -129,7 +129,7 @@ impl Planner<'_> {
                     .iter()
                     .any(|e| self.pattern_has_binding_collisions(e))
                     || if let RestPattern::Bind { name, .. } = rest {
-                        !self.facts.is_unused_rest_binding(rest) && self.is_declared(name)
+                        !self.facts.is_unused_rest_binding(rest) && self.shadows_declaration(name)
                     } else {
                         false
                     }
@@ -143,7 +143,7 @@ impl Planner<'_> {
                 ..
             } => {
                 self.pattern_has_binding_collisions(inner)
-                    || (!self.facts.is_unused_binding(p) && self.is_declared(name))
+                    || (!self.facts.is_unused_binding(p) && self.shadows_declaration(name))
             }
             Pattern::WildCard { .. } | Pattern::Literal { .. } | Pattern::Unit { .. } => false,
         }
@@ -227,7 +227,7 @@ impl Planner<'_> {
         go_name: String,
         resolved: &Type,
     ) {
-        let go_name = if self.is_declared(&go_name) {
+        let go_name = if self.shadows_declaration(&go_name) {
             self.fresh_var(Some(lisette_name))
         } else {
             go_name

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -145,7 +145,7 @@ pub(crate) fn tree_binding_statements(
             fresh
         } else {
             let name = planner.scope.bind(&binding.lisette_name, go_name.clone());
-            if planner.try_declare(&name) {
+            if !planner.package.is_package_block_name(&name) && planner.try_declare(&name) {
                 name
             } else {
                 let fresh = planner.fresh_var(Some(&binding.lisette_name));

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -11,6 +11,7 @@ use crate::patterns::tree_emitter::{MatchSubject, TreePlanner};
 use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
+use crate::state::scope::PairStatusKind;
 use syntax::ast::{Expression, MatchArm, Pattern};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
@@ -96,7 +97,12 @@ impl ResultFusePlan<'_> {
         matches!(self.shape, CallableReturnAbi::Result { .. })
     }
 
-    pub(super) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> LoweredPair {
+    pub(super) fn bind(
+        self,
+        planner: &mut Planner<'_>,
+        slot: CommaOkValueSlot,
+        error_name: Option<&str>,
+    ) -> LoweredPair {
         let carries_value = self.carries_payload();
         let (setup, call) = planner
             .lower_call(self.subject, None, ExpressionContext::value())
@@ -109,7 +115,25 @@ impl ResultFusePlan<'_> {
                 carries_value,
                 nil_guard: self.nil_guard,
             },
+            error_name,
         )
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum ArmBinding<'a> {
+    Alias { name: &'a str, go_name: &'a str },
+    Copy { name: &'a str, value: &'a str },
+}
+
+impl<'a> ArmBinding<'a> {
+    pub(super) fn alias(name: Option<&'a str>, go_name: &'a str) -> Option<Self> {
+        name.map(|name| Self::Alias { name, go_name })
+    }
+
+    pub(super) fn copy(name: Option<&'a str>, value: Option<&'a str>) -> Option<Self> {
+        name.zip(value)
+            .map(|(name, value)| Self::Copy { name, value })
     }
 }
 
@@ -498,7 +522,7 @@ impl Planner<'_> {
             None if ok_name.is_some() => CommaOkValueSlot::Temp,
             None => CommaOkValueSlot::Unused,
         };
-        let bound = fuse.bind(self, slot);
+        let bound = fuse.bind(self, slot, err_name);
         let ok_condition = self.pair_success_condition(&bound);
         let err_condition = self.pair_failure_condition(&bound);
 
@@ -509,7 +533,8 @@ impl Planner<'_> {
             } else {
                 Some(UNIT_VALUE)
             };
-            self.lower_fused_arm(&[ok_name.zip(ok_value)], &ok.arm.expression, place)
+            let ok_binding = ArmBinding::copy(ok_name, ok_value);
+            self.lower_fused_arm(&[ok_binding], &ok.arm.expression, place)
                 .0
         });
         let arm_place = if destination.is_some() {
@@ -517,11 +542,9 @@ impl Planner<'_> {
         } else {
             place
         };
-        let (mut else_body, err_used) = self.lower_fused_arm(
-            &[err_name.map(|n| (n, bound.status()))],
-            &err.arm.expression,
-            arm_place,
-        );
+        let err_binding = ArmBinding::alias(err_name, bound.status());
+        let (mut else_body, err_used) =
+            self.lower_fused_arm(&[err_binding], &err.arm.expression, arm_place);
 
         if has_nil_guard && err_used.into_iter().any(|used| used) {
             self.require_errors();
@@ -603,33 +626,36 @@ impl Planner<'_> {
         let nilable = self.partial_ok_is_nilable(&ok_ty);
         let val_used = ok_name.is_some() || both_val.is_some() || nilable;
 
-        let val_var = val_used.then(|| {
-            let v = self.fresh_var(Some("ret"));
-            self.declare(&v);
-            v
-        });
-        let err_var = self.fresh_var(Some("ret"));
-        self.declare(&err_var);
-
         let (mut statements, call_str) = self
             .lower_call(subject, None, ExpressionContext::value())
             .into_parts();
+        let val_var = val_used.then(|| self.fresh_pair_value());
+        let err_var = self.pair_status(
+            both_err.or(err_name),
+            PairStatusKind::Error,
+            val_var.is_none(),
+        );
         let bind_line = match &val_var {
-            Some(v) => format!("{}, {} := {}\n", v, err_var, call_str),
-            None => format!("_, {} := {}\n", err_var, call_str),
+            Some(v) => format!("{}, {} := {}", v, err_var, call_str),
+            None => format!("_, {} := {}", err_var, call_str),
         };
-        statements.push(LoweredStatement::RawGo(bind_line));
+        let condition = if val_var.is_some() {
+            statements.push(LoweredStatement::RawGo(format!("{bind_line}\n")));
+            format!("{} == nil", err_var)
+        } else {
+            format!("{bind_line}; {} == nil", err_var)
+        };
 
         let (ok_body, _) = self.lower_fused_arm(
-            &[ok_name.zip(val_var.as_deref())],
+            &[ArmBinding::copy(ok_name, val_var.as_deref())],
             &ok_arm.expression,
             place,
         );
         let both_body = self
             .lower_fused_arm(
                 &[
-                    both_val.zip(val_var.as_deref()),
-                    both_err.zip(Some(err_var.as_str())),
+                    ArmBinding::copy(both_val, val_var.as_deref()),
+                    ArmBinding::alias(both_err, &err_var),
                 ],
                 &both_arm.expression,
                 place,
@@ -643,7 +669,7 @@ impl Planner<'_> {
         let else_arm = match nil_check {
             Some(check) => {
                 let (err_body, _) = self.lower_fused_arm(
-                    &[err_name.zip(Some(err_var.as_str()))],
+                    &[ArmBinding::alias(err_name, &err_var)],
                     &err_arm.expression,
                     place,
                 );
@@ -659,7 +685,7 @@ impl Planner<'_> {
 
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: format!("{} == nil", err_var),
+            condition,
             then_body: ok_body,
             else_arm,
         }));
@@ -708,17 +734,12 @@ impl Planner<'_> {
         let condition_needs_value = nil_guard.is_some()
             && matches!(arms.variant, PartialVariant::Both | PartialVariant::Err);
         let may_need_value = value_binding.is_some() || condition_needs_value;
-        let value = may_need_value.then(|| {
-            let name = self.fresh_var(Some("ret"));
-            self.declare(&name);
-            name
-        });
-        let error = self.fresh_var(Some("err"));
-        self.declare(&error);
+        let value = may_need_value.then(|| self.fresh_pair_value());
+        let error = self.pair_status(error_binding, PairStatusKind::Error, value.is_none());
         let (selected, binding_uses) = self.lower_fused_arm(
             &[
-                value_binding.zip(value.as_deref()),
-                error_binding.map(|name| (name, error.as_str())),
+                ArmBinding::copy(value_binding, value.as_deref()),
+                ArmBinding::alias(error_binding, &error),
             ],
             &arms.selected.expression,
             place,
@@ -733,11 +754,11 @@ impl Planner<'_> {
         }
 
         let value_is_used = binding_uses.first().copied().unwrap_or(false);
-        let result_slots = if condition_needs_value || value_is_used {
-            let value = value.as_deref().expect("value use allocates a result slot");
-            format!("{value}, {error}")
-        } else {
-            format!("_, {error}")
+        let value_slot = (condition_needs_value || value_is_used)
+            .then(|| value.as_deref().expect("value use allocates a result slot"));
+        let result_slots = match value_slot {
+            Some(value) => format!("{value}, {error}"),
+            None => format!("_, {error}"),
         };
         let condition = match arms.variant {
             PartialVariant::Ok => format!("{error} == nil"),
@@ -760,9 +781,14 @@ impl Planner<'_> {
                 format!("{error} != nil && {}", guard.is_nil(value))
             }
         };
-        statements.push(LoweredStatement::RawGo(format!(
-            "{result_slots} := {call}\n"
-        )));
+        let condition = if value_slot.is_some() {
+            statements.push(LoweredStatement::RawGo(format!(
+                "{result_slots} := {call}\n"
+            )));
+            condition
+        } else {
+            format!("{result_slots} := {call}; {condition}")
+        };
         let selected_diverges = selected.ends_with_diverge();
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -791,11 +817,8 @@ impl Planner<'_> {
         };
         let bound = fuse.bind(self, slot);
 
-        let (then_body, _) = self.lower_fused_arm(
-            &[arms.some_binding.zip(bound.value.as_deref())],
-            arms.some_body,
-            place,
-        );
+        let some_binding = ArmBinding::copy(arms.some_binding, bound.value.as_deref());
+        let (then_body, _) = self.lower_fused_arm(&[some_binding], arms.some_body, place);
         let (else_body, _) = self.lower_fused_arm(&[], arms.none_body, place);
 
         let invert = then_body.renders_empty() && !else_body.renders_empty();
@@ -826,18 +849,23 @@ impl Planner<'_> {
 
     pub(super) fn lower_fused_arm(
         &mut self,
-        bindings: &[Option<(&str, &str)>],
+        bindings: &[Option<ArmBinding<'_>>],
         body: &Expression,
         place: &PlacePlan,
     ) -> (LoweredBlock, Vec<bool>) {
         self.with_binding_frame(|this| {
-            let bound: Vec<Option<(String, String)>> = bindings
+            let bound: Vec<Option<(String, Option<String>)>> = bindings
                 .iter()
                 .map(|binding| {
-                    binding.map(|(name, value)| {
-                        let go_name = this.scope.bind(name, name);
-                        this.declare(&go_name);
-                        (go_name, value.to_string())
+                    binding.map(|binding| match binding {
+                        ArmBinding::Alias { name, go_name } => {
+                            (this.scope.bind(name, go_name), None)
+                        }
+                        ArmBinding::Copy { name, value } => {
+                            let go_name = this.scope.bind(name, name);
+                            this.declare(&go_name);
+                            (go_name, Some(value.to_string()))
+                        }
                     })
                 })
                 .collect();
@@ -853,7 +881,7 @@ impl Planner<'_> {
                 })
                 .collect::<Vec<_>>();
             for (binding, is_used) in bound.iter().zip(&binding_uses) {
-                let Some((go_name, value)) = binding else {
+                let Some((go_name, Some(value))) = binding else {
                     continue;
                 };
                 if !is_used {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -14,7 +14,7 @@ use crate::patterns::binding_emit::{
     tree_assignment_statements, tree_binding_statements, with_tree_bindings,
 };
 use crate::patterns::decision_tree::{self, PatternInfo, SubjectRoot, render_condition};
-use crate::patterns::matching::{field_binding, ok_pattern_field, some_pattern_field};
+use crate::patterns::matching::{ArmBinding, field_binding, ok_pattern_field, some_pattern_field};
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan,
 };
@@ -272,7 +272,7 @@ impl Planner<'_> {
             Some((_, go_name)) => CommaOkValueSlot::Named(go_name.clone()),
             None => CommaOkValueSlot::Unused,
         };
-        let bound = fuse.bind(self, slot);
+        let bound = fuse.bind(self, slot, None);
         let fail_condition = self.pair_failure_condition(&bound);
         Some(self.finish_fused_let_else(bound.statements, fail_condition, binding, else_block))
     }
@@ -326,7 +326,7 @@ impl Planner<'_> {
     fn declare_fused_binding(&mut self, pattern: &Pattern) -> Option<(String, String)> {
         self.go_name_for_binding(pattern).map(|name| {
             let escaped = go_name::escape_reserved(&name).into_owned();
-            let go_name = if self.is_declared(&escaped) {
+            let go_name = if self.shadows_declaration(&escaped) {
                 self.fresh_var(Some(&name))
             } else {
                 escaped
@@ -477,7 +477,7 @@ impl Planner<'_> {
             else_arm: ElseArm::None,
         }));
         let (body_block, _) = self.lower_fused_arm(
-            &[binding.zip(bound.value.as_deref())],
+            &[ArmBinding::copy(binding, bound.value.as_deref())],
             body,
             &PlacePlan::Statement,
         );

--- a/crates/emit/src/plan/mod.rs
+++ b/crates/emit/src/plan/mod.rs
@@ -18,6 +18,8 @@ impl Planner<'_> {
     /// Resolve package-wide names and collisions before any item is rendered.
     pub(crate) fn build_package_plan(&mut self, files: &[&File]) -> PackagePlan {
         self.collect_escape_remap(files);
+        let package_block_names = self.package_block_names(files);
+        self.package.record_package_block_names(package_block_names);
         self.derive_package_go_consts(files);
         self.collect_generic_renames(files);
         let collision_diagnostics = self.detect_name_collisions(files);

--- a/crates/emit/src/state/package_state.rs
+++ b/crates/emit/src/state/package_state.rs
@@ -8,6 +8,7 @@ pub(crate) struct PackageState {
     escape_remap: HashMap<String, String>,
     generic_renames: HashMap<String, String>,
     go_const_bindings: HashSet<String>,
+    package_block_names: HashSet<String>,
 }
 
 impl PackageState {
@@ -35,6 +36,18 @@ impl PackageState {
 
     pub(crate) fn generic_rename(&self, source_name: &str) -> Option<&str> {
         self.generic_renames.get(source_name).map(String::as_str)
+    }
+
+    pub(crate) fn record_package_block_names(&mut self, names: HashSet<String>) {
+        self.package_block_names = names;
+    }
+
+    pub(crate) fn package_block_names(&self) -> &HashSet<String> {
+        &self.package_block_names
+    }
+
+    pub(crate) fn is_package_block_name(&self, go_name: &str) -> bool {
+        self.package_block_names.contains(go_name)
     }
 
     pub(crate) fn extend_go_const_bindings(&mut self, names: impl IntoIterator<Item = String>) {

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -41,6 +41,12 @@ enum DeclarationKind {
     TypeParameter,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PairStatusKind {
+    Error,
+    Ok,
+}
+
 impl ScopeState {
     pub(crate) fn new() -> Self {
         Self {
@@ -162,6 +168,10 @@ impl ScopeState {
             current.insert(go_name.to_string(), DeclarationKind::Local);
             true
         }
+    }
+
+    pub(crate) fn current_block_declares(&self, go_name: &str) -> bool {
+        self.current_declarations().contains_key(go_name)
     }
 
     pub(crate) fn is_go_name_declared(&self, go_name: &str) -> bool {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -71,7 +71,7 @@ impl Planner<'_> {
         force_fresh: bool,
     ) -> String {
         let escaped = escape_reserved(raw_go_name);
-        if force_fresh || self.is_declared(&escaped) {
+        if force_fresh || self.shadows_declaration(&escaped) {
             self.fresh_var(Some(identifier))
         } else {
             escaped.into_owned()
@@ -105,7 +105,7 @@ impl Planner<'_> {
         };
         if needs_temp {
             let go_identifier = escape_reserved(raw_go_name);
-            if !self.is_declared(&go_identifier)
+            if !self.shadows_declaration(&go_identifier)
                 && !expression_contains_binding(value, identifier)
                 && !self.scope.is_active_assign_target(&go_identifier)
                 && !self.scope.has_binding_for_go_name(&go_identifier)
@@ -122,7 +122,9 @@ impl Planner<'_> {
                     return statements;
                 }
             }
-            if self.is_declared(&go_identifier) || expression_contains_binding(value, identifier) {
+            if self.shadows_declaration(&go_identifier)
+                || expression_contains_binding(value, identifier)
+            {
                 let fresh = self.fresh_var(Some(identifier));
                 let statements = self.lower_let_temp(&fresh, value, binding_ty);
                 self.scope.bind(identifier, &fresh);
@@ -188,7 +190,7 @@ impl Planner<'_> {
             return statements;
         };
         let escaped = escape_reserved(raw_go_name);
-        if self.is_declared(&escaped) {
+        if self.shadows_declaration(&escaped) {
             let fresh = self.fresh_var(Some(identifier));
             self.declare(&fresh);
             statements.push(LoweredStatement::TempBind {
@@ -235,7 +237,7 @@ impl Planner<'_> {
         statements.extend(coercion_setup);
 
         let bound = self.scope.bind(identifier, raw_go_name);
-        let is_new = self.try_declare(&bound);
+        let is_new = !self.package.is_package_block_name(&bound) && self.try_declare(&bound);
         let go_identifier = if !is_new || self.scope.is_active_assign_target(&bound) {
             let fresh = self.fresh_var(Some(identifier));
             self.scope.bind(identifier, &fresh);
@@ -277,7 +279,7 @@ impl Planner<'_> {
         binding_ty: &Type,
     ) -> Option<Vec<LoweredStatement>> {
         let go_identifier = escape_reserved(raw_go_name);
-        if self.is_declared(&go_identifier)
+        if self.shadows_declaration(&go_identifier)
             || self.scope.is_active_assign_target(&go_identifier)
             || self.scope.has_binding_for_go_name(&go_identifier)
         {
@@ -574,7 +576,7 @@ impl<'a, 'e> LetPlanner<'a, 'e> {
                     && let Some(go_name) = self.planner.go_name_for_binding(pattern)
                 {
                     let escaped = escape_reserved(&go_name).into_owned();
-                    let name = if self.planner.is_declared(&escaped) {
+                    let name = if self.planner.shadows_declaration(&escaped) {
                         let fresh = self.planner.fresh_var(Some(identifier));
                         any_new = true;
                         fresh

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -11,8 +11,8 @@ import (
 
 func main() {
 	raw := store.GetValue("count")
-	ret_1, ok_2 := raw.(int)
-	if ok_2 {
+	ret_1, ok := raw.(int)
+	if ok {
 		n := ret_1
 		fmt.Print(n)
 	} else {

--- a/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
+++ b/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
@@ -14,8 +14,8 @@ func main() {
 	x := 100
 	fmt.Println(x)
 	x_1 := 200
-	ret_2, err_3 := parse()
-	if err_3 == nil {
+	ret_2, err := parse()
+	if err == nil {
 		x := ret_2
 		fmt.Println(x)
 	} else {

--- a/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
+++ b/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
@@ -11,12 +11,11 @@ import (
 
 func main() {
 	parse := strconv.Atoi
-	ret_1, err_2 := parse("42")
-	if err_2 == nil {
+	ret_1, e := parse("42")
+	if e == nil {
 		n := ret_1
 		fmt.Printf("parsed: %d\n", n)
 	} else {
-		e := err_2
 		msg := e.Error()
 		fmt.Println(msg)
 	}

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
@@ -12,8 +12,8 @@ import (
 
 func main() {
 	reader := strings.NewReader("hello")
-	ret_1, ret_2 := io.ReadAll(reader)
-	if ret_2 == nil {
+	ret_1, err := io.ReadAll(reader)
+	if err == nil {
 		fmt.Print("ok")
 	} else if ret_1 == nil {
 		fmt.Print("err")

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
@@ -11,8 +11,8 @@ import (
 )
 
 func main() {
-	ret_1, ret_2 := parser.ParseExpr("1 + 2")
-	if ret_2 == nil {
+	ret_1, err := parser.ParseExpr("1 + 2")
+	if err == nil {
 		fmt.Print("ok")
 	} else if lisette.IsNilInterface(ret_1) {
 		fmt.Print("err")

--- a/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
+++ b/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
@@ -12,8 +12,8 @@ import (
 func main() {
 	m := sync.Map{}
 	m.Store("key", "value")
-	ret_1, ok_2 := m.Load("key")
-	if ok_2 {
+	ret_1, ok := m.Load("key")
+	if ok {
 		v := ret_1
 		fmt.Printf("got: %v\n", v)
 	} else {

--- a/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
+++ b/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
@@ -14,12 +14,11 @@ func parseInt(s string) (int, error) {
 }
 
 func main() {
-	ret_1, err_2 := parseInt("42")
-	if err_2 == nil {
+	ret_1, e := parseInt("42")
+	if e == nil {
 		n := ret_1
 		fmt.Println(n)
 	} else {
-		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -19,12 +19,11 @@ func (w Widget) MarshalJSON() ([]uint8, error) {
 
 func main() {
 	w := Widget{id: 7}
-	ret_1, err_2 := json.Marshal(w)
-	if err_2 == nil {
+	ret_1, e := json.Marshal(w)
+	if e == nil {
 		b := ret_1
 		fmt.Println(string(b))
 	} else {
-		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2228,3 +2228,149 @@ fn test() {
 "#;
     assert_emit_snapshot!(input);
 }
+
+#[test]
+fn fused_pairs_take_distinct_status_names_in_one_block() {
+    let input = r#"
+import "go:os"
+import "go:strconv"
+
+fn run(path: string) -> Result<int, error> {
+  let text = os.ReadFile(path)?
+  let Ok(n) = strconv.Atoi(os.Getenv("N")) else { return Ok(text.length()) }
+  os.Remove(path)?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_status_avoids_a_live_err_binding() {
+    let input = r#"
+import "go:errors"
+import "go:strconv"
+
+fn run() -> Result<int, error> {
+  let err = errors.New("outer")
+  let n = strconv.Atoi("1")?
+  if n == 0 { return Err(err) }
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_status_takes_the_err_arm_name() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  match strconv.Atoi("1") {
+    Ok(n) => fmt.Println(n),
+    Err(failure) => fmt.Println(failure),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_status_only_call_opens_the_if_initializer() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  if let Err(err) = os.Remove("a") {
+    fmt.Println(err)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_status_shadows_err_inside_a_nested_block() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let first = match strconv.Atoi("1") {
+    Ok(n) => n,
+    Err(_) => { return },
+  }
+  if first > 0 {
+    let second = match strconv.Atoi("2") {
+      Ok(n) => n,
+      Err(err) => {
+        fmt.Println(err)
+        return
+      },
+    }
+    fmt.Println(second)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_status_of_another_kind_is_not_redeclared() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn run(m: Map<string, int>) {
+  let parsed = match strconv.Atoi("1") {
+    Ok(n) => n,
+    Err(ok) => {
+      fmt.Println(ok)
+      return
+    },
+  }
+  let Some(v) = m.get("a") else { return }
+  fmt.Println(parsed, v)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
+    let input = r#"
+import "go:strconv"
+
+fn double(n: int) -> Result<int, error> { Ok(n * 2) }
+
+fn run() -> Result<int, error> {
+  let d = double(strconv.Atoi("1")?)?
+  Ok(d)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pairs_of_different_error_types_take_distinct_statuses() {
+    let input = r#"
+import "go:strconv"
+
+pub interface AppError {
+  fn Error() -> string
+  fn status() -> int
+}
+
+fn first() -> Result<int, AppError> { Ok(1) }
+
+fn run() -> Result<int, error> {
+  let a = first()?
+  let b = strconv.Atoi("2")?
+  Ok(a + b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}

--- a/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
+++ b/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
@@ -12,13 +12,13 @@ description: |
 package main
 
 func first(xs []int) int {
-	ret_1, ok_2 := func(s []int) ([3]int, bool) {
+	ret_1, ok := func(s []int) ([3]int, bool) {
 		if len(s) != 3 {
 			return [3]int{}, false
 		}
 		return ([3]int)(s), true
 	}(xs)
-	if ok_2 {
+	if ok {
 		a := ret_1
 		return a[0]
 	} else {

--- a/tests/spec/emit/snapshots/array_from_propagates_with_question_mark.snap
+++ b/tests/spec/emit/snapshots/array_from_propagates_with_question_mark.snap
@@ -10,15 +10,14 @@ description: |
 package main
 
 func first(xs []int) (int, bool) {
-	ret_1, ret_2 := func(s []int) ([3]int, bool) {
+	a, ok := func(s []int) ([3]int, bool) {
 		if len(s) != 3 {
 			return [3]int{}, false
 		}
 		return ([3]int)(s), true
 	}(xs)
-	if !ret_2 {
+	if !ok {
 		return 0, false
 	}
-	a := ret_1
 	return a[0], true
 }

--- a/tests/spec/emit/snapshots/assert_type_boundary_return_fuses.snap
+++ b/tests/spec/emit/snapshots/assert_type_boundary_return_fuses.snap
@@ -9,6 +9,6 @@ description: |
 package main
 
 func test(value any) (int, bool) {
-	ret_1, ok_2 := value.(int)
-	return ret_1, ok_2
+	ret_1, ok := value.(int)
+	return ret_1, ok
 }

--- a/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/auto_addressed_receiver_with_own_setup_pinned_before_effectful_arg.snap
@@ -47,18 +47,18 @@ func bump(i *int) (int, error) {
 
 func run() error {
 	i := 0
-	ret_1, ret_2 := seed()
-	if ret_2 != nil {
-		return ret_2
+	ret_1, err := seed()
+	if err != nil {
+		return err
 	}
-	ref_3 := &Cell{
+	ref_2 := &Cell{
 		a: ret_1,
 		b: i,
 	}
-	ret_4, ret_5 := bump(&i)
-	if ret_5 != nil {
-		return ret_5
+	ret_3, err_4 := bump(&i)
+	if err_4 != nil {
+		return err_4
 	}
-	Cell_add[int](ref_3, ret_4)
+	Cell_add[int](ref_2, ret_3)
 	return nil
 }

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -35,8 +35,8 @@ func (l Loader) Load(_ string) (int, error) {
 }
 
 func run(s svc.Alias) int {
-	ret_1, err_2 := s.Load("k")
-	if err_2 == nil {
+	ret_1, err := s.Load("k")
+	if err == nil {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/deref_map_value_method_call.snap
+++ b/tests/spec/emit/snapshots/deref_map_value_method_call.snap
@@ -26,8 +26,8 @@ func (c *Counter) increment() {
 }
 
 func test(m map[string]*Counter) {
-	c, ok_1 := m["a"]
-	if !ok_1 {
+	c, ok := m["a"]
+	if !ok {
 		return
 	}
 	c.increment()

--- a/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_after_setup_arg_no_capture.snap
@@ -27,9 +27,9 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	ret_1, ret_2 := getX()
-	if ret_2 != nil {
-		return 0, ret_2
+	ret_1, err := getX()
+	if err != nil {
+		return 0, err
 	}
 	return add(ret_1, side()), nil
 }

--- a/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
+++ b/tests/spec/emit/snapshots/emitted_expr_call_before_setup_arg_capture.snap
@@ -27,10 +27,10 @@ func add(_, _ int) int {
 }
 
 func run() (int, error) {
-	arg_3 := side()
-	ret_1, ret_2 := getY()
-	if ret_2 != nil {
-		return 0, ret_2
+	arg_2 := side()
+	ret_1, err := getY()
+	if err != nil {
+		return 0, err
 	}
-	return add(arg_3, ret_1), nil
+	return add(arg_2, ret_1), nil
 }

--- a/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
+++ b/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
@@ -48,18 +48,16 @@ func bail(flag bool) (int, error) {
 }
 
 func test() {
-	_, err_1 := bail(true)
-	if err_1 == nil {
+	if _, e := bail(true); e == nil {
 		panic("expected error")
 	} else {
-		e := err_1
 		if e.Error() != "a failed" {
 			panic("wrong literal error")
 		}
 	}
-	ret_2, err_3 := bail(false)
-	if err_3 == nil {
-		v := ret_2
+	ret_1, err := bail(false)
+	if err == nil {
+		v := ret_1
 		if v != 1 {
 			panic("wrong ok value")
 		}

--- a/tests/spec/emit/snapshots/format_string_concatenation_is_captured_before_later_argument_setup.snap
+++ b/tests/spec/emit/snapshots/format_string_concatenation_is_captured_before_later_argument_setup.snap
@@ -31,14 +31,14 @@ func show(a, b string) string {
 }
 
 func run() (string, error) {
-	ret_1, ret_2 := next("one")
-	if ret_2 != nil {
-		return "", ret_2
+	ret_1, err := next("one")
+	if err != nil {
+		return "", err
 	}
-	arg_5 := ret_1 + log("two")
-	ret_3, ret_4 := next("three")
-	if ret_4 != nil {
-		return "", ret_4
+	arg_4 := ret_1 + log("two")
+	ret_2, err_3 := next("three")
+	if err_3 != nil {
+		return "", err_3
 	}
-	return show(arg_5, ret_3), nil
+	return show(arg_4, ret_2), nil
 }

--- a/tests/spec/emit/snapshots/fused_bare_error_match_binds_unit_payload.snap
+++ b/tests/spec/emit/snapshots/fused_bare_error_match_binds_unit_payload.snap
@@ -20,12 +20,10 @@ import (
 )
 
 func test() {
-	err_1 := os.Remove("f")
-	if err_1 == nil {
+	if e := os.Remove("f"); e == nil {
 		x := struct{}{}
 		fmt.Println(x)
 	} else {
-		e := err_1
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
+++ b/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
@@ -22,15 +22,14 @@ import (
 )
 
 func test() {
-	ret_1, err_2 := net.Dial("tcp", "addr")
-	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
+	ret_1, e := net.Dial("tcp", "addr")
+	if e == nil && !lisette.IsNilInterface(ret_1) {
 		conn := ret_1
 		_ = conn
 	} else {
-		if err_2 == nil {
-			err_2 = errors.New("unexpected nil")
+		if e == nil {
+			e = errors.New("unexpected nil")
 		}
-		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
@@ -21,14 +21,13 @@ import (
 )
 
 func test() {
-	ret_1, err_2 := os.Create("f")
-	if err_2 == nil && ret_1 != nil {
+	ret_1, e := os.Create("f")
+	if e == nil && ret_1 != nil {
 		fmt.Println("made")
 	} else {
-		if err_2 == nil {
-			err_2 = errors.New("unexpected nil")
+		if e == nil {
+			e = errors.New("unexpected nil")
 		}
-		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_unused_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_unused_err.snap
@@ -24,8 +24,8 @@ import (
 )
 
 func test() {
-	file, err_1 := os.Create("f")
-	if err_1 != nil || file == nil {
+	file, err := os.Create("f")
+	if err != nil || file == nil {
 		fmt.Println("error")
 		return
 	}

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_used_err.snap
@@ -25,12 +25,11 @@ import (
 )
 
 func test() {
-	file, err_1 := os.Create("f")
-	if err_1 != nil || file == nil {
-		if err_1 == nil {
-			err_1 = errors.New("unexpected nil")
+	file, e := os.Create("f")
+	if e != nil || file == nil {
+		if e == nil {
+			e = errors.New("unexpected nil")
 		}
-		e := err_1
 		fmt.Println(e)
 		return
 	}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
@@ -19,8 +19,8 @@ import (
 )
 
 func test(name string) string {
-	ret_1, err_2 := os.Stat(name)
-	if err_2 != nil || lisette.IsNilInterface(ret_1) {
+	ret_1, err := os.Stat(name)
+	if err != nil || lisette.IsNilInterface(ret_1) {
 		return name
 	}
 	return "found"

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
@@ -16,8 +16,8 @@ package main
 import "os"
 
 func test(name string) bool {
-	ret_1, err_2 := os.Open(name)
-	if err_2 != nil || ret_1 == nil {
+	ret_1, err := os.Open(name)
+	if err != nil || ret_1 == nil {
 		return false
 	}
 	return true

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
@@ -21,12 +21,11 @@ import (
 )
 
 func test(name string) {
-	ret_1, err_2 := os.Stat(name)
-	if err_2 != nil || lisette.IsNilInterface(ret_1) {
-		if err_2 == nil {
-			err_2 = errors.New("unexpected nil")
+	ret_1, e := os.Stat(name)
+	if e != nil || lisette.IsNilInterface(ret_1) {
+		if e == nil {
+			e = errors.New("unexpected nil")
 		}
-		e := err_2
 		fmt.Println(e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
@@ -20,8 +20,8 @@ import (
 )
 
 func test(name string) {
-	ret_1, err_2 := os.Stat(name)
-	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
+	ret_1, err := os.Stat(name)
+	if err == nil && !lisette.IsNilInterface(ret_1) {
 		info := ret_1
 		fmt.Println(info.Name())
 	}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
@@ -22,8 +22,8 @@ import (
 )
 
 func test(name string) {
-	ret_1, err_2 := os.Stat(name)
-	if err_2 == nil && !lisette.IsNilInterface(ret_1) {
+	ret_1, err := os.Stat(name)
+	if err == nil && !lisette.IsNilInterface(ret_1) {
 		info := ret_1
 		fmt.Println(info.Name())
 	} else {

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
@@ -19,8 +19,8 @@ import (
 )
 
 func test(name string) bool {
-	ret_1, err_2 := os.Stat(name)
-	if err_2 != nil || lisette.IsNilInterface(ret_1) {
+	ret_1, err := os.Stat(name)
+	if err != nil || lisette.IsNilInterface(ret_1) {
 		return false
 	}
 	return true

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_interface_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_interface_return.snap
@@ -19,8 +19,8 @@ import (
 )
 
 func test(name string) bool {
-	info, err_1 := os.Stat(name)
-	if err_1 != nil || lisette.IsNilInterface(info) {
+	info, err := os.Stat(name)
+	if err != nil || lisette.IsNilInterface(info) {
 		return false
 	}
 	return info.IsDir()

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_pointer_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_pointer_return.snap
@@ -16,8 +16,8 @@ package main
 import "net/url"
 
 func test(raw string) string {
-	parsed, err_1 := url.Parse(raw)
-	if err_1 != nil || parsed == nil {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil {
 		return "bad"
 	}
 	return parsed.Scheme

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_shadows_outer_binding.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_shadows_outer_binding.snap
@@ -24,8 +24,8 @@ import (
 func test(text string) int {
 	parsed := "outer"
 	fmt.Println(parsed)
-	parsed_1, err_2 := strconv.Atoi(text)
-	if err_2 != nil {
+	parsed_1, err := strconv.Atoi(text)
+	if err != nil {
 		return -1
 	}
 	return parsed_1

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_without_nil_guard.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_without_nil_guard.snap
@@ -16,8 +16,8 @@ package main
 import "strconv"
 
 func test(text string) int {
-	parsed, err_1 := strconv.Atoi(text)
-	if err_1 != nil {
+	parsed, err := strconv.Atoi(text)
+	if err != nil {
 		return -1
 	}
 	return parsed

--- a/tests/spec/emit/snapshots/fused_lisette_result_let_else.snap
+++ b/tests/spec/emit/snapshots/fused_lisette_result_let_else.snap
@@ -27,8 +27,8 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() int {
-	x, err_1 := fallible(true)
-	if err_1 != nil {
+	x, err := fallible(true)
+	if err != nil {
 		return -1
 	}
 	return x

--- a/tests/spec/emit/snapshots/fused_pairs_take_distinct_status_names_in_one_block.snap
+++ b/tests/spec/emit/snapshots/fused_pairs_take_distinct_status_names_in_one_block.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:os"
+  import "go:strconv"
+  
+  fn run(path: string) -> Result<int, error> {
+    let text = os.ReadFile(path)?
+    let Ok(n) = strconv.Atoi(os.Getenv("N")) else { return Ok(text.length()) }
+    os.Remove(path)?
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+func run(path string) (int, error) {
+	text, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	n, err_1 := strconv.Atoi(os.Getenv("N"))
+	if err_1 != nil {
+		return len(text), nil
+	}
+	if err := os.Remove(path); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_go_write_call.snap
@@ -24,8 +24,8 @@ import (
 )
 
 func writeAll(file *os.File) {
-	ret_1, ret_2 := file.Write([]byte{'h', 'i'})
-	if ret_2 == nil {
+	ret_1, e := file.Write([]byte{'h', 'i'})
+	if e == nil {
 		n := ret_1
 		fmt.Println(n)
 	} else {

--- a/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
@@ -28,8 +28,8 @@ func attempt(ok bool) (int, error) {
 }
 
 func test() int {
-	ret_1, ret_2 := attempt(true)
-	if ret_2 == nil {
+	ret_1, err := attempt(true)
+	if err == nil {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
@@ -27,8 +27,8 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	ret_1, err_2 := fallible(true)
-	if err_2 == nil {
+	ret_1, err := fallible(true)
+	if err == nil {
 		x := ret_1
 		_ = x
 	}

--- a/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_unused_named_payload.snap
@@ -27,9 +27,7 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	_, err_1 := fallible(true)
-	if err_1 != nil {
-		e := err_1
+	if _, e := fallible(true); e != nil {
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_ok_wildcard.snap
@@ -27,9 +27,7 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	_, err_1 := fallible(true)
-	if err_1 != nil {
-		e := err_1
+	if _, e := fallible(true); e != nil {
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/fused_selective_partial_both_omits_unused_named_value.snap
+++ b/tests/spec/emit/snapshots/fused_selective_partial_both_omits_unused_named_value.snap
@@ -16,9 +16,7 @@ package main
 import "os"
 
 func write(file *os.File) error {
-	_, err_2 := file.Write([]byte{'h', 'i'})
-	if err_2 != nil {
-		err := err_2
+	if _, err := file.Write([]byte{'h', 'i'}); err != nil {
 		return err
 	}
 	return nil

--- a/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
+++ b/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
@@ -20,9 +20,8 @@ import (
 )
 
 func main() {
-	ret_1, err_2 := aws.Read()
-	if err_2 != nil && ret_1 == nil {
-		e := err_2
+	ret_1, e := aws.Read()
+	if e != nil && ret_1 == nil {
 		fmt.Println("err", e)
 	}
 }

--- a/tests/spec/emit/snapshots/fused_status_avoids_a_live_err_binding.snap
+++ b/tests/spec/emit/snapshots/fused_status_avoids_a_live_err_binding.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:errors"
+  import "go:strconv"
+  
+  fn run() -> Result<int, error> {
+    let err = errors.New("outer")
+    let n = strconv.Atoi("1")?
+    if n == 0 { return Err(err) }
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"errors"
+	"strconv"
+)
+
+func run() (int, error) {
+	err := errors.New("outer")
+	n, err_1 := strconv.Atoi("1")
+	if err_1 != nil {
+		return 0, err_1
+	}
+	if n == 0 {
+		return 0, err
+	}
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/fused_status_of_another_kind_is_not_redeclared.snap
+++ b/tests/spec/emit/snapshots/fused_status_of_another_kind_is_not_redeclared.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn run(m: Map<string, int>) {
+    let parsed = match strconv.Atoi("1") {
+      Ok(n) => n,
+      Err(ok) => {
+        fmt.Println(ok)
+        return
+      },
+    }
+    let Some(v) = m.get("a") else { return }
+    fmt.Println(parsed, v)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func run(m map[string]int) {
+	parsed, ok := strconv.Atoi("1")
+	if ok != nil {
+		fmt.Println(ok)
+		return
+	}
+	v, ok_1 := m["a"]
+	if !ok_1 {
+		return
+	}
+	fmt.Println(parsed, v)
+}

--- a/tests/spec/emit/snapshots/fused_status_only_call_opens_the_if_initializer.snap
+++ b/tests/spec/emit/snapshots/fused_status_only_call_opens_the_if_initializer.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    if let Err(err) = os.Remove("a") {
+      fmt.Println(err)
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := os.Remove("a"); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_status_shadows_err_inside_a_nested_block.snap
+++ b/tests/spec/emit/snapshots/fused_status_shadows_err_inside_a_nested_block.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let first = match strconv.Atoi("1") {
+      Ok(n) => n,
+      Err(_) => { return },
+    }
+    if first > 0 {
+      let second = match strconv.Atoi("2") {
+        Ok(n) => n,
+        Err(err) => {
+          fmt.Println(err)
+          return
+        },
+      }
+      fmt.Println(second)
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	first, err := strconv.Atoi("1")
+	if err != nil {
+		return
+	}
+	if first > 0 {
+		second, err := strconv.Atoi("2")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		fmt.Println(second)
+	}
+}

--- a/tests/spec/emit/snapshots/fused_status_takes_the_err_arm_name.snap
+++ b/tests/spec/emit/snapshots/fused_status_takes_the_err_arm_name.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    match strconv.Atoi("1") {
+      Ok(n) => fmt.Println(n),
+      Err(failure) => fmt.Println(failure),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	ret_1, failure := strconv.Atoi("1")
+	if failure == nil {
+		n := ret_1
+		fmt.Println(n)
+	} else {
+		fmt.Println(failure)
+	}
+}

--- a/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
+++ b/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
@@ -25,8 +25,8 @@ import (
 )
 
 func parseWith(f func(string) (int, error), s string) int {
-	ret_1, err_2 := f(s)
-	if err_2 == nil {
+	ret_1, err := f(s)
+	if err == nil {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
+++ b/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
@@ -18,8 +18,8 @@ import "container/ring"
 
 func test() int {
 	r := ring.Ring{Value: 1}
-	ret_1, ok_2 := r.Value.(int)
-	if ok_2 {
+	ret_1, ok := r.Value.(int)
+	if ok {
 		n := ret_1
 		return n
 	} else {

--- a/tests/spec/emit/snapshots/if_let_none_on_comma_ok_call.snap
+++ b/tests/spec/emit/snapshots/if_let_none_on_comma_ok_call.snap
@@ -26,8 +26,7 @@ func divide(a, b int) (int, bool) {
 }
 
 func test() {
-	_, ok_1 := divide(100, 0)
-	if !ok_1 {
+	if _, ok := divide(100, 0); !ok {
 		fmt.Print("division by zero\n")
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_without_else_branch.snap
@@ -26,8 +26,8 @@ func divide(a, b int) (int, bool) {
 }
 
 func test() {
-	ret_1, ok_2 := divide(100, 10)
-	if ok_2 {
+	ret_1, ok := divide(100, 10)
+	if ok {
 		x := ret_1
 		fmt.Printf("Result: %d\n", x)
 	}

--- a/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
@@ -21,8 +21,8 @@ package main
 import "os"
 
 func apply(f func(string) (string, bool), key string) string {
-	ret_1, ok_2 := f(key)
-	if ok_2 {
+	ret_1, ok := f(key)
+	if ok {
 		v := ret_1
 		return v
 	} else {

--- a/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
@@ -16,8 +16,8 @@ package main
 import "example.com/reg"
 
 func main() {
-	ret_1, ok_2 := reg.Lookup("a")
-	if ok_2 && ret_1 != nil {
+	ret_1, ok := reg.Lookup("a")
+	if ok && ret_1 != nil {
 		m := ret_1
 		_ = len(m)
 	}

--- a/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
@@ -16,8 +16,8 @@ package main
 import "os"
 
 func main() {
-	ret_1, ok_2 := os.LookupEnv("HOME")
-	if ok_2 {
+	ret_1, ok := os.LookupEnv("HOME")
+	if ok {
 		v := ret_1
 		_ = v
 	}

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
@@ -27,23 +27,22 @@ import (
 
 func lookup(k string) (string, bool) {
 	tryResult_1 := func() lisette.Option[string] {
-		ret_2, ret_3 := os.LookupEnv(k)
-		if !ret_3 {
+		v, ok := os.LookupEnv(k)
+		if !ok {
 			return lisette.MakeOptionNone[string]()
 		}
-		v := ret_2
 		return lisette.MakeOptionSome[string](v)
 	}()
-	v_4 := tryResult_1
-	if v_4.Tag == lisette.OptionSome {
-		return v_4.SomeVal, true
+	v_2 := tryResult_1
+	if v_2.Tag == lisette.OptionSome {
+		return v_2.SomeVal, true
 	}
 	return "", false
 }
 
 func main() {
-	ret_1, ok_2 := lookup("HOME")
-	if ok_2 {
+	ret_1, ok := lookup("HOME")
+	if ok {
 		v := ret_1
 		_ = v
 	}

--- a/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
@@ -39,16 +39,14 @@ func main() {
 		}
 		return wrapped_4, ret_3
 	}
-	ret_7, ret_8 := f()
-	if ret_8 == nil {
+	ret_7, e := f()
+	if e == nil {
 		xs := ret_7
 		fmt.Println("ok", len(xs))
 	} else if ret_7 == nil {
-		e := ret_8
 		fmt.Println("err", e)
 	} else {
 		xs := ret_7
-		e := ret_8
 		fmt.Println("both", len(xs), e)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
@@ -42,8 +42,8 @@ func main() {
 		}
 		return wrapped_4, ret_3
 	}
-	ret_7, err_8 := f()
-	if err_8 == nil {
+	ret_7, e := f()
+	if e == nil {
 		xs := ret_7
 		for _, x := range xs {
 			if x.Tag == lisette.OptionSome {
@@ -53,7 +53,6 @@ func main() {
 			}
 		}
 	} else {
-		e := err_8
 		_ = e
 	}
 }

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
@@ -53,34 +53,29 @@ func root(t *template.Template) (*parse.ListNode, error) {
 
 func main() {
 	t := template.New("greeting")
-	ret_1, err_2 := t.Parse("hello {{.}}")
-	if err_2 == nil && ret_1 != nil {
+	ret_1, e := t.Parse("hello {{.}}")
+	if e == nil && ret_1 != nil {
 		parsed := ret_1
-		_, err_3 := root(parsed)
-		if err_3 == nil {
+		if _, e := root(parsed); e == nil {
 			fmt.Println("root is available")
 		} else {
-			e := err_3
 			fmt.Println("error", e)
 		}
-		opt_4 := lisette.MakeOptionNone[*parse.ListNode]()
-		var unwrap_5 *parse.ListNode
-		if opt_4.Tag == lisette.OptionSome {
-			unwrap_5 = opt_4.SomeVal
+		opt_2 := lisette.MakeOptionNone[*parse.ListNode]()
+		var unwrap_3 *parse.ListNode
+		if opt_2.Tag == lisette.OptionSome {
+			unwrap_3 = opt_2.SomeVal
 		}
-		parsed.Root = unwrap_5
-		_, err_6 := root(parsed)
-		if err_6 == nil {
+		parsed.Root = unwrap_3
+		if _, e := root(parsed); e == nil {
 			fmt.Println("root is available")
 		} else {
-			e := err_6
 			fmt.Println("error", e)
 		}
 	} else {
-		if err_2 == nil {
-			err_2 = errors.New("unexpected nil")
+		if e == nil {
+			e = errors.New("unexpected nil")
 		}
-		e := err_2
 		fmt.Println("parse failed", e)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_propagate_slice_option_return.snap
@@ -29,19 +29,19 @@ import (
 )
 
 func run() error {
-	ret_1, ret_2 := aws.Make()
-	if ret_2 != nil {
-		return ret_2
+	ret_1, err := aws.Make()
+	if err != nil {
+		return err
 	}
-	wrapped_3 := make([]lisette.Option[string], len(ret_1))
-	for i_4, v_5 := range ret_1 {
-		if v_5 != nil {
-			wrapped_3[i_4] = lisette.MakeOptionSome[string](*v_5)
+	wrapped_2 := make([]lisette.Option[string], len(ret_1))
+	for i_3, v_4 := range ret_1 {
+		if v_4 != nil {
+			wrapped_2[i_3] = lisette.MakeOptionSome[string](*v_4)
 		} else {
-			wrapped_3[i_4] = lisette.MakeOptionNone[string]()
+			wrapped_2[i_3] = lisette.MakeOptionNone[string]()
 		}
 	}
-	xs := wrapped_3
+	xs := wrapped_2
 	for _, x := range xs {
 		if x.Tag == lisette.OptionSome {
 			fmt.Println(x.SomeVal)

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -16,8 +16,8 @@ package main
 import "example.com/legacy"
 
 func main() {
-	ret_1, err_2 := legacy.Close()
-	if err_2 == nil {
+	ret_1, err := legacy.Close()
+	if err == nil {
 		stored := ret_1
 		_ = stored
 	}

--- a/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_result_map_field_assignment.snap
@@ -35,23 +35,23 @@ type Holder struct {
 func main() {
 	m := make(map[string]Holder)
 	m["a"] = Holder{f: strconv.Atoi}
-	found, ok_1 := m["a"]
-	if !ok_1 {
+	found, ok := m["a"]
+	if !ok {
 		return
 	}
 	entry := found
 	entry.f = strconv.Atoi
 	m["a"] = entry
-	h, ok_2 := m["a"]
-	if !ok_2 {
+	h, ok_1 := m["a"]
+	if !ok_1 {
 		return
 	}
-	ret_3, ret_4 := h.f("1")
+	ret_2, ret_3 := h.f("1")
 	var r lisette.Result[int, error]
-	if ret_4 != nil {
-		r = lisette.MakeResultErr[int, error](ret_4)
+	if ret_3 != nil {
+		r = lisette.MakeResultErr[int, error](ret_3)
 	} else {
-		r = lisette.MakeResultOk[int, error](ret_3)
+		r = lisette.MakeResultOk[int, error](ret_2)
 	}
 	if r.Tag == lisette.ResultOk {
 		_ = r.OkVal

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -28,28 +28,26 @@ import (
 
 func sumParsed(a, b string) (int, error) {
 	tryResult_1 := func() lisette.Result[int, error] {
-		ret_2, ret_3 := strconv.Atoi(a)
-		if ret_3 != nil {
-			return lisette.MakeResultErr[int, error](ret_3)
+		x, err := strconv.Atoi(a)
+		if err != nil {
+			return lisette.MakeResultErr[int, error](err)
 		}
-		x := ret_2
-		ret_4, ret_5 := strconv.Atoi(b)
-		if ret_5 != nil {
-			return lisette.MakeResultErr[int, error](ret_5)
+		y, err_2 := strconv.Atoi(b)
+		if err_2 != nil {
+			return lisette.MakeResultErr[int, error](err_2)
 		}
-		y := ret_4
 		return lisette.MakeResultOk[int, error](x + y)
 	}()
-	v_6 := tryResult_1
-	if v_6.Tag == lisette.ResultOk {
-		return v_6.OkVal, nil
+	v_3 := tryResult_1
+	if v_3.Tag == lisette.ResultOk {
+		return v_3.OkVal, nil
 	}
-	return 0, v_6.ErrVal
+	return 0, v_3.ErrVal
 }
 
 func main() {
-	ret_1, err_2 := sumParsed("3", "4")
-	if err_2 == nil {
+	ret_1, err := sumParsed("3", "4")
+	if err == nil {
 		n := ret_1
 		_ = n
 	}

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -31,37 +31,36 @@ import (
 
 func openAndCheck(path, n string) (int, error) {
 	tryResult_1 := func() lisette.Result[int, error] {
-		ret_2, ret_3 := os.Open(path)
-		if ret_3 != nil {
-			return lisette.MakeResultErr[int, error](ret_3)
+		f, err := os.Open(path)
+		if err != nil {
+			return lisette.MakeResultErr[int, error](err)
 		}
-		if ret_2 == nil {
+		if f == nil {
 			return lisette.MakeResultErr[int, error](errors.New("unexpected nil"))
 		}
-		f := ret_2
-		ret_4, ret_5 := f.Stat()
-		if ret_5 != nil {
-			return lisette.MakeResultErr[int, error](ret_5)
+		ret_2, err_3 := f.Stat()
+		if err_3 != nil {
+			return lisette.MakeResultErr[int, error](err_3)
 		}
-		if lisette.IsNilInterface(ret_4) {
+		if lisette.IsNilInterface(ret_2) {
 			return lisette.MakeResultErr[int, error](errors.New("unexpected nil"))
 		}
-		ret_6, ret_7 := strconv.Atoi(n)
-		if ret_7 != nil {
-			return lisette.MakeResultErr[int, error](ret_7)
+		ret_4, err_5 := strconv.Atoi(n)
+		if err_5 != nil {
+			return lisette.MakeResultErr[int, error](err_5)
 		}
-		return lisette.MakeResultOk[int, error](ret_6)
+		return lisette.MakeResultOk[int, error](ret_4)
 	}()
-	v_8 := tryResult_1
-	if v_8.Tag == lisette.ResultOk {
-		return v_8.OkVal, nil
+	v_6 := tryResult_1
+	if v_6.Tag == lisette.ResultOk {
+		return v_6.OkVal, nil
 	}
-	return 0, v_8.ErrVal
+	return 0, v_6.ErrVal
 }
 
 func main() {
-	ret_1, err_2 := openAndCheck("/tmp/x", "7")
-	if err_2 == nil {
+	ret_1, err := openAndCheck("/tmp/x", "7")
+	if err == nil {
 		v := ret_1
 		_ = v
 	}

--- a/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
@@ -21,8 +21,8 @@ package main
 import "example.com/idx"
 
 func apply(f func(string, string) (int, bool), s string) int {
-	ret_1, ok_2 := f(s, "ll")
-	if ok_2 {
+	ret_1, ok := f(s, "ll")
+	if ok {
 		v := ret_1
 		return v
 	} else {

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
@@ -28,8 +28,8 @@ func identity(value int) int {
 }
 
 func describe(value any) string {
-	ret_1, ok_2 := value.(string)
-	if ok_2 {
+	ret_1, ok := value.(string)
+	if ok {
 		text := ret_1
 		return text
 	} else {

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -36,8 +36,8 @@ func fallible() (int, error) {
 }
 
 func describe(value any) string {
-	ret_1, ok_2 := value.(string)
-	if ok_2 {
+	ret_1, ok := value.(string)
+	if ok {
 		text := ret_1
 		return text
 	} else {
@@ -47,9 +47,9 @@ func describe(value any) string {
 
 func run() (string, error) {
 	var value any
-	ret_1, ret_2 := fallible()
-	if ret_2 != nil {
-		return "", ret_2
+	ret_1, err := fallible()
+	if err != nil {
+		return "", err
 	}
 	value = ret_1
 	value = "two"
@@ -58,8 +58,8 @@ func run() (string, error) {
 
 func test() {
 	var text_1 string
-	ret_2, err_3 := run()
-	if err_3 == nil {
+	ret_2, err := run()
+	if err == nil {
 		text := ret_2
 		text_1 = text
 	} else {

--- a/tests/spec/emit/snapshots/let_else_option_direct_call.snap
+++ b/tests/spec/emit/snapshots/let_else_option_direct_call.snap
@@ -21,8 +21,8 @@ func getValue(s string) (int, bool) {
 }
 
 func test() int {
-	x, ok_1 := getValue("ok")
-	if !ok_1 {
+	x, ok := getValue("ok")
+	if !ok {
 		return 0
 	}
 	return x

--- a/tests/spec/emit/snapshots/let_fused_go_result_match_binds_call_slot.snap
+++ b/tests/spec/emit/snapshots/let_fused_go_result_match_binds_call_slot.snap
@@ -24,8 +24,8 @@ import (
 )
 
 func test(name string) {
-	file, err_1 := os.Open(name)
-	if err_1 != nil || file == nil {
+	file, err := os.Open(name)
+	if err != nil || file == nil {
 		fmt.Println("cannot open")
 		return
 	}

--- a/tests/spec/emit/snapshots/let_fused_go_result_match_binds_interface_call_slot.snap
+++ b/tests/spec/emit/snapshots/let_fused_go_result_match_binds_interface_call_slot.snap
@@ -25,8 +25,8 @@ import (
 )
 
 func test(addr string) {
-	conn, err_1 := net.Dial("tcp", addr)
-	if err_1 != nil || lisette.IsNilInterface(conn) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil || lisette.IsNilInterface(conn) {
 		fmt.Println("cannot dial")
 		return
 	}

--- a/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
@@ -25,8 +25,8 @@ import (
 
 func test(name string) {
 	var label string
-	ret_1, err_2 := os.Open(name)
-	if err_2 == nil && ret_1 != nil {
+	ret_1, err := os.Open(name)
+	if err == nil && ret_1 != nil {
 		f := ret_1
 		label = f.Name()
 	} else {

--- a/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
@@ -18,8 +18,8 @@ import "strconv"
 
 func test(text string) int {
 	var parsed int
-	ret_1, err_2 := strconv.Atoi(text)
-	if err_2 == nil {
+	ret_1, err := strconv.Atoi(text)
+	if err == nil {
 		n := ret_1
 		parsed = n
 	} else {

--- a/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
@@ -29,8 +29,8 @@ func identity(value int) int {
 }
 
 func describe(value any) string {
-	ret_1, ok_2 := value.(string)
-	if ok_2 {
+	ret_1, ok := value.(string)
+	if ok {
 		text := ret_1
 		return text
 	} else {

--- a/tests/spec/emit/snapshots/local_callable_shadow_does_not_inherit_global_abi.snap
+++ b/tests/spec/emit/snapshots/local_callable_shadow_does_not_inherit_global_abi.snap
@@ -17,9 +17,9 @@ func apply(x int) (int, error) {
 }
 
 func main() {
-	apply := func(x int) int {
+	apply_1 := func(x int) int {
 		return x + 1
 	}
-	value := apply(1)
+	value := apply_1(1)
 	_ = value
 }

--- a/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
+++ b/tests/spec/emit/snapshots/loop_label_for_break_in_let_else_inside_match.snap
@@ -39,8 +39,8 @@ func test() int {
 			break
 		}
 		if count == 1 {
-			v, ok_1 := maybe(true)
-			if !ok_1 {
+			v, ok := maybe(true)
+			if !ok {
 				break
 			}
 			_ = v

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -23,11 +23,11 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	o, ok_1 := m["a"]
-	if !ok_1 {
+	o, ok := m["a"]
+	if !ok {
 		return
 	}
-	ref_2 := o.items
-	*ref_2 = append(*o.items, 2)
+	ref_1 := o.items
+	*ref_1 = append(*o.items, 2)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append_expr_position.snap
@@ -23,13 +23,13 @@ func main() {
 	items := []int{1}
 	m := make(map[string]Outer)
 	m["a"] = Outer{items: &items}
-	o, ok_1 := m["a"]
-	if !ok_1 {
+	o, ok := m["a"]
+	if !ok {
 		return
 	}
-	var tmp_2 []int
-	recv_3 := *o.items
-	tmp_2 = append(recv_3[:len(recv_3):len(recv_3)], 2)
-	_ = tmp_2
+	var tmp_1 []int
+	recv_2 := *o.items
+	tmp_1 = append(recv_2[:len(recv_2):len(recv_2)], 2)
+	_ = tmp_1
 	_ = items
 }

--- a/tests/spec/emit/snapshots/map_get.snap
+++ b/tests/spec/emit/snapshots/map_get.snap
@@ -9,6 +9,6 @@ description: |
 package main
 
 func test(m map[string]int, key string) (int, bool) {
-	ret_1, ok_2 := m[key]
-	return ret_1, ok_2
+	ret_1, ok := m[key]
+	return ret_1, ok
 }

--- a/tests/spec/emit/snapshots/map_get_let_else_reserved_name_binding.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_reserved_name_binding.snap
@@ -16,8 +16,8 @@ package main
 func test(m map[string]int) int {
 	len_ := 3
 	_ = len_ + 1
-	len_1, ok_2 := m["a"]
-	if !ok_2 {
+	len_1, ok := m["a"]
+	if !ok {
 		return 0
 	}
 	return len_1

--- a/tests/spec/emit/snapshots/map_get_let_else_shadow_outer_visible_in_else.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_shadow_outer_visible_in_else.snap
@@ -15,8 +15,8 @@ description: |
 package main
 
 func test(m map[string]string, x int) string {
-	x_1, ok_2 := m["a"]
-	if !ok_2 {
+	x_1, ok := m["a"]
+	if !ok {
 		if x > 0 {
 			return "positive"
 		}

--- a/tests/spec/emit/snapshots/map_get_let_else_shadowed_binding_freshens.snap
+++ b/tests/spec/emit/snapshots/map_get_let_else_shadowed_binding_freshens.snap
@@ -14,8 +14,8 @@ package main
 
 func test(m map[string]string, v int) string {
 	_ = v + 1
-	v_1, ok_2 := m["a"]
-	if !ok_2 {
+	v_1, ok := m["a"]
+	if !ok {
 		return ""
 	}
 	return v_1

--- a/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
@@ -16,8 +16,8 @@ package main
 import "fmt"
 
 func test(m map[string]int, key string) int {
-	ret_1, ok_2 := m[key]
-	if ok_2 {
+	ret_1, ok := m[key]
+	if ok {
 		v := ret_1
 		return v
 	} else {

--- a/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_field_assign.snap
@@ -21,8 +21,8 @@ func main() {
 	w := Wrap(1)
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	r, ok_1 := m["a"]
-	if !ok_1 {
+	r, ok := m["a"]
+	if !ok {
 		return
 	}
 	*r = Wrap(2)

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_append.snap
@@ -35,8 +35,8 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	o, ok_1 := m["a"]
-	if !ok_1 {
+	o, ok := m["a"]
+	if !ok {
 		return
 	}
 	inner := Inner{items: slices.Clone(Inner(*o.w).items)}

--- a/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_mid_chain_field_assign.snap
@@ -33,8 +33,8 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]Outer)
 	m["a"] = Outer{w: &w}
-	o, ok_1 := m["a"]
-	if !ok_1 {
+	o, ok := m["a"]
+	if !ok {
 		return
 	}
 	inner := Inner(*o.w)

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_append.snap
@@ -30,8 +30,8 @@ func main() {
 	w := Wrap(Inner{items: []int{1}})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	r, ok_1 := m["a"]
-	if !ok_1 {
+	r, ok := m["a"]
+	if !ok {
 		return
 	}
 	inner := Inner{items: slices.Clone(Inner(*r).items)}

--- a/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_nested_field_assign.snap
@@ -28,8 +28,8 @@ func main() {
 	w := Wrap(Inner{x: 0})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	r, ok_1 := m["a"]
-	if !ok_1 {
+	r, ok := m["a"]
+	if !ok {
 		return
 	}
 	inner := Inner(*r)

--- a/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_ref_newtype_slice_append.snap
@@ -21,12 +21,12 @@ func main() {
 	w := Wrap([]int{1})
 	m := make(map[string]*Wrap)
 	m["a"] = &w
-	r, ok_1 := m["a"]
-	if !ok_1 {
+	r, ok := m["a"]
+	if !ok {
 		return
 	}
-	ref_3 := r
-	recv_2 := ([]int)(*r)
-	*ref_3 = Wrap(append(recv_2[:len(recv_2):len(recv_2)], 2))
+	ref_2 := r
+	recv_1 := ([]int)(*r)
+	*ref_2 = Wrap(append(recv_1[:len(recv_1):len(recv_1)], 2))
 	_ = w
 }

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -30,8 +30,8 @@ func safeDivide(a, b float64) (float64, bool) {
 
 func parseAndDivide(a, b float64) lisette.Result[string, string] {
 	var result float64
-	ret_1, ok_2 := safeDivide(a, b)
-	if ok_2 {
+	ret_1, ok := safeDivide(a, b)
+	if ok {
 		v := ret_1
 		result = v
 	} else {

--- a/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
+++ b/tests/spec/emit/snapshots/match_statement_option_unit_arms.snap
@@ -27,8 +27,7 @@ func maybe(b bool) (int, bool) {
 }
 
 func test() {
-	_, ok_1 := maybe(true)
-	if ok_1 {
+	if _, ok := maybe(true); ok {
 		noop()
 	} else {
 		noop()

--- a/tests/spec/emit/snapshots/nested_propagate_in_call_args_binds_the_inner_pair_first.snap
+++ b/tests/spec/emit/snapshots/nested_propagate_in_call_args_binds_the_inner_pair_first.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn double(n: int) -> Result<int, error> { Ok(n * 2) }
+  
+  fn run() -> Result<int, error> {
+    let d = double(strconv.Atoi("1")?)?
+    Ok(d)
+  }
+---
+package main
+
+import "strconv"
+
+func double(n int) (int, error) {
+	return n * 2, nil
+}
+
+func run() (int, error) {
+	ret_1, err := strconv.Atoi("1")
+	if err != nil {
+		return 0, err
+	}
+	d, err_2 := double(ret_1)
+	if err_2 != nil {
+		return 0, err_2
+	}
+	return d, nil
+}

--- a/tests/spec/emit/snapshots/pairs_of_different_error_types_take_distinct_statuses.snap
+++ b/tests/spec/emit/snapshots/pairs_of_different_error_types_take_distinct_statuses.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  pub interface AppError {
+    fn Error() -> string
+    fn status() -> int
+  }
+  
+  fn first() -> Result<int, AppError> { Ok(1) }
+  
+  fn run() -> Result<int, error> {
+    let a = first()?
+    let b = strconv.Atoi("2")?
+    Ok(a + b)
+  }
+---
+package main
+
+import "strconv"
+
+type AppError interface {
+	Error() string
+	Status() int
+}
+
+func first() (int, AppError) {
+	return 1, nil
+}
+
+func run() (int, error) {
+	a, err := first()
+	if err != nil {
+		return 0, err
+	}
+	b, err_1 := strconv.Atoi("2")
+	if err_1 != nil {
+		return 0, err_1
+	}
+	return a + b, nil
+}

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_keeps_nil_guard.snap
@@ -17,9 +17,9 @@ import (
 )
 
 func openFirst(path string) (int, error) {
-	ret_1, ret_2 := os.Open(path)
-	if ret_2 != nil {
-		return 0, ret_2
+	ret_1, err := os.Open(path)
+	if err != nil {
+		return 0, err
 	}
 	if ret_1 == nil {
 		return 0, errors.New("unexpected nil")

--- a/tests/spec/emit/snapshots/propagate_go_pointer_result_returns_value_fuses.snap
+++ b/tests/spec/emit/snapshots/propagate_go_pointer_result_returns_value_fuses.snap
@@ -17,13 +17,12 @@ import (
 )
 
 func open(path string) (*os.File, error) {
-	ret_1, ret_2 := os.Open(path)
-	if ret_2 != nil {
-		return nil, ret_2
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
 	}
-	if ret_1 == nil {
+	if file == nil {
 		return nil, errors.New("unexpected nil")
 	}
-	file := ret_1
 	return file, nil
 }

--- a/tests/spec/emit/snapshots/propagate_option_in_function.snap
+++ b/tests/spec/emit/snapshots/propagate_option_in_function.snap
@@ -18,10 +18,9 @@ func maybeGet() (int, bool) {
 }
 
 func process() (int, bool) {
-	ret_1, ret_2 := maybeGet()
-	if !ret_2 {
+	x, ok := maybeGet()
+	if !ok {
 		return 0, false
 	}
-	x := ret_1
 	return x + 1, true
 }

--- a/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
+++ b/tests/spec/emit/snapshots/propagate_rebind_uses_old_binding_in_rhs.snap
@@ -27,10 +27,9 @@ func parse(s string) (int, error) {
 
 func process() (int, error) {
 	x := 42
-	ret_2, ret_3 := parse(fmt.Sprint(x))
-	if ret_3 != nil {
-		return 0, ret_3
+	x_1, err := parse(fmt.Sprint(x))
+	if err != nil {
+		return 0, err
 	}
-	x_1 := ret_2
 	return x_1 + 1, nil
 }

--- a/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
+++ b/tests/spec/emit/snapshots/propagate_unused_binding_option.snap
@@ -16,8 +16,7 @@ func maybe() (int, bool) {
 }
 
 func test() (struct{}, bool) {
-	_, ret_1 := maybe()
-	if !ret_1 {
+	if _, ok := maybe(); !ok {
 		return struct{}{}, false
 	}
 	return struct{}{}, true

--- a/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
@@ -66,18 +66,16 @@ func load(name string) (string, error) {
 }
 
 func test() {
-	_, err_1 := load("")
-	if err_1 == nil {
+	if _, e := load(""); e == nil {
 		panic("expected error")
 	} else {
-		e := err_1
 		if e.Error() != "name: required" {
 			panic("wrong widened error")
 		}
 	}
-	ret_2, err_3 := load("ada")
-	if err_3 == nil {
-		v := ret_2
+	ret_1, err := load("ada")
+	if err == nil {
+		v := ret_1
 		if v != "ada" {
 			panic("wrong ok value")
 		}

--- a/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_error_slot_through_adapter.snap
@@ -67,14 +67,12 @@ func widen() (int, Failing[lisette.Result[int, error]]) {
 }
 
 func main() {
-	_, err_1 := widen()
-	if err_1 == nil {
+	if _, f := widen(); f == nil {
 		panic("expected error")
 	} else {
-		f := err_1
-		subject_2 := f.get()
-		if subject_2.Tag == lisette.ResultOk {
-			if subject_2.OkVal != 1 {
+		subject_1 := f.get()
+		if subject_1.Tag == lisette.ResultOk {
+			if subject_1.OkVal != 1 {
 				panic("wrong adapted value")
 			}
 		} else {

--- a/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_ref_with_pointer_receiver_error_method.snap
@@ -41,20 +41,17 @@ func readValue() (int, *FileError) {
 }
 
 func load() (int, error) {
-	ret_1, ret_2 := readValue()
-	if ret_2 != nil {
-		return 0, ret_2
+	n, err := readValue()
+	if err != nil {
+		return 0, err
 	}
-	n := ret_1
 	return n, nil
 }
 
 func test() {
-	_, err_1 := load()
-	if err_1 == nil {
+	if _, e := load(); e == nil {
 		panic("expected error")
 	} else {
-		e := err_1
 		if e.Error() != "cannot open a.txt" {
 			panic("wrong ref error")
 		}

--- a/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
@@ -78,18 +78,16 @@ func handler(ok bool) (int, AppError) {
 }
 
 func test() {
-	_, err_1 := handler(false)
-	if err_1 == nil {
+	if _, e := handler(false); e == nil {
 		panic("expected error")
 	} else {
-		e := err_1
 		if e.Status() != 500 || e.Error() != "db down" {
 			panic("wrong app error")
 		}
 	}
-	ret_2, err_3 := handler(true)
-	if err_3 == nil {
-		n := ret_2
+	ret_1, err := handler(true)
+	if err == nil {
+		n := ret_1
 		if n != 3 {
 			panic("wrong ok length")
 		}

--- a/tests/spec/emit/snapshots/propagates_call_returning_option_alias.snap
+++ b/tests/spec/emit/snapshots/propagates_call_returning_option_alias.snap
@@ -24,10 +24,9 @@ func source() (int, bool) {
 }
 
 func consume() (int, bool) {
-	ret_1, ret_2 := source()
-	if !ret_2 {
+	n, ok := source()
+	if !ok {
 		return 0, false
 	}
-	n := ret_1
 	return n + 1, true
 }

--- a/tests/spec/emit/snapshots/propagates_call_returning_result_alias.snap
+++ b/tests/spec/emit/snapshots/propagates_call_returning_result_alias.snap
@@ -24,10 +24,9 @@ func source() (int, error) {
 }
 
 func consume() (int, error) {
-	ret_1, ret_2 := source()
-	if ret_2 != nil {
-		return 0, ret_2
+	n, err := source()
+	if err != nil {
+		return 0, err
 	}
-	n := ret_1
 	return n + 1, nil
 }

--- a/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_concrete_error.snap
@@ -36,11 +36,9 @@ func bail() (int, error) {
 }
 
 func test() {
-	_, err_1 := bail()
-	if err_1 == nil {
+	if _, e := bail(); e == nil {
 		panic("expected error")
 	} else {
-		e := err_1
 		if e.Error() != "a failed" {
 			panic("wrong returned error")
 		}

--- a/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
+++ b/tests/spec/emit/snapshots/return_err_widens_error_slot_through_adapter.snap
@@ -44,8 +44,7 @@ func bail() (int, Failing[lisette.Result[int, error]]) {
 }
 
 func main() {
-	_, err_1 := bail()
-	if err_1 == nil {
+	if _, err := bail(); err == nil {
 		panic("expected error")
 	}
 }

--- a/tests/spec/emit/snapshots/selective_partial_ok_unused_name_does_not_bind_nilable_value.snap
+++ b/tests/spec/emit/snapshots/selective_partial_ok_unused_name_does_not_bind_nilable_value.snap
@@ -19,8 +19,7 @@ import (
 )
 
 func main() {
-	_, err_2 := os.ReadDir(".")
-	if err_2 == nil {
+	if _, err := os.ReadDir("."); err == nil {
 		fmt.Println("ok")
 	}
 }

--- a/tests/spec/emit/snapshots/selective_partial_ok_wildcard_does_not_bind_nilable_value.snap
+++ b/tests/spec/emit/snapshots/selective_partial_ok_wildcard_does_not_bind_nilable_value.snap
@@ -19,8 +19,7 @@ import (
 )
 
 func main() {
-	_, err_1 := os.ReadDir(".")
-	if err_1 == nil {
+	if _, err := os.ReadDir("."); err == nil {
 		fmt.Println("ok")
 	}
 }

--- a/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
+++ b/tests/spec/emit/snapshots/spread_with_setup_preserves_sibling_eval_order.snap
@@ -27,10 +27,10 @@ func variadic(_ int, _ ...int) int {
 }
 
 func run() (int, error) {
-	arg_3 := sideA()
-	ret_1, ret_2 := getXs()
-	if ret_2 != nil {
-		return 0, ret_2
+	arg_2 := sideA()
+	ret_1, err := getXs()
+	if err != nil {
+		return 0, err
 	}
-	return variadic(arg_3, ret_1...), nil
+	return variadic(arg_2, ret_1...), nil
 }

--- a/tests/spec/emit/snapshots/try_block_annotated_with_result_alias.snap
+++ b/tests/spec/emit/snapshots/try_block_annotated_with_result_alias.snap
@@ -29,11 +29,10 @@ func source() (int, error) {
 func main() {
 	var r lisette.Result[int, error]
 	tryResult_1 := func() lisette.Result[int, error] {
-		ret_2, ret_3 := source()
-		if ret_3 != nil {
-			return lisette.MakeResultErr[int, error](ret_3)
+		n, err := source()
+		if err != nil {
+			return lisette.MakeResultErr[int, error](err)
 		}
-		n := ret_2
 		return lisette.MakeResultOk[int, error](n + 1)
 	}()
 	r = tryResult_1

--- a/tests/spec/emit/snapshots/try_block_option.snap
+++ b/tests/spec/emit/snapshots/try_block_option.snap
@@ -28,11 +28,10 @@ func maybeGet() (int, bool) {
 func test() int {
 	var opt lisette.Option[int]
 	tryResult_1 := func() lisette.Option[int] {
-		ret_2, ret_3 := maybeGet()
-		if !ret_3 {
+		x, ok := maybeGet()
+		if !ok {
 			return lisette.MakeOptionNone[int]()
 		}
-		x := ret_2
 		return lisette.MakeOptionSome[int](x + 1)
 	}()
 	opt = tryResult_1

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
@@ -20,8 +20,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func describe(pair lisette.Tuple2[int, any]) string {
-	ret_1, ok_2 := pair.Second.(string)
-	if ok_2 {
+	ret_1, ok := pair.Second.(string)
+	if ok {
 		text := ret_1
 		return text
 	} else {

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
@@ -21,8 +21,8 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func second(pair lisette.Tuple2[string, any]) int {
-	ret_1, ok_2 := pair.Second.(int)
-	if ok_2 {
+	ret_1, ok := pair.Second.(int)
+	if ok {
 		value := ret_1
 		return value
 	} else {

--- a/tests/spec/emit/snapshots/while_let_option_function_call.snap
+++ b/tests/spec/emit/snapshots/while_let_option_function_call.snap
@@ -30,8 +30,8 @@ func nextItem(counter int) (int, bool) {
 func test() {
 	i := 0
 	for {
-		ret_1, ok_2 := nextItem(i)
-		if !ok_2 {
+		ret_1, ok := nextItem(i)
+		if !ok {
 			break
 		}
 		x := ret_1


### PR DESCRIPTION
  The error variable of a `match` on a Go call that returns an error now takes the name bound in the `Err` arm, or `err`, in place of a numbered `err_N` slot that the `Err` arm rebound on its first line.
  
  ```rs
  import "go:fmt"
  import "go:strconv"
  
  fn main() {
    match strconv.Atoi("42") {
      Ok(n) => fmt.Println("number", n),
      Err(err) => fmt.Println("bad", err),
    }
  }
  ```
  
  Before:
  
  ```go
  func main() {
	  ret_1, err_2 := strconv.Atoi("42")
	  if err_2 == nil {
		  n := ret_1
		  fmt.Println("number", n)
	  } else {
		  err := err_2
		  fmt.Println("bad", err)
	  }
  }
  ```
  
  After:
  
  ```go
  func main() {
	  ret_1, err := strconv.Atoi("42") // error name
	  if err == nil {
		  n := ret_1
		  fmt.Println("number", n)
	  } else {
		  // no copy
		  fmt.Println("bad", err)
	  }
  }
  ```