### PR TITLE
feat: idiomatic Go for `unwrap_or` and `map_or` on Go calls

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -484,6 +484,9 @@ impl<'a> Planner<'a> {
         if let Some(predicate) = self.lower_fused_predicate_value(call_expression, false) {
             return predicate;
         }
+        if let Some(defaulted) = self.lower_defaulted_call_value(call_expression) {
+            return defaulted;
+        }
 
         match &plan.resolved.origin {
             CallableOrigin::TupleStructConstructor => {

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod predicates;
 mod regular;
 mod slice_loop;
 mod ufcs;
+mod unwrap_or;
 pub(crate) mod wrap_err;
 
 use crate::plan::values::CaptureBoundary;

--- a/crates/emit/src/calls/unwrap_or.rs
+++ b/crates/emit/src/calls/unwrap_or.rs
@@ -1,0 +1,265 @@
+use crate::Planner;
+use crate::calls::comma_ok::CommaOkValueSlot;
+use crate::context::expression::ExpressionContext;
+use crate::patterns::matching::{OptionArms, OptionFusePlan, ResultFusePlan};
+use crate::plan::bodies::{AssignForm, ElseArm, IfPlan, LoweredBlock, LoweredStatement, PlacePlan};
+use crate::plan::placement::collapse_declared_temp;
+use crate::plan::values::ValuePlan;
+use syntax::ast::{Expression, Literal, Pattern};
+use syntax::types::Type;
+
+/// `call.unwrap_or(default)`, `call.map_or(default, |v| ..)`, or `call.map(|v| ..).unwrap_or(default)`.
+struct DefaultedCall<'a> {
+    fuse: FusedCall<'a>,
+    map: Option<MapLambda<'a>>,
+    default: &'a Expression,
+}
+
+enum FusedCall<'a> {
+    Result(ResultFusePlan<'a>),
+    Option(OptionFusePlan<'a>),
+}
+
+struct MapLambda<'a> {
+    param: Option<&'a str>,
+    body: &'a Expression,
+}
+
+/// A statement that would leave the lambda if its body ran inline.
+fn escapes_lambda(expression: &Expression) -> bool {
+    match expression {
+        Expression::Return { .. }
+        | Expression::Propagate { .. }
+        | Expression::Defer { .. }
+        | Expression::Task { .. } => true,
+        Expression::Lambda { .. } | Expression::Function { .. } => false,
+        _ => expression.children().into_iter().any(escapes_lambda),
+    }
+}
+
+fn is_literal_default(default: &Expression) -> bool {
+    let Expression::Literal { literal, .. } = default.unwrap_parens() else {
+        return false;
+    };
+    match literal {
+        Literal::Integer { .. }
+        | Literal::Float { .. }
+        | Literal::Boolean(_)
+        | Literal::String { .. }
+        | Literal::Char(_) => true,
+        Literal::Slice(items) => items.iter().all(is_literal_default),
+        Literal::Imaginary(_) | Literal::FormatString(_) => false,
+    }
+}
+
+fn map_lambda(function: &Expression) -> Option<MapLambda<'_>> {
+    let Expression::Lambda { params, body, .. } = function.unwrap_parens() else {
+        return None;
+    };
+    let [param] = params.as_slice() else {
+        return None;
+    };
+    let param = match &param.pattern {
+        Pattern::Identifier { identifier, .. } => Some(identifier.as_str()),
+        Pattern::WildCard { .. } => None,
+        _ => return None,
+    };
+    (!escapes_lambda(body)).then_some(MapLambda { param, body })
+}
+
+impl Planner<'_> {
+    fn prelude_method_call<'a>(
+        &self,
+        expression: &'a Expression,
+        method: &str,
+    ) -> Option<(&'a Expression, &'a [Expression])> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            ..
+        } = expression.unwrap_parens()
+        else {
+            return None;
+        };
+        if spread.is_some() {
+            return None;
+        }
+        let Expression::DotAccess {
+            expression: receiver,
+            member,
+            ..
+        } = callee.unwrap_parens()
+        else {
+            return None;
+        };
+        if member != method
+            || !self
+                .plan_call(expression.unwrap_parens())?
+                .resolved
+                .is_prelude_dispatch
+        {
+            return None;
+        }
+        Some((receiver, args))
+    }
+
+    fn defaulted_call<'a>(&self, expression: &'a Expression) -> Option<DefaultedCall<'a>> {
+        let (receiver, map, default) = if let Some((receiver, [default])) =
+            self.prelude_method_call(expression, "unwrap_or")
+        {
+            match self.prelude_method_call(receiver, "map") {
+                Some((inner, [function])) => (inner, Some(map_lambda(function)?), default),
+                _ => (receiver, None, default),
+            }
+        } else if let Some((receiver, [default, function])) =
+            self.prelude_method_call(expression, "map_or")
+        {
+            (receiver, Some(map_lambda(function)?), default)
+        } else {
+            return None;
+        };
+        // map_or evaluates its default before the mapper; map(...).unwrap_or(...) after.
+        if map.is_some() && !is_literal_default(default) {
+            return None;
+        }
+        let receiver_ty = self.facts.peel_alias(&receiver.get_type());
+        let fuse = if receiver_ty.is_option() {
+            FusedCall::Option(self.option_fuse_plan(receiver)?)
+        } else if receiver_ty.is_result() && map.is_none() {
+            let fuse = self.result_fuse_plan(receiver)?;
+            if !fuse.carries_payload() {
+                return None;
+            }
+            FusedCall::Result(fuse)
+        } else {
+            return None;
+        };
+        Some(DefaultedCall { fuse, map, default })
+    }
+
+    /// `x, ok := call` then `if !ok { x = default }`, with `x` as `slot` names it.
+    fn lower_default_into_slot(
+        &mut self,
+        fuse: FusedCall<'_>,
+        default: &Expression,
+        slot: CommaOkValueSlot,
+    ) -> (Vec<LoweredStatement>, String) {
+        let (mut statements, failure, value) = match fuse {
+            FusedCall::Result(fuse) => {
+                let pair = fuse.bind(self, slot, None);
+                let failure = self.pair_failure_condition(&pair);
+                let value = pair.value.clone().expect("a payload slot was requested");
+                (pair.statements, failure, value)
+            }
+            FusedCall::Option(fuse) => {
+                let bound = fuse.bind(self, slot);
+                let failure = bound.none_condition(self);
+                let value = bound
+                    .value()
+                    .expect("a payload slot was requested")
+                    .to_string();
+                (bound.statements, failure, value)
+            }
+        };
+        let literal_default = is_literal_default(default);
+        let value_plan = self.lower_value(default, ExpressionContext::value());
+        let mut default = if literal_default {
+            value_plan
+        } else {
+            self.eager_operand(default, value_plan, "default")
+        };
+        statements.append(&mut default.setup);
+        statements.push(LoweredStatement::If(IfPlan {
+            condition_setup: Vec::new(),
+            condition: failure,
+            then_body: LoweredBlock {
+                statements: vec![LoweredStatement::Assign(AssignForm::Simple {
+                    target_capture: Vec::new(),
+                    target_str: value.clone(),
+                    value: default,
+                })],
+            },
+            else_arm: ElseArm::None,
+        }));
+        (statements, value)
+    }
+
+    fn lower_mapped_default_into(
+        &mut self,
+        fuse: OptionFusePlan<'_>,
+        map: MapLambda<'_>,
+        default: &Expression,
+        target: &str,
+        target_ty: &Type,
+    ) -> Vec<LoweredStatement> {
+        let arms = OptionArms {
+            some_binding: map.param,
+            some_body: map.body,
+            none_body: default,
+        };
+        self.lower_fused_option_arms(
+            fuse,
+            arms,
+            &PlacePlan::Assign {
+                local: target,
+                target_ty: Some(target_ty),
+            },
+        )
+    }
+
+    /// `let x = call.unwrap_or(default)` writes straight into `x`.
+    pub(crate) fn lower_defaulted_call_into(
+        &mut self,
+        value: &Expression,
+        go_name: &str,
+    ) -> Option<Vec<LoweredStatement>> {
+        let call = self.defaulted_call(value)?;
+        self.declare(go_name);
+        let Some(map) = call.map else {
+            let slot = CommaOkValueSlot::Named(go_name.to_string());
+            return Some(
+                self.lower_default_into_slot(call.fuse, call.default, slot)
+                    .0,
+            );
+        };
+        let FusedCall::Option(fuse) = call.fuse else {
+            unreachable!("a mapped chain is recognized on Option receivers only");
+        };
+        let ty = value.get_type();
+        let mut statements = vec![LoweredStatement::VarDecl {
+            name: go_name.to_string(),
+            go_type: self.use_go_type(&ty),
+            value: None,
+        }];
+        statements.extend(self.lower_mapped_default_into(fuse, map, call.default, go_name, &ty));
+        Some(statements)
+    }
+
+    pub(crate) fn lower_defaulted_call_value(
+        &mut self,
+        expression: &Expression,
+    ) -> Option<ValuePlan> {
+        let call = self.defaulted_call(expression)?;
+        let Some(map) = call.map else {
+            let (statements, value) =
+                self.lower_default_into_slot(call.fuse, call.default, CommaOkValueSlot::Temp);
+            return Some(ValuePlan::captured(statements, value));
+        };
+        let FusedCall::Option(fuse) = call.fuse else {
+            unreachable!("a mapped chain is recognized on Option receivers only");
+        };
+        let ty = expression.get_type();
+        let (result_var, declaration) = self.operand_temp_declaration(&ty);
+        let mut statements = vec![declaration];
+        statements.extend(self.lower_mapped_default_into(
+            fuse,
+            map,
+            call.default,
+            &result_var,
+            &ty,
+        ));
+        collapse_declared_temp(&mut statements, &result_var);
+        Some(ValuePlan::captured(statements, result_var))
+    }
+}

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -51,7 +51,7 @@ enum BoundSource {
 }
 
 impl BoundOption {
-    pub(super) fn value(&self) -> Option<&str> {
+    pub(crate) fn value(&self) -> Option<&str> {
         match &self.source {
             BoundSource::Pair(pair) => pair.value.as_deref(),
             BoundSource::Nullable { value, .. } => Some(value),
@@ -151,7 +151,7 @@ impl ResultFusePlan<'_> {
         &self.shape
     }
 
-    pub(super) fn carries_payload(&self) -> bool {
+    pub(crate) fn carries_payload(&self) -> bool {
         matches!(self.shape, CallableReturnAbi::Result { .. })
     }
 
@@ -902,7 +902,15 @@ impl Planner<'_> {
     ) -> Option<Vec<LoweredStatement>> {
         let fuse = self.option_fuse_plan(subject)?;
         let arms = classify_option_arms(arms)?;
+        Some(self.lower_fused_option_arms(fuse, arms, place))
+    }
 
+    pub(crate) fn lower_fused_option_arms(
+        &mut self,
+        fuse: OptionFusePlan<'_>,
+        arms: OptionArms<'_>,
+        place: &PlacePlan,
+    ) -> Vec<LoweredStatement> {
         let slot = match arms.some_binding {
             Some(name) => CommaOkValueSlot::Arm(self.arm_value_name(name)),
             None => CommaOkValueSlot::Unused,
@@ -939,7 +947,7 @@ impl Planner<'_> {
         };
         let mut statements = bound.statements;
         statements.push(LoweredStatement::If(plan));
-        Some(statements)
+        statements
     }
 
     pub(super) fn lower_fused_arm(
@@ -1167,11 +1175,11 @@ fn classify_selective_partial_arms(arms: &[MatchArm]) -> Option<SelectivePartial
     })
 }
 
-struct OptionArms<'a> {
+pub(crate) struct OptionArms<'a> {
     /// `None` when the Some arm binds no payload.
-    some_binding: Option<&'a str>,
-    some_body: &'a Expression,
-    none_body: &'a Expression,
+    pub(crate) some_binding: Option<&'a str>,
+    pub(crate) some_body: &'a Expression,
+    pub(crate) none_body: &'a Expression,
 }
 
 enum OptionArmKind<'a> {

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -103,24 +103,26 @@ impl Planner<'_> {
                 self.lower_discard_value(value)
             };
         };
