### PR TITLE
feat: idiomatic Go for `wrap_err` on Go calls

### DIFF
--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -293,6 +293,17 @@ impl Planner<'_> {
         }
     }
 
+    pub(crate) fn declared_arm_value_name(&mut self, name: &str) -> String {
+        let candidate = self.arm_value_name(name);
+        let name = if self.is_declared(&candidate) {
+            self.fresh_var(Some(&candidate))
+        } else {
+            candidate
+        };
+        self.declare(&name);
+        name
+    }
+
     /// Fresh within a Go block; nested blocks may shadow outer statuses.
     pub(crate) fn pair_status(
         &mut self,

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod predicates;
 mod regular;
 mod slice_loop;
 mod ufcs;
+pub(crate) mod wrap_err;
 
 use crate::plan::values::CaptureBoundary;
 use crate::types::native::NativeGoType;

--- a/crates/emit/src/calls/wrap_err.rs
+++ b/crates/emit/src/calls/wrap_err.rs
@@ -1,0 +1,129 @@
+use crate::Planner;
+use crate::context::expression::ExpressionContext;
+use crate::expressions::literals::convert_escape_sequences;
+use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::GoExpression;
+use syntax::ast::{Expression, FormatStringPart, Literal};
+
+pub(crate) struct WrapMessage {
+    format: String,
+    args: Vec<String>,
+}
+
+impl Planner<'_> {
+    /// The call under a chain of `.wrap_err(message)`, with the messages inner to outer.
+    pub(crate) fn peel_wrap_err<'a>(
+        &self,
+        expression: &'a Expression,
+    ) -> (&'a Expression, Vec<&'a Expression>) {
+        let mut expression = expression.unwrap_parens();
+        let mut messages = Vec::new();
+        while let Some((receiver, message)) = self.wrap_err_call(expression) {
+            messages.push(message);
+            expression = receiver.unwrap_parens();
+        }
+        messages.reverse();
+        (expression, messages)
+    }
+
+    fn wrap_err_call<'a>(
+        &self,
+        expression: &'a Expression,
+    ) -> Option<(&'a Expression, &'a Expression)> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            ..
+        } = expression
+        else {
+            return None;
+        };
+        let [message] = args.as_slice() else {
+            return None;
+        };
+        if spread.is_some() || !self.plan_call(expression)?.resolved.is_prelude_dispatch {
+            return None;
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return None;
+        };
+        let wraps = member == "wrap_err" && self.facts.peel_alias(&receiver.get_type()).is_result();
+        wraps.then_some((receiver.as_ref(), message))
+    }
+
+    /// Messages, including custom String calls, must run even on success.
+    pub(crate) fn prepare_wrap_messages(
+        &mut self,
+        messages: &[&Expression],
+        read_error: bool,
+    ) -> (Vec<LoweredStatement>, Vec<WrapMessage>) {
+        let mut setup = Vec::new();
+        let mut prepared = Vec::new();
+        for message in messages {
+            if !read_error {
+                setup.extend(self.lower_discard_value(message));
+                continue;
+            }
+            let (format, args) = match message.unwrap_parens() {
+                Expression::Literal {
+                    literal: Literal::String { value, raw: false },
+                    ..
+                } => (
+                    convert_escape_sequences(value).replace('%', "%%"),
+                    Vec::new(),
+                ),
+                Expression::Literal {
+                    literal: Literal::FormatString(parts),
+                    ..
+                } if parts.iter().all(|part| match part {
+                    FormatStringPart::Expression(e) => {
+                        self.facts.peel_alias(&e.get_type()).as_simple().is_some()
+                    }
+                    FormatStringPart::Text(_) => true,
+                }) =>
+                {
+                    let mut values = Vec::new();
+                    for part in parts {
+                        if let FormatStringPart::Expression(expression) = part {
+                            let value =
+                                self.lower_composite_value(expression, ExpressionContext::value());
+                            let (part_setup, value) =
+                                self.eager_operand(expression, value, "fmtarg").into_parts();
+                            setup.extend(part_setup);
+                            values.push(GoExpression::opaque(value));
+                        }
+                    }
+                    self.sprintf_pieces(parts, values, true)
+                }
+                _ => {
+                    let value = self.lower_composite_value(message, ExpressionContext::value());
+                    let (message_setup, value) =
+                        self.eager_operand(message, value, "msg").into_parts();
+                    setup.extend(message_setup);
+                    ("%s".to_string(), vec![value])
+                }
+            };
+            prepared.push(WrapMessage { format, args });
+        }
+        (setup, prepared)
+    }
+
+    pub(crate) fn wrap_error(&mut self, messages: &[WrapMessage], error: String) -> String {
+        messages.iter().fold(error, |error, message| {
+            self.require_fmt();
+            let mut args = message.args.clone();
+            args.push(error);
+            format!(
+                "fmt.Errorf(\"{}: %w\", {})",
+                message.format,
+                args.join(", ")
+            )
+        })
+    }
+}

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -179,8 +179,9 @@ impl Planner<'_> {
         fallible: &Fallible,
         result_var_name: Option<&str>,
     ) -> Option<(Vec<LoweredStatement>, String)> {
-        let plan = self.plan_call(expression)?;
-        let expression_ty = expression.get_type();
+        let (call, wraps) = self.peel_wrap_err(expression);
+        let plan = self.plan_call(call)?;
+        let expression_ty = call.get_type();
         let ok_ty = self.facts.peel_alias(&expression_ty).ok_type();
         let shape = plan.resolved.abi.result.clone();
         let comma_ok = match shape {
@@ -225,7 +226,7 @@ impl Planner<'_> {
         }
 
         let (mut statements, call_str) = self
-            .lower_call(expression, None, ExpressionContext::value())
+            .lower_call(call, None, ExpressionContext::value())
             .into_parts();
         let want_value = !matches!(result_var_name, Some("_"));
         let let_slot = result_var_name.filter(|name| {
@@ -244,18 +245,21 @@ impl Planner<'_> {
         } else {
             PairStatusKind::Error
         };
-        let outcome_var = self.pair_status(None, status_kind, value_var.is_none());
+        let (message_setup, wraps) = self.prepare_wrap_messages(&wraps, true);
+        let opens_if = value_var.is_none() && message_setup.is_empty();
+        let outcome_var = self.pair_status(None, status_kind, opens_if);
         let bind_line = match &value_var {
             Some(value) => format!("{value}, {outcome_var} := {call_str}"),
             None if has_value_slot => format!("_, {outcome_var} := {call_str}"),
             None => format!("{outcome_var} := {call_str}"),
         };
-        let initializer = if value_var.is_some() {
+        let initializer = if opens_if {
+            Some(bind_line)
+        } else {
             statements.push(LoweredStatement::RawGo(format!("{bind_line}\n")));
             None
-        } else {
-            Some(bind_line)
         };
+        statements.extend(message_setup);
         let open_if = |condition: String| match &initializer {
             Some(initializer) => format!("{initializer}; {condition}"),
             None => condition,
@@ -282,8 +286,8 @@ impl Planner<'_> {
                 failure_values,
             ));
         } else {
-            let (failure_setup, failure_values) =
-                self.propagate_failure_values(fallible, &outcome_var);
+            let error = self.wrap_error(&wraps, outcome_var.clone());
+            let (failure_setup, failure_values) = self.propagate_failure_values(fallible, &error);
             statements.push(transition::tag_check(
                 open_if(format!("{} != nil", outcome_var)),
                 failure_setup,
@@ -297,8 +301,8 @@ impl Planner<'_> {
                     self.require_stdlib();
                 }
                 self.require_errors();
-                let (nil_setup, nil_failure) =
-                    self.propagate_failure_values(fallible, "errors.New(\"unexpected nil\")");
+                let error = self.wrap_error(&wraps, "errors.New(\"unexpected nil\")".to_string());
+                let (nil_setup, nil_failure) = self.propagate_failure_values(fallible, &error);
                 statements.push(transition::tag_check(
                     guard.is_nil(val),
                     nil_setup,
@@ -450,6 +454,7 @@ impl Planner<'_> {
                 &fallible,
                 &return_ty,
                 lowered.as_ref(),
+                &[],
             ));
             return Some(statements);
         }
@@ -532,12 +537,25 @@ impl Planner<'_> {
         else {
             unreachable!("lower_wrapped_call_return requires a Call expression");
         };
+        let (inner, wraps) = self.peel_wrap_err(expression);
+        if let Expression::Call {
+            expression: inner_callee,
+            args: inner_args,
+            ..
+        } = inner
+            && !wraps.is_empty()
+            && fallible.classify_constructor(inner_callee) == Some(ConstructorKind::Failure)
+        {
+            return self.lower_failure_constructor_return(
+                inner_args, fallible, return_ty, lowered, &wraps,
+            );
+        }
         match fallible.classify_constructor(call_expression) {
             Some(ConstructorKind::Success) => {
                 self.lower_success_constructor_return(args, fallible, lowered)
             }
             Some(ConstructorKind::Failure) => {
-                self.lower_failure_constructor_return(args, fallible, return_ty, lowered)
+                self.lower_failure_constructor_return(args, fallible, return_ty, lowered, &[])
             }
             None => self.lower_wrapped_passthrough_return(expression, return_ty, lowered),
         }
@@ -601,45 +619,37 @@ impl Planner<'_> {
         fallible: &Fallible,
         return_ty: &Type,
         lowered: Option<&CallableReturnAbi>,
+        wraps: &[&Expression],
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
-        if let Some(shape) = lowered {
-            if args.is_empty() {
-                statements.push(transition::multi_value_return(
-                    transition::lowered_none_values(self, shape, return_ty),
-                ));
+        let error = args.first().map(|arg| {
+            let error = self.lower_composite_value(arg, ExpressionContext::value());
+            let (message_setup, wraps) = self.prepare_wrap_messages(wraps, true);
+            let error = if message_setup.is_empty() {
+                error
             } else {
-                let (setup, err_expr) = self
-                    .lower_composite_value(&args[0], ExpressionContext::value())
-                    .into_parts();
-                statements.extend(setup);
-                let from = args[0].get_type();
-                let to = self
-                    .contextual_err_ty(fallible)
-                    .expect("Result must have error type");
-                let err_expr = self.coerce_value(&mut statements, err_expr, &from, &to);
-                let values = transition::lowered_err_values(self, shape, return_ty, &err_expr);
-                statements.push(transition::multi_value_return(values));
-            }
-        } else {
-            let failure = if fallible.is_result() {
-                let (setup, arg) = self
-                    .lower_composite_value(&args[0], ExpressionContext::value())
-                    .into_parts();
-                statements.extend(setup);
-                let from = args[0].get_type();
-                let to = self
-                    .contextual_err_ty(fallible)
-                    .expect("Result must have error type");
-                let arg = self.coerce_value(&mut statements, arg, &from, &to);
-                let mut fe = FalliblePlanner::new(self, fallible);
-                fe.emit_failure(Some(&arg))
-            } else {
-                let mut fe = FalliblePlanner::new(self, fallible);
-                fe.emit_failure(None)
+                self.eager_operand(arg, error, "err")
             };
-            statements.push(plain_return(failure));
-        }
+            let (setup, error) = error.into_parts();
+            statements.extend(setup);
+            let to = self
+                .contextual_err_ty(fallible)
+                .expect("Result must have error type");
+            let error = self.coerce_value(&mut statements, error, &arg.get_type(), &to);
+            statements.extend(message_setup);
+            self.wrap_error(&wraps, error)
+        });
+        let returned = if let Some(shape) = lowered {
+            let values = match error {
+                Some(error) => transition::lowered_err_values(self, shape, return_ty, &error),
+                None => transition::lowered_none_values(self, shape, return_ty),
+            };
+            transition::multi_value_return(values)
+        } else {
+            let mut fe = FalliblePlanner::new(self, fallible);
+            plain_return(fe.emit_failure(error.as_deref()))
+        };
+        statements.push(returned);
         statements
     }
 
@@ -651,6 +661,21 @@ impl Planner<'_> {
         lowered: Option<&CallableReturnAbi>,
     ) -> Vec<LoweredStatement> {
         let mut statements = Vec::new();
+        if let Some(shape) = lowered
+            && matches!(
+                shape,
+                CallableReturnAbi::Result { .. } | CallableReturnAbi::BareError
+            )
+            && !self.peel_wrap_err(expression).1.is_empty()
+            && self.result_fuse_plan(expression).is_some()
+        {
+            let (setup, value) = self.lower_propagate(expression, None);
+            statements.extend(setup);
+            statements.push(transition::multi_value_return(
+                transition::lowered_ok_values(shape, &value),
+            ));
+            return statements;
+        }
         if let Some(shape) = lowered
             && self.callee_matches_lowered_shape(expression, shape)
         {

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -671,8 +671,12 @@ impl Planner<'_> {
         {
             let (setup, value) = self.lower_propagate(expression, None);
             statements.extend(setup);
+            let ok_ty = self.facts.peel_alias(return_ty).ok_type();
+            let (projection, payload) =
+                transition::lowered_payload_values(self, shape, &ok_ty, &value);
+            statements.extend(projection);
             statements.push(transition::multi_value_return(
-                transition::lowered_ok_values(shape, &value),
+                transition::lowered_ok_values(shape, payload),
             ));
             return statements;
         }

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -199,32 +199,7 @@ impl Planner<'_> {
             return ValuePlan::computed(setup, concatenation, effect);
         }
 
-        let mut format_string = String::new();
-        let mut args = Vec::with_capacity(values.len());
-
-        for part in parts {
-            match part {
-                FormatStringPart::Text(text) => {
-                    let unescaped = text.replace("{{", "{").replace("}}", "}");
-                    let unescaped = convert_escape_sequences(&unescaped);
-                    if has_interpolation {
-                        format_string.push_str(&unescaped.replace('%', "%%"));
-                    } else {
-                        format_string.push_str(&unescaped);
-                    }
-                }
-                FormatStringPart::Expression(expression) => {
-                    let peeled = self.facts.peel_alias(&expression.get_type());
-                    format_string.push_str(format_verb_for(&peeled));
-                    args.push(
-                        values
-                            .next()
-                            .expect("sequenced count matches expression parts")
-                            .rendered(),
-                    );
-                }
-            }
-        }
+        let (format_string, args) = self.sprintf_pieces(parts, values, has_interpolation);
 
         if args.is_empty() {
             return ValuePlan::evaluated_literal(setup, format!("\"{}\"", format_string), effect);
@@ -253,6 +228,42 @@ impl Planner<'_> {
             GoExpression::call(GoExpression::opaque("fmt.Sprintf".to_string()), arguments),
             effect,
         )
+    }
+
+    /// The `fmt` format text and arguments for the parts, given their lowered values in order.
+    pub(crate) fn sprintf_pieces(
+        &self,
+        parts: &[FormatStringPart],
+        values: impl IntoIterator<Item = GoExpression>,
+        escape_percent: bool,
+    ) -> (String, Vec<String>) {
+        let mut values = values.into_iter();
+        let mut format_string = String::new();
+        let mut args = Vec::new();
+        for part in parts {
+            match part {
+                FormatStringPart::Text(text) => {
+                    let unescaped = text.replace("{{", "{").replace("}}", "}");
+                    let unescaped = convert_escape_sequences(&unescaped);
+                    if escape_percent {
+                        format_string.push_str(&unescaped.replace('%', "%%"));
+                    } else {
+                        format_string.push_str(&unescaped);
+                    }
+                }
+                FormatStringPart::Expression(expression) => {
+                    let peeled = self.facts.peel_alias(&expression.get_type());
+                    format_string.push_str(format_verb_for(&peeled));
+                    args.push(
+                        values
+                            .next()
+                            .expect("sequenced count matches expression parts")
+                            .rendered(),
+                    );
+                }
+            }
+        }
+        (format_string, args)
     }
 
     pub(crate) fn format_string_lowers_to_sprintf(&self, parts: &[FormatStringPart]) -> bool {

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -78,6 +78,25 @@ impl Planner<'_> {
         staged.replace_with_pinned_name(tmp);
     }
 
+    pub(crate) fn eager_operand(
+        &mut self,
+        source: &Expression,
+        mut value: ValuePlan,
+        prefix: &str,
+    ) -> ValuePlan {
+        if !value.evaluation.stability.is_fixed()
+            && value.expression.constant_kind().is_none()
+            && !self.plan_rests_in_stable_name(&value)
+        {
+            // Keep the source type when Go would default an untyped shift to int.
+            if self.contains_untyped_constant_shift(source) {
+                value = value.conversion(self.use_go_type(&source.get_type()));
+            }
+            self.pin_staged(&mut value, prefix);
+        }
+        value
+    }
+
     pub(crate) fn capture_value_at_boundary(
         &mut self,
         setup: &mut Vec<LoweredStatement>,

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -3,6 +3,7 @@ use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
 use crate::calls::comma_ok::CommaOkSource;
 use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind, header_call};
 use crate::calls::go_interop::NilGuard;
+use crate::calls::wrap_err::WrapMessage;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::is_plain_identifier;
 use crate::patterns::binding_decls::pattern_binds_name;
@@ -21,6 +22,7 @@ pub(crate) struct ResultFusePlan<'a> {
     subject: &'a Expression,
     shape: CallableReturnAbi,
     nil_guard: Option<NilGuard>,
+    wraps: Vec<&'a Expression>,
 }
 
 pub(crate) enum OptionFusePlan<'a> {
