### PR TITLE
feat: idiomatic Go for casts, zero fills, and zero values

### DIFF
--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -5,7 +5,7 @@ use crate::names::go_name;
 use crate::plan::bodies::ConstPlan;
 use crate::plan::values::ValuePlan;
 use syntax::ast::{Expression, Generic};
-use syntax::types::Type;
+use syntax::types::{SimpleKind, Type};
 
 #[derive(Clone, Copy)]
 pub(crate) enum ConstScope {
@@ -71,7 +71,14 @@ impl Planner<'_> {
             self.try_declare(&fresh);
             fresh
         };
-        let ty_str = self.use_go_type(ty);
+        let is_const = self.is_go_constant_expression(expression);
+        // An untyped string or bool constant also assigns to named types.
+        let ty_str =
+            if is_const && matches!(ty, Type::Simple(SimpleKind::String | SimpleKind::Bool)) {
+                String::new()
+            } else {
+                self.use_go_type(ty)
+            };
 
         // `is_go_constant_expression` admits only literals, identifiers, and
         // constexpr unary/binary, none of which carry setup statements.
@@ -82,7 +89,6 @@ impl Planner<'_> {
         } else {
             ValuePlan::opaque(value_text)
         };
-        let is_const = self.is_go_constant_expression(expression);
         if is_const && matches!(scope, ConstScope::Local) {
             self.scope.mark_go_const(identifier);
         }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -271,7 +271,11 @@ impl Planner<'_> {
                 if field_ty.is_slice() {
                     continue;
                 }
-                self.lisette_zero(&field_ty)
+                let zero = self.lisette_zero(&field_ty);
+                if is_go_zero_literal(&zero) {
+                    continue;
+                }
+                zero
             };
             let go_field_name = self.resolve_struct_call_field_name(&field_name, ctx);
             field_pairs.push((go_field_name, zero));
@@ -856,6 +860,12 @@ fn apply_substitution(ty: &Type, map: &SubstitutionMap) -> Type {
     } else {
         types::substitute(ty, map)
     }
+}
+
+/// Go gives an omitted field this value already.
+fn is_go_zero_literal(value: &str) -> bool {
+    matches!(value, "0" | "0.0" | "false" | "\"\"" | "nil" | "struct{}{}")
+        || (value.starts_with("lisette.MakeOptionNone[") && value.ends_with("]()"))
 }
 
 fn unspecified_pairs<'a>(

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -399,9 +399,10 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> ValuePlan {
         let slot_origin = self.function_type_origin(ty, SlotOrigin::Lisette);
-        let inner = self.lower_value(expression, ctx.with_function_slot_origin(slot_origin));
+        let ctx = ctx.with_function_slot_origin(slot_origin);
 
         if self.facts.is_interface(ty) {
+            let inner = self.lower_value(expression, ctx);
             let source_ty = expression.get_type();
             let coercion = CoercionPlan::internal(self, &source_ty, ty);
             let mut converted =
@@ -416,6 +417,8 @@ impl Planner<'_> {
             return converted;
         }
 
+        let expression = expression.unwrap_parens();
+        let inner = self.lower_value(expression, ctx);
         let go_type = self.use_go_type(ty);
 
         let function_bridge = self.function_slot_bridge(expression, ty);
@@ -434,6 +437,14 @@ impl Planner<'_> {
         }
 
         inner.conversion(go_type)
