### PR TITLE
feat: idiomatic Go for `is_err` and `is_some` on Go calls

### DIFF
--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -8,6 +8,7 @@ use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::CallableOrigin;
 use crate::state::scope::PairStatusKind;
 use crate::types::native::NativeGoType;
+use std::borrow::Cow;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -42,6 +43,8 @@ pub(crate) enum CommaOkValueSlot {
     Arm(String),
     /// No payload use. The value is still captured when the nil guard needs it.
     Unused,
+    /// No payload use, bound as a statement so the status can serve as a value.
+    Discarded,
 }
 
 #[derive(Clone, Copy)]
@@ -92,7 +95,39 @@ impl LoweredPair {
 
     fn initializer(&self) -> Option<String> {
         let call = self.initializer_call.as_ref()?;
-        Some(format!("{} := {call}", self.binding()))
+        Some(format!("{} := {}", self.binding(), header_call(call)))
+    }
+}
+
+/// Go reads a bare `T{` in an `if` header as the block, so such a receiver takes parentheses.
+pub(crate) fn header_call(call: &str) -> Cow<'_, str> {
+    let mut rest = call.trim_start_matches(['&', '*']);
+    let type_name_end = rest
+        .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == '.'))
+        .unwrap_or(rest.len());
+    if type_name_end == 0 {
+        return Cow::Borrowed(call);
+    }
+    rest = &rest[type_name_end..];
+    if let Some(after_bracket) = rest.strip_prefix('[') {
+        let mut depth = 1usize;
+        let close = after_bracket.char_indices().find(|(_, character)| {
+            match character {
+                '[' => depth += 1,
+                ']' => depth -= 1,
+                _ => {}
+            }
+            depth == 0
+        });
+        let Some((close, _)) = close else {
+            return Cow::Borrowed(call);
+        };
+        rest = &after_bracket[close + 1..];
+    }
+    if rest.starts_with('{') {
+        Cow::Owned(format!("({call})"))
+    } else {
+        Cow::Borrowed(call)
     }
 }
 
@@ -209,12 +244,14 @@ impl Planner<'_> {
                 PairStatusKind::Error,
             ),
         };
