### PR TITLE
feat: idiomatic Go for `Some` and `None` in nullable Go slots

### DIFF
--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -1,15 +1,83 @@
 use crate::Planner;
 use crate::abi::callable::PayloadLayout;
-use crate::abi::coercion::{BridgeDirection, LayoutBridge};
-use crate::abi::layout::ValueLayout;
+use crate::abi::coercion::{BridgeDirection, CoercionPlan, LayoutBridge};
+use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::calls::go_interop::build_tuple_literal;
 use crate::calls::go_interop::wrappers::{WrapperOutcome, WrapperTarget, leaf_block};
+use crate::context::expression::ExpressionContext;
 use crate::control_flow::fallible::{Fallible, FalliblePlanner, OPTION_SOME_TAG};
 use crate::plan::bodies::{ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
+use crate::plan::values::{GoExpression, ValuePlan};
 use std::iter;
+use syntax::ast::Expression;
 use syntax::types::Type;
 
 impl Planner<'_> {
+    /// `Some(e)` and `None` written straight into a nullable Go slot.
+    pub(crate) fn lower_option_literal_into_layout(
+        &mut self,
+        expression: &Expression,
+        target: &ValueLayout,
+    ) -> Option<ValuePlan> {
+        let source = self.value_layout(&expression.get_type(), SlotOrigin::Lisette);
+        let CoercionPlan::Layout(bridge) = CoercionPlan::bridge(self, &source, target) else {
+            return None;
+        };
+        let (payload, pointee) = match &bridge {
+            LayoutBridge::UnwrapNullableOption { payload, .. } => (payload, None),
+            LayoutBridge::UnwrapPointerOption {
+                payload,
+                target_payload,
+                ..
+            } => (payload, Some(target_payload)),
+            _ => return None,
+        };
+        let expression = expression.unwrap_parens();
+        if expression.is_none_literal() {
+            return Some(ValuePlan::literal("nil".to_string()));
+        }
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            ..
+        } = expression
+        else {
+            return None;
+        };
+        let [inner] = args.as_slice() else {
+            return None;
+        };
+        if spread.is_some() || callee.as_option_constructor() != Some(Ok(())) {
+            return None;
+        }
+        let inner = self.lower_composite_value(inner, ExpressionContext::value());
+        Some(
+            inner.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
+                let value = self.plan_layout_bridge(setup, &value, payload);
+                let Some(pointee) = pointee else {
+                    return GoExpression::opaque_with_deferred_evaluation(
+                        value,
+                        contains_deferred_evaluation,
+                    );
+                };
+                let go_type = pointee.go_type(self);
+                let go_type = self.use_rendered_go_type(go_type);
+                let copy = self.fresh_var(Some("ptr"));
+                self.declare(&copy);
+                setup.push(LoweredStatement::VarDecl {
+                    name: copy.clone(),
+                    go_type,
+                    value: Some(value),
+                });
+                GoExpression::opaque_with_deferred_evaluation(
+                    format!("&{copy}"),
+                    contains_deferred_evaluation,
+                )
+            }),
+        )
+    }
+
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.
     pub(crate) fn lower_sentinel_wrapping(
         &mut self,

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -1128,11 +1128,14 @@ impl<'a> Planner<'a> {
                 EvaluationEffect::PureCall,
             );
         }
+        let target = self.argument_slot_layout(parameter);
+        if let Some(literal) = self.lower_option_literal_into_layout(argument, &target) {
+            return literal;
+        }
         let raw_source = self.go_physical_expression_layout(argument);
         let source = raw_source
             .clone()
             .unwrap_or_else(|| self.argument_source_layout(argument, parameter));
