### PR TITLE
feat: idiomatic Go for `get` and `find` in binding sites

### DIFF
--- a/crates/emit/src/calls/bounds.rs
+++ b/crates/emit/src/calls/bounds.rs
@@ -1,0 +1,63 @@
+use super::NativeMethodCall;
+use super::comma_ok::parenthesize_prefixed;
+use crate::Planner;
+use crate::context::expression::ExpressionContext;
+use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::CaptureBoundary;
+
+pub(crate) struct BoundsCheckedIndex {
+    pub element: String,
+    pub in_bounds: String,
+    pub out_of_bounds: String,
+}
+
+impl Planner<'_> {
+    /// `xs.get(i)` as a bounds test and a direct index, each operand evaluated once.
+    pub(crate) fn lower_bounds_checked_index(
+        &mut self,
+        call: &NativeMethodCall<'_>,
+    ) -> (Vec<LoweredStatement>, BoundsCheckedIndex) {
+        let mut receiver = self.plan_operand(call.receiver, ExpressionContext::value());
+        if receiver.evaluation.effect.has_call() {
+            self.pin_staged(&mut receiver, "recv");
+        }
+        let mut index = self.plan_operand(&call.arguments[0], ExpressionContext::value());
+        if index.evaluation.effect.has_call() {
+            self.pin_staged(&mut index, "idx");
+        }
+        let sequenced = self.sequence_values(
+            vec![receiver, index],
+            CaptureBoundary::SiblingSequence,
+            "arg",
+        );
+        let (setup, mut values) = sequenced.into_rendered();
+        let index = values.pop().expect("index operand");
+        let mut receiver = values.pop().expect("receiver operand");
+        if call.receiver.get_type().is_ref() {
+            receiver = format!("*{receiver}");
+        }
+        let length = format!("len({receiver})");
+        let element = format!("{}[{index}]", parenthesize_prefixed(receiver));
+        let (in_bounds, out_of_bounds) = if index == "0" {
+            (format!("{length} > 0"), format!("{length} == 0"))
+        } else if index.parse::<u64>().is_ok() {
+            (
+                format!("{length} > {index}"),
+                format!("{length} <= {index}"),
+            )
+        } else {
+            (
+                format!("{index} >= 0 && {index} < {length}"),
+                format!("{index} < 0 || {index} >= {length}"),
+            )
+        };
+        (
+            setup,
+            BoundsCheckedIndex {
+                element,
+                in_bounds,
+                out_of_bounds,
+            },
+        )
+    }
+}

--- a/crates/emit/src/calls/mod.rs
+++ b/crates/emit/src/calls/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bounds;
 mod clone;
 pub(crate) mod comma_ok;
 pub(crate) mod dispatch;
@@ -5,15 +6,69 @@ pub(crate) mod go_interop;
 pub(crate) mod native;
 pub(crate) mod predicates;
 mod regular;
-mod slice_loop;
+pub(crate) mod slice_loop;
 mod ufcs;
 mod unwrap_or;
 pub(crate) mod wrap_err;
 
+use crate::Planner;
+use crate::calls::dispatch::extract_native_method_name;
+use crate::plan::calls::CallableOrigin;
 use crate::plan::values::CaptureBoundary;
 use crate::types::native::NativeGoType;
 use syntax::ast::{Expression, ResolvedCallTypeArguments};
+use syntax::program::NativeTypeKind;
 use syntax::types::Type;
+
+pub(crate) struct NativeMethodCall<'a> {
+    pub kind: NativeTypeKind,
+    pub method: &'a str,
+    pub function: &'a Expression,
+    pub args: &'a [Expression],
+    pub spread: Option<&'a Expression>,
+    pub resolved_type_args: ResolvedCallTypeArguments<'a>,
+    pub receiver: &'a Expression,
+    pub arguments: &'a [Expression],
+}
+
+impl Planner<'_> {
+    pub(crate) fn native_method_call<'a>(
+        &self,
+        value: &'a Expression,
+    ) -> Option<NativeMethodCall<'a>> {
+        let Expression::Call {
+            expression: callee,
+            args,
+            spread,
+            type_arguments,
+            ..
+        } = value.unwrap_parens()
+        else {
+            return None;
+        };
+        let plan = self.plan_call(value.unwrap_parens())?;
+        let (CallableOrigin::NativeMethod(kind) | CallableOrigin::NativeMethodIdentifier(kind)) =
+            &plan.resolved.origin
+        else {
+            return None;
+        };
+        let function = callee.unwrap_parens();
+        let (receiver, arguments) = match function {
+            Expression::DotAccess { expression, .. } => (expression.as_ref(), args.as_slice()),
+            _ => args.split_first()?,
+        };
+        Some(NativeMethodCall {
+            kind: *kind,
+            method: extract_native_method_name(function),
+            function,
+            args,
+            spread: spread.as_deref(),
+            resolved_type_args: type_arguments.resolved_types()?,
+            receiver,
+            arguments,
+        })
+    }
+}
 
 pub(super) struct NativeCallContext<'a> {
     pub function: &'a Expression,

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -631,7 +631,8 @@ impl Planner<'_> {
         }
 
         if matches!(ctx.native_type, NativeGoType::Slice)