-        let opens_if = !matches!(slot, CommaOkValueSlot::Named(_) | CommaOkValueSlot::Temp);
+        let opens_if = matches!(slot, CommaOkValueSlot::Arm(_) | CommaOkValueSlot::Unused);
         let value = carries_value
             .then(|| match slot {
                 CommaOkValueSlot::Named(name) | CommaOkValueSlot::Arm(name) => Some(name),
                 CommaOkValueSlot::Temp => Some(self.fresh_pair_value()),
-                CommaOkValueSlot::Unused => nil_guard.map(|_| self.fresh_pair_value()),
+                CommaOkValueSlot::Unused | CommaOkValueSlot::Discarded => {
+                    nil_guard.map(|_| self.fresh_pair_value())
+                }
             })
             .flatten();
         let mut status = self.pair_status(status_hint, status_kind, opens_if);

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -481,6 +481,10 @@ impl<'a> Planner<'a> {
             .resolved_types()
             .expect("emission requires checked call type arguments");
 
+        if let Some(predicate) = self.lower_fused_predicate_value(call_expression, false) {
+            return predicate;
+        }
+
         match &plan.resolved.origin {
             CallableOrigin::TupleStructConstructor => {
                 if let Some(result) = self.try_lower_tuple_struct_call(function, args, call_ty, ctx)

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod comma_ok;
 pub(crate) mod dispatch;
 pub(crate) mod go_interop;
 pub(crate) mod native;
+pub(crate) mod predicates;
 mod regular;
 mod slice_loop;
 mod ufcs;

--- a/crates/emit/src/calls/predicates.rs
+++ b/crates/emit/src/calls/predicates.rs
@@ -1,0 +1,124 @@
+use crate::Planner;
+use crate::calls::comma_ok::CommaOkValueSlot;
+use crate::patterns::matching::{OptionFusePlan, ResultFusePlan};
+use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
+use syntax::ast::{Expression, UnaryOperator};
+use syntax::program::CallKind;
+
+enum FusedPredicate<'a> {
+    Result {
+        fuse: ResultFusePlan<'a>,
+        succeeds: bool,
+    },
+    Option {
+        fuse: OptionFusePlan<'a>,
+        succeeds: bool,
+    },
+}
+
+pub(crate) fn strip_negations(expression: &Expression) -> (&Expression, bool) {
+    let mut expression = expression.unwrap_parens();
+    let mut negated = false;
+    while let Expression::Unary {
+        operator: UnaryOperator::Not,
+        expression: inner,
+        ..
+    } = expression
+    {
+        negated = !negated;
+        expression = inner.unwrap_parens();
+    }
+    (expression, negated)
+}
+
+impl Planner<'_> {
+    /// `call().is_ok()` and its siblings on a call whose Go result can be tested directly.
+    fn fused_predicate<'a>(&self, expression: &'a Expression) -> Option<FusedPredicate<'a>> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            call_kind,
+            ..
+        } = expression
+        else {
+            return None;
+        };
+        if !args.is_empty() || spread.is_some() || *call_kind != CallKind::Regular {
+            return None;
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return None;
+        };
+        let receiver_ty = self.facts.peel_alias(&receiver.get_type());
+        match member.as_str() {
+            "is_ok" | "is_err" if receiver_ty.is_result() => Some(FusedPredicate::Result {
+                fuse: self.result_fuse_plan(receiver)?,
+                succeeds: member == "is_ok",
+            }),
+            "is_some" | "is_none" if receiver_ty.is_option() => Some(FusedPredicate::Option {
+                fuse: self.option_fuse_plan(receiver)?,
+                succeeds: member == "is_some",
+            }),
+            _ => None,
+        }
+    }
+
+    fn bind_fused_predicate(
+        &mut self,
+        predicate: FusedPredicate<'_>,
+        negated: bool,
+        slot: CommaOkValueSlot,
+    ) -> (Vec<LoweredStatement>, String) {
+        match predicate {
+            FusedPredicate::Result { fuse, succeeds } => {
+                let pair = fuse.bind(self, slot, None);
+                let condition = if succeeds != negated {
+                    self.pair_success_condition(&pair)
+                } else {
+                    self.pair_failure_condition(&pair)
+                };
+                (pair.statements, condition)
+            }
+            FusedPredicate::Option { fuse, succeeds } => {
+                let bound = fuse.bind(self, slot);
+                let condition = if succeeds != negated {
+                    bound.some_condition(self)
+                } else {
+                    bound.none_condition(self)
+                };
+                (bound.statements, condition)
+            }
+        }
+    }
+
+    pub(crate) fn lower_fused_predicate_condition(
+        &mut self,
+        condition: &Expression,
+    ) -> Option<(Vec<LoweredStatement>, String)> {
+        let (target, negated) = strip_negations(condition);
+        let predicate = self.fused_predicate(target)?;
+        Some(self.bind_fused_predicate(predicate, negated, CommaOkValueSlot::Unused))
+    }
+
+    pub(crate) fn lower_fused_predicate_value(
+        &mut self,
+        expression: &Expression,
+        negated: bool,
+    ) -> Option<ValuePlan> {
+        let predicate = self.fused_predicate(expression)?;
+        let (setup, condition) =
+            self.bind_fused_predicate(predicate, negated, CommaOkValueSlot::Discarded);
+        Some(ValuePlan::plain_call(
+            setup,
+            GoExpression::opaque_with_deferred_evaluation(condition, true),
+            EvaluationEffect::EffectfulCall,
+        ))
+    }
+}

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -1,6 +1,7 @@
 use crate::Planner;
 use crate::Renderer;
 use crate::analyze::facts::EmitFacts;
