### PR TITLE
feat: idiomatic Go for two-arm `match` on Go calls

### DIFF
--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -39,6 +39,7 @@ pub(crate) enum CommaOkValueSlot {
     Named(String),
     /// Allocate a fresh temporary.
     Temp,
+    Arm(String),
     /// No payload use. The value is still captured when the nil guard needs it.
     Unused,
 }
@@ -66,12 +67,32 @@ pub(crate) struct LoweredPair {
     status: String,
     success: PairSuccess,
     nil_guard: Option<NilGuard>,
-    initializer: Option<String>,
+    has_value_slot: bool,
+    initializer_call: Option<String>,
 }
 
 impl LoweredPair {
     pub(crate) fn status(&self) -> &str {
         &self.status
+    }
+
+    pub(crate) fn discard_value(&mut self) {
+        if self.nil_guard.is_none() {
+            self.value = None;
+        }
+    }
+
+    fn binding(&self) -> String {
+        match (self.has_value_slot, &self.value) {
+            (true, Some(value)) => format!("{value}, {}", self.status),
+            (true, None) => format!("_, {}", self.status),
+            (false, _) => self.status.clone(),
+        }
+    }
+
+    fn initializer(&self) -> Option<String> {
+        let call = self.initializer_call.as_ref()?;
+        Some(format!("{} := {call}", self.binding()))
     }
 }
 
@@ -168,7 +189,7 @@ impl Planner<'_> {
 
     pub(crate) fn bind_pair(
         &mut self,
-        mut statements: Vec<LoweredStatement>,
+        statements: Vec<LoweredStatement>,
         expression: String,
         slot: CommaOkValueSlot,
         kind: PairKind,
@@ -188,41 +209,51 @@ impl Planner<'_> {
                 PairStatusKind::Error,
             ),
         };
+        let opens_if = !matches!(slot, CommaOkValueSlot::Named(_) | CommaOkValueSlot::Temp);
         let value = carries_value
             .then(|| match slot {
-                CommaOkValueSlot::Named(name) => Some(name),
+                CommaOkValueSlot::Named(name) | CommaOkValueSlot::Arm(name) => Some(name),
                 CommaOkValueSlot::Temp => Some(self.fresh_pair_value()),
                 CommaOkValueSlot::Unused => nil_guard.map(|_| self.fresh_pair_value()),
             })
             .flatten();
-        let opens_if = value.is_none();
-        let status = self.pair_status(status_hint, status_kind, opens_if);
-        let binding = match (carries_value, value.as_deref()) {
-            (true, Some(value)) => format!("{value}, {status}"),
-            (true, None) => format!("_, {status}"),
-            (false, _) => status.clone(),
-        };
-        let line = format!("{binding} := {expression}");
-        let initializer = if opens_if {
-            Some(line)
-        } else {
-            statements.push(LoweredStatement::RawGo(format!("{line}\n")));
-            None
-        };
-        LoweredPair {
+        let mut status = self.pair_status(status_hint, status_kind, opens_if);
+        if opens_if && value.as_deref() == Some(status.as_str()) {
+            status = self.fresh_var(Some(&status));
+        }
+        let mut pair = LoweredPair {
             statements,
             value,
             status,
             success,
             nil_guard,
-            initializer,
+            has_value_slot: carries_value,
+            initializer_call: None,
+        };
+        if opens_if {
+            pair.initializer_call = Some(expression);
+        } else {
+            let line = format!("{} := {expression}\n", pair.binding());
+            pair.statements.push(LoweredStatement::RawGo(line));
         }
+        pair
     }
 
     pub(crate) fn fresh_pair_value(&mut self) -> String {
         let v = self.fresh_var(Some("ret"));
         self.declare(&v);
         v
+    }
+
+    pub(crate) fn arm_value_name(&mut self, name: &str) -> String {
+        let candidate = escape_reserved(name);
+        if self.scope.has_binding_for_go_name(&candidate)
+            || self.package.is_package_block_name(&candidate)
+        {
+            self.fresh_var(Some(&candidate))
+        } else {
+            candidate.into_owned()
+        }
     }
 
     /// Fresh within a Go block; nested blocks may shadow outer statuses.
@@ -284,7 +315,7 @@ impl Planner<'_> {
                 format!("{status} {operator} {nil_condition}")
             }
         };
