### PR TITLE
feat: idiomatic Go for call operands with stable values

### DIFF
--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -8,7 +8,7 @@ use super::NativeCallContext;
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::abi::is_prelude_container_type;
-use crate::calls::native::native_method_lowers_to_plain_call;
+use crate::calls::native::{native_method_is_pure, native_method_lowers_to_plain_call};
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
@@ -548,8 +548,10 @@ impl<'a> Planner<'a> {
         let result = self.lower_native_method(ctx);
         let effect = if matches!(origin, CallableOrigin::NativeConstructor(_)) {
             self.native_constructor_effect(ctx, result.argument_effect)
-        } else if matches!(origin, CallableOrigin::NativeMethod(_))
-            && matches!(ctx.method, "length" | "capacity")
+        } else if matches!(
+            origin,
+            CallableOrigin::NativeMethod(_) | CallableOrigin::NativeMethodIdentifier(_)
+        ) && native_method_is_pure(ctx.native_type, ctx.method)
         {
             EvaluationEffect::PureCall.combine(result.argument_effect)
         } else {

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -9,7 +9,6 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
-use crate::utils::reads_mutable_operand;
 use std::iter;
 use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
 use syntax::program::{CallKind, DotAccessKind, NativeTypeKind};
@@ -260,6 +259,44 @@ pub(crate) fn clip_shared_capacity(receiver: &str) -> String {
 
 fn grows_into_capacity(method: &str, appends_anything: bool) -> bool {
     method == "reserve" || (method == "append" && appends_anything)
+}
+
+/// Natives that write no memory a sibling operand can read and run no caller code.
+pub(super) fn native_method_is_pure(native_type: &NativeGoType, method: &str) -> bool {
+    match native_type {
+        NativeGoType::String => matches!(
+            method,
+            "length"
+                | "is_empty"
+                | "contains"
+                | "split"
+                | "starts_with"
+                | "ends_with"
+                | "byte_at"
+                | "rune_at"
+                | "bytes"
+                | "runes"
+                | "substring"
+        ),
+        NativeGoType::Array => matches!(method, "length" | "get" | "to_slice"),
+        NativeGoType::Slice => matches!(
+            method,
+            "length"
+                | "is_empty"
+                | "capacity"
+                | "get"
+                | "append"
+                | "contains"
+                | "enumerate"
+                | "clone"
+                | "join"
+        ),
+        NativeGoType::Map => matches!(method, "length" | "is_empty" | "get" | "clone"),
+        NativeGoType::Channel | NativeGoType::Sender | NativeGoType::Receiver => {
+            matches!(method, "length" | "is_empty" | "capacity")
+        }
+        NativeGoType::EnumeratedSlice => method == "clone",
+    }
 }
 
 pub(crate) fn is_clip_safe_path(value: &str) -> bool {
@@ -788,25 +825,6 @@ impl Planner<'_> {
         Some(inlined)
     }
 
-    /// Pin the receiver stage to a temp when it reads a mutable operand,
-    /// carries no setup of its own, and a later argument (or the spread)
-    /// contains a call, so the receiver is captured before those args can
-    /// mutate it. A receiver that is itself a call already evaluates eagerly.
-    fn pin_receiver_if_mutated(
-        &mut self,
-        stage: &mut ValuePlan,
-        receiver: &Expression,
-        rest_has_call: bool,
-    ) {
-        if !matches!(receiver.unwrap_parens(), Expression::Call { .. })
-            && reads_mutable_operand(receiver)
-            && stage.setup.is_empty()
-            && rest_has_call
-        {
-            self.pin_staged(stage, "recv");
-        }
-    }
-
     /// Stage `to_slice()` as `arr[:]` when the consumer cannot observe the skipped clone.
     fn try_stage_to_slice_view(
         &mut self,
@@ -817,10 +835,7 @@ impl Planner<'_> {
         if !matches!(ctx.native_type, NativeGoType::Slice) {
             return None;
         }
-        if !matches!(
-            ctx.capture_boundary,
-            CaptureBoundary::SiblingSequence | CaptureBoundary::AssignmentRightHandSide
-        ) {
+        if !matches!(ctx.capture_boundary, CaptureBoundary::SiblingSequence) {
             return None;
         }
         if ctx.spread.is_some()
@@ -901,11 +916,6 @@ impl Planner<'_> {
         let spread_stage = ctx
             .spread
             .map(|spread| self.plan_operand(spread, ExpressionContext::value()));
-        let rest_has_call = stages[1..]
-            .iter()
-            .chain(spread_stage.iter())
-            .any(|stage| stage.evaluation.effect.has_call());
-        self.pin_receiver_if_mutated(&mut stages[0], receiver, rest_has_call);
         if matches!(form, NativeMethodForm::Dot) && receiver.get_type().is_ref() {
             let receiver = stages.remove(0).unary("*");
             stages.insert(0, receiver);

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -13,6 +13,7 @@ use crate::abi::coercion::CoercionPlan;
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::abi::transition::{emit_fn_arg_shape_adapter, emit_lisette_callback_wrapper};
 use crate::context::expression::ExpressionContext;
+use crate::expressions::staging::LaterStages;
 use crate::expressions::staging::{SpreadSequenceOptions, VariadicCombine};
 use crate::names::generics::extract_type_mapping;
 use crate::plan::bodies::LoweredStatement;
@@ -20,7 +21,6 @@ use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee}
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
-use crate::utils::{reads_mutable_operand, reads_unsequenced_mutable_operand};
 use crate::write_line;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::types::Type;
@@ -339,12 +339,10 @@ impl<'a> Planner<'a> {
             .and_then(|builtin| builtin_constant(builtin, &sequenced_args.values));
         let (args_setup, args_strings) = sequenced_args.into_rendered();
 
-        let delayed_after_arg_setup = !args_setup.is_empty() && reads_mutable_operand(function);
-        let racing_inline_arg_calls =
-            args_effect.has_effectful_call() && reads_unsequenced_mutable_operand(function);
         let callee_needs_pin = setup.is_empty()
             && type_args_string.is_empty()
-            && (delayed_after_arg_setup || racing_inline_arg_calls);
+            && LaterStages::sequenced(&args_setup, args_effect)
+                .can_change(self.place_read_stability(function));
         if callee_needs_pin {
             function_string =
                 self.hoist_tmp_value_statement(&mut setup, "callee", &function_string);

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -11,8 +11,9 @@ use crate::abi::layout::SlotOrigin;
 use crate::context::expression::ExpressionContext;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
+use crate::plan::values::{EvaluationEffect, GoExpression, Stability, ValuePlan};
 use crate::types::go_type::render_conversion;
+use crate::utils::reads_value_member;
 
 struct NullableFieldAccess<'a> {
     expression_string: &'a str,
@@ -60,6 +61,16 @@ impl Planner<'_> {
             self.plan_coerced_expression(expression, receiver_coercion, ctx)
         };
         let effect = base_plan.evaluation.effect;
+        let stability = if reads_value_member(
+            dot_access_kind,
+            receiver_coercion,
+            expression,
+            &expression_ty,
+        ) {
+            base_plan.evaluation.stability
+        } else {
+            Stability::Observable
+        };
         let base_contains_deferred_evaluation = base_plan.expression.contains_deferred_evaluation();
         let (mut setup, expression_string) = base_plan.into_parts();
 
@@ -80,7 +91,8 @@ impl Planner<'_> {
                     base_contains_deferred_evaluation || is_newtype_conversion,
                 ),
                 effect,
-            );
+            )
+            .with_stability(stability);
         }
 
         let is_exported =
@@ -124,7 +136,7 @@ impl Planner<'_> {
         } else {
             GoExpression::opaque_with_deferred_evaluation(result, base_contains_deferred_evaluation)
         };