+use crate::calls::predicates::strip_negations;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -247,6 +248,14 @@ impl Planner<'_> {
                 plan.parenthesized()
             } else {
                 plan
+            };
+        }
+        let (innermost, inner_negated) = strip_negations(expression);
+        if let Some(predicate) = self.lower_fused_predicate_value(innermost, !inner_negated) {
+            return if preserve_parens {
+                predicate.parenthesized()
+            } else {
+                predicate
             };
         }
         if matches!(target, Expression::Call { .. }) {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,7 +1,7 @@
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use crate::calls::comma_ok::CommaOkSource;
-use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind};
+use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind, header_call};
 use crate::calls::go_interop::NilGuard;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::is_plain_identifier;
@@ -17,13 +17,13 @@ use syntax::ast::{Expression, MatchArm, Pattern};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
-pub(super) struct ResultFusePlan<'a> {
+pub(crate) struct ResultFusePlan<'a> {
     subject: &'a Expression,
     shape: CallableReturnAbi,
     nil_guard: Option<NilGuard>,
 }
 
-pub(super) enum OptionFusePlan<'a> {
+pub(crate) enum OptionFusePlan<'a> {
     CommaOk {
         subject: &'a Expression,
         source: CommaOkSource,
@@ -34,8 +34,8 @@ pub(super) enum OptionFusePlan<'a> {
     },
 }
 
-pub(super) struct BoundOption {
-    pub(super) statements: Vec<LoweredStatement>,
+pub(crate) struct BoundOption {
+    pub(crate) statements: Vec<LoweredStatement>,
     source: BoundSource,
 }
 
@@ -62,11 +62,11 @@ impl BoundOption {
         }
     }
 
-    pub(super) fn some_condition(&self, planner: &mut Planner<'_>) -> String {
+    pub(crate) fn some_condition(&self, planner: &mut Planner<'_>) -> String {
         self.condition(planner, true)
     }
 
-    pub(super) fn none_condition(&self, planner: &mut Planner<'_>) -> String {
+    pub(crate) fn none_condition(&self, planner: &mut Planner<'_>) -> String {
         self.condition(planner, false)
     }
 
@@ -88,7 +88,7 @@ impl BoundOption {
                     nil_guard.is_nil(value)
                 };
                 match initializer_call {
-                    Some(call) => format!("{value} := {call}; {test}"),
+                    Some(call) => format!("{value} := {}; {test}", header_call(call)),
                     None => test,
                 }
             }
@@ -97,7 +97,7 @@ impl BoundOption {
 }
 
 impl OptionFusePlan<'_> {
-    pub(super) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> BoundOption {
+    pub(crate) fn bind(self, planner: &mut Planner<'_>, slot: CommaOkValueSlot) -> BoundOption {
         match self {
             Self::CommaOk { subject, source } => {
                 let mut pair = planner.bind_comma_ok_pair(subject, source, slot);
@@ -113,7 +113,9 @@ impl OptionFusePlan<'_> {
                 let (value, opens_if) = match slot {
                     CommaOkValueSlot::Named(name) => (name, false),
                     CommaOkValueSlot::Arm(name) => (name, true),
-                    CommaOkValueSlot::Temp => (planner.fresh_pair_value(), false),
+                    CommaOkValueSlot::Temp | CommaOkValueSlot::Discarded => {
+                        (planner.fresh_pair_value(), false)
+                    }
                     CommaOkValueSlot::Unused => (planner.fresh_pair_value(), true),
                 };
                 let initializer_call = if opens_if {
@@ -151,7 +153,7 @@ impl ResultFusePlan<'_> {
         matches!(self.shape, CallableReturnAbi::Result { .. })
     }
 
-    pub(super) fn bind(
+    pub(crate) fn bind(
         self,
         planner: &mut Planner<'_>,
         slot: CommaOkValueSlot,
@@ -376,7 +378,7 @@ impl Planner<'_> {
     }
 
     /// Recognize a Lisette `Result` function or a Go `(T, error)` one.
-    pub(super) fn result_fuse_plan<'a>(
+    pub(crate) fn result_fuse_plan<'a>(
         &self,
         subject: &'a Expression,
     ) -> Option<ResultFusePlan<'a>> {
@@ -417,7 +419,7 @@ impl Planner<'_> {
 
     /// Recognize an Option-producing call whose physical Go result can be
     /// tested directly, without first constructing a tagged Option.
-    pub(super) fn option_fuse_plan<'a>(
+    pub(crate) fn option_fuse_plan<'a>(
         &self,
         subject: &'a Expression,
     ) -> Option<OptionFusePlan<'a>> {
@@ -711,8 +713,8 @@ impl Planner<'_> {
         );
         let val_used = nilable || ok_uses[0] || both_uses[0];
         let header = match val_var.as_deref().filter(|_| val_used) {
-            Some(v) => format!("{}, {} := {}", v, err_var, call_str),
-            None => format!("_, {} := {}", err_var, call_str),
+            Some(v) => format!("{}, {} := {}", v, err_var, header_call(&call_str)),
+            None => format!("_, {} := {}", err_var, header_call(&call_str)),
         };
         let condition = format!("{header}; {} == nil", err_var);
 
@@ -840,7 +842,7 @@ impl Planner<'_> {
                 format!("{error} != nil && {}", guard.is_nil(value))
             }
         };
-        let condition = format!("{result_slots} := {call}; {condition}");
+        let condition = format!("{result_slots} := {}; {condition}", header_call(&call));
         let selected_diverges = selected.ends_with_diverge();
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),