-        if needs_temp {
-            let go_identifier = escape_reserved(raw_go_name);
-            if !self.shadows_declaration(&go_identifier)
-                && !self.scope.is_active_assign_target(&go_identifier)
-                && !self.scope.has_binding_for_go_name(&go_identifier)
-                && value.get_type().demoted() == binding_ty.demoted()
-            {
-                if let Some(statements) = self.lower_fused_result_match_into(value, &go_identifier)
-                {
-                    self.scope.bind(identifier, raw_go_name);
-                    return statements;
-                }
-                if let Some(statements) = self.lower_fused_option_match_into(value, &go_identifier)
-                {
-                    self.scope.bind(identifier, raw_go_name);
-                    return statements;
-                }
+        let go_identifier = escape_reserved(raw_go_name);
+        if !self.shadows_declaration(&go_identifier)
+            && !self.scope.is_active_assign_target(&go_identifier)
+            && !self.scope.has_binding_for_go_name(&go_identifier)
+            && value.get_type().demoted() == binding_ty.demoted()
+        {
+            if let Some(statements) = self.lower_fused_result_match_into(value, &go_identifier) {
+                self.scope.bind(identifier, raw_go_name);
+                return statements;
             }
+            if let Some(statements) = self.lower_fused_option_match_into(value, &go_identifier) {
+                self.scope.bind(identifier, raw_go_name);
+                return statements;
+            }
+            if let Some(statements) = self.lower_defaulted_call_into(value, &go_identifier) {
+                self.scope.bind(identifier, raw_go_name);
+                return statements;
+            }
+        }
+        if needs_temp {
             if self.shadows_declaration(&go_identifier)
                 || expression_contains_binding(value, identifier)
             {

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2836,6 +2836,117 @@ fn main() {
 }
 
 #[test]
+fn unwrap_or_on_comma_ok_go_call_assigns_the_default_on_failure() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let home = os.LookupEnv("HOME").unwrap_or("unset")
+  fmt.Println(home)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unwrap_or_on_go_result_call_assigns_the_default_on_error() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn main() {
+  let port = strconv.Atoi("x").unwrap_or(80)
+  fmt.Println(port)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unwrap_or_on_map_get_as_an_argument() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let counts = Map.new<string, int>()
+  fmt.Println(counts.get("a").unwrap_or(0) + 1)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_then_unwrap_or_on_comma_ok_go_call_branches_on_the_header() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let shown = os.LookupEnv("HOME").map(|h| "home=" + h).unwrap_or("unset")
+  fmt.Println(shown)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_or_on_nullable_go_call_as_an_argument() {
+    let input = r#"
+import "go:context"
+import "go:fmt"
+
+fn main() {
+  let ctx = context.Background()
+  fmt.Println(ctx.Err().map_or("clean", |err| err.Error()))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_with_a_returning_lambda_keeps_the_tagged_path() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let shown = os.LookupEnv("HOME").map(|h| { return "home=" + h }).unwrap_or("unset")
+  fmt.Println(shown)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_alone_keeps_the_option() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let shown = os.LookupEnv("HOME").map(|h| "home=" + h)
+  fmt.Println(shown.is_some())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unwrap_or_on_a_stored_option_keeps_the_tagged_path() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let home = os.LookupEnv("HOME")
+  fmt.Println(home.unwrap_or("unset"))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"
@@ -2845,6 +2956,42 @@ fn double(n: int) -> Result<int, error> { Ok(n * 2) }
 fn run() -> Result<int, error> {
   let d = double(strconv.Atoi("1")?)?
   Ok(d)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unwrap_or_evaluates_an_effectful_default_before_the_error_test() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn fallback() -> int {
+  fmt.Println("fallback ran")
+  7
+}
+
+fn one() -> int {
+  strconv.Atoi("1").unwrap_or(fallback())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn map_or_with_an_effectful_default_keeps_the_helper_call() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn fallback() -> int {
+  fmt.Println("fallback ran")
+  0
+}
+
+fn home_length() -> int {
+  os.LookupEnv("HOME").map_or(fallback(), |home| home.length())
 }
 "#;
     assert_emit_snapshot!(input);
@@ -2864,6 +3011,33 @@ fn message() -> string {
 fn two() -> Result<int, error> {
   let n = strconv.Atoi("2").wrap_err(message())?
   Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn fused_wrap_and_default_arguments_preserve_eager_order() {
+    let input = r#"
+import "go:strconv"
+
+fn choose(raw: string) -> int {
+  let mut trace = ""
+  let message = || -> string {
+    trace = trace + "message;"
+    "context"
+  }
+  let fallback = || -> int {
+    trace = trace + "default;"
+    7
+  }
+  let n = strconv.Atoi(raw).wrap_err(message()).unwrap_or(fallback())
+  if trace != "message;default;" { panic(trace) }
+  n
+}
+
+fn main() {
+  if choose("1") != 1 || choose("bad") != 7 { panic("wrong result") }
 }
 "#;
     assert_emit_snapshot!(input);
@@ -2905,6 +3079,26 @@ fn main() {
 }
 
 #[test]
+fn eager_defaults_preserve_numeric_types() {
+    let input = r#"
+import "go:strconv"
+
+fn shifted(sh: uint64) -> uint64 {
+  strconv.ParseUint("bad", 10, 64).unwrap_or(1 << sh)
+}
+
+fn negative() -> int64 {
+  strconv.ParseInt("bad", 10, 64).unwrap_or(-1)
+}
+
+fn main() {
+  if shifted(63) != 9223372036854775808 || negative() != -1 { panic("wrong default") }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn wrap_err_message_with_a_nested_propagate_keeps_the_outer_error() {
     let input = r#"
 import "go:strconv"
@@ -2912,6 +3106,60 @@ import "go:strconv"
 fn three() -> Result<int, error> {
   let n = strconv.Atoi("x").wrap_err(f"{strconv.Atoi("0")?}")?
   Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn unwrap_or_default_with_a_nested_propagate_keeps_the_outer_error() {
+    let input = r#"
+import "go:strconv"
+
+fn one() -> Result<int, error> {
+  Ok(strconv.Atoi("bad").unwrap_or(strconv.Atoi("7")?))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn wrap_err_messages_run_where_nothing_reads_the_wrapped_error() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn message() -> string {
+  fmt.Println("message ran")
+  "ctx"
+}
+
+fn predicate() -> bool {
+  strconv.Atoi("1").wrap_err(message()).is_err()
+}
+
+fn defaulted() -> int {
+  strconv.Atoi("1").wrap_err(message()).unwrap_or(0)
+}
+
+fn let_else() -> int {
+  let Ok(v) = strconv.Atoi("1").wrap_err(message()) else { return -1 }
+  v
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn shift_defaults_and_display_interpolations_run_before_the_error_test() {
+    let input = r#"
+import "go:strconv"
+import "go:time"
+
+fn three(d: time.Duration, sh: int) -> Result<int, error> {
+  let a = strconv.Atoi("1").wrap_err(f"took {d}")?
+  let b = strconv.Atoi("2").unwrap_or(1 << sh)
+  Ok(a + b)
 }
 "#;
     assert_emit_snapshot!(input);
@@ -2985,6 +3233,21 @@ fn six() -> int {
     },
   }
   a + b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn defaulted_let_that_calls_a_function_of_its_own_name_keeps_a_temp() {
+    let input = r#"
+import "go:strconv"
+
+fn n() -> int { 9 }
+
+fn seven() -> int {
+  let n = strconv.Atoi("bad").unwrap_or(n())
+  n
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/defaulted_let_that_calls_a_function_of_its_own_name_keeps_a_temp.snap
+++ b/tests/spec/emit/snapshots/defaulted_let_that_calls_a_function_of_its_own_name_keeps_a_temp.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn n() -> int { 9 }
+  
+  fn seven() -> int {
+    let n = strconv.Atoi("bad").unwrap_or(n())
+    n
+  }
+---
+package main
+
+import "strconv"
+
+func n() int {
+	return 9
+}
+
+func seven() int {
+	ret_1, err := strconv.Atoi("bad")
+	default_2 := n()
+	if err != nil {
+		ret_1 = default_2
+	}
+	n_3 := ret_1
+	return n_3
+}

--- a/tests/spec/emit/snapshots/eager_defaults_preserve_numeric_types.snap
+++ b/tests/spec/emit/snapshots/eager_defaults_preserve_numeric_types.snap
@@ -1,0 +1,44 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn shifted(sh: uint64) -> uint64 {
+    strconv.ParseUint("bad", 10, 64).unwrap_or(1 << sh)
+  }
+  
+  fn negative() -> int64 {
+    strconv.ParseInt("bad", 10, 64).unwrap_or(-1)
+  }
+  
+  fn main() {
+    if shifted(63) != 9223372036854775808 || negative() != -1 { panic("wrong default") }
+  }
+---
+package main
+
+import "strconv"
+
+func shifted(sh uint64) uint64 {
+	ret_1, err := strconv.ParseUint("bad", 10, 64)
+	default_2 := uint64(1 << sh)
+	if err != nil {
+		ret_1 = default_2
+	}
+	return ret_1
+}
+
+func negative() int64 {
+	ret_1, err := strconv.ParseInt("bad", 10, 64)
+	if err != nil {
+		ret_1 = -1
+	}
+	return ret_1
+}
+
+func main() {
+	if shifted(63) != 9223372036854775808 || negative() != -1 {
+		panic("wrong default")
+	}
+}

--- a/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
+++ b/tests/spec/emit/snapshots/empty_slice_literal_is_not_nil_at_go_boundary.snap
@@ -23,10 +23,7 @@ description: |
 ---
 package main
 
-import (
-	"encoding/json"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "encoding/json"
 
 type Payload struct {
 	Items []int
@@ -34,26 +31,20 @@ type Payload struct {
 
 func main() {
 	xs := []int{}
-	ret_1, ret_2 := json.Marshal(xs)
-	var result_3 lisette.Result[[]byte, error]
-	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[[]byte, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[[]byte, error](ret_1)
+	ret_1, err := json.Marshal(xs)
+	if err != nil {
+		ret_1 = []byte{}
 	}
-	encoded := string(result_3.UnwrapOr([]byte{}))
+	encoded := string(ret_1)
 	if encoded != "[]" {
 		panic("expected an explicit empty literal to encode as [], got " + encoded)
 	}
 	payload := Payload{Items: []int{}}
-	ret_4, ret_5 := json.Marshal(payload)
-	var result_6 lisette.Result[[]byte, error]
-	if ret_5 != nil {
-		result_6 = lisette.MakeResultErr[[]byte, error](ret_5)
-	} else {
-		result_6 = lisette.MakeResultOk[[]byte, error](ret_4)
+	ret_2, err_3 := json.Marshal(payload)
+	if err_3 != nil {
+		ret_2 = []byte{}
 	}
-	wrapped := string(result_6.UnwrapOr([]byte{}))
+	wrapped := string(ret_2)
 	if wrapped != "{\"Items\":[]}" {
 		panic("expected an empty slice field to encode as [], got " + wrapped)
 	}

--- a/tests/spec/emit/snapshots/fused_wrap_and_default_arguments_preserve_eager_order.snap
+++ b/tests/spec/emit/snapshots/fused_wrap_and_default_arguments_preserve_eager_order.snap
@@ -1,0 +1,56 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn choose(raw: string) -> int {
+    let mut trace = ""
+    let message = || -> string {
+      trace = trace + "message;"
+      "context"
+    }
+    let fallback = || -> int {
+      trace = trace + "default;"
+      7
+    }
+    let n = strconv.Atoi(raw).wrap_err(message()).unwrap_or(fallback())
+    if trace != "message;default;" { panic(trace) }
+    n
+  }
+  
+  fn main() {
+    if choose("1") != 1 || choose("bad") != 7 { panic("wrong result") }
+  }
+---
+package main
+
+import "strconv"
+
+func choose(raw string) int {
+	trace := ""
+	message := func() string {
+		trace += "message;"
+		return "context"
+	}
+	fallback := func() int {
+		trace += "default;"
+		return 7
+	}
+	n, err := strconv.Atoi(raw)
+	_ = message()
+	default_1 := fallback()
+	if err != nil {
+		n = default_1
+	}
+	if trace != "message;default;" {
+		panic(trace)
+	}
+	return n
+}
+
+func main() {
+	if choose("1") != 1 || choose("bad") != 7 {
+		panic("wrong result")
+	}
+}

--- a/tests/spec/emit/snapshots/fused_wrap_evaluates_custom_display_on_success_and_failure.snap
+++ b/tests/spec/emit/snapshots/fused_wrap_evaluates_custom_display_on_success_and_failure.snap
@@ -35,7 +35,6 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"strconv"
 )
 
@@ -71,19 +70,15 @@ func main() {
 		return "label"
 	}
 	label := Label{describe: describe}
-	ret_1, ret_2 := parse("1", label)
-	var result_3 lisette.Result[int, error]
-	if ret_2 != nil {
-		result_3 = lisette.MakeResultErr[int, error](ret_2)
-	} else {
-		result_3 = lisette.MakeResultOk[int, error](ret_1)
+	good, err := parse("1", label)
+	if err != nil {
+		good = 0
 	}
-	good := result_3.UnwrapOr(0)
 	if good != 1 || seen != 1 {
 		panic("success skipped display")
 	}
-	_, err := parse("bad", label)
-	bad := err == nil
+	_, err_1 := parse("bad", label)
+	bad := err_1 == nil
 	if bad || seen != 2 {
 		panic("failure skipped display")
 	}

--- a/tests/spec/emit/snapshots/map_alone_keeps_the_option.snap
+++ b/tests/spec/emit/snapshots/map_alone_keeps_the_option.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let shown = os.LookupEnv("HOME").map(|h| "home=" + h)
+    fmt.Println(shown.is_some())
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func main() {
+	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
+	shown := lisette.OptionMap(option_1, func(h string) string {
+		return "home=" + h
+	})
+	fmt.Println(shown.IsSome())
+}

--- a/tests/spec/emit/snapshots/map_or_on_nullable_go_call_as_an_argument.snap
+++ b/tests/spec/emit/snapshots/map_or_on_nullable_go_call_as_an_argument.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:context"
+  import "go:fmt"
+  
+  fn main() {
+    let ctx = context.Background()
+    fmt.Println(ctx.Err().map_or("clean", |err| err.Error()))
+  }
+---
+package main
+
+import (
+	"context"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	ctx := context.Background()
+	var tmp_1 string
+	if err := ctx.Err(); !lisette.IsNilInterface(err) {
+		tmp_1 = err.Error()
+	} else {
+		tmp_1 = "clean"
+	}
+	fmt.Println(tmp_1)
+}

--- a/tests/spec/emit/snapshots/map_or_with_an_effectful_default_keeps_the_helper_call.snap
+++ b/tests/spec/emit/snapshots/map_or_with_an_effectful_default_keeps_the_helper_call.snap
@@ -1,0 +1,35 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn fallback() -> int {
+    fmt.Println("fallback ran")
+    0
+  }
+  
+  fn home_length() -> int {
+    os.LookupEnv("HOME").map_or(fallback(), |home| home.length())
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func fallback() int {
+	fmt.Println("fallback ran")
+	return 0
+}
+
+func homeLength() int {
+	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
+	return lisette.OptionMapOr(option_1, fallback(), func(home string) int {
+		return len(home)
+	})
+}

--- a/tests/spec/emit/snapshots/map_then_unwrap_or_on_comma_ok_go_call_branches_on_the_header.snap
+++ b/tests/spec/emit/snapshots/map_then_unwrap_or_on_comma_ok_go_call_branches_on_the_header.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let shown = os.LookupEnv("HOME").map(|h| "home=" + h).unwrap_or("unset")
+    fmt.Println(shown)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	var shown string
+	if h, ok := os.LookupEnv("HOME"); ok {
+		shown = "home=" + h
+	} else {
+		shown = "unset"
+	}
+	fmt.Println(shown)
+}

--- a/tests/spec/emit/snapshots/map_with_a_returning_lambda_keeps_the_tagged_path.snap
+++ b/tests/spec/emit/snapshots/map_with_a_returning_lambda_keeps_the_tagged_path.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let shown = os.LookupEnv("HOME").map(|h| { return "home=" + h }).unwrap_or("unset")
+    fmt.Println(shown)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func main() {
+	option_1 := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
+	shown := lisette.OptionMap(option_1, func(h string) string {
+		return "home=" + h
+	}).UnwrapOr("unset")
+	fmt.Println(shown)
+}

--- a/tests/spec/emit/snapshots/shift_defaults_and_display_interpolations_run_before_the_error_test.snap
+++ b/tests/spec/emit/snapshots/shift_defaults_and_display_interpolations_run_before_the_error_test.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  import "go:time"
+  
+  fn three(d: time.Duration, sh: int) -> Result<int, error> {
+    let a = strconv.Atoi("1").wrap_err(f"took {d}")?
+    let b = strconv.Atoi("2").unwrap_or(1 << sh)
+    Ok(a + b)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+func three(d time.Duration, sh int) (int, error) {
+	a, err := strconv.Atoi("1")
+	msg_1 := fmt.Sprintf("took %v", d)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", msg_1, err)
+	}
+	b, err_2 := strconv.Atoi("2")
+	default_3 := int(1 << sh)
+	if err_2 != nil {
+		b = default_3
+	}
+	return a + b, nil
+}

--- a/tests/spec/emit/snapshots/unwrap_or_default_with_a_nested_propagate_keeps_the_outer_error.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_default_with_a_nested_propagate_keeps_the_outer_error.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:strconv"
+  
+  fn one() -> Result<int, error> {
+    Ok(strconv.Atoi("bad").unwrap_or(strconv.Atoi("7")?))
+  }
+---
+package main
+
+import "strconv"
+
+func one() (int, error) {
+	ret_1, err := strconv.Atoi("bad")
+	ret_2, err_3 := strconv.Atoi("7")
+	if err_3 != nil {
+		return 0, err_3
+	}
+	default_4 := ret_2
+	if err != nil {
+		ret_1 = default_4
+	}
+	return ret_1, nil
+}

--- a/tests/spec/emit/snapshots/unwrap_or_evaluates_an_effectful_default_before_the_error_test.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_evaluates_an_effectful_default_before_the_error_test.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn fallback() -> int {
+    fmt.Println("fallback ran")
+    7
+  }
+  
+  fn one() -> int {
+    strconv.Atoi("1").unwrap_or(fallback())
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func fallback() int {
+	fmt.Println("fallback ran")
+	return 7
+}
+
+func one() int {
+	ret_1, err := strconv.Atoi("1")
+	default_2 := fallback()
+	if err != nil {
+		ret_1 = default_2
+	}
+	return ret_1
+}

--- a/tests/spec/emit/snapshots/unwrap_or_on_a_stored_option_keeps_the_tagged_path.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_on_a_stored_option_keeps_the_tagged_path.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let home = os.LookupEnv("HOME")
+    fmt.Println(home.unwrap_or("unset"))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"os"
+)
+
+func main() {
+	home := lisette.OptionFromCommaOk[string](os.LookupEnv("HOME"))
+	fmt.Println(home.UnwrapOr("unset"))
+}

--- a/tests/spec/emit/snapshots/unwrap_or_on_comma_ok_go_call_assigns_the_default_on_failure.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_on_comma_ok_go_call_assigns_the_default_on_failure.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let home = os.LookupEnv("HOME").unwrap_or("unset")
+    fmt.Println(home)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	home, ok := os.LookupEnv("HOME")
+	if !ok {
+		home = "unset"
+	}
+	fmt.Println(home)
+}

--- a/tests/spec/emit/snapshots/unwrap_or_on_go_result_call_assigns_the_default_on_error.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_on_go_result_call_assigns_the_default_on_error.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn main() {
+    let port = strconv.Atoi("x").unwrap_or(80)
+    fmt.Println(port)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	port, err := strconv.Atoi("x")
+	if err != nil {
+		port = 80
+	}
+	fmt.Println(port)
+}

--- a/tests/spec/emit/snapshots/unwrap_or_on_map_get_as_an_argument.snap
+++ b/tests/spec/emit/snapshots/unwrap_or_on_map_get_as_an_argument.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let counts = Map.new<string, int>()
+    fmt.Println(counts.get("a").unwrap_or(0) + 1)
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	counts := make(map[string]int)
+	ret_1, ok := counts["a"]
+	if !ok {
+		ret_1 = 0
+	}
+	fmt.Println(ret_1 + 1)
+}

--- a/tests/spec/emit/snapshots/wrap_err_messages_run_where_nothing_reads_the_wrapped_error.snap
+++ b/tests/spec/emit/snapshots/wrap_err_messages_run_where_nothing_reads_the_wrapped_error.snap
@@ -1,0 +1,60 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn message() -> string {
+    fmt.Println("message ran")
+    "ctx"
+  }
+  
+  fn predicate() -> bool {
+    strconv.Atoi("1").wrap_err(message()).is_err()
+  }
+  
+  fn defaulted() -> int {
+    strconv.Atoi("1").wrap_err(message()).unwrap_or(0)
+  }
+  
+  fn let_else() -> int {
+    let Ok(v) = strconv.Atoi("1").wrap_err(message()) else { return -1 }
+    v
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func message() string {
+	fmt.Println("message ran")
+	return "ctx"
+}
+
+func predicate() bool {
+	_, err := strconv.Atoi("1")
+	_ = message()
+	return err != nil
+}
+
+func defaulted() int {
+	ret_1, err := strconv.Atoi("1")
+	_ = message()
+	if err != nil {
+		ret_1 = 0
+	}
+	return ret_1
+}
+
+func letElse() int {
+	v, err := strconv.Atoi("1")
+	_ = message()
+	if err != nil {
+		return -1
+	}
+	return v
+}


### PR DESCRIPTION
`unwrap_or` and `map_or` with a literal default on a Go call that returns an error or a comma-ok pair now emit an `if` that assigns the default on the failure path, instead of a `lisette.Result` or `lisette.Option` value built from the call and then unwrapped by a prelude method. Defaults that are not literals keep the helper.

```rs
import "go:strconv"

fn parse(text: string) -> int {
  strconv.Atoi(text).unwrap_or(0)
}
```

Before:

```go
func parse(text string) int {
	ret_1, ret_2 := strconv.Atoi(text)
	var result_3 lisette.Result[int, error]
	if ret_2 != nil {
		result_3 = lisette.MakeResultErr[int, error](ret_2)
	} else {
		result_3 = lisette.MakeResultOk[int, error](ret_1)
	}
	return result_3.UnwrapOr(0)
}
```

After:

```go
func parse(text string) int {
	ret_1, err := strconv.Atoi(text)
	if err != nil {
		ret_1 = 0 // the default on the failure path
	}
	return ret_1 // no Result value
}
```