-            && let Some(result) = self.try_lower_slice_loop(ctx, receiver_expression, arguments)
+            && let Some(result) =
+                self.try_lower_slice_loop(ctx, receiver_expression, arguments, None)
         {
             return result;
         }

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -1,9 +1,8 @@
 use syntax::ast::{Binding, Expression, Pattern};
 use syntax::types::Type;
 
-use super::NativeCallContext;
-use super::dispatch::extract_native_method_name;
 use super::native::NativeCallResult;
+use super::{NativeCallContext, NativeMethodCall};
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
@@ -89,6 +88,32 @@ struct SliceLoopBody<'a> {
     result: &'a str,
     element_name: &'a str,
     index: Option<&'a str>,
+    found: Option<FoundSink<'a>>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FoundSink<'a> {
+    pub value: Option<&'a str>,
+    pub flag: &'a str,
+}
+
+fn loop_context<'a>(
+    call: &NativeMethodCall<'a>,
+    call_ty: &'a Type,
+    result_name: Option<&'a str>,
+) -> NativeCallContext<'a> {
+    NativeCallContext {
+        function: call.function,
+        args: call.args,
+        spread: call.spread,
+        resolved_type_args: call.resolved_type_args,
+        call_ty: Some(call_ty),
+        native_type: &NativeGoType::Slice,
+        method: call.method,
+        capture_boundary: CaptureBoundary::SiblingSequence,
+        retired_receiver: None,
+        result_name,
+    }
 }
 
 fn peel_single_expression_block(body: &Expression) -> &Expression {
@@ -157,46 +182,49 @@ impl Planner<'_> {
         value: &Expression,
         go_name: &str,
     ) -> Option<Vec<LoweredStatement>> {
-        let Expression::Call {
-            expression: callee,
-            args,
-            spread,
-            type_arguments,
-            ..
-        } = value.unwrap_parens()
-        else {
-            return None;
-        };
-        let plan = self.plan_call(value.unwrap_parens())?;
-        let (CallableOrigin::NativeMethod(kind) | CallableOrigin::NativeMethodIdentifier(kind)) =
-            &plan.resolved.origin
-        else {
-            return None;
-        };
-        let native_type = NativeGoType::from_kind(*kind);
-        if !matches!(native_type, NativeGoType::Slice) {
+        let call = self.native_method_call(value)?;
+        if !matches!(NativeGoType::from_kind(call.kind), NativeGoType::Slice) {
             return None;
         }
-        let function = callee.unwrap_parens();
         let ty = value.get_type();
-        let ctx = NativeCallContext {
-            function,
-            args,
-            spread: spread.as_deref(),
-            resolved_type_args: type_arguments.resolved_types()?,
-            call_ty: Some(&ty),
-            native_type: &native_type,
-            method: extract_native_method_name(function),
-            capture_boundary: CaptureBoundary::SiblingSequence,
-            retired_receiver: None,
-            result_name: Some(go_name),
-        };
-        let (receiver, arguments) = match function {
-            Expression::DotAccess { expression, .. } => (expression.as_ref(), args.as_slice()),
-            _ => args.split_first()?,
-        };
-        self.slice_loop_shape(&ctx, receiver, arguments)?;
-        Some(self.lower_native_call(&ctx, &plan.resolved.origin).setup)
+        let ctx = loop_context(&call, &ty, Some(go_name));
+        self.slice_loop_shape(&ctx, call.receiver, call.arguments)?;
+        Some(
+            self.lower_native_call(&ctx, &CallableOrigin::NativeMethod(call.kind))
+                .setup,
+        )
+    }
+
+    pub(crate) fn find_loop_fuses(
+        &self,
+        subject: &Expression,
+        call: &NativeMethodCall<'_>,
+    ) -> bool {
+        if !matches!(NativeGoType::from_kind(call.kind), NativeGoType::Slice)
+            || call.method != "find"
+        {
+            return false;
+        }
+        let ty = subject.get_type();
+        self.slice_loop_shape(
+            &loop_context(call, &ty, None),
+            call.receiver,
+            call.arguments,
+        )
+        .is_some()
+    }
+
+    pub(crate) fn lower_find_loop(
+        &mut self,
+        subject: &Expression,
+        call: &NativeMethodCall<'_>,
+        sink: FoundSink<'_>,
+    ) -> Vec<LoweredStatement> {
+        let ty = subject.get_type();
+        let ctx = loop_context(call, &ty, None);
+        self.try_lower_slice_loop(&ctx, call.receiver, call.arguments, Some(sink))
+            .expect("find_loop_fuses accepted this call")
+            .setup
     }
 
     /// Lower `xs.map(|x| ...)` and its siblings to the loop the prelude helper
@@ -206,6 +234,7 @@ impl Planner<'_> {
         ctx: &NativeCallContext,
         receiver: &Expression,
         args: &[Expression],
+        found: Option<FoundSink<'_>>,
     ) -> Option<NativeCallResult> {
         let SliceLoopShape {
             kind,
@@ -230,12 +259,37 @@ impl Planner<'_> {
         let (mut setup, values) = sequenced.into_rendered();
         let source = values[0].clone();
 
-        let result = match ctx.result_name {
-            Some(name) => name.to_string(),
-            None => self.fresh_var(Some("result")),
+        let result = match (found, ctx.result_name) {
+            (Some(sink), _) => sink.value.unwrap_or_default().to_string(),
+            (None, Some(name)) => name.to_string(),
+            (None, None) => self.fresh_var(Some("result")),
         };
-        self.declare(&result);
-        setup.push(self.slice_loop_declaration(kind, &result, &result_ty, &source, values.get(1)));
+        match found {
+            Some(sink) => {
+                if let Some(value) = sink.value {
+                    let go_type = self.use_go_type(&element_ty);
+                    setup.push(LoweredStatement::VarDecl {
+                        name: value.to_string(),
+                        go_type,
+                        value: None,
+                    });
+                }
+                setup.push(LoweredStatement::TempBind {
+                    name: sink.flag.to_string(),
+                    value: "false".to_string(),
+                });
+            }
+            None => {
+                self.declare(&result);
+                setup.push(self.slice_loop_declaration(
+                    kind,
+                    &result,
+                    &result_ty,
+                    &source,
+                    values.get(1),
+                ));
+            }
+        }
 
         let index = (kind == SliceLoop::Map).then(|| {
             let index = self.fresh_var(Some("i"));
@@ -256,6 +310,7 @@ impl Planner<'_> {
                 result: &result,
                 element_name: &element_name,
                 index: index.as_deref(),
+                found,
             });
             (element_name, statements)
         });
@@ -370,6 +425,7 @@ impl Planner<'_> {
             result,
             element_name,
             index,
+            found,
         } = *loop_body;
 
         // Map and fold store their body's value, so it lowers into the slot.
