### PR TITLE
feat: idiomatic Go for slice lengths and `let` map results

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -13,7 +13,7 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, CallableOrigin};
-use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, Stability, ValuePlan};
 use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
 use syntax::EcoString;
@@ -440,6 +440,7 @@ impl<'a> Planner<'a> {
             method,
             capture_boundary: CaptureBoundary::SiblingSequence,
             retired_receiver: None,
+            result_name: None,
         };
         self.try_emit_negated_native_method(setup, &native_ctx)
     }
@@ -521,6 +522,7 @@ impl<'a> Planner<'a> {
                     method,
                     capture_boundary: ctx.capture_boundary(),
                     retired_receiver: ctx.retired_receiver(),
+                    result_name: None,
                 };
                 return self.lower_native_call(&native_ctx, &plan.resolved.origin);
             }
@@ -535,7 +537,11 @@ impl<'a> Planner<'a> {
         self.lower_regular_call(call_expression, &plan, call_ty, ctx)
     }
 
-    fn lower_native_call(&mut self, ctx: &NativeCallContext, origin: &CallableOrigin) -> ValuePlan {
+    pub(super) fn lower_native_call(
+        &mut self,
+        ctx: &NativeCallContext,
+        origin: &CallableOrigin,
+    ) -> ValuePlan {
         if let Some(result) = self.try_lower_native_constructor(ctx) {
             return result;
         }
@@ -549,6 +555,18 @@ impl<'a> Planner<'a> {
         } else {
             EvaluationEffect::EffectfulCall
         };
+        let receiver = match ctx.function {
+            Expression::DotAccess { expression, .. } => Some(expression.as_ref()),
+            _ => ctx.args.first(),
+        };
+        // Channel length can change without rebinding the receiver.
+        let reads_fixed_length = matches!(ctx.method, "length" | "capacity")
+            && !matches!(origin, CallableOrigin::NativeConstructor(_))
+            && !matches!(
+                ctx.native_type,
+                NativeGoType::Channel | NativeGoType::Sender | NativeGoType::Receiver
+            )
+            && receiver.is_some_and(|receiver| self.is_unmutated_identifier(receiver));
         if result
             .setup
             .iter()
@@ -563,33 +581,37 @@ impl<'a> Planner<'a> {
         };
         let plain_call = !matches!(origin, CallableOrigin::NativeConstructor(_))
             && native_method_lowers_to_plain_call(ctx.native_type, ctx.method, receiver_arity);
-        if plain_call {
-            return ValuePlan::plain_call(
+        let mut plan = if plain_call {
+            ValuePlan::plain_call(
                 result.setup,
                 GoExpression::opaque_with_deferred_evaluation(result.value, true),
                 effect,
-            );
-        }
-
-        let contains_deferred_evaluation = match ctx.method {
-            "enumerate" => result.arguments_contain_deferred_evaluation,
-            "append" if receiver_arity == 0 => result.arguments_contain_deferred_evaluation,
-            _ => true,
-        };
-        let expression = if ctx.method == "byte_at" {
-            GoExpression::opaque_with_deferred_evaluation(
-                result.value,
-                result.arguments_contain_deferred_evaluation,
             )
-        } else if ctx.method == "is_empty" {
-            GoExpression::opaque_with_deferred_evaluation(result.value, true)
         } else {
-            GoExpression::opaque_with_deferred_evaluation(
-                result.value,
-                contains_deferred_evaluation,
-            )
+            let contains_deferred_evaluation = match ctx.method {
+                "enumerate" => result.arguments_contain_deferred_evaluation,
+                "append" if receiver_arity == 0 => result.arguments_contain_deferred_evaluation,
+                _ => true,
+            };
+            let expression = if ctx.method == "byte_at" {
+                GoExpression::opaque_with_deferred_evaluation(
+                    result.value,
+                    result.arguments_contain_deferred_evaluation,
+                )
+            } else if ctx.method == "is_empty" {
+                GoExpression::opaque_with_deferred_evaluation(result.value, true)
+            } else {
+                GoExpression::opaque_with_deferred_evaluation(
+                    result.value,
+                    contains_deferred_evaluation,
+                )
+            };
+            ValuePlan::computed(result.setup, expression, effect)
         };
-        ValuePlan::computed(result.setup, expression, effect)
+        if reads_fixed_length {
+            plan.evaluation.stability = Stability::Fixed;
+        }
+        plan
     }
 
     pub(super) fn infer_return_only_type_args(

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -25,4 +25,5 @@ pub(super) struct NativeCallContext<'a> {
     pub method: &'a str,
     pub capture_boundary: CaptureBoundary,
     pub retired_receiver: Option<&'a Expression>,
+    pub result_name: Option<&'a str>,
 }

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -968,6 +968,7 @@ impl Planner<'_> {
             method: "get",
             capture_boundary: CaptureBoundary::SiblingSequence,
             retired_receiver: None,
+            result_name: None,
         };
         let staged = self.stage_native_method(&ctx, NativeMethodForm::Dot);
         let receiver = super::comma_ok::parenthesize_prefixed(staged.receiver);

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -2,6 +2,7 @@ use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
 
 use super::NativeCallContext;
+use super::dispatch::extract_native_method_name;
 use super::native::NativeCallResult;
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
@@ -9,7 +10,9 @@ use crate::names::go_name;
 use crate::plan::bodies::{
     ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan,
 };
-use crate::plan::values::EvaluationEffect;
+use crate::plan::calls::CallableOrigin;
+use crate::plan::values::{CaptureBoundary, EvaluationEffect};
+use crate::types::native::NativeGoType;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SliceLoop {
@@ -97,15 +100,22 @@ fn peel_single_expression_block(body: &Expression) -> &Expression {
     }
 }
 
+struct SliceLoopShape<'a> {
+    kind: SliceLoop,
+    body: &'a Expression,
+    patterns: Vec<&'a Pattern>,
+    result_ty: Type,
+    element_ty: Type,
+}
+
 impl Planner<'_> {
-    /// Lower `xs.map(|x| ...)` and its siblings to the loop the prelude helper
-    /// runs. `None` keeps the helper call.
-    pub(super) fn try_lower_slice_loop(
-        &mut self,
-        ctx: &NativeCallContext,
+    /// The parts of a `map`, `filter`, `fold`, or `find` call that inline as a loop.
+    fn slice_loop_shape<'a>(
+        &self,
+        ctx: &NativeCallContext<'_>,
         receiver: &Expression,
-        args: &[Expression],
-    ) -> Option<NativeCallResult> {
+        args: &'a [Expression],
+    ) -> Option<SliceLoopShape<'a>> {
         let kind = SliceLoop::from_method(ctx.method)?;
         if args.len() != kind.argument_count() || ctx.spread.is_some() {
             return None;
@@ -125,7 +135,6 @@ impl Planner<'_> {
         if expects_accumulator && body_captures_by_reference(body) {
             return None;
         }
-
         let result_ty = ctx.call_ty?.clone();
         let element_ty = self
             .facts
@@ -133,6 +142,79 @@ impl Planner<'_> {
             .get_type_params()?
             .first()?
             .clone();
+        Some(SliceLoopShape {
+            kind,
+            body,
+            patterns,
+            result_ty,
+            element_ty,
+        })
+    }
+
+    /// `let xs = ys.map(..)` fills `xs` as the loop's own result.
+    pub(crate) fn lower_slice_loop_into(
+        &mut self,
+        value: &Expression,
+        go_name: &str,
+    ) -> Option<Vec<LoweredStatement>> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            type_arguments,
+            ..
+        } = value.unwrap_parens()
+        else {
+            return None;
+        };
+        let plan = self.plan_call(value.unwrap_parens())?;
+        let (CallableOrigin::NativeMethod(kind) | CallableOrigin::NativeMethodIdentifier(kind)) =
+            &plan.resolved.origin
+        else {
+            return None;
+        };
+        let native_type = NativeGoType::from_kind(*kind);
+        if !matches!(native_type, NativeGoType::Slice) {
+            return None;
+        }
+        let function = callee.unwrap_parens();
+        let ty = value.get_type();
+        let ctx = NativeCallContext {
+            function,
+            args,
+            spread: spread.as_deref(),
+            resolved_type_args: type_arguments.resolved_types()?,
+            call_ty: Some(&ty),
+            native_type: &native_type,
+            method: extract_native_method_name(function),
+            capture_boundary: CaptureBoundary::SiblingSequence,
+            retired_receiver: None,
+            result_name: Some(go_name),
+        };
+        let (receiver, arguments) = match function {
+            Expression::DotAccess { expression, .. } => (expression.as_ref(), args.as_slice()),
+            _ => args.split_first()?,
+        };
+        self.slice_loop_shape(&ctx, receiver, arguments)?;
+        Some(self.lower_native_call(&ctx, &plan.resolved.origin).setup)
+    }
+
+    /// Lower `xs.map(|x| ...)` and its siblings to the loop the prelude helper
+    /// runs. `None` keeps the helper call.
+    pub(super) fn try_lower_slice_loop(
+        &mut self,
+        ctx: &NativeCallContext,
+        receiver: &Expression,
+        args: &[Expression],
+    ) -> Option<NativeCallResult> {
+        let SliceLoopShape {
+            kind,
+            body,
+            patterns,
+            result_ty,
+            element_ty,
+        } = self.slice_loop_shape(ctx, receiver, args)?;
+        let expects_accumulator = kind == SliceLoop::Fold;
 
         let mut source_staged = self.plan_operand(receiver, ExpressionContext::value());
         // `map` reads the source twice, for its length and for the range.
@@ -148,7 +230,10 @@ impl Planner<'_> {
         let (mut setup, values) = sequenced.into_rendered();
         let source = values[0].clone();
 
-        let result = self.fresh_var(Some("result"));
+        let result = match ctx.result_name {
+            Some(name) => name.to_string(),
+            None => self.fresh_var(Some("result")),
+        };
         self.declare(&result);
         setup.push(self.slice_loop_declaration(kind, &result, &result_ty, &source, values.get(1)));
 

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -121,6 +121,10 @@ impl Planner<'_> {
                 self.scope.bind(identifier, raw_go_name);
                 return statements;
             }
