### PR TITLE
feat: idiomatic Go for `let` bound from a matched Go call

### DIFF
--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -106,7 +106,6 @@ impl Planner<'_> {
         if needs_temp {
             let go_identifier = escape_reserved(raw_go_name);
             if !self.shadows_declaration(&go_identifier)
-                && !expression_contains_binding(value, identifier)
                 && !self.scope.is_active_assign_target(&go_identifier)
                 && !self.scope.has_binding_for_go_name(&go_identifier)
                 && value.get_type().demoted() == binding_ty.demoted()

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2424,6 +2424,65 @@ fn write_all(file: Ref<os.File>) {
 }
 
 #[test]
+fn let_named_like_its_ok_binding_fuses() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let bytes = match os.ReadFile("tasks.json") {
+    Ok(bytes) => bytes,
+    Err(err) => {
+      fmt.Println(err)
+      return
+    },
+  }
+  fmt.Println(bytes.length())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_named_like_its_ok_binding_keeps_an_inner_let_apart() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let bytes = match os.ReadFile("tasks.json") {
+    Ok(bytes) => bytes,
+    Err(err) => {
+      let bytes = err.Error().bytes()
+      fmt.Println(bytes.length())
+      return
+    },
+  }
+  fmt.Println(bytes.length())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_named_like_its_some_binding_fuses() {
+    let input = r#"
+import "go:context"
+import "go:fmt"
+
+fn main() {
+  let ctx = context.Background()
+  let err = match ctx.Err() {
+    Some(err) => err,
+    None => { return },
+  }
+  fmt.Println(err)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/let_named_like_its_ok_binding_fuses.snap
+++ b/tests/spec/emit/snapshots/let_named_like_its_ok_binding_fuses.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let bytes = match os.ReadFile("tasks.json") {
+      Ok(bytes) => bytes,
+      Err(err) => {
+        fmt.Println(err)
+        return
+      },
+    }
+    fmt.Println(bytes.length())
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	bytes, err := os.ReadFile("tasks.json")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(len(bytes))
+}

--- a/tests/spec/emit/snapshots/let_named_like_its_ok_binding_keeps_an_inner_let_apart.snap
+++ b/tests/spec/emit/snapshots/let_named_like_its_ok_binding_keeps_an_inner_let_apart.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let bytes = match os.ReadFile("tasks.json") {
+      Ok(bytes) => bytes,
+      Err(err) => {
+        let bytes = err.Error().bytes()
+        fmt.Println(bytes.length())
+        return
+      },
+    }
+    fmt.Println(bytes.length())
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	bytes, err := os.ReadFile("tasks.json")
+	if err != nil {
+		bytes_1 := []byte(err.Error())
+		fmt.Println(len(bytes_1))
+		return
+	}
+	fmt.Println(len(bytes))
+}

--- a/tests/spec/emit/snapshots/let_named_like_its_some_binding_fuses.snap
+++ b/tests/spec/emit/snapshots/let_named_like_its_some_binding_fuses.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:context"
+  import "go:fmt"
+  
+  fn main() {
+    let ctx = context.Background()
+    let err = match ctx.Err() {
+      Some(err) => err,
+      None => { return },
+    }
+    fmt.Println(err)
+  }
+---
+package main
+
+import (
+	"context"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ctx := context.Background()
+	err := ctx.Err()
+	if lisette.IsNilInterface(err) {
+		return
+	}
+	fmt.Println(err)
+}


### PR DESCRIPTION
A `let` bound from a `match` on a Go call that returns an error, where the `let` name is also the `Ok` binding, now emits one `name, err := call` line, in place of a `var name_N` declaration that the `if` header filled.

```rs
import "go:fmt"
import "go:os"

fn main() {
  let bytes = match os.ReadFile("tasks.json") {
    Ok(bytes) => bytes,
    Err(err) => {
      fmt.Println(err)
      return
    },
  }
  fmt.Println(bytes.length())
}
```

Before:

```go
func main() {
	var bytes_1 []byte
	if bytes, err := os.ReadFile("tasks.json"); err == nil {
		bytes_1 = bytes
	} else {
		fmt.Println(err)
		return
	}
	fmt.Println(len(bytes_1))
}
```

After:

```go
func main() {
	bytes, err := os.ReadFile("tasks.json") // the let binds the call directly
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(len(bytes)) // no bytes_1
}
```