@@ -399,20 +455,30 @@ impl Planner<'_> {
                 ))],
             },
             SliceLoop::Find => {
-                self.require_stdlib();
-                let payload = self.use_go_type(element_ty);
-                LoweredBlock {
-                    statements: vec![
-                        LoweredStatement::RawGo(format!(
+                let mut statements = Vec::new();
+                match found {
+                    Some(sink) => {
+                        if let Some(value) = sink.value {
+                            statements.push(LoweredStatement::RawGo(format!(
+                                "{value} = {element_name}\n"
+                            )));
+                        }
+                        statements.push(LoweredStatement::RawGo(format!("{} = true\n", sink.flag)));
+                    }
+                    None => {
+                        self.require_stdlib();
+                        let payload = self.use_go_type(element_ty);
+                        statements.push(LoweredStatement::RawGo(format!(
                             "{} = {}.MakeOptionSome[{}]({})\n",
                             result,
                             go_name::GO_STDLIB_PKG,
                             payload,
                             element_name
-                        )),
-                        LoweredStatement::RawGo("break\n".to_string()),
-                    ],
+                        )));
+                    }
                 }
+                statements.push(LoweredStatement::RawGo("break\n".to_string()));
+                LoweredBlock { statements }
             }
             SliceLoop::Map | SliceLoop::Fold => unreachable!("assign-place kinds returned above"),
         };

--- a/crates/emit/src/calls/unwrap_or.rs
+++ b/crates/emit/src/calls/unwrap_or.rs
@@ -125,7 +125,11 @@ impl Planner<'_> {
         }
         let receiver_ty = self.facts.peel_alias(&receiver.get_type());
         let fuse = if receiver_ty.is_option() {
-            FusedCall::Option(self.option_fuse_plan(receiver)?)
+            let fuse = self.option_fuse_plan(receiver)?;
+            if matches!(fuse, OptionFusePlan::Index { .. }) {
+                return None;
+            }
+            FusedCall::Option(fuse)
         } else if receiver_ty.is_result() && map.is_none() {
             let fuse = self.result_fuse_plan(receiver)?;
             if !fuse.carries_payload() {

--- a/crates/emit/src/patterns/matching.rs
+++ b/crates/emit/src/patterns/matching.rs
@@ -1,8 +1,11 @@
 use crate::Planner;
 use crate::abi::callable::{CallableReturnAbi, OptionReturnAbi};
+use crate::calls::NativeMethodCall;
+use crate::calls::bounds::BoundsCheckedIndex;
 use crate::calls::comma_ok::CommaOkSource;
 use crate::calls::comma_ok::{CommaOkValueSlot, LoweredPair, PairKind, header_call};
 use crate::calls::go_interop::NilGuard;
+use crate::calls::slice_loop::FoundSink;
 use crate::calls::wrap_err::WrapMessage;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name::is_plain_identifier;
@@ -13,8 +16,9 @@ use crate::plan::bodies::{ElseArm, IfPlan, LoweredBlock, LoweredStatement, Place
 use crate::plan::calls::{CallPlan, CallableOrigin};
 use crate::plan::values::{CaptureBoundary, GoExpression, ValuePlan};
 use crate::state::scope::PairStatusKind;
+use crate::types::native::NativeGoType;
 use std::mem;
-use syntax::ast::{Expression, MatchArm, Pattern};
+use syntax::ast::{Expression, Literal, MatchArm, Pattern};
 use syntax::parse::TUPLE_FIELDS;
 use syntax::types::Type;
 
@@ -34,6 +38,12 @@ pub(crate) enum OptionFusePlan<'a> {
         subject: &'a Expression,
         nil_guard: NilGuard,
     },
+    /// `xs.get(i)` on a slice or array: a bounds test guards a direct index.
+    Index { call: NativeMethodCall<'a> },
+    Found {
+        subject: &'a Expression,
+        call: NativeMethodCall<'a>,
+    },
 }
 
 pub(crate) struct BoundOption {
@@ -48,19 +58,56 @@ enum BoundSource {
         nil_guard: NilGuard,
         initializer_call: Option<String>,
     },
+    Index {
+        index: BoundsCheckedIndex,
+        target: Option<String>,
+    },
+    Found {
+        value: Option<String>,
+        flag: String,
+    },
 }
 
 impl BoundOption {
+    /// The payload expression, valid once the some-condition holds.
     pub(crate) fn value(&self) -> Option<&str> {
         match &self.source {
             BoundSource::Pair(pair) => pair.value.as_deref(),
             BoundSource::Nullable { value, .. } => Some(value),
+            BoundSource::Index { index, .. } => Some(&index.element),
+            BoundSource::Found { value, .. } => value.as_deref(),
         }
     }
 
+    pub(crate) fn binds_value(&self) -> bool {
+        !matches!(self.source, BoundSource::Index { .. })
+    }
+
+    /// The statement that reads a late payload into its requested name.
+    pub(crate) fn late_binding(&self) -> Option<LoweredStatement> {
+        let BoundSource::Index {
+            index,
+            target: Some(target),
+        } = &self.source
+        else {
+            return None;
+        };
+        Some(LoweredStatement::TempBind {
+            name: target.clone(),
+            value: index.element.clone(),
+        })
+    }
+
     pub(super) fn discard_value(&mut self) {
-        if let BoundSource::Pair(pair) = &mut self.source {
-            pair.discard_value();
+        match &mut self.source {
+            BoundSource::Pair(pair) => pair.discard_value(),
+            BoundSource::Found {
+                value: Some(value), ..
+            } => {
+                self.statements
+                    .push(LoweredStatement::RawGo(format!("_ = {value}\n")));
+            }
+            _ => {}
         }
     }
 
@@ -94,6 +141,10 @@ impl BoundOption {
                     None => test,
                 }
             }
+            BoundSource::Index { index, .. } if success => index.in_bounds.clone(),
+            BoundSource::Index { index, .. } => index.out_of_bounds.clone(),
+            BoundSource::Found { flag, .. } if success => flag.clone(),
+            BoundSource::Found { flag, .. } => format!("!{flag}"),
         }
     }
 }