-        match &pair.initializer {
+        match pair.initializer() {
             Some(initializer) => format!("{initializer}; {condition}"),
             None => condition,
         }

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -12,6 +12,7 @@ use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, Place
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::scope::PairStatusKind;
+use std::mem;
 use syntax::ast::{Expression, MatchArm, Pattern};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
@@ -35,49 +36,102 @@ pub(super) enum OptionFusePlan<'a> {
 
 pub(super) struct BoundOption {
     pub(super) statements: Vec<LoweredStatement>,
-    pub(super) value: Option<String>,
-    pub(super) some_condition: String,
-    pub(super) none_condition: String,
+    source: BoundSource,
+}
+
+enum BoundSource {
+    Pair(LoweredPair),
+    Nullable {
+        value: String,
+        nil_guard: NilGuard,
+        initializer_call: Option<String>,
+    },
+}
+
+impl BoundOption {
+    pub(super) fn value(&self) -> Option<&str> {
+        match &self.source {
+            BoundSource::Pair(pair) => pair.value.as_deref(),
+            BoundSource::Nullable { value, .. } => Some(value),
+        }
+    }
+
+    pub(super) fn discard_value(&mut self) {
+        if let BoundSource::Pair(pair) = &mut self.source {
+            pair.discard_value();
+        }
+    }
+
+    pub(super) fn some_condition(&self, planner: &mut Planner<'_>) -> String {
+        self.condition(planner, true)
+    }
+
+    pub(super) fn none_condition(&self, planner: &mut Planner<'_>) -> String {
+        self.condition(planner, false)
+    }
+
+    fn condition(&self, planner: &mut Planner<'_>, success: bool) -> String {
+        match &self.source {
+            BoundSource::Pair(pair) if success => planner.pair_success_condition(pair),
+            BoundSource::Pair(pair) => planner.pair_failure_condition(pair),
+            BoundSource::Nullable {
+                value,
+                nil_guard,
+                initializer_call,
+            } => {
+                if nil_guard.is_interface() {
+                    planner.require_stdlib();
+                }
+                let test = if success {
+                    nil_guard.non_nil(value)
+                } else {
+                    nil_guard.is_nil(value)
+                };
+                match initializer_call {
+                    Some(call) => format!("{value} := {call}; {test}"),
+                    None => test,
+                }
+            }
+        }
+    }
 }
 
 impl OptionFusePlan<'_> {
     pub(super) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> BoundOption {
         match self {
             Self::CommaOk { subject, source } => {
-                let pair = planner.bind_comma_ok_pair(subject, source, slot);
-                let some_condition = planner.pair_success_condition(&pair);
-                let none_condition = planner.pair_failure_condition(&pair);
+                let mut pair = planner.bind_comma_ok_pair(subject, source, slot);
                 BoundOption {
-                    statements: pair.statements,
-                    value: pair.value,
-                    some_condition,
-                    none_condition,
+                    statements: mem::take(&mut pair.statements),
+                    source: BoundSource::Pair(pair),
                 }
             }
             Self::Nullable { subject, nil_guard } => {
                 let (mut statements, call) = planner
                     .lower_call(subject, None, ExpressionContext::value())
                     .into_parts();
-                let value = match slot {
-                    CommaOkValueSlot::Named(name) => name,
-                    CommaOkValueSlot::Temp | CommaOkValueSlot::Unused => {
-                        let name = planner.fresh_var(Some("ret"));
-                        planner.declare(&name);
-                        name
-                    }
+                let (value, opens_if) = match slot {
+                    CommaOkValueSlot::Named(name) => (name, false),
+                    CommaOkValueSlot::Arm(name) => (name, true),
+                    CommaOkValueSlot::Temp => (planner.fresh_pair_value(), false),
+                    CommaOkValueSlot::Unused => (planner.fresh_pair_value(), true),
                 };
-                statements.push(LoweredStatement::TempBind {
-                    name: value.clone(),
-                    value: call,
-                });
-                if nil_guard.is_interface() {
-                    planner.require_stdlib();
-                }
+                let initializer_call = if opens_if {
+                    Some(call)
+                } else {
+                    statements.push(LoweredStatement::TempBind {
+                        name: value.clone(),
+                        value: call,
+                    });
+                    None
+                };
                 BoundOption {
                     statements,
-                    some_condition: nil_guard.non_nil(&value),
-                    none_condition: nil_guard.is_nil(&value),
-                    value: Some(value),
+                    source: BoundSource::Nullable {
+                        value,
+                        nil_guard,
+                        initializer_call,
+                    },
                 }
             }
         }
@@ -127,8 +181,9 @@ pub(super) enum ArmBinding<'a> {
 }
 
 impl<'a> ArmBinding<'a> {
-    pub(super) fn alias(name: Option<&'a str>, go_name: &'a str) -> Option<Self> {
-        name.map(|name| Self::Alias { name, go_name })
+    pub(super) fn alias(name: Option<&'a str>, go_name: Option<&'a str>) -> Option<Self> {
+        name.zip(go_name)
+            .map(|(name, go_name)| Self::Alias { name, go_name })
     }
 
     pub(super) fn copy(name: Option<&'a str>, value: Option<&'a str>) -> Option<Self> {
@@ -432,11 +487,12 @@ impl Planner<'_> {
 
         self.declare(go_name);
         let bound = fuse.bind(self, CommaOkValueSlot::Named(go_name.to_string()));
+        let none_condition = bound.none_condition(self);
         let fail_body = self.lower_block_as_body(arms.none_body);
         let mut statements = bound.statements;
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: bound.none_condition,
+            condition: none_condition,
             then_body: fail_body,
             else_arm: ElseArm::None,
         }));
@@ -517,32 +573,29 @@ impl Planner<'_> {
 
         let has_nil_guard = fuse.has_nil_guard();
         let carries_payload = fuse.carries_payload();
-        let slot = match destination {
-            Some(name) => CommaOkValueSlot::Named(name.to_string()),
-            None if ok_name.is_some() => CommaOkValueSlot::Temp,
-            None => CommaOkValueSlot::Unused,
+        let slot = match (destination, ok_name) {
+            (Some(name), _) => CommaOkValueSlot::Named(name.to_string()),
+            (None, Some(name)) => CommaOkValueSlot::Arm(self.arm_value_name(name)),
+            (None, None) => CommaOkValueSlot::Unused,
         };
-        let bound = fuse.bind(self, slot, err_name);
-        let ok_condition = self.pair_success_condition(&bound);
-        let err_condition = self.pair_failure_condition(&bound);
+        let mut bound = fuse.bind(self, slot, err_name);
 
         let then_body = destination.is_none().then(|| {
             // A call returning only `error` has no value, so `Ok(x)` takes unit.
-            let ok_value = if carries_payload {
-                bound.value.as_deref()
+            let ok_binding = if carries_payload {
+                ArmBinding::alias(ok_name, bound.value.as_deref())
             } else {
-                Some(UNIT_VALUE)
+                ArmBinding::copy(ok_name, Some(UNIT_VALUE))
             };
-            let ok_binding = ArmBinding::copy(ok_name, ok_value);
-            self.lower_fused_arm(&[ok_binding], &ok.arm.expression, place)
-                .0
+            let (body, uses) = self.lower_fused_arm(&[ok_binding], &ok.arm.expression, place);
+            (body, uses.first().copied().unwrap_or(false))
         });
         let arm_place = if destination.is_some() {
             &PlacePlan::Statement
         } else {
             place
         };
-        let err_binding = ArmBinding::alias(err_name, bound.status());
+        let err_binding = ArmBinding::alias(err_name, Some(bound.status()));
         let (mut else_body, err_used) =
             self.lower_fused_arm(&[err_binding], &err.arm.expression, arm_place);
 
@@ -556,6 +609,12 @@ impl Planner<'_> {
                 )),
             );
         }
