### PR TITLE
fix: widen `mut` on Go interface params across packages

### DIFF
--- a/bindgen/bindgen.stdlib.json
+++ b/bindgen/bindgen.stdlib.json
@@ -183,6 +183,9 @@
       "nilable_return": {
       },
       "non_mutating_param": {
+        "archive/zip": {
+          "pooledFlateWriter.Write": ["p"]
+        },
         "compress/flate": {
           "Writer.Write": ["data"]
         },
@@ -203,11 +206,15 @@
         "hash/crc32": {
           "Checksum": ["data"],
           "ChecksumIEEE": ["data"],
-          "Update": ["p"]
+          "Update": ["p"],
+          "digest.Write": ["p"]
         },
         "net/http/httputil": {
           "ClientConn.Do": ["req"],
           "ClientConn.Write": ["req"]
+        },
+        "testing/slogtest": {
+          "wrapper.Handle": ["r"]
         }
       },
       "mutates_param": {

--- a/bindgen/internal/convert/interface_widening_test.go
+++ b/bindgen/internal/convert/interface_widening_test.go
@@ -1,0 +1,229 @@
+package convert
+
+import (
+	"go/types"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func analyzePackages(t *testing.T, files map[string]string, patterns ...string) (*MutationAnalysis, map[string]*packages.Package) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module probe\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &packages.Config{Mode: packages.LoadAllSyntax, Dir: dir}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := make(map[string]*packages.Package, len(pkgs))
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			t.Fatalf("load failed: %v", pkg.Errors)
+		}
+		byPath[pkg.PkgPath] = pkg
+	}
+	nilness, err := NewNilnessAnalysis(pkgs, nil)
+	if err != nil || nilness == nil {
+		t.Fatalf("SSA build failed: %v", err)
+	}
+	analysis, err := NewMutationAnalysis(nilness, pkgs)
+	if err != nil || analysis == nil {
+		t.Fatalf("mutation analysis unavailable: %v", err)
+	}
+	return analysis, byPath
+}
+
+func interfaceMethodMutations(t *testing.T, analysis *MutationAnalysis, pkg *packages.Package, typeName, methodName string) []string {
+	t.Helper()
+	named := pkg.Types.Scope().Lookup(typeName).(*types.TypeName).Type().(*types.Named)
+	for method := range named.Underlying().(*types.Interface).Methods() {
+		if method.Name() != methodName {
+			continue
+		}
+		facts, _ := analysis.Function(method)
+		sig := method.Type().(*types.Signature)
+		var out []string
+		for i := 0; i < sig.Params().Len(); i++ {
+			if facts.Mutates(i) {
+				out = append(out, sig.Params().At(i).Name())
+			}
+		}
+		return out
+	}
+	t.Fatalf("no method %s.%s", typeName, methodName)
+	return nil
+}
+
+func TestInterfaceWidensAcrossPackages(t *testing.T) {
+	analysis, pkgs := analyzePackages(t, map[string]string{
+		"iface/iface.go": `package iface
+
+type Box[T any] struct{ Value T }
+
+type Plain interface {
+	Apply(b *Box[string])
+}
+
+type Generic[T any] interface {
+	Apply(b *Box[T])
+}
+
+type Reader interface {
+	Read(b *Box[string])
+}
+`,
+		"impl/impl.go": `package impl
+
+import "probe/iface"
+
+type PlainImpl struct{}
+
+func (*PlainImpl) Apply(b *iface.Box[string]) { b.Value = "x" }
+
+type GenericImpl[T any] struct{}
+
+func (*GenericImpl[T]) Apply(b *iface.Box[T]) {
+	var zero T
+	b.Value = zero
+}
+
+type ReaderImpl struct{}
+
+func (ReaderImpl) Read(b *iface.Box[string]) { _ = b.Value }
+`,
+	}, "probe/iface", "probe/impl")
+	iface := pkgs["probe/iface"]
+	assertMutates(t, interfaceMethodMutations(t, analysis, iface, "Plain", "Apply"), "b")
+	assertMutates(t, interfaceMethodMutations(t, analysis, iface, "Generic", "Apply"), "b")
+	assertMutates(t, interfaceMethodMutations(t, analysis, iface, "Reader", "Read"))
+}
+
+func TestInterfaceWideningFollowsRecordedInstantiations(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Box struct{ Value int }
+
+type Store[T any] interface {
+	Put(b *Box, value T)
+}
+
+type IntStore struct{}
+
+func (IntStore) Put(b *Box, value int) { b.Value = value }
+
+var _ Store[int] = IntStore{}
+
+type Silent[T any] interface {
+	Keep(b *Box, value T)
+}
+
+type IntKeeper struct{}
+
+func (IntKeeper) Keep(b *Box, value int) { b.Value = value }
+
+type Typed[T ~int] interface {
+	Visit(b *Box, value T)
+}
+
+type StringVisitor struct{}
+
+func (StringVisitor) Visit(b *Box, value string) { b.Value = len(value) }
+
+type IntVisitor struct{}
+
+func (IntVisitor) Visit(b *Box, value int) { _ = b.Value }
+
+var _ Typed[int] = IntVisitor{}
+`)
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "Store", "Put"), "b")
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "Silent", "Keep"))
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "Typed", "Visit"))
+}
+
+func TestInterfaceWideningRespectsGenericImplementerConstraints(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Box struct{ Value int }
+
+type IntOnly[T ~int] interface {
+	Fill(b *Box, value T)
+}
+
+type StringFiller[U ~string] struct{}
+
+func (StringFiller[U]) Fill(b *Box, value U) { b.Value = 1 }
+
+type IntAlso[T ~int] interface {
+	Stamp(b *Box, value T)
+}
+
+type IntStamper[U ~int] struct{}
+
+func (IntStamper[U]) Stamp(b *Box, value U) { b.Value = 1 }
+`)
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "IntOnly", "Fill"))
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "IntAlso", "Stamp"), "b")
+}
+
+func TestInterfaceWideningReachesInstantiatedCopies(t *testing.T) {
+	analysis, pkg := analyzeSource(t, `
+type Box[T any] struct{ Value T }
+
+type Generic[T any] interface {
+	Apply(b *Box[T])
+}
+
+type Labeled interface {
+	Generic[string]
+	Label() string
+}
+
+type LabeledImpl struct{}
+
+func (LabeledImpl) Apply(b *Box[string]) { b.Value = "x" }
+func (LabeledImpl) Label() string        { return "" }
+`)
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "Generic", "Apply"), "b")
+	assertMutates(t, interfaceMethodMutations(t, analysis, pkg, "Labeled", "Apply"), "b")
+}
+
+func TestPromotedGenericMethodKeepsItsVerdict(t *testing.T) {
+	analysis, pkgs := analyzePackages(t, map[string]string{
+		"base/base.go": `package base
+
+type Base[T any] struct{ value T }
+
+func (b *Base[T]) Get() T { return b.value }
+`,
+		"wrap/wrap.go": `package wrap
+
+import "probe/base"
+
+type Wrapper struct{ base.Base[int] }
+`,
+	}, "probe/wrap")
+	wrapper := pkgs["probe/wrap"].Types.Scope().Lookup("Wrapper").(*types.TypeName).Type().(*types.Named)
+	selection := analysis.program.MethodSets.MethodSet(types.NewPointer(wrapper)).Lookup(nil, "Get")
+	if selection == nil {
+		t.Fatal("Wrapper has no promoted Get")
+	}
+	facts, ok := analysis.Function(selection.Obj())
+	if !ok {
+		t.Fatal("no verdict for the promoted Get")
+	}
+	if facts.ReceiverMutates {
+		t.Fatal("Get does not write through its receiver")
+	}
+}