@@ -136,6 +187,39 @@ impl OptionFusePlan<'_> {
                         nil_guard,
                         initializer_call,
                     },
+                }
+            }
+            Self::Index { call } => {
+                let (statements, index) = planner.lower_bounds_checked_index(&call);
+                let target = match slot {
+                    CommaOkValueSlot::Named(name) => Some(name),
+                    _ => None,
+                };
+                BoundOption {
+                    statements,
+                    source: BoundSource::Index { index, target },
+                }
+            }
+            Self::Found { subject, call } => {
+                let value = match slot {
+                    CommaOkValueSlot::Named(name) => Some(name),
+                    CommaOkValueSlot::Arm(name) => Some(planner.declared_arm_value_name(&name)),
+                    CommaOkValueSlot::Temp => Some(planner.fresh_pair_value()),
+                    CommaOkValueSlot::Unused | CommaOkValueSlot::Discarded => None,
+                };
+                let flag = planner.fresh_var(Some("found"));
+                planner.declare(&flag);
+                let statements = planner.lower_find_loop(
+                    subject,
+                    &call,
+                    FoundSink {
+                        value: value.as_deref(),
+                        flag: &flag,
+                    },
+                );
+                BoundOption {
+                    statements,
+                    source: BoundSource::Found { value, flag },
                 }
             }
         }
@@ -446,14 +530,41 @@ impl Planner<'_> {
         })
     }
 
-    /// Recognize an Option-producing call whose physical Go result can be
-    /// tested directly, without first constructing a tagged Option.
+    /// Go rejects invalid constant indexes even behind a bounds check.
+    fn index_fuses(&self, receiver: &Expression, index: &Expression) -> bool {
+        match index.unwrap_parens() {
+            Expression::Literal {
+                literal: Literal::Integer { value, .. },
+                ..
+            } => match self.facts.strip_and_peel(&receiver.get_type()) {
+                Type::Array { length, .. } => *value < length,
+                _ => true,
+            },
+            other => !self.is_go_constant_expression(other),
+        }
+    }
+
     pub(crate) fn option_fuse_plan<'a>(
         &self,
         subject: &'a Expression,
     ) -> Option<OptionFusePlan<'a>> {
         if let Some(source) = self.comma_ok_source(subject) {
             return Some(OptionFusePlan::CommaOk { subject, source });
+        }
+        if let Some(call) = self.native_method_call(subject) {
+            let indexes = matches!(
+                NativeGoType::from_kind(call.kind),
+                NativeGoType::Slice | NativeGoType::Array
+            ) && call.method == "get"
+                && call.arguments.len() == 1
+                && call.spread.is_none()
+                && self.index_fuses(call.receiver, &call.arguments[0]);
+            if indexes {
+                return Some(OptionFusePlan::Index { call });
+            }
+            if self.find_loop_fuses(subject, &call) {
+                return Some(OptionFusePlan::Found { subject, call });
+            }
         }
 
         let plan = self.plan_call(subject)?;
@@ -493,8 +604,8 @@ impl Planner<'_> {
         self.lower_fused_lowered_match(subject, arms, &PlacePlan::Statement, Some(go_name))
     }
 