-        let target = self.argument_slot_layout(parameter);
         let coercion = CoercionPlan::bridge(self, &source, &target);
         let value = if raw_source.is_some() {
             if matches!(argument.unwrap_parens(), Expression::Call { .. }) {

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -75,9 +75,34 @@ impl Planner<'_> {
 
         let is_go_struct = self.is_go_abi_type(ty);
 
+        let field_slots: Vec<(Option<Type>, Option<ValueLayout>)> = field_assignments
+            .iter()
+            .map(|f| {
+                let field_ty = self.lookup_struct_field_ty(ty, &f.name);
+                let value_ty = f.value.get_type();
+                let layout = self.field_slot_layout(
+                    ty,
+                    None,
+                    &f.name,
+                    field_ty.as_ref().unwrap_or(&value_ty),
+                );
+                (field_ty, layout)
+            })
+            .collect();
+        let mut literal_slots = vec![false; field_assignments.len()];
         let stages: Vec<ValuePlan> = field_assignments
             .iter()
-            .map(|f| self.lower_composite_value(&f.value, ExpressionContext::value()))
+            .zip(&field_slots)
+            .zip(&mut literal_slots)
+            .map(|((f, (_, layout)), literal_slot)| {
+                if let Some(layout) = layout
+                    && let Some(literal) = self.lower_option_literal_into_layout(&f.value, layout)
+                {
+                    *literal_slot = true;
+                    return literal;
+                }
+                self.lower_composite_value(&f.value, ExpressionContext::value())
+            })
             .collect();
         let field_evaluations: Vec<bool> = stages
             .iter()
@@ -90,23 +115,25 @@ impl Planner<'_> {
 
         let mut fields =
             Vec::with_capacity(field_assignments.len() + usize::from(ctx.enum_ctx.is_some()));
-        for ((f, has_observable_evaluation), mut value) in field_assignments
+        for (
+            (((f, has_observable_evaluation), mut value), (field_ty, field_layout)),
+            literal_slot,
+        ) in field_assignments
             .iter()
             .zip(field_evaluations)
             .zip(emitted_values)
+            .zip(field_slots)
+            .zip(literal_slots)
         {
             let field_name = self.resolve_struct_call_field_name(&f.name, &ctx);
             value = self.wrap_recursive_enum_field(&mut setup, value, f, &ctx);
             let value_ty = f.value.get_type();
-            let field_ty = self.lookup_struct_field_ty(ty, &f.name);
-            let field_layout =
-                self.field_slot_layout(ty, None, &f.name, field_ty.as_ref().unwrap_or(&value_ty));
             value = self.coerce_struct_field(
                 &mut setup,
                 value,
                 &value_ty,
                 field_ty.as_ref(),
-                field_layout.as_ref(),
+                field_layout.as_ref().filter(|_| !literal_slot),
             );
             fields.push(StructCallField {
                 name: field_name,

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -513,7 +513,27 @@ impl Planner<'_> {
         target: &Expression,
         value: &Expression,
     ) -> Vec<LoweredStatement> {
-        let right_hand_side = self.lower_composite_value(value, ExpressionContext::value());
+        let go_field_layout = match target {
+            Expression::DotAccess {
+                expression: receiver,
+                member,
+                ty,
+                resolution,
+                ..
+            } => self.field_slot_layout(
+                &receiver.get_type(),
+                resolution.declaring_type(),
+                member,
+                ty,
+            ),
+            _ => None,
+        };
+        let literal_slot = go_field_layout
+            .as_ref()
+            .and_then(|layout| self.lower_option_literal_into_layout(value, layout));
+        let is_literal_slot = literal_slot.is_some();
+        let right_hand_side = literal_slot
+            .unwrap_or_else(|| self.lower_composite_value(value, ExpressionContext::value()));
         let mut setup: Vec<LoweredStatement> = Vec::new();
         let target_str = if is_order_sensitive(target) {
             self.emit_left_value_capturing(&mut setup, target, Some(&right_hand_side))
@@ -523,19 +543,8 @@ impl Planner<'_> {
         let (rhs_setup, rhs_value) = right_hand_side.into_parts();
         setup.extend(rhs_setup);
 
-        if let Expression::DotAccess {
-            expression: receiver,
-            member,
-            ty,
-            resolution,
-            ..
-        } = target
-            && let Some(target_layout) = self.field_slot_layout(
-                &receiver.get_type(),
-                resolution.declaring_type(),
-                member,
-                ty,
-            )
+        if let Some(target_layout) = go_field_layout
+            && !is_literal_slot
         {
             let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
             let coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -432,6 +432,14 @@ impl ValuePlan {
         )
     }
 
+    pub(crate) fn literal(rendered: String) -> Self {
+        Self::from_facts(
+            Vec::new(),
+            GoExpression::literal(rendered),
+            EvaluationFacts::literal(),
+        )
+    }
+
     pub(crate) fn evaluated_literal(
         setup: Vec<LoweredStatement>,
         rendered: String,

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -55,13 +55,21 @@ impl Planner<'_> {
         // `target = value`. Stage RHS first (so the target capture knows
         // whether RHS produced setup), capture the target, then fold RHS
         // setup + coercion setup into the value plan in emission order.
-        let right_hand_side = self.lower_composite_value(
-            value,
-            ExpressionContext::value().with_retired_receiver(target),
-        );
+        let literal_slot = go_field_slot
+            .as_ref()
+            .and_then(|(_, layout)| self.lower_option_literal_into_layout(value, layout));
+        let is_literal_slot = literal_slot.is_some();
+        let right_hand_side = literal_slot.unwrap_or_else(|| {
+            self.lower_composite_value(
+                value,
+                ExpressionContext::value().with_retired_receiver(target),
+            )
+        });
         let (target_capture, target_str) =
             self.capture_assignment_target(target, Some(&right_hand_side));
-        let coercion = if let Some((_target_ty, target_layout)) = go_field_slot {
+        let coercion = if is_literal_slot {
+            CoercionPlan::Identity
+        } else if let Some((_target_ty, target_layout)) = go_field_slot {
             let source_layout = self.value_layout(&value.get_type(), SlotOrigin::Lisette);
             CoercionPlan::bridge(self, &source_layout, &target_layout)
         } else {

--- a/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
+++ b/tests/spec/build/snapshots/go_map_nullable_value_unwrap_preserves_none_keys.snap
@@ -21,43 +21,32 @@ func main() {
 	objects := make(map[string]lisette.Option[*ast.Object])
 	objects["present"] = lisette.MakeOptionSome(&obj)
 	objects["absent"] = lisette.MakeOptionNone[*ast.Object]()
-	opt_1 := lisette.MakeOptionNone[*ast.Scope]()
-	var unwrap_2 *ast.Scope
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	opt_3 := lisette.MakeOptionSome(objects)
-	var unwrap_4 map[string]*ast.Object
-	if opt_3.Tag == lisette.OptionSome {
-		src_5 := opt_3.SomeVal
-		unwrapped_6 := make(map[string]*ast.Object, len(src_5))
-		for i_7, v_8 := range src_5 {
-			if v_8.Tag == lisette.OptionSome {
-				unwrapped_6[i_7] = v_8.SomeVal
-			} else {
-				unwrapped_6[i_7] = nil
-			}
+	unwrapped_1 := make(map[string]*ast.Object, len(objects))
+	for i_2, v_3 := range objects {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = v_3.SomeVal
+		} else {
+			unwrapped_1[i_2] = nil
 		}
-		unwrap_4 = unwrapped_6
 	}
 	scope := ast.Scope{
-		Outer:   unwrap_2,
-		Objects: unwrap_4,
+		Outer:   nil,
+		Objects: unwrapped_1,
 	}
-	raw_9 := scope.Objects
-	var option_10 lisette.Option[map[string]lisette.Option[*ast.Object]]
-	if raw_9 != nil {
-		wrapped_11 := make(map[string]lisette.Option[*ast.Object], len(raw_9))
-		for i_12, v_13 := range raw_9 {
-			if v_13 != nil {
-				wrapped_11[i_12] = lisette.MakeOptionSome[*ast.Object](v_13)
+	raw_4 := scope.Objects
+	var option_5 lisette.Option[map[string]lisette.Option[*ast.Object]]
+	if raw_4 != nil {
+		wrapped_6 := make(map[string]lisette.Option[*ast.Object], len(raw_4))
+		for i_7, v_8 := range raw_4 {
+			if v_8 != nil {
+				wrapped_6[i_7] = lisette.MakeOptionSome[*ast.Object](v_8)
 			} else {
-				wrapped_11[i_12] = lisette.MakeOptionNone[*ast.Object]()
+				wrapped_6[i_7] = lisette.MakeOptionNone[*ast.Object]()
 			}
 		}
-		option_10 = lisette.MakeOptionSome[map[string]lisette.Option[*ast.Object]](wrapped_11)
+		option_5 = lisette.MakeOptionSome[map[string]lisette.Option[*ast.Object]](wrapped_6)
 	} else {
-		option_10 = lisette.MakeOptionNone[map[string]lisette.Option[*ast.Object]]()
+		option_5 = lisette.MakeOptionNone[map[string]lisette.Option[*ast.Object]]()
 	}
-	fmt.Print(option_10)
+	fmt.Print(option_5)
 }

--- a/tests/spec/build/snapshots/go_struct_field_assignment_unwrap.snap
+++ b/tests/spec/build/snapshots/go_struct_field_assignment_unwrap.snap
@@ -6,38 +6,22 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"runtime/debug"
 )
 
 func main() {
-	opt_1 := lisette.MakeOptionNone[*debug.Module]()
-	var unwrap_2 *debug.Module
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
 	replacement := debug.Module{
 		Path:    "example.com/replacement",
 		Version: "v2.0.0",
 		Sum:     "",
-		Replace: unwrap_2,
-	}
-	opt_3 := lisette.MakeOptionNone[*debug.Module]()
-	var unwrap_4 *debug.Module
-	if opt_3.Tag == lisette.OptionSome {
-		unwrap_4 = opt_3.SomeVal
+		Replace: nil,
 	}
 	mod_ := debug.Module{
 		Path:    "example.com/mod",
 		Version: "v1.0.0",
 		Sum:     "",
-		Replace: unwrap_4,
+		Replace: nil,
 	}
-	opt_5 := lisette.MakeOptionSome(&replacement)
-	var unwrap_6 *debug.Module
-	if opt_5.Tag == lisette.OptionSome {
-		unwrap_6 = opt_5.SomeVal
-	}
-	mod_.Replace = unwrap_6
+	mod_.Replace = &replacement
 	fmt.Print(mod_.Path)
 }

--- a/tests/spec/build/snapshots/go_struct_literal_none_unwrap.snap
+++ b/tests/spec/build/snapshots/go_struct_literal_none_unwrap.snap
@@ -6,21 +6,15 @@ package main
 
 import (
 	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
 	"runtime/debug"
 )
 
 func main() {
-	opt_1 := lisette.MakeOptionNone[*debug.Module]()
-	var unwrap_2 *debug.Module
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
 	mod_ := debug.Module{
 		Path:    "example.com/mod",
 		Version: "v1.0.0",
 		Sum:     "",
-		Replace: unwrap_2,
+		Replace: nil,
 	}
 	fmt.Print(mod_.Path)
 }

--- a/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
+++ b/tests/spec/build/snapshots/go_struct_nullable_field_raw_temp_var_no_collision.snap
@@ -11,20 +11,15 @@ import (
 )
 
 func main() {
-	opt_1 := lisette.MakeOptionNone[*debug.Module]()
-	var unwrap_2 *debug.Module
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
 	mod_ := debug.Module{
 		Path:    "example.com/mod",
 		Version: "v1.0.0",
 		Sum:     "",
-		Replace: unwrap_2,
+		Replace: nil,
 	}
-	raw_3 := mod_.Replace
-	r := lisette.OptionFromNilable[*debug.Module](raw_3, raw_3 == nil)
-	raw_1 := 3
+	raw_1 := mod_.Replace
+	r := lisette.OptionFromNilable[*debug.Module](raw_1, raw_1 == nil)
+	raw_1_3 := 3
 	fmt.Println(r)
-	fmt.Println(raw_1)
+	fmt.Println(raw_1_3)
 }

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2947,6 +2947,52 @@ fn main() {
 }
 
 #[test]
+fn some_call_into_nullable_go_parameter_passes_the_value() {
+    let input = r#"
+import "go:fmt"
+import "go:net/http"
+import "go:strings"
+
+fn main() {
+  let req = http.NewRequest("POST", "https://example.com", Some(strings.NewReader("hello")))
+  fmt.Println(req.is_ok())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn option_variable_into_nullable_go_parameter_keeps_the_tag_test() {
+    let input = r#"
+import "go:fmt"
+import "go:net/http"
+import "go:os"
+
+fn main() {
+  let body = if os.Args.length() > 1 { Some(os.Stdin) } else { None }
+  let req = http.NewRequest("POST", "https://example.com", body)
+  fmt.Println(req.is_ok())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn some_into_nullable_go_field_assignment_passes_the_value() {
+    let input = r#"
+import "go:fmt"
+import "go:net/http"
+
+fn main() {
+  let mut server = http.Server { Addr: ":8080", .. }
+  server.Handler = Some(http.NewServeMux())
+  fmt.Println(server.Addr)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
+++ b/tests/spec/emit/snapshots/go_some_for_interface_parameter.snap
@@ -18,26 +18,20 @@ import (
 	"errors"
 	"fmt"
 	lisette "github.com/ivov/lisette/prelude"
-	"io"
 	"net/http"
 	"strings"
 )
 
 func main() {
 	body := strings.NewReader("hello")
-	opt_1 := lisette.MakeOptionSome[io.Reader](body)
-	var unwrap_2 io.Reader
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	ret_3, ret_4 := http.NewRequest("POST", "https://example.com", unwrap_2)
+	ret_1, ret_2 := http.NewRequest("POST", "https://example.com", body)
 	var req lisette.Result[*http.Request, error]
-	if ret_4 != nil {
-		req = lisette.MakeResultErr[*http.Request, error](ret_4)
-	} else if ret_3 == nil {
+	if ret_2 != nil {
+		req = lisette.MakeResultErr[*http.Request, error](ret_2)
+	} else if ret_1 == nil {
 		req = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
 	} else {
-		req = lisette.MakeResultOk[*http.Request, error](ret_3)
+		req = lisette.MakeResultOk[*http.Request, error](ret_1)
 	}
 	fmt.Println(req)
 }

--- a/tests/spec/emit/snapshots/go_struct_map_field_written_through_some.snap
+++ b/tests/spec/emit/snapshots/go_struct_map_field_written_through_some.snap
@@ -24,19 +24,14 @@ import (
 func test() string {
 	headers := make(map[string]string)
 	headers["key"] = "value"
-	opt_1 := lisette.MakeOptionSome(headers)
-	var unwrap_2 map[string]string
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
 	b := pem.Block{
 		Type:    "X",
-		Headers: unwrap_2,
+		Headers: headers,
 	}
-	raw_3 := b.Headers
-	option_4 := lisette.OptionFromNilable[map[string]string](raw_3, raw_3 == nil)
-	if option_4.Tag == lisette.OptionSome {
-		return option_4.SomeVal["key"]
+	raw_1 := b.Headers
+	option_2 := lisette.OptionFromNilable[map[string]string](raw_1, raw_1 == nil)
+	if option_2.Tag == lisette.OptionSome {
+		return option_2.SomeVal["key"]
 	}
 	return ""
 }

--- a/tests/spec/emit/snapshots/interop_fn_arg_nested_option_slice.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_nested_option_slice.snap
@@ -17,23 +17,19 @@ import (
 )
 
 func main() {
-	opt_1 := lisette.MakeOptionSome([]lisette.Option[string]{
+	src_1 := []lisette.Option[string]{
 		lisette.MakeOptionSome("hi"),
 		lisette.MakeOptionNone[string](),
-	})
-	var ptr_2 *[]*string
-	if opt_1.Tag == lisette.OptionSome {
-		src_3 := opt_1.SomeVal
-		unwrapped_4 := make([]*string, len(src_3))
-		for i_5, v_6 := range src_3 {
-			if v_6.Tag == lisette.OptionSome {
-				unwrapped_4[i_5] = &v_6.SomeVal
-			} else {
-				unwrapped_4[i_5] = nil
-			}
-		}
-		ptr_2 = &unwrapped_4
 	}
-	aws.Use(ptr_2)
+	unwrapped_2 := make([]*string, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = &v_4.SomeVal
+		} else {
+			unwrapped_2[i_3] = nil
+		}
+	}
+	var ptr_5 []*string = unwrapped_2
+	aws.Use(&ptr_5)
 	aws.Use(nil)
 }

--- a/tests/spec/emit/snapshots/interop_fn_arg_variadic_option_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_fn_arg_variadic_option_pointer.snap
@@ -11,17 +11,9 @@ description: |
 ---
 package main
 
-import (
-	"example.com/aws"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/aws"
 
 func main() {
 	n := aws.Node{}
-	opt_1 := lisette.MakeOptionSome(&n)
-	var unwrap_2 *aws.Node
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	aws.Use(unwrap_2, nil)
+	aws.Use(&n, nil)
 }

--- a/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
+++ b/tests/spec/emit/snapshots/interop_map_alias_value_unwrapped_at_go_struct_literal.snap
@@ -44,28 +44,17 @@ func main() {
 	objects := make(map[string]lisette.Option[*ast.Object])
 	objects["present"] = lisette.MakeOptionSome(&obj)
 	objects["absent"] = lisette.MakeOptionNone[*ast.Object]()
-	opt_1 := lisette.MakeOptionNone[*ast.Scope]()
-	var unwrap_2 *ast.Scope
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	opt_3 := lisette.MakeOptionSome(objects)
-	var unwrap_4 map[string]*ast.Object
-	if opt_3.Tag == lisette.OptionSome {
-		src_5 := opt_3.SomeVal
-		unwrapped_6 := make(map[string]*ast.Object, len(src_5))
-		for i_7, v_8 := range src_5 {
-			if v_8.Tag == lisette.OptionSome {
-				unwrapped_6[i_7] = v_8.SomeVal
-			} else {
-				unwrapped_6[i_7] = nil
-			}
+	unwrapped_1 := make(map[string]*ast.Object, len(objects))
+	for i_2, v_3 := range objects {
+		if v_3.Tag == lisette.OptionSome {
+			unwrapped_1[i_2] = v_3.SomeVal
+		} else {
+			unwrapped_1[i_2] = nil
 		}
-		unwrap_4 = unwrapped_6
 	}
 	scope := ast.Scope{
-		Outer:   unwrap_2,
-		Objects: unwrap_4,
+		Outer:   nil,
+		Objects: unwrapped_1,
 	}
 	_ = scope
 }

--- a/tests/spec/emit/snapshots/interop_nullable_field_assign_through_go_struct_alias_unwraps.snap
+++ b/tests/spec/emit/snapshots/interop_nullable_field_assign_through_go_struct_alias_unwraps.snap
@@ -13,19 +13,11 @@ description: |
 ---
 package main
 
-import (
-	"flag"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "flag"
 
 type MyFlag = flag.Flag
 
 func main() {
 	f := flag.Flag{}
-	opt_1 := lisette.MakeOptionNone[flag.Value]()
-	var unwrap_2 flag.Value
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	f.Value = unwrap_2
+	f.Value = nil
 }

--- a/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
+++ b/tests/spec/emit/snapshots/interop_option_ref_slice_option.snap
@@ -37,23 +37,18 @@ func main() {
 		option_2 = lisette.MakeOptionNone[*[]lisette.Option[string]]()
 	}
 	if option_2.Tag == lisette.OptionSome {
-		opt_8 := lisette.MakeOptionSome(option_2.SomeVal)
-		var unwrap_9 *[]*string
-		if opt_8.Tag == lisette.OptionSome {
-			src_10 := opt_8.SomeVal
-			src_11 := *src_10
-			unwrapped_12 := make([]*string, len(src_11))
-			for i_13, v_14 := range src_11 {
-				if v_14.Tag == lisette.OptionSome {
-					unwrapped_12[i_13] = &v_14.SomeVal
-				} else {
-					unwrapped_12[i_13] = nil
-				}
+		src_8 := option_2.SomeVal
+		src_9 := *src_8
+		unwrapped_10 := make([]*string, len(src_9))
+		for i_11, v_12 := range src_9 {
+			if v_12.Tag == lisette.OptionSome {
+				unwrapped_10[i_11] = &v_12.SomeVal
+			} else {
+				unwrapped_10[i_11] = nil
 			}
-			ref_15 := &unwrapped_12
-			unwrap_9 = ref_15
 		}
-		aws.Use(unwrap_9)
+		ref_13 := &unwrapped_10
+		aws.Use(ref_13)
 	} else {
 		aws.Use(nil)
 	}

--- a/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
+++ b/tests/spec/emit/snapshots/interop_pointer_scalar_param_some.snap
@@ -10,16 +10,9 @@ description: |
 ---
 package main
 
-import (
-	"example.com/cfg"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/cfg"
 
 func main() {
-	opt_1 := lisette.MakeOptionSome("custom")
-	var ptr_2 *string
-	if opt_1.Tag == lisette.OptionSome {
-		ptr_2 = &opt_1.SomeVal
-	}
-	cfg.Configure(ptr_2)
+	var ptr_1 string = "custom"
+	cfg.Configure(&ptr_1)
 }

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_round_trip.snap
@@ -59,12 +59,7 @@ func main() {
 		} else {
 			fmt.Println("error", e)
 		}
-		opt_1 := lisette.MakeOptionNone[*parse.ListNode]()
-		var unwrap_2 *parse.ListNode
-		if opt_1.Tag == lisette.OptionSome {
-			unwrap_2 = opt_1.SomeVal
-		}
-		parsed.Root = unwrap_2
+		parsed.Root = nil
 		if _, e := root(parsed); e == nil {
 			fmt.Println("root is available")
 		} else {

--- a/tests/spec/emit/snapshots/interop_promoted_nullable_field_write_unwraps_option.snap
+++ b/tests/spec/emit/snapshots/interop_promoted_nullable_field_write_unwraps_option.snap
@@ -10,16 +10,8 @@ description: |
 ---
 package main
 
-import (
-	"example.com/promoted"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/promoted"
 
 func clear_(client *promoted.Client) {
-	opt_1 := lisette.MakeOptionNone[*promoted.Group]()
-	var unwrap_2 *promoted.Group
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	client.Group = unwrap_2
+	client.Group = nil
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_int32.snap
@@ -12,23 +12,11 @@ description: |
 ---
 package main
 
-import (
-	"example.com/aws"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/aws"
 
 func main() {
 	b := aws.ListInput{}
-	opt_1 := lisette.MakeOptionSome(int32(5))
-	var ptr_2 *int32
-	if opt_1.Tag == lisette.OptionSome {
-		ptr_2 = &opt_1.SomeVal
-	}
-	b.MaxItems = ptr_2
-	opt_3 := lisette.MakeOptionNone[int32]()
-	var ptr_4 *int32
-	if opt_3.Tag == lisette.OptionSome {
-		ptr_4 = &opt_3.SomeVal
-	}
-	b.MaxItems = ptr_4
+	var ptr_1 int32 = 5
+	b.MaxItems = &ptr_1
+	b.MaxItems = nil
 }

--- a/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
+++ b/tests/spec/emit/snapshots/interop_struct_field_assign_option_string.snap
@@ -11,17 +11,10 @@ description: |
 ---
 package main
 
-import (
-	"example.com/aws"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/aws"
 
 func main() {
 	b := aws.Bucket{}
-	opt_1 := lisette.MakeOptionSome("hi")
-	var ptr_2 *string
-	if opt_1.Tag == lisette.OptionSome {
-		ptr_2 = &opt_1.SomeVal
-	}
-	b.Name = ptr_2
+	var ptr_1 string = "hi"
+	b.Name = &ptr_1
 }

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_none_to_pointer.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_none_to_pointer.snap
@@ -12,16 +12,8 @@ description: |
 ---
 package main
 
-import (
-	"example.com/cb"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/cb"
 
 func main() {
-	opt_1 := lisette.MakeOptionNone[cb.Direction]()
-	var ptr_2 *cb.Direction
-	if opt_1.Tag == lisette.OptionSome {
-		ptr_2 = &opt_1.SomeVal
-	}
-	_ = cb.Options{Direction: ptr_2}
+	_ = cb.Options{Direction: nil}
 }

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_named_scalar.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_named_scalar.snap
@@ -12,16 +12,9 @@ description: |
 ---
 package main
 
-import (
-	"example.com/cb"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/cb"
 
 func main() {
-	opt_1 := lisette.MakeOptionSome(cb.DirectionDefault)
-	var ptr_2 *cb.Direction
-	if opt_1.Tag == lisette.OptionSome {
-		ptr_2 = &opt_1.SomeVal
-	}
-	_ = cb.Options{Direction: ptr_2}
+	var ptr_1 cb.Direction = cb.DirectionDefault
+	_ = cb.Options{Direction: &ptr_1}
 }

--- a/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_struct.snap
+++ b/tests/spec/emit/snapshots/interop_struct_literal_option_to_pointer_struct.snap
@@ -13,17 +13,9 @@ description: |
 ---
 package main
 
-import (
-	"example.com/cb"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "example.com/cb"
 
 func main() {
 	inner := cb.Inner{Tag: "x"}
-	opt_1 := lisette.MakeOptionSome(&inner)
-	var unwrap_2 *cb.Inner
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	_ = cb.Outer{Slot: unwrap_2}
+	_ = cb.Outer{Slot: &inner}
 }

--- a/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
+++ b/tests/spec/emit/snapshots/interop_typed_nil_interface_collection.snap
@@ -33,35 +33,30 @@ import (
 )
 
 func main() {
-	opt_1 := lisette.MakeOptionNone[ast.Expr]()
-	var unwrap_2 ast.Expr
-	if opt_1.Tag == lisette.OptionSome {
-		unwrap_2 = opt_1.SomeVal
-	}
-	src_3 := []lisette.Option[ast.Expr]{}
-	unwrapped_4 := make([]ast.Expr, len(src_3))
-	for i_5, v_6 := range src_3 {
-		if v_6.Tag == lisette.OptionSome {
-			unwrapped_4[i_5] = v_6.SomeVal
+	src_1 := []lisette.Option[ast.Expr]{}
+	unwrapped_2 := make([]ast.Expr, len(src_1))
+	for i_3, v_4 := range src_1 {
+		if v_4.Tag == lisette.OptionSome {
+			unwrapped_2[i_3] = v_4.SomeVal
 		}
 	}
 	lit := ast.CompositeLit{
-		Type:       unwrap_2,
+		Type:       nil,
 		Lbrace:     token.Pos(0),
-		Elts:       unwrapped_4,
+		Elts:       unwrapped_2,
 		Rbrace:     token.Pos(0),
 		Incomplete: false,
 	}
-	raw_7 := lit.Elts
-	wrapped_8 := make([]lisette.Option[ast.Expr], len(raw_7))
-	for i_9, v_10 := range raw_7 {
-		if !lisette.IsNilInterface(v_10) {
-			wrapped_8[i_9] = lisette.MakeOptionSome[ast.Expr](v_10)
+	raw_5 := lit.Elts
+	wrapped_6 := make([]lisette.Option[ast.Expr], len(raw_5))
+	for i_7, v_8 := range raw_5 {
+		if !lisette.IsNilInterface(v_8) {
+			wrapped_6[i_7] = lisette.MakeOptionSome[ast.Expr](v_8)
 		} else {
-			wrapped_8[i_9] = lisette.MakeOptionNone[ast.Expr]()
+			wrapped_6[i_7] = lisette.MakeOptionNone[ast.Expr]()
 		}
 	}
-	elts := wrapped_8
+	elts := wrapped_6
 	for _, elt := range elts {
 		if elt.Tag == lisette.OptionSome {
 			fmt.Println(elt.SomeVal.Pos())

--- a/tests/spec/emit/snapshots/option_variable_into_nullable_go_parameter_keeps_the_tag_test.snap
+++ b/tests/spec/emit/snapshots/option_variable_into_nullable_go_parameter_keeps_the_tag_test.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:net/http"
+  import "go:os"
+  
+  fn main() {
+    let body = if os.Args.length() > 1 { Some(os.Stdin) } else { None }
+    let req = http.NewRequest("POST", "https://example.com", body)
+    fmt.Println(req.is_ok())
+  }
+---
+package main
+
+import (
+	"errors"
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"io"
+	"net/http"
+	"os"
+)
+
+func main() {
+	var body lisette.Option[*os.File]
+	if len(os.Args) > 1 {
+		body = lisette.MakeOptionSome[*os.File](os.Stdin)
+	} else {
+		body = lisette.MakeOptionNone[*os.File]()
+	}
+	var unwrap_1 io.Reader
+	if body.Tag == lisette.OptionSome {
+		unwrap_1 = body.SomeVal
+	}
+	ret_2, ret_3 := http.NewRequest("POST", "https://example.com", unwrap_1)
+	var req lisette.Result[*http.Request, error]
+	if ret_3 != nil {
+		req = lisette.MakeResultErr[*http.Request, error](ret_3)
+	} else if ret_2 == nil {
+		req = lisette.MakeResultErr[*http.Request, error](errors.New("unexpected nil"))
+	} else {
+		req = lisette.MakeResultOk[*http.Request, error](ret_2)
+	}
+	fmt.Println(req.IsOk())
+}

--- a/tests/spec/emit/snapshots/some_call_into_nullable_go_parameter_passes_the_value.snap
+++ b/tests/spec/emit/snapshots/some_call_into_nullable_go_parameter_passes_the_value.snap
@@ -1,7 +1,16 @@
 ---
-source: tests/spec/build/mod.rs
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:net/http"
+  import "go:strings"
+  
+  fn main() {
+    let req = http.NewRequest("POST", "https://example.com", Some(strings.NewReader("hello")))
+    fmt.Println(req.is_ok())
+  }
 ---
-// === main.go ===
 package main
 
 import (
@@ -13,8 +22,7 @@ import (
 )
 
 func main() {
-	body := strings.NewReader("hello")
-	ret_1, ret_2 := http.NewRequest("POST", "https://example.com", body)
+	ret_1, ret_2 := http.NewRequest("POST", "https://example.com", strings.NewReader("hello"))
 	var req lisette.Result[*http.Request, error]
 	if ret_2 != nil {
 		req = lisette.MakeResultErr[*http.Request, error](ret_2)
@@ -23,7 +31,5 @@ func main() {
 	} else {
 		req = lisette.MakeResultOk[*http.Request, error](ret_1)
 	}
-	unwrap_2 := 7
-	_ = unwrap_2
-	fmt.Println(req)
+	fmt.Println(req.IsOk())
 }

--- a/tests/spec/emit/snapshots/some_into_nullable_go_field_assignment_passes_the_value.snap
+++ b/tests/spec/emit/snapshots/some_into_nullable_go_field_assignment_passes_the_value.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:net/http"
+  
+  fn main() {
+    let mut server = http.Server { Addr: ":8080", .. }
+    server.Handler = Some(http.NewServeMux())
+    fmt.Println(server.Addr)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	server := http.Server{Addr: ":8080"}
+	server.Handler = http.NewServeMux()
+	fmt.Println(server.Addr)
+}


### PR DESCRIPTION
A `Some(value)` or `None` literal written into a nullable Go slot (e.g. pointer or interface param, field, or struct literal field) now emits the value or `nil` directly, instead of a `lisette.Option` built from the literal and then unwrapped by tag.

```rs
import "go:fmt"
import "go:net/http"

fn main() {
  let mut server = http.Server { Addr: ":8080", .. }
  server.Handler = Some(http.NewServeMux())
  fmt.Println(server.Addr)
}
```

Before:

```go
func main() {
	server := http.Server{Addr: ":8080"}
	opt_1 := lisette.MakeOptionSome[http.Handler](http.NewServeMux())
	var unwrap_2 http.Handler
	if opt_1.Tag == lisette.OptionSome {
		unwrap_2 = opt_1.SomeVal
	}
	server.Handler = unwrap_2
	fmt.Println(server.Addr)
}
```

After:

```go
func main() {
	server := http.Server{Addr: ":8080"}
	server.Handler = http.NewServeMux() // the value goes straight into the slot
	fmt.Println(server.Addr)
}
```