+        if matches!(then_body, Some((_, false))) {
+            bound.discard_value();
+        }
+        let then_body = then_body.map(|(body, _)| body);
+        let ok_condition = self.pair_success_condition(&bound);
+        let err_condition = self.pair_failure_condition(&bound);
         let mut statements = bound.statements;
 
         let Some(then_body) = then_body else {
@@ -624,43 +683,38 @@ impl Planner<'_> {
 
         let ok_ty = self.facts.peel_alias(&subject.get_type()).ok_type();
         let nilable = self.partial_ok_is_nilable(&ok_ty);
-        let val_used = ok_name.is_some() || both_val.is_some() || nilable;
 
         let (mut statements, call_str) = self
             .lower_call(subject, None, ExpressionContext::value())
             .into_parts();
-        let val_var = val_used.then(|| self.fresh_pair_value());
-        let err_var = self.pair_status(
-            both_err.or(err_name),
-            PairStatusKind::Error,
-            val_var.is_none(),
-        );
-        let bind_line = match &val_var {
-            Some(v) => format!("{}, {} := {}", v, err_var, call_str),
-            None => format!("_, {} := {}", err_var, call_str),
+        let val_var = match ok_name.or(both_val) {
+            Some(name) => Some(self.arm_value_name(name)),
+            None => nilable.then(|| self.fresh_var(Some("ret"))),
         };
-        let condition = if val_var.is_some() {
-            statements.push(LoweredStatement::RawGo(format!("{bind_line}\n")));
-            format!("{} == nil", err_var)
-        } else {
-            format!("{bind_line}; {} == nil", err_var)
-        };
+        let mut err_var = self.pair_status(both_err.or(err_name), PairStatusKind::Error, true);
+        if val_var.as_deref() == Some(err_var.as_str()) {
+            err_var = self.fresh_var(Some(&err_var));
+        }
 
-        let (ok_body, _) = self.lower_fused_arm(
-            &[ArmBinding::copy(ok_name, val_var.as_deref())],
+        let (ok_body, ok_uses) = self.lower_fused_arm(
+            &[ArmBinding::alias(ok_name, val_var.as_deref())],
             &ok_arm.expression,
             place,
         );
-        let both_body = self
-            .lower_fused_arm(
-                &[
-                    ArmBinding::copy(both_val, val_var.as_deref()),
-                    ArmBinding::alias(both_err, &err_var),
-                ],
-                &both_arm.expression,
-                place,
-            )
-            .0;
+        let (both_body, both_uses) = self.lower_fused_arm(
+            &[
+                ArmBinding::alias(both_val, val_var.as_deref()),
+                ArmBinding::alias(both_err, Some(&err_var)),
+            ],
+            &both_arm.expression,
+            place,
+        );
+        let val_used = nilable || ok_uses[0] || both_uses[0];
+        let header = match val_var.as_deref().filter(|_| val_used) {
+            Some(v) => format!("{}, {} := {}", v, err_var, call_str),
+            None => format!("_, {} := {}", err_var, call_str),
+        };
+        let condition = format!("{header}; {} == nil", err_var);
 
         let nil_check = val_var
             .as_deref()
@@ -669,7 +723,7 @@ impl Planner<'_> {
         let else_arm = match nil_check {
             Some(check) => {
                 let (err_body, _) = self.lower_fused_arm(
-                    &[ArmBinding::alias(err_name, &err_var)],
+                    &[ArmBinding::alias(err_name, Some(&err_var))],
                     &err_arm.expression,
                     place,
                 );
@@ -733,13 +787,18 @@ impl Planner<'_> {
 
         let condition_needs_value = nil_guard.is_some()
             && matches!(arms.variant, PartialVariant::Both | PartialVariant::Err);
-        let may_need_value = value_binding.is_some() || condition_needs_value;
-        let value = may_need_value.then(|| self.fresh_pair_value());
-        let error = self.pair_status(error_binding, PairStatusKind::Error, value.is_none());
+        let value = match value_binding {
+            Some(name) => Some(self.arm_value_name(name)),
+            None => condition_needs_value.then(|| self.fresh_var(Some("ret"))),
+        };
+        let mut error = self.pair_status(error_binding, PairStatusKind::Error, true);
+        if value.as_deref() == Some(error.as_str()) {
+            error = self.fresh_var(Some(&error));
+        }
         let (selected, binding_uses) = self.lower_fused_arm(
             &[
-                ArmBinding::copy(value_binding, value.as_deref()),
-                ArmBinding::alias(error_binding, &error),
+                ArmBinding::alias(value_binding, value.as_deref()),
+                ArmBinding::alias(error_binding, Some(&error)),
             ],
             &arms.selected.expression,
             place,
@@ -781,14 +840,7 @@ impl Planner<'_> {
                 format!("{error} != nil && {}", guard.is_nil(value))
             }
         };
-        let condition = if value_slot.is_some() {
-            statements.push(LoweredStatement::RawGo(format!(
-                "{result_slots} := {call}\n"
-            )));
-            condition
-        } else {
-            format!("{result_slots} := {call}; {condition}")
-        };
+        let condition = format!("{result_slots} := {call}; {condition}");
         let selected_diverges = selected.ends_with_diverge();
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -810,22 +862,24 @@ impl Planner<'_> {
         let fuse = self.option_fuse_plan(subject)?;
         let arms = classify_option_arms(arms)?;
 
-        let slot = if arms.some_binding.is_some() {
-            CommaOkValueSlot::Temp
-        } else {
-            CommaOkValueSlot::Unused
+        let slot = match arms.some_binding {
+            Some(name) => CommaOkValueSlot::Arm(self.arm_value_name(name)),
+            None => CommaOkValueSlot::Unused,
         };
-        let bound = fuse.bind(self, slot);
+        let mut bound = fuse.bind(self, slot);
 
-        let some_binding = ArmBinding::copy(arms.some_binding, bound.value.as_deref());
-        let (then_body, _) = self.lower_fused_arm(&[some_binding], arms.some_body, place);
+        let some_binding = ArmBinding::alias(arms.some_binding, bound.value());
+        let (then_body, some_uses) = self.lower_fused_arm(&[some_binding], arms.some_body, place);
         let (else_body, _) = self.lower_fused_arm(&[], arms.none_body, place);
+        if !some_uses.first().copied().unwrap_or(false) {
+            bound.discard_value();
+        }
 
         let invert = then_body.renders_empty() && !else_body.renders_empty();
         let condition = if invert {
-            bound.none_condition
+            bound.none_condition(self)
         } else {
-            bound.some_condition
+            bound.some_condition(self)
         };
         let plan = if invert {
             IfPlan {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -294,12 +294,8 @@ impl Planner<'_> {
             None => CommaOkValueSlot::Unused,
         };
         let bound = fuse.bind(self, slot);
-        Some(self.finish_fused_let_else(
-            bound.statements,
-            bound.none_condition,
-            binding,
-            else_block,
-        ))
+        let none_condition = bound.none_condition(self);
+        Some(self.finish_fused_let_else(bound.statements, none_condition, binding, else_block))
     }
 
     fn finish_fused_let_else(
@@ -463,11 +459,13 @@ impl Planner<'_> {
             CommaOkValueSlot::Unused
         };
         let bound = fuse.bind(self, slot);
+        let none_condition = bound.none_condition(self);
+        let value = bound.value().map(str::to_string);
 
         let mut loop_body = bound.statements;
         loop_body.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
-            condition: bound.none_condition,
+            condition: none_condition,
             then_body: LoweredBlock {
                 statements: vec![LoweredStatement::Break(
                     self.current_loop_id()
@@ -477,7 +475,7 @@ impl Planner<'_> {
             else_arm: ElseArm::None,
         }));
         let (body_block, _) = self.lower_fused_arm(
-            &[ArmBinding::copy(binding, bound.value.as_deref())],
+            &[ArmBinding::copy(binding, value.as_deref())],
             body,
             &PlacePlan::Statement,
         );

--- a/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
+++ b/tests/spec/build/snapshots/assert_type_emits_concrete_type_arg.snap
@@ -11,9 +11,7 @@ import (
 
 func main() {
 	raw := store.GetValue("count")
-	ret_1, ok := raw.(int)
-	if ok {
-		n := ret_1
+	if n, ok := raw.(int); ok {
 		fmt.Print(n)
 	} else {
 		fmt.Print("not an int")

--- a/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
+++ b/tests/spec/build/snapshots/fused_match_arm_bindings_dont_leak.snap
@@ -14,9 +14,7 @@ func main() {
 	x := 100
 	fmt.Println(x)
 	x_1 := 200
-	ret_2, err := parse()
-	if err == nil {
-		x := ret_2
+	if x, err := parse(); err == nil {
 		fmt.Println(x)
 	} else {
 		fmt.Println("err")

--- a/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
+++ b/tests/spec/build/snapshots/go_function_value_result_wrapping.snap
@@ -11,9 +11,7 @@ import (
 
 func main() {
 	parse := strconv.Atoi
-	ret_1, e := parse("42")
-	if e == nil {
-		n := ret_1
+	if n, e := parse("42"); e == nil {
 		fmt.Printf("parsed: %d\n", n)
 	} else {
 		msg := e.Error()

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_collection.snap
@@ -12,8 +12,7 @@ import (
 
 func main() {
 	reader := strings.NewReader("hello")
-	ret_1, err := io.ReadAll(reader)
-	if err == nil {
+	if ret_1, err := io.ReadAll(reader); err == nil {
 		fmt.Print("ok")
 	} else if ret_1 == nil {
 		fmt.Print("err")

--- a/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
+++ b/tests/spec/build/snapshots/go_partial_wrap_nil_guards_nilable_ok.snap
@@ -11,8 +11,7 @@ import (
 )
 
 func main() {
-	ret_1, err := parser.ParseExpr("1 + 2")
-	if err == nil {
+	if ret_1, err := parser.ParseExpr("1 + 2"); err == nil {
 		fmt.Print("ok")
 	} else if lisette.IsNilInterface(ret_1) {
 		fmt.Print("err")

--- a/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
+++ b/tests/spec/build/snapshots/go_type_same_name_as_prelude_uses_go_methods.snap
@@ -12,9 +12,7 @@ import (
 func main() {
 	m := sync.Map{}
 	m.Store("key", "value")
-	ret_1, ok := m.Load("key")
-	if ok {
-		v := ret_1
+	if v, ok := m.Load("key"); ok {
 		fmt.Printf("got: %v\n", v)
 	} else {
 		fmt.Println("not found")

--- a/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
+++ b/tests/spec/build/snapshots/user_function_returning_result_no_type_args.snap
@@ -14,9 +14,7 @@ func parseInt(s string) (int, error) {
 }
 
 func main() {
-	ret_1, e := parseInt("42")
-	if e == nil {
-		n := ret_1
+	if n, e := parseInt("42"); e == nil {
 		fmt.Println(n)
 	} else {
 		fmt.Println(e)

--- a/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
+++ b/tests/spec/build/snapshots/user_marshal_json_lowers_to_go_abi_shape.snap
@@ -19,9 +19,7 @@ func (w Widget) MarshalJSON() ([]uint8, error) {
 
 func main() {
 	w := Widget{id: 7}
-	ret_1, e := json.Marshal(w)
-	if e == nil {
-		b := ret_1
+	if b, e := json.Marshal(w); e == nil {
 		fmt.Println(string(b))
 	} else {
 		fmt.Println(e)

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2340,6 +2340,90 @@ fn run(m: Map<string, int>) {
 }
 
 #[test]
+fn value_position_match_assigns_from_the_if_initializer() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let doubled = match strconv.Atoi("21") {
+    Ok(n) => n * 2,
+    Err(_) => 0,
+  }
+  fmt.Println(doubled)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn option_match_on_nullable_call_names_the_value() {
+    let input = r#"
+import "go:context"
+import "go:fmt"
+
+fn main() {
+  let ctx = context.Background()
+  match ctx.Err() {
+    Some(err) => fmt.Println(err),
+    None => fmt.Println("no error"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn ok_binding_shadowing_a_live_name_gets_a_fresh_header_name() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let n = 1
+  match strconv.Atoi("2") {
+    Ok(n) => fmt.Println(n),
+    Err(_) => fmt.Println(n),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn ok_and_err_arms_sharing_a_name_get_distinct_slots() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  match strconv.Atoi("2") {
+    Ok(x) => fmt.Println(x),
+    Err(x) => fmt.Println(x),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn partial_match_aliases_the_both_arm_names() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn write_all(file: Ref<os.File>) {
+  match file.Write(['h', 'i']) {
+    Ok(n) => fmt.Println(n),
+    Both(m, e) => fmt.Println(m, e),
+    Err(e) => fmt.Println(e),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
+++ b/tests/spec/emit/snapshots/array_from_in_match_binds_comma_ok_pair.snap
@@ -12,14 +12,12 @@ description: |
 package main
 
 func first(xs []int) int {
-	ret_1, ok := func(s []int) ([3]int, bool) {
+	if a, ok := func(s []int) ([3]int, bool) {
 		if len(s) != 3 {
 			return [3]int{}, false
 		}
 		return ([3]int)(s), true
-	}(xs)
-	if ok {
-		a := ret_1
+	}(xs); ok {
 		return a[0]
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
+++ b/tests/spec/emit/snapshots/cast_to_aliased_go_interface_resolves_through_alias.snap
@@ -35,9 +35,7 @@ func (l Loader) Load(_ string) (int, error) {
 }
 
 func run(s svc.Alias) int {
-	ret_1, err := s.Load("k")
-	if err == nil {
-		n := ret_1
+	if n, err := s.Load("k"); err == nil {
 		return n
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
+++ b/tests/spec/emit/snapshots/err_literal_propagate_widens.snap
@@ -55,9 +55,7 @@ func test() {
 			panic("wrong literal error")
 		}
 	}
-	ret_1, err := bail(false)
-	if err == nil {
-		v := ret_1
+	if v, err := bail(false); err == nil {
 		if v != 1 {
 			panic("wrong ok value")
 		}

--- a/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
+++ b/tests/spec/emit/snapshots/fused_go_interface_result_match_uses_nil_interface_guard.snap
@@ -22,9 +22,7 @@ import (
 )
 
 func test() {
-	ret_1, e := net.Dial("tcp", "addr")
-	if e == nil && !lisette.IsNilInterface(ret_1) {
-		conn := ret_1
+	if conn, e := net.Dial("tcp", "addr"); e == nil && !lisette.IsNilInterface(conn) {
 		_ = conn
 	} else {
 		if e == nil {

--- a/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
+++ b/tests/spec/emit/snapshots/fused_go_pointer_result_match_ok_wildcard.snap
@@ -21,8 +21,7 @@ import (
 )
 
 func test() {
-	ret_1, e := os.Create("f")
-	if e == nil && ret_1 != nil {
+	if ret_1, e := os.Create("f"); e == nil && ret_1 != nil {
 		fmt.Println("made")
 	} else {
 		if e == nil {

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err.snap
@@ -19,8 +19,7 @@ import (
 )
 
 func test(name string) string {
-	ret_1, err := os.Stat(name)
-	if err != nil || lisette.IsNilInterface(ret_1) {
+	if ret_1, err := os.Stat(name); err != nil || lisette.IsNilInterface(ret_1) {
 		return name
 	}
 	return "found"

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_on_pointer_return.snap
@@ -16,8 +16,7 @@ package main
 import "os"
 
 func test(name string) bool {
-	ret_1, err := os.Open(name)
-	if err != nil || ret_1 == nil {
+	if ret_1, err := os.Open(name); err != nil || ret_1 == nil {
 		return false
 	}
 	return true

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_err_reads_payload.snap
@@ -21,8 +21,7 @@ import (
 )
 
 func test(name string) {
-	ret_1, e := os.Stat(name)
-	if e != nil || lisette.IsNilInterface(ret_1) {
+	if ret_1, e := os.Stat(name); e != nil || lisette.IsNilInterface(ret_1) {
 		if e == nil {
 			e = errors.New("unexpected nil")
 		}

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok.snap
@@ -20,9 +20,7 @@ import (
 )
 
 func test(name string) {
-	ret_1, err := os.Stat(name)
-	if err == nil && !lisette.IsNilInterface(ret_1) {
-		info := ret_1
+	if info, err := os.Stat(name); err == nil && !lisette.IsNilInterface(info) {
 		fmt.Println(info.Name())
 	}
 }

--- a/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_if_let_ok_with_else.snap
@@ -22,9 +22,7 @@ import (
 )
 
 func test(name string) {
-	ret_1, err := os.Stat(name)
-	if err == nil && !lisette.IsNilInterface(ret_1) {
-		info := ret_1
+	if info, err := os.Stat(name); err == nil && !lisette.IsNilInterface(info) {
 		fmt.Println(info.Name())
 	} else {
 		fmt.Println("missing")

--- a/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
+++ b/tests/spec/emit/snapshots/fused_go_result_let_else_discarded_payload.snap
@@ -19,8 +19,7 @@ import (
 )
 
 func test(name string) bool {
-	ret_1, err := os.Stat(name)
-	if err != nil || lisette.IsNilInterface(ret_1) {
+	if ret_1, err := os.Stat(name); err != nil || lisette.IsNilInterface(ret_1) {
 		return false
 	}
 	return true

--- a/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
+++ b/tests/spec/emit/snapshots/fused_partial_match_on_lowered_call.snap
@@ -28,12 +28,9 @@ func attempt(ok bool) (int, error) {
 }
 
 func test() int {
-	ret_1, err := attempt(true)
-	if err == nil {
-		n := ret_1
+	if n, err := attempt(true); err == nil {
 		return n
 	} else {
-		n := ret_1
 		return n
 	}
 }

--- a/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
+++ b/tests/spec/emit/snapshots/fused_result_match_err_unused_named_payload.snap
@@ -27,9 +27,7 @@ func fallible(ok bool) (int, error) {
 }
 
 func test() {
-	ret_1, err := fallible(true)
-	if err == nil {
-		x := ret_1
+	if x, err := fallible(true); err == nil {
 		_ = x
 	}
 }

--- a/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
+++ b/tests/spec/emit/snapshots/fused_selective_partial_err_checks_nilable_value.snap
@@ -20,8 +20,7 @@ import (
 )
 
 func main() {
-	ret_1, e := aws.Read()
-	if e != nil && ret_1 == nil {
+	if ret_1, e := aws.Read(); e != nil && ret_1 == nil {
 		fmt.Println("err", e)
 	}
 }

--- a/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
+++ b/tests/spec/emit/snapshots/go_function_value_result_wrapper.snap
@@ -25,9 +25,7 @@ import (
 )
 
 func parseWith(f func(string) (int, error), s string) int {
-	ret_1, err := f(s)
-	if err == nil {
-		n := ret_1
+	if n, err := f(s); err == nil {
 		return n
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
+++ b/tests/spec/emit/snapshots/go_partially_hidden_struct_autofill_struct_literal.snap
@@ -18,9 +18,7 @@ import "container/ring"
 
 func test() int {
 	r := ring.Ring{Value: 1}
-	ret_1, ok := r.Value.(int)
-	if ok {
-		n := ret_1
+	if n, ok := r.Value.(int); ok {
 		return n
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/if_let_without_else_branch.snap
+++ b/tests/spec/emit/snapshots/if_let_without_else_branch.snap
@@ -26,9 +26,7 @@ func divide(a, b int) (int, bool) {
 }
 
 func test() {
-	ret_1, ok := divide(100, 10)
-	if ok {
-		x := ret_1
+	if x, ok := divide(100, 10); ok {
 		fmt.Printf("Result: %d\n", x)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_call_arg.snap
@@ -21,9 +21,7 @@ package main
 import "os"
 
 func apply(f func(string) (string, bool), key string) string {
-	ret_1, ok := f(key)
-	if ok {
-		v := ret_1
+	if v, ok := f(key); ok {
 		return v
 	} else {
 		return "unset"

--- a/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_map_return_keeps_bool.snap
@@ -16,9 +16,7 @@ package main
 import "example.com/reg"
 
 func main() {
-	ret_1, ok := reg.Lookup("a")
-	if ok && ret_1 != nil {
-		m := ret_1
+	if m, ok := reg.Lookup("a"); ok && m != nil {
 		_ = len(m)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_match_subject_fuses.snap
@@ -16,9 +16,7 @@ package main
 import "os"
 
 func main() {
-	ret_1, ok := os.LookupEnv("HOME")
-	if ok {
-		v := ret_1
+	if v, ok := os.LookupEnv("HOME"); ok {
 		_ = v
 	}
 }

--- a/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
+++ b/tests/spec/emit/snapshots/interop_comma_ok_propagate_in_try_block_fuses.snap
@@ -41,9 +41,7 @@ func lookup(k string) (string, bool) {
 }
 
 func main() {
-	ret_1, ok := lookup("HOME")
-	if ok {
-		v := ret_1
+	if v, ok := lookup("HOME"); ok {
 		_ = v
 	}
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_partial_slice_option.snap
@@ -39,14 +39,11 @@ func main() {
 		}
 		return wrapped_4, ret_3
 	}
-	ret_7, e := f()
-	if e == nil {
-		xs := ret_7
+	if xs, e := f(); e == nil {
 		fmt.Println("ok", len(xs))
-	} else if ret_7 == nil {
+	} else if xs == nil {
 		fmt.Println("err", e)
 	} else {
-		xs := ret_7
 		fmt.Println("both", len(xs), e)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
+++ b/tests/spec/emit/snapshots/interop_fn_value_result_slice_option_return.snap
@@ -42,9 +42,7 @@ func main() {
 		}
 		return wrapped_4, ret_3
 	}
-	ret_7, e := f()
-	if e == nil {
-		xs := ret_7
+	if xs, e := f(); e == nil {
 		for _, x := range xs {
 			if x.Tag == lisette.OptionSome {
 				fmt.Println(x.SomeVal)

--- a/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_channel_return.snap
@@ -19,9 +19,7 @@ import (
 )
 
 func main() {
-	ret_1 := reg.Events()
-	if ret_1 != nil {
-		ch := ret_1
+	if ch := reg.Events(); ch != nil {
 		_ = lisette.ChannelReceive(ch)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_map_return.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_map_return.snap
@@ -16,9 +16,7 @@ package main
 import "example.com/reg"
 
 func main() {
-	ret_1 := reg.Registry(true)
-	if ret_1 != nil {
-		m := ret_1
+	if m := reg.Registry(true); m != nil {
 		_ = len(m)
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
+++ b/tests/spec/emit/snapshots/interop_nilable_return_through_chained_newtypes.snap
@@ -16,9 +16,7 @@ package main
 import "example.com/reg"
 
 func main() {
-	ret_1 := reg.Lookup()
-	if ret_1 != nil {
-		idx := ret_1
+	if idx := reg.Lookup(); idx != nil {
 		_ = idx
 	}
 }

--- a/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_call_arg.snap
@@ -21,8 +21,7 @@ package main
 import "flag"
 
 func apply(f func(string) *flag.Flag, name string) bool {
-	ret_1 := f(name)
-	if ret_1 != nil {
+	if ret_1 := f(name); ret_1 != nil {
 		return true
 	} else {
 		return false

--- a/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
+++ b/tests/spec/emit/snapshots/interop_option_of_aliased_interface_uses_is_nil_interface.snap
@@ -21,9 +21,7 @@ import (
 )
 
 func main() {
-	ret_1 := evts.Peek()
-	if !lisette.IsNilInterface(ret_1) {
-		e := ret_1
+	if e := evts.Peek(); !lisette.IsNilInterface(e) {
 		fmt.Println(e)
 	} else {
 		fmt.Println("none")

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
@@ -53,20 +53,18 @@ func root(t *template.Template) (*parse.ListNode, error) {
 
 func main() {
 	t := template.New("greeting")
-	ret_1, e := t.Parse("hello {{.}}")
-	if e == nil && ret_1 != nil {
-		parsed := ret_1
+	if parsed, e := t.Parse("hello {{.}}"); e == nil && parsed != nil {
 		if _, e := root(parsed); e == nil {
 			fmt.Println("root is available")
 		} else {
 			fmt.Println("error", e)
 		}
-		opt_2 := lisette.MakeOptionNone[*parse.ListNode]()
-		var unwrap_3 *parse.ListNode
-		if opt_2.Tag == lisette.OptionSome {
-			unwrap_3 = opt_2.SomeVal
+		opt_1 := lisette.MakeOptionNone[*parse.ListNode]()
+		var unwrap_2 *parse.ListNode
+		if opt_1.Tag == lisette.OptionSome {
+			unwrap_2 = opt_1.SomeVal
 		}
-		parsed.Root = unwrap_3
+		parsed.Root = unwrap_2
 		if _, e := root(parsed); e == nil {
 			fmt.Println("root is available")
 		} else {

--- a/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_error_ok_skips_nil_guard.snap
@@ -16,9 +16,7 @@ package main
 import "example.com/legacy"
 
 func main() {
-	ret_1, err := legacy.Close()
-	if err == nil {
-		stored := ret_1
+	if stored, err := legacy.Close(); err == nil {
 		_ = stored
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block.snap
@@ -46,9 +46,7 @@ func sumParsed(a, b string) (int, error) {
 }
 
 func main() {
-	ret_1, err := sumParsed("3", "4")
-	if err == nil {
-		n := ret_1
+	if n, err := sumParsed("3", "4"); err == nil {
 		_ = n
 	}
 }

--- a/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
+++ b/tests/spec/emit/snapshots/interop_result_propagate_in_try_block_discard_and_nil_guard.snap
@@ -59,9 +59,7 @@ func openAndCheck(path, n string) (int, error) {
 }
 
 func main() {
-	ret_1, err := openAndCheck("/tmp/x", "7")
-	if err == nil {
-		v := ret_1
+	if v, err := openAndCheck("/tmp/x", "7"); err == nil {
 		_ = v
 	}
 }

--- a/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
+++ b/tests/spec/emit/snapshots/interop_sentinel_call_arg.snap
@@ -21,9 +21,7 @@ package main
 import "example.com/idx"
 
 func apply(f func(string, string) (int, bool), s string) int {
-	ret_1, ok := f(s, "ll")
-	if ok {
-		v := ret_1
+	if v, ok := f(s, "ll"); ok {
 		return v
 	} else {
 		return -2

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_concrete_value.snap
@@ -28,9 +28,7 @@ func identity(value int) int {
 }
 
 func describe(value any) string {
-	ret_1, ok := value.(string)
-	if ok {
-		text := ret_1
+	if text, ok := value.(string); ok {
 		return text
 	} else {
 		return ""

--- a/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
+++ b/tests/spec/emit/snapshots/let_annotated_unknown_declares_any_for_propagated_value.snap
@@ -36,9 +36,7 @@ func fallible() (int, error) {
 }
 
 func describe(value any) string {
-	ret_1, ok := value.(string)
-	if ok {
-		text := ret_1
+	if text, ok := value.(string); ok {
 		return text
 	} else {
 		return ""
@@ -58,9 +56,7 @@ func run() (string, error) {
 
 func test() {
 	var text_1 string
-	ret_2, err := run()
-	if err == nil {
-		text := ret_2
+	if text, err := run(); err == nil {
 		text_1 = text
 	} else {
 		text_1 = ""

--- a/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_computed_ok_arm_keeps_declaration.snap
@@ -25,9 +25,7 @@ import (
 
 func test(name string) {
 	var label string
-	ret_1, err := os.Open(name)
-	if err == nil && ret_1 != nil {
-		f := ret_1
+	if f, err := os.Open(name); err == nil && f != nil {
 		label = f.Name()
 	} else {
 		fmt.Println("cannot open")

--- a/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
+++ b/tests/spec/emit/snapshots/let_match_with_non_diverging_err_arm_keeps_declaration.snap
@@ -18,9 +18,7 @@ import "strconv"
 
 func test(text string) int {
 	var parsed int
-	ret_1, err := strconv.Atoi(text)
-	if err == nil {
-		n := ret_1
+	if n, err := strconv.Atoi(text); err == nil {
 		parsed = n
 	} else {
 		parsed = -1

--- a/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
+++ b/tests/spec/emit/snapshots/let_shadowing_annotated_unknown_declares_any.snap
@@ -29,9 +29,7 @@ func identity(value int) int {
 }
 
 func describe(value any) string {
-	ret_1, ok := value.(string)
-	if ok {
-		text := ret_1
+	if text, ok := value.(string); ok {
 		return text
 	} else {
 		return ""

--- a/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
+++ b/tests/spec/emit/snapshots/map_get_match_subject_fuses.snap
@@ -16,9 +16,7 @@ package main
 import "fmt"
 
 func test(m map[string]int, key string) int {
-	ret_1, ok := m[key]
-	if ok {
-		v := ret_1
+	if v, ok := m[key]; ok {
 		return v
 	} else {
 		fmt.Print("missing\n")

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -30,9 +30,7 @@ func safeDivide(a, b float64) (float64, bool) {
 
 func parseAndDivide(a, b float64) lisette.Result[string, string] {
 	var result float64
-	ret_1, ok := safeDivide(a, b)
-	if ok {
-		v := ret_1
+	if v, ok := safeDivide(a, b); ok {
 		result = v
 	} else {
 		return lisette.MakeResultErr[string, string]("division by zero")

--- a/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
+++ b/tests/spec/emit/snapshots/nullable_interface_reencodes_comma_ok_option_impl.snap
@@ -56,9 +56,7 @@ func (b Bar[T]) find() (T, bool) {
 }
 
 func useOpt(o Opt) {
-	ret_1 := o.find()
-	if ret_1 != nil {
-		t := ret_1
+	if t := o.find(); t != nil {
 		_ = t
 	}
 }

--- a/tests/spec/emit/snapshots/nullable_match_destination_preserves_interface_adapter.snap
+++ b/tests/spec/emit/snapshots/nullable_match_destination_preserves_interface_adapter.snap
@@ -60,16 +60,12 @@ func maybeBar(bar *Bar[*Thing]) *Bar[*Thing] {
 func main() {
 	bar := Bar[*Thing]{x: lisette.MakeOptionSome(&Thing{})}
 	var opt Opt
-	ret_1 := maybeBar(&bar)
-	if ret_1 != nil {
-		found := ret_1
+	if found := maybeBar(&bar); found != nil {
 		opt = _lisAdapter_Bar_Opt_0{inner: found}
 	} else {
 		return
 	}
-	ret_5 := opt.find()
-	if ret_5 != nil {
-		thing := ret_5
+	if thing := opt.find(); thing != nil {
 		_ = thing
 	}
 }
@@ -79,15 +75,15 @@ type _lisAdapter_Bar_Opt_0 struct {
 }
 
 func (a _lisAdapter_Bar_Opt_0) find() *Thing {
-	ret_2, ret_3 := a.inner.find()
-	var option_4 lisette.Option[*Thing]
-	if ret_3 && ret_2 != nil {
-		option_4 = lisette.MakeOptionSome[*Thing](ret_2)
+	ret_1, ret_2 := a.inner.find()
+	var option_3 lisette.Option[*Thing]
+	if ret_2 && ret_1 != nil {
+		option_3 = lisette.MakeOptionSome[*Thing](ret_1)
 	} else {
-		option_4 = lisette.MakeOptionNone[*Thing]()
+		option_3 = lisette.MakeOptionNone[*Thing]()
 	}
-	if option_4.Tag == lisette.OptionSome {
-		return option_4.SomeVal
+	if option_3.Tag == lisette.OptionSome {
+		return option_3.SomeVal
 	}
 	return nil
 }

--- a/tests/spec/emit/snapshots/ok_and_err_arms_sharing_a_name_get_distinct_slots.snap
+++ b/tests/spec/emit/snapshots/ok_and_err_arms_sharing_a_name_get_distinct_slots.snap
@@ -6,9 +6,9 @@ description: |
   import "go:strconv"
   
   fn main() {
-    match strconv.Atoi("1") {
-      Ok(n) => fmt.Println(n),
-      Err(failure) => fmt.Println(failure),
+    match strconv.Atoi("2") {
+      Ok(x) => fmt.Println(x),
+      Err(x) => fmt.Println(x),
     }
   }
 ---
@@ -20,9 +20,9 @@ import (
 )
 
 func main() {
-	if n, failure := strconv.Atoi("1"); failure == nil {
-		fmt.Println(n)
+	if x, x_1 := strconv.Atoi("2"); x_1 == nil {
+		fmt.Println(x)
 	} else {
-		fmt.Println(failure)
+		fmt.Println(x_1)
 	}
 }

--- a/tests/spec/emit/snapshots/ok_binding_shadowing_a_live_name_gets_a_fresh_header_name.snap
+++ b/tests/spec/emit/snapshots/ok_binding_shadowing_a_live_name_gets_a_fresh_header_name.snap
@@ -6,9 +6,10 @@ description: |
   import "go:strconv"
   
   fn main() {
-    match strconv.Atoi("1") {
+    let n = 1
+    match strconv.Atoi("2") {
       Ok(n) => fmt.Println(n),
-      Err(failure) => fmt.Println(failure),
+      Err(_) => fmt.Println(n),
     }
   }
 ---
@@ -20,9 +21,10 @@ import (
 )
 
 func main() {
-	if n, failure := strconv.Atoi("1"); failure == nil {
-		fmt.Println(n)
+	n := 1
+	if n_1, err := strconv.Atoi("2"); err == nil {
+		fmt.Println(n_1)
 	} else {
-		fmt.Println(failure)
+		fmt.Println(n)
 	}
 }

--- a/tests/spec/emit/snapshots/option_match_on_nullable_call_names_the_value.snap
+++ b/tests/spec/emit/snapshots/option_match_on_nullable_call_names_the_value.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/spec/emit/interop_matrix.rs
+source: tests/spec/emit/result_option_patterns.rs
 description: |
   
   import "go:context"
@@ -8,7 +8,7 @@ description: |
   fn main() {
     let ctx = context.Background()
     match ctx.Err() {
-      Some(e) => fmt.Println(e.Error()),
+      Some(err) => fmt.Println(err),
       None => fmt.Println("no error"),
     }
   }
@@ -23,8 +23,8 @@ import (
 
 func main() {
 	ctx := context.Background()
-	if e := ctx.Err(); !lisette.IsNilInterface(e) {
-		fmt.Println(e.Error())
+	if err := ctx.Err(); !lisette.IsNilInterface(err) {
+		fmt.Println(err)
 	} else {
 		fmt.Println("no error")
 	}

--- a/tests/spec/emit/snapshots/partial_match_aliases_the_both_arm_names.snap
+++ b/tests/spec/emit/snapshots/partial_match_aliases_the_both_arm_names.snap
@@ -1,18 +1,15 @@
 ---
-source: tests/spec/emit/partial.rs
+source: tests/spec/emit/result_option_patterns.rs
 description: |
   
-  import "go:os"
   import "go:fmt"
+  import "go:os"
   
   fn write_all(file: Ref<os.File>) {
     match file.Write(['h', 'i']) {
       Ok(n) => fmt.Println(n),
-      Both(n, _) => fmt.Println(n),
-      Err(e) => {
-        fmt.Println(e)
-        return
-      },
+      Both(m, e) => fmt.Println(m, e),
+      Err(e) => fmt.Println(e),
     }
   }
 ---
@@ -27,6 +24,6 @@ func writeAll(file *os.File) {
 	if n, e := file.Write([]byte{'h', 'i'}); e == nil {
 		fmt.Println(n)
 	} else {
-		fmt.Println(n)
+		fmt.Println(n, e)
 	}
 }

--- a/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_concrete_error_in_lowered_return.snap
@@ -73,9 +73,7 @@ func test() {
 			panic("wrong widened error")
 		}
 	}
-	ret_1, err := load("ada")
-	if err == nil {
-		v := ret_1
+	if v, err := load("ada"); err == nil {
 		if v != "ada" {
 			panic("wrong ok value")
 		}

--- a/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
+++ b/tests/spec/emit/snapshots/propagate_widens_to_custom_interface_with_different_ok_types.snap
@@ -85,9 +85,7 @@ func test() {
 			panic("wrong app error")
 		}
 	}
-	ret_1, err := handler(true)
-	if err == nil {
-		n := ret_1
+	if n, err := handler(true); err == nil {
 		if n != 3 {
 			panic("wrong ok length")
 		}

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_argument_position.snap
@@ -20,9 +20,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func describe(pair lisette.Tuple2[int, any]) string {
-	ret_1, ok := pair.Second.(string)
-	if ok {
-		text := ret_1
+	if text, ok := pair.Second.(string); ok {
 		return text
 	} else {
 		return ""

--- a/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
+++ b/tests/spec/emit/snapshots/tuple_of_concrete_widens_to_unknown_elements_in_slice_literal.snap
@@ -21,9 +21,7 @@ package main
 import lisette "github.com/ivov/lisette/prelude"
 
 func second(pair lisette.Tuple2[string, any]) int {
-	ret_1, ok := pair.Second.(int)
-	if ok {
-		value := ret_1
+	if value, ok := pair.Second.(int); ok {
 		return value
 	} else {
 		return 0

--- a/tests/spec/emit/snapshots/value_position_match_assigns_from_the_if_initializer.snap
+++ b/tests/spec/emit/snapshots/value_position_match_assigns_from_the_if_initializer.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let doubled = match strconv.Atoi("21") {
+      Ok(n) => n * 2,
+      Err(_) => 0,
+    }
+    fmt.Println(doubled)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	var doubled int
+	if n, err := strconv.Atoi("21"); err == nil {
+		doubled = n * 2
+	} else {
+		doubled = 0
+	}
+	fmt.Println(doubled)
+}


### PR DESCRIPTION
A two-arm `match` on a Go call that returns an error now emits the call in the `if` header and names the value after the `Ok` arm binding, in place of a `ret_N` slot that the `Ok` arm copied on its first line.

```rs
import "go:fmt"
import "go:strconv"

fn main() {
  match strconv.Atoi("42") {
    Ok(n) => fmt.Println("number", n),
    Err(err) => fmt.Println("bad", err),
  }
}
```

Before:

```go
func main() {
	ret_1, err := strconv.Atoi("42")
	if err == nil {
		n := ret_1
		fmt.Println("number", n)
	} else {
		fmt.Println("bad", err)
	}
}
```

After:

```go
func main() {
	if n, err := strconv.Atoi("42"); err == nil { // call in the header, value named from the Ok arm
		// no copy
		fmt.Println("number", n)
	} else {
		fmt.Println("bad", err)
	}
}
```