-        ValuePlan::computed(setup, expression, effect)
+        ValuePlan::computed(setup, expression, effect).with_stability(stability)
     }
 
     /// Dispatch kinds that can resolve without the receiver emitted first.

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -8,9 +8,11 @@ use crate::plan::calls::CallableOrigin;
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, Stability, ValuePlan,
 };
+use crate::utils::reads_value_member;
 use std::iter;
 use std::mem;
-use syntax::ast::{Expression, IdentifierResolution};
+use syntax::ast::{Expression, IdentifierResolution, UnaryOperator};
+use syntax::program::DotAccessKind;
 use syntax::types::{FunctionParameter, Type};
 
 /// Folds `f(leading, spread...)` into `f(append([]T{leading}, spread...)...)`: Go rejects the former.
@@ -28,20 +30,30 @@ pub(crate) struct SpreadSequenceOptions {
 }
 
 #[derive(Default)]
-struct LaterStages {
+pub(crate) struct LaterStages {
     has_setup: bool,
     has_effectful_call: bool,
     has_pin: bool,
 }
 
 impl LaterStages {
+    pub(crate) fn sequenced(setup: &[LoweredStatement], effect: EvaluationEffect) -> Self {
+        Self {
+            has_setup: !setup.is_empty(),
+            has_effectful_call: effect.has_effectful_call(),
+            has_pin: false,
+        }
+    }
+
+    /// Setup can rebind any name, a call only a name mutated through an alias.
+    pub(crate) fn can_change(&self, stability: Stability) -> bool {
+        stability.is_observable()
+            && (self.has_setup || (self.has_effectful_call && !stability.is_stable_across_calls()))
+    }
+
     fn prepend(&mut self, stage: &ValuePlan) -> bool {
         let stage_has_setup = !stage.setup.is_empty();
-        let later_can_change_value = self.has_setup
-            || (self.has_effectful_call && !stage.evaluation.stability.is_stable_across_calls());
-        let value_pin = !stage_has_setup
-            && stage.evaluation.stability.is_observable()
-            && later_can_change_value;
+        let value_pin = !stage_has_setup && self.can_change(stage.evaluation.stability);
         let ordering_pin = stage.evaluation.effect.has_call()
             && stage.expression.contains_deferred_evaluation()
             && (self.has_setup || self.has_pin);
@@ -187,6 +199,39 @@ impl Planner<'_> {
             } => !self.facts.is_alias_mutated(*id),
             Expression::Identifier { .. } => true,
             _ => false,
+        }
+    }
+
+    pub(crate) fn place_read_stability(&self, place: &Expression) -> Stability {
+        match place.unwrap_parens() {
+            Expression::Identifier { .. } => self.identifier_read_stability(place),
+            Expression::Call { .. } => Stability::StableAcrossCalls,
+            Expression::DotAccess {
+                expression,
+                resolution,
+                ..
+            } => match resolution.kind() {
+                Some(
+                    DotAccessKind::StructField { .. }
+                    | DotAccessKind::TupleStructField { .. }
+                    | DotAccessKind::TupleElement,
+                ) if !reads_value_member(
+                    resolution.kind(),
+                    resolution.receiver_coercion(),
+                    expression,
+                    &expression.get_type(),
+                ) =>
+                {
+                    Stability::Observable
+                }
+                _ => self.place_read_stability(expression),
+            },
+            Expression::IndexedAccess { .. } => Stability::Observable,
+            Expression::Unary {
+                operator: UnaryOperator::Deref,
+                ..
+            } => Stability::Observable,
+            _ => Stability::StableAcrossCalls,
         }
     }
 

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -324,7 +324,6 @@ pub(crate) enum CaptureBoundary {
     DeferSite,
     TaskSite,
     LoopLifetime,
-    AssignmentRightHandSide,
 }
 
 impl CaptureBoundary {
@@ -608,6 +607,11 @@ impl ValuePlan {
         } else {
             Stability::Observable
         };
+        self
+    }
+
+    pub(crate) fn with_stability(mut self, stability: Stability) -> Self {
+        self.evaluation.stability = stability;
         self
     }
 

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -2,10 +2,11 @@ use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::abi::layout::{SlotOrigin, ValueLayout};
 use crate::context::expression::ExpressionContext;