+            if let Some(statements) = self.lower_slice_loop_into(value, &go_identifier) {
+                self.scope.bind(identifier, raw_go_name);
+                return statements;
+            }
         }
         if needs_temp {
             if self.shadows_declaration(&go_identifier)

--- a/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
+++ b/tests/spec/build/snapshots/slice_map_with_different_output_type.snap
@@ -8,11 +8,10 @@ import "fmt"
 
 func main() {
 	nums := []int{1, 2, 3}
-	result_1 := make([]string, len(nums))
-	for i_2, x := range nums {
-		result_1[i_2] = fmt.Sprintf("n=%d", x)
+	strs := make([]string, len(nums))
+	for i_1, x := range nums {
+		strs[i_1] = fmt.Sprintf("n=%d", x)
 	}
-	strs := result_1
 	for _, s := range strs {
 		fmt.Println(s)
 	}

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -3110,6 +3110,70 @@ fn main() {
 }
 
 #[test]
+fn range_bound_over_an_unmutated_slice_reads_len_in_the_header() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let args = os.Args
+  for i in 1..args.length() {
+    fmt.Println(args[i])
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn range_bound_over_a_mutated_slice_keeps_the_bound_temp() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let mut items = [1, 2, 3]
+  for i in 0..items.length() {
+    items = items.append(i)
+    fmt.Println(items.length())
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_map_fills_the_let_name_as_the_result() {
+    let input = r#"
+import "go:fmt"
+
+struct Task { id: int, done: bool }
+
+fn main() {
+  let tasks = [Task { id: 1, done: false }, Task { id: 2, done: true }]
+  let ids = tasks.map(|t| t.id)
+  let open = tasks.filter(|t| !t.done)
+  let total = tasks.fold(0, |sum, t| sum + t.id)
+  fmt.Println(ids, open.length(), total)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_map_with_a_returning_lambda_keeps_the_helper_call() {
+    let input = r#"
+import "go:fmt"
+
+fn main() {
+  let nums = [1, 2, 3]
+  let doubled = nums.map(|n| { return n * 2 })
+  fmt.Println(doubled)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn nested_propagate_in_call_args_binds_the_inner_pair_first() {
     let input = r#"
 import "go:strconv"
@@ -3450,6 +3514,19 @@ fn two() -> Result<int, error> {
 }
 
 #[test]
+fn let_map_over_a_function_of_its_own_name_keeps_a_temp() {
+    let input = r#"
+fn items() -> Slice<int> { [1, 2, 3] }
+
+fn three() -> int {
+  let items = items().filter(|x| x > 1)
+  items.length()
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn propagate_message_that_calls_a_function_of_the_let_name_keeps_a_temp() {
     let input = r#"
 import "go:strconv"
@@ -3546,6 +3623,62 @@ fn let_match() {
     Err(_) => { return },
   }
   fmt.Println(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generated_names_avoid_renamed_package_functions() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn get_items() -> Slice<int> { [1, 2, 3] }
+
+fn len() -> string { "context" }
+
+fn direct_let() -> int {
+  let getItems = 5
+  getItems + get_items().length()
+}
+
+fn filtered_let() -> int {
+  let getItems = get_items().filter(|x| x > 1)
+  getItems.length() + get_items().length()
+}
+
+fn parameter(getItems: int) -> int {
+  let (first, rest) = (getItems, 2)
+  first + rest + get_items().length()
+}
+
+fn arm_in_other_arm() {
+  match strconv.Atoi("bad") {
+    Ok(len) => fmt.Println(len),
+    Err(_) => fmt.Println(len()),
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn range_bound_over_a_channel_length_keeps_the_bound_temp() {
+    let input = r#"
+import "go:fmt"
+
+fn six() {
+  let ch = Channel.buffered<int>(3)
+  ch.send(1)
+  ch.send(2)
+  ch.send(3)
+  let mut iterations = 0
+  for _i in 1..ch.length() {
+    let _ = ch.receive()
+    iterations += 1
+  }
+  fmt.Println("iterations", iterations)
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_excluded_methods.snap
+++ b/tests/spec/emit/snapshots/array_to_slice_chain_keeps_copy_for_excluded_methods.snap
@@ -17,11 +17,10 @@ import "slices"
 
 func f(arr [3]int) ([]int, int, int, []int, []int) {
 	src_1 := slices.Clone(arr[:])
-	result_2 := make([]int, len(src_1))
-	for i_3, x := range src_1 {
-		result_2[i_3] = x * 2
+	doubled := make([]int, len(src_1))
+	for i_2, x := range src_1 {
+		doubled[i_2] = x * 2
 	}
-	doubled := result_2
 	stomped := copy(slices.Clone(arr[:]), []int{7, 8})
 	room := cap(slices.Clone(arr[:]))
 	grown := slices.Grow(slices.Clone(arr[:]), 10)

--- a/tests/spec/emit/snapshots/generated_names_avoid_renamed_package_functions.snap
+++ b/tests/spec/emit/snapshots/generated_names_avoid_renamed_package_functions.snap
@@ -1,0 +1,80 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn get_items() -> Slice<int> { [1, 2, 3] }
+  
+  fn len() -> string { "context" }
+  
+  fn direct_let() -> int {
+    let getItems = 5
+    getItems + get_items().length()
+  }
+  
+  fn filtered_let() -> int {
+    let getItems = get_items().filter(|x| x > 1)
+    getItems.length() + get_items().length()
+  }
+  
+  fn parameter(getItems: int) -> int {
+    let (first, rest) = (getItems, 2)
+    first + rest + get_items().length()
+  }
+  
+  fn arm_in_other_arm() {
+    match strconv.Atoi("bad") {
+      Ok(len) => fmt.Println(len),
+      Err(_) => fmt.Println(len()),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+	"strconv"
+)
+
+func getItems() []int {
+	return []int{1, 2, 3}
+}
+
+func len_() string {
+	return "context"
+}
+
+func directLet() int {
+	getItems_1 := 5
+	return getItems_1 + len(getItems())
+}
+
+func filteredLet() int {
+	var result_1 []int
+	for _, x := range getItems() {
+		if x > 1 {
+			result_1 = append(result_1, x)
+		}
+	}
+	getItems_2 := result_1
+	return len(getItems_2) + len(getItems())
+}
+
+func parameter(getItems_1 int) int {
+	tmp_2 := lisette.MakeTuple2[int, int](getItems_1, 2)
+	first := tmp_2.First
+	rest := tmp_2.Second
+	left_3 := first + rest
+	return left_3 + len(getItems())
+}
+
+func armInOtherArm() {
+	if len__1, err := strconv.Atoi("bad"); err == nil {
+		fmt.Println(len__1)
+	} else {
+		fmt.Println(len_())
+	}
+}

--- a/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
+++ b/tests/spec/emit/snapshots/interop_collapsed_type_param_reconstructs_when_uninferrable.snap
@@ -31,6 +31,5 @@ func main() {
 	empty := slices.Concat[[]byte, byte]()
 	value := slices.Clone[[]byte, byte]
 	out := apply(slices.Clone[[]byte, byte], empty)
-	arg_1 := len(empty)
-	fmt.Println(arg_1, len(value(empty)), len(out))
+	fmt.Println(len(empty), len(value(empty)), len(out))
 }

--- a/tests/spec/emit/snapshots/let_map_fills_the_let_name_as_the_result.snap
+++ b/tests/spec/emit/snapshots/let_map_fills_the_let_name_as_the_result.snap
@@ -1,0 +1,49 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  struct Task { id: int, done: bool }
+  
+  fn main() {
+    let tasks = [Task { id: 1, done: false }, Task { id: 2, done: true }]
+    let ids = tasks.map(|t| t.id)
+    let open = tasks.filter(|t| !t.done)
+    let total = tasks.fold(0, |sum, t| sum + t.id)
+    fmt.Println(ids, open.length(), total)
+  }
+---
+package main
+
+import "fmt"
+
+type Task struct {
+	id   int
+	done bool
+}
+
+func main() {
+	tasks := []Task{{
+		id:   1,
+		done: false,
+	}, {
+		id:   2,
+		done: true,
+	}}
+	ids := make([]int, len(tasks))
+	for i_1, t := range tasks {
+		ids[i_1] = t.id
+	}
+	var open []Task
+	for _, t := range tasks {
+		if !t.done {
+			open = append(open, t)
+		}
+	}
+	total := 0
+	for _, t := range tasks {
+		total = total + t.id
+	}
+	fmt.Println(ids, len(open), total)
+}

--- a/tests/spec/emit/snapshots/let_map_over_a_function_of_its_own_name_keeps_a_temp.snap
+++ b/tests/spec/emit/snapshots/let_map_over_a_function_of_its_own_name_keeps_a_temp.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn items() -> Slice<int> { [1, 2, 3] }
+  
+  fn three() -> int {
+    let items = items().filter(|x| x > 1)
+    items.length()
+  }
+---
+package main
+
+func items() []int {
+	return []int{1, 2, 3}
+}
+
+func three() int {
+	var result_1 []int
+	for _, x := range items() {
+		if x > 1 {
+			result_1 = append(result_1, x)
+		}
+	}
+	items_2 := result_1
+	return len(items_2)
+}

--- a/tests/spec/emit/snapshots/let_map_with_a_returning_lambda_keeps_the_helper_call.snap
+++ b/tests/spec/emit/snapshots/let_map_with_a_returning_lambda_keeps_the_helper_call.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let nums = [1, 2, 3]
+    let doubled = nums.map(|n| { return n * 2 })
+    fmt.Println(doubled)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func main() {
+	nums := []int{1, 2, 3}
+	doubled := lisette.SliceMap(nums, func(n int) int {
+		return n * 2
+	})
+	fmt.Println(doubled)
+}

--- a/tests/spec/emit/snapshots/range_bound_over_a_channel_length_keeps_the_bound_temp.snap
+++ b/tests/spec/emit/snapshots/range_bound_over_a_channel_length_keeps_the_bound_temp.snap
@@ -1,0 +1,39 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn six() {
+    let ch = Channel.buffered<int>(3)
+    ch.send(1)
+    ch.send(2)
+    ch.send(3)
+    let mut iterations = 0
+    for _i in 1..ch.length() {
+      let _ = ch.receive()
+      iterations += 1
+    }
+    fmt.Println("iterations", iterations)
+  }
+---
+package main
+
+import (
+	"fmt"
+	lisette "github.com/ivov/lisette/prelude"
+)
+
+func six() {
+	ch := make(chan int, 3)
+	_ = lisette.ChannelSend(ch, 1)
+	_ = lisette.ChannelSend(ch, 2)
+	_ = lisette.ChannelSend(ch, 3)
+	iterations := 0
+	bound_1 := len(ch)
+	for i_2 := 1; i_2 < bound_1; i_2++ {
+		_ = lisette.ChannelReceive(ch)
+		iterations++
+	}
+	fmt.Println("iterations", iterations)
+}

--- a/tests/spec/emit/snapshots/range_bound_over_a_mutated_slice_keeps_the_bound_temp.snap
+++ b/tests/spec/emit/snapshots/range_bound_over_a_mutated_slice_keeps_the_bound_temp.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn main() {
+    let mut items = [1, 2, 3]
+    for i in 0..items.length() {
+      items = items.append(i)
+      fmt.Println(items.length())
+    }
+  }
+---
+package main
+
+import "fmt"
+
+func main() {
+	items := []int{1, 2, 3}
+	bound_1 := len(items)
+	for i := range bound_1 {
+		items = append(items, i)
+		fmt.Println(len(items))
+	}
+}

--- a/tests/spec/emit/snapshots/range_bound_over_an_unmutated_slice_reads_len_in_the_header.snap
+++ b/tests/spec/emit/snapshots/range_bound_over_an_unmutated_slice_reads_len_in_the_header.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let args = os.Args
+    for i in 1..args.length() {
+      fmt.Println(args[i])
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args
+	for i := 1; i < len(args); i++ {
+		fmt.Println(args[i])
+	}
+}

--- a/tests/spec/emit/snapshots/slice_map_capturing_lambda_becomes_a_loop.snap
+++ b/tests/spec/emit/snapshots/slice_map_capturing_lambda_becomes_a_loop.snap
@@ -15,11 +15,10 @@ package main
 
 func test(s []int, factor int) []int {
 	seen := 0
-	result_1 := make([]int, len(s))
-	for i_2, x := range s {
+	doubled := make([]int, len(s))
+	for i_1, x := range s {
 		seen++
-		result_1[i_2] = x * factor
+		doubled[i_1] = x * factor
 	}
-	doubled := result_1
 	return append(doubled[:len(doubled):len(doubled)], seen)
 }


### PR DESCRIPTION
A counted loop bounded by the length of a slice that the loop does not mutate now reads `len(xs)` in the `for` header, instead of taking a `bound_N` copy before the loop. Also, a `let` bound from `map` on a slice now fills in the var directly, without using a `result_N` copy.

```rs
import "go:fmt"
import "go:os"

fn main() {
  let args = os.Args
  for i in 1..args.length() {
    fmt.Println(args[i])
  }
}
```

Before:

```go
func main() {
	args := os.Args
	bound_1 := len(args)
	for i := 1; i < bound_1; i++ {
		fmt.Println(args[i])
	}
}
```

After:

```go
func main() {
	args := os.Args
	for i := 1; i < len(args); i++ { // the length is read in the header, no copy
		fmt.Println(args[i])
	}
}
```