-    /// Bind `let x = match nullable_call() { Some(v) => v, None => diverge }`
-    /// straight into `x` and test the raw Go value for nil.
+    /// Bind `let x = match <lowered Option source> { Some(v) => v, None => diverge }`
+    /// straight into `x` and test the physical Go result.
     pub(crate) fn lower_fused_option_match_into(
         &mut self,
         value: &Expression,
@@ -504,9 +615,6 @@ impl Planner<'_> {
             return None;
         };
         let fuse = self.option_fuse_plan(subject)?;
-        if !matches!(&fuse, OptionFusePlan::Nullable { .. }) {
-            return None;
-        }
         let arms = classify_option_arms(arms)?;
         let payload = arms.some_binding?;
         if !arms.none_body.get_type().is_never()
@@ -520,6 +628,7 @@ impl Planner<'_> {
         let bound = fuse.bind(self, CommaOkValueSlot::Named(go_name.to_string()));
         let none_condition = bound.none_condition(self);
         let fail_body = self.lower_block_as_body(arms.none_body);
+        let late_binding = bound.late_binding();
         let mut statements = bound.statements;
         statements.push(LoweredStatement::If(IfPlan {
             condition_setup: Vec::new(),
@@ -527,6 +636,7 @@ impl Planner<'_> {
             then_body: fail_body,
             else_arm: ElseArm::None,
         }));
+        statements.extend(late_binding);
         Some(statements)
     }
 
@@ -917,7 +1027,11 @@ impl Planner<'_> {
         };
         let mut bound = fuse.bind(self, slot);
 
-        let some_binding = ArmBinding::alias(arms.some_binding, bound.value());
+        let some_binding = if bound.binds_value() {
+            ArmBinding::alias(arms.some_binding, bound.value())
+        } else {
+            ArmBinding::copy(arms.some_binding, bound.value())
+        };
         let (then_body, some_uses) = self.lower_fused_arm(&[some_binding], arms.some_body, place);
         let (else_body, _) = self.lower_fused_arm(&[], arms.none_body, place);
         if !some_uses.first().copied().unwrap_or(false) {

--- a/crates/emit/src/patterns/sites.rs
+++ b/crates/emit/src/patterns/sites.rs
@@ -334,7 +334,11 @@ impl Planner<'_> {
         };
         let bound = fuse.bind(self, slot);
         let none_condition = bound.none_condition(self);