@@ -159,11 +161,34 @@ impl ResultFusePlan<'_> {
         slot: CommaOkValueSlot,
         error_name: Option<&str>,
     ) -> LoweredPair {
+        self.bind_wrapped(planner, slot, error_name, false).0
+    }
+
+    fn bind_wrapped(
+        self,
+        planner: &mut Planner<'_>,
+        slot: CommaOkValueSlot,
+        error_name: Option<&str>,
+        read_error: bool,
+    ) -> (LoweredPair, Vec<WrapMessage>) {
         let carries_value = self.carries_payload();
         let (setup, call) = planner
             .lower_call(self.subject, None, ExpressionContext::value())
             .into_parts();
-        planner.bind_pair(
+        let (message_setup, messages) = planner.prepare_wrap_messages(&self.wraps, read_error);
+        // Bind before any eager message setup.
+        let slot = if message_setup.is_empty() {
+            slot
+        } else {
+            match slot {
+                CommaOkValueSlot::Arm(name) => {
+                    CommaOkValueSlot::Named(planner.declared_arm_value_name(&name))
+                }
+                CommaOkValueSlot::Unused => CommaOkValueSlot::Discarded,
+                slot => slot,
+            }
+        };
+        let mut pair = planner.bind_pair(
             setup,
             call,
             slot,
@@ -172,7 +197,9 @@ impl ResultFusePlan<'_> {
                 nil_guard: self.nil_guard,
             },
             error_name,
-        )
+        );
+        pair.statements.extend(message_setup);
+        (pair, messages)
     }
 }
 