+    }
+
+    /// `T(x)` is a primary expression, so parentheses around it add nothing.
+    pub(crate) fn is_conversion_cast(&self, expression: &Expression) -> bool {
+        matches!(
+            expression.unwrap_parens(),
+            Expression::Cast { ty, .. } if !self.facts.is_interface(ty)
+        )
     }
 
     fn shift_pin_go_type(&mut self, expression: &Expression, target_ty: &Type) -> Option<String> {

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -688,6 +688,9 @@ impl Planner<'_> {
             );
         }
         match expression {
+            Expression::Paren { expression, .. } if self.is_conversion_cast(expression) => {
+                self.plan_operand(expression, ctx)
+            }
             Expression::Paren { expression, .. } => {
                 self.plan_operand(expression, ctx).parenthesized()
             }

--- a/crates/emit/src/render/bodies.rs
+++ b/crates/emit/src/render/bodies.rs
@@ -325,14 +325,18 @@ impl Renderer {
     pub(crate) fn render_const_declaration(&self, output: &mut String, plan: &ConstPlan) {
         let value_text = self.render_value(output, &plan.value);
         let keyword = if plan.is_const { "const" } else { "var" };
-        write_line!(
-            output,
-            "{} {} {} = {}",
-            keyword,
-            plan.name,
-            plan.ty_str,
-            value_text
-        );
+        if plan.ty_str.is_empty() {
+            write_line!(output, "{} {} = {}", keyword, plan.name, value_text);
+        } else {
+            write_line!(
+                output,
+                "{} {} {} = {}",
+                keyword,
+                plan.name,
+                plan.ty_str,
+                value_text
+            );
+        }
     }
 
     fn render_loop(&self, output: &mut String, plan: &LoopPlan) {

--- a/crates/emit/src/types/go_type.rs
+++ b/crates/emit/src/types/go_type.rs
@@ -455,6 +455,22 @@ impl Planner<'_> {
                     | CompoundKind::Receiver,
                 ..
             }) => "nil".to_string(),
+            ValueLayout::Tuple { .. } | ValueLayout::TaggedOption { .. } => {
+                format!("{}{{}}", go_ty.code)
+            }
+            ValueLayout::Plain(Type::Nominal { id, .. })
+                if self
+                    .facts
+                    .definition(id.as_str())
+                    .is_some_and(|definition| {
+                        matches!(
+                            definition.body,
+                            DefinitionBody::Struct { .. } | DefinitionBody::Enum { .. }
+                        )
+                    }) =>
+            {
+                format!("{}{{}}", go_ty.code)
+            }
             _ => format!("*new({})", go_ty.code),
         };
         (value, packages)