-        Some(self.finish_fused_let_else(bound.statements, none_condition, binding, else_block))
+        let late_binding = bound.late_binding();
+        let mut statements =
+            self.finish_fused_let_else(bound.statements, none_condition, binding, else_block);
+        statements.extend(late_binding);
+        Some(statements)
     }
 
     fn finish_fused_let_else(

--- a/tests/spec/emit/result_option_patterns.rs
+++ b/tests/spec/emit/result_option_patterns.rs
@@ -3189,6 +3189,129 @@ fn run() -> Result<int, error> {
 }
 
 #[test]
+fn let_else_on_slice_get_tests_bounds_and_indexes() {
+    let input = r#"
+import "go:fmt"
+import "go:os"
+
+fn main() {
+  let Some(command) = os.Args.get(1) else {
+    fmt.Println("usage: app <command>")
+    return
+  }
+  fmt.Println(command)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_on_slice_get_with_a_variable_index_guards_both_bounds() {
+    let input = r#"
+fn pick(xs: Slice<int>, i: int) -> int {
+  match xs.get(i) {
+    Some(v) => v,
+    None => -1,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn if_let_on_array_get_indexes_the_array_directly() {
+    let input = r#"
+fn first(a: Array<int, 3>, i: int) -> int {
+  if let Some(v) = a.get(i) { v } else { 0 }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_get_with_call_operands_pins_them_once() {
+    let input = r#"
+fn xs() -> Slice<int> { [1, 2] }
+fn idx() -> int { 1 }
+
+fn run() -> int {
+  let Some(v) = xs().get(idx()) else { return 0 }
+  v
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn is_some_on_slice_get_is_a_bounds_test() {
+    let input = r#"
+fn has(xs: Slice<int>, i: int) -> bool { xs.get(i).is_some() }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn slice_get_through_a_ref_receiver_derefs_once() {
+    let input = r#"
+fn head(xs: Ref<Slice<int>>) -> int {
+  let Some(v) = xs.get(0) else { return 0 }
+  v
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn while_let_on_slice_get_reads_after_the_bounds_test() {
+    let input = r#"
+fn sum(xs: Slice<int>) -> int {
+  let mut i = 0
+  let mut total = 0
+  while let Some(x) = xs.get(i) {
+    total = total + x
+    i = i + 1
+  }
+  total
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn let_match_on_natives_binds_the_let_name_directly() {
+    let input = r#"
+fn pick(xs: Slice<int>, i: int) -> int {
+  let v = match xs.get(i) { Some(v) => v, None => return -1 }
+  v + 1
+}
+
+fn lookup(m: Map<string, int>, k: string) -> int {
+  let v = match m.get(k) { Some(v) => v, None => return -1 }
+  v + 1
+}
+
+fn first_even(nums: Slice<int>) -> int {
+  let n = match nums.find(|n| n % 2 == 0) { Some(n) => n, None => return -1 }
+  n + 1
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn match_on_find_uses_a_found_flag() {
+    let input = r#"
+fn first_even(nums: Slice<int>) -> int {
+  match nums.find(|n| n % 2 == 0) {
+    Some(n) => n,
+    None => -1,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn unwrap_or_evaluates_an_effectful_default_before_the_error_test() {
     let input = r#"
 import "go:fmt"
@@ -3333,6 +3456,44 @@ import "go:strconv"
 fn three() -> Result<int, error> {
   let n = strconv.Atoi("x").wrap_err(f"{strconv.Atoi("0")?}")?
   Ok(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn get_with_a_constant_index_go_rejects_keeps_the_helper() {
+    let input = r#"
+fn past_the_end(xs: Array<int, 2>) -> int {
+  match xs.get(2) {
+    Some(v) => v,
+    None => -1,
+  }
+}
+
+fn negative(xs: Slice<int>) -> int {
+  match xs.get(-1) {
+    Some(v) => v,
+    None => -1,
+  }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn adjacent_find_matches_take_distinct_payload_names() {
+    let input = r#"
+import "go:fmt"
+
+fn five(xs: Slice<int>) -> int {
+  if let Some(x) = xs.find(|n| n > 1) {
+    fmt.Println(x)
+  }
+  if let Some(x) = xs.find(|n| n > 2) {
+    fmt.Println(x)
+  }
+  0
 }
 "#;
     assert_emit_snapshot!(input);
@@ -3623,6 +3784,45 @@ fn let_match() {
     Err(_) => { return },
   }
   fmt.Println(n)
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn generated_names_avoid_package_functions() {
+    let input = r#"
+import "go:fmt"
+import "go:strconv"
+
+fn err() -> int { 3 }
+fn n() -> string { "context" }
+fn items() -> Slice<int> { [1, 2] }
+
+fn status() -> Result<int, error> {
+  let count = strconv.Atoi("2")?
+  Ok(count + err())
+}
+
+fn arm_after_message() {
+  match strconv.Atoi("2").wrap_err(n()) {
+    Ok(n) => fmt.Println(n),
+    Err(e) => fmt.Println(e),
+  }
+}
+
+fn arm_in_other_arm() {
+  match strconv.Atoi("bad") {
+    Ok(n) => fmt.Println(n),
+    Err(_) => fmt.Println(n()),
+  }
+}
+
+fn find_arm() {
+  match items().find(|x| x > 1) {
+    Some(items) => fmt.Println(items),
+    None => fmt.Println("none"),
+  }
 }
 "#;
     assert_emit_snapshot!(input);

--- a/tests/spec/emit/snapshots/adjacent_find_matches_take_distinct_payload_names.snap
+++ b/tests/spec/emit/snapshots/adjacent_find_matches_take_distinct_payload_names.snap
@@ -1,0 +1,47 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  
+  fn five(xs: Slice<int>) -> int {
+    if let Some(x) = xs.find(|n| n > 1) {
+      fmt.Println(x)
+    }
+    if let Some(x) = xs.find(|n| n > 2) {
+      fmt.Println(x)
+    }
+    0
+  }
+---
+package main
+
+import "fmt"
+
+func five(xs []int) int {
+	var x int
+	found_1 := false
+	for _, n := range xs {
+		if n > 1 {
+			x = n
+			found_1 = true
+			break
+		}
+	}
+	if found_1 {
+		fmt.Println(x)
+	}
+	var x_2 int
+	found_3 := false
+	for _, n := range xs {
+		if n > 2 {
+			x_2 = n
+			found_3 = true
+			break
+		}
+	}
+	if found_3 {
+		fmt.Println(x_2)
+	}
+	return 0
+}

--- a/tests/spec/emit/snapshots/find_result_in_a_let_else_needs_no_subject_temp.snap
+++ b/tests/spec/emit/snapshots/find_result_in_a_let_else_needs_no_subject_temp.snap
@@ -12,23 +12,21 @@ description: |
 ---
 package main
 
-import (
-	"fmt"
-	lisette "github.com/ivov/lisette/prelude"
-)
+import "fmt"
 
 func main() {
 	nums := []int{1, 2, 3}
-	result_1 := lisette.MakeOptionNone[int]()
+	var even int
+	found_1 := false
 	for _, n := range nums {
 		if n%2 == 0 {
-			result_1 = lisette.MakeOptionSome[int](n)
+			even = n
+			found_1 = true
 			break
 		}
 	}
-	if result_1.Tag != lisette.OptionSome {
+	if !found_1 {
 		return
 	}
-	even := result_1.SomeVal
 	fmt.Println(even)
 }

--- a/tests/spec/emit/snapshots/generated_names_avoid_package_functions.snap
+++ b/tests/spec/emit/snapshots/generated_names_avoid_package_functions.snap
@@ -1,0 +1,99 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:strconv"
+  
+  fn err() -> int { 3 }
+  fn n() -> string { "context" }
+  fn items() -> Slice<int> { [1, 2] }
+  
+  fn status() -> Result<int, error> {
+    let count = strconv.Atoi("2")?
+    Ok(count + err())
+  }
+  
+  fn arm_after_message() {
+    match strconv.Atoi("2").wrap_err(n()) {
+      Ok(n) => fmt.Println(n),
+      Err(e) => fmt.Println(e),
+    }
+  }
+  
+  fn arm_in_other_arm() {
+    match strconv.Atoi("bad") {
+      Ok(n) => fmt.Println(n),
+      Err(_) => fmt.Println(n()),
+    }
+  }
+  
+  fn find_arm() {
+    match items().find(|x| x > 1) {
+      Some(items) => fmt.Println(items),
+      None => fmt.Println("none"),
+    }
+  }
+---
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func err() int {
+	return 3
+}
+
+func n() string {
+	return "context"
+}
+
+func items() []int {
+	return []int{1, 2}
+}
+
+func status() (int, error) {
+	count, err_1 := strconv.Atoi("2")
+	if err_1 != nil {
+		return 0, err_1
+	}
+	return count + err(), nil
+}
+
+func armAfterMessage() {
+	n_1, e := strconv.Atoi("2")
+	msg_2 := n()
+	if e == nil {
+		fmt.Println(n_1)
+	} else {
+		e = fmt.Errorf("%s: %w", msg_2, e)
+		fmt.Println(e)
+	}
+}
+
+func armInOtherArm() {
+	if n_1, err_2 := strconv.Atoi("bad"); err_2 == nil {
+		fmt.Println(n_1)
+	} else {
+		fmt.Println(n())
+	}
+}
+
+func findArm() {
+	var items_1 int
+	found_2 := false
+	for _, x := range items() {
+		if x > 1 {
+			items_1 = x
+			found_2 = true
+			break
+		}
+	}
+	if found_2 {
+		fmt.Println(items_1)
+	} else {
+		fmt.Println("none")
+	}
+}

--- a/tests/spec/emit/snapshots/get_with_a_constant_index_go_rejects_keeps_the_helper.snap
+++ b/tests/spec/emit/snapshots/get_with_a_constant_index_go_rejects_keeps_the_helper.snap
@@ -1,0 +1,37 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn past_the_end(xs: Array<int, 2>) -> int {
+    match xs.get(2) {
+      Some(v) => v,
+      None => -1,
+    }
+  }
+  
+  fn negative(xs: Slice<int>) -> int {
+    match xs.get(-1) {
+      Some(v) => v,
+      None => -1,
+    }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func pastTheEnd(xs [2]int) int {
+	subject_1 := lisette.SliceGet(xs[:], 2)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return -1
+}
+
+func negative(xs []int) int {
+	subject_1 := lisette.SliceGet(xs, -1)
+	if subject_1.Tag == lisette.OptionSome {
+		return subject_1.SomeVal
+	}
+	return -1
+}

--- a/tests/spec/emit/snapshots/if_let_on_array_get_indexes_the_array_directly.snap
+++ b/tests/spec/emit/snapshots/if_let_on_array_get_indexes_the_array_directly.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn first(a: Array<int, 3>, i: int) -> int {
+    if let Some(v) = a.get(i) { v } else { 0 }
+  }
+---
+package main
+
+func first(a [3]int, i int) int {
+	if i >= 0 && i < len(a) {
+		v := a[i]
+		return v
+	} else {
+		return 0
+	}
+}

--- a/tests/spec/emit/snapshots/is_some_on_slice_get_is_a_bounds_test.snap
+++ b/tests/spec/emit/snapshots/is_some_on_slice_get_is_a_bounds_test.snap
@@ -1,0 +1,11 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn has(xs: Slice<int>, i: int) -> bool { xs.get(i).is_some() }
+---
+package main
+
+func has(xs []int, i int) bool {
+	return i >= 0 && i < len(xs)
+}

--- a/tests/spec/emit/snapshots/let_else_on_slice_get_tests_bounds_and_indexes.snap
+++ b/tests/spec/emit/snapshots/let_else_on_slice_get_tests_bounds_and_indexes.snap
@@ -1,0 +1,30 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  import "go:fmt"
+  import "go:os"
+  
+  fn main() {
+    let Some(command) = os.Args.get(1) else {
+      fmt.Println("usage: app <command>")
+      return
+    }
+    fmt.Println(command)
+  }
+---
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) <= 1 {
+		fmt.Println("usage: app <command>")
+		return
+	}
+	command := os.Args[1]
+	fmt.Println(command)
+}

--- a/tests/spec/emit/snapshots/let_match_on_natives_binds_the_let_name_directly.snap
+++ b/tests/spec/emit/snapshots/let_match_on_natives_binds_the_let_name_directly.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn pick(xs: Slice<int>, i: int) -> int {
+    let v = match xs.get(i) { Some(v) => v, None => return -1 }
+    v + 1
+  }
+  
+  fn lookup(m: Map<string, int>, k: string) -> int {
+    let v = match m.get(k) { Some(v) => v, None => return -1 }
+    v + 1
+  }
+  
+  fn first_even(nums: Slice<int>) -> int {
+    let n = match nums.find(|n| n % 2 == 0) { Some(n) => n, None => return -1 }
+    n + 1
+  }
+---
+package main
+
+func pick(xs []int, i int) int {
+	if i < 0 || i >= len(xs) {
+		return -1
+	}
+	v := xs[i]
+	return v + 1
+}
+
+func lookup(m map[string]int, k string) int {
+	v, ok := m[k]
+	if !ok {
+		return -1
+	}
+	return v + 1
+}
+
+func firstEven(nums []int) int {
+	var n int
+	found_1 := false
+	for _, n_2 := range nums {
+		if n_2%2 == 0 {
+			n = n_2
+			found_1 = true
+			break
+		}
+	}
+	if !found_1 {
+		return -1
+	}
+	return n + 1
+}

--- a/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
+++ b/tests/spec/emit/snapshots/match_arm_with_return_err_assigned_to_variable.snap
@@ -29,10 +29,8 @@ func safeDivide(a, b float64) (float64, bool) {
 }
 
 func parseAndDivide(a, b float64) lisette.Result[string, string] {
-	var result float64
-	if v, ok := safeDivide(a, b); ok {
-		result = v
-	} else {
+	result, ok := safeDivide(a, b)
+	if !ok {
 		return lisette.MakeResultErr[string, string]("division by zero")
 	}
 	return lisette.MakeResultOk[string, string](fmt.Sprint(result))

--- a/tests/spec/emit/snapshots/match_on_find_uses_a_found_flag.snap
+++ b/tests/spec/emit/snapshots/match_on_find_uses_a_found_flag.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn first_even(nums: Slice<int>) -> int {
+    match nums.find(|n| n % 2 == 0) {
+      Some(n) => n,
+      None => -1,
+    }
+  }
+---
+package main
+
+func firstEven(nums []int) int {
+	var n int
+	found_1 := false
+	for _, n_2 := range nums {
+		if n_2%2 == 0 {
+			n = n_2
+			found_1 = true
+			break
+		}
+	}
+	if found_1 {
+		return n
+	} else {
+		return -1
+	}
+}

--- a/tests/spec/emit/snapshots/match_on_slice_get_with_a_variable_index_guards_both_bounds.snap
+++ b/tests/spec/emit/snapshots/match_on_slice_get_with_a_variable_index_guards_both_bounds.snap
@@ -1,0 +1,21 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn pick(xs: Slice<int>, i: int) -> int {
+    match xs.get(i) {
+      Some(v) => v,
+      None => -1,
+    }
+  }
+---
+package main
+
+func pick(xs []int, i int) int {
+	if i >= 0 && i < len(xs) {
+		v := xs[i]
+		return v
+	} else {
+		return -1
+	}
+}

--- a/tests/spec/emit/snapshots/slice_get_through_a_ref_receiver_derefs_once.snap
+++ b/tests/spec/emit/snapshots/slice_get_through_a_ref_receiver_derefs_once.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn head(xs: Ref<Slice<int>>) -> int {
+    let Some(v) = xs.get(0) else { return 0 }
+    v
+  }
+---
+package main
+
+func head(xs *[]int) int {
+	if len(*xs) == 0 {
+		return 0
+	}
+	v := (*xs)[0]
+	return v
+}

--- a/tests/spec/emit/snapshots/slice_get_with_call_operands_pins_them_once.snap
+++ b/tests/spec/emit/snapshots/slice_get_with_call_operands_pins_them_once.snap
@@ -1,0 +1,31 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn xs() -> Slice<int> { [1, 2] }
+  fn idx() -> int { 1 }
+  
+  fn run() -> int {
+    let Some(v) = xs().get(idx()) else { return 0 }
+    v
+  }
+---
+package main
+
+func xs() []int {
+	return []int{1, 2}
+}
+
+func idx() int {
+	return 1
+}
+
+func run() int {
+	recv_1 := xs()
+	idx_2 := idx()
+	if idx_2 < 0 || idx_2 >= len(recv_1) {
+		return 0
+	}
+	v := recv_1[idx_2]
+	return v
+}

--- a/tests/spec/emit/snapshots/while_let_on_slice_get_reads_after_the_bounds_test.snap
+++ b/tests/spec/emit/snapshots/while_let_on_slice_get_reads_after_the_bounds_test.snap
@@ -1,0 +1,29 @@
+---
+source: tests/spec/emit/result_option_patterns.rs
+description: |
+  
+  fn sum(xs: Slice<int>) -> int {
+    let mut i = 0
+    let mut total = 0
+    while let Some(x) = xs.get(i) {
+      total = total + x
+      i = i + 1
+    }
+    total
+  }
+---
+package main
+
+func sum(xs []int) int {
+	i := 0
+	total := 0
+	for {
+		if i < 0 || i >= len(xs) {
+			break
+		}
+		x := xs[i]
+		total += x
+		i++
+	}
+	return total
+}


### PR DESCRIPTION
`get` on a slice in a `let else`, `match`, `if let`, or `while let` now emits a bounds check and a direct index, instead of a `lisette.Option` built by a prelude helper and then checked by tag. `find` in the same sites now emits a loop with a found flag, and a `get` with a constant index that Go rejects keeps the helper.

```rs
import "go:fmt"
import "go:os"

fn main() {
  let Some(command) = os.Args.get(1) else {
    fmt.Println("usage: app <command>")
    return
  }
  fmt.Println(command)
}
```

Before:

```go
func main() {
	subject_1 := lisette.SliceGet(os.Args, 1)
	if subject_1.Tag != lisette.OptionSome {
		fmt.Println("usage: app <command>")
		return
	}
	command := subject_1.SomeVal
	fmt.Println(command)
}
```

After:

```go
func main() {
	if len(os.Args) <= 1 { // the bounds test replaces the Option value
		fmt.Println("usage: app <command>")
		return
	}
	command := os.Args[1] // direct index after the check
	fmt.Println(command)
}
```