--- a/bindgen/internal/convert/mutation.go
+++ b/bindgen/internal/convert/mutation.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ivov/lisette/bindgen/internal/config"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 )
@@ -373,7 +374,7 @@ func NewMutationAnalysis(nilness *NilnessAnalysis, roots []*packages.Package) (a
 				}
 				for sel := range analysis.program.MethodSets.MethodSet(types.NewPointer(named)).Methods() {
 					if fn, ok := sel.Obj().(*types.Func); ok {
-						bound = append(bound, fn)
+						bound = append(bound, fn.Origin())
 					}
 				}
 			}
@@ -391,77 +392,183 @@ func NewMutationAnalysis(nilness *NilnessAnalysis, roots []*packages.Package) (a
 	for _, fn := range bound {
 		analysis.record(fn)
 	}
-	analysis.widenInterfaceMethods(wellTyped)
+	analysis.widenInterfaceMethods(wellTyped, nilness.cfg)
 	return analysis, nil
 }
 
 type implementation struct {
 	abstract *types.Func
 	concrete *types.Func
+	readOnly []bool
 }
 
-// widenInterfaceMethods marks an interface parameter writable when a same-package implementer writes it.
-func (a *MutationAnalysis) widenInterfaceMethods(pkgs []*packages.Package) {
-	var implementations []implementation
+func (a *MutationAnalysis) widenInterfaceMethods(pkgs []*packages.Package, cfg *config.Config) {
+	var interfaces, implementers []*types.Named
+	seen := make(map[string]bool)
+	consider := func(named *types.Named) {
+		key := types.TypeString(named, nil)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		if iface, ok := named.Underlying().(*types.Interface); ok {
+			if iface.IsMethodSet() && iface.NumMethods() > 0 {
+				interfaces = append(interfaces, named)
+			}
+			return
+		}
+		implementers = append(implementers, named)
+	}
 	for _, pkg := range pkgs {
-		implementations = append(implementations, a.packageImplementations(pkg)...)
+		scope := pkg.Types.Scope()
+		for _, name := range scope.Names() {
+			if typeName, ok := scope.Lookup(name).(*types.TypeName); ok {
+				if named, ok := typeName.Type().(*types.Named); ok {
+					consider(named)
+				}
+			}
+		}
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		// TypesInfo.Instances lists each instantiation written in the source, such as Generic[string].
+		for _, instance := range pkg.TypesInfo.Instances {
+			if named, ok := instance.Type.(*types.Named); ok {
+				consider(named)
+			}
+		}
+	}
+	byMethod := make(map[string][]*types.Named)
+	for _, implementer := range implementers {
+		receiver := types.NewPointer(selfInstantiated(implementer))
+		for sel := range a.program.MethodSets.MethodSet(receiver).Methods() {
+			byMethod[sel.Obj().Name()] = append(byMethod[sel.Obj().Name()], implementer)
+		}
+	}
+	var implementations []implementation
+	for _, iface := range interfaces {
+		for _, implementer := range candidateImplementers(iface, byMethod) {
+			for _, pair := range a.implementationPairs(iface, implementer) {
+				pair.readOnly = curatedReadOnly(cfg, pair.concrete)
+				implementations = append(implementations, pair)
+			}
+		}
 	}
 	for changed := true; changed; {
 		changed = false
 		for _, pair := range implementations {
-			if written, ok := a.verdicts[pair.concrete]; ok && a.mergeWrittenParams(pair.abstract, written) {
+			if written, ok := a.verdicts[pair.concrete]; ok && a.mergeWrittenParams(pair.abstract, written, pair.readOnly) {
 				changed = true
 			}
 		}
 	}
 }
 
-func (a *MutationAnalysis) packageImplementations(pkg *packages.Package) []implementation {
-	var interfaces []*types.Interface
-	var implementers []*types.Pointer
-	scope := pkg.Types.Scope()
-	for _, name := range scope.Names() {
-		typeName, ok := scope.Lookup(name).(*types.TypeName)
-		if !ok {
-			continue
-		}
-		named, ok := typeName.Type().(*types.Named)
-		if !ok || named.TypeParams().Len() > 0 {
-			continue
-		}
-		if iface, ok := named.Underlying().(*types.Interface); ok {
-			if iface.IsMethodSet() && iface.NumMethods() > 0 {
-				interfaces = append(interfaces, iface)
-			}
-			continue
-		}
-		implementers = append(implementers, types.NewPointer(named))
+func curatedReadOnly(cfg *config.Config, fn *types.Func) []bool {
+	sig := fn.Type().(*types.Signature)
+	if cfg == nil || sig.Recv() == nil || fn.Pkg() == nil {
+		return nil
 	}
-	var out []implementation
-	for _, iface := range interfaces {
-		for _, implementer := range implementers {
-			if !types.Implements(implementer, iface) {
-				continue
-			}
-			methods := a.program.MethodSets.MethodSet(implementer)
-			for method := range iface.Methods() {
-				if selection := methods.Lookup(method.Pkg(), method.Name()); selection != nil {
-					out = append(out, implementation{abstract: method, concrete: selection.Obj().(*types.Func)})
-				}
-			}
+	receiver := sig.Recv().Type()
+	if pointer, ok := receiver.(*types.Pointer); ok {
+		receiver = pointer.Elem()
+	}
+	named, ok := receiver.(*types.Named)
+	if !ok {
+		return nil
+	}
+	curated := cfg.NonMutatingParams(fn.Pkg().Path(), named.Obj().Name()+"."+fn.Name())
+	if len(curated) == 0 {
+		return nil
+	}
+	names := paramNames(sig)
+	readOnly := make([]bool, len(names))
+	for index, name := range names {
+		readOnly[index] = slices.Contains(curated, name)
+	}
+	return readOnly
+}
+
+func candidateImplementers(iface *types.Named, byMethod map[string][]*types.Named) []*types.Named {
+	var candidates []*types.Named
+	first := true
+	for method := range iface.Underlying().(*types.Interface).Methods() {
+		having := byMethod[method.Name()]
+		if first || len(having) < len(candidates) {
+			candidates, first = having, false
 		}
+	}
+	return candidates
+}
+
+func (a *MutationAnalysis) implementationPairs(iface, implementer *types.Named) []implementation {
+	interfaceType := interfaceFor(iface, implementer)
+	if interfaceType == nil {
+		return nil
+	}
+	receiver := types.NewPointer(selfInstantiated(implementer))
+	if !types.Implements(receiver, interfaceType) {
+		return nil
+	}
+	methods := a.program.MethodSets.MethodSet(receiver)
+	var out []implementation
+	for method := range interfaceType.Methods() {
+		selection := methods.Lookup(method.Pkg(), method.Name())
+		if selection == nil {
+			return nil
+		}
+		concrete := selection.Obj().(*types.Func)
+		out = append(out, implementation{abstract: method.Origin(), concrete: concrete.Origin()})
 	}
 	return out
 }
 
-func (a *MutationAnalysis) mergeWrittenParams(method *types.Func, written FunctionMutation) bool {
+// interfaceFor instantiates a generic interface with the implementer's type parameters.
+func interfaceFor(iface, implementer *types.Named) *types.Interface {
+	if iface.TypeArgs().Len() > 0 || iface.TypeParams().Len() == 0 {
+		return iface.Underlying().(*types.Interface)
+	}
+	own := implementer.TypeParams()
+	if own.Len() != iface.TypeParams().Len() || implementer.TypeArgs().Len() > 0 {
+		return nil
+	}
+	args := make([]types.Type, own.Len())
+	for i := range args {
+		args[i] = own.At(i)
+	}
+	instantiated, err := types.Instantiate(nil, iface, args, true)
+	if err != nil {
+		return nil
+	}
+	return instantiated.Underlying().(*types.Interface)
+}
+
+// selfInstantiated instantiates a generic type with its declared type parameters, so its methods use them too.
+func selfInstantiated(named *types.Named) types.Type {
+	params := named.TypeParams()
+	if params.Len() == 0 || named.TypeArgs().Len() > 0 {
+		return named
+	}
+	args := make([]types.Type, params.Len())
+	for i := range args {
+		args[i] = params.At(i)
+	}
+	instantiated, err := types.Instantiate(nil, named, args, false)
+	if err != nil {
+		return named
+	}
+	return instantiated
+}
+
+func (a *MutationAnalysis) mergeWrittenParams(method *types.Func, written FunctionMutation, readOnly []bool) bool {
 	facts, ok := a.verdicts[method]
 	if !ok {
 		facts = FunctionMutation{Params: make([]bool, method.Type().(*types.Signature).Params().Len())}
 	}
 	changed := false
 	for index := range facts.Params {
-		if !facts.Params[index] && written.Mutates(index) {
+		curated := index < len(readOnly) && readOnly[index]
+		if !facts.Params[index] && written.Mutates(index) && !curated {
 			facts.Params[index] = true
 			changed = true
 		}
@@ -480,7 +587,7 @@ func (a *MutationAnalysis) Function(obj types.Object) (FunctionMutation, bool) {
 	if !ok {
 		return FunctionMutation{}, false
 	}
-	facts, ok := a.verdicts[fn]
+	facts, ok := a.verdicts[fn.Origin()]
 	return facts, ok
 }
 
@@ -493,7 +600,7 @@ func (a *MutationAnalysis) Views(obj types.Object) (FunctionViews, bool) {
 	if !ok {
 		return FunctionViews{}, false
 	}
-	facts, ok := a.views[fn]
+	facts, ok := a.views[fn.Origin()]
 	return facts, ok
 }
 

--- a/bindgen/tests/testdata/fixtures/interface_implementers/interface_implementers.go
+++ b/bindgen/tests/testdata/fixtures/interface_implementers/interface_implementers.go
@@ -55,6 +55,55 @@ type IntStore struct{}
 
 func (IntStore) Put(n *Node, value int) { n.Value = value }
 
+var _ Store[int] = IntStore{}
+
+type Box[T any] struct{ Value T }
+
+type Applier[T any] interface {
+	Apply(b *Box[T])
+}
+
+type GenericApplier[T any] struct{}
+
+func (*GenericApplier[T]) Apply(b *Box[T]) {
+	var zero T
+	b.Value = zero
+}
+
+type StringApplier interface {
+	Apply(b *Box[string])
+}
+
+var _ StringApplier = (*GenericApplier[string])(nil)
+
+type Labeled interface {
+	Applier[string]
+	Label() string
+}
+
+type LabeledApplier struct{}
+
+func (LabeledApplier) Apply(b *Box[string]) { b.Value = "" }
+func (LabeledApplier) Label() string        { return "" }
+
+type Peeker[T any] interface {
+	Peek(b *Box[T])
+}
+
+type IntPeeker struct{}
+
+func (IntPeeker) Peek(b *Box[int]) { _ = b.Value }
+
+type Pair[K comparable, V any] interface {
+	Set(m map[K]V, k K, v V)
+}
+
+type StringIntPair struct{}
+
+func (StringIntPair) Set(m map[string]int, k string, v int) { m[k] = v }
+
+var _ Pair[string, int] = StringIntPair{}
+
 type Router interface {
 	Serve(n *Node)
 }

--- a/bindgen/tests/testdata/snapshots/interface_implementers.d.lis
+++ b/bindgen/tests/testdata/snapshots/interface_implementers.d.lis
@@ -3,10 +3,20 @@
 // Go: 0.0.0
 // Lisette: 0.0.0
 
+pub interface Applier<T> {
+  fn Apply(b: mut Ref<Box<T>>)
+}
+
+pub struct Box<T> {
+  pub Value: T,
+}
+
 pub interface Bundle {
   fn Name() -> string
   fn Run(n: mut Ref<Node>)
 }
+
+pub type GenericApplier<T>
 
 pub interface Hook {
   fn Run(n: mut Ref<Node>)
@@ -18,7 +28,16 @@ pub interface Inspector {
   fn Inspect(n: Ref<Node>)
 }
 
+pub type IntPeeker
+
 pub type IntStore
+
+pub interface Labeled {
+  fn Apply(b: mut Ref<Box<string>>)
+  fn Label() -> string
+}
+
+pub type LabeledApplier
 
 pub interface Marker {
   fn Mark(n: mut Ref<Node>)
@@ -39,6 +58,14 @@ pub interface Orphan {
   fn Touch(n: Ref<Node>)
 }
 
+pub interface Pair<K: Comparable, V> {
+  fn Set(m: mut Map<K, V>, k: K, v: V)
+}
+
+pub interface Peeker<T> {
+  fn Peek(b: Ref<Box<T>>)
+}
+
 pub type Printer
 
 pub type Reader
@@ -48,8 +75,14 @@ pub interface Router {
 }
 
 pub interface Store<T> {
-  fn Put(n: Ref<Node>, value: T)
+  fn Put(n: mut Ref<Node>, value: T)
 }
+
+pub interface StringApplier {
+  fn Apply(b: mut Ref<Box<string>>)
+}
+
+pub type StringIntPair
 
 pub interface Visitor {
   fn Visit(n: mut Ref<Node>)
@@ -62,12 +95,25 @@ pub struct Wrapped {
   pub Hook: Option<Hook>,
 }
 
+impl<T> GenericApplier<T> {
+  fn Apply(self: Ref<GenericApplier<T>>, b: mut Ref<Box<T>>)
+}
+
 impl HookFunc {
   fn Run(self, n: mut Ref<Node>)
 }
 
+impl IntPeeker {
+  fn Peek(self, b: Ref<Box<int>>)
+}
+
 impl IntStore {
   fn Put(self, n: mut Ref<Node>, value: int)
+}
+
+impl LabeledApplier {
+  fn Apply(self, b: mut Ref<Box<string>>)
+  fn Label(self) -> string
 }
 
 impl Mux {
@@ -80,6 +126,10 @@ impl Printer {
 
 impl Reader {
   fn Visit(self, n: Ref<Node>)
+}
+
+impl StringIntPair {
+  fn Set(self, m: mut Map<string, int>, k: string, v: int)
 }
 
 impl VisitorFunc {

--- a/crates/cli/src/handlers/reconciliation.rs
+++ b/crates/cli/src/handlers/reconciliation.rs
@@ -319,6 +319,7 @@ pub(crate) fn reconcile_root(
     let bindgenned = walk_typedef_cache(dep, workspace, &mut graph, replacements)?;
     expand_unwalked_modules(workspace, &mut graph, locals)?;
     rebuild_drifted_cache_entries(workspace, &graph, &bindgenned, replacements);
+    workspace.invalidate_warm_stamp();
     Ok(graph)
 }
 

--- a/crates/cli/src/handlers/sync.rs
+++ b/crates/cli/src/handlers/sync.rs
@@ -8,7 +8,7 @@ use crate::handlers::reconciliation::{finalize_manifest_via, reconcile_declared_
 use crate::output::print_sync_summary;
 use crate::typedef_regen::prewarm_typedef_cache;
 use crate::typedef_scan::{SourceScanError, scan_source_imports};
-use crate::workspace::WorkspaceBindgen;
+use crate::workspace::{GoWorkspace, WorkspaceBindgen, warm_typedefs};
 use crate::{cli_error, error};
 use std::path::Path;
 
@@ -94,8 +94,10 @@ pub fn sync(script: Option<&str>) -> i32 {
             target,
         ));
         let locator = locator.with_bindgen(runner.clone());
+        let workspace = GoWorkspace::new(target_dir, typedef_cache_dir, target);
+        let warmed = warm_typedefs(project_root, &workspace, &locator);
         let result = prewarm_typedef_cache(&non_blank_imports, &locator);
-        (result, runner.progress_emitted())
+        (result, warmed || runner.progress_emitted())
     } else {
         (Ok(()), false)
     };

--- a/crates/cli/src/workspace.rs
+++ b/crates/cli/src/workspace.rs
@@ -857,6 +857,9 @@ impl GoWorkspace<'_> {
             }
             if atomic_write(&path, &entry.content).is_ok() {
                 written += 1;
+                if matches!(replacement, Some(deps::ResolvedReplacement::Local)) {
+                    locator.stamp_local_typedef(&path);
+                }
             }
         }
 
@@ -871,6 +874,10 @@ impl GoWorkspace<'_> {
 
     fn warm_stamp_matches(&self, content: &str) -> bool {
         fs::read_to_string(self.warm_stamp_path()).is_ok_and(|existing| existing == content)
+    }
+
+    pub(crate) fn invalidate_warm_stamp(&self) {
+        let _ = fs::remove_file(self.warm_stamp_path());
     }
 
     fn write_warm_stamp(&self, content: &str) {
@@ -888,39 +895,32 @@ pub(crate) fn warm_typedefs(
     project_root: &Path,
     workspace: &GoWorkspace<'_>,
     locator: &TypedefLocator,
-) {
+) -> bool {
     if locator.deps().is_empty() {
-        return;
+        return false;
     }
 
     let src_dir = project_root.join("src");
     let Ok(scanned) = typedef_scan::scan_source_imports(&src_dir) else {
-        return;
+        return false;
     };
 
-    // The warm batch writes no stamp sidecars, so the gate would discard its
-    // local typedefs. Those resolve through the stamp-gated lazy path instead.
-    let is_local = |pkg: &str| {
-        matches!(
-            locator.module_for_package(pkg),
-            Some((_, _, Some(deps::ResolvedReplacement::Local)))
-        )
-    };
+    // Local packages join the batch so bindgen sees an interface and its implementers together.
     let mut seen: HashSet<String> = HashSet::new();
     let mut roots: Vec<String> = scanned
         .non_blank()
-        .filter(|pkg| locator.is_declared_go_dep(pkg) && !is_local(pkg))
+        .filter(|pkg| locator.is_declared_go_dep(pkg))
         .filter(|pkg| seen.insert((*pkg).to_string()))
         .map(str::to_string)
         .collect();
     if roots.is_empty() {
-        return;
+        return false;
     }
     roots.sort();
 
     let stamp = warm_stamp_for(&roots, locator);
     if workspace.warm_stamp_matches(&stamp) {
-        return;
+        return false;
     }
 
     output::print_progress(&format!(
@@ -934,9 +934,10 @@ pub(crate) fn warm_typedefs(
             && workspace.cache_typedefs(&manifest, locator) > 0
         {
             workspace.write_warm_stamp(&stamp);
-            return;
+            return true;
         }
     }
+    true
 }
 
 fn warm_stamp_for(roots: &[String], locator: &TypedefLocator) -> String {
@@ -958,7 +959,13 @@ fn warm_stamp_for(roots: &[String], locator: &TypedefLocator) -> String {
             format!("{} {}", module, source)
         })
         .collect();
-    format!("{}\n--\n{}", roots.join("\n"), deps.join("\n"))
+    let local = locator.local_stamp_value().unwrap_or("");
+    format!(
+        "{}\n--\n{}\n--\n{}",
+        roots.join("\n"),
+        deps.join("\n"),
+        local
+    )
 }
 
 fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
@@ -1117,10 +1124,21 @@ impl Bindgen for WorkspaceBindgen {
             return Err(BindgenFailure::GoToolchainMissing);
         }
 
+        let workspace = GoWorkspace::new(&self.target_dir, &self.typedef_cache_dir, self.target);
+
+        if let Some(project_root) = self.target_dir.parent()
+            && let Ok((_, locator)) =
+                TypedefLocator::from_project_with_manifest(project_root, self.target)
+        {
+            warm_typedefs(project_root, &workspace, &locator);
+            if typedef_path.exists() {
+                self.progress_emitted.store(true, Ordering::Relaxed);
+                return Ok(());
+            }
+        }
+
         output::print_progress(&format!("Generating typedef for {}", pkg.package));
         self.progress_emitted.store(true, Ordering::Relaxed);
-
-        let workspace = GoWorkspace::new(&self.target_dir, &self.typedef_cache_dir, self.target);
 
         let module = GoModule {
             path: pkg.module.path,

--- a/crates/deps/src/local_source.rs
+++ b/crates/deps/src/local_source.rs
@@ -114,17 +114,21 @@ pub(crate) fn gate_local_typedef(typedef_path: &Path, stamp: &str) -> Result<(),
     if local_typedef_is_fresh(typedef_path, stamp) {
         return Ok(());
     }
-    let stamp_path = stamp_path_for_typedef(typedef_path);
     match fs::remove_file(typedef_path) {
         Ok(()) => {}
         Err(error) if error.kind() == ErrorKind::NotFound => {}
         Err(error) => return Err(error),
     }
+    write_local_stamp(typedef_path, stamp);
+    Ok(())
+}
+
+pub(crate) fn write_local_stamp(typedef_path: &Path, stamp: &str) {
+    let stamp_path = stamp_path_for_typedef(typedef_path);
     if let Some(parent) = stamp_path.parent() {
         let _ = fs::create_dir_all(parent);
     }
     let _ = fs::write(&stamp_path, stamp);
-    Ok(())
 }
 
 /// FNV-1a, matching the other deterministic hashes in the workspace.

--- a/crates/deps/src/typedef_locator.rs
+++ b/crates/deps/src/typedef_locator.rs
@@ -268,6 +268,12 @@ impl TypedefLocator {
             .as_deref()
     }
 
+    pub fn stamp_local_typedef(&self, typedef_path: &Path) {
+        if let Some(stamp) = self.local_stamp_value() {
+            local_source::write_local_stamp(typedef_path, stamp);
+        }
+    }
+
     pub fn from_project(project_root: &Path) -> Result<Self, String> {
         let (_, locator) = Self::from_project_with_manifest(project_root, Target::host())?;
         Ok(locator)

--- a/crates/diagnostics/src/infer.rs
+++ b/crates/diagnostics/src/infer.rs
@@ -2714,6 +2714,7 @@ pub enum InterfaceMethodViolation {
         expected: Type,
         actual: Type,
         impl_span: Option<Span>,
+        through_type_parameter: bool,
     },
 }
 
@@ -2765,6 +2766,7 @@ fn labelled_methods<'a>(
                 expected,
                 actual,
                 impl_span,
+                ..
             } = method
             else {
                 return None;
@@ -3099,6 +3101,20 @@ pub fn builtin_type_cannot_implement_interface(
         .with_help(format!(
             "Built-in types have no Go methods, so they cannot satisfy interfaces. Wrap the \
              value in a struct that implements `{interface_name}`."
+        ))
+}
+
+pub fn unsupported_generic_go_interface(
+    interface_name: &str,
+    type_name: &str,
+    span: Span,
+) -> LisetteDiagnostic {
+    LisetteDiagnostic::error("Not supported yet")
+        .with_infer_code("unsupported_generic_go_interface")
+        .with_span_label(&span, "unsupported")
+        .with_help(format!(
+            "Lisette does not yet support using `{}` as the generic Go interface `{}`",
+            type_name, interface_name
         ))
 }
 

--- a/crates/semantics/src/checker/infer/interface.rs
+++ b/crates/semantics/src/checker/infer/interface.rs
@@ -8,7 +8,7 @@ use syntax::program::{
     DefinitionBody, InterfaceRequirement, Methods, interface_declares_any_method,
     interface_requirements,
 };
-use syntax::types::{GO_IMPORT_PREFIX, Symbol, Type, unqualified_name};
+use syntax::types::{FunctionParameter, GO_IMPORT_PREFIX, Symbol, Type, unqualified_name};
 
 use crate::checker::infer::InferCtx;
 use syntax::go_names;
@@ -190,6 +190,16 @@ impl InferCtx<'_> {
                 .map_or_else(|| resolved.to_string(), str::to_owned);
             self.sink
                 .push(diagnostics::infer::builtin_type_cannot_implement_interface(
+                    unqualified_name(interface_qualified_id),
+                    &type_name,
+                    *span,
+                ));
+        } else if blocked_by_type_parameter_permission(&violations) {
+            let type_name = resolved
+                .get_name()
+                .map_or_else(|| resolved.to_string(), str::to_owned);
+            self.sink
+                .push(diagnostics::infer::unsupported_generic_go_interface(
                     unqualified_name(interface_qualified_id),
                     &type_name,
                     *span,
@@ -604,6 +614,12 @@ impl InferCtx<'_> {
                         .symbol_methods
                         .get(impl_method_name.as_str())
                         .and_then(|method| method.name_span);
+                    let through_type_parameter = interface_qualified_id.starts_with("go:")
+                        && permission_gap_only_at_type_parameters(
+                            &requirement.method.ty,
+                            &expected,
+                            &actual,
+                        );
                     check.push_violation(
                         interface_qualified_id,
                         requirement.parent_of.as_ref(),
@@ -612,6 +628,7 @@ impl InferCtx<'_> {
                             expected,
                             actual,
                             impl_span,
+                            through_type_parameter,
                         },
                     );
                 }
@@ -861,4 +878,147 @@ fn covariant_return_adjustment(
         impl_f.bounds.clone(),
         iface_ret.clone(),
     ))
+}
+
+fn blocked_by_type_parameter_permission(violations: &[InterfaceViolation]) -> bool {
+    let mut methods = violations
+        .iter()
+        .flat_map(|violation| &violation.methods)
+        .peekable();
+    methods.peek().is_some()
+        && methods.all(|method| {
+            matches!(
+                method,
+                InterfaceMethodViolation::Incompatible {
+                    through_type_parameter: true,
+                    ..
+                }
+            )
+        })
+}
+
+fn permission_gap_only_at_type_parameters(declared: &Type, expected: &Type, actual: &Type) -> bool {
+    let declared = declared.unwrap_forall();
+    match (
+        erase_at_parameters(declared, expected.unwrap_forall()),
+        erase_at_parameters(declared, actual.unwrap_forall()),
+    ) {
+        (Some(expected), Some(actual)) => expected == actual,
+        _ => false,
+    }
+}
+
+fn erase_at_parameters(declared: &Type, ty: &Type) -> Option<Type> {
+    match (declared, ty) {
+        (Type::Parameter(_), _) => Some(erase_permissions(ty)),
+        (Type::Function(declared), Type::Function(f)) => {
+            if declared.params.len() != f.params.len() {
+                return None;
+            }
+            let params = declared
+                .params
+                .iter()
+                .zip(&f.params)
+                .map(|(declared, param)| {
+                    erase_at_parameters(&declared.ty, &param.ty)
+                        .map(|ty| FunctionParameter::named(ty, param.name.clone()))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            let return_type = erase_at_parameters(&declared.return_type, &f.return_type)?;
+            Some(f.rebuild(params, Vec::new(), Box::new(return_type)))
+        }
+        (
+            Type::Compound { args: declared, .. },
+            Type::Compound {
+                kind,
+                args,
+                writable,
+            },
+        ) if declared.len() == args.len() => {
+            let args = declared
+                .iter()
+                .zip(args)
+                .map(|(declared, arg)| erase_at_parameters(declared, arg))
+                .collect::<Option<Vec<_>>>()?;
+            Some(Type::Compound {
+                kind: *kind,
+                args,
+                writable: *writable,
+            })
+        }
+        (
+            Type::Nominal {
+                params: declared, ..
+            },
+            Type::Nominal {
+                id,
+                params,
+                writable,
+            },
+        ) if declared.len() == params.len() => {
+            let params = declared
+                .iter()
+                .zip(params)
+                .map(|(declared, param)| erase_at_parameters(declared, param))
+                .collect::<Option<Vec<_>>>()?;
+            Some(Type::Nominal {
+                id: id.clone(),
+                params,
+                writable: *writable,
+            })
+        }
+        (Type::Tuple(declared), Type::Tuple(elements)) if declared.len() == elements.len() => {
+            let elements = declared
+                .iter()
+                .zip(elements)
+                .map(|(declared, element)| erase_at_parameters(declared, element))
+                .collect::<Option<Vec<_>>>()?;
+            Some(Type::Tuple(elements))
+        }
+        (
+            Type::Array {
+                element: declared, ..
+            },
+            Type::Array { length, element },
+        ) => Some(Type::Array {
+            length: *length,
+            element: Box::new(erase_at_parameters(declared, element)?),
+        }),
+        _ => Some(ty.clone()),
+    }
+}
+
+fn erase_permissions(ty: &Type) -> Type {
+    match ty {
+        Type::Compound { kind, args, .. } => Type::Compound {
+            kind: *kind,
+            args: args.iter().map(erase_permissions).collect(),
+            writable: false,
+        },
+        Type::Nominal { id, params, .. } => Type::Nominal {
+            id: id.clone(),
+            params: params.iter().map(erase_permissions).collect(),
+            writable: false,
+        },
+        Type::Tuple(elements) => Type::Tuple(elements.iter().map(erase_permissions).collect()),
+        Type::Array { length, element } => Type::Array {
+            length: *length,
+            element: Box::new(erase_permissions(element)),
+        },
+        Type::Function(f) => f.rebuild(
+            f.params
+                .iter()
+                .map(|param| {
+                    FunctionParameter::named(erase_permissions(&param.ty), param.name.clone())
+                })
+                .collect(),
+            Vec::new(),
+            Box::new(erase_permissions(&f.return_type)),
+        ),
+        Type::Forall { vars, body } => Type::Forall {
+            vars: vars.clone(),
+            body: Box::new(erase_permissions(body)),
+        },
+        other => other.clone(),
+    }
 }

--- a/crates/stdlib/typedefs/database/sql/driver.d.lis
+++ b/crates/stdlib/typedefs/database/sql/driver.d.lis
@@ -140,7 +140,7 @@ pub struct NamedValue {
 /// path is used for the argument. Drivers may wish to return [ErrSkip] after
 /// they have exhausted their own special cases.
 pub interface NamedValueChecker {
-  fn CheckNamedValue(namedValue: Ref<NamedValue>) -> Result<(), error>
+  fn CheckNamedValue(namedValue: mut Ref<NamedValue>) -> Result<(), error>
 }
 
 /// NotNull is a type that implements [ValueConverter] by disallowing nil

--- a/crates/stdlib/typedefs/net/rpc.d.lis
+++ b/crates/stdlib/typedefs/net/rpc.d.lis
@@ -104,7 +104,7 @@ pub interface ClientCodec {
   #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ReadResponseBody(any: Unknown) -> Result<(), error>
-  fn ReadResponseHeader(response: Ref<Response>) -> Result<(), error>
+  fn ReadResponseHeader(response: mut Ref<Response>) -> Result<(), error>
   fn WriteRequest(request: Ref<Request>, any: Unknown) -> Result<(), error>
 }
 
@@ -142,7 +142,7 @@ pub interface ServerCodec {
   #[allow(unused_result)]
   fn Close() -> Result<(), error>
   fn ReadRequestBody(any: Unknown) -> Result<(), error>
-  fn ReadRequestHeader(request: Ref<Request>) -> Result<(), error>
+  fn ReadRequestHeader(request: mut Ref<Request>) -> Result<(), error>
   fn WriteResponse(response: Ref<Response>, any: Unknown) -> Result<(), error>
 }
 

--- a/tests/ui/errors/mod.rs
+++ b/tests/ui/errors/mod.rs
@@ -5099,6 +5099,35 @@ fn main() {
 }
 
 #[test]
+fn infer_unsupported_generic_go_interface() {
+    let typedef = r#"
+pub struct Node {
+  pub Value: int,
+}
+
+pub interface Applier<T> {
+  fn Apply(items: mut Slice<T>)
+}
+
+pub type Impl<K>
+
+impl<K: Comparable> Impl<K> {
+  fn Apply(self, items: mut Slice<mut Ref<Node>>)
+}
+
+pub fn New() -> Impl<int>
+
+pub fn Use(a: Applier<Ref<Node>>)
+"#;
+    let input = r#"import "go:example.com/lib"
+fn main() {
+  lib.Use(lib.New())
+}
+"#;
+    assert_infer_error_snapshot!(input, &[("go:example.com/lib", typedef)]);
+}
+
+#[test]
 fn infer_comma_ok_abi_mismatch() {
     let typedef = r#"
 pub interface Lookup {

--- a/tests/ui/errors/snapshots/infer_unsupported_generic_go_interface.snap
+++ b/tests/ui/errors/snapshots/infer_unsupported_generic_go_interface.snap
@@ -1,0 +1,12 @@
+---
+source: tests/ui/errors/mod.rs
+---
+  ✕ Not supported yet
+   ╭─[test.lis:3:11]
+ 2 │ fn main() {
+ 3 │   lib.Use(lib.New())
+   ·           ────┬────
+   ·               ╰── unsupported
+ 4 │ }
+   ╰────
+  help: Lisette does not yet support using `Impl` as the generic Go interface `Applier` · code: [infer.unsupported_generic_go_interface]


### PR DESCRIPTION
Go implementations that write through an interface method's param now satisfy that interface when the interface is generic or declared in another package, instead of failing with `does not implement`.

```rs
import "go:context"
import "go:github.com/cloudwego/eino/adk"

fn run() -> Result<(), error> {
  let ctx = context.Background()
  let mut config = adk.ChatModelAgentConfig{ .. }
  let mut agent = adk.NewChatModelAgent(ctx, &config)?
  let runner = adk.NewRunner(Some(ctx), adk.RunnerConfig{ Agent: Some(agent), .. })
  let _ = runner
  Ok(())
}

fn main() {
  let _ = run()
}
```

An implementation that writes through values the interface types with a type param, e.g. `model.BaseModel[M]` taking `[]M`, is out of scope. Lis cannot express that `mut` yet, so this case reports `Not supported yet` for now.

Fix #1411