--- a/tests/spec/build/snapshots/aliased_local_package_survives_go_import_name_clash.snap
+++ b/tests/spec/build/snapshots/aliased_local_package_survives_go_import_name_clash.snap
@@ -24,7 +24,7 @@ func main() {
 	made := foo.Foo_New()
 	built := foo.Foo{}
 	n := 1
-	pinned := float64(int((http.StatusOK << n)))
+	pinned := float64(int(http.StatusOK << n))
 	fmt.Println(made)
 	fmt.Println(built)
 	fmt.Println(http.MethodGet)

--- a/tests/spec/build/snapshots/cast_shift_imported_package_const_count_needs_no_pin.snap
+++ b/tests/spec/build/snapshots/cast_shift_imported_package_const_count_needs_no_pin.snap
@@ -16,5 +16,5 @@ import (
 )
 
 func main() {
-	fmt.Println(float64((1 << config.Shift)))
+	fmt.Println(float64(1 << config.Shift))
 }

--- a/tests/spec/emit/functions.rs
+++ b/tests/spec/emit/functions.rs
@@ -379,6 +379,32 @@ fn test() -> float64 {
 }
 
 #[test]
+fn cast_of_a_parenthesized_operand_emits_one_pair() {
+    let input = r#"
+fn gray(r: int, g: int) -> uint8 {
+  ((r / 256 + g / 256) / 2) as uint8
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn string_and_bool_constants_emit_untyped() {
+    let input = r#"
+const NAME = "app"
+const DEBUG = true
+const LIMIT = 3
+
+fn label() -> string {
+  if DEBUG { NAME } else { "" }
+}
+
+fn cap() -> int { LIMIT }
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn cast_string_to_byte_slice() {
     let input = r#"
 fn test() -> Slice<byte> {

--- a/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
+++ b/tests/spec/emit/snapshots/assoc_fn_returning_option_self.snap
@@ -27,7 +27,7 @@ func Thing_maybeCreate(name string) (Thing, bool) {
 	if len(name) > 0 {
 		return Thing{name: name}, true
 	}
-	return *new(Thing), false
+	return Thing{}, false
 }
 
 func test() (Thing, bool) {

--- a/tests/spec/emit/snapshots/autofill_omits_zero_fields_and_keeps_maps.snap
+++ b/tests/spec/emit/snapshots/autofill_omits_zero_fields_and_keeps_maps.snap
@@ -1,0 +1,40 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  struct Counter {
+    label: string,
+    i: int,
+    rows: int,
+    ratio: float64,
+    done: bool,
+    parent: Option<int>,
+    tags: Slice<string>,
+    hits: Map<string, int>,
+  }
+  
+  fn make() -> Counter {
+    Counter { label: "x", .. }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+type Counter struct {
+	label  string
+	i      int
+	rows   int
+	ratio  float64
+	done   bool
+	parent lisette.Option[int]
+	tags   []string
+	hits   map[string]int
+}
+
+func make_() Counter {
+	return Counter{
+		label: "x",
+		hits:  map[string]int{},
+	}
+}

--- a/tests/spec/emit/snapshots/cast_constant_shift_to_float_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_constant_shift_to_float_needs_no_pin.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale() float64 {
-	return float64((2 << 3))
+	return float64(2 << 3)
 }

--- a/tests/spec/emit/snapshots/cast_constant_shift_with_arithmetic_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_constant_shift_with_arithmetic_count_needs_no_pin.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale() float64 {
-	return float64((1 << (50 + 50)))
+	return float64(1 << (50 + 50))
 }

--- a/tests/spec/emit/snapshots/cast_in_complex_expression.snap
+++ b/tests/spec/emit/snapshots/cast_in_complex_expression.snap
@@ -15,5 +15,5 @@ func test() float64 {
 	a := 3
 	b := 4
 	c := 2
-	return (float64((a + b))) / (float64(c))
+	return float64(a+b) / float64(c)
 }

--- a/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
+++ b/tests/spec/emit/snapshots/cast_nested_shift_to_float_pins_integer_type.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale(level int) float64 {
-	return float64(int(((2 << level) + 3)))
+	return float64(int((2 << level) + 3))
 }

--- a/tests/spec/emit/snapshots/cast_of_a_parenthesized_operand_emits_one_pair.snap
+++ b/tests/spec/emit/snapshots/cast_of_a_parenthesized_operand_emits_one_pair.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  fn gray(r: int, g: int) -> uint8 {
+    ((r / 256 + g / 256) / 2) as uint8
+  }
+---
+package main
+
+func gray(r, g int) uint8 {
+	return uint8((r/256 + g/256) / 2)
+}

--- a/tests/spec/emit/snapshots/cast_shift_forward_alias_const_stays_const.snap
+++ b/tests/spec/emit/snapshots/cast_shift_forward_alias_const_stays_const.snap
@@ -16,5 +16,5 @@ const Shift int = Later
 const Later int = 60 + 8
 
 func scale() float64 {
-	return float64((1 << Shift))
+	return float64(1 << Shift)
 }

--- a/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_imported_const_count_no_pin_but_var_count_pins.snap
@@ -21,9 +21,9 @@ import (
 )
 
 func constCount() float64 {
-	return float64((1 << math.MaxInt8))
+	return float64(1 << math.MaxInt8)
 }
 
 func varCount() float64 {
-	return float64(int((1 << runtime.MemProfileRate)))
+	return float64(int(1 << runtime.MemProfileRate))
 }

--- a/tests/spec/emit/snapshots/cast_shift_imported_const_shifted_operand_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_imported_const_shifted_operand_pins.snap
@@ -13,5 +13,5 @@ package main
 import "math"
 
 func scale(level int) float64 {
-	return float64(int((math.MaxInt8 << level)))
+	return float64(int(math.MaxInt8 << level))
 }

--- a/tests/spec/emit/snapshots/cast_shift_to_float_pins_integer_type.snap
+++ b/tests/spec/emit/snapshots/cast_shift_to_float_pins_integer_type.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func heal(level int, potency float64) float64 {
-	return (float64(int((2 << level)))) * potency
+	return float64(int(2<<level)) * potency
 }

--- a/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_const_count_needs_no_pin.snap
@@ -13,5 +13,5 @@ package main
 const Shift int = 60 + 8
 
 func scale() float64 {
-	return float64((1 << Shift))
+	return float64(1 << Shift)
 }

--- a/tests/spec/emit/snapshots/cast_shift_with_constant_arithmetic_base_pins.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_constant_arithmetic_base_pins.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale(level int) float64 {
-	return float64(int(((1 + 1) << level)))
+	return float64(int((1 + 1) << level))
 }

--- a/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_shift_with_local_const_count_needs_no_pin.snap
@@ -11,5 +11,5 @@ package main
 
 func scale() float64 {
 	const Shift int = 60 + 8
-	return float64((1 << Shift))
+	return float64(1 << Shift)
 }

--- a/tests/spec/emit/snapshots/cast_variable_shift_to_float_needs_no_pin.snap
+++ b/tests/spec/emit/snapshots/cast_variable_shift_to_float_needs_no_pin.snap
@@ -9,5 +9,5 @@ description: |
 package main
 
 func scale(base, level int) float64 {
-	return float64((base << level))
+	return float64(base << level)
 }

--- a/tests/spec/emit/snapshots/const_string.snap
+++ b/tests/spec/emit/snapshots/const_string.snap
@@ -14,7 +14,7 @@ package main
 
 import "fmt"
 
-const Greeting string = "Hello, World!"
+const Greeting = "Hello, World!"
 
 func test() {
 	fmt.Print(Greeting)

--- a/tests/spec/emit/snapshots/enumerated_slice_find.snap
+++ b/tests/spec/emit/snapshots/enumerated_slice_find.snap
@@ -18,5 +18,5 @@ func test(s []int) (lisette.Tuple2[int, int], bool) {
 	if v_2.Tag == lisette.OptionSome {
 		return v_2.SomeVal, true
 	}
-	return *new(lisette.Tuple2[int, int]), false
+	return lisette.Tuple2[int, int]{}, false
 }

--- a/tests/spec/emit/snapshots/err_constructor_wrap_err_in_return_position.snap
+++ b/tests/spec/emit/snapshots/err_constructor_wrap_err_in_return_position.snap
@@ -34,7 +34,7 @@ import (
 	"os"
 )
 
-const File string = "tasks.json"
+const File = "tasks.json"
 
 func load() ([]byte, error) {
 	bytes, err := os.ReadFile(File)

--- a/tests/spec/emit/snapshots/interop_flattened_result_tuple_tail_repackages_payload.snap
+++ b/tests/spec/emit/snapshots/interop_flattened_result_tuple_tail_repackages_payload.snap
@@ -27,5 +27,5 @@ func load() (lisette.Tuple2[string, int], error) {
 	if result_5.Tag == lisette.ResultOk {
 		return result_5.OkVal, nil
 	}
-	return *new(lisette.Tuple2[string, int]), result_5.ErrVal
+	return lisette.Tuple2[string, int]{}, result_5.ErrVal
 }

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_binds_to_annotated_go_fn_type.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_binds_to_annotated_go_fn_type.snap
@@ -36,7 +36,7 @@ func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
 	if result_5.Tag == lisette.ResultOk {
 		return result_5.OkVal, nil
 	}
-	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+	return lisette.Tuple2[int, []byte]{}, result_5.ErrVal
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_casts_to_go_fn_type.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_casts_to_go_fn_type.snap
@@ -32,7 +32,7 @@ func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
 	if result_5.Tag == lisette.ResultOk {
 		return result_5.OkVal, nil
 	}
-	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+	return lisette.Tuple2[int, []byte]{}, result_5.ErrVal
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_reaches_go_fn_type_return_field_and_assignment.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_reaches_go_fn_type_return_field_and_assignment.snap
@@ -48,7 +48,7 @@ func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
 	if result_5.Tag == lisette.ResultOk {
 		return result_5.OkVal, nil
 	}
-	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+	return lisette.Tuple2[int, []byte]{}, result_5.ErrVal
 }
 
 func pick() bufio.SplitFunc {

--- a/tests/spec/emit/snapshots/interop_lisette_fn_value_with_tuple_error_result_adapts_to_go_callback_param.snap
+++ b/tests/spec/emit/snapshots/interop_lisette_fn_value_with_tuple_error_result_adapts_to_go_callback_param.snap
@@ -46,7 +46,7 @@ func splitWords(data []byte, at_eof bool) (lisette.Tuple2[int, []byte], error) {
 	if result_5.Tag == lisette.ResultOk {
 		return result_5.OkVal, nil
 	}
-	return *new(lisette.Tuple2[int, []byte]), result_5.ErrVal
+	return lisette.Tuple2[int, []byte]{}, result_5.ErrVal
 }
 
 func count(input string, split bufio.SplitFunc) int {

--- a/tests/spec/emit/snapshots/map_from_non_literal_keys_keeps_prelude_call.snap
+++ b/tests/spec/emit/snapshots/map_from_non_literal_keys_keeps_prelude_call.snap
@@ -12,7 +12,7 @@ package main
 
 import lisette "github.com/ivov/lisette/prelude"
 
-const Key string = "a"
+const Key = "a"
 
 func test() map[string]int {
 	return lisette.MapFrom([]lisette.Tuple2[string, int]{

--- a/tests/spec/emit/snapshots/option_tuple_return_zero_is_a_composite_literal.snap
+++ b/tests/spec/emit/snapshots/option_tuple_return_zero_is_a_composite_literal.snap
@@ -1,0 +1,18 @@
+---
+source: tests/spec/emit/types.rs
+description: |
+  
+  fn pair(ok: bool) -> Option<(string, int)> {
+    if ok { Some(("a", 1)) } else { None }
+  }
+---
+package main
+
+import lisette "github.com/ivov/lisette/prelude"
+
+func pair(ok bool) (lisette.Tuple2[string, int], bool) {
+	if ok {
+		return lisette.MakeTuple2[string, int]("a", 1), true
+	}
+	return lisette.Tuple2[string, int]{}, false
+}

--- a/tests/spec/emit/snapshots/shift_by_imported_nonliteral_constant_not_pinned.snap
+++ b/tests/spec/emit/snapshots/shift_by_imported_nonliteral_constant_not_pinned.snap
@@ -13,5 +13,5 @@ package main
 import "example.com/consts"
 
 func main() {
-	_ = float64((1 << consts.SHIFT))
+	_ = float64(1 << consts.SHIFT)
 }

--- a/tests/spec/emit/snapshots/string_and_bool_constants_emit_untyped.snap
+++ b/tests/spec/emit/snapshots/string_and_bool_constants_emit_untyped.snap
@@ -1,0 +1,32 @@
+---
+source: tests/spec/emit/functions.rs
+description: |
+  
+  const NAME = "app"
+  const DEBUG = true
+  const LIMIT = 3
+  
+  fn label() -> string {
+    if DEBUG { NAME } else { "" }
+  }
+  
+  fn cap() -> int { LIMIT }
+---
+package main
+
+const Name = "app"
+
+const Debug = true
+
+const Limit int = 3
+
+func label() string {
+	if Debug {
+		return Name
+	}
+	return ""
+}
+
+func cap_() int {
+	return Limit
+}

--- a/tests/spec/emit/snapshots/struct_autofill_enum_struct_variant.snap
+++ b/tests/spec/emit/snapshots/struct_autofill_enum_struct_variant.snap
@@ -37,9 +37,7 @@ type Action struct {
 
 func test() Action {
 	return Action{
-		Tag:  ActionMove,
-		X:    5,
-		Y:    0,
-		Dist: 0,
+		Tag: ActionMove,
+		X:   5,
 	}
 }

--- a/tests/spec/emit/snapshots/struct_autofill_lisette_option_emits_none.snap
+++ b/tests/spec/emit/snapshots/struct_autofill_lisette_option_emits_none.snap
@@ -18,8 +18,5 @@ type Conf struct {
 }
 
 func test() Conf {
-	return Conf{
-		name: "x",
-		opt:  lisette.MakeOptionNone[int](),
-	}
+	return Conf{name: "x"}
 }

--- a/tests/spec/emit/snapshots/struct_autofill_lisette_primitives.snap
+++ b/tests/spec/emit/snapshots/struct_autofill_lisette_primitives.snap
@@ -17,9 +17,5 @@ type Conf struct {
 }
 
 func test() Conf {
-	return Conf{
-		name:  "x",
-		count: 0,
-		on:    false,
-	}
+	return Conf{name: "x"}
 }

--- a/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
+++ b/tests/spec/emit/snapshots/user_fn_option_tuple_return_call.snap
@@ -18,7 +18,7 @@ func maybePair(n int) (lisette.Tuple2[int, int], bool) {
 	if n > 0 {
 		return lisette.MakeTuple2[int, int](n, n+1), true
 	}
-	return *new(lisette.Tuple2[int, int]), false
+	return lisette.Tuple2[int, int]{}, false
 }
 
 func main() {

--- a/tests/spec/emit/snapshots/wrap_err_propagate_on_go_calls_uses_errorf.snap
+++ b/tests/spec/emit/snapshots/wrap_err_propagate_on_go_calls_uses_errorf.snap
@@ -28,7 +28,7 @@ import (
 	"os"
 )
 
-const File string = "nums.json"
+const File = "nums.json"
 
 func load() ([]int, error) {
 	bytes, err := os.ReadFile(File)

--- a/tests/spec/emit/types.rs
+++ b/tests/spec/emit/types.rs
@@ -2392,6 +2392,37 @@ fn make() -> Probe {
 }
 
 #[test]
+fn autofill_omits_zero_fields_and_keeps_maps() {
+    let input = r#"
+struct Counter {
+  label: string,
+  i: int,
+  rows: int,
+  ratio: float64,
+  done: bool,
+  parent: Option<int>,
+  tags: Slice<string>,
+  hits: Map<string, int>,
+}
+
+fn make() -> Counter {
+  Counter { label: "x", .. }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
+fn option_tuple_return_zero_is_a_composite_literal() {
+    let input = r#"
+fn pair(ok: bool) -> Option<(string, int)> {
+  if ok { Some(("a", 1)) } else { None }
+}
+"#;
+    assert_emit_snapshot!(input);
+}
+
+#[test]
 fn tuple_struct_multi_field_def() {
     let input = r#"
 struct Point(int, int)


### PR DESCRIPTION
A cast now emits _one_ pair of parentheses, e.g. `float64(a+b)` instead of `(float64((a + b)))`. A struct literal with `..` no longer fills fields with explicit zeros, and a zero value emits as `T{}` instead of `*new(T)` for tuples, structs, and enums.

```rs
fn test() -> float64 {
  let a: int = 3;
  let b: int = 4;
  let c: int = 2;
  ((a + b) as float64) / (c as float64)
}
```

Before:

```go
func test() float64 {
	a := 3
	b := 4
	c := 2
	return (float64((a + b))) / (float64(c))
}
```

After:

```go
func test() float64 {
	a := 3
	b := 4
	c := 2
	return float64(a+b) / float64(c) // one pair of parentheses per cast
}
```