+use crate::expressions::staging::LaterStages;
 use crate::is_order_sensitive;
 use crate::names::go_name;
 use crate::plan::bodies::{AssignForm, CompoundKind, LoweredBlock, LoweredStatement};
-use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
+use crate::plan::values::{GoExpression, ValuePlan};
 use crate::state::bindings::BindingValue;
 use syntax::ast::Literal;
 use syntax::ast::{BinaryOperator, Expression, IdentifierResolution, UnaryOperator};
@@ -117,14 +118,10 @@ impl Planner<'_> {
         }
 
         let right_hand_side = self.plan_operand(rhs, ExpressionContext::value());
-        let right_hand_side_has_setup = !right_hand_side.setup.is_empty();
-        let right_hand_side_has_effectful_call =
-            right_hand_side.evaluation.effect.has_effectful_call();
         let (mut target_capture, target_str) =
             self.capture_assignment_target(target, Some(&right_hand_side));
-        let needs_left_pin = right_hand_side_has_setup
-            || (right_hand_side_has_effectful_call
-                && !self.identifier_immune_to_calls(target.unwrap_parens()));
+        let needs_left_pin =
+            later_stages(Some(&right_hand_side)).can_change(self.place_read_stability(target));
         let pinned_left = needs_left_pin.then(|| {
             let tmp = self.fresh_var(Some("left"));
             self.declare(&tmp);
@@ -229,7 +226,7 @@ impl Planner<'_> {
                 operator: UnaryOperator::Deref,
                 expression,
                 ..
-            } => self.emit_deref_lvalue(setup, expression, false),
+            } => self.emit_deref_lvalue(setup, expression, None),
             Expression::Call { .. } if expression.get_type().is_ref() => {
                 let call_str = self.capture_operand_into(setup, expression);
                 self.hoist_tmp_value_statement(setup, "ref", &call_str)
@@ -245,14 +242,13 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         pointee: &Expression,
-        rhs_has_setup: bool,
+        right_hand_side: Option<&ValuePlan>,
     ) -> String {
         let pointee_plan = self.plan_operand(pointee, ExpressionContext::value());
-        let pointee_is_observable = pointee_plan.evaluation.stability.is_observable();
+        let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
+            || later_stages(right_hand_side).can_change(pointee_plan.evaluation.stability);
         let (pointee_setup, pointee_string) = pointee_plan.into_parts();
         setup.extend(pointee_setup);
-        let needs_capture = matches!(pointee.unwrap_parens(), Expression::Call { .. })
-            || (rhs_has_setup && pointee_is_observable);
         if needs_capture {
             let tmp = self.hoist_tmp_value_statement(setup, "ref", &pointee_string);
             return format!("*{}", tmp);
@@ -308,12 +304,8 @@ impl Planner<'_> {
             } => {
                 if assignment_requires_target_capture(right_hand_side) {
                     let base_str = self.emit_indexed_base_lvalue(setup, base, right_hand_side);
-                    let index_str = self.capture_value_at_boundary(
-                        setup,
-                        index,
-                        "idx",
-                        CaptureBoundary::AssignmentRightHandSide,
-                    );
+                    let index_str =
+                        self.capture_assignment_operand(setup, index, "idx", right_hand_side);
                     format!("{}[{}]", base_str, index_str)
                 } else {
                     self.emit_indexed_lvalue_inline(setup, base, index)
@@ -326,27 +318,11 @@ impl Planner<'_> {
                 ..
             } => {
                 let base_str = if let Some(inner) = base.deref_inner() {
-                    if assignment_requires_target_capture(right_hand_side) {
-                        self.capture_value_at_boundary(
-                            setup,
-                            inner,
-                            "ref",
-                            CaptureBoundary::AssignmentRightHandSide,
-                        )
-                    } else {
-                        self.capture_operand_into(setup, inner)
-                    }
+                    self.capture_assignment_operand(setup, inner, "ref", right_hand_side)
                 } else if is_order_sensitive(base) {
                     self.emit_left_value_capturing(setup, base, right_hand_side)
-                } else if assignment_requires_target_capture(right_hand_side)
-                    && base.get_type().is_ref()
-                {
-                    self.capture_value_at_boundary(
-                        setup,
-                        base,
-                        "ref",
-                        CaptureBoundary::AssignmentRightHandSide,
-                    )
+                } else if base.get_type().is_ref() {
+                    self.capture_assignment_operand(setup, base, "ref", right_hand_side)
                 } else {
                     self.emit_left_value(setup, base)
                 };
@@ -357,11 +333,7 @@ impl Planner<'_> {
                 operator: UnaryOperator::Deref,
                 expression: inner,
                 ..
-            } => self.emit_deref_lvalue(
-                setup,
-                inner,
-                assignment_requires_target_capture(right_hand_side),
-            ),
+            } => self.emit_deref_lvalue(setup, inner, right_hand_side),
             _ => self.emit_left_value(setup, expression),
         }
     }