--- a/crates/emit/src/patterns/mod.rs
+++ b/crates/emit/src/patterns/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod binding_decls;
 pub(crate) mod binding_emit;
 pub(crate) mod decision_tree;
-mod matching;
+pub(crate) mod matching;
 pub(crate) mod sites;
 mod tree_emitter;

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -1,6 +1,7 @@
 use crate::Planner;
 use crate::Renderer;
 use crate::abi::transition::try_emit_lowered_tail_return;
+use crate::calls::predicates::strip_negations;
 use crate::context::expression::ExpressionContext;
 use crate::control_flow::propagation::plain_return;
 use crate::control_flow::targets::legalize_source_loop;
@@ -715,8 +716,23 @@ impl Planner<'_> {
         plan.into_parts()
     }
 
+    fn lower_if_condition(&mut self, condition: &Expression) -> (Vec<LoweredStatement>, String) {
+        if let Some(fused) = self.lower_fused_predicate_condition(condition) {
+            return fused;
+        }
+        let (setup, rendered) = self.lower_condition(condition);
+        (setup, wrap_if_struct_literal(rendered))
+    }
+
     fn lower_while(&mut self, condition: &Expression, body: &Expression) -> LoopPlan {
         self.with_loop("_", |this| {
+            let (target, negated) = strip_negations(condition);
+            if let Some(exit) = this.lower_fused_predicate_value(target, !negated) {
+                let (setup, failure) = exit.into_parts();
+                let setup_text = Renderer.render_setup(&setup);
+                let header = format!("for {{\n{setup_text}if {failure} {{ break }}\n");
+                return this.lower_loop_with_header(header, body);
+            }
             let (setup, rendered) = this.lower_condition(condition);
             let header = if !setup.is_empty() {
                 let setup_text = Renderer.render_setup(&setup);
@@ -976,8 +992,7 @@ impl Planner<'_> {
         alternative: Option<&Expression>,
         place: &PlacePlan,
     ) -> IfPlan {
-        let (condition_setup, condition_string) = self.lower_condition(condition);
-        let condition = wrap_if_struct_literal(condition_string);
+        let (condition_setup, condition) = self.lower_if_condition(condition);
 
         let then_body = self.with_scope(|this| this.lower_block_to_place(consequence, place));
 
@@ -1009,8 +1024,7 @@ impl Planner<'_> {
             ..
         } = alternative
         {
-            let (condition_setup, condition_string) = self.lower_condition(condition);
-            let condition = wrap_if_struct_literal(condition_string);
+            let (condition_setup, condition) = self.lower_if_condition(condition);
 
             // With-setup else-if renders as a nested block (`} else { setup; if
             // ... }`), so its body sits in an inner scope inside an outer scope

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2483,6 +2483,201 @@ fn main() {
 }
 
 #[test]
+fn is_err_on_go_call_opens_the_if_header() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  if os.Remove("missing.txt").is_err() {
+    fmt.Println("nothing to remove")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn negated_is_ok_on_go_call_flips_the_nil_test() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  if !strconv.Atoi("x").is_ok() {
+    fmt.Println("not a number")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_ok_on_pointer_returning_go_call_keeps_the_nil_guard() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  if os.Open("a").is_ok() {
+    fmt.Println("readable")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_err_on_lisette_result_calls_opens_the_if_header() {
+    let input = r#"
+import "go:fmt"
+
+fn count() -> Result<int, error> { Ok(1) }
+fn touch() -> Result<(), error> { Ok(()) }
+
+fn main() {
+  if count().is_err() {
+    fmt.Println("count failed")
+  }
+  if touch().is_err() {
+    fmt.Println("touch failed")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_some_on_map_get_opens_the_if_header() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let m = Map.new<string, int>()
+  if m.get("a").is_some() {
+    fmt.Println("has a")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_none_on_nullable_go_call_opens_the_if_header() {
+    let input = r#"
+import "go:context"
+import "go:fmt"
+
+fn main() {
+  let ctx = context.Background()
+  if ctx.Err().is_none() {
+    fmt.Println("clean")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_ok_as_a_value_binds_the_call_first() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let raw = "8080"
+  let succeeded = strconv.Atoi(raw).is_ok()
+  let failed = !strconv.Atoi(raw).is_ok()
+  fmt.Println(succeeded, failed)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn predicate_value_is_pinned_before_a_later_sibling_binds_err() {
+    let input = r#"
+fn first() -> Result<int, error> { Ok(1) }
+fn second() -> Result<int, error> { Ok(2) }
+fn pick(flag: bool, n: int) -> int { if flag { n } else { 0 } }
+
+fn run() -> Result<int, error> {
+  Ok(pick(first().is_ok(), second()?))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_ok_in_a_while_condition_runs_the_call_each_iteration() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let mut text = "1"
+  while strconv.Atoi(text).is_ok() {
+    text = text + "x"
+  }
+  fmt.Println(text)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_ok_under_logical_and_stays_an_expression() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let ready = true
+  if ready && strconv.Atoi("1").is_ok() {
+    fmt.Println("both")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_ok_on_partial_keeps_the_tagged_path() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn write_all(file: Ref<os.File>) {
+  if file.Write(['h', 'i']).is_ok() {
+    fmt.Println("written")
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_literal_receiver_in_an_if_header() {
+    let input = r#"
+import "go:fmt"
+
+struct Parser { src: string }
+
+impl Parser {
+  fn parse(self: Parser) -> Result<int, error> { Ok(self.src.length()) }
+}
+
+fn main() {
+  match Parser { src: "ab" }.parse() {
+    Ok(n) => fmt.Println(n),
+    Err(err) => fmt.Println(err),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"
@@ -2492,6 +2687,22 @@ fn double(n: int) -> Result<int, error> { Ok(n * 2) }
 fn run() -> Result<int, error> {
   let d = double(strconv.Atoi("1")?)?
   Ok(d)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn if_let_header_parenthesizes_a_nested_generic_receiver() {
+    let input = r#"
+struct Box<T> { v: T }
+
+impl<T> Box<T> {
+  fn parse(self) -> Option<int> { Some(1) }
+}
+
+fn eight() -> int {
+  if let Some(v) = Box { v: [1] }.parse() { v } else { 0 }
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_and_short_circuits_rhs_with_setup.snap
@@ -19,8 +19,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func track(flag *bool) (int, error) {
 	*flag = true
 	return 1, nil
@@ -29,14 +27,8 @@ func track(flag *bool) (int, error) {
 func test() {
 	ran := false
 	if false && func() bool {
-		ret_1, ret_2 := track(&ran)
-		var result_3 lisette.Result[int, error]
-		if ret_2 != nil {
-			result_3 = lisette.MakeResultErr[int, error](ret_2)
-		} else {
-			result_3 = lisette.MakeResultOk[int, error](ret_1)
-		}
-		return result_3.IsOk()
+		_, err := track(&ran)
+		return err == nil
 	}() {
 		panic("body should not run")
 	}

--- a/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
+++ b/tests/spec/emit/snapshots/binary_logical_or_short_circuits_rhs_with_setup.snap
@@ -20,8 +20,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func track(flag *bool) (int, error) {
 	*flag = true
 	return 1, nil
@@ -30,14 +28,8 @@ func track(flag *bool) (int, error) {
 func test() {
 	ran := false
 	if true || func() bool {
-		ret_1, ret_2 := track(&ran)
-		var result_3 lisette.Result[int, error]
-		if ret_2 != nil {
-			result_3 = lisette.MakeResultErr[int, error](ret_2)
-		} else {
-			result_3 = lisette.MakeResultOk[int, error](ret_1)
-		}
-		return result_3.IsOk()
+		_, err := track(&ran)
+		return err == nil
 	}() {
 		if ran {
 			panic("rhs evaluated despite short-circuit")

--- a/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
+++ b/tests/spec/emit/snapshots/else_if_condition_setup_emitted_in_else_scope.snap
@@ -20,8 +20,6 @@ description: |
 ---
 package main
 
-import lisette "github.com/ivov/lisette/prelude"
-
 func track(flag *bool) (int, error) {
 	*flag = true
 	return 1, nil
@@ -30,15 +28,6 @@ func track(flag *bool) (int, error) {
 func test() {
 	ran := false
 	if true {
-	} else {
-		ret_1, ret_2 := track(&ran)
-		var result_3 lisette.Result[int, error]
-		if ret_2 != nil {
-			result_3 = lisette.MakeResultErr[int, error](ret_2)
-		} else {
-			result_3 = lisette.MakeResultOk[int, error](ret_1)
-		}
-		if result_3.IsOk() {
-		}
+	} else if _, err := track(&ran); err == nil {
 	}
 }

--- a/tests/spec/emit/snapshots/if_let_header_parenthesizes_a_nested_generic_receiver.snap
+++ b/tests/spec/emit/snapshots/if_let_header_parenthesizes_a_nested_generic_receiver.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  struct Box<T> { v: T }
+  
+  impl<T> Box<T> {
+    fn parse(self) -> Option<int> { Some(1) }
+  }
+  
+  fn eight() -> int {
+    if let Some(v) = Box { v: [1] }.parse() { v } else { 0 }
+  }
+---
+package main
+
+type Box[T any] struct {
+	v T
+}
+
+func (b Box[T]) parse() (int, bool) {
+	return 1, true
+}
+
+func eight() int {
+	if v, ok := (Box[[]int]{v: []int{1}}.parse()); ok {
+		return v
+	} else {
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/is_err_on_go_call_opens_the_if_header.snap
+++ b/tests/spec/emit/snapshots/is_err_on_go_call_opens_the_if_header.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    if os.Remove("missing.txt").is_err() {
+      fmt.Println("nothing to remove")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := os.Remove("missing.txt"); err != nil {
+		fmt.Println("nothing to remove")
+	}
+}

--- a/tests/spec/emit/snapshots/is_err_on_lisette_result_calls_opens_the_if_header.snap
+++ b/tests/spec/emit/snapshots/is_err_on_lisette_result_calls_opens_the_if_header.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn count() -> Result<int, error> { Ok(1) }
+  fn touch() -> Result<(), error> { Ok(()) }
+  
+  fn main() {
+    if count().is_err() {
+      fmt.Println("count failed")
+    }
+    if touch().is_err() {
+      fmt.Println("touch failed")
+    }
+  }
+---
+package main
+
+import "fmt"
+
+func count() (int, error) {
+	return 1, nil
+}
+
+func touch() error {
+	return nil
+}
+
+func main() {
+	if _, err := count(); err != nil {
+		fmt.Println("count failed")
+	}
+	if err := touch(); err != nil {
+		fmt.Println("touch failed")
+	}
+}

--- a/tests/spec/emit/snapshots/is_none_on_nullable_go_call_opens_the_if_header.snap
+++ b/tests/spec/emit/snapshots/is_none_on_nullable_go_call_opens_the_if_header.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:context"
+  import "go:fmt"
+  
+  fn main() {
+    let ctx = context.Background()
+    if ctx.Err().is_none() {
+      fmt.Println("clean")
+    }
+  }
+---
+package main
+
+import (
+	"context"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ctx := context.Background()
+	if ret_1 := ctx.Err(); lisette.IsNilInterface(ret_1) {
+		fmt.Println("clean")
+	}
+}

--- a/tests/spec/emit/snapshots/is_ok_as_a_value_binds_the_call_first.snap
+++ b/tests/spec/emit/snapshots/is_ok_as_a_value_binds_the_call_first.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let raw = "8080"
+    let succeeded = strconv.Atoi(raw).is_ok()
+    let failed = !strconv.Atoi(raw).is_ok()
+    fmt.Println(succeeded, failed)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	raw := "8080"
+	_, err := strconv.Atoi(raw)
+	succeeded := err == nil
+	_, err_1 := strconv.Atoi(raw)
+	failed := err_1 != nil
+	fmt.Println(succeeded, failed)
+}

--- a/tests/spec/emit/snapshots/is_ok_in_a_while_condition_runs_the_call_each_iteration.snap
+++ b/tests/spec/emit/snapshots/is_ok_in_a_while_condition_runs_the_call_each_iteration.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let mut text = "1"
+    while strconv.Atoi(text).is_ok() {
+      text = text + "x"
+    }
+    fmt.Println(text)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	text := "1"
+	for {
+		_, err := strconv.Atoi(text)
+		if err != nil {
+			break
+		}
+		text += "x"
+	}
+	fmt.Println(text)
+}

--- a/tests/spec/emit/snapshots/is_ok_on_partial_keeps_the_tagged_path.snap
+++ b/tests/spec/emit/snapshots/is_ok_on_partial_keeps_the_tagged_path.snap
@@ -1,0 +1,33 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn write_all(file: Ref<os.File>) {
+    if file.Write(['h', 'i']).is_ok() {
+      fmt.Println("written")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func writeAll(file *os.File) {
+	ret_1, ret_2 := file.Write([]byte{'h', 'i'})
+	var result_3 lisette.Partial[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakePartialBoth[int, error](ret_1, ret_2)
+	} else {
+		result_3 = lisette.MakePartialOk[int, error](ret_1)
+	}
+	if result_3.IsOk() {
+		fmt.Println("written")
+	}
+}

--- a/tests/spec/emit/snapshots/is_ok_on_pointer_returning_go_call_keeps_the_nil_guard.snap
+++ b/tests/spec/emit/snapshots/is_ok_on_pointer_returning_go_call_keeps_the_nil_guard.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    if os.Open("a").is_ok() {
+      fmt.Println("readable")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if ret_1, err := os.Open("a"); err == nil && ret_1 != nil {
+		fmt.Println("readable")
+	}
+}

--- a/tests/spec/emit/snapshots/is_ok_under_logical_and_stays_an_expression.snap
+++ b/tests/spec/emit/snapshots/is_ok_under_logical_and_stays_an_expression.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let ready = true
+    if ready && strconv.Atoi("1").is_ok() {
+      fmt.Println("both")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	ready := true
+	if ready && func() bool {
+		_, err := strconv.Atoi("1")
+		return err == nil
+	}() {
+		fmt.Println("both")
+	}
+}

--- a/tests/spec/emit/snapshots/is_some_on_map_get_opens_the_if_header.snap
+++ b/tests/spec/emit/snapshots/is_some_on_map_get_opens_the_if_header.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let m = Map.new<string, int>()
+    if m.get("a").is_some() {
+      fmt.Println("has a")
+    }
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	m := make(map[string]int)
+	if _, ok := m["a"]; ok {
+		fmt.Println("has a")
+	}
+}

--- a/tests/spec/emit/snapshots/negated_is_ok_on_go_call_flips_the_nil_test.snap
+++ b/tests/spec/emit/snapshots/negated_is_ok_on_go_call_flips_the_nil_test.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    if !strconv.Atoi("x").is_ok() {
+      fmt.Println("not a number")
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	if _, err := strconv.Atoi("x"); err != nil {
+		fmt.Println("not a number")
+	}
+}

--- a/tests/spec/emit/snapshots/predicate_value_is_pinned_before_a_later_sibling_binds_err.snap
+++ b/tests/spec/emit/snapshots/predicate_value_is_pinned_before_a_later_sibling_binds_err.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn first() -> Result<int, error> { Ok(1) }
+  fn second() -> Result<int, error> { Ok(2) }
+  fn pick(flag: bool, n: int) -> int { if flag { n } else { 0 } }
+  
+  fn run() -> Result<int, error> {
+    Ok(pick(first().is_ok(), second()?))
+  }
+---
+package main
+
+func first() (int, error) {
+	return 1, nil
+}
+
+func second() (int, error) {
+	return 2, nil
+}
+
+func pick(flag bool, n int) int {
+	if flag {
+		return n
+	}
+	return 0
+}
+
+func run() (int, error) {
+	_, err := first()
+	arg_3 := err == nil
+	ret_1, err_2 := second()
+	if err_2 != nil {
+		return 0, err_2
+	}
+	return pick(arg_3, ret_1), nil
+}

--- a/tests/spec/emit/snapshots/struct_literal_receiver_in_an_if_header.snap
+++ b/tests/spec/emit/snapshots/struct_literal_receiver_in_an_if_header.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Parser { src: string }
+  
+  impl Parser {
+    fn parse(self: Parser) -> Result<int, error> { Ok(self.src.length()) }
+  }
+  
+  fn main() {
+    match Parser { src: "ab" }.parse() {
+      Ok(n) => fmt.Println(n),
+      Err(err) => fmt.Println(err),
+    }
+  }
+---
+package main
+
+import "fmt"
+
+type Parser struct {
+	src string
+}
+
+func (p Parser) parse() (int, error) {
+	return len(p.src), nil
+}
+
+func main() {
+	if n, err := (Parser{src: "ab"}.parse()); err == nil {
+		fmt.Println(n)
+	} else {
+		fmt.Println(err)
+	}
+}


### PR DESCRIPTION
`is_err`, `is_ok`, `is_some`, and `is_none` on a Go call now emit a direct nil test in the `if` header, in place of a `lisette.Result` or `lisette.Option` value built from the call and then tested.

```rs
import "go:fmt"
import "go:os"

fn main() {
  if os.Remove("missing.txt").is_err() {
    fmt.Println("nothing to remove")
  }
}
```

Before:

```go
func main() {
	ret_1 := os.Remove("missing.txt")
	var result_2 lisette.Result[struct{}, error]
	if ret_1 != nil {
		result_2 = lisette.MakeResultErr[struct{}, error](ret_1)
	} else {
		result_2 = lisette.MakeResultOk[struct{}, error](struct{}{})
	}
	if result_2.IsErr() {
		fmt.Println("nothing to remove")
	}
}
```

After:

```go
func main() {
	if err := os.Remove("missing.txt"); err != nil { // nil test in the header, no Result value
		fmt.Println("nothing to remove")
	}
}
```