### PR TITLE
feat: idiomatic Go for `match` on field paths and loop results

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -549,6 +549,13 @@ impl<'a> Planner<'a> {
         } else {
             EvaluationEffect::EffectfulCall
         };
+        if result
+            .setup
+            .iter()
+            .any(|statement| statement.binds_name(&result.value))
+        {
+            return ValuePlan::captured_with_effect(result.setup, result.value, effect);
+        }
         let receiver_arity = if matches!(origin, CallableOrigin::NativeMethodIdentifier(_)) {
             ctx.args.len().saturating_sub(1)
         } else {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1029,7 +1029,12 @@ impl Planner<'_> {
         let rests_in_stable_name = self.plan_rests_in_stable_name(&staged);
         let (subject_setup, value) = staged.into_parts();
         setup.extend(subject_setup);
-        if !any_guard && is_plain_identifier(&value) {
+        let reads_in_place = is_plain_identifier(&value)
+            || self.field_path_reads_in_place(subject, &value, |root| {
+                arms.iter()
+                    .any(|arm| pattern_binds_name(&arm.pattern, root))
+            });
+        if !any_guard && reads_in_place {
             return (value, SubjectDeclaration::None);
         }
         if any_guard && rests_in_stable_name {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -100,6 +100,28 @@ struct RefutableAlternative<'s> {
     ok_var: Option<String>,
 }
 
+/// The identifier under a chain of field accesses.
+fn field_path_root(expression: &Expression) -> Option<&str> {
+    let mut expression = expression.unwrap_parens();
+    while let Expression::DotAccess {
+        expression: inner, ..
+    } = expression
+    {
+        expression = inner.unwrap_parens();
+    }
+    match expression {
+        Expression::Identifier { value, .. } => Some(value),
+        _ => None,
+    }
+}
+
+fn is_field_path(rendered: &str) -> bool {
+    let mut segments = rendered.split('.');
+    segments.next().is_some_and(go_name::is_plain_identifier)
+        && rendered.contains('.')
+        && segments.all(go_name::is_plain_identifier)
+}
+
 impl Planner<'_> {
     pub(crate) fn can_reuse_subject_identifier(&self, value: &str, binds_name: bool) -> bool {
         !binds_name
@@ -108,6 +130,19 @@ impl Planner<'_> {
                 self.scope.resolve_identifier_binding(value),
                 Some(BindingValue::InlineExpr(_))
             )
+    }
+
+    /// A field path such as `t.status` is read where it sits when nothing rebinds its root.
+    pub(crate) fn field_path_reads_in_place(
+        &self,
+        subject: &Expression,
+        rendered: &str,
+        binds_root: impl Fn(&str) -> bool,
+    ) -> bool {
+        let Some(root) = field_path_root(subject) else {
+            return false;
+        };
+        is_field_path(rendered) && self.can_reuse_subject_identifier(root, binds_root(root))
     }
 
     fn resolve_pattern_subject(
@@ -132,7 +167,11 @@ impl Planner<'_> {
                 let rests_in_stable_name = self.plan_rests_in_stable_name(&plan);
                 let (op_setup, expression) = plan.into_parts();
                 setup.extend(op_setup);
-                if rests_in_stable_name {
+                if rests_in_stable_name
+                    || self.field_path_reads_in_place(scrutinee, &expression, |root| {
+                        pattern_binds_name(pattern, root)
+                    })
+                {
                     return ResolvedSubject::Existing { var: expression };
                 }
                 let var = self.fresh_var(temp_hint);
@@ -345,9 +384,14 @@ impl Planner<'_> {
                 return (self.reference_go_name(value), Vec::new());
             }
         }
-        let var = self.fresh_var(Some("subject"));
         let staged = self.plan_operand(scrutinee, ExpressionContext::value());
         let (mut setup, value) = staged.into_parts();
+        if self
+            .field_path_reads_in_place(scrutinee, &value, |root| pattern_binds_name(pattern, root))
+        {
+            return (value, setup);
+        }
+        let var = self.fresh_var(Some("subject"));
         setup.push(LoweredStatement::TempBind {
             name: var.clone(),
             value,

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -454,10 +454,18 @@ impl ValuePlan {
 
     /// A name the setup just bound, or which nothing can rebind.
     pub(crate) fn captured(setup: Vec<LoweredStatement>, name: String) -> Self {
+        Self::captured_with_effect(setup, name, EvaluationEffect::Pure)
+    }
+
+    pub(crate) fn captured_with_effect(
+        setup: Vec<LoweredStatement>,
+        name: String,
+        effect: EvaluationEffect,
+    ) -> Self {
         Self::from_facts(
             setup,
             GoExpression::name(name),
-            EvaluationFacts::new(OperandForm::Name, Stability::Fixed, EvaluationEffect::Pure),
+            EvaluationFacts::new(OperandForm::Name, Stability::Fixed, effect),
         )
     }
 

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -2993,6 +2993,123 @@ fn main() {
 }
 
 #[test]
+fn match_on_a_field_path_reads_the_field_in_place() {
+    let input = r#"
+import "go:fmt"
+
+enum Status { Pending, Done }
+
+struct Task { status: Status }
+
+impl Task {
+  fn icon(self: Ref<Task>) -> string {
+    match self.status {
+      Status.Pending => "[ ]",
+      Status.Done => "[x]",
+    }
+  }
+}
+
+fn main() {
+  let t = Task { status: Status.Pending }
+  fmt.Println(t.icon())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_on_a_field_path_with_a_guard_keeps_the_subject_temp() {
+    let input = r#"
+import "go:fmt"
+
+struct Task { retries: Option<int> }
+
+fn describe(t: Ref<Task>) -> string {
+  match t.retries {
+    Some(n) if n > 3 => "many",
+    Some(_) => "some",
+    None => "none",
+  }
+}
+
+fn main() {
+  fmt.Println(describe(&Task { retries: Some(1) }))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_on_a_field_path_whose_arm_rebinds_the_root_keeps_the_subject_temp() {
+    let input = r#"
+import "go:fmt"
+
+struct Node { next: Option<int> }
+
+fn main() {
+  let t = Node { next: Some(2) }
+  match t.next {
+    Some(t) => fmt.Println(t),
+    None => fmt.Println("end"),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_else_on_a_field_path_reads_the_field_in_place() {
+    let input = r#"
+import "go:fmt"
+
+struct Task { parent: Option<int> }
+
+fn parent_of(item: Ref<Task>) -> int {
+  let Some(id) = item.parent else { return -1 }
+  id
+}
+
+fn main() {
+  fmt.Println(parent_of(&Task { parent: Some(7) }))
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn while_let_on_a_field_path_reads_the_field_each_iteration() {
+    let input = r#"
+import "go:fmt"
+
+struct Cursor { next: Option<int> }
+
+fn main() {
+  let mut cursor = Cursor { next: Some(3) }
+  while let Some(n) = cursor.next {
+    fmt.Println(n)
+    cursor.next = if n > 0 { Some(n - 1) } else { None }
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn find_result_in_a_let_else_needs_no_subject_temp() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let nums = [1, 2, 3]
+  let Some(even) = nums.find(|n| n % 2 == 0) else { return }
+  fmt.Println(even)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"

--- a/tests/spec/emit/snapshots/find_result_in_a_let_else_needs_no_subject_temp.snap
+++ b/tests/spec/emit/snapshots/find_result_in_a_let_else_needs_no_subject_temp.snap
@@ -1,0 +1,34 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let nums = [1, 2, 3]
+    let Some(even) = nums.find(|n| n % 2 == 0) else { return }
+    fmt.Println(even)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	nums := []int{1, 2, 3}
+	result_1 := lisette.MakeOptionNone[int]()
+	for _, n := range nums {
+		if n%2 == 0 {
+			result_1 = lisette.MakeOptionSome[int](n)
+			break
+		}
+	}
+	if result_1.Tag != lisette.OptionSome {
+		return
+	}
+	even := result_1.SomeVal
+	fmt.Println(even)
+}

--- a/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
+++ b/tests/spec/emit/snapshots/impl_method_pattern_binding_no_receiver_shadow.snap
@@ -31,9 +31,8 @@ type Node struct {
 }
 
 func (n Node) sum() int {
-	subject_1 := n.Next
-	if subject_1.Tag == lisette.OptionSome {
-		return n.Value + subject_1.SomeVal
+	if n.Next.Tag == lisette.OptionSome {
+		return n.Value + n.Next.SomeVal
 	}
 	return n.Value
 }

--- a/tests/spec/emit/snapshots/let_else_on_a_field_path_reads_the_field_in_place.snap
+++ b/tests/spec/emit/snapshots/let_else_on_a_field_path_reads_the_field_in_place.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Task { parent: Option<int> }
+  
+  fn parent_of(item: Ref<Task>) -> int {
+    let Some(id) = item.parent else { return -1 }
+    id
+  }
+  
+  fn main() {
+    fmt.Println(parent_of(&Task { parent: Some(7) }))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Task struct {
+	parent lisette.Option[int]
+}
+
+func parentOf(item *Task) int {
+	if item.parent.Tag != lisette.OptionSome {
+		return -1
+	}
+	id := item.parent.SomeVal
+	return id
+}
+
+func main() {
+	fmt.Println(parentOf(&Task{parent: lisette.MakeOptionSome(7)}))
+}

--- a/tests/spec/emit/snapshots/match_on_a_field_path_reads_the_field_in_place.snap
+++ b/tests/spec/emit/snapshots/match_on_a_field_path_reads_the_field_in_place.snap
@@ -1,0 +1,62 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  enum Status { Pending, Done }
+  
+  struct Task { status: Status }
+  
+  impl Task {
+    fn icon(self: Ref<Task>) -> string {
+      match self.status {
+        Status.Pending => "[ ]",
+        Status.Done => "[x]",
+      }
+    }
+  }
+  
+  fn main() {
+    let t = Task { status: Status.Pending }
+    fmt.Println(t.icon())
+  }
+---
+package main
+
+import "fmt"
+
+func MakeStatusPending() Status {
+	return Status{Tag: StatusPending}
+}
+
+func MakeStatusDone() Status {
+	return Status{Tag: StatusDone}
+}
+
+type StatusTag uint8
+
+const (
+	StatusPending StatusTag = iota
+	StatusDone
+)
+
+type Status struct {
+	Tag StatusTag
+}
+
+type Task struct {
+	status Status
+}
+
+func (t *Task) icon() string {
+	if t.status.Tag == StatusPending {
+		return "[ ]"
+	}
+	return "[x]"
+}
+
+func main() {
+	t := Task{status: MakeStatusPending()}
+	fmt.Println(t.icon())
+}

--- a/tests/spec/emit/snapshots/match_on_a_field_path_whose_arm_rebinds_the_root_keeps_the_subject_temp.snap
+++ b/tests/spec/emit/snapshots/match_on_a_field_path_whose_arm_rebinds_the_root_keeps_the_subject_temp.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Node { next: Option<int> }
+  
+  fn main() {
+    let t = Node { next: Some(2) }
+    match t.next {
+      Some(t) => fmt.Println(t),
+      None => fmt.Println("end"),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Node struct {
+	next lisette.Option[int]
+}
+
+func main() {
+	t := Node{next: lisette.MakeOptionSome(2)}
+	subject_1 := t.next
+	if subject_1.Tag == lisette.OptionSome {
+		fmt.Println(subject_1.SomeVal)
+	} else {
+		fmt.Println("end")
+	}
+}

--- a/tests/spec/emit/snapshots/match_on_a_field_path_with_a_guard_keeps_the_subject_temp.snap
+++ b/tests/spec/emit/snapshots/match_on_a_field_path_with_a_guard_keeps_the_subject_temp.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Task { retries: Option<int> }
+  
+  fn describe(t: Ref<Task>) -> string {
+    match t.retries {
+      Some(n) if n > 3 => "many",
+      Some(_) => "some",
+      None => "none",
+    }
+  }
+  
+  fn main() {
+    fmt.Println(describe(&Task { retries: Some(1) }))
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Task struct {
+	retries lisette.Option[int]
+}
+
+func describe(t *Task) string {
+	subject_1 := t.retries
+	if subject_1.Tag == lisette.OptionSome {
+		if subject_1.SomeVal > 3 {
+			return "many"
+		}
+		return "some"
+	}
+	return "none"
+}
+
+func main() {
+	fmt.Println(describe(&Task{retries: lisette.MakeOptionSome(1)}))
+}

--- a/tests/spec/emit/snapshots/while_let_on_a_field_path_reads_the_field_each_iteration.snap
+++ b/tests/spec/emit/snapshots/while_let_on_a_field_path_reads_the_field_each_iteration.snap
@@ -1,0 +1,45 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Cursor { next: Option<int> }
+  
+  fn main() {
+    let mut cursor = Cursor { next: Some(3) }
+    while let Some(n) = cursor.next {
+      fmt.Println(n)
+      cursor.next = if n > 0 { Some(n - 1) } else { None }
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+type Cursor struct {
+	next lisette.Option[int]
+}
+
+func main() {
+	cursor := Cursor{next: lisette.MakeOptionSome(3)}
+	for {
+		if cursor.next.Tag == lisette.OptionSome {
+			n := cursor.next.SomeVal
+			fmt.Println(n)
+			var tmp_1 lisette.Option[int]
+			if n > 0 {
+				tmp_1 = lisette.MakeOptionSome[int](n - 1)
+			} else {
+				tmp_1 = lisette.MakeOptionNone[int]()
+			}
+			cursor.next = tmp_1
+		} else {
+			break
+		}
+	}
+}


### PR DESCRIPTION
A `match` on a field path, when no arm writes to the path, now checks the field in place, instead of taking a `subject_N` copy before the check. Same for a `let else` or `match` on a `find` or `map` result, which no longer takes a copy of the loop result.

```rs
import "go:fmt"

enum Status { Pending, Done }

struct Task { status: Status }

impl Task {
  fn icon(self: Ref<Task>) -> string {
    match self.status {
      Status.Pending => "[ ]",
      Status.Done => "[x]",
    }
  }
}
```

Before:

```go
func (t *Task) icon() string {
	subject_1 := t.status
	if subject_1.Tag == StatusPending {
		return "[ ]"
	}
	return "[x]"
}
```

After:

```go
func (t *Task) icon() string {
	if t.status.Tag == StatusPending { // the field is read in place, no copy
		return "[ ]"
	}
	return "[x]"
}
```