@@ -387,39 +359,36 @@ impl Planner<'_> {
         right_hand_side: Option<&ValuePlan>,
     ) -> String {
         if let Some(inner) = base.deref_inner() {
-            let inner_str = self.emit_base_operand(setup, inner, true);
+            let inner_str = self.capture_assignment_operand(setup, inner, "base", right_hand_side);
             format!("(*{})", inner_str)
         } else {
-            let base_plan = self.lower_composite_value(base, ExpressionContext::value());
-            let force = base_plan.evaluation.stability.is_observable()
-                && (assignment_has_setup(right_hand_side)
-                    || !self.identifier_immune_to_calls(base.unwrap_parens()));
-            let (base_setup, base_value) = base_plan.into_parts();
-            setup.extend(base_setup);
-            if force {
-                return self.hoist_tmp_value_statement(setup, "base", &base_value);
-            }
-            base_value
+            self.capture_assignment_operand(setup, base, "base", right_hand_side)
         }
     }
 
-    fn emit_base_operand(
+    fn capture_assignment_operand(
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         expression: &Expression,
-        force_capture: bool,
+        prefix: &str,
+        right_hand_side: Option<&ValuePlan>,
     ) -> String {
-        if force_capture {
-            self.capture_value_at_boundary(
-                setup,
-                expression,
-                "base",
-                CaptureBoundary::AssignmentRightHandSide,
-            )
+        let plan = self.lower_composite_value(expression, ExpressionContext::value());
+        let pin = later_stages(right_hand_side).can_change(plan.evaluation.stability);
+        let (value_setup, value) = plan.into_parts();
+        setup.extend(value_setup);
+        if pin {
+            self.hoist_tmp_value_statement(setup, prefix, &value)
         } else {
-            self.capture_operand_into(setup, expression)
+            value
         }
     }
+}
+
+fn later_stages(right_hand_side: Option<&ValuePlan>) -> LaterStages {
+    right_hand_side.map_or_else(LaterStages::default, |value| {
+        LaterStages::sequenced(&value.setup, value.evaluation.effect)
+    })
 }
 
 fn assignment_has_setup(right_hand_side: Option<&ValuePlan>) -> bool {

--- a/crates/emit/src/utils.rs
+++ b/crates/emit/src/utils.rs
@@ -1,5 +1,6 @@
-use syntax::ast::{Expression, Literal, UnaryOperator};
-use syntax::program::DotAccessKind;
+use syntax::ast::{Expression, Literal};
+use syntax::program::{DotAccessKind, ReceiverCoercion};
+use syntax::types::Type;
 
 macro_rules! write_line {
     ($dst:expr, $($arg:tt)*) => {
@@ -115,49 +116,20 @@ pub(crate) fn is_order_sensitive(expression: &Expression) -> bool {
         || matches!(expression.unwrap_parens(), Expression::Identifier { .. }))
 }
 
-pub(crate) fn reads_mutable_operand(expression: &Expression) -> bool {
-    match expression.unwrap_parens() {
-        Expression::IndexedAccess { .. } | Expression::Call { .. } => true,
-        Expression::Unary {
-            operator: UnaryOperator::Deref,
-            ..
-        } => true,
-        Expression::DotAccess {
-            expression,
-            resolution,
-            ..
-        } => match resolution.kind() {
-            Some(
-                DotAccessKind::StructField { .. }
+pub(crate) fn reads_value_member(
+    kind: Option<DotAccessKind>,
+    coercion: Option<ReceiverCoercion>,
+    base: &Expression,
+    base_ty: &Type,
+) -> bool {
+    matches!(
+        kind,
+        Some(
+            DotAccessKind::StructField { .. }
                 | DotAccessKind::TupleStructField { .. }
                 | DotAccessKind::TupleElement,
-            ) => true,
-            _ => reads_mutable_operand(expression),
-        },
-        _ => false,
-    }
-}
-
-pub(crate) fn reads_unsequenced_mutable_operand(expression: &Expression) -> bool {
-    match expression.unwrap_parens() {
-        Expression::Call { .. } => false,
-        Expression::IndexedAccess { .. } => true,
-        Expression::Unary {
-            operator: UnaryOperator::Deref,
-            ..
-        } => true,
-        Expression::DotAccess {
-            expression,
-            resolution,
-            ..
-        } => match resolution.kind() {
-            Some(
-                DotAccessKind::StructField { .. }
-                | DotAccessKind::TupleStructField { .. }
-                | DotAccessKind::TupleElement,
-            ) => true,
-            _ => reads_unsequenced_mutable_operand(expression),
-        },
-        _ => false,
-    }
+        )
+    ) && coercion.is_none()
+        && base.deref_inner().is_none()
+        && !base_ty.is_ref()
 }

--- a/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
+++ b/tests/spec/build/snapshots/multiple_bounded_impl_blocks_use_declared_constraints.snap
@@ -23,8 +23,7 @@ type Container[T interface {
 }
 
 func (c Container[T]) display() string {
-	fmtarg_1 := c.label
-	return "[" + fmtarg_1 + "] " + c.value.PrintVal()
+	return "[" + c.label + "] " + c.value.PrintVal()
 }
 
 func (c Container[T]) total() int {

--- a/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
+++ b/tests/spec/build/snapshots/nested_generics_with_bounded_impls.snap
@@ -78,8 +78,7 @@ type Tagged[T traits.Showable] struct {
 }
 
 func (t Tagged[T]) Show() string {
-	fmtarg_1 := t.Label
-	return "[" + fmtarg_1 + "] " + t.Value.Show()
+	return "[" + t.Label + "] " + t.Value.Show()
 }
 
 func (t Tagged[T]) Display() string {

--- a/tests/spec/emit/expressions.rs
+++ b/tests/spec/emit/expressions.rs
@@ -5039,6 +5039,132 @@ fn run() -> int {
 }
 
 #[test]
+fn pointer_receiver_field_assignment_reads_receiver_in_place() {
+    let input = r#"
+struct Clock { now: int, step: int }
+
+fn advance(now: int, step: int) -> int { now + step }
+
+impl Clock {
+  fn tick(self: mut Ref<Clock>) {
+    self.now = advance(self.now, self.step)
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn pointer_field_assignment_pins_pointer_a_closure_retargets() {
+    let input = r#"
+struct Clock { now: int, step: int }
+
+fn run() -> int {
+  let mut a = Clock { now: 0, step: 1 }
+  let mut b = Clock { now: 10, step: 1 }
+  let mut c = &a
+  let swap = || -> int { c = &b; 5 }
+  c.now = swap()
+  a.now
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_literal_field_read_not_pinned_before_append() {
+    let input = r#"
+struct Suite { name: string, cases: Slice<string> }
+
+impl Suite {
+  fn with_case(self: Suite, name: string) -> Suite {
+    Suite { name: self.name, cases: self.cases.append(name) }
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_literal_field_read_pinned_before_mut_ref_to_its_root() {
+    let input = r#"
+struct Suite { name: string }
+struct Pair { a: string, b: string }
+
+fn rename(s: mut Ref<Suite>) -> string { s.name = "z"; "b" }
+
+fn run() -> string {
+  let mut s = Suite { name: "a" }
+  let p = Pair { a: s.name, b: rename(&s) }
+  p.a + p.b
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn struct_literal_field_read_through_pointer_pinned_before_call() {
+    let input = r#"
+struct Suite { name: string }
+struct Pair { a: string, b: string }
+
+fn rename(s: mut Ref<Suite>) -> string { s.name = "z"; "b" }
+
+fn pair(s: Ref<Suite>, other: mut Ref<Suite>) -> Pair {
+  Pair { a: s.name, b: rename(other) }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn value_field_callee_not_pinned_before_effectful_arg() {
+    let input = r#"
+struct Handler { f: fn(int) -> int }
+
+fn run(h: Handler) -> int {
+  let mut i = 0
+  let bump = || -> int { i = 1; 7 }
+  h.f(bump())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn value_field_callee_pinned_when_a_closure_reassigns_its_root() {
+    let input = r#"
+struct Handler { f: fn(int) -> int }
+
+fn f0(x: int) -> int { x + 10 }
+fn f1(x: int) -> int { x + 20 }
+
+fn run() -> int {
+  let mut h = Handler { f: f0 }
+  let swap = || -> int { h = Handler { f: f1 }; 7 }
+  h.f(swap())
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn value_struct_compound_field_assignment_reads_field_in_place() {
+    let input = r#"
+struct Counter { total: int }
+
+fn price() -> int { 3 }
+
+fn run() -> int {
+  let mut c = Counter { total: 1 }
+  c.total = c.total + price()
+  c.total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn pure_constructor_does_not_force_sibling_pins() {
     let input = r#"
 struct Wrap(int)

--- a/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
+++ b/tests/spec/emit/snapshots/field_receiver_append_arg_mutates_field.snap
@@ -23,7 +23,7 @@ func run() int {
 		h.slc = []int{99}
 		return 7
 	}
-	recv_1 := h.slc
-	ys := append(recv_1[:len(recv_1):len(recv_1)], bump())
+	arg_1 := h.slc
+	ys := append(arg_1[:len(arg_1):len(arg_1)], bump())
 	return ys[0]
 }

--- a/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
+++ b/tests/spec/emit/snapshots/map_field_ref_slice_append.snap
@@ -27,7 +27,6 @@ func main() {
 	if !ok {
 		return
 	}
-	ref_1 := o.items
-	*ref_1 = append(*o.items, 2)
+	*o.items = append(*o.items, 2)
 	_ = items
 }

--- a/tests/spec/emit/snapshots/newtype_field_access_through_alias.snap
+++ b/tests/spec/emit/snapshots/newtype_field_access_through_alias.snap
@@ -49,7 +49,5 @@ func main() {
 	f := Flag(true)
 	t := Ticket(3)
 	o := lisette.MakeOptionSome(Flag(false))
-	arg_1 := bool(f)
-	arg_2 := int(t)
-	fmt.Println(arg_1, arg_2, read(f), deep(t), bool(o.UnwrapOr(Flag(true))))
+	fmt.Println(bool(f), int(t), read(f), deep(t), bool(o.UnwrapOr(Flag(true))))
 }

--- a/tests/spec/emit/snapshots/pointer_field_assignment_pins_pointer_a_closure_retargets.snap
+++ b/tests/spec/emit/snapshots/pointer_field_assignment_pins_pointer_a_closure_retargets.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Clock { now: int, step: int }
+  
+  fn run() -> int {
+    let mut a = Clock { now: 0, step: 1 }
+    let mut b = Clock { now: 10, step: 1 }
+    let mut c = &a
+    let swap = || -> int { c = &b; 5 }
+    c.now = swap()
+    a.now
+  }
+---
+package main
+
+type Clock struct {
+	now  int
+	step int
+}
+
+func run() int {
+	a := Clock{
+		now:  0,
+		step: 1,
+	}
+	b := Clock{
+		now:  10,
+		step: 1,
+	}
+	c := &a
+	swap := func() int {
+		c = &b
+		return 5
+	}
+	ref_1 := c
+	ref_1.now = swap()
+	return a.now
+}

--- a/tests/spec/emit/snapshots/pointer_receiver_field_assignment_reads_receiver_in_place.snap
+++ b/tests/spec/emit/snapshots/pointer_receiver_field_assignment_reads_receiver_in_place.snap
@@ -1,0 +1,28 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Clock { now: int, step: int }
+  
+  fn advance(now: int, step: int) -> int { now + step }
+  
+  impl Clock {
+    fn tick(self: mut Ref<Clock>) {
+      self.now = advance(self.now, self.step)
+    }
+  }
+---
+package main
+
+type Clock struct {
+	now  int
+	step int
+}
+
+func advance(now, step int) int {
+	return now + step
+}
+
+func (c *Clock) tick() {
+	c.now = advance(c.now, c.step)
+}

--- a/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
+++ b/tests/spec/emit/snapshots/recursive_generic_enum_payload_wrapped.snap
@@ -55,8 +55,7 @@ func total(c Cycle[int]) int {
 		return 0
 	}
 	l := *c.Next
-	left_1 := l.Value
-	return left_1 + total(l.Next)
+	return l.Value + total(l.Next)
 }
 
 func test() int {

--- a/tests/spec/emit/snapshots/ref_slice_append_statement_rewrite.snap
+++ b/tests/spec/emit/snapshots/ref_slice_append_statement_rewrite.snap
@@ -14,7 +14,6 @@ package main
 func main() {
 	s := []int{1}
 	r := &s
-	ref_1 := r
-	*ref_1 = append(*r, 2)
+	*r = append(*r, 2)
 	_ = s
 }

--- a/tests/spec/emit/snapshots/struct_literal_field_read_not_pinned_before_append.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_read_not_pinned_before_append.snap
@@ -1,0 +1,25 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Suite { name: string, cases: Slice<string> }
+  
+  impl Suite {
+    fn with_case(self: Suite, name: string) -> Suite {
+      Suite { name: self.name, cases: self.cases.append(name) }
+    }
+  }
+---
+package main
+
+type Suite struct {
+	name  string
+	cases []string
+}
+
+func (s Suite) withCase(name string) Suite {
+	return Suite{
+		name:  s.name,
+		cases: append(s.cases[:len(s.cases):len(s.cases)], name),
+	}
+}

--- a/tests/spec/emit/snapshots/struct_literal_field_read_pinned_before_mut_ref_to_its_root.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_read_pinned_before_mut_ref_to_its_root.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Suite { name: string }
+  struct Pair { a: string, b: string }
+  
+  fn rename(s: mut Ref<Suite>) -> string { s.name = "z"; "b" }
+  
+  fn run() -> string {
+    let mut s = Suite { name: "a" }
+    let p = Pair { a: s.name, b: rename(&s) }
+    p.a + p.b
+  }
+---
+package main
+
+type Suite struct {
+	name string
+}
+
+type Pair struct {
+	a string
+	b string
+}
+
+func rename(s *Suite) string {
+	s.name = "z"
+	return "b"
+}
+
+func run() string {
+	s := Suite{name: "a"}
+	field_1 := s.name
+	p := Pair{
+		a: field_1,
+		b: rename(&s),
+	}
+	return p.a + p.b
+}

--- a/tests/spec/emit/snapshots/struct_literal_field_read_through_pointer_pinned_before_call.snap
+++ b/tests/spec/emit/snapshots/struct_literal_field_read_through_pointer_pinned_before_call.snap
@@ -1,0 +1,36 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Suite { name: string }
+  struct Pair { a: string, b: string }
+  
+  fn rename(s: mut Ref<Suite>) -> string { s.name = "z"; "b" }
+  
+  fn pair(s: Ref<Suite>, other: mut Ref<Suite>) -> Pair {
+    Pair { a: s.name, b: rename(other) }
+  }
+---
+package main
+
+type Suite struct {
+	name string
+}
+
+type Pair struct {
+	a string
+	b string
+}
+
+func rename(s *Suite) string {
+	s.name = "z"
+	return "b"
+}
+
+func pair(s, other *Suite) Pair {
+	field_1 := s.name
+	return Pair{
+		a: field_1,
+		b: rename(other),
+	}
+}

--- a/tests/spec/emit/snapshots/value_field_callee_not_pinned_before_effectful_arg.snap
+++ b/tests/spec/emit/snapshots/value_field_callee_not_pinned_before_effectful_arg.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Handler { f: fn(int) -> int }
+  
+  fn run(h: Handler) -> int {
+    let mut i = 0
+    let bump = || -> int { i = 1; 7 }
+    h.f(bump())
+  }
+---
+package main
+
+type Handler struct {
+	f func(int) int
+}
+
+func run(h Handler) int {
+	bump := func() int {
+		return 7
+	}
+	return h.f(bump())
+}

--- a/tests/spec/emit/snapshots/value_field_callee_pinned_when_a_closure_reassigns_its_root.snap
+++ b/tests/spec/emit/snapshots/value_field_callee_pinned_when_a_closure_reassigns_its_root.snap
@@ -1,0 +1,38 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Handler { f: fn(int) -> int }
+  
+  fn f0(x: int) -> int { x + 10 }
+  fn f1(x: int) -> int { x + 20 }
+  
+  fn run() -> int {
+    let mut h = Handler { f: f0 }
+    let swap = || -> int { h = Handler { f: f1 }; 7 }
+    h.f(swap())
+  }
+---
+package main
+
+type Handler struct {
+	f func(int) int
+}
+
+func f0(x int) int {
+	return x + 10
+}
+
+func f1(x int) int {
+	return x + 20
+}
+
+func run() int {
+	h := Handler{f: f0}
+	swap := func() int {
+		h = Handler{f: f1}
+		return 7
+	}
+	callee_1 := h.f
+	return callee_1(swap())
+}

--- a/tests/spec/emit/snapshots/value_struct_compound_field_assignment_reads_field_in_place.snap
+++ b/tests/spec/emit/snapshots/value_struct_compound_field_assignment_reads_field_in_place.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/expressions.rs
+description: |
+  
+  struct Counter { total: int }
+  
+  fn price() -> int { 3 }
+  
+  fn run() -> int {
+    let mut c = Counter { total: 1 }
+    c.total = c.total + price()
+    c.total
+  }
+---
+package main
+
+type Counter struct {
+	total int
+}
+
+func price() int {
+	return 3
+}
+
+func run() int {
+	c := Counter{total: 1}
+	c.total += price()
+	return c.total
+}


### PR DESCRIPTION
An operand next to a call (e.g. assignment target, receiver, left side of an operator) now stays in place when the call cannot change it, instead of taking a `ref_N`, `callee_N`, or `left_N` copy before the call to pin its eval order. A copy remains when the call can change the operand.

```rs
fn main() {
  let mut s = [1]
  let mut r: mut Ref<mut Slice<int>> = &s
  r.* = r.*.append(2)
  let _ = s
}
```

Before:

```go
func main() {
	s := []int{1}
	r := &s
	ref_1 := r
	*ref_1 = append(*r, 2)
	_ = s
}
```

After:

```go
func main() {
	s := []int{1}
	r := &s
	*r = append(*r, 2) // the target is used in place, no copy
	_ = s
}
```