@@ -382,6 +409,7 @@ impl Planner<'_> {
         &self,
         subject: &'a Expression,
     ) -> Option<ResultFusePlan<'a>> {
+        let (subject, wraps) = self.peel_wrap_err(subject);
         let plan = self.plan_call(subject)?;
         let shape = plan.resolved.abi.result.clone();
         let nil_guard = match &plan.resolved.origin {
@@ -414,6 +442,7 @@ impl Planner<'_> {
             subject,
             shape,
             nil_guard,
+            wraps,
         })
     }
 
@@ -580,7 +609,8 @@ impl Planner<'_> {
             (None, Some(name)) => CommaOkValueSlot::Arm(self.arm_value_name(name)),
             (None, None) => CommaOkValueSlot::Unused,
         };
-        let mut bound = fuse.bind(self, slot, err_name);
+        let (mut bound, wraps) = fuse.bind_wrapped(self, slot, err_name, err_name.is_some());
+        let error = bound.status().to_string();
 
         let then_body = destination.is_none().then(|| {
             // A call returning only `error` has no value, so `Ok(x)` takes unit.
@@ -601,7 +631,8 @@ impl Planner<'_> {
         let (mut else_body, err_used) =
             self.lower_fused_arm(&[err_binding], &err.arm.expression, arm_place);
 
-        if has_nil_guard && err_used.into_iter().any(|used| used) {
+        let err_read = err_used.first().copied().unwrap_or(false) || !wraps.is_empty();
+        if has_nil_guard && err_read {
             self.require_errors();
             let error = bound.status();
             else_body.statements.insert(
@@ -610,6 +641,14 @@ impl Planner<'_> {
                     "if {error} == nil {{\n{error} = errors.New(\"unexpected nil\")\n}}\n"
                 )),
             );
+        }
+        if !wraps.is_empty() {
+            let wrapped = self.wrap_error(&wraps, error.clone());
+            let prologue = vec![LoweredStatement::RawGo(format!("{error} = {wrapped}\n"))];
+            let after_nil_guard = usize::from(has_nil_guard);
+            else_body
+                .statements
+                .splice(after_nil_guard..after_nil_guard, prologue);
         }
         if matches!(then_body, Some((_, false))) {
             bound.discard_value();

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2678,6 +2678,164 @@ fn main() {
 }
 
 #[test]
+fn wrap_err_propagate_on_go_calls_uses_errorf() {
+    let input = r#"
+import "go:encoding/json"
+import "go:fmt"
+import "go:os"
+
+const FILE = "nums.json"
+
+fn load() -> Result<Slice<int>, error> {
+  let bytes = os.ReadFile(FILE).wrap_err(f"reading {FILE}")?
+  let mut nums: Slice<int> = []
+  json.Unmarshal(bytes, &nums).wrap_err("parsing nums")?
+  Ok(nums)
+}
+
+fn main() {
+  fmt.Println(load())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_message_escapes_percent_and_interpolates_values() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn parse(raw: string, attempt: int) -> Result<int, error> {
+  let n = strconv.Atoi(raw).wrap_err(f"attempt {attempt} at 100% of {raw}")?
+  Ok(n)
+}
+
+fn main() {
+  fmt.Println(parse("1", 2))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_computed_message_uses_a_string_verb() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn describe(raw: string) -> string { "parsing " + raw }
+
+fn parse(raw: string) -> Result<int, error> {
+  let n = strconv.Atoi(raw).wrap_err(describe(raw))?
+  Ok(n)
+}
+
+fn main() {
+  fmt.Println(parse("1"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_on_pointer_returning_go_call_wraps_both_failures() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn open(path: string) -> Result<Ref<os.File>, error> {
+  let file = os.Open(path).wrap_err("open")?
+  Ok(file)
+}
+
+fn main() {
+  fmt.Println(open("missing.txt"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn err_constructor_wrap_err_in_return_position() {
+    let input = r#"
+import "go:errors"
+import "go:fmt"
+import "go:io/fs"
+import "go:os"
+
+const FILE = "tasks.json"
+
+fn load() -> Result<Slice<byte>, error> {
+  let bytes = match os.ReadFile(FILE) {
+    Ok(bytes) => bytes,
+    Err(err) => {
+      if errors.Is(err, fs.ErrNotExist) { return Ok([]) }
+      return Err(err).wrap_err(f"reading {FILE}")
+    },
+  }
+  Ok(bytes)
+}
+
+fn main() {
+  fmt.Println(load())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_on_wrap_err_of_go_call_wraps_in_the_err_arm() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  match strconv.Atoi("x").wrap_err("parse") {
+    Ok(n) => fmt.Println(n),
+    Err(err) => fmt.Println(err),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn tail_return_of_wrap_err_on_go_call() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn port(raw: string) -> Result<int, error> {
+  strconv.Atoi(raw).wrap_err("read port")
+}
+
+fn main() {
+  fmt.Println(port("8080"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn nested_wrap_err_wraps_inner_message_first() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn parse(raw: string) -> Result<int, error> {
+  let n = strconv.Atoi(raw).wrap_err("inner").wrap_err("outer")?
+  Ok(n)
+}
+
+fn main() {
+  fmt.Println(parse("1"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"
@@ -2687,6 +2845,146 @@ fn double(n: int) -> Result<int, error> { Ok(n * 2) }
 fn run() -> Result<int, error> {
   let d = double(strconv.Atoi("1")?)?
   Ok(d)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_evaluates_an_effectful_message_before_the_error_test() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn message() -> string {
+  fmt.Println("message ran")
+  "ctx"
+}
+
+fn two() -> Result<int, error> {
+  let n = strconv.Atoi("2").wrap_err(message())?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_wrap_evaluates_custom_display_on_success_and_failure() {
+    let input = r#"
+import "go:strconv"
+
+#[display]
+struct Label { describe: fn() -> string }
+
+impl Label {
+  fn string(self) -> string {
+    self.describe()
+  }
+}
+
+fn parse(raw: string, label: Label) -> Result<int, error> {
+  let n = strconv.Atoi(raw).wrap_err(f"took {label}")?
+  Ok(n)
+}
+
+fn main() {
+  let mut seen = 0
+  let describe = || -> string {
+    seen = seen + 1
+    "label"
+  }
+  let label = Label { describe }
+  let good = parse("1", label).unwrap_or(0)
+  if good != 1 || seen != 1 { panic("success skipped display") }
+  let bad = parse("bad", label).is_ok()
+  if bad || seen != 2 { panic("failure skipped display") }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_message_with_a_nested_propagate_keeps_the_outer_error() {
+    let input = r#"
+import "go:strconv"
+
+fn three() -> Result<int, error> {
+  let n = strconv.Atoi("x").wrap_err(f"{strconv.Atoi("0")?}")?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn chained_wrap_err_reads_an_earlier_message_before_a_later_effect() {
+    let input = r#"
+import "go:strconv"
+
+fn four(initial: string) -> Result<int, error> {
+  let mut text = initial
+  let update = || -> string {
+    text = "changed"
+    "outer"
+  }
+  let n = strconv.Atoi("bad").wrap_err(text).wrap_err(update())?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrapped_error_constructor_evaluates_its_argument_first() {
+    let input = r#"
+import "go:errors"
+import "go:fmt"
+
+fn message() -> string {
+  fmt.Println("message ran")
+  "ctx"
+}
+
+fn make_error() -> error {
+  fmt.Println("make_error ran")
+  errors.New("boom")
+}
+
+fn five() -> Result<int, error> {
+  Err(make_error()).wrap_err(message())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn adjacent_wrapped_matches_take_fresh_payload_names() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn message() -> string {
+  fmt.Println("message ran")
+  "ctx"
+}
+
+fn six() -> int {
+  let a = match strconv.Atoi("1").wrap_err(message()) {
+    Ok(n) => n,
+    Err(e) => {
+      fmt.Println(e)
+      0
+    },
+  }
+  let b = match strconv.Atoi("2").wrap_err(message()) {
+    Ok(n) => n,
+    Err(e) => {
+      fmt.Println(e)
+      0
+    },
+  }
+  a + b
 }
 "#;
     assert_emit_snapshot!(input);
@@ -2709,6 +3007,59 @@ fn eight() -> int {
 }
 
 #[test]
+fn wrapped_error_variable_is_read_before_a_message_that_rebinds_it() {
+    let input = r#"
+import "go:errors"
+
+fn two() -> Result<int, error> {
+  let mut e = errors.New("before")
+  let update = || -> string {
+    e = errors.New("after")
+    "context"
+  }
+  Err(e).wrap_err(update())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn propagate_message_that_calls_a_function_of_the_let_name_keeps_a_temp() {
+    let input = r#"
+import "go:strconv"
+
+fn n() -> int { 9 }
+
+fn four() -> Result<int, error> {
+  let n = strconv.Atoi("bad").wrap_err(f"{n()}")?
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn err_arm_closure_keeps_its_error_past_a_later_pair() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn message() -> string { "context" }
+
+fn parse() -> Result<int, error> {
+  let show = match strconv.Atoi("bad").wrap_err(message()) {
+    Ok(_) => || fmt.Println("ok"),
+    Err(err) => || fmt.Println(err),
+  }
+  let n = strconv.Atoi("2")?
+  let _ = show()
+  Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn pairs_of_different_error_types_take_distinct_statuses() {
     let input = r#"
 import "go:strconv"
@@ -2724,6 +3075,51 @@ fn run() -> Result<int, error> {
   let a = first()?
   let b = strconv.Atoi("2")?
   Ok(a + b)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn ignored_error_arm_still_runs_an_effectful_wrap_message() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn message() -> string {
+  fmt.Println("message")
+  "context"
+}
+
+fn main() {
+  match strconv.Atoi("2").wrap_err(message()) {
+    Ok(n) => fmt.Println(n),
+    Err(_) => fmt.Println("bad"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn result_binding_sites_keep_a_temp_when_a_message_reads_the_let_name() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn n() -> string { "context" }
+
+fn let_else() {
+  let Ok(n) = strconv.Atoi("2").wrap_err(n()) else { return }
+  fmt.Println(n)
+}
+
+fn let_match() {
+  let n = match strconv.Atoi("2").wrap_err(n()) {
+    Ok(x) => x,
+    Err(_) => { return },
+  }
+  fmt.Println(n)
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/adjacent_wrapped_matches_take_fresh_payload_names.snap
+++ b/tests/spec/emit/snapshots/adjacent_wrapped_matches_take_fresh_payload_names.snap
@@ -1,0 +1,65 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn message() -> string {
+    fmt.Println("message ran")
+    "ctx"
+  }
+  
+  fn six() -> int {
+    let a = match strconv.Atoi("1").wrap_err(message()) {
+      Ok(n) => n,
+      Err(e) => {
+        fmt.Println(e)
+        0
+      },
+    }
+    let b = match strconv.Atoi("2").wrap_err(message()) {
+      Ok(n) => n,
+      Err(e) => {
+        fmt.Println(e)
+        0
+      },
+    }
+    a + b
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func message() string {
+	fmt.Println("message ran")
+	return "ctx"
+}
+
+func six() int {
+	var a int
+	n, e := strconv.Atoi("1")
+	msg_1 := message()
+	if e == nil {
+		a = n
+	} else {
+		e = fmt.Errorf("%s: %w", msg_1, e)
+		fmt.Println(e)
+		a = 0
+	}
+	var b int
+	n_3, e_4 := strconv.Atoi("2")
+	msg_2 := message()
+	if e_4 == nil {
+		b = n_3
+	} else {
+		e_4 = fmt.Errorf("%s: %w", msg_2, e_4)
+		fmt.Println(e_4)
+		b = 0
+	}
+	return a + b
+}

--- a/tests/spec/emit/snapshots/chained_wrap_err_reads_an_earlier_message_before_a_later_effect.snap
+++ b/tests/spec/emit/snapshots/chained_wrap_err_reads_an_earlier_message_before_a_later_effect.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn four(initial: string) -> Result<int, error> {
+    let mut text = initial
+    let update = || -> string {
+      text = "changed"
+      "outer"
+    }
+    let n = strconv.Atoi("bad").wrap_err(text).wrap_err(update())?
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func four(initial string) (int, error) {
+	text := initial
+	update := func() string {
+		text = "changed"
+		return "outer"
+	}
+	n, err := strconv.Atoi("bad")
+	msg_1 := text
+	msg_2 := update()
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", msg_2, fmt.Errorf("%s: %w", msg_1, err))
+	}
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/err_arm_closure_keeps_its_error_past_a_later_pair.snap
+++ b/tests/spec/emit/snapshots/err_arm_closure_keeps_its_error_past_a_later_pair.snap
@@ -1,0 +1,51 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn message() -> string { "context" }
+  
+  fn parse() -> Result<int, error> {
+    let show = match strconv.Atoi("bad").wrap_err(message()) {
+      Ok(_) => || fmt.Println("ok"),
+      Err(err) => || fmt.Println(err),
+    }
+    let n = strconv.Atoi("2")?
+    let _ = show()
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func message() string {
+	return "context"
+}
+
+func parse() (int, error) {
+	var show func() (int, error)
+	_, err := strconv.Atoi("bad")
+	msg_1 := message()
+	if err == nil {
+		show = func() (int, error) {
+			return fmt.Println("ok")
+		}
+	} else {
+		err = fmt.Errorf("%s: %w", msg_1, err)
+		show = func() (int, error) {
+			return fmt.Println(err)
+		}
+	}
+	n, err_2 := strconv.Atoi("2")
+	if err_2 != nil {
+		return 0, err_2
+	}
+	show()
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/err_constructor_wrap_err_in_return_position.snap
+++ b/tests/spec/emit/snapshots/err_constructor_wrap_err_in_return_position.snap
@@ -1,0 +1,59 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:errors"
+  import "go:fmt"
+  import "go:io/fs"
+  import "go:os"
+  
+  const FILE = "tasks.json"
+  
+  fn load() -> Result<Slice<byte>, error> {
+    let bytes = match os.ReadFile(FILE) {
+      Ok(bytes) => bytes,
+      Err(err) => {
+        if errors.Is(err, fs.ErrNotExist) { return Ok([]) }
+        return Err(err).wrap_err(f"reading {FILE}")
+      },
+    }
+    Ok(bytes)
+  }
+  
+  fn main() {
+    fmt.Println(load())
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"io/fs"
+	"os"
+)
+
+const File string = "tasks.json"
+
+func load() ([]byte, error) {
+	bytes, err := os.ReadFile(File)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return []byte{}, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", File, err)
+	}
+	return bytes, nil
+}
+
+func main() {
+	ret_1, ret_2 := load()
+	var result_3 lisette.Result[[]byte, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]byte, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[[]byte, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/fused_wrap_evaluates_custom_display_on_success_and_failure.snap
+++ b/tests/spec/emit/snapshots/fused_wrap_evaluates_custom_display_on_success_and_failure.snap
@@ -1,0 +1,90 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  #[display]
+  struct Label { describe: fn() -> string }
+  
+  impl Label {
+    fn string(self) -> string {
+      self.describe()
+    }
+  }
+  
+  fn parse(raw: string, label: Label) -> Result<int, error> {
+    let n = strconv.Atoi(raw).wrap_err(f"took {label}")?
+    Ok(n)
+  }
+  
+  fn main() {
+    let mut seen = 0
+    let describe = || -> string {
+      seen = seen + 1
+      "label"
+    }
+    let label = Label { describe }
+    let good = parse("1", label).unwrap_or(0)
+    if good != 1 || seen != 1 { panic("success skipped display") }
+    let bad = parse("bad", label).is_ok()
+    if bad || seen != 2 { panic("failure skipped display") }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+type Label struct {
+	describe func() string
+}
+
+func (l Label) GoString() string {
+	return fmt.Sprintf("Label { describe: %p }", l.describe)
+}
+
+func (l Label) toString() string {
+	return l.String()
+}
+
+func (l Label) String() string {
+	return l.describe()
+}
+
+func parse(raw string, label Label) (int, error) {
+	n, err := strconv.Atoi(raw)
+	msg_1 := fmt.Sprintf("took %v", label)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", msg_1, err)
+	}
+	return n, nil
+}
+
+func main() {
+	seen := 0
+	describe := func() string {
+		seen++
+		return "label"
+	}
+	label := Label{describe: describe}
+	ret_1, ret_2 := parse("1", label)
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	good := result_3.UnwrapOr(0)
+	if good != 1 || seen != 1 {
+		panic("success skipped display")
+	}
+	_, err := parse("bad", label)
+	bad := err == nil
+	if bad || seen != 2 {
+		panic("failure skipped display")
+	}
+}

--- a/tests/spec/emit/snapshots/ignored_error_arm_still_runs_an_effectful_wrap_message.snap
+++ b/tests/spec/emit/snapshots/ignored_error_arm_still_runs_an_effectful_wrap_message.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn message() -> string {
+    fmt.Println("message")
+    "context"
+  }
+  
+  fn main() {
+    match strconv.Atoi("2").wrap_err(message()) {
+      Ok(n) => fmt.Println(n),
+      Err(_) => fmt.Println("bad"),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func message() string {
+	fmt.Println("message")
+	return "context"
+}
+
+func main() {
+	n, err := strconv.Atoi("2")
+	_ = message()
+	if err == nil {
+		fmt.Println(n)
+	} else {
+		fmt.Println("bad")
+	}
+}

--- a/tests/spec/emit/snapshots/match_on_wrap_err_of_go_call_wraps_in_the_err_arm.snap
+++ b/tests/spec/emit/snapshots/match_on_wrap_err_of_go_call_wraps_in_the_err_arm.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    match strconv.Atoi("x").wrap_err("parse") {
+      Ok(n) => fmt.Println(n),
+      Err(err) => fmt.Println(err),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	if n, err := strconv.Atoi("x"); err == nil {
+		fmt.Println(n)
+	} else {
+		err = fmt.Errorf("parse: %w", err)
+		fmt.Println(err)
+	}
+}

--- a/tests/spec/emit/snapshots/nested_wrap_err_wraps_inner_message_first.snap
+++ b/tests/spec/emit/snapshots/nested_wrap_err_wraps_inner_message_first.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn parse(raw: string) -> Result<int, error> {
+    let n = strconv.Atoi(raw).wrap_err("inner").wrap_err("outer")?
+    Ok(n)
+  }
+  
+  fn main() {
+    fmt.Println(parse("1"))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func parse(raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", err))
+	}
+	return n, nil
+}
+
+func main() {
+	ret_1, ret_2 := parse("1")
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/propagate_message_that_calls_a_function_of_the_let_name_keeps_a_temp.snap
+++ b/tests/spec/emit/snapshots/propagate_message_that_calls_a_function_of_the_let_name_keeps_a_temp.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn n() -> int { 9 }
+  
+  fn four() -> Result<int, error> {
+    let n = strconv.Atoi("bad").wrap_err(f"{n()}")?
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func n() int {
+	return 9
+}
+
+func four() (int, error) {
+	n_1, err := strconv.Atoi("bad")
+	fmtarg_2 := n()
+	if err != nil {
+		return 0, fmt.Errorf("%d: %w", fmtarg_2, err)
+	}
+	return n_1, nil
+}

--- a/tests/spec/emit/snapshots/result_binding_sites_keep_a_temp_when_a_message_reads_the_let_name.snap
+++ b/tests/spec/emit/snapshots/result_binding_sites_keep_a_temp_when_a_message_reads_the_let_name.snap
@@ -1,0 +1,53 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn n() -> string { "context" }
+  
+  fn let_else() {
+    let Ok(n) = strconv.Atoi("2").wrap_err(n()) else { return }
+    fmt.Println(n)
+  }
+  
+  fn let_match() {
+    let n = match strconv.Atoi("2").wrap_err(n()) {
+      Ok(x) => x,
+      Err(_) => { return },
+    }
+    fmt.Println(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func n() string {
+	return "context"
+}
+
+func letElse() {
+	n_1, err := strconv.Atoi("2")
+	_ = n()
+	if err != nil {
+		return
+	}
+	fmt.Println(n_1)
+}
+
+func letMatch() {
+	var n_1 int
+	x, err := strconv.Atoi("2")
+	_ = n()
+	if err == nil {
+		n_1 = x
+	} else {
+		return
+	}
+	fmt.Println(n_1)
+}

--- a/tests/spec/emit/snapshots/tail_return_of_wrap_err_on_go_call.snap
+++ b/tests/spec/emit/snapshots/tail_return_of_wrap_err_on_go_call.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn port(raw: string) -> Result<int, error> {
+    strconv.Atoi(raw).wrap_err("read port")
+  }
+  
+  fn main() {
+    fmt.Println(port("8080"))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func port(raw string) (int, error) {
+	ret_1, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("read port: %w", err)
+	}
+	return ret_1, nil
+}
+
+func main() {
+	ret_1, ret_2 := port("8080")
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/wrap_err_computed_message_uses_a_string_verb.snap
+++ b/tests/spec/emit/snapshots/wrap_err_computed_message_uses_a_string_verb.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn describe(raw: string) -> string { "parsing " + raw }
+  
+  fn parse(raw: string) -> Result<int, error> {
+    let n = strconv.Atoi(raw).wrap_err(describe(raw))?
+    Ok(n)
+  }
+  
+  fn main() {
+    fmt.Println(parse("1"))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func describe(raw string) string {
+	return "parsing " + raw
+}
+
+func parse(raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	msg_1 := describe(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", msg_1, err)
+	}
+	return n, nil
+}
+
+func main() {
+	ret_1, ret_2 := parse("1")
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/wrap_err_evaluates_an_effectful_message_before_the_error_test.snap
+++ b/tests/spec/emit/snapshots/wrap_err_evaluates_an_effectful_message_before_the_error_test.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn message() -> string {
+    fmt.Println("message ran")
+    "ctx"
+  }
+  
+  fn two() -> Result<int, error> {
+    let n = strconv.Atoi("2").wrap_err(message())?
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func message() string {
+	fmt.Println("message ran")
+	return "ctx"
+}
+
+func two() (int, error) {
+	n, err := strconv.Atoi("2")
+	msg_1 := message()
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", msg_1, err)
+	}
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/wrap_err_message_escapes_percent_and_interpolates_values.snap
+++ b/tests/spec/emit/snapshots/wrap_err_message_escapes_percent_and_interpolates_values.snap
@@ -1,0 +1,42 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn parse(raw: string, attempt: int) -> Result<int, error> {
+    let n = strconv.Atoi(raw).wrap_err(f"attempt {attempt} at 100% of {raw}")?
+    Ok(n)
+  }
+  
+  fn main() {
+    fmt.Println(parse("1", 2))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func parse(raw string, attempt int) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("attempt %d at 100%% of %s: %w", attempt, raw, err)
+	}
+	return n, nil
+}
+
+func main() {
+	ret_1, ret_2 := parse("1", 2)
+	var result_3 lisette.Result[int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/wrap_err_message_with_a_nested_propagate_keeps_the_outer_error.snap
+++ b/tests/spec/emit/snapshots/wrap_err_message_with_a_nested_propagate_keeps_the_outer_error.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn three() -> Result<int, error> {
+    let n = strconv.Atoi("x").wrap_err(f"{strconv.Atoi("0")?}")?
+    Ok(n)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func three() (int, error) {
+	n, err_3 := strconv.Atoi("x")
+	ret_1, err := strconv.Atoi("0")
+	if err != nil {
+		return 0, err
+	}
+	fmtarg_2 := ret_1
+	if err_3 != nil {
+		return 0, fmt.Errorf("%d: %w", fmtarg_2, err_3)
+	}
+	return n, nil
+}

--- a/tests/spec/emit/snapshots/wrap_err_on_pointer_returning_go_call_wraps_both_failures.snap
+++ b/tests/spec/emit/snapshots/wrap_err_on_pointer_returning_go_call_wraps_both_failures.snap
@@ -1,0 +1,48 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn open(path: string) -> Result<Ref<os.File>, error> {
+    let file = os.Open(path).wrap_err("open")?
+    Ok(file)
+  }
+  
+  fn main() {
+    fmt.Println(open("missing.txt"))
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func open(path string) (*os.File, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	if file == nil {
+		return nil, fmt.Errorf("open: %w", errors.New("unexpected nil"))
+	}
+	return file, nil
+}
+
+func main() {
+	ret_1, ret_2 := open("missing.txt")
+	var result_3 lisette.Result[*os.File, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[*os.File, error](ret_2)
+	} else if ret_1 == nil {
+		result_3 = lisette.MakeResultErr[*os.File, error](errors.New("unexpected nil"))
+	} else {
+		result_3 = lisette.MakeResultOk[*os.File, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/wrap_err_propagate_on_go_calls_uses_errorf.snap
+++ b/tests/spec/emit/snapshots/wrap_err_propagate_on_go_calls_uses_errorf.snap
@@ -1,0 +1,54 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:encoding/json"
+  import "go:fmt"
+  import "go:os"
+  
+  const FILE = "nums.json"
+  
+  fn load() -> Result<Slice<int>, error> {
+    let bytes = os.ReadFile(FILE).wrap_err(f"reading {FILE}")?
+    let mut nums: Slice<int> = []
+    json.Unmarshal(bytes, &nums).wrap_err("parsing nums")?
+    Ok(nums)
+  }
+  
+  fn main() {
+    fmt.Println(load())
+  }
+---
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+const File string = "nums.json"
+
+func load() ([]int, error) {
+	bytes, err := os.ReadFile(File)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", File, err)
+	}
+	nums := []int{}
+	if err := json.Unmarshal(bytes, &nums); err != nil {
+		return nil, fmt.Errorf("parsing nums: %w", err)
+	}
+	return nums, nil
+}
+
+func main() {
+	ret_1, ret_2 := load()
+	var result_3 lisette.Result[[]int, error]
+	if ret_2 != nil {
+		result_3 = lisette.MakeResultErr[[]int, error](ret_2)
+	} else {
+		result_3 = lisette.MakeResultOk[[]int, error](ret_1)
+	}
+	fmt.Println(result_3)
+}

--- a/tests/spec/emit/snapshots/wrapped_error_constructor_evaluates_its_argument_first.snap
+++ b/tests/spec/emit/snapshots/wrapped_error_constructor_evaluates_its_argument_first.snap
@@ -1,0 +1,43 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:errors"
+  import "go:fmt"
+  
+  fn message() -> string {
+    fmt.Println("message ran")
+    "ctx"
+  }
+  
+  fn make_error() -> error {
+    fmt.Println("make_error ran")
+    errors.New("boom")
+  }
+  
+  fn five() -> Result<int, error> {
+    Err(make_error()).wrap_err(message())
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func message() string {
+	fmt.Println("message ran")
+	return "ctx"
+}
+
+func makeError() error {
+	fmt.Println("make_error ran")
+	return errors.New("boom")
+}
+
+func five() (int, error) {
+	err_2 := makeError()
+	msg_1 := message()
+	return 0, fmt.Errorf("%s: %w", msg_1, err_2)
+}

--- a/tests/spec/emit/snapshots/wrapped_error_variable_is_read_before_a_message_that_rebinds_it.snap
+++ b/tests/spec/emit/snapshots/wrapped_error_variable_is_read_before_a_message_that_rebinds_it.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:errors"
+  
+  fn two() -> Result<int, error> {
+    let mut e = errors.New("before")
+    let update = || -> string {
+      e = errors.New("after")
+      "context"
+    }
+    Err(e).wrap_err(update())
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func two() (int, error) {
+	e := errors.New("before")
+	update := func() string {
+		e = errors.New("after")
+		return "context"
+	}
+	err_2 := e
+	msg_1 := update()
+	return 0, fmt.Errorf("%s: %w", msg_1, err_2)
+}


### PR DESCRIPTION
`wrap_err` with a string literal msg on a Go call that returns an error now emits `fmt.Errorf("message: %w", err)` on the error path, instead of a `lisette.Result` value built from the call. Messages that are not string literals keep the helper.

```rs
import "go:strconv"

fn parse(text: string) -> Result<int, error> {
  let n = strconv.Atoi(text).wrap_err("bad number")?
  Ok(n * 2)
}
```

Before:

```go
func parse(text string) (int, error) {
	ret_1, ret_2 := strconv.Atoi(text)
	var result_3 lisette.Result[int, error]
	if ret_2 != nil {
		result_3 = lisette.MakeResultErr[int, error](ret_2)
	} else {
		result_3 = lisette.MakeResultOk[int, error](ret_1)
	}
	check_4 := lisette.ResultWrapErr(result_3, "bad number")
	if check_4.Tag != lisette.ResultOk {
		return 0, check_4.ErrVal
	}
	n := check_4.OkVal
	return n * 2, nil
}
```

After:

```go
func parse(text string) (int, error) {
	n, err := strconv.Atoi(text)
	if err != nil {
		return 0, fmt.Errorf("bad number: %w", err) // the message wraps here
	}
	return n * 2, nil // no Result value, no copy
}
```
