### PR TITLE
refactor: lower expression producers to `GoExpressionNode` trees

### DIFF
--- a/crates/emit/src/abi/coercion.rs
+++ b/crates/emit/src/abi/coercion.rs
@@ -7,7 +7,8 @@ use crate::Renderer;
 use crate::definitions::interface_adapter::AdapterPlan;
 use crate::names::go_name;
 use crate::plan::bodies::{LoopKind, LoopPlan, LoweredBlock, LoweredStatement};
-use crate::types::go_type::render_conversion;
+use crate::plan::go_expression::CompositeLayout;
+use crate::plan::values::GoExpression;
 
 use super::callable::AbiTransition;
 use super::layout::{FunctionLayout, ValueLayout};
@@ -129,28 +130,37 @@ impl CoercionPlan {
     pub(crate) fn lower(
         self,
         planner: &mut Planner<'_>,
-        value: String,
-    ) -> (Vec<LoweredStatement>, String) {
+        value: GoExpression,
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let mut statements = Vec::new();
         let value = match self {
             Self::Identity => value,
             Self::WrapAsInterface(plan) => {
                 let adapter_name = planner.ensure_adapter_type(plan);
-                format!("{}{{inner: {}}}", adapter_name, value)
+                let deferred = value.contains_deferred_evaluation();
+                GoExpression::composite(
+                    Some(adapter_name),
+                    vec![(Some("inner".to_string()), value)],
+                    CompositeLayout::Inline { padded: false },
+                    deferred,
+                )
             }
             Self::WrapNewtype { ty } => {
                 let type_name = planner.use_go_type(&ty);
-                render_conversion(&type_name, &value)
+                GoExpression::conversion(type_name, value)
             }
-            Self::Layout(bridge) => planner.plan_layout_bridge(&mut statements, &value, &bridge),
+            Self::Layout(bridge) => {
+                let bridged = planner.plan_layout_bridge(&mut statements, value.as_str(), &bridge);
+                GoExpression::opaque(bridged)
+            }
             Self::RebuildArray {
                 array_type,
                 element,
-            } => planner.plan_array_rebuild(&mut statements, &value, &array_type, *element),
+            } => planner.plan_array_rebuild(&mut statements, value.as_str(), &array_type, *element),
             Self::RebuildTuple {
                 slot_types,
                 elements,
-            } => planner.plan_tuple_rebuild(&mut statements, &value, &slot_types, elements),
+            } => planner.plan_tuple_rebuild(&mut statements, value.as_str(), &slot_types, elements),
         };
         (statements, value)
     }
@@ -162,8 +172,8 @@ impl Planner<'_> {
         output: &mut String,
         target_ty: Option<&Type>,
         expression: &Expression,
-        emitted: String,
-    ) -> String {
+        emitted: GoExpression,
+    ) -> GoExpression {
         let Some(target) = target_ty else {
             return emitted;
         };
@@ -179,7 +189,7 @@ impl Planner<'_> {
         value: &str,
         array_type: &Type,
         element: CoercionPlan,
-    ) -> String {
+    ) -> GoExpression {
         let source = self.stable_source(statements, "src", value);
         let go_type = self.use_go_type(array_type);
         let output = self.fresh_var(Some("boxed"));
@@ -192,7 +202,11 @@ impl Planner<'_> {
 
         let index = self.fresh_var(Some("i"));
         self.declare(&index);
-        let (mut body, coerced) = element.lower(self, format!("{source}[{index}]"));
+        let element_read = GoExpression::index(
+            GoExpression::name(source.clone()),
+            GoExpression::name(index.clone()),
+        );
+        let (mut body, coerced) = element.lower(self, element_read);
         body.push(LoweredStatement::RawGo(format!(
             "{output}[{index}] = {coerced}\n"
         )));
@@ -202,7 +216,7 @@ impl Planner<'_> {
             header: format!("for {index} := range {source} {{\n"),
             body: LoweredBlock { statements: body },
         }));
-        output
+        GoExpression::name(output)
     }
 
     fn plan_tuple_rebuild(
@@ -211,20 +225,21 @@ impl Planner<'_> {
         value: &str,
         slot_types: &[Type],
         elements: Vec<CoercionPlan>,
-    ) -> String {
+    ) -> GoExpression {
         let source = self.stable_source(statements, "tup", value);
 
         let mut arguments = Vec::with_capacity(elements.len());
         for (index, element) in elements.into_iter().enumerate() {
             let field = TUPLE_FIELDS.get(index).expect("oversize tuple arity");
-            let (element_setup, coerced) = element.lower(self, format!("{source}.{field}"));
+            let slot_read =
+                GoExpression::selector(GoExpression::name(source.clone()), field.to_string());
+            let (element_setup, coerced) = element.lower(self, slot_read);
             statements.extend(element_setup);
             arguments.push(coerced);
         }
-        format!(
-            "{}({})",
+        GoExpression::call(
             self.make_tuple_callee(slot_types, slot_types.len()),
-            arguments.join(", ")
+            arguments,
         )
     }
 }

--- a/crates/emit/src/abi/transition.rs
+++ b/crates/emit/src/abi/transition.rs
@@ -297,11 +297,14 @@ pub(crate) fn lowered_tuple_literal_values(
             _ => planner.lower_composite_value(e, ExpressionContext::value()),
         })
         .collect();
-    let (mut statements, parts) = planner
-        .sequence_values(stages, CaptureBoundary::SiblingSequence, "ret")
-        .into_rendered();
-    let parts = planner.coerce_elements_to_slots(&mut statements, elements, parts, &slot_tys);
-    (statements, parts)
+    let sequenced = planner.sequence_values(stages, CaptureBoundary::SiblingSequence, "ret");
+    let mut statements = sequenced.setup;
+    let parts =
+        planner.coerce_elements_to_slots(&mut statements, elements, sequenced.values, &slot_tys);
+    (
+        statements,
+        parts.iter().map(GoExpression::rendered).collect(),
+    )
 }
 
 impl Planner<'_> {
@@ -774,8 +777,9 @@ fn lower_nullable_slot_value(
     }
     let value = planner.lower_value(expression, ExpressionContext::value());
     let inner = planner.use_go_type(&slot_ty.ok_type());
-    value.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
-        let projected = planner.plan_option_projection(setup, &value, "unwrap", &inner, false);
-        GoExpression::opaque_with_deferred_evaluation(projected, true)
+    value.map_expression_as_computed(|setup, value| {
+        let projected =
+            planner.plan_option_projection(setup, value.as_str(), "unwrap", &inner, false);
+        GoExpression::name(projected).with_deferred_evaluation(true)
     })
 }

--- a/crates/emit/src/calls/clone.rs
+++ b/crates/emit/src/calls/clone.rs
@@ -3,11 +3,17 @@ use syntax::types::{CompoundKind, Type};
 
 use crate::Planner;
 use crate::names::go_name;
+use crate::plan::values::GoExpression;
 
 impl Planner<'_> {
     pub(crate) fn render_clone(&mut self, value: &str, ty: &Type) -> String {
+        self.clone_expression(GoExpression::opaque(value.to_string()), ty)
+            .rendered()
+    }
+
+    pub(crate) fn clone_expression(&mut self, value: GoExpression, ty: &Type) -> GoExpression {
         let peeled = self.facts.peel_alias(ty);
-        match &peeled {
+        let (function, closure) = match &peeled {
             Type::Compound {
                 kind: CompoundKind::Slice | CompoundKind::EnumeratedSlice,
                 args,
@@ -15,14 +21,14 @@ impl Planner<'_> {
             } => match args.first().and_then(|elem| self.element_clone(elem)) {
                 Some(clone) => {
                     self.require_stdlib();
-                    format!(
-                        "{}.SliceCloneFunc({value}, {clone})",
-                        go_name::GO_STDLIB_PKG
+                    (
+                        format!("{}.SliceCloneFunc", go_name::GO_STDLIB_PKG),
+                        Some(clone),
                     )
                 }
                 None => {
                     self.require_slices();
-                    format!("slices.Clone({value})")
+                    ("slices.Clone".to_string(), None)
                 }
             },
             Type::Compound {
@@ -32,15 +38,21 @@ impl Planner<'_> {
             } => match args.get(1).and_then(|v| self.element_clone(v)) {
                 Some(clone) => {
                     self.require_stdlib();
-                    format!("{}.MapCloneFunc({value}, {clone})", go_name::GO_STDLIB_PKG)
+                    (
+                        format!("{}.MapCloneFunc", go_name::GO_STDLIB_PKG),
+                        Some(clone),
+                    )
                 }
                 None => {
                     self.require_stdlib();
-                    format!("{}.MapClone({value})", go_name::GO_STDLIB_PKG)
+                    (format!("{}.MapClone", go_name::GO_STDLIB_PKG), None)
                 }
             },
-            _ => value.to_string(),
-        }
+            _ => return value,
+        };
+        let mut arguments = vec![value];
+        arguments.extend(closure.map(GoExpression::opaque));
+        GoExpression::call(GoExpression::name(function), arguments)
     }
 
     fn element_clone(&mut self, ty: &Type) -> Option<String> {

--- a/crates/emit/src/calls/comma_ok.rs
+++ b/crates/emit/src/calls/comma_ok.rs
@@ -6,6 +6,7 @@ use crate::context::expression::ExpressionContext;
 use crate::escape_reserved;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::CallableOrigin;
+use crate::plan::values::GoExpression;
 use crate::state::scope::PairStatusKind;
 use crate::types::native::NativeGoType;
 use std::borrow::Cow;
@@ -400,6 +401,15 @@ impl Planner<'_> {
 pub(super) fn parenthesize_prefixed(operand: String) -> String {
     if operand.starts_with('*') || operand.starts_with('&') {
         format!("({operand})")
+    } else {
+        operand
+    }
+}
+
+/// `*x` and `&x` bind looser than a postfix `[k]` or `.(T)`.
+pub(super) fn parenthesize_prefixed_expression(operand: GoExpression) -> GoExpression {
+    if operand.as_str().starts_with('*') || operand.as_str().starts_with('&') {
+        GoExpression::parenthesized(operand)
     } else {
         operand
     }

--- a/crates/emit/src/calls/dispatch.rs
+++ b/crates/emit/src/calls/dispatch.rs
@@ -1,5 +1,4 @@
 use crate::expressions::access::struct_call::emit_struct_literal;
-use crate::expressions::literals::elide_element_type;
 use crate::names::generics::extract_type_mapping;
 use rustc_hash::FxHashMap as HashMap;
 use std::borrow::Cow;
@@ -13,6 +12,7 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, CallableOrigin};
+use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, Stability, ValuePlan};
 use crate::types::go_type::render_conversion;
 use crate::types::native::NativeGoType;
@@ -144,15 +144,17 @@ impl<'a> Planner<'a> {
     fn stage_size_argument(
         &mut self,
         ctx: &NativeCallContext,
-    ) -> (Vec<LoweredStatement>, String, EvaluationEffect) {
+    ) -> (Vec<LoweredStatement>, GoExpression, EvaluationEffect) {
         match ctx.args.first() {
             Some(a) => {
                 let staged = self.plan_operand(a, ExpressionContext::value());
-                let effect = staged.evaluation.effect;
-                let (setup, value) = staged.into_parts();
-                (setup, value, effect)
+                (staged.setup, staged.expression, staged.evaluation.effect)
             }
-            None => (Vec::new(), "0".to_string(), EvaluationEffect::Pure),
+            None => (
+                Vec::new(),
+                GoExpression::literal("0".to_string()),
+                EvaluationEffect::Pure,
+            ),
         }
     }
 
@@ -165,7 +167,7 @@ impl<'a> Planner<'a> {
                     Vec::new(),
                     GoExpression::call(
                         GoExpression::name("make".to_string()),
-                        vec![GoExpression::opaque(format!("chan {}", element))],
+                        vec![GoExpression::type_name(format!("chan {}", element))],
                     ),
                     self.native_constructor_effect(ctx, EvaluationEffect::Pure),
                 ))
@@ -179,8 +181,8 @@ impl<'a> Planner<'a> {
                     GoExpression::call(
                         GoExpression::name("make".to_string()),
                         vec![
-                            GoExpression::opaque(format!("chan {}", element)),
-                            GoExpression::opaque(capacity),
+                            GoExpression::type_name(format!("chan {}", element)),
+                            capacity,
                         ],
                     ),
                     self.native_constructor_effect(ctx, argument_effect),
@@ -193,7 +195,7 @@ impl<'a> Planner<'a> {
                     Vec::new(),
                     GoExpression::call(
                         GoExpression::name("make".to_string()),
-                        vec![GoExpression::opaque(format!("map[{}]{}", key, val))],
+                        vec![GoExpression::type_name(format!("map[{}]{}", key, val))],
                     ),
                     self.native_constructor_effect(ctx, EvaluationEffect::Pure),
                 ))
@@ -204,7 +206,7 @@ impl<'a> Planner<'a> {
                     self.resolve_element_type(ctx.function, ctx.resolved_type_args, ctx.call_ty);
                 Some(ValuePlan::computed(
                     Vec::new(),
-                    GoExpression::composite_literal(format!("[]{}{{}}", element), false),
+                    GoExpression::empty_composite(format!("[]{}", element)),
                     self.native_constructor_effect(ctx, EvaluationEffect::Pure),
                 ))
             }
@@ -219,10 +221,7 @@ impl<'a> Planner<'a> {
                 let value = if self.element_go_zero_ok(&element_ty) {
                     GoExpression::call(
                         GoExpression::name("make".to_string()),
-                        vec![
-                            GoExpression::opaque(format!("[]{}", element)),
-                            GoExpression::opaque(length),
-                        ],
+                        vec![GoExpression::type_name(format!("[]{}", element)), length],
                     )
                 } else {
                     let zero = self.lisette_zero(&element_ty);
@@ -328,7 +327,7 @@ impl<'a> Planner<'a> {
         if pairs.is_empty() {
             return Some(ValuePlan::computed(
                 Vec::new(),
-                GoExpression::composite_literal(format!("{map_ty}{{}}"), false),
+                GoExpression::empty_composite(map_ty),
                 self.native_constructor_effect(ctx, EvaluationEffect::Pure),
             ));
         }
@@ -342,45 +341,35 @@ impl<'a> Planner<'a> {
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
-        let values = sequenced.values;
+        let mut values = sequenced.values.into_iter();
 
         let mut lowered = Vec::with_capacity(pairs.len());
         let mut widest = 0;
-        for ((key, value), staged) in pairs.iter().zip(values.chunks_exact(2)) {
-            let [staged_key, staged_value] = staged else {
-                unreachable!("each pair stages exactly two values")
-            };
-            let (key_setup, coerced_key) = CoercionPlan::internal(self, &key.get_type(), &key_ty)
-                .lower(self, staged_key.rendered());
+        for (key, value) in &pairs {
+            let staged_key = values.next().expect("each pair stages a key");
+            let staged_value = values.next().expect("each pair stages a value");
+            let (key_setup, coerced_key) =
+                CoercionPlan::internal(self, &key.get_type(), &key_ty).lower(self, staged_key);
             setup.extend(key_setup);
             let value_coercion = CoercionPlan::internal(self, &value.get_type(), &value_ty);
             let is_whole_literal =
                 value_coercion.is_identity() && staged_value.is_composite_literal();
-            let (value_setup, coerced_value) = value_coercion.lower(self, staged_value.rendered());
+            let (value_setup, coerced_value) = value_coercion.lower(self, staged_value);
             setup.extend(value_setup);
-            widest = widest.max(coerced_key.len() + coerced_value.len() + ": ".len());
+            widest =
+                widest.max(coerced_key.as_str().len() + coerced_value.as_str().len() + ": ".len());
             let coerced_value = if is_whole_literal {
-                elide_element_type(&value_go_ty, coerced_value)
+                coerced_value.elide_composite_type(&value_go_ty)
             } else {
                 coerced_value
             };
-            lowered.push(format!("{coerced_key}: {coerced_value}"));
+            lowered.push((Some(coerced_key.rendered()), coerced_value));
         }
 
-        let value = if lowered.len() > 1 && widest > 30 {
-            let indented = lowered
-                .iter()
-                .map(|entry| format!("\t{}", entry))
-                .collect::<Vec<_>>()
-                .join(",\n");
-            format!("{map_ty}{{\n{indented},\n}}")
-        } else {
-            format!("{map_ty}{{ {} }}", lowered.join(", "))
-        };
-
+        let layout = CompositeLayout::for_elements(lowered.len(), widest);
         Some(ValuePlan::computed(
             setup,
-            GoExpression::composite_literal(value, contains_deferred_evaluation),
+            GoExpression::composite(Some(map_ty), lowered, layout, contains_deferred_evaluation),
             self.native_constructor_effect(ctx, effect),
         ))
     }
@@ -405,7 +394,7 @@ impl<'a> Planner<'a> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         call_expression: &Expression,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let Expression::Call {
             expression: callee,
             args,
@@ -498,11 +487,7 @@ impl<'a> Planner<'a> {
             }
             CallableOrigin::AssertType => {
                 let (setup, value) = self.lower_assert_type(function, args, resolved_type_args);
-                return ValuePlan::plain_call(
-                    setup,
-                    GoExpression::opaque_with_deferred_evaluation(value, true),
-                    EvaluationEffect::EffectfulCall,
-                );
+                return ValuePlan::plain_call(setup, value, EvaluationEffect::EffectfulCall);
             }
             CallableOrigin::UfcsMethod => {
                 return self.lower_ufcs_call(function, args, resolved_type_args, spread, &plan);
@@ -572,9 +557,9 @@ impl<'a> Planner<'a> {
         if result
             .setup
             .iter()
-            .any(|statement| statement.binds_name(&result.value))
+            .any(|statement| statement.binds_name(result.value.as_str()))
         {
-            return ValuePlan::captured_with_effect(result.setup, result.value, effect);
+            return ValuePlan::captured_with_effect(result.setup, result.value.rendered(), effect);
         }
         let receiver_arity = if matches!(origin, CallableOrigin::NativeMethodIdentifier(_)) {
             ctx.args.len().saturating_sub(1)
@@ -586,29 +571,22 @@ impl<'a> Planner<'a> {
         let mut plan = if plain_call {
             ValuePlan::plain_call(
                 result.setup,
-                GoExpression::opaque_with_deferred_evaluation(result.value, true),
+                result.value.with_deferred_evaluation(true),
                 effect,
             )
         } else {
             let contains_deferred_evaluation = match ctx.method {
-                "enumerate" => result.arguments_contain_deferred_evaluation,
+                "byte_at" | "enumerate" => result.arguments_contain_deferred_evaluation,
                 "append" if receiver_arity == 0 => result.arguments_contain_deferred_evaluation,
                 _ => true,
             };
-            let expression = if ctx.method == "byte_at" {
-                GoExpression::opaque_with_deferred_evaluation(
-                    result.value,
-                    result.arguments_contain_deferred_evaluation,
-                )
-            } else if ctx.method == "is_empty" {
-                GoExpression::opaque_with_deferred_evaluation(result.value, true)
-            } else {
-                GoExpression::opaque_with_deferred_evaluation(
-                    result.value,
-                    contains_deferred_evaluation,
-                )
-            };
-            ValuePlan::computed(result.setup, expression, effect)
+            ValuePlan::computed(
+                result.setup,
+                result
+                    .value
+                    .with_deferred_evaluation(contains_deferred_evaluation),
+                effect,
+            )
         };
         if reads_fixed_length {
             plan.evaluation.stability = Stability::Fixed;
@@ -680,14 +658,14 @@ impl<'a> Planner<'a> {
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "arg");
         let effect = EvaluationEffect::PureCall.combine(sequenced.effect);
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (mut setup, values) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
 
-        let mut field_pairs: Vec<(String, String)> = Vec::with_capacity(target.field_tys.len());
+        let mut field_pairs = Vec::with_capacity(target.field_tys.len());
         for (i, ((field_ty, arg), value)) in target
             .field_tys
             .iter()
             .zip(args.iter())
-            .zip(values)
+            .zip(sequenced.values)
             .enumerate()
         {
             let value_ty = arg.get_type();
@@ -699,8 +677,10 @@ impl<'a> Planner<'a> {
 
         Some(ValuePlan::computed(
             setup,
-            GoExpression::composite_literal(
-                emit_struct_literal(&target.go_ty, &field_pairs, ctx),
+            emit_struct_literal(
+                &target.go_ty,
+                field_pairs,
+                ctx,
                 contains_deferred_evaluation,
             ),
             effect,
@@ -761,7 +741,7 @@ impl<'a> Planner<'a> {
         function: &Expression,
         args: &[Expression],
         type_args: ResolvedCallTypeArguments<'_>,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let target_ty = if !type_args.is_empty() {
             self.use_go_type(&type_args[0])
         } else {
@@ -769,20 +749,22 @@ impl<'a> Planner<'a> {
                 .expect("AssertType must have constructor return type");
             self.use_go_type(&param)
         };
-        let (setup, arg_expression) = match args.first() {
-            Some(a) => self
-                .lower_composite_value(a, ExpressionContext::value())
-                .into_parts(),
-            None => (Vec::new(), String::new()),
+        let (setup, arguments) = match args.first() {
+            Some(a) => {
+                let staged = self.lower_composite_value(a, ExpressionContext::value());
+                (staged.setup, vec![staged.expression])
+            }
+            None => (Vec::new(), Vec::new()),
         };
         self.require_stdlib();
         (
             setup,
-            format!(
-                "{}.AssertType[{}]({})",
-                go_name::GO_STDLIB_PKG,
-                target_ty,
-                arg_expression
+            GoExpression::call(
+                GoExpression::instantiation(
+                    GoExpression::name(format!("{}.AssertType", go_name::GO_STDLIB_PKG)),
+                    format!("[{target_ty}]"),
+                ),
+                arguments,
             ),
         )
     }

--- a/crates/emit/src/calls/go_interop/mod.rs
+++ b/crates/emit/src/calls/go_interop/mod.rs
@@ -24,12 +24,12 @@ impl Planner<'_> {
     ) -> ValuePlan {
         if let Some(bridges) = self.go_tuple_result_bridges(abi, result_ty) {
             let call = self.lower_call(call_expression, None, ExpressionContext::value());
-            return call.map_rendered_as_observable_computed(|setup, call_string, _| {
+            return call.map_expression_as_observable_computed(|setup, call| {
                 let values = self.create_temp_vars("ret", bridges.len());
                 setup.push(LoweredStatement::RawGo(format!(
                     "{} := {}\n",
                     values.join(", "),
-                    call_string
+                    call
                 )));
                 let values = values
                     .into_iter()
@@ -37,41 +37,37 @@ impl Planner<'_> {
                     .map(|(value, bridge)| self.plan_layout_bridge(setup, &value, bridge))
                     .collect::<Vec<_>>();
                 let tuple = self.plan_tuple_from_vars(setup, &values, result_ty);
-                GoExpression::opaque(tuple)
+                GoExpression::name(tuple)
             });
         }
 
         if let Some(bridge) = self.go_result_layout_bridge(abi, result_ty) {
             let call = self.lower_call(call_expression, None, ExpressionContext::value());
-            return call.map_rendered_as_observable_computed(
-                |setup, call_string, _contains_deferred_evaluation| {
-                    let (bridge_setup, value) = bridge.lower(self, call_string);
-                    setup.extend(bridge_setup);
-                    GoExpression::opaque(value)
-                },
-            );
+            return call.map_expression_as_observable_computed(|setup, call| {
+                let (bridge_setup, value) = bridge.lower(self, call);
+                setup.extend(bridge_setup);
+                value.with_deferred_evaluation(false)
+            });
         }
 
         let payload_bridge = self.go_return_payload_bridge(abi, result_ty);
         let call_plan = self.lower_call(call_expression, None, ExpressionContext::value());
-        call_plan.map_rendered_as_observable_computed(
-            |setup, call_string, _contains_deferred_evaluation| {
-                let (wrap, value) = if payload_bridge.is_some() {
-                    let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
-                        &call_string,
-                        &abi.result,
-                        result_ty,
-                        payload_bridge.as_ref(),
-                        WrapperTarget::FreshSlot,
-                    );
-                    (wrap, outcome.expect("wrapper produced no slot"))
-                } else {
-                    self.lower_abi_to_tagged(&call_string, &abi.result, result_ty)
-                };
-                setup.extend(wrap);
-                GoExpression::opaque(value)
-            },
-        )
+        call_plan.map_expression_as_observable_computed(|setup, call| {
+            let (wrap, value) = if payload_bridge.is_some() {
+                let (wrap, outcome) = self.lower_abi_wrapping_with_payload_bridge(
+                    call.as_str(),
+                    &abi.result,
+                    result_ty,
+                    payload_bridge.as_ref(),
+                    WrapperTarget::FreshSlot,
+                );
+                (wrap, outcome.expect("wrapper produced no slot"))
+            } else {
+                self.lower_abi_to_tagged(call.as_str(), &abi.result, result_ty)
+            };
+            setup.extend(wrap);
+            GoExpression::name(value)
+        })
     }
 
     pub(crate) fn go_result_layout_bridge(

--- a/crates/emit/src/calls/go_interop/nullable.rs
+++ b/crates/emit/src/calls/go_interop/nullable.rs
@@ -52,30 +52,28 @@ impl Planner<'_> {
             return None;
         }
         let inner = self.lower_composite_value(inner, ExpressionContext::value());
-        Some(
-            inner.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
-                let value = self.plan_layout_bridge(setup, &value, payload);
-                let Some(pointee) = pointee else {
-                    return GoExpression::opaque_with_deferred_evaluation(
-                        value,
-                        contains_deferred_evaluation,
-                    );
-                };
-                let go_type = pointee.go_type(self);
-                let go_type = self.use_rendered_go_type(go_type);
-                let copy = self.fresh_var(Some("ptr"));
-                self.declare(&copy);
-                setup.push(LoweredStatement::VarDecl {
-                    name: copy.clone(),
-                    go_type,
-                    value: Some(value),
-                });
-                GoExpression::opaque_with_deferred_evaluation(
-                    format!("&{copy}"),
-                    contains_deferred_evaluation,
-                )
-            }),
-        )
+        Some(inner.map_expression_as_computed(|setup, value| {
+            let contains_deferred_evaluation = value.contains_deferred_evaluation();
+            let value = if payload.is_identity() {
+                value
+            } else {
+                GoExpression::opaque(self.plan_layout_bridge(setup, value.as_str(), payload))
+            };
+            let Some(pointee) = pointee else {
+                return value.with_deferred_evaluation(contains_deferred_evaluation);
+            };
+            let go_type = pointee.go_type(self);
+            let go_type = self.use_rendered_go_type(go_type);
+            let copy = self.fresh_var(Some("ptr"));
+            self.declare(&copy);
+            setup.push(LoweredStatement::VarDecl {
+                name: copy.clone(),
+                go_type,
+                value: Some(value.rendered()),
+            });
+            GoExpression::address_of(GoExpression::name(copy))
+                .with_deferred_evaluation(contains_deferred_evaluation)
+        }))
     }
 
     /// Wrap a sentinel-call via `OptionFromCommaOk` with `raw != sentinel`.

--- a/crates/emit/src/calls/native.rs
+++ b/crates/emit/src/calls/native.rs
@@ -9,14 +9,13 @@ use crate::plan::calls::plan_variadic_spread;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::statements::assignments::lvalues_match;
 use crate::types::native::NativeGoType;
-use std::iter;
 use syntax::ast::{Expression, Generic, Literal, UnaryOperator};
 use syntax::program::{CallKind, DotAccessKind, NativeTypeKind};
 use syntax::types::{CompoundKind, Type, peel_to_range_type};
 
 pub(super) struct NativeCallResult {
     pub setup: Vec<LoweredStatement>,
-    pub value: String,
+    pub value: GoExpression,
     pub argument_effect: EvaluationEffect,
     pub arguments_contain_deferred_evaluation: bool,
 }
@@ -24,7 +23,7 @@ pub(super) struct NativeCallResult {
 impl NativeCallResult {
     pub(super) fn new(
         setup: Vec<LoweredStatement>,
-        value: String,
+        value: GoExpression,
         argument_effect: EvaluationEffect,
         arguments_contain_deferred_evaluation: bool,
     ) -> Self {
@@ -45,15 +44,26 @@ pub(super) enum InlineImport {
     Stdlib,
 }
 
+/// The Go shape a native method inlines to, given the receiver and arguments.
+#[derive(Clone, Copy)]
+enum InlineForm {
+    /// `callee(receiver, arguments...)`.
+    Call(&'static str),
+    /// `len(receiver) == 0`. The negated method flips the operator instead of
+    /// prepending `!`, which binds tighter than `==` in Go.
+    IsEmpty,
+    Receiver,
+    /// `T(receiver)`.
+    Conversion(&'static str),
+    /// `receiver[argument]`.
+    Index,
+}
+
 struct InlineRule {
     types: &'static [NativeGoType],
     method: &'static str,
     arity: RuleArity,
-    template: &'static str,
-    /// Direct Go form of the negated method. Set when the positive template
-    /// emits a comparison, so `!method(...)` can flip the operator instead
-    /// of prepending `!` (Go's `!` binds tighter than `==`).
-    negated_template: Option<&'static str>,
+    form: InlineForm,
     import: InlineImport,
 }
 
@@ -94,16 +104,14 @@ static INLINE_METHODS: &[InlineRule] = &[
         ],
         method: "length",
         arity: RuleArity::Exact(0),
-        template: "len({r})",
-        negated_template: None,
+        form: InlineForm::Call("len"),
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::Slice, N::Channel, N::Sender, N::Receiver],
         method: "capacity",
         arity: RuleArity::Exact(0),
-        template: "cap({r})",
-        negated_template: None,
+        form: InlineForm::Call("cap"),
         import: InlineImport::None,
     },
     InlineRule {
@@ -117,32 +125,28 @@ static INLINE_METHODS: &[InlineRule] = &[
         ],
         method: "is_empty",
         arity: RuleArity::Exact(0),
-        template: "len({r}) == 0",
-        negated_template: Some("len({r}) != 0"),
+        form: InlineForm::IsEmpty,
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "enumerate",
         arity: RuleArity::Exact(0),
-        template: "{r}",
-        negated_template: None,
+        form: InlineForm::Receiver,
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::String],
         method: "bytes",
         arity: RuleArity::Exact(0),
-        template: "[]byte({r})",
-        negated_template: None,
+        form: InlineForm::Conversion("[]byte"),
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::String],
         method: "runes",
         arity: RuleArity::Exact(0),
-        template: "[]rune({r})",
-        negated_template: None,
+        form: InlineForm::Conversion("[]rune"),
         import: InlineImport::None,
     },
     // Single-arg methods
@@ -150,96 +154,84 @@ static INLINE_METHODS: &[InlineRule] = &[
         types: &[N::Map],
         method: "delete",
         arity: RuleArity::Exact(1),
-        template: "delete({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("delete"),
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "copy_from",
         arity: RuleArity::Exact(1),
-        template: "copy({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("copy"),
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::Slice],
         method: "contains",
         arity: RuleArity::Exact(1),
-        template: "slices.Contains({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("slices.Contains"),
         import: InlineImport::Slices,
     },
     InlineRule {
         types: &[N::String],
         method: "contains",
         arity: RuleArity::Exact(1),
-        template: "strings.Contains({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("strings.Contains"),
         import: InlineImport::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "split",
         arity: RuleArity::Exact(1),
-        template: "strings.Split({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("strings.Split"),
         import: InlineImport::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "starts_with",
         arity: RuleArity::Exact(1),
-        template: "strings.HasPrefix({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("strings.HasPrefix"),
         import: InlineImport::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "ends_with",
         arity: RuleArity::Exact(1),
-        template: "strings.HasSuffix({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("strings.HasSuffix"),
         import: InlineImport::Strings,
     },
     InlineRule {
         types: &[N::String],
         method: "byte_at",
         arity: RuleArity::Exact(1),
-        template: "{r}[{0}]",
-        negated_template: None,
+        form: InlineForm::Index,
         import: InlineImport::None,
     },
     InlineRule {
         types: &[N::String],
         method: "rune_at",
         arity: RuleArity::Exact(1),
-        template: "lisette.RuneAt({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("lisette.RuneAt"),
         import: InlineImport::Stdlib,
     },
     InlineRule {
         types: &[N::Slice],
         method: "join",
         arity: RuleArity::Exact(1),
-        template: "strings.Join({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("strings.Join"),
         import: InlineImport::Strings,
     },
     InlineRule {
         types: &[N::Slice],
         method: "any",
         arity: RuleArity::Exact(1),
-        template: "slices.ContainsFunc({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("slices.ContainsFunc"),
         import: InlineImport::Slices,
     },
     InlineRule {
         types: &[N::Slice],
         method: "reserve",
         arity: RuleArity::Exact(1),
-        template: "slices.Grow({r}, {0})",
-        negated_template: None,
+        form: InlineForm::Call("slices.Grow"),
         import: InlineImport::Slices,
     },
     // Variadic methods
@@ -247,14 +239,18 @@ static INLINE_METHODS: &[InlineRule] = &[
         types: &[N::Slice],
         method: "append",
         arity: RuleArity::Variadic,
-        template: "append({r+args})",
-        negated_template: None,
+        form: InlineForm::Call("append"),
         import: InlineImport::None,
     },
 ];
 
-pub(crate) fn clip_shared_capacity(receiver: &str) -> String {
-    format!("{r}[:len({r}):len({r})]", r = receiver)
+/// `receiver[:len(receiver):len(receiver)]`, so a later `append` cannot write through an alias.
+pub(crate) fn clip_shared_capacity(receiver: GoExpression) -> GoExpression {
+    let length = GoExpression::call(
+        GoExpression::name("len".to_string()),
+        vec![receiver.clone()],
+    );
+    GoExpression::slice(receiver, None, Some(&length), Some(&length))
 }
 
 fn grows_into_capacity(method: &str, appends_anything: bool) -> bool {
@@ -372,27 +368,48 @@ fn is_selector_chain(rendered: &str) -> bool {
     rendered.split('.').all(go_name::is_plain_identifier)
 }
 
-fn render_inline(template: &str, receiver: &str, args: &[String]) -> String {
-    let receiver = if template.contains("{r}[") && !is_selector_chain(receiver) {
-        format!("({receiver})")
-    } else {
-        receiver.to_string()
-    };
-    let mut result = template.replace("{r}", &receiver);
-    for (i, arg) in args.iter().enumerate() {
-        result = result.replace(&format!("{{{}}}", i), arg);
+fn build_inline(
+    form: InlineForm,
+    receiver: &GoExpression,
+    arguments: &[GoExpression],
+    negated: bool,
+) -> GoExpression {
+    match form {
+        InlineForm::Call(callee) => {
+            let mut all = vec![receiver.clone()];
+            all.extend(arguments.iter().cloned());
+            GoExpression::call(GoExpression::name(callee.to_string()), all)
+        }
+        InlineForm::IsEmpty => {
+            let operator = if negated { "!=" } else { "==" };
+            GoExpression::binary(
+                GoExpression::call(
+                    GoExpression::name("len".to_string()),
+                    vec![receiver.clone()],
+                ),
+                operator,
+                GoExpression::literal("0".to_string()),
+            )
+        }
+        InlineForm::Receiver => receiver.clone(),
+        // A slice type needs no parentheses as a callee, unlike `Conversion`'s general form.
+        InlineForm::Conversion(go_type) => GoExpression::call(
+            GoExpression::type_name(go_type.to_string()),
+            vec![receiver.clone()],
+        ),
+        InlineForm::Index => {
+            let base = if is_selector_chain(receiver.as_str()) {
+                receiver.clone()
+            } else {
+                GoExpression::parenthesized(receiver.clone())
+            };
+            let index = arguments
+                .first()
+                .expect("an index rule takes one argument")
+                .clone();
+            GoExpression::index(base, index)
+        }
     }
-    if result.contains("{args}") {
-        result = result.replace("{args}", &args.join(", "));
-    }
-    if result.contains("{r+args}") {
-        let all = iter::once(receiver)
-            .chain(args.iter().cloned())
-            .collect::<Vec<_>>()
-            .join(", ");
-        result = result.replace("{r+args}", &all);
-    }
-    result
 }
 
 fn lookup_inline_rule(
@@ -405,27 +422,28 @@ fn lookup_inline_rule(
         .find(|rule| rule.matches(*native_type, method, arity))
 }
 
-/// Try to inline a native-type method call. `negated` picks the rule's
-/// `negated_template` (returning `None` when the rule lacks one).
+/// Try to inline a native-type method call. `negated` asks for the rule's
+/// negated form (`None` when the rule has none).
 pub(super) fn try_inline_native_method(
     native_type: &NativeGoType,
     method: &str,
-    receiver: &str,
-    args: &[String],
+    receiver: &GoExpression,
+    arguments: &[GoExpression],
     negated: bool,
-) -> Option<(String, InlineImport)> {
+) -> Option<(GoExpression, InlineImport)> {
     // Go's `append` requires at least 2 args, so zero-arg `append` returns
     // the receiver unchanged.
-    if !negated && method == "append" && args.is_empty() {
-        return Some((receiver.to_string(), InlineImport::None));
+    if !negated && method == "append" && arguments.is_empty() {
+        return Some((receiver.clone(), InlineImport::None));
     }
-    let rule = lookup_inline_rule(native_type, method, args.len())?;
-    let template = if negated {
-        rule.negated_template?
-    } else {
-        rule.template
-    };
-    Some((render_inline(template, receiver, args), rule.import))
+    let rule = lookup_inline_rule(native_type, method, arguments.len())?;
+    if negated && !matches!(rule.form, InlineForm::IsEmpty) {
+        return None;
+    }
+    Some((
+        build_inline(rule.form, receiver, arguments, negated),
+        rule.import,
+    ))
 }
 
 fn is_native_array_method(method: &str) -> bool {
@@ -499,11 +517,10 @@ pub(super) fn native_method_lowers_to_plain_call(
     )
 }
 
-/// Whether a rule for `(type, method, arity)` defines a negated template.
+/// Whether a rule for `(type, method, arity)` has a negated form.
 fn has_inline_negation(native_type: &NativeGoType, method: &str, arity: usize) -> bool {
     lookup_inline_rule(native_type, method, arity)
-        .and_then(|r| r.negated_template)
-        .is_some()
+        .is_some_and(|rule| matches!(rule.form, InlineForm::IsEmpty))
 }
 
 /// Resolve the inline rule for a dot-access form, applying the static-receiver
@@ -512,10 +529,10 @@ fn apply_inline_lookup(
     planner: &mut Planner,
     native_type: &NativeGoType,
     method: &str,
-    receiver: &str,
-    emitted_args: &[String],
+    receiver: &GoExpression,
+    emitted_args: &[GoExpression],
     negated: bool,
-) -> Option<String> {
+) -> Option<GoExpression> {
     if let Some((inlined, import)) =
         try_inline_native_method(native_type, method, receiver, emitted_args, negated)
     {
@@ -540,14 +557,14 @@ enum NativeMethodForm {
 
 struct StagedNativeMethod {
     setup: Vec<LoweredStatement>,
-    receiver: String,
-    arguments: Vec<String>,
+    receiver: GoExpression,
+    arguments: Vec<GoExpression>,
     effect: EvaluationEffect,
     contains_deferred_evaluation: bool,
 }
 
 impl StagedNativeMethod {
-    fn finish(self, value: String) -> NativeCallResult {
+    fn finish(self, value: GoExpression) -> NativeCallResult {
         NativeCallResult::new(
             self.setup,
             value,
@@ -589,8 +606,13 @@ impl Planner<'_> {
             let receiver_ty = self.facts.strip_and_peel(&receiver_expression.get_type());
             if receiver_ty.is_slice() || receiver_ty.is_map() {
                 let staged = self.stage_native_method(ctx, form);
-                let body =
-                    self.render_equality(&staged.receiver, &staged.arguments[0], &receiver_ty, &[]);
+                let body = self.equality_test(
+                    staged.receiver.clone(),
+                    staged.arguments[0].clone(),
+                    &receiver_ty,
+                    &[],
+                    false,
+                );
                 return staged.finish(body);
             }
         }
@@ -603,10 +625,13 @@ impl Planner<'_> {
             {
                 let mut staged = self.stage_native_method(ctx, form);
                 self.require_slices();
-                let searched = staged.arguments[0].clone();
+                let searched = staged.arguments[0].as_str().to_string();
                 let target = self.hoist_tmp_value_statement(&mut staged.setup, "want", &searched);
                 let predicate = self.contains_predicate(&element, &target, &[]);
-                let body = format!("slices.ContainsFunc({}, {predicate})", staged.receiver);
+                let body = GoExpression::call(
+                    GoExpression::name("slices.ContainsFunc".to_string()),
+                    vec![staged.receiver.clone(), GoExpression::opaque(predicate)],
+                );
                 return staged.finish(body);
             }
         }
@@ -619,7 +644,7 @@ impl Planner<'_> {
             )
         {
             let mut staged = self.stage_native_method(ctx, form);
-            let index = staged.arguments.first();
+            let index = staged.arguments.first().cloned();
             let body = self.lower_array_method_body(
                 ctx.method,
                 receiver_expression,
@@ -641,14 +666,14 @@ impl Planner<'_> {
             let receiver_ty = self.facts.strip_and_peel(&receiver_expression.get_type());
             if is_cloneable_container(&receiver_ty) {
                 let staged = self.stage_native_method(ctx, form);
-                let body = self.render_clone(&staged.receiver, &receiver_ty);
+                let body = self.clone_expression(staged.receiver.clone(), &receiver_ty);
                 return staged.finish(body);
             }
         }
 
         let mut staged = self.stage_native_method(ctx, form);
         if growth_clip_applies(ctx, receiver_expression) {
-            staged.receiver = clip_shared_capacity(&staged.receiver);
+            staged.receiver = clip_shared_capacity(staged.receiver);
         }
 
         let inlined = match form {
@@ -676,8 +701,6 @@ impl Planner<'_> {
             return staged.finish(inlined);
         }
 
-        let mut emitted_args = vec![staged.receiver.clone()];
-        emitted_args.extend(staged.arguments.iter().cloned());
         self.require_stdlib();
         let fn_name = format!(
             "{}.{}{}",
@@ -698,30 +721,35 @@ impl Planner<'_> {
                 self.format_resolved_type_args(ctx.resolved_type_args)
             }
         };
-        staged.finish(format!("{fn_name}{type_args}({})", emitted_args.join(", ")))
+        let mut emitted_args = vec![staged.receiver.clone()];
+        emitted_args.extend(staged.arguments.iter().cloned());
+        staged.finish(GoExpression::call(
+            GoExpression::instantiation(GoExpression::name(fn_name), type_args),
+            emitted_args,
+        ))
     }
 
     fn lower_array_method_body(
         &mut self,
         method: &str,
         receiver_expr: &Expression,
-        receiver: String,
-        index: Option<&String>,
+        receiver: GoExpression,
+        index: Option<GoExpression>,
         setup: &mut Vec<LoweredStatement>,
-    ) -> String {
+    ) -> GoExpression {
         match method {
             "to_slice" => {
                 self.require_slices();
                 let view = self.sliceable_receiver(receiver_expr, receiver, setup);
-                format!("slices.Clone({view})")
+                GoExpression::call(GoExpression::name("slices.Clone".to_string()), vec![view])
             }
             "get" => {
                 self.require_stdlib();
                 let view = self.sliceable_receiver(receiver_expr, receiver, setup);
                 let pkg = go_name::GO_STDLIB_PKG;
-                format!(
-                    "{pkg}.SliceGet({view}, {})",
-                    index.expect("get needs an index")
+                GoExpression::call(
+                    GoExpression::name(format!("{pkg}.SliceGet")),
+                    vec![view, index.expect("get needs an index")],
                 )
             }
             other => unreachable!("not a native array method: {other}"),
@@ -731,19 +759,19 @@ impl Planner<'_> {
     fn sliceable_receiver(
         &mut self,
         expression: &Expression,
-        receiver: String,
+        receiver: GoExpression,
         setup: &mut Vec<LoweredStatement>,
-    ) -> String {
+    ) -> GoExpression {
         let base = if self.receiver_is_addressable(expression) {
-            if receiver.starts_with('*') {
-                format!("({receiver})")
+            if receiver.as_str().starts_with('*') {
+                GoExpression::parenthesized(receiver)
             } else {
                 receiver
             }
         } else {
-            self.hoist_tmp_value_statement(setup, "arr", &receiver)
+            GoExpression::name(self.hoist_tmp_value_statement(setup, "arr", receiver.as_str()))
         };
-        format!("{base}[:]")
+        GoExpression::slice(base, None, None, None)
     }
 
     fn receiver_is_addressable(&self, expression: &Expression) -> bool {
@@ -788,7 +816,7 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         ctx: &NativeCallContext,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let (form, arity) = if matches!(ctx.function, Expression::DotAccess { .. }) {
             (NativeMethodForm::Dot, ctx.args.len())
         } else {
@@ -872,13 +900,15 @@ impl Planner<'_> {
         if !self.receiver_is_addressable(array) {
             self.pin_staged(&mut staged, "arr");
         }
-        staged.map_rendered_as_observable_computed(|_setup, rendered, deferred| {
-            let base = if rendered.starts_with('*') {
-                format!("({rendered})")
+        staged.map_expression_as_observable_computed(|_setup, array| {
+            let base = if array.as_str().starts_with('*') {
+                GoExpression::parenthesized(array)
             } else {
-                rendered
+                array
             };
-            GoExpression::opaque_with_deferred_evaluation(format!("{base}[:]"), deferred)
+            let contains_deferred_evaluation = base.contains_deferred_evaluation();
+            GoExpression::slice(base, None, None, None)
+                .with_deferred_evaluation(contains_deferred_evaluation)
         })
     }
 
@@ -921,9 +951,7 @@ impl Planner<'_> {
             let receiver = stages.remove(0).unary("*");
             stages.insert(0, receiver);
         }
-        if growth_clip_applies(ctx, receiver)
-            && !is_clip_safe_path(&stages[0].expression.rendered())
-        {
+        if growth_clip_applies(ctx, receiver) && !is_clip_safe_path(stages[0].expression.as_str()) {
             self.pin_staged(&mut stages[0], "recv");
         }
         let spread_index = spread_stage.map(|stage| {
@@ -940,10 +968,10 @@ impl Planner<'_> {
         }
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (setup, mut values) = sequenced.into_rendered();
+        let mut values = sequenced.values;
         let receiver = values.remove(0);
         StagedNativeMethod {
-            setup,
+            setup: sequenced.setup,
             receiver,
             arguments: values,
             effect,
@@ -981,12 +1009,10 @@ impl Planner<'_> {
             retired_receiver: None,
             result_name: None,
         };
-        let staged = self.stage_native_method(&ctx, NativeMethodForm::Dot);
-        let receiver = super::comma_ok::parenthesize_prefixed(staged.receiver);
-        (
-            staged.setup,
-            format!("{}[{}]", receiver, staged.arguments[0]),
-        )
+        let mut staged = self.stage_native_method(&ctx, NativeMethodForm::Dot);
+        let receiver = super::comma_ok::parenthesize_prefixed_expression(staged.receiver);
+        let key = staged.arguments.remove(0);
+        (staged.setup, GoExpression::index(receiver, key).rendered())
     }
 
     fn lower_string_substring(
@@ -998,11 +1024,11 @@ impl Planner<'_> {
         self.require_stdlib();
         let arg = &args[0];
         let is_ref_receiver = receiver_expr.get_type().is_ref();
-        let deref = |raw: &str| -> String {
+        let deref = |raw: GoExpression| -> GoExpression {
             if is_ref_receiver {
-                format!("*{}", raw)
+                GoExpression::dereference(raw)
             } else {
-                raw.to_string()
+                raw
             }
         };
 
@@ -1023,24 +1049,22 @@ impl Planner<'_> {
             let sequenced = self.sequence_values(stages, capture_boundary, "arg");
             let effect = sequenced.effect;
             let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-            let (setup, values) = sequenced.into_rendered();
-            let mut bounds = values.iter().skip(1);
-            let start_bound = start.is_some().then(|| bounds.next().unwrap().clone());
+            let mut values = sequenced.values.into_iter();
+            let receiver = values.next().expect("substring has a receiver");
+            let start_bound = start
+                .is_some()
+                .then(|| values.next().expect("range has a start"));
             let end_bound = end.is_some().then(|| {
-                let e = bounds.next().unwrap();
+                let end = values.next().expect("range has an end");
                 if *inclusive {
-                    format!("{}+1", e)
+                    GoExpression::binary(end, "+", GoExpression::literal("1".to_string()))
                 } else {
-                    e.clone()
+                    end
                 }
             });
             return NativeCallResult::new(
-                setup,
-                format_substring_call(
-                    &deref(&values[0]),
-                    start_bound.as_deref(),
-                    end_bound.as_deref(),
-                ),
+                sequenced.setup,
+                substring_call(deref(receiver), start_bound, end_bound),
                 effect,
                 contains_deferred_evaluation,
             );
@@ -1056,11 +1080,13 @@ impl Planner<'_> {
             self.sequence_values(vec![receiver_staged, range_staged], capture_boundary, "arg");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (setup, values) = sequenced.into_rendered();
-        let (start, end) = range_var_bounds(&values[1], &range_kind);
+        let mut values = sequenced.values.into_iter();
+        let receiver = values.next().expect("substring has a receiver");
+        let range = values.next().expect("substring has a range");
+        let (start, end) = range_var_bounds(&range, &range_kind);
         NativeCallResult::new(
-            setup,
-            format_substring_call(&deref(&values[0]), start.as_deref(), end.as_deref()),
+            sequenced.setup,
+            substring_call(deref(receiver), start, end),
             effect,
             contains_deferred_evaluation,
         )
@@ -1073,7 +1099,14 @@ impl Planner<'_> {
         ty: &Type,
         generics: &[Generic],
     ) -> String {
-        self.render_equality_test(lhs, rhs, ty, generics, false)
+        self.equality_test(
+            GoExpression::opaque(lhs.to_string()),
+            GoExpression::opaque(rhs.to_string()),
+            ty,
+            generics,
+            false,
+        )
+        .rendered()
     }
 
     /// `!=` where equality is an operator, a `!` prefix where it is a call.
@@ -1084,30 +1117,50 @@ impl Planner<'_> {
         ty: &Type,
         generics: &[Generic],
     ) -> String {
-        self.render_equality_test(lhs, rhs, ty, generics, true)
+        self.equality_test(
+            GoExpression::opaque(lhs.to_string()),
+            GoExpression::opaque(rhs.to_string()),
+            ty,
+            generics,
+            true,
+        )
+        .rendered()
     }
 
-    fn render_equality_test(
+    fn equality_test(
         &mut self,
-        lhs: &str,
-        rhs: &str,
+        lhs: GoExpression,
+        rhs: GoExpression,
         ty: &Type,
         generics: &[Generic],
         negated: bool,
-    ) -> String {
-        let (operator, prefix) = if negated { ("!=", "!") } else { ("==", "") };
+    ) -> GoExpression {
+        let operator = if negated { "!=" } else { "==" };
+        let negate = |call: GoExpression| {
+            if negated {
+                GoExpression::unary("!", call)
+            } else {
+                call
+            }
+        };
         let peeled = self.facts.peel_alias(ty);
         if peeled.is_ref() {
-            return format!("{lhs} {operator} {rhs}");
+            return GoExpression::binary(lhs, operator, rhs);
         }
         if peeled.is_slice() {
             self.require_slices();
             return match peeled.inner() {
                 Some(elem) if self.needs_custom_equality(&elem, generics) => {
                     let eq = self.equality_closure(&elem, generics);
-                    format!("{prefix}slices.EqualFunc({lhs}, {rhs}, {eq})")
+                    negate(GoExpression::call(
+                        GoExpression::name("slices.EqualFunc".to_string()),
+                        vec![lhs, rhs, GoExpression::opaque(eq)],
+                    ))
                 }
-                _ => format!("{prefix}slices.Equal({lhs}, {rhs})"),
+                _ => negate(GoExpression::call(
+                    GoExpression::name("slices.Equal".to_string()),
+                    vec![lhs, rhs],
+                )),
             };
         }
         if peeled.is_map() {
@@ -1118,15 +1171,25 @@ impl Planner<'_> {
             return match value {
                 Some(value) if self.needs_custom_equality(&value, generics) => {
                     let eq = self.equality_closure(&value, generics);
-                    format!("{prefix}maps.EqualFunc({lhs}, {rhs}, {eq})")
+                    negate(GoExpression::call(
+                        GoExpression::name("maps.EqualFunc".to_string()),
+                        vec![lhs, rhs, GoExpression::opaque(eq)],
+                    ))
                 }
-                _ => format!("{prefix}maps.Equal({lhs}, {rhs})"),
+                _ => negate(GoExpression::call(
+                    GoExpression::name("maps.Equal".to_string()),
+                    vec![lhs, rhs],
+                )),
             };
         }
         if self.type_has_equals(&peeled, generics) {
-            return format!("{prefix}{lhs}.{}({rhs})", self.equals_method_go_name());
+            let method = self.equals_method_go_name();
+            return negate(GoExpression::call(
+                GoExpression::selector(lhs, method.to_string()),
+                vec![rhs],
+            ));
         }
-        format!("{lhs} {operator} {rhs}")
+        GoExpression::binary(lhs, operator, rhs)
     }
 
     fn equality_closure(&mut self, ty: &Type, generics: &[Generic]) -> String {
@@ -1164,14 +1227,21 @@ fn is_cloneable_container(ty: &Type) -> bool {
     )
 }
 
-fn format_substring_call(receiver: &str, start: Option<&str>, end: Option<&str>) -> String {
+fn substring_call(
+    receiver: GoExpression,
+    start: Option<GoExpression>,
+    end: Option<GoExpression>,
+) -> GoExpression {
     let pkg = go_name::GO_STDLIB_PKG;
-    match (start, end) {
-        (Some(s), Some(e)) => format!("{}.Substring({}, {}, {})", pkg, receiver, s, e),
-        (Some(s), None) => format!("{}.SubstringFrom({}, {})", pkg, receiver, s),
-        (None, Some(e)) => format!("{}.SubstringTo({}, {})", pkg, receiver, e),
+    let (function, bounds) = match (start, end) {
+        (Some(start), Some(end)) => ("Substring", vec![start, end]),
+        (Some(start), None) => ("SubstringFrom", vec![start]),
+        (None, Some(end)) => ("SubstringTo", vec![end]),
         (None, None) => unreachable!("`s.substring(..)` is rejected upstream"),
-    }
+    };
+    let mut arguments = vec![receiver];
+    arguments.extend(bounds);
+    GoExpression::call(GoExpression::name(format!("{pkg}.{function}")), arguments)
 }
 
 pub(super) fn apply_inline_import(planner: &mut Planner, import: InlineImport) {

--- a/crates/emit/src/calls/regular.rs
+++ b/crates/emit/src/calls/regular.rs
@@ -18,6 +18,7 @@ use crate::expressions::staging::{SpreadSequenceOptions, VariadicCombine};
 use crate::names::generics::extract_type_mapping;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{ArgumentPlan, CallPlan, CallableOrigin, ResolvedCallee};
+use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, SequencedValues, ValuePlan,
 };
@@ -172,53 +173,57 @@ impl FmtPrint {
     }
 }
 
+/// The arguments of `callee(...)` when the expression is a call to that name.
+fn call_arguments_of<'n>(
+    expression: &'n GoExpressionNode,
+    callee: &str,
+) -> Option<&'n [GoExpressionNode]> {
+    let GoExpressionNode::Call {
+        callee: called,
+        arguments,
+    } = expression
+    else {
+        return None;
+    };
+    (called.print() == callee).then_some(arguments.as_slice())
+}
+
 /// Collapse redundant fmt wrappers:
 /// - `fmt.Print{ln}(fmt.Sprintf(...))` → `fmt.Printf(..., "\n")`
 /// - `fmt.Print{ln}(fmt.Sprint(x))` → `fmt.Print{ln}(x)`
 fn collapse_fmt_print(
     planner: &Planner,
-    function_string: &str,
+    callee: &GoExpression,
     args: &[Expression],
-    args_strings: &[String],
-    call_str: String,
-) -> String {
-    let Some(print) = FmtPrint::from_callee(function_string) else {
-        return call_str;
-    };
-    let ([arg_expression], [arg]) = (args, args_strings) else {
-        return call_str;
+    arguments: &[GoExpression],
+) -> Option<GoExpression> {
+    let print = FmtPrint::from_callee(callee.as_str())?;
+    let ([arg_expression], [argument]) = (args, arguments) else {
+        return None;
     };
 
-    match classify_fmt_argument(planner, arg_expression) {
-        Some(FmtArgument::Sprintf) => {
-            let Some(inner) = arg
-                .strip_prefix("fmt.Sprintf(")
-                .and_then(|s| s.strip_suffix(')'))
-            else {
-                return call_str;
-            };
-            match print {
-                FmtPrint::Print => format!("fmt.Printf({})", inner),
-                FmtPrint::Println => {
-                    let Some(close_quote) = find_go_string_literal_close(inner) else {
-                        return call_str;
-                    };
-                    let format_open = &inner[..close_quote];
-                    let close_and_rest = &inner[close_quote..];
-                    format!("fmt.Printf({}\\n{})", format_open, close_and_rest)
-                }
+    match classify_fmt_argument(planner, arg_expression)? {
+        FmtArgument::Sprintf => {
+            let mut inner = call_arguments_of(argument.node(), "fmt.Sprintf")?.to_vec();
+            if let FmtPrint::Println = print {
+                let Some(GoExpressionNode::Literal(format)) = inner.first_mut() else {
+                    return None;
+                };
+                let close_quote = find_go_string_literal_close(format)?;
+                format.insert_str(close_quote, "\\n");
             }
+            Some(GoExpression::call(
+                GoExpression::name("fmt.Printf".to_string()),
+                inner.into_iter().map(GoExpression::from_node).collect(),
+            ))
         }
-        Some(FmtArgument::Sprint) => {
-            let Some(inner) = arg
-                .strip_prefix("fmt.Sprint(")
-                .and_then(|s| s.strip_suffix(')'))
-            else {
-                return call_str;
-            };
-            format!("{}({})", function_string, inner)
+        FmtArgument::Sprint => {
+            let inner = call_arguments_of(argument.node(), "fmt.Sprint")?;
+            Some(GoExpression::call(
+                callee.clone(),
+                inner.iter().cloned().map(GoExpression::from_node).collect(),
+            ))
         }
-        None => call_str,
     }
 }
 
@@ -275,24 +280,24 @@ impl<'a> Planner<'a> {
                 },
             );
             let effect = self.regular_call_effect(function, sequenced.effect);
-            let (setup, args_strings) = sequenced.into_rendered();
-            let expression = GoExpression::call(
-                GoExpression::opaque(go_name),
-                args_strings.into_iter().map(GoExpression::opaque).collect(),
-            );
+            let expression = GoExpression::call(GoExpression::name(go_name), sequenced.values);
             return if self.callee_lowers_to_type_construction(function) {
-                ValuePlan::observable_call(setup, expression, effect)
+                ValuePlan::observable_call(sequenced.setup, expression, effect)
             } else {
-                ValuePlan::plain_call(setup, expression, effect)
+                ValuePlan::plain_call(sequenced.setup, expression, effect)
             };
         }
 
         let callee_staged = self.plan_operand(function, expression_ctx.callee());
         let callee_effect = callee_staged.evaluation.effect;
-        let (mut setup, mut function_string) = callee_staged.into_parts();
+        let ValuePlan {
+            mut setup,
+            expression: mut callee,
+            ..
+        } = callee_staged;
 
         if function.deref_inner().is_some() {
-            function_string = format!("({})", function_string);
+            callee = GoExpression::parenthesized(callee);
         }
 
         let mut type_args_string = self.resolve_call_type_args(CallTypeArgsRequest {
@@ -312,10 +317,8 @@ impl<'a> Planner<'a> {
         if builtin_conversion.is_some() {
             type_args_string = String::new();
         }
-        if !type_args_string.is_empty()
-            && let Some(bracket_start) = function_string.find('[')
-        {
-            function_string.truncate(bracket_start);
+        if !type_args_string.is_empty() {
+            callee = callee.without_instantiation();
         }
 
         let args_ctx = CallArgsContext {
@@ -337,27 +340,34 @@ impl<'a> Planner<'a> {
         let constant_result = go_builtin_name(function)
             .filter(|_| builtin_conversion.is_none())
             .and_then(|builtin| builtin_constant(builtin, &sequenced_args.values));
-        let (args_setup, args_strings) = sequenced_args.into_rendered();
+        let SequencedValues {
+            setup: args_setup,
+            values: arguments,
+            ..
+        } = sequenced_args;
 
         let callee_needs_pin = setup.is_empty()
             && type_args_string.is_empty()
             && LaterStages::sequenced(&args_setup, args_effect)
                 .can_change(self.place_read_stability(function));
         if callee_needs_pin {
-            function_string =
-                self.hoist_tmp_value_statement(&mut setup, "callee", &function_string);
+            callee = GoExpression::name(self.hoist_tmp_value_statement(
+                &mut setup,
+                "callee",
+                callee.as_str(),
+            ));
         }
 
-        let call_str = format!(
-            "{}{}({})",
-            function_string,
-            type_args_string,
-            args_strings.join(", ")
-        );
-        let call_str = collapse_fmt_print(self, &function_string, args, &args_strings, call_str);
-        let call_str = match &builtin_conversion {
-            Some(go_type) => format!("{go_type}({call_str})"),
-            None => call_str,
+        let call = match collapse_fmt_print(self, &callee, args, &arguments) {
+            Some(collapsed) => collapsed,
+            None => GoExpression::call(
+                GoExpression::instantiation(callee, type_args_string),
+                arguments,
+            ),
+        };
+        let call = match builtin_conversion {
+            Some(go_type) => GoExpression::conversion(go_type, call),
+            None => call,
         };
 
         setup.extend(args_setup);
@@ -365,8 +375,7 @@ impl<'a> Planner<'a> {
         let effect = self
             .regular_call_effect(function, args_effect)
             .combine(callee_effect);
-        let expression = GoExpression::opaque_with_deferred_evaluation(call_str, true)
-            .with_constant(constant_result);
+        let expression = call.with_constant(constant_result);
         if self.callee_lowers_to_type_construction(function) {
             ValuePlan::computed(setup, expression, effect)
         } else {
@@ -407,20 +416,19 @@ impl<'a> Planner<'a> {
             .values
             .pop()
             .expect("sequenced exactly one argument");
-        let sprintf_arguments = value
-            .as_str()
-            .strip_prefix("fmt.Sprintf(")
-            .and_then(|value| value.strip_suffix(')'))
-            .map(str::to_string);
-        let call = match sprintf_arguments {
-            Some(arguments) => GoExpression::opaque_with_deferred_evaluation(
-                format!("fmt.Errorf({arguments})"),
-                true,
+        let call = match call_arguments_of(value.node(), "fmt.Sprintf") {
+            Some(arguments) => GoExpression::call(
+                GoExpression::name("fmt.Errorf".to_string()),
+                arguments
+                    .iter()
+                    .cloned()
+                    .map(GoExpression::from_node)
+                    .collect(),
             ),
             None => {
                 let qualifier = self.require_package_import("go:errors");
                 GoExpression::call(
-                    GoExpression::opaque(format!("{}.New", qualifier)),
+                    GoExpression::name(format!("{}.New", qualifier)),
                     vec![value],
                 )
             }
@@ -618,8 +626,8 @@ impl<'a> Planner<'a> {
                     effective_param_ty.expect("TaggedGoLowering requires effective_param_ty");
                 let arg_ctx = self.direct_arg_emit_ctx(param, true);
                 let argument = self.lower_composite_value(arg, arg_ctx);
-                argument.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
-                    let lowered = self.emit_lower_arg_to_tagged(setup, &value, target);
+                argument.map_expression_as_computed(|setup, value| {
+                    let lowered = self.emit_lower_arg_to_tagged(setup, value.as_str(), target);
                     GoExpression::opaque_with_deferred_evaluation(lowered, true)
                 })
             }
@@ -773,10 +781,11 @@ impl<'a> Planner<'a> {
         if coercion.is_identity() {
             return argument;
         }
-        argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
+        argument.map_expression_as_computed(|setup, value| {
+            let contains_deferred_evaluation = value.contains_deferred_evaluation();
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            GoExpression::opaque_with_deferred_evaluation(coerced, contains_deferred_evaluation)
+            coerced.with_deferred_evaluation(contains_deferred_evaluation)
         })
     }
 
@@ -877,11 +886,17 @@ impl<'a> Planner<'a> {
             arg,
             ExpressionContext::value().with_function_slot_origin(param_origin),
         );
-        Some(argument.map_rendered_as_computed(|setup, value, _| {
+        Some(argument.map_expression_as_computed(|setup, value| {
             let mut buffer = String::new();
-            let adapted =
-                emit_fn_arg_shape_adapter(self, &mut buffer, &value, &arg_fn, &arg_abi, &param_abi)
-                    .expect("fn_arg_shapes resolved a function signature");
+            let adapted = emit_fn_arg_shape_adapter(
+                self,
+                &mut buffer,
+                value.as_str(),
+                &arg_fn,
+                &arg_abi,
+                &param_abi,
+            )
+            .expect("fn_arg_shapes resolved a function signature");
             if !buffer.is_empty() {
                 setup.push(LoweredStatement::RawGo(buffer));
             }
@@ -924,8 +939,12 @@ impl<'a> Planner<'a> {
 
         let source = self
             .lower_value(spread, ExpressionContext::value())
-            .map_rendered_as_name(|setup, source_value, _| {
-                GoExpression::name(self.hoist_tmp_value_statement(setup, "src", &source_value))
+            .map_expression_as_name(|setup, source_value| {
+                GoExpression::name(self.hoist_tmp_value_statement(
+                    setup,
+                    "src",
+                    source_value.as_str(),
+                ))
             });
         let source_variable = source.rendered();
 
@@ -950,19 +969,17 @@ impl<'a> Planner<'a> {
             emit_fn_arg_shape_adapter(self, &mut body, &loop_cb, &arg_fn, &arg_abi, &param_abi)?;
         write_line!(body, "{}[i] = {}", adapted, closure);
 
-        Some(
-            source.map_rendered_as_name(|setup, _source_value, _contains_deferred_evaluation| {
-                setup.push(LoweredStatement::RawGo(format!(
-                    "{} := make([]{}, len({}))\n",
-                    adapted, target_element_ty, source_variable
-                )));
-                setup.push(LoweredStatement::RawGo(format!(
-                    "for i, {} := range {} {{\n{}}}\n",
-                    loop_cb, source_variable, body
-                )));
-                GoExpression::name(adapted)
-            }),
-        )
+        Some(source.map_expression_as_name(|setup, _source_value| {
+            setup.push(LoweredStatement::RawGo(format!(
+                "{} := make([]{}, len({}))\n",
+                adapted, target_element_ty, source_variable
+            )));
+            setup.push(LoweredStatement::RawGo(format!(
+                "for i, {} := range {} {{\n{}}}\n",
+                loop_cb, source_variable, body
+            )));
+            GoExpression::name(adapted)
+        }))
     }
 
     /// Resolve the source and target callback contracts at a Go call boundary.
@@ -1018,7 +1035,9 @@ impl<'a> Planner<'a> {
                 ExpressionContext::value().with_forced_tagged_go_function(true),
             ),
         };
-        argument.map_rendered_as_computed(|setup, value, contains_deferred_evaluation| {
+        argument.map_expression_as_computed(|setup, value| {
+            let contains_deferred_evaluation = value.contains_deferred_evaluation()
+                || !matches!(transition, AbiTransition::Identity);
             let result = match transition {
                 AbiTransition::Identity => value,
                 AbiTransition::LowerFromTagged => {
@@ -1026,7 +1045,12 @@ impl<'a> Planner<'a> {
                         .facts
                         .resolve_to_function_type(effective_param_ty.unwrap_forall())
                         .expect("callback target resolves to a fn type");
-                    emit_lisette_callback_wrapper(self, setup, &value, &param_fn_ty)
+                    GoExpression::opaque(emit_lisette_callback_wrapper(
+                        self,
+                        setup,
+                        value.as_str(),
+                        &param_fn_ty,
+                    ))
                 }
                 AbiTransition::WrapToTagged | AbiTransition::Reencode => {
                     let arg_fn_ty = self
@@ -1037,7 +1061,7 @@ impl<'a> Planner<'a> {
                     let adapted = emit_fn_arg_shape_adapter(
                         self,
                         &mut buffer,
-                        &value,
+                        value.as_str(),
                         &arg_fn_ty,
                         source,
                         target,
@@ -1046,16 +1070,13 @@ impl<'a> Planner<'a> {
                     if !buffer.is_empty() {
                         setup.push(LoweredStatement::RawGo(buffer));
                     }
-                    adapted
+                    GoExpression::opaque(adapted)
                 }
                 AbiTransition::Incompatible => {
                     unreachable!("type-checked callback ABIs must describe the same result")
                 }
             };
-            GoExpression::opaque_with_deferred_evaluation(
-                result,
-                contains_deferred_evaluation || !matches!(transition, AbiTransition::Identity),
-            )
+            result.with_deferred_evaluation(contains_deferred_evaluation)
         })
     }
 
@@ -1148,10 +1169,10 @@ impl<'a> Planner<'a> {
         } else {
             self.lower_value(argument, ExpressionContext::value())
         };
-        value.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
+        value.map_expression_as_computed(|setup, value| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            GoExpression::opaque_with_deferred_evaluation(coerced, true)
+            coerced.with_deferred_evaluation(true)
         })
     }
 
@@ -1200,10 +1221,10 @@ impl<'a> Planner<'a> {
         } else {
             self.lower_value(spread, ExpressionContext::value())
         };
-        Some(value.map_rendered_as_computed(|setup, value, _| {
+        Some(value.map_expression_as_computed(|setup, value| {
             let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            GoExpression::opaque_with_deferred_evaluation(coerced, true)
+            coerced.with_deferred_evaluation(true)
         }))
     }
 }

--- a/crates/emit/src/calls/slice_loop.rs
+++ b/crates/emit/src/calls/slice_loop.rs
@@ -10,7 +10,7 @@ use crate::plan::bodies::{
     ElseArm, IfPlan, LoopKind, LoopPlan, LoweredBlock, LoweredStatement, PlacePlan,
 };
 use crate::plan::calls::CallableOrigin;
-use crate::plan::values::{CaptureBoundary, EvaluationEffect};
+use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression};
 use crate::types::native::NativeGoType;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -336,6 +336,11 @@ impl Planner<'_> {
             },
         }));
 
+        let result = if result.is_empty() {
+            GoExpression::empty()
+        } else {
+            GoExpression::name(result)
+        };
         Some(NativeCallResult::new(
             setup,
             result,

--- a/crates/emit/src/calls/ufcs.rs
+++ b/crates/emit/src/calls/ufcs.rs
@@ -10,8 +10,10 @@ use crate::names::generics::extract_type_mapping;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::{CallPlan, ResolvedCallee};
+use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
 use crate::types::native::NativeGoType;
+use std::mem;
 use syntax::EcoString;
 use syntax::ast::{Expression, Literal, ResolvedCallTypeArguments};
 use syntax::program::ReceiverCoercion;
@@ -122,7 +124,7 @@ impl Planner<'_> {
         let (setup, receiver_arg, emitted_args, arguments_contain_deferred_evaluation) =
             self.lower_ufcs_call_args(site, receiver, args, spread, coercion);
         let receiver_arg = match coercion {
-            Some(ReceiverCoercion::AutoDeref) => format!("*{receiver_arg}"),
+            Some(ReceiverCoercion::AutoDeref) => GoExpression::dereference(receiver_arg),
             Some(ReceiverCoercion::AutoAddress) | None => receiver_arg,
         };
 
@@ -135,8 +137,7 @@ impl Planner<'_> {
                 native_method_lowers_to_plain_call(&native_type, member, emitted_args.len());
             let deferred_evaluation =
                 plain_call || member == "is_empty" || arguments_contain_deferred_evaluation;
-            let expression =
-                GoExpression::opaque_with_deferred_evaluation(inlined, deferred_evaluation);
+            let expression = inlined.with_deferred_evaluation(deferred_evaluation);
             return if plain_call {
                 ValuePlan::plain_call(setup, expression, EvaluationEffect::EffectfulCall)
             } else {
@@ -147,7 +148,7 @@ impl Planner<'_> {
         let mut new_args = vec![receiver_arg];
         new_args.extend(emitted_args);
 
-        let fn_name = self.build_ufcs_qualified_call(
+        let callee = self.build_ufcs_qualified_call(
             site,
             &receiver_ty,
             member,
@@ -157,10 +158,7 @@ impl Planner<'_> {
                 has_spread: spread.is_some(),
             },
         );
-        let expression = GoExpression::call(
-            GoExpression::opaque(fn_name),
-            new_args.into_iter().map(GoExpression::opaque).collect(),
-        );
+        let expression = GoExpression::call(callee, new_args);
         if self.callee_lowers_to_type_construction(function) {
             ValuePlan::observable_call(setup, expression, EvaluationEffect::EffectfulCall)
         } else {
@@ -175,7 +173,7 @@ impl Planner<'_> {
         args: &[Expression],
         spread: Option<&Expression>,
         coercion: Option<ReceiverCoercion>,
-    ) -> (Vec<LoweredStatement>, String, Vec<String>, bool) {
+    ) -> (Vec<LoweredStatement>, GoExpression, Vec<GoExpression>, bool) {
         let UfcsCallSite { function, callee } = site;
         // The DotAccess function type curries `self` out, so its params line
         // up 1:1 with the user args. Pair each so a function-typed param
@@ -263,13 +261,12 @@ impl Planner<'_> {
             },
         );
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (setup, all_values) = sequenced.into_rendered();
-        let receiver_arg = all_values[0].clone();
-        let emitted_args: Vec<String> = all_values[1..].to_vec();
+        let mut all_values = sequenced.values;
+        let receiver_arg = all_values.remove(0);
         (
-            setup,
+            sequenced.setup,
             receiver_arg,
-            emitted_args,
+            all_values,
             contains_deferred_evaluation,
         )
     }
@@ -297,7 +294,7 @@ impl Planner<'_> {
         member: &str,
         type_args: ResolvedCallTypeArguments<'_>,
         arg_shape: CallArgShape,
-    ) -> String {
+    ) -> GoExpression {
         let UfcsCallSite { function, callee } = site;
         let Type::Nominal {
             id: qualified_name, ..
@@ -316,7 +313,7 @@ impl Planner<'_> {
             || self.method_needs_export(member);
 
         let qualified_method_name = self.qualify_method_call(qualified_name, member, is_public);
-        format!("{}{}", qualified_method_name, type_args_string)
+        GoExpression::instantiation(GoExpression::name(qualified_method_name), type_args_string)
     }
 
     fn coerce_receiver_address_stage(
@@ -324,22 +321,22 @@ impl Planner<'_> {
         receiver: &Expression,
         mut stage: ValuePlan,
     ) -> ValuePlan {
-        let value = stage.expression.rendered();
+        let value = mem::replace(&mut stage.expression, GoExpression::empty());
         if matches!(receiver.unwrap_parens(), Expression::Call { .. }) {
-            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", &value);
-            stage.expression = GoExpression::opaque(format!("&{tmp}"));
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", value.as_str());
+            stage.expression = GoExpression::address_of(GoExpression::name(tmp));
             return stage.into_addressed_location();
         }
-        let addressed = format!("&{value}");
+        let addressed = GoExpression::address_of(value);
         if matches!(receiver.unwrap_parens(), Expression::Identifier { .. }) {
-            stage.expression = GoExpression::opaque(addressed);
+            stage.expression = addressed;
             stage.into_addressed_location()
         } else if stage.setup.is_empty() {
-            stage.expression = GoExpression::opaque(addressed);
+            stage.expression = addressed;
             stage.make_observable_computed();
             stage
         } else {
-            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", &addressed);
+            let tmp = self.hoist_tmp_value_statement(&mut stage.setup, "ref", addressed.as_str());
             ValuePlan::captured(stage.setup, tmp)
         }
     }
@@ -374,29 +371,26 @@ impl Planner<'_> {
                 boundary: CaptureBoundary::SiblingSequence,
             },
         );
-        let (setup, emitted_all) = sequenced.into_rendered();
+        let mut emitted_all = sequenced.values;
+        let receiver = emitted_all.remove(0);
 
-        let receiver = emitted_all[0].clone();
-        let emitted_rest: Vec<String> = emitted_all[1..].to_vec();
-
-        let receiver = if let Some(stripped) = receiver.strip_prefix('&') {
-            if is_address_of_composite_literal(args.first()) {
-                format!("(&{})", stripped)
-            } else {
-                stripped.to_string()
+        // The method call takes the value's own address, so `&x` unwraps.
+        let addressed = match receiver.node() {
+            GoExpressionNode::AddressOf(inner) => Some(GoExpression::from_node((**inner).clone())),
+            _ => None,
+        };
+        let receiver = match addressed {
+            Some(inner) if is_address_of_composite_literal(args.first()) => {
+                GoExpression::parenthesized(GoExpression::address_of(inner))
             }
-        } else if receiver.starts_with('*') {
-            format!("({})", receiver)
-        } else {
-            receiver
+            Some(inner) => inner,
+            None if receiver.as_str().starts_with('*') => GoExpression::parenthesized(receiver),
+            None => receiver,
         };
 
         ValuePlan::observable_call(
-            setup,
-            GoExpression::call(
-                GoExpression::opaque(format!("{}.{}", receiver, go_method)),
-                emitted_rest.into_iter().map(GoExpression::opaque).collect(),
-            ),
+            sequenced.setup,
+            GoExpression::call(GoExpression::selector(receiver, go_method), emitted_all),
             EvaluationEffect::EffectfulCall,
         )
     }
@@ -406,9 +400,9 @@ fn try_inline_native_ufcs(
     planner: &mut Planner,
     receiver: &Expression,
     member: &str,
-    receiver_arg: &str,
-    emitted_args: &[String],
-) -> Option<String> {
+    receiver_arg: &GoExpression,
+    emitted_args: &[GoExpression],
+) -> Option<GoExpression> {
     let native_type = NativeGoType::from_type(&receiver.get_type())?;
     let (inlined, extra_import) = super::native::try_inline_native_method(
         &native_type,

--- a/crates/emit/src/calls/wrap_err.rs
+++ b/crates/emit/src/calls/wrap_err.rs
@@ -2,7 +2,7 @@ use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::expressions::literals::convert_escape_sequences;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::values::GoExpression;
+use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::{Expression, FormatStringPart, Literal};
 
 pub(crate) struct WrapMessage {
@@ -93,13 +93,17 @@ impl Planner<'_> {
                         if let FormatStringPart::Expression(expression) = part {
                             let value =
                                 self.lower_composite_value(expression, ExpressionContext::value());
-                            let (part_setup, value) =
-                                self.eager_operand(expression, value, "fmtarg").into_parts();
+                            let ValuePlan {
+                                setup: part_setup,
+                                expression: value,
+                                ..
+                            } = self.eager_operand(expression, value, "fmtarg");
                             setup.extend(part_setup);
-                            values.push(GoExpression::opaque(value));
+                            values.push(value);
                         }
                     }
-                    self.sprintf_pieces(parts, values, true)
+                    let (format, args) = self.sprintf_pieces(parts, values, true);
+                    (format, args.iter().map(GoExpression::rendered).collect())
                 }
                 _ => {
                     let value = self.lower_composite_value(message, ExpressionContext::value());

--- a/crates/emit/src/control_flow/fallible.rs
+++ b/crates/emit/src/control_flow/fallible.rs
@@ -2,6 +2,7 @@ use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::values::GoExpression;
 use syntax::ast::Expression;
 use syntax::types::Type;
 
@@ -153,9 +154,9 @@ impl Planner<'_> {
         to: &Type,
     ) -> String {
         let coercion = CoercionPlan::internal(self, from, to);
-        let (setup, value) = coercion.lower(self, value);
+        let (setup, value) = coercion.lower(self, GoExpression::opaque(value));
         statements.extend(setup);
-        value
+        value.rendered()
     }
 
     pub(crate) fn convert_error_to_return_context(
@@ -275,17 +276,20 @@ impl<'a, 'e> FalliblePlanner<'a, 'e> {
     pub(crate) fn format_constructor_call(
         &mut self,
         constructor: &str,
-        arg: Option<&str>,
-    ) -> String {
+        arg: Option<GoExpression>,
+    ) -> GoExpression {
         let inner_ty = self.ok_type_string();
-        let arg_str = arg.unwrap_or("");
-        if self.fallible.is_result() {
+        let type_args = if self.fallible.is_result() {
             let err_ty = self
                 .err_type_string()
                 .expect("Result type must have an error type");
-            format!("{}[{}, {}]({})", constructor, inner_ty, err_ty, arg_str)
+            format!("[{}, {}]", inner_ty, err_ty)
         } else {
-            format!("{}[{}]({})", constructor, inner_ty, arg_str)
-        }
+            format!("[{}]", inner_ty)
+        };
+        GoExpression::call(
+            GoExpression::instantiation(GoExpression::name(constructor.to_string()), type_args),
+            arg.into_iter().collect(),
+        )
     }
 }

--- a/crates/emit/src/control_flow/propagation.rs
+++ b/crates/emit/src/control_flow/propagation.rs
@@ -41,7 +41,7 @@ impl Planner<'_> {
         &mut self,
         expression: &Expression,
         result_var_name: Option<&str>,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let expression_ty = self.facts.peel_alias(&expression.get_type());
         let fallible = Fallible::from_type(&expression_ty)
             .expect("lower_propagate called on non-Result/Option type");
@@ -54,12 +54,18 @@ impl Planner<'_> {
         {
             statements.extend(head);
             self.declare_zero_for_dead_path(&mut statements, var_name, &fallible);
-            return (statements, String::new());
+            return (statements, GoExpression::empty());
         }
 
-        if let Some(fused) = self.try_lower_fused_propagate(expression, &fallible, result_var_name)
+        if let Some((statements, value)) =
+            self.try_lower_fused_propagate(expression, &fallible, result_var_name)
         {
-            return fused;
+            let value = if value.is_empty() {
+                GoExpression::empty()
+            } else {
+                GoExpression::name(value)
+            };
+            return (statements, value);
         }
 
         self.require_stdlib();
@@ -67,13 +73,16 @@ impl Planner<'_> {
         statements.extend(check_setup);
         statements.push(self.build_propagate_failure_check(&check_var, &fallible));
 
-        let ok_access = format!("{}.{}", check_var, fallible.ok_field());
+        let ok_access = GoExpression::selector(
+            GoExpression::name(check_var),
+            fallible.ok_field().to_string(),
+        );
         let value = match result_var_name {
             None => ok_access,
-            Some("_") => "_".to_string(),
+            Some("_") => GoExpression::name("_".to_string()),
             Some(name) => {
-                statements.push(self.bind_propagate_ok(name, &ok_access));
-                name.to_string()
+                statements.push(self.bind_propagate_ok(name, ok_access.as_str()));
+                GoExpression::name(name.to_string())
             }
         };
         (statements, value)
@@ -386,24 +395,20 @@ impl Planner<'_> {
 
         let plan = self.lower_value(expression, ExpressionContext::value());
         ReturnForm::Plain {
-            value: plan.map_rendered_as_computed(
-                |setup, raw_value, contains_deferred_evaluation| {
-                    let mut coercion_buffer = String::new();
-                    let final_value = self.apply_type_coercion(
-                        &mut coercion_buffer,
-                        return_ctx.ty(),
-                        expression,
-                        raw_value,
-                    );
-                    if !coercion_buffer.is_empty() {
-                        setup.push(LoweredStatement::RawGo(coercion_buffer));
-                    }
-                    GoExpression::opaque_with_deferred_evaluation(
-                        final_value,
-                        contains_deferred_evaluation,
-                    )
-                },
-            ),
+            value: plan.map_expression_as_computed(|setup, raw_value| {
+                let contains_deferred_evaluation = raw_value.contains_deferred_evaluation();
+                let mut coercion_buffer = String::new();
+                let final_value = self.apply_type_coercion(
+                    &mut coercion_buffer,
+                    return_ctx.ty(),
+                    expression,
+                    raw_value,
+                );
+                if !coercion_buffer.is_empty() {
+                    setup.push(LoweredStatement::RawGo(coercion_buffer));
+                }
+                final_value.with_deferred_evaluation(contains_deferred_evaluation)
+            }),
         }
     }
 
@@ -485,7 +490,11 @@ impl Planner<'_> {
         {
             let (setup, value) = self.lower_propagate(inner, None);
             statements.extend(setup);
-            statements.extend(self.wrapped_value_return(value, &return_ty, lowered.as_ref()));
+            statements.extend(self.wrapped_value_return(
+                value.rendered(),
+                &return_ty,
+                lowered.as_ref(),
+            ));
             return Some(statements);
         }
 
@@ -673,7 +682,7 @@ impl Planner<'_> {
             statements.extend(setup);
             let ok_ty = self.facts.peel_alias(return_ty).ok_type();
             let (projection, payload) =
-                transition::lowered_payload_values(self, shape, &ok_ty, &value);
+                transition::lowered_payload_values(self, shape, &ok_ty, value.as_str());
             statements.extend(projection);
             statements.push(transition::multi_value_return(
                 transition::lowered_ok_values(shape, payload),

--- a/crates/emit/src/control_flow/select.rs
+++ b/crates/emit/src/control_flow/select.rs
@@ -7,6 +7,7 @@ use crate::plan::bodies::{
     ElseArm, IfPlan, LoopTransfer, LoweredBlock, LoweredStatement, PlacePlan, SelectArmPlan,
     SelectStatementPlan,
 };
+use crate::plan::go_expression::GoExpressionNode;
 use crate::plan::placement::unreachable_panic_if_needed;
 use crate::plan::values::{GoExpression, ValuePlan};
 use syntax::ast::{Expression, MatchArm, Pattern, SelectArm};
@@ -14,8 +15,8 @@ use syntax::program::{ChannelOperation, channel_operation};
 use syntax::types::Type;
 
 enum PreparedChannelOperation {
-    Send(String, String),
-    Receive(String),
+    Send(GoExpression, GoExpression),
+    Receive(GoExpression),
 }
 
 struct SelectReceiveContext<'a> {
@@ -207,12 +208,7 @@ impl Planner<'_> {
         if let Some(ChannelOperation::Receive { channel }) = channel_operation(unwrapped) {
             let plan = self.lower_value(channel, ExpressionContext::value());
             if channel.get_type().is_ref() {
-                return plan.map_rendered(|_, value, contains_deferred_evaluation| {
-                    GoExpression::opaque_with_deferred_evaluation(
-                        cancel_deref_of_address(value),
-                        contains_deferred_evaluation,
-                    )
-                });
+                return plan.map_expression(|_, value| cancel_deref_of_address(value));
             }
             return plan;
         }
@@ -434,22 +430,26 @@ impl Planner<'_> {
             let channel = operation.channel();
             let channel_plan = self.lower_value(channel, ExpressionContext::value());
             let ch_has_call = needs_hoist && channel_plan.evaluation.effect.has_call();
-            let (op_setup, mut ch) = channel_plan.into_parts();
-            setup.extend(op_setup);
+            setup.extend(channel_plan.setup);
+            let mut ch = channel_plan.expression;
             if channel.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }
             if ch_has_call {
-                ch = self.hoist_tmp_value_statement(setup, "ch", &ch);
+                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch.as_str()));
             }
             match operation {
                 ChannelOperation::Send { value, .. } => {
                     let value_plan = self.lower_composite_value(value, ExpressionContext::value());
                     let val_has_call = needs_hoist && value_plan.evaluation.effect.has_call();
-                    let (val_setup, mut val) = value_plan.into_parts();
-                    setup.extend(val_setup);
+                    setup.extend(value_plan.setup);
+                    let mut val = value_plan.expression;
                     if val_has_call {
-                        val = self.hoist_tmp_value_statement(setup, "send_val", &val);
+                        val = GoExpression::name(self.hoist_tmp_value_statement(
+                            setup,
+                            "send_val",
+                            val.as_str(),
+                        ));
                     }
                     PreparedChannelOperation::Send(ch, val)
                 }
@@ -458,13 +458,13 @@ impl Planner<'_> {
         } else {
             let expression_plan = self.lower_value(send_expression, ExpressionContext::value());
             let expression_has_call = needs_hoist && expression_plan.evaluation.effect.has_call();
-            let (op_setup, mut ch) = expression_plan.into_parts();
-            setup.extend(op_setup);
+            setup.extend(expression_plan.setup);
+            let mut ch = expression_plan.expression;
             if send_expression.get_type().is_ref() {
                 ch = cancel_deref_of_address(ch);
             }
             if expression_has_call {
-                ch = self.hoist_tmp_value_statement(setup, "ch", &ch);
+                ch = GoExpression::name(self.hoist_tmp_value_statement(setup, "ch", ch.as_str()));
             }
             PreparedChannelOperation::Receive(ch)
         }
@@ -484,7 +484,7 @@ impl Planner<'_> {
                 body: block,
             },
             PreparedChannelOperation::Receive(ch) => SelectArmPlan::Send {
-                operation: GoExpression::receive(GoExpression::opaque(ch.clone())),
+                operation: GoExpression::receive(ch.clone()),
                 body: block,
             },
         }
@@ -585,13 +585,21 @@ impl Planner<'_> {
 
 /// `*&x` → `x` (avoids redundant deref when the emitter has already
 /// produced an `&`-prefixed expression).
-fn cancel_deref_of_address(ch: String) -> String {
-    if let Some(inner) = ch.strip_prefix("(&").and_then(|s| s.strip_suffix(')')) {
-        inner.to_string()
-    } else if let Some(inner) = ch.strip_prefix('&') {
-        inner.to_string()
-    } else {
-        format!("*{}", ch)
+/// `*&x` is `x`. Any other pointer gets dereferenced.
+fn cancel_deref_of_address(channel: GoExpression) -> GoExpression {
+    let contains_deferred_evaluation = channel.contains_deferred_evaluation();
+    let addressed = match channel.node() {
+        GoExpressionNode::AddressOf(inner) => Some(inner.as_ref()),
+        GoExpressionNode::Parenthesized(inner) => match inner.as_ref() {
+            GoExpressionNode::AddressOf(inner) => Some(inner.as_ref()),
+            _ => None,
+        },
+        _ => None,
+    };
+    match addressed {
+        Some(inner) => GoExpression::from_node(inner.clone())
+            .with_deferred_evaluation(contains_deferred_evaluation),
+        None => GoExpression::dereference(channel),
     }
 }
 

--- a/crates/emit/src/definitions/toplevel.rs
+++ b/crates/emit/src/definitions/toplevel.rs
@@ -3,7 +3,7 @@ use crate::Renderer;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::ConstPlan;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{EvaluationEffect, GoExpression, ValuePlan};
 use syntax::ast::{Expression, Generic};
 use syntax::types::{SimpleKind, Type};
 
@@ -83,12 +83,12 @@ impl Planner<'_> {
         // `is_go_constant_expression` admits only literals, identifiers, and
         // constexpr unary/binary, none of which carry setup statements.
         let raw_value = self.lower_value(expression, ExpressionContext::value());
-        let value_text = raw_value.rendered();
-        let value = if value_text.is_empty() {
-            ValuePlan::opaque("struct{}{}".to_string())
+        let value = if raw_value.is_empty() {
+            GoExpression::empty_composite("struct{}".to_string())
         } else {
-            ValuePlan::opaque(value_text)
+            raw_value.expression
         };
+        let value = ValuePlan::computed(Vec::new(), value, EvaluationEffect::Pure);
         if is_const && matches!(scope, ConstScope::Local) {
             self.scope.mark_go_const(identifier);
         }

--- a/crates/emit/src/expressions/access/dot_access.rs
+++ b/crates/emit/src/expressions/access/dot_access.rs
@@ -12,11 +12,10 @@ use crate::context::expression::ExpressionContext;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::values::{EvaluationEffect, GoExpression, Stability, ValuePlan};
-use crate::types::go_type::render_conversion;
 use crate::utils::reads_value_member;
 
 struct NullableFieldAccess<'a> {
-    expression_string: &'a str,
+    base: &'a GoExpression,
     member: &'a str,
     field: &'a str,
     expression_ty: &'a Type,
@@ -43,14 +42,10 @@ impl Planner<'_> {
         let dot_access_kind = resolution.kind();
         let receiver_coercion = resolution.receiver_coercion();
 
-        if let Some(s) =
+        if let Some(expression) =
             self.try_emit_pre_receiver_dot(expression, member, result_ty, dot_access_kind, ctx)
         {
-            return ValuePlan::computed(
-                Vec::new(),
-                GoExpression::opaque(s),
-                EvaluationEffect::Pure,
-            );
+            return ValuePlan::computed(Vec::new(), expression, EvaluationEffect::Pure);
         }
 
         let expression_ty = expression.get_type();
@@ -71,23 +66,23 @@ impl Planner<'_> {
         } else {
             Stability::Observable
         };
-        let base_contains_deferred_evaluation = base_plan.expression.contains_deferred_evaluation();
-        let (mut setup, expression_string) = base_plan.into_parts();
+        let ValuePlan {
+            mut setup,
+            expression: base,
+            ..
+        } = base_plan;
+        let base_contains_deferred_evaluation = base.contains_deferred_evaluation();
 
-        if let Some(s) = self.try_emit_tuple_member_dot(
-            &expression_string,
-            &expression_ty,
-            member,
-            dot_access_kind,
-        ) {
+        if let Some(member_access) =
+            self.try_emit_tuple_member_dot(&base, &expression_ty, member, dot_access_kind)
+        {
             let is_newtype_conversion = matches!(
                 dot_access_kind,
                 Some(SemanticDotKind::TupleStructField { is_newtype: true })
             );
             return ValuePlan::computed(
                 setup,
-                GoExpression::opaque_with_deferred_evaluation(
-                    s,
+                member_access.with_deferred_evaluation(
                     base_contains_deferred_evaluation || is_newtype_conversion,
                 ),
                 effect,
@@ -102,10 +97,10 @@ impl Planner<'_> {
             .try_resolve_cross_package_const(&expression_ty, member)
             .unwrap_or_else(|| go_field_name(&expression_ty, member, is_exported, is_embedded));
 
-        if let Some(s) = self.plan_nullable_field_access(
+        if let Some(wrapped) = self.plan_nullable_field_access(
             &mut setup,
             NullableFieldAccess {
-                expression_string: &expression_string,
+                base: &base,
                 member,
                 field: &field,
                 expression_ty: &expression_ty,
@@ -113,29 +108,12 @@ impl Planner<'_> {
                 result_ty,
             },
         ) {
-            return ValuePlan::computed(setup, GoExpression::opaque(s), effect);
+            return ValuePlan::computed(setup, wrapped, effect);
         }
 
-        let selector = GoExpression::selector(
-            GoExpression::opaque_with_deferred_evaluation(
-                expression_string,
-                base_contains_deferred_evaluation,
-            ),
-            field,
-        );
-        let rendered_selector = selector.rendered();
-        let result = self.append_cross_package_type_args(
-            rendered_selector.clone(),
-            &expression_ty,
-            member,
-            result_ty,
-            ctx,
-        );
-        let expression = if result == rendered_selector {
-            selector
-        } else {
-            GoExpression::opaque_with_deferred_evaluation(result, base_contains_deferred_evaluation)
-        };
+        let selector = GoExpression::selector(base, field);
+        let expression =
+            self.append_cross_package_type_args(selector, &expression_ty, member, result_ty, ctx);
         ValuePlan::computed(setup, expression, effect).with_stability(stability)
     }
 
@@ -149,7 +127,7 @@ impl Planner<'_> {
         result_ty: &Type,
         dot_access_kind: Option<SemanticDotKind>,
         ctx: ExpressionContext<'_>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         match dot_access_kind {
             Some(SemanticDotKind::EnumVariant) => self.emit_enum_variant_dot(member, result_ty),
             Some(SemanticDotKind::StaticMethod { .. }) => {
@@ -181,11 +159,11 @@ impl Planner<'_> {
     /// cast when the struct has a single field and no generics.
     fn try_emit_tuple_member_dot(
         &mut self,
-        expression_string: &str,
+        base: &GoExpression,
         expression_ty: &Type,
         member: &str,
         dot_access_kind: Option<SemanticDotKind>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let Ok(index) = member.parse::<usize>() else {
             return None;
         };
@@ -194,15 +172,13 @@ impl Planner<'_> {
                 let field = parse::TUPLE_FIELDS
                     .get(index)
                     .expect("oversize tuple arity");
-                Some(format!("{}.{}", expression_string, field))
+                Some(GoExpression::selector(base.clone(), field.to_string()))
             }
             Some(SemanticDotKind::TupleStructField { is_newtype }) => {
-                if is_newtype
-                    && let Some(cast) = self.try_emit_newtype_cast(expression_ty, expression_string)
-                {
+                if is_newtype && let Some(cast) = self.try_emit_newtype_cast(expression_ty, base) {
                     return Some(cast);
                 }
-                Some(format!("{}.F{}", expression_string, index))
+                Some(GoExpression::selector(base.clone(), format!("F{}", index)))
             }
             _ => None,
         }
@@ -242,9 +218,9 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         access: NullableFieldAccess<'_>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let NullableFieldAccess {
-            expression_string,
+            base,
             member,
             field,
             expression_ty,
@@ -258,9 +234,9 @@ impl Planner<'_> {
         if coercion.is_identity() {
             return None;
         }
-        let raw_access = format!("{}.{}", expression_string, field);
-        let raw_var = self.hoist_tmp_value_statement(setup, "raw", &raw_access);
-        let (coercion_setup, coerced) = coercion.lower(self, raw_var);
+        let raw_access = GoExpression::selector(base.clone(), field.to_string());
+        let raw_var = self.hoist_tmp_value_statement(setup, "raw", raw_access.as_str());
+        let (coercion_setup, coerced) = coercion.lower(self, GoExpression::name(raw_var));
         setup.extend(coercion_setup);
         Some(coerced)
     }
@@ -270,12 +246,12 @@ impl Planner<'_> {
     /// Callee-position accesses skip this because the call site re-instantiates.
     fn append_cross_package_type_args(
         &mut self,
-        base_access: String,
+        base_access: GoExpression,
         expression_ty: &Type,
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-    ) -> String {
+    ) -> GoExpression {
         if ctx.is_callee() {
             return base_access;
         }
@@ -284,7 +260,7 @@ impl Planner<'_> {
         };
         let qualified = format!("{}.{}", package, member);
         match self.format_cross_package_type_args(&qualified, result_ty) {
-            Some(type_args) => format!("{}{}", base_access, type_args),
+            Some(type_args) => GoExpression::instantiation(base_access, type_args),
             None => base_access,
         }
     }
@@ -295,16 +271,16 @@ impl Planner<'_> {
     fn try_emit_newtype_cast(
         &mut self,
         expression_ty: &Type,
-        expression_string: &str,
-    ) -> Option<String> {
+        base: &GoExpression,
+    ) -> Option<GoExpression> {
         let field_ty = self.get_newtype_underlying(expression_ty)?;
         let go_type = self.use_go_type(&field_ty);
         let operand = if expression_ty.is_ref() {
-            format!("*{}", expression_string)
+            GoExpression::dereference(base.clone())
         } else {
-            expression_string.to_string()
+            base.clone()
         };
-        Some(render_conversion(&go_type, &operand))
+        Some(GoExpression::conversion(go_type, operand))
     }
 
     /// Compute whether a dot access context requires exported (capitalized) Go names.
@@ -333,31 +309,23 @@ impl Planner<'_> {
             (self.plan_operand(expression, ctx), false)
         };
         let is_absorbed_ref = self.is_absorbed_ref_generic(expression);
-        staged.map_rendered(
-            |setup, expression_string, mut contains_deferred_evaluation| {
-                let value = match (coercion, had_explicit_deref) {
-                    _ if is_absorbed_ref => expression_string,
-                    (Some(ReceiverCoercion::AutoAddress), true) => expression_string,
-                    (Some(ReceiverCoercion::AutoAddress), false) => {
-                        match expression.unwrap_parens() {
-                            Expression::Call { .. } => {
-                                contains_deferred_evaluation = false;
-                                self.hoist_tmp_value_statement(setup, "ref", &expression_string)
-                            }
-                            Expression::StructCall { .. } => {
-                                contains_deferred_evaluation = true;
-                                format!("(&{})", expression_string)
-                            }
-                            _ => expression_string,
-                        }
-                    }
-                    (Some(ReceiverCoercion::AutoDeref), _) => expression_string,
-                    (None, true) => expression_string,
-                    (None, false) => expression_string,
-                };
-                GoExpression::opaque_with_deferred_evaluation(value, contains_deferred_evaluation)
-            },
-        )
+        staged.map_expression(|setup, base| {
+            if is_absorbed_ref
+                || coercion != Some(ReceiverCoercion::AutoAddress)
+                || had_explicit_deref
+            {
+                return base;
+            }
+            match expression.unwrap_parens() {
+                Expression::Call { .. } => {
+                    GoExpression::name(self.hoist_tmp_value_statement(setup, "ref", base.as_str()))
+                }
+                Expression::StructCall { .. } => {
+                    GoExpression::parenthesized(GoExpression::address_of(base))
+                }
+                _ => base,
+            }
+        })
     }
 
     /// Check if expression has an absorbed `Ref<T>` generic (T already emitted as `*Concrete`).

--- a/crates/emit/src/expressions/access/index_access.rs
+++ b/crates/emit/src/expressions/access/index_access.rs
@@ -45,11 +45,13 @@ impl Planner<'_> {
             );
             let effect = sequenced.effect;
             let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-            let (setup, values) = sequenced.into_rendered();
-            let value = emit_range_var_slice(&values[0], &values[1], &range_kind, needs_cap);
+            let mut values = sequenced.values.into_iter();
+            let base = values.next().expect("range index has a base");
+            let range = values.next().expect("range index has a range");
+            let value = range_var_slice(base, &range, &range_kind, needs_cap);
             return ValuePlan::computed(
-                setup,
-                GoExpression::opaque_with_deferred_evaluation(value, contains_deferred_evaluation),
+                sequenced.setup,
+                value.with_deferred_evaluation(contains_deferred_evaluation),
                 effect,
             );
         }
@@ -203,22 +205,20 @@ impl Planner<'_> {
     }
 }
 
+/// The `[start:end]` bounds a range-typed value denotes, by range kind.
 pub(crate) fn range_var_bounds(
-    range_var: &str,
+    range: &GoExpression,
     range_kind: &str,
-) -> (Option<String>, Option<String>) {
+) -> (Option<GoExpression>, Option<GoExpression>) {
+    let start = || GoExpression::selector(range.clone(), "Start".to_string());
+    let end = || GoExpression::selector(range.clone(), "End".to_string());
+    let end_inclusive = || GoExpression::binary(end(), "+", GoExpression::literal("1".to_string()));
     match range_kind {
-        "Range" => (
-            Some(format!("{}.Start", range_var)),
-            Some(format!("{}.End", range_var)),
-        ),
-        "RangeInclusive" => (
-            Some(format!("{}.Start", range_var)),
-            Some(format!("{}.End+1", range_var)),
-        ),
-        "RangeFrom" => (Some(format!("{}.Start", range_var)), None),
-        "RangeTo" => (None, Some(format!("{}.End", range_var))),
-        "RangeToInclusive" => (None, Some(format!("{}.End+1", range_var))),
+        "Range" => (Some(start()), Some(end())),
+        "RangeInclusive" => (Some(start()), Some(end_inclusive())),
+        "RangeFrom" => (Some(start()), None),
+        "RangeTo" => (None, Some(end())),
+        "RangeToInclusive" => (None, Some(end_inclusive())),
         _ => unreachable!("unexpected range kind: {}", range_kind),
     }
 }
@@ -227,20 +227,18 @@ pub(crate) fn range_var_bounds(
 /// third index that caps capacity at length to block append-through-alias
 /// corruption; range field accesses (`.End`) are pure, so repeating them
 /// in the cap position is safe.
-fn emit_range_var_slice(base: &str, range: &str, range_kind: &str, needs_cap: bool) -> String {
+fn range_var_slice(
+    base: GoExpression,
+    range: &GoExpression,
+    range_kind: &str,
+    needs_cap: bool,
+) -> GoExpression {
     let (start, end) = range_var_bounds(range, range_kind);
-    let start_str = start.as_deref().unwrap_or("");
-    let end_str = end.as_deref().unwrap_or("");
-
     if !needs_cap {
-        return format!("{}[{}:{}]", base, start_str, end_str);
+        return GoExpression::slice(base, start.as_ref(), end.as_ref(), None);
     }
-
-    let bound = if end_str.is_empty() {
-        format!("len({})", base)
-    } else {
-        end_str.to_string()
-    };
-
-    format!("{}[{}:{}:{}]", base, start_str, bound, bound)
+    let bound = end.unwrap_or_else(|| {
+        GoExpression::call(GoExpression::name("len".to_string()), vec![base.clone()])
+    });
+    GoExpression::slice(base, start.as_ref(), Some(&bound), Some(&bound))
 }

--- a/crates/emit/src/expressions/access/struct_call.rs
+++ b/crates/emit/src/expressions/access/struct_call.rs
@@ -12,8 +12,8 @@ use crate::context::expression::ExpressionContext;
 use crate::definitions::enum_layout;
 use crate::go_name;
 use crate::plan::bodies::LoweredStatement;
+use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{CaptureBoundary, EvaluationEffect, GoExpression, ValuePlan};
-use crate::types::go_type::render_conversion;
 use crate::utils::is_order_sensitive;
 use syntax::program::AliasKind;
 use syntax::types;
@@ -22,7 +22,7 @@ use syntax::types::SubstitutionMap;
 struct SpreadInput<'a> {
     base: &'a Expression,
     base_staged: ValuePlan,
-    field_pairs: Vec<(String, String)>,
+    field_pairs: Vec<(String, GoExpression)>,
     fields_contain_deferred_evaluation: bool,
 }
 
@@ -43,12 +43,12 @@ struct EnumCallContext {
 
 struct StructCallField {
     name: String,
-    value: String,
+    value: GoExpression,
     has_observable_evaluation: bool,
 }
 
 impl StructCallField {
-    fn into_pair(self) -> (String, String) {
+    fn into_pair(self) -> (String, GoExpression) {
         (self.name, self.value)
     }
 }
@@ -69,7 +69,7 @@ impl Planner<'_> {
         let tag_field = ctx.enum_ctx.as_ref().map(|e| {
             (
                 enum_layout::ENUM_TAG_FIELD.to_string(),
-                e.tag_constant.clone(),
+                GoExpression::name(e.tag_constant.clone()),
             )
         });
 
@@ -111,7 +111,8 @@ impl Planner<'_> {
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "field");
         let mut effect = sequenced.effect;
         let fields_contain_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (mut setup, emitted_values) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
+        let emitted_values = sequenced.values;
 
         let mut fields =
             Vec::with_capacity(field_assignments.len() + usize::from(ctx.enum_ctx.is_some()));
@@ -162,10 +163,8 @@ impl Planner<'_> {
                         effect = effect.combine(EvaluationEffect::EffectfulCall);
                     }
                     setup.push(self.lower_statement(base));
-                    GoExpression::composite_literal(
-                        format!("{}{{}}", ctx.go_type),
-                        fields_contain_deferred_evaluation,
-                    )
+                    GoExpression::empty_composite(ctx.go_type.clone())
+                        .with_deferred_evaluation(fields_contain_deferred_evaluation)
                 } else {
                     let base_staged = self.plan_operand(base, ExpressionContext::value());
                     effect = effect.combine(base_staged.evaluation.effect);
@@ -190,13 +189,15 @@ impl Planner<'_> {
                 }
             }
             StructSpread::Autofill { .. } => match self.go_imported_newtype_zero(ty) {
-                Some(zero) => GoExpression::opaque(zero),
+                Some(zero) => zero.with_deferred_evaluation(false),
                 None => {
                     let mut field_pairs =
                         fields.into_iter().map(StructCallField::into_pair).collect();
                     self.append_autofills(&mut field_pairs, field_assignments, &ctx, is_go_struct);
-                    GoExpression::composite_literal(
-                        emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                    emit_struct_literal(
+                        &ctx.go_type,
+                        field_pairs,
+                        expression_ctx,
                         fields_contain_deferred_evaluation,
                     )
                 }
@@ -204,8 +205,10 @@ impl Planner<'_> {
             StructSpread::None => {
                 let field_pairs: Vec<_> =
                     fields.into_iter().map(StructCallField::into_pair).collect();
-                GoExpression::composite_literal(
-                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                emit_struct_literal(
+                    &ctx.go_type,
+                    field_pairs,
+                    expression_ctx,
                     fields_contain_deferred_evaluation,
                 )
             }
@@ -220,11 +223,11 @@ impl Planner<'_> {
     fn coerce_struct_field(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        mut value: String,
+        mut value: GoExpression,
         value_ty: &Type,
         field_ty: Option<&Type>,
         field_layout: Option<&ValueLayout>,
-    ) -> String {
+    ) -> GoExpression {
         if let Some(field_layout) = field_layout {
             let source_layout = self.value_layout(value_ty, SlotOrigin::Lisette);
             let coercion = CoercionPlan::bridge(self, &source_layout, field_layout);
@@ -250,7 +253,7 @@ impl Planner<'_> {
     /// maps need one, their nil being the sole zero that panics on write.
     fn append_autofills(
         &mut self,
-        field_pairs: &mut Vec<(String, String)>,
+        field_pairs: &mut Vec<(String, GoExpression)>,
         field_assignments: &[StructFieldAssignment],
         ctx: &StructCallContext<'_>,
         is_go_struct: bool,
@@ -272,7 +275,7 @@ impl Planner<'_> {
                     continue;
                 }
                 let zero = self.lisette_zero(&field_ty);
-                if is_go_zero_literal(&zero) {
+                if is_go_zero_literal(zero.as_str()) {
                     continue;
                 }
                 zero
@@ -283,13 +286,20 @@ impl Planner<'_> {
     }
 
     /// Empty-map literal in the field's Go type, sound as empty needs no coercion.
-    fn go_field_map_zero(&mut self, owner: &Type, field: &str, field_ty: &Type) -> Option<String> {
+    fn go_field_map_zero(
+        &mut self,
+        owner: &Type,
+        field: &str,
+        field_ty: &Type,
+    ) -> Option<GoExpression> {
         let layout = self.field_slot_layout(owner, None, field, field_ty)?;
         if !layout_is_map(&layout) {
             return None;
         }
         let go_type = layout.go_type(self);
-        Some(format!("{}{{}}", self.use_rendered_go_type(go_type)))
+        Some(GoExpression::empty_composite(
+            self.use_rendered_go_type(go_type),
+        ))
     }
 
     /// Look up unspecified fields of a Lisette-defined struct or enum struct variant,
@@ -349,7 +359,7 @@ impl Planner<'_> {
 
     /// Zero for `T{..}` on a Go-imported newtype, a named non-struct with
     /// no fields for the autofill to name.
-    fn go_imported_newtype_zero(&mut self, ty: &Type) -> Option<String> {
+    fn go_imported_newtype_zero(&mut self, ty: &Type) -> Option<GoExpression> {
         let Type::Nominal { id, .. } = ty else {
             return None;
         };
@@ -358,37 +368,40 @@ impl Planner<'_> {
         }
         let underlying = self.get_newtype_underlying(ty)?;
         let go_ty = self.use_go_type(ty);
-        self.go_newtype_zero(&go_ty, &underlying)
+        self.go_newtype_zero(go_ty, &underlying)
     }
 
     /// Zero for a Go named non-struct, in a form Go takes as an operand.
-    fn go_newtype_zero(&mut self, go_ty: &str, underlying: &Type) -> Option<String> {
+    fn go_newtype_zero(&mut self, go_ty: String, underlying: &Type) -> Option<GoExpression> {
         let underlying = self.facts.peel_underlying(underlying);
         if underlying.is_map() || matches!(underlying, Type::Array { .. }) {
-            return Some(format!("{}{{}}", go_ty));
+            return Some(GoExpression::empty_composite(go_ty));
         }
         if underlying.is_slice() {
-            return Some(render_conversion(go_ty, "nil"));
+            return Some(GoExpression::conversion(
+                go_ty,
+                GoExpression::literal("nil".to_string()),
+            ));
         }
         matches!(underlying, Type::Simple(_)).then(|| {
             let inner = self.lisette_zero(&underlying);
-            render_conversion(go_ty, &inner)
+            GoExpression::conversion(go_ty, inner)
         })
     }
 
-    fn go_imported_zero(&mut self, ty: &Type, id: &str) -> String {
+    fn go_imported_zero(&mut self, ty: &Type, id: &str) -> GoExpression {
         if self.facts.is_interface(ty) || self.facts.resolve_to_function_type(ty).is_some() {
-            return "nil".to_string();
+            return GoExpression::literal("nil".to_string());
         }
         let go_ty = self.use_go_type(ty);
         let is_newtype = self.facts.definition(id).is_some_and(|d| d.is_newtype());
         if is_newtype {
             if let Some(underlying) = self.get_newtype_underlying(ty)
-                && let Some(zero) = self.go_newtype_zero(&go_ty, &underlying)
+                && let Some(zero) = self.go_newtype_zero(go_ty.clone(), &underlying)
             {
                 return zero;
             }
-            return format!("*new({})", go_ty);
+            return dereferenced_new(go_ty);
         }
         let is_struct = matches!(
             self.facts.definition(id).map(|d| &d.body),
@@ -402,12 +415,12 @@ impl Planner<'_> {
             })
         );
         if !is_struct && !is_opaque {
-            return format!("*new({})", go_ty);
+            return dereferenced_new(go_ty);
         }
         if is_struct
             && let Some(fields) = self.lookup_unspecified_fields(ty, "", None, &HashSet::default())
         {
-            let mut pairs: Vec<(String, String)> = Vec::new();
+            let mut pairs: Vec<(String, GoExpression)> = Vec::new();
             for (name, field_ty) in fields {
                 let Some(zero) = self.go_field_map_zero(ty, &name, &field_ty) else {
                     continue;
@@ -421,19 +434,19 @@ impl Planner<'_> {
                 };
                 pairs.push((go_field_name, zero));
             }
-            return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
+            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value(), false);
         }
-        format!("{}{{}}", go_ty)
+        GoExpression::empty_composite(go_ty)
     }
 
-    pub(crate) fn lisette_zero(&mut self, ty: &Type) -> String {
+    pub(crate) fn lisette_zero(&mut self, ty: &Type) -> GoExpression {
         let layout = self.value_layout(ty, SlotOrigin::Lisette);
         match (ty, &layout) {
             (Type::Simple(kind), _) => match kind {
-                SimpleKind::Bool => "false".to_string(),
-                SimpleKind::String => "\"\"".to_string(),
-                SimpleKind::Unit => "struct{}{}".to_string(),
-                _ => "0".to_string(),
+                SimpleKind::Bool => GoExpression::literal("false".to_string()),
+                SimpleKind::String => GoExpression::literal("\"\"".to_string()),
+                SimpleKind::Unit => GoExpression::empty_composite("struct{}".to_string()),
+                _ => GoExpression::literal("0".to_string()),
             },
             (
                 Type::Compound {
@@ -444,7 +457,7 @@ impl Planner<'_> {
             ) => {
                 let element = element.go_type(self);
                 let go_type = format!("[]{}", self.use_rendered_go_type(element));
-                render_conversion(&go_type, "nil")
+                GoExpression::conversion(go_type, GoExpression::literal("nil".to_string()))
             }
             (
                 Type::Compound {
@@ -457,38 +470,44 @@ impl Planner<'_> {
                 let value = value.go_type(self);
                 let key = self.use_rendered_go_type(key);
                 let value = self.use_rendered_go_type(value);
-                format!("map[{key}]{value}{{}}")
+                GoExpression::empty_composite(format!("map[{key}]{value}"))
             }
-            (Type::Compound { .. }, _) => format!("{}{{}}", self.use_go_type(ty)),
+            (Type::Compound { .. }, _) => GoExpression::empty_composite(self.use_go_type(ty)),
             (Type::Nominal { id, params, .. }, _) => {
                 self.lisette_zero_nominal(ty, id.as_str(), params)
             }
             (Type::Tuple(slots), ValueLayout::Tuple { elements, .. }) => {
-                let parts: Vec<String> = elements
+                let parts: Vec<GoExpression> = elements
                     .iter()
                     .map(|element| self.lisette_zero(element.logical_type()))
                     .collect();
                 let callee = self.make_tuple_callee(slots, parts.len());
-                format!("{}({})", callee, parts.join(", "))
+                GoExpression::call(callee, parts)
             }
             (
                 Type::Array { .. },
                 ValueLayout::Array {
                     length, element, ..
                 },
-            ) => self.array_zero(*length, element.logical_type()).rendered(),
-            _ => format!("{}{{}}", self.use_go_type(ty)),
+            ) => self.array_zero(*length, element.logical_type()),
+            _ => GoExpression::empty_composite(self.use_go_type(ty)),
         }
     }
 
-    fn lisette_zero_nominal(&mut self, ty: &Type, id: &str, params: &[Type]) -> String {
+    fn lisette_zero_nominal(&mut self, ty: &Type, id: &str, params: &[Type]) -> GoExpression {
         if id == "prelude.Option" {
             let inner = params
                 .first()
                 .map(|a| self.use_go_type(a))
                 .unwrap_or_else(|| "any".to_string());
             self.require_stdlib();
-            return format!("{}.MakeOptionNone[{}]()", go_name::GO_STDLIB_PKG, inner);
+            return GoExpression::call(
+                GoExpression::instantiation(
+                    GoExpression::name(format!("{}.MakeOptionNone", go_name::GO_STDLIB_PKG)),
+                    format!("[{inner}]"),
+                ),
+                Vec::new(),
+            );
         }
         if go_name::is_go_import(id) {
             return self.go_imported_zero(ty, id);
@@ -496,12 +515,12 @@ impl Planner<'_> {
         if let Some(underlying) = self.get_newtype_underlying(ty) {
             let go_ty = self.use_go_type(ty);
             let inner = self.lisette_zero(&underlying);
-            return render_conversion(&go_ty, &inner);
+            return GoExpression::conversion(go_ty, inner);
         }
         if let Some(fields) = self.lookup_unspecified_fields(ty, "", None, &HashSet::default()) {
             let go_ty = self.use_go_type(ty);
             let is_tuple = self.is_tuple_struct_type(ty);
-            let pairs: Vec<(String, String)> = fields
+            let pairs: Vec<(String, GoExpression)> = fields
                 .into_iter()
                 .enumerate()
                 .filter(|(_, (_, field_ty))| !field_ty.is_slice())
@@ -518,12 +537,12 @@ impl Planner<'_> {
                     (go_name, self.lisette_zero(&field_ty))
                 })
                 .collect();
-            return emit_struct_literal(&go_ty, &pairs, ExpressionContext::value());
+            return emit_struct_literal(&go_ty, pairs, ExpressionContext::value(), false);
         }
         if let Some(underlying) = self.facts.underlying_type(ty) {
             return self.lisette_zero(&underlying);
         }
-        format!("{}{{}}", self.use_go_type(ty))
+        GoExpression::empty_composite(self.use_go_type(ty))
     }
 
     /// Array zero value, filling per index with `lisette_zero` when Go's own
@@ -531,7 +550,7 @@ impl Planner<'_> {
     pub(crate) fn array_zero(&mut self, len: u64, elem: &Type) -> GoExpression {
         let elem_go = self.use_go_type(elem);
         if len == 0 || self.element_go_zero_ok(elem) {
-            return GoExpression::composite_literal(format!("[{}]{}{{}}", len, elem_go), false);
+            return GoExpression::empty_composite(format!("[{}]{}", len, elem_go));
         }
         let zero = self.lisette_zero(elem);
         // Go has no syntax to repeat a value across all N slots, so fill each index.
@@ -568,10 +587,10 @@ impl Planner<'_> {
     fn wrap_recursive_enum_field(
         &mut self,
         statements: &mut Vec<LoweredStatement>,
-        value: String,
+        value: GoExpression,
         field: &StructFieldAssignment,
         ctx: &StructCallContext<'_>,
-    ) -> String {
+    ) -> GoExpression {
         let needs_pointer = ctx
             .enum_ctx
             .as_ref()
@@ -579,8 +598,8 @@ impl Planner<'_> {
         if !needs_pointer {
             return value;
         }
-        let temp = self.hoist_tmp_value_statement(statements, "ptr", &value);
-        format!("&{}", temp)
+        let temp = self.hoist_tmp_value_statement(statements, "ptr", value.as_str());
+        GoExpression::address_of(GoExpression::name(temp))
     }
 
     /// Analyze a struct call to determine Go type and enum context.
@@ -736,13 +755,14 @@ impl Planner<'_> {
         &mut self,
         statements: &mut Vec<LoweredStatement>,
         fields: Vec<StructCallField>,
-    ) -> Vec<(String, String)> {
+    ) -> Vec<(String, GoExpression)> {
         fields
             .into_iter()
             .map(|field| {
                 if field.has_observable_evaluation {
-                    let temp = self.hoist_tmp_value_statement(statements, "field", &field.value);
-                    (field.name, temp)
+                    let temp =
+                        self.hoist_tmp_value_statement(statements, "field", field.value.as_str());
+                    (field.name, GoExpression::name(temp))
                 } else {
                     field.into_pair()
                 }
@@ -753,7 +773,7 @@ impl Planner<'_> {
     fn lower_struct_update(
         &mut self,
         base_staged: ValuePlan,
-        fields: &[(String, String)],
+        fields: &[(String, GoExpression)],
     ) -> (Vec<LoweredStatement>, GoExpression) {
         // A spread that assigns nothing is its base, whatever shape that has.
         if fields.is_empty() {
@@ -791,36 +811,56 @@ impl Planner<'_> {
             .lookup_unspecified_fields(ctx.ty, ctx.name, ctx.enum_ctx.as_ref(), &assigned)
             .unwrap_or_default();
 
-        let (mut statements, base_value) = base_staged.into_parts();
+        let ValuePlan {
+            setup: mut statements,
+            expression: base_value,
+            ..
+        } = base_staged;
 
         if carried.is_empty() {
             statements.push(LoweredStatement::RawGo(format!("_ = {}\n", base_value)));
             return (
                 statements,
-                GoExpression::composite_literal(
-                    emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+                emit_struct_literal(
+                    &ctx.go_type,
+                    field_pairs,
+                    expression_ctx,
                     fields_contain_deferred_evaluation,
                 ),
             );
         }
 
         let source = if is_order_sensitive(base) {
-            self.hoist_tmp_value_statement(&mut statements, "spread", &base_value)
+            GoExpression::name(self.hoist_tmp_value_statement(
+                &mut statements,
+                "spread",
+                base_value.as_str(),
+            ))
         } else {
             base_value
         };
         for (field_name, _) in carried {
             let slot = self.resolve_struct_call_field_name(&field_name, ctx);
-            field_pairs.push((slot.clone(), format!("{}.{}", source, slot)));
+            field_pairs.push((slot.clone(), GoExpression::selector(source.clone(), slot)));
         }
         (
             statements,
-            GoExpression::composite_literal(
-                emit_struct_literal(&ctx.go_type, &field_pairs, expression_ctx),
+            emit_struct_literal(
+                &ctx.go_type,
+                field_pairs,
+                expression_ctx,
                 fields_contain_deferred_evaluation,
             ),
         )
     }
+}
+
+/// `*new(T)`, the zero of a Go named type with no literal form.
+fn dereferenced_new(go_type: String) -> GoExpression {
+    GoExpression::dereference(GoExpression::call(
+        GoExpression::name("new".to_string()),
+        vec![GoExpression::type_name(go_type)],
+    ))
 }
 
 /// Whether a Go slot layout is a map, seeing through a named map type.
@@ -881,28 +921,31 @@ fn unspecified_pairs<'a>(
 
 pub(crate) fn emit_struct_literal(
     ty: &str,
-    fields: &[(String, String)],
+    fields: Vec<(String, GoExpression)>,
     ctx: ExpressionContext<'_>,
-) -> String {
-    let raw = if fields.is_empty() {
-        format!("{}{{}}", ty)
-    } else if fields.len() == 1 {
-        let (name, value) = &fields[0];
-        format!("{}{{ {}: {} }}", ty, name, value)
+    contains_deferred_evaluation: bool,
+) -> GoExpression {
+    let layout = if fields.len() > 1 {
+        CompositeLayout::MultiLine { indented: false }
     } else {
-        let field_strs: Vec<String> = fields
-            .iter()
-            .map(|(name, value)| format!("{}: {},", name, value))
-            .collect();
-        format!("{}{{\n{}\n}}", ty, field_strs.join("\n"))
+        CompositeLayout::Inline { padded: true }
     };
+    let literal = GoExpression::composite(
+        Some(ty.to_string()),
+        fields
+            .into_iter()
+            .map(|(name, value)| (Some(name), value))
+            .collect(),
+        layout,
+        contains_deferred_evaluation,
+    );
 
     // Generic composite literals (`Type[Args]{...}`) need inner parens in
     // condition contexts because gofmt strips outer condition parens for
     // generics, producing invalid Go in `if`/`for`/`switch`.
     if ctx.is_condition() && ty.contains('[') {
-        format!("({})", raw)
+        GoExpression::parenthesized(literal).with_deferred_evaluation(contains_deferred_evaluation)
     } else {
-        raw
+        literal
     }
 }

--- a/crates/emit/src/expressions/dot_classify.rs
+++ b/crates/emit/src/expressions/dot_classify.rs
@@ -1,6 +1,8 @@
 use crate::Planner;
 use crate::context::expression::ExpressionContext;
+use crate::expressions::identifiers::method_expression;
 use crate::names::go_name;
+use crate::plan::values::GoExpression;
 use syntax::ast::Expression;
 use syntax::program::DefinitionBody;
 use syntax::types::{Type, unqualified_name};
@@ -11,7 +13,7 @@ impl Planner<'_> {
         &mut self,
         member: &str,
         result_ty: &Type,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         if let Some(s) = self.emit_enum_variant_constructor(member, result_ty) {
             return Some(s);
         }
@@ -25,7 +27,7 @@ impl Planner<'_> {
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         if let Some(s) = self.emit_cross_package_static_method(expression, member, result_ty, ctx) {
             return Some(s);
         }
@@ -41,7 +43,7 @@ impl Planner<'_> {
         &mut self,
         variant_name: &str,
         result_ty: &Type,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let Type::Function(f) = result_ty else {
             return None;
         };
@@ -74,22 +76,25 @@ impl Planner<'_> {
                 if let Some(package) = resolved.package {
                     self.require_generated_package(package);
                 }
-                format!("{}{}", resolved.name, type_args)
+                resolved.name.to_string()
             } else {
                 let pkg = self.require_package_import(enum_package);
-                format!("{}.{}{}", pkg, make_fn_name, type_args)
+                format!("{}.{}", pkg, make_fn_name)
             }
         } else {
-            format!("{}{}", make_fn_name, type_args)
+            make_fn_name.to_string()
         };
-        Some(make_fn)
+        Some(GoExpression::instantiation(
+            GoExpression::name(make_fn),
+            type_args,
+        ))
     }
 
     fn emit_unit_variant_constructor(
         &mut self,
         variant_name: &str,
         result_ty: &Type,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let Type::Nominal {
             id: enum_id,
             params,
@@ -116,18 +121,22 @@ impl Planner<'_> {
         let make_fn = self.facts.make_function_name(enum_id, variant_name)?;
         let type_args = self.format_type_args(params);
 
-        if is_prelude {
+        let callee = if is_prelude {
             let resolved = go_name::resolve(&make_fn);
             if let Some(package) = resolved.package {
                 self.require_generated_package(package);
             }
-            Some(format!("{}{}()", resolved.name, type_args))
+            resolved.name.to_string()
         } else if is_cross_package {
             let pkg = self.require_package_import(enum_package);
-            Some(format!("{}.{}{}()", pkg, make_fn, type_args))
+            format!("{}.{}", pkg, make_fn)
         } else {
-            Some(format!("{}{}()", make_fn, type_args))
-        }
+            make_fn.to_string()
+        };
+        Some(GoExpression::call(
+            GoExpression::instantiation(GoExpression::name(callee), type_args),
+            Vec::new(),
+        ))
     }
 
     /// Handles `Alias.new(1)` where `type Alias = Box` → emit as `Box_new(1)`.
@@ -137,7 +146,7 @@ impl Planner<'_> {
         expression: &Expression,
         member: &str,
         result_ty: &Type,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         let func_ty = result_ty.unwrap_forall();
         if !matches!(func_ty, Type::Function(_)) {
             return None;
@@ -154,7 +163,7 @@ impl Planner<'_> {
         let capitalized = self.capitalize_static_method_if_public(&resolved_name);
         let go_name = self.resolve_go_name(&capitalized, None, false);
 
-        Some(go_name)
+        Some(GoExpression::name(go_name))
     }
 
     /// Instance method used as a value (e.g. `lib.Point.area` callback →
@@ -166,7 +175,7 @@ impl Planner<'_> {
         result_ty: &Type,
         is_exported: bool,
         is_pointer_receiver: bool,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         if let Expression::Identifier { value, .. } = expression {
             let go_method = if is_exported {
                 go_name::snake_to_camel(member)
@@ -178,11 +187,11 @@ impl Planner<'_> {
                 .unwrap_or_else(|| value.to_string());
             let type_go = go_name::escape_type_name(&type_name);
             let type_args = self.method_expression_type_args(result_ty);
-            return Some(if is_pointer_receiver {
-                format!("(*{}{}).{}", type_go, type_args, go_method)
-            } else {
-                format!("{}{}.{}", type_go, type_args, go_method)
-            });
+            return Some(method_expression(
+                format!("{}{}", type_go, type_args),
+                is_pointer_receiver,
+                go_method,
+            ));
         }
 
         let Expression::DotAccess {
@@ -217,13 +226,11 @@ impl Planner<'_> {
         let go_type_name = go_name::snake_to_camel(type_name);
         let type_args = self.method_expression_type_args(result_ty);
 
-        let method_expression = if is_pointer_receiver {
-            format!("(*{}.{}{}).{}", pkg, go_type_name, type_args, go_method)
-        } else {
-            format!("{}.{}{}.{}", pkg, go_type_name, type_args, go_method)
-        };
-
-        Some(method_expression)
+        Some(method_expression(
+            format!("{}.{}{}", pkg, go_type_name, type_args),
+            is_pointer_receiver,
+            go_method,
+        ))
     }
 
     fn method_expression_type_args(&mut self, result_ty: &Type) -> String {
@@ -255,7 +262,7 @@ impl Planner<'_> {
         member: &str,
         result_ty: &Type,
         ctx: ExpressionContext<'_>,
-    ) -> Option<String> {
+    ) -> Option<GoExpression> {
         if !matches!(result_ty.unwrap_forall(), Type::Function(_)) {
             return None;
         }
@@ -324,6 +331,9 @@ impl Planner<'_> {
             String::new()
         };
 
-        Some(format!("{}{}", qualified_name, type_args))
+        Some(GoExpression::instantiation(
+            GoExpression::name(qualified_name),
+            type_args,
+        ))
     }
 }

--- a/crates/emit/src/expressions/identifiers.rs
+++ b/crates/emit/src/expressions/identifiers.rs
@@ -29,16 +29,12 @@ impl Planner<'_> {
         ctx: ExpressionContext<'_>,
     ) -> GoExpression {
         if let Some(BindingValue::InlineExpr(expr)) = self.scope.resolve_identifier_binding(value) {
-            let text = expr.as_str().to_string();
+            let expression = expr.expression().clone();
             let refs = expr.refs().to_vec();
-            let contains_deferred_evaluation = expr.contains_deferred_evaluation();
             for go_name in &refs {
                 self.scope.record_go_use(go_name);
             }
-            return GoExpression::opaque_with_deferred_evaluation(
-                text,
-                contains_deferred_evaluation,
-            );
+            return expression;
         }
         let bound_go_name = self
             .scope
@@ -48,33 +44,29 @@ impl Planner<'_> {
             self.scope.record_go_use(go_name);
         }
         match self.classify_identifier(value, ty, ctx) {
-            IdentifierKind::UnitValue => {
-                GoExpression::composite_literal("struct{}{}".to_string(), false)
-            }
+            IdentifierKind::UnitValue => GoExpression::empty_composite("struct{}".to_string()),
             IdentifierKind::PublicFunction { capitalized } => GoExpression::name(capitalized),
             IdentifierKind::UnitConstructor { name, type_args } => GoExpression::call(
-                GoExpression::opaque(format!(
-                    "{}{}",
-                    self.resolve_go_name(&name, None, false),
-                    type_args
-                )),
+                GoExpression::instantiation(
+                    GoExpression::name(self.resolve_go_name(&name, None, false)),
+                    type_args,
+                ),
                 Vec::new(),
             ),
-            IdentifierKind::ConstructorFunction { name, type_args } => GoExpression::name(format!(
-                "{}{}",
-                self.resolve_go_name(&name, None, false),
-                type_args
-            )),
+            IdentifierKind::ConstructorFunction { name, type_args } => GoExpression::instantiation(
+                GoExpression::name(self.resolve_go_name(&name, None, false)),
+                type_args,
+            ),
             IdentifierKind::Regular { name } => {
                 if let Some(expression) = self.try_emit_method_expression(&name, ty) {
-                    return GoExpression::opaque(expression);
+                    return expression;
                 }
                 let resolved = self.capitalize_static_method_if_public(&name);
                 let go_name = self.resolve_go_name(&resolved, qualified, bound_go_name.is_some());
                 if !ctx.is_callee()
                     && let Some(type_args) = self.format_generic_value_type_args(&name, ty)
                 {
-                    return GoExpression::name(format!("{}{}", go_name, type_args));
+                    return GoExpression::instantiation(GoExpression::name(go_name), type_args);
                 }
                 GoExpression::name(go_name)
             }
@@ -258,7 +250,7 @@ impl Planner<'_> {
 
     /// Return Go method-expression syntax for a `Type.method` referring to an
     /// instance method (first param is `self`); `None` for static methods.
-    fn try_emit_method_expression(&mut self, name: &str, id_ty: &Type) -> Option<String> {
+    fn try_emit_method_expression(&mut self, name: &str, id_ty: &Type) -> Option<GoExpression> {
         let (type_part, method_part) = name.split_once('.')?;
 
         if method_part.contains('.') {
@@ -316,11 +308,11 @@ impl Planner<'_> {
         };
 
         let type_go = go_name::escape_type_name(type_part);
-        if is_pointer {
-            Some(format!("(*{}{}).{}", type_go, type_args, go_method))
-        } else {
-            Some(format!("{}{}.{}", type_go, type_args, go_method))
-        }
+        Some(method_expression(
+            format!("{}{}", type_go, type_args),
+            is_pointer,
+            go_method,
+        ))
     }
 
     /// Resolve `package.Type.method` as a cross-package static method call.
@@ -373,4 +365,18 @@ impl Planner<'_> {
 
         Some(go_name::snake_to_camel(name))
     }
+}
+
+/// Go method expression on a type, `T.method` or `(*T).method`.
+pub(crate) fn method_expression(
+    receiver_type: String,
+    pointer_receiver: bool,
+    go_method: String,
+) -> GoExpression {
+    let receiver = if pointer_receiver {
+        format!("(*{})", receiver_type)
+    } else {
+        receiver_type
+    };
+    GoExpression::selector(GoExpression::type_name(receiver), go_method)
 }

--- a/crates/emit/src/expressions/literals.rs
+++ b/crates/emit/src/expressions/literals.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use crate::Planner;
 use crate::abi::coercion::CoercionPlan;
 use crate::context::expression::ExpressionContext;
+use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{
     CaptureBoundary, ConstantKind, EvaluationEffect, GoExpression, ValuePlan,
 };
@@ -93,13 +94,11 @@ impl Planner<'_> {
         };
         let element_ty = self.use_go_type(&element_lisette_ty);
 
+        let go_type = format!("{}{}", type_prefix, element_ty);
         if elements.is_empty() {
             return ValuePlan::computed(
                 Vec::new(),
-                GoExpression::composite_literal(
-                    format!("{}{}{{}}", type_prefix, element_ty),
-                    false,
-                ),
+                GoExpression::empty_composite(go_type),
                 EvaluationEffect::Pure,
             );
         }
@@ -112,37 +111,29 @@ impl Planner<'_> {
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
         let mut setup = sequenced.setup;
-        let values = sequenced.values;
 
-        let mut wrapped: Vec<String> = Vec::with_capacity(values.len());
+        let mut wrapped = Vec::with_capacity(sequenced.values.len());
         let mut widest = 0;
-        for (expr, value) in elements.iter().zip(&values) {
+        for (expr, value) in elements.iter().zip(sequenced.values) {
             let coercion = CoercionPlan::internal(self, &expr.get_type(), &element_lisette_ty);
             let is_whole_literal = coercion.is_identity() && value.is_composite_literal();
-            let (coercion_setup, coerced) = coercion.lower(self, value.rendered());
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
-            widest = widest.max(coerced.len());
-            wrapped.push(if is_whole_literal {
-                elide_element_type(&element_ty, coerced)
-            } else {
-                coerced
-            });
+            widest = widest.max(coerced.as_str().len());
+            wrapped.push((
+                None,
+                if is_whole_literal {
+                    coerced.elide_composite_type(&element_ty)
+                } else {
+                    coerced
+                },
+            ));
         }
-        let elements = wrapped;
 
-        let value = if elements.len() > 1 && widest > 30 {
-            let indented = elements
-                .iter()
-                .map(|e| format!("\t{}", e))
-                .collect::<Vec<_>>()
-                .join(",\n");
-            format!("{}{}{{\n{},\n}}", type_prefix, element_ty, indented)
-        } else {
-            format!("{}{}{{ {} }}", type_prefix, element_ty, elements.join(", "))
-        };
+        let layout = CompositeLayout::for_elements(wrapped.len(), widest);
         ValuePlan::computed(
             setup,
-            GoExpression::composite_literal(value, contains_deferred_evaluation),
+            GoExpression::composite(Some(go_type), wrapped, layout, contains_deferred_evaluation),
             effect,
         )
     }
@@ -209,23 +200,20 @@ impl Planner<'_> {
         // Solo-expression f-strings round-trip through fmt.Sprint, which skips
         // the format-string parse. Excluded: `%c`, because Sprint on a rune
         // prints the integer codepoint instead of the character.
-        if let ([FormatStringPart::Expression(_)], [arg]) = (parts, args.as_slice())
+        if let ([FormatStringPart::Expression(_)], [_]) = (parts, args.as_slice())
             && format_string != "%c"
         {
             return ValuePlan::observable_call(
                 setup,
-                GoExpression::call(
-                    GoExpression::opaque("fmt.Sprint".to_string()),
-                    vec![GoExpression::opaque(arg.clone())],
-                ),
+                GoExpression::call(GoExpression::name("fmt.Sprint".to_string()), args),
                 effect,
             );
         }
         let mut arguments = vec![GoExpression::literal(format!("\"{}\"", format_string))];
-        arguments.extend(args.into_iter().map(GoExpression::opaque));
+        arguments.extend(args);
         ValuePlan::observable_call(
             setup,
-            GoExpression::call(GoExpression::opaque("fmt.Sprintf".to_string()), arguments),
+            GoExpression::call(GoExpression::name("fmt.Sprintf".to_string()), arguments),
             effect,
         )
     }
@@ -236,7 +224,7 @@ impl Planner<'_> {
         parts: &[FormatStringPart],
         values: impl IntoIterator<Item = GoExpression>,
         escape_percent: bool,
-    ) -> (String, Vec<String>) {
+    ) -> (String, Vec<GoExpression>) {
         let mut values = values.into_iter();
         let mut format_string = String::new();
         let mut args = Vec::new();
@@ -257,8 +245,7 @@ impl Planner<'_> {
                     args.push(
                         values
                             .next()
-                            .expect("sequenced count matches expression parts")
-                            .rendered(),
+                            .expect("sequenced count matches expression parts"),
                     );
                 }
             }
@@ -305,13 +292,6 @@ fn format_verb_for(ty: &Type) -> &'static str {
         Some(k) if k.is_signed_int() || k.is_unsigned_int() => "%d",
         Some(k) if k.is_float() => "%g",
         _ => "%v",
-    }
-}
-
-pub(crate) fn elide_element_type(element_ty: &str, rendered: String) -> String {
-    match rendered.strip_prefix(element_ty) {
-        Some(literal) if literal.starts_with('{') => literal.to_string(),
-        _ => rendered,
     }
 }
 

--- a/crates/emit/src/expressions/operators.rs
+++ b/crates/emit/src/expressions/operators.rs
@@ -67,13 +67,13 @@ impl Planner<'_> {
                 && !left_ty.is_complex()
             {
                 let staged = self.plan_operand(left_expression, ctx);
-                return staged.map_rendered_as_computed(|_, value, _| {
+                return staged.map_expression_as_computed(|_, value| {
                     GoExpression::call(
                         GoExpression::name("complex".to_string()),
                         vec![
                             GoExpression::literal("0".to_string()),
                             GoExpression::binary(
-                                GoExpression::opaque_with_deferred_evaluation(value, true),
+                                value,
                                 "*",
                                 GoExpression::literal(imag_coef.to_string()),
                             ),
@@ -89,13 +89,13 @@ impl Planner<'_> {
                 && !right_ty.is_complex()
             {
                 let staged = self.plan_operand(right_expression, ctx);
-                return staged.map_rendered_as_computed(|_, value, _| {
+                return staged.map_expression_as_computed(|_, value| {
                     GoExpression::call(
                         GoExpression::name("complex".to_string()),
                         vec![
                             GoExpression::literal("0".to_string()),
                             GoExpression::binary(
-                                GoExpression::opaque_with_deferred_evaluation(value, true),
+                                value,
                                 "*",
                                 GoExpression::literal(imag_coef.to_string()),
                             ),
@@ -144,40 +144,27 @@ impl Planner<'_> {
     ) -> ValuePlan {
         let left_staged = self.lower_composite_value(left_expression, ctx);
         let left_effect = left_staged.evaluation.effect;
-        let left_contains_deferred_evaluation =
-            left_staged.expression.contains_deferred_evaluation();
-        let (left_setup, left_value) = left_staged.into_parts();
 
         // Wrap RHS setup in an IIFE so it runs only when control reaches the
         // RHS. Hoisting it before the operator would defeat short-circuit.
         let right_staged = self.lower_composite_value(right_expression, ctx);
         let right_effect = right_staged.evaluation.effect;
-        let right_contains_deferred_evaluation =
-            right_staged.expression.contains_deferred_evaluation();
-        let (right_setup, right_value) = right_staged.into_parts();
-        let right_string = if right_setup.is_empty() {
-            right_value
+        let right_value = if right_staged.setup.is_empty() {
+            right_staged.expression
         } else {
-            format!(
-                "func() bool {{\n{}return {}\n}}()",
-                Renderer.render_setup(&right_setup),
-                right_value
+            GoExpression::opaque_with_deferred_evaluation(
+                format!(
+                    "func() bool {{\n{}return {}\n}}()",
+                    Renderer.render_setup(&right_staged.setup),
+                    right_staged.expression
+                ),
+                true,
             )
         };
 
         ValuePlan::computed(
-            left_setup,
-            GoExpression::binary(
-                GoExpression::opaque_with_deferred_evaluation(
-                    left_value,
-                    left_contains_deferred_evaluation,
-                ),
-                operator.to_string(),
-                GoExpression::opaque_with_deferred_evaluation(
-                    right_string,
-                    right_contains_deferred_evaluation || !right_setup.is_empty(),
-                ),
-            ),
+            left_staged.setup,
+            GoExpression::binary(left_staged.expression, operator.to_string(), right_value),
             left_effect.combine(right_effect),
         )
     }
@@ -227,13 +214,6 @@ impl Planner<'_> {
     ) -> ValuePlan {
         let target = expression.unwrap_parens();
         let preserve_parens = matches!(expression, Expression::Paren { .. });
-        let wrap = |s: String| {
-            if preserve_parens {
-                format!("({})", s)
-            } else {
-                s
-            }
-        };
         if let Expression::Binary {
             operator: cmp,
             left,
@@ -261,9 +241,14 @@ impl Planner<'_> {
         if matches!(target, Expression::Call { .. }) {
             let mut setup: Vec<LoweredStatement> = Vec::new();
             if let Some(negated) = self.try_emit_negated_call(&mut setup, target) {
+                let negated = if preserve_parens {
+                    GoExpression::parenthesized(negated)
+                } else {
+                    negated
+                };
                 return ValuePlan::computed(
                     setup,
-                    GoExpression::opaque_with_deferred_evaluation(wrap(negated), true),
+                    negated.with_deferred_evaluation(true),
                     EvaluationEffect::EffectfulCall,
                 );
             }

--- a/crates/emit/src/expressions/staging.rs
+++ b/crates/emit/src/expressions/staging.rs
@@ -5,11 +5,11 @@ use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::calls::CallableOrigin;
+use crate::plan::go_expression::CompositeLayout;
 use crate::plan::values::{
     CaptureBoundary, EvaluationEffect, GoExpression, SequencedValues, Stability, ValuePlan,
 };
 use crate::utils::reads_value_member;
-use std::iter;
 use std::mem;
 use syntax::ast::{Expression, IdentifierResolution, UnaryOperator};
 use syntax::program::DotAccessKind;
@@ -84,9 +84,8 @@ impl Planner<'_> {
     /// Pin a staged operand's value into a temp so it evaluates before any
     /// later sibling.
     pub(crate) fn pin_staged(&mut self, staged: &mut ValuePlan, prefix: &str) {
-        let value =
-            mem::replace(&mut staged.expression, GoExpression::opaque(String::new())).rendered();
-        let tmp = self.hoist_tmp_value_statement(&mut staged.setup, prefix, &value);
+        let tmp =
+            self.hoist_tmp_value_statement(&mut staged.setup, prefix, staged.expression.as_str());
         staged.replace_with_pinned_name(tmp);
     }
 
@@ -251,16 +250,14 @@ impl Planner<'_> {
                 .detect_lower_arg_to_tagged(expression, param_ty)
                 .is_some()
         {
-            return staged.map_rendered_as_computed(
-                |setup, value, _contains_deferred_evaluation| {
-                    let tagged = self.emit_lower_arg_to_tagged(
-                        setup,
-                        &value,
-                        param_ty.expect("detected lowering requires a parameter type"),
-                    );
-                    GoExpression::opaque_with_deferred_evaluation(tagged, true)
-                },
-            );
+            return staged.map_expression_as_computed(|setup, value| {
+                let tagged = self.emit_lower_arg_to_tagged(
+                    setup,
+                    value.as_str(),
+                    param_ty.expect("detected lowering requires a parameter type"),
+                );
+                GoExpression::opaque_with_deferred_evaluation(tagged, true)
+            });
         }
 
         staged
@@ -341,38 +338,35 @@ impl Planner<'_> {
     ) {
         if wrap_to_any {
             self.require_stdlib();
-            let rendered = format!(
-                "{}.SliceToAny({})",
-                go_name::GO_STDLIB_PKG,
-                values[spread_index].rendered()
+            let spread_value = mem::replace(&mut values[spread_index], GoExpression::empty());
+            values[spread_index] = GoExpression::call(
+                GoExpression::name(format!("{}.SliceToAny", go_name::GO_STDLIB_PKG)),
+                vec![spread_value],
             );
-            values[spread_index] = GoExpression::opaque_with_deferred_evaluation(rendered, true);
         }
         match combine {
             Some(c) if spread_index > c.fixed_count => {
                 let element_go = self.use_go_type(&c.element_ty);
-                let leading = values[c.fixed_count..spread_index]
-                    .iter()
-                    .map(GoExpression::rendered)
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let spread_value = values[spread_index].rendered();
-                let combined = format!("append([]{element_go}{{{leading}}}, {spread_value}...)...");
-                values.splice(
-                    c.fixed_count..=spread_index,
-                    iter::once(GoExpression::opaque_with_deferred_evaluation(
-                        combined, true,
-                    )),
+                let mut combined: Vec<GoExpression> =
+                    values.drain(c.fixed_count..=spread_index).collect();
+                let spread_value = combined
+                    .pop()
+                    .expect("the spread value follows the leading arguments");
+                let leading = GoExpression::composite(
+                    Some(format!("[]{element_go}")),
+                    combined.into_iter().map(|value| (None, value)).collect(),
+                    CompositeLayout::Inline { padded: false },
+                    false,
                 );
+                let appended = GoExpression::call(
+                    GoExpression::name("append".to_string()),
+                    vec![leading, GoExpression::spread(spread_value)],
+                );
+                values.insert(c.fixed_count, GoExpression::spread(appended));
             }
             _ => {
-                let contains_deferred_evaluation =
-                    values[spread_index].contains_deferred_evaluation();
-                let rendered = format!("{}...", values[spread_index].rendered());
-                values[spread_index] = GoExpression::opaque_with_deferred_evaluation(
-                    rendered,
-                    contains_deferred_evaluation,
-                );
+                let spread_value = mem::replace(&mut values[spread_index], GoExpression::empty());
+                values[spread_index] = GoExpression::spread(spread_value);
             }
         }
     }
@@ -416,10 +410,7 @@ impl Planner<'_> {
         let mut results = Vec::with_capacity(stages.len());
         for i in 0..stages.len() {
             let s_non_literal = !stages[i].evaluation.stability.is_fixed();
-            let s_expression = mem::replace(
-                &mut stages[i].expression,
-                GoExpression::opaque(String::new()),
-            );
+            let s_expression = mem::replace(&mut stages[i].expression, GoExpression::empty());
             let s_setup = mem::take(&mut stages[i].setup);
 
             setup.extend(s_setup);

--- a/crates/emit/src/expressions/values.rs
+++ b/crates/emit/src/expressions/values.rs
@@ -46,10 +46,10 @@ impl Planner<'_> {
                 let layout_coercion = CoercionPlan::bridge(self, &source_layout, &target_layout);
                 if !layout_coercion.is_identity() {
                     let value = self.plan_operand(expression, ctx);
-                    return value.map_rendered_as_computed(|setup, value, _| {
+                    return value.map_expression_as_computed(|setup, value| {
                         let (bridge_setup, value) = layout_coercion.lower(self, value);
                         setup.extend(bridge_setup);
-                        GoExpression::opaque_with_deferred_evaluation(value, true)
+                        value.with_deferred_evaluation(true)
                     });
                 }
             }
@@ -91,11 +91,11 @@ impl Planner<'_> {
         {
             return self
                 .lower_value(expression, ctx)
-                .map_rendered_as_observable_computed(|setup, call_string, _| {
-                    if !call_string.is_empty() {
-                        setup.push(LoweredStatement::RawGo(format!("{call_string}\n")));
+                .map_expression_as_observable_computed(|setup, call| {
+                    if !call.is_empty() {
+                        setup.push(LoweredStatement::RawGo(format!("{call}\n")));
                     }
-                    GoExpression::composite_literal("struct{}{}".to_string(), false)
+                    GoExpression::empty_composite("struct{}".to_string())
                 });
         }
         self.lower_value(expression, ctx)
@@ -117,13 +117,11 @@ impl Planner<'_> {
             let call_type =
                 matches!(result_transition, AbiTransition::Identity).then_some(result_type);
             let call = self.lower_call_with_plan(expression, call_type, context, plan);
-            return call.map_rendered_as_observable_computed(
-                |setup, call_string, _contains_deferred_evaluation| {
-                    let (bridge_setup, value) = bridge.lower(self, call_string);
-                    setup.extend(bridge_setup);
-                    GoExpression::opaque(value)
-                },
-            );
+            return call.map_expression_as_observable_computed(|setup, call| {
+                let (bridge_setup, value) = bridge.lower(self, call);
+                setup.extend(bridge_setup);
+                value.with_deferred_evaluation(false)
+            });
         }
 
         match result_transition {
@@ -250,11 +248,11 @@ impl Planner<'_> {
                 if adapter_setup.is_empty() {
                     plan
                 } else {
-                    plan.map_rendered_as_computed(|setup, _, contains_deferred_evaluation| {
+                    plan.map_expression_as_computed(|setup, identifier| {
                         setup.extend(adapter_setup);
                         GoExpression::opaque_with_deferred_evaluation(
                             value,
-                            contains_deferred_evaluation,
+                            identifier.contains_deferred_evaluation(),
                         )
                     })
                 }
@@ -263,7 +261,7 @@ impl Planner<'_> {
             Expression::RawGo { text } => ValuePlan::opaque(text.clone()),
             Expression::Unit { .. } => ValuePlan::computed(
                 Vec::new(),
-                GoExpression::composite_literal("struct{}{}".to_string(), false),
+                GoExpression::empty_composite("struct{}".to_string()),
                 EvaluationEffect::Pure,
             ),
             Expression::Lambda {
@@ -286,7 +284,7 @@ impl Planner<'_> {
                 let plan = self.build_return_plan(return_expression);
                 ValuePlan::computed(
                     vec![LoweredStatement::Return(plan)],
-                    GoExpression::opaque(String::new()),
+                    GoExpression::empty(),
                     EvaluationEffect::Pure,
                 )
             }
@@ -294,13 +292,14 @@ impl Planner<'_> {
                 let setup = self.lower_assignment_operand(target, value);
                 ValuePlan::computed(
                     setup,
-                    GoExpression::opaque("struct{}{}".to_string()),
+                    GoExpression::empty_composite("struct{}".to_string())
+                        .with_deferred_evaluation(false),
                     EvaluationEffect::Pure,
                 )
             }
             Expression::Assert { .. } => ValuePlan::computed(
                 vec![self.lower_assert_statement(expression)],
-                GoExpression::opaque("struct{}{}".to_string()),
+                GoExpression::empty_composite("struct{}".to_string()),
                 EvaluationEffect::Pure,
             ),
             _ => unreachable!(
@@ -314,33 +313,34 @@ impl Planner<'_> {
         &mut self,
         setup: &mut Vec<LoweredStatement>,
         elements: &[Expression],
-        rendered: Vec<String>,
+        values: Vec<GoExpression>,
         slot_types: &[Type],
-    ) -> Vec<String> {
-        let mut coerced_elements = Vec::with_capacity(rendered.len());
-        for (index, (element, rendered)) in elements.iter().zip(rendered).enumerate() {
+    ) -> Vec<GoExpression> {
+        let mut coerced_elements = Vec::with_capacity(values.len());
+        for (index, (element, value)) in elements.iter().zip(values).enumerate() {
             let Some(slot) = slot_types.get(index) else {
-                coerced_elements.push(rendered);
+                coerced_elements.push(value);
                 continue;
             };
             let coercion = CoercionPlan::internal(self, &element.get_type(), slot);
-            let (coercion_setup, coerced) = coercion.lower(self, rendered);
+            let (coercion_setup, coerced) = coercion.lower(self, value);
             setup.extend(coercion_setup);
             coerced_elements.push(coerced);
         }
         coerced_elements
     }
 
-    pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> String {
+    pub(crate) fn make_tuple_callee(&mut self, slot_types: &[Type], arity: usize) -> GoExpression {
         self.require_stdlib();
+        let callee = GoExpression::name(format!("lisette.MakeTuple{}", arity));
         if slot_types.len() != arity {
-            return format!("lisette.MakeTuple{}", arity);
+            return callee;
         }
         let rendered: Vec<String> = slot_types
             .iter()
             .map(|slot| self.use_go_type(slot))
             .collect();
-        format!("lisette.MakeTuple{}[{}]", arity, rendered.join(", "))
+        GoExpression::instantiation(callee, format!("[{}]", rendered.join(", ")))
     }
 
     pub(crate) fn plan_tuple_value(
@@ -369,20 +369,14 @@ impl Planner<'_> {
             .collect();
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "v");
         let effect = sequenced.effect;
-        let (mut setup, element_expressions) = sequenced.into_rendered();
+        let mut setup = sequenced.setup;
 
         let element_expressions =
-            self.coerce_elements_to_slots(&mut setup, elements, element_expressions, &slot_types);
+            self.coerce_elements_to_slots(&mut setup, elements, sequenced.values, &slot_types);
         let callee = self.make_tuple_callee(&slot_types, element_expressions.len());
         ValuePlan::observable_call(
             setup,
-            GoExpression::call(
-                GoExpression::opaque(callee),
-                element_expressions
-                    .into_iter()
-                    .map(GoExpression::opaque)
-                    .collect(),
-            ),
+            GoExpression::call(callee, element_expressions),
             effect,
         )
     }
@@ -405,12 +399,11 @@ impl Planner<'_> {
             let inner = self.lower_value(expression, ctx);
             let source_ty = expression.get_type();
             let coercion = CoercionPlan::internal(self, &source_ty, ty);
-            let mut converted =
-                inner.map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
-                    let (coercion_setup, coerced) = coercion.lower(self, value);
-                    setup.extend(coercion_setup);
-                    GoExpression::opaque_with_deferred_evaluation(coerced, true)
-                });
+            let mut converted = inner.map_expression_as_computed(|setup, value| {
+                let (coercion_setup, coerced) = coercion.lower(self, value);
+                setup.extend(coercion_setup);
+                coerced.with_deferred_evaluation(true)
+            });
             if !converted.evaluation.stability.is_stable_across_calls() {
                 converted.make_observable();
             }
@@ -424,10 +417,10 @@ impl Planner<'_> {
         let function_bridge = self.function_slot_bridge(expression, ty);
         if !function_bridge.is_identity() {
             return inner
-                .map_rendered_as_computed(|setup, value, _contains_deferred_evaluation| {
+                .map_expression_as_computed(|setup, value| {
                     let (bridge_setup, bridged) = function_bridge.lower(self, value);
                     setup.extend(bridge_setup);
-                    GoExpression::opaque_with_deferred_evaluation(bridged, true)
+                    bridged.with_deferred_evaluation(true)
                 })
                 .conversion(go_type);
         }
@@ -467,38 +460,32 @@ impl Planner<'_> {
     pub(crate) fn plan_reference(&mut self, inner: &Expression, ty: &Type) -> ValuePlan {
         if inner.get_type().is_unit() && matches!(inner.unwrap_parens(), Expression::Call { .. }) {
             let staged = self.plan_operand(inner.unwrap_parens(), ExpressionContext::value());
-            return staged.map_rendered_as_observable_computed(
-                |setup, staged_value, _contains_deferred_evaluation| {
-                    if !staged_value.is_empty() {
-                        setup.push(LoweredStatement::Expression(
-                            ExpressionStatementForm::Async {
-                                value: ValuePlan::opaque(staged_value),
-                            },
-                        ));
-                    }
-                    let tmp = self.hoist_tmp_value_statement(setup, "ref", "struct{}{}");
-                    GoExpression::opaque(format!("&{}", tmp))
-                },
-            );
+            return staged.map_expression_as_observable_computed(|setup, staged_value| {
+                if !staged_value.is_empty() {
+                    setup.push(LoweredStatement::Expression(
+                        ExpressionStatementForm::Async {
+                            value: ValuePlan::opaque(staged_value.rendered()),
+                        },
+                    ));
+                }
+                let tmp = self.hoist_tmp_value_statement(setup, "ref", "struct{}{}");
+                GoExpression::address_of(GoExpression::name(tmp))
+            });
         }
 
         let inner_plan = self.lower_value(inner, ExpressionContext::value());
-        inner_plan.map_rendered_as_observable_computed(
-            |setup, emitted, mut contains_deferred_evaluation| {
-                let value = if inner.get_type() == *ty {
-                    emitted
-                } else if self.is_go_unaddressable(inner)
-                    || matches!(inner.get_type(), Type::Function(_))
-                {
-                    contains_deferred_evaluation = false;
-                    let tmp = self.hoist_tmp_value_statement(setup, "ref", &emitted);
-                    format!("&{}", tmp)
-                } else {
-                    format!("&{}", emitted)
-                };
-                GoExpression::opaque_with_deferred_evaluation(value, contains_deferred_evaluation)
-            },
-        )
+        inner_plan.map_expression_as_observable_computed(|setup, emitted| {
+            if inner.get_type() == *ty {
+                emitted
+            } else if self.is_go_unaddressable(inner)
+                || matches!(inner.get_type(), Type::Function(_))
+            {
+                let tmp = self.hoist_tmp_value_statement(setup, "ref", emitted.as_str());
+                GoExpression::address_of(GoExpression::name(tmp))
+            } else {
+                GoExpression::address_of(emitted)
+            }
+        })
     }
 
     pub(crate) fn contains_newtype_access(&self, expression: &Expression) -> bool {
@@ -551,7 +538,11 @@ impl Planner<'_> {
         } else {
             self.emit_left_value(&mut setup, target)
         };
-        let (rhs_setup, rhs_value) = right_hand_side.into_parts();
+        let ValuePlan {
+            setup: rhs_setup,
+            expression: rhs_value,
+            ..
+        } = right_hand_side;
         setup.extend(rhs_setup);
 
         if let Some(target_layout) = go_field_layout
@@ -597,7 +588,7 @@ impl Planner<'_> {
         if stages.is_empty() {
             return ValuePlan::computed(
                 Vec::new(),
-                GoExpression::composite_literal("struct{}{}".to_string(), false),
+                GoExpression::empty_composite("struct{}".to_string()),
                 EvaluationEffect::Pure,
             );
         }
@@ -605,23 +596,27 @@ impl Planner<'_> {
         let sequenced = self.sequence_values(stages, CaptureBoundary::SiblingSequence, "range");
         let effect = sequenced.effect;
         let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (setup, values) = sequenced.into_rendered();
+        let mut values = sequenced.values.into_iter();
         let mut fields = Vec::new();
         if has_start {
-            fields.push(("Start".to_string(), values[0].clone()));
-            if values.len() > 1 {
-                fields.push(("End".to_string(), values[1].clone()));
+            fields.push((
+                "Start".to_string(),
+                values.next().expect("range has a start"),
+            ));
+            if let Some(end_value) = values.next() {
+                fields.push(("End".to_string(), end_value));
             }
         } else {
-            fields.push(("End".to_string(), values[0].clone()));
+            fields.push(("End".to_string(), values.next().expect("range has an end")));
         }
 
-        let value = emit_struct_literal(&type_string, &fields, ExpressionContext::value());
-        ValuePlan::computed(
-            setup,
-            GoExpression::composite_literal(value, contains_deferred_evaluation),
-            effect,
-        )
+        let value = emit_struct_literal(
+            &type_string,
+            fields,
+            ExpressionContext::value(),
+            contains_deferred_evaluation,
+        );
+        ValuePlan::computed(sequenced.setup, value, effect)
     }
 
     /// Plan a `Task`/`Defer` operand.
@@ -639,11 +634,7 @@ impl Planner<'_> {
                     body,
                 },
             )];
-            return ValuePlan::computed(
-                setup,
-                GoExpression::opaque(String::new()),
-                EvaluationEffect::Pure,
-            );
+            return ValuePlan::computed(setup, GoExpression::empty(), EvaluationEffect::Pure);
         }
 
         let mut setup: Vec<LoweredStatement> = Vec::new();
@@ -689,11 +680,7 @@ impl Planner<'_> {
                     body,
                 },
             ));
-            return ValuePlan::computed(
-                setup,
-                GoExpression::opaque(String::new()),
-                EvaluationEffect::Pure,
-            );
+            return ValuePlan::computed(setup, GoExpression::empty(), EvaluationEffect::Pure);
         }
         let (setup, inner) = plan.into_parts();
         ValuePlan::computed(

--- a/crates/emit/src/patterns/binding_emit.rs
+++ b/crates/emit/src/patterns/binding_emit.rs
@@ -5,7 +5,7 @@ use crate::patterns::decision_tree::{
 };
 use crate::plan::bodies::LoweredStatement;
 use crate::plan::placement::simple_assign;
-use crate::plan::values::ValuePlan;
+use crate::plan::values::{EvaluationEffect, ValuePlan};
 use crate::state::bindings::InlineExpr;
 use std::borrow::Cow;
 use syntax::ast::Expression;
@@ -120,16 +120,19 @@ pub(crate) fn tree_binding_statements(
             continue;
         };
 
-        let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
+        let access_expression = binding
+            .path
+            .render(SubjectRoot::Var(subject_var))
+            .rendered();
 
         if analyze_inline_candidate(&binding.lisette_name, consumers) == InlineDecision::Inline {
-            let safe_text = binding
+            let composable = binding
                 .path
                 .render_composable(SubjectRoot::Var(subject_var));
             planner.scope.bind_inline_expr(
                 &binding.lisette_name,
                 InlineExpr::new(
-                    safe_text,
+                    composable,
                     vec![subject_var.to_string()],
                     binding.path.contains_deferred_evaluation(),
                 ),
@@ -195,6 +198,9 @@ pub(crate) fn tree_assignment_statements(
         let name = registered_name.to_string();
         planner.scope.record_go_use(subject_var);
         let access_expression = binding.path.render(SubjectRoot::Var(subject_var));
-        statements.push(simple_assign(&name, ValuePlan::opaque(access_expression)));
+        statements.push(simple_assign(
+            &name,
+            ValuePlan::computed(Vec::new(), access_expression, EvaluationEffect::Pure),
+        ));
     }
 }

--- a/crates/emit/src/patterns/decision_tree.rs
+++ b/crates/emit/src/patterns/decision_tree.rs
@@ -13,7 +13,7 @@ use crate::Planner;
 use crate::names::packages::PackageRequirements;
 use crate::names::{generics, go_name};
 use crate::patterns::binding_decls::emit_pattern_literal;
-use crate::types::go_type::render_conversion;
+use crate::plan::values::GoExpression;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PathSegment {
@@ -98,39 +98,50 @@ impl AccessPath {
         new
     }
 
-    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> String {
-        let (mut result, segments) = subject.resolve(&self.segments);
+    pub(crate) fn render(&self, subject: SubjectRoot<'_>) -> GoExpression {
+        let (root, segments) = subject.resolve(&self.segments);
+        let mut result = GoExpression::name(root);
         let last = segments.len().saturating_sub(1);
         for (i, seg) in segments.iter().enumerate() {
-            match seg {
-                PathSegment::Field(name) => result = format!("{}.{}", result, name),
-                PathSegment::Index(index) => result = format!("{}[{}]", result, index),
-                PathSegment::SliceFrom(offset) => result = format!("{}[{}:]", result, offset),
-                PathSegment::ArraySliceFrom { offset, go_type } => {
-                    result = render_conversion(go_type, &format!("{}[{}:]", result, offset))
+            result = match seg {
+                PathSegment::Field(name) => GoExpression::selector(result, name.clone()),
+                PathSegment::Index(index) => {
+                    GoExpression::index(result, GoExpression::literal(index.to_string()))
                 }
+                PathSegment::SliceFrom(offset) => GoExpression::slice(
+                    result,
+                    Some(&GoExpression::literal(offset.to_string())),
+                    None,
+                    None,
+                ),
+                PathSegment::ArraySliceFrom { offset, go_type } => GoExpression::conversion(
+                    go_type.clone(),
+                    GoExpression::slice(
+                        result,
+                        Some(&GoExpression::literal(offset.to_string())),
+                        None,
+                        None,
+                    ),
+                ),
+                PathSegment::Deref if i == last => GoExpression::dereference(result),
                 PathSegment::Deref => {
-                    if i == last {
-                        result = format!("*{}", result);
-                    } else {
-                        result = format!("(*{})", result);
-                    }
+                    GoExpression::parenthesized(GoExpression::dereference(result))
                 }
-                PathSegment::NewtypeCast(go_type) => result = render_conversion(go_type, &result),
-                PathSegment::AssertedAs(ty) => {
-                    result = format!("{}.({})", result, ty);
+                PathSegment::NewtypeCast(go_type) => {
+                    GoExpression::conversion(go_type.clone(), result)
                 }
-            }
+                PathSegment::AssertedAs(ty) => GoExpression::type_assertion(result, ty.clone()),
+            };
         }
         result
     }
 
     /// Like `render`, but a tail-`Deref` is parenthesized so the result is
     /// safe as a selector receiver, index target, or call callee.
-    pub(crate) fn render_composable(&self, subject: SubjectRoot<'_>) -> String {
+    pub(crate) fn render_composable(&self, subject: SubjectRoot<'_>) -> GoExpression {
         let rendered = self.render(subject);
         if matches!(self.segments.last(), Some(PathSegment::Deref)) {
-            format!("({})", rendered)
+            GoExpression::parenthesized(rendered)
         } else {
             rendered
         }
@@ -198,12 +209,12 @@ impl Check {
         let negative = matches!(polarity, CheckPolarity::Negative);
         match self {
             Check::EnumTag { path, tag_constant } => {
-                let rendered_path = path.render(subject);
+                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "!=" } else { "==" };
                 format!("{rendered_path}.Tag {operator} {tag_constant}")
             }
             Check::Literal { path, go_literal } => {
-                let rendered_path = path.render(subject);
+                let rendered_path = path.render(subject).rendered();
                 match (go_literal.as_str(), negative) {
                     ("true", false) | ("false", true) => rendered_path,
                     ("true", true) | ("false", false) => format!("!{rendered_path}"),
@@ -212,12 +223,12 @@ impl Check {
                 }
             }
             Check::SliceLenEq { path, length } => {
-                let rendered_path = path.render(subject);
+                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "!=" } else { "==" };
                 format!("len({rendered_path}) {operator} {length}")
             }
             Check::SliceLenGe { path, min_length } => {
-                let rendered_path = path.render(subject);
+                let rendered_path = path.render(subject).rendered();
                 let operator = if negative { "<" } else { ">=" };
                 format!("len({rendered_path}) {operator} {min_length}")
             }
@@ -248,7 +259,7 @@ impl Check {
             }
             Check::TypeAssert { path, go_type } if !negative => format!(
                 "func() bool {{ _, ok := {}.({}); return ok }}()",
-                path.render(subject),
+                path.render(subject).rendered(),
                 go_type,
             ),
             Check::Or { .. } | Check::TypeAssert { .. } => {

--- a/crates/emit/src/patterns/tree_emitter.rs
+++ b/crates/emit/src/patterns/tree_emitter.rs
@@ -594,7 +594,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
                 branches,
                 fallback,
             } => {
-                let rendered_path = path.render(self.subject.root());
+                let rendered_path = path.render(self.subject.root()).rendered();
                 let (cased, lifted) = split_with_default_lift(branches, fallback.as_deref());
                 for branch in cased {
                     self.record_subject_use();
@@ -648,11 +648,11 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             if binding.go_name.is_none() {
                 continue;
             }
-            let text = binding.path.render_composable(self.subject.root());
+            let composable = binding.path.render_composable(self.subject.root());
             self.planner.scope.bind_inline_expr(
                 &binding.lisette_name,
                 InlineExpr::new(
-                    text,
+                    composable,
                     vec![self.subject.var().to_string()],
                     binding.path.contains_deferred_evaluation(),
                 ),
@@ -739,7 +739,7 @@ impl<'a, 'e> TreePlanner<'a, 'e> {
             unreachable!("walk_switch requires a Switch decision");
         };
         let fallback = fallback.as_deref();
-        let rendered_path = path.render(self.subject.root());
+        let rendered_path = path.render(self.subject.root()).rendered();
         match shape {
             SwitchShape::TypeSwitch => {
                 self.record_subject_use();

--- a/crates/emit/src/plan/go_expression.rs
+++ b/crates/emit/src/plan/go_expression.rs
@@ -6,10 +6,23 @@ use crate::types::go_type::render_conversion;
 pub(crate) enum GoExpressionNode {
     Identifier(String),
     Literal(String),
-    CompositeLiteral(String),
+    /// A Go type in operand position, such as the element type of `make`.
+    Type(String),
+    CompositeLiteral {
+        /// `None` inside an enclosing literal that already names the element type.
+        go_type: Option<String>,
+        elements: Vec<CompositeElement>,
+        layout: CompositeLayout,
+    },
     Call {
         callee: Box<GoExpressionNode>,
         arguments: Vec<GoExpressionNode>,
+    },
+    /// A generic function or type with its type arguments, `f[T, U]`.
+    Instantiation {
+        base: Box<GoExpressionNode>,
+        /// Bracketed Go type list, `[T, U]`.
+        type_arguments: String,
     },
     Selector {
         base: Box<GoExpressionNode>,
@@ -25,10 +38,16 @@ pub(crate) enum GoExpressionNode {
         high: Option<Box<GoExpressionNode>>,
         max: Option<Box<GoExpressionNode>>,
     },
+    TypeAssertion {
+        base: Box<GoExpressionNode>,
+        go_type: String,
+    },
     Unary {
         operator: String,
         operand: Box<GoExpressionNode>,
     },
+    AddressOf(Box<GoExpressionNode>),
+    Dereference(Box<GoExpressionNode>),
     Binary {
         operator: String,
         left: Box<GoExpressionNode>,
@@ -40,8 +59,38 @@ pub(crate) enum GoExpressionNode {
         operand: Box<GoExpressionNode>,
     },
     Receive(Box<GoExpressionNode>),
+    /// A variadic argument, `values...`.
+    Spread(Box<GoExpressionNode>),
     /// Go text that is not yet a node.
     Raw(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompositeElement {
+    pub key: Option<String>,
+    pub value: GoExpressionNode,
+}
+
+/// The whitespace forms match the text the string emitters produced, because
+/// element widths feed the layout choice of an enclosing literal. `gofmt`
+/// erases the difference in the output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompositeLayout {
+    /// `{ a, b }`, or `{a, b}` when not padded.
+    Inline { padded: bool },
+    /// One element per line, each behind a tab when indented.
+    MultiLine { indented: bool },
+}
+
+impl CompositeLayout {
+    /// One element per line once several wide elements would crowd one line.
+    pub(crate) fn for_elements(count: usize, widest: usize) -> Self {
+        if count > 1 && widest > 30 {
+            Self::MultiLine { indented: true }
+        } else {
+            Self::Inline { padded: true }
+        }
+    }
 }
 
 impl GoExpressionNode {
@@ -54,10 +103,45 @@ impl GoExpressionNode {
 
     fn write(&self, output: &mut String) {
         match self {
-            Self::Identifier(text)
-            | Self::Literal(text)
-            | Self::CompositeLiteral(text)
-            | Self::Raw(text) => output.push_str(text),
+            Self::Identifier(text) | Self::Literal(text) | Self::Type(text) | Self::Raw(text) => {
+                output.push_str(text)
+            }
+            Self::CompositeLiteral {
+                go_type,
+                elements,
+                layout,
+            } => {
+                if let Some(go_type) = go_type {
+                    output.push_str(go_type);
+                }
+                match layout {
+                    _ if elements.is_empty() => output.push_str("{}"),
+                    CompositeLayout::Inline { padded } => {
+                        let padding = if *padded { " " } else { "" };
+                        output.push('{');
+                        output.push_str(padding);
+                        for (index, element) in elements.iter().enumerate() {
+                            if index > 0 {
+                                output.push_str(", ");
+                            }
+                            element.write(output);
+                        }
+                        output.push_str(padding);
+                        output.push('}');
+                    }
+                    CompositeLayout::MultiLine { indented } => {
+                        output.push_str("{\n");
+                        for element in elements {
+                            if *indented {
+                                output.push('\t');
+                            }
+                            element.write(output);
+                            output.push_str(",\n");
+                        }
+                        output.push('}');
+                    }
+                }
+            }
             Self::Call { callee, arguments } => {
                 callee.write(output);
                 output.push('(');
@@ -68,6 +152,13 @@ impl GoExpressionNode {
                     argument.write(output);
                 }
                 output.push(')');
+            }
+            Self::Instantiation {
+                base,
+                type_arguments,
+            } => {
+                base.write(output);
+                output.push_str(type_arguments);
             }
             Self::Selector { base, field } => {
                 base.write(output);
@@ -101,6 +192,12 @@ impl GoExpressionNode {
                 }
                 output.push(']');
             }
+            Self::TypeAssertion { base, go_type } => {
+                base.write(output);
+                output.push_str(".(");
+                output.push_str(go_type);
+                output.push(')');
+            }
             Self::Unary { operator, operand } => {
                 let operand = operand.print();
                 // Go reads `--x` as a decrement, so a negated negative keeps its parentheses.
@@ -112,6 +209,14 @@ impl GoExpressionNode {
                     output.push_str(operator);
                     output.push_str(&operand);
                 }
+            }
+            Self::AddressOf(operand) => {
+                output.push('&');
+                operand.write(output);
+            }
+            Self::Dereference(operand) => {
+                output.push('*');
+                operand.write(output);
             }
             Self::Binary {
                 operator,
@@ -136,6 +241,20 @@ impl GoExpressionNode {
                 output.push_str("<-");
                 channel.write(output);
             }
+            Self::Spread(operand) => {
+                operand.write(output);
+                output.push_str("...");
+            }
         }
+    }
+}
+
+impl CompositeElement {
+    fn write(&self, output: &mut String) {
+        if let Some(key) = &self.key {
+            output.push_str(key);
+            output.push_str(": ");
+        }
+        self.value.write(output);
     }
 }

--- a/crates/emit/src/plan/lower.rs
+++ b/crates/emit/src/plan/lower.rs
@@ -14,7 +14,7 @@ use crate::plan::bodies::{
     LoweredStatement, PlacePlan, directed,
 };
 use crate::plan::placement::{collapse_declared_temp, requires_temp_var, try_elide_tail_let};
-use crate::plan::values::{OperandForm, ValuePlan};
+use crate::plan::values::{GoExpression, OperandForm, ValuePlan};
 use crate::utils::wrap_if_struct_literal;
 use std::slice;
 use syntax::ast::{
@@ -434,7 +434,7 @@ impl Planner<'_> {
     pub(crate) fn lower_test_log_call(
         &mut self,
         expression: &Expression,
-    ) -> (Vec<LoweredStatement>, String) {
+    ) -> (Vec<LoweredStatement>, GoExpression) {
         let Expression::Call {
             expression: callee,
             args,
@@ -454,22 +454,24 @@ impl Planner<'_> {
         self.require_stdlib();
 
         let mut statements = Vec::new();
-        let (recv_setup, handle) = self
-            .lower_value(receiver, ExpressionContext::value())
-            .into_parts();
-        statements.extend(recv_setup);
-        let (arg_setup, value) = self
-            .lower_value(&args[0], ExpressionContext::value())
-            .into_parts();
-        statements.extend(arg_setup);
+        let handle = self.lower_value(receiver, ExpressionContext::value());
+        statements.extend(handle.setup);
+        let value = self.lower_value(&args[0], ExpressionContext::value());
+        statements.extend(value.setup);
 
         let prelude = prelude_qualifier();
         let span = args[0].get_span();
-        let call = format!(
-            "{handle}.Log({}, {}, {}, {prelude}.Debug({value}))",
-            span.file_id,
-            span.byte_offset,
-            span.byte_offset + span.byte_length,
+        let call = GoExpression::call(
+            GoExpression::selector(handle.expression, "Log".to_string()),
+            vec![
+                GoExpression::literal(span.file_id.to_string()),
+                GoExpression::literal(span.byte_offset.to_string()),
+                GoExpression::literal((span.byte_offset + span.byte_length).to_string()),
+                GoExpression::call(
+                    GoExpression::name(format!("{prelude}.Debug")),
+                    vec![value.expression],
+                ),
+            ],
         );
         (statements, call)
     }
@@ -972,15 +974,15 @@ impl Planner<'_> {
             }
             statements
         } else {
-            let (mut statements, expression_string) = self.lower_tail_value(last);
+            let (mut statements, expression) = self.lower_tail_value(last);
             let return_ctx = self.return_ctx();
             let mut coercion = String::new();
-            let expression_string =
-                self.apply_type_coercion(&mut coercion, return_ctx.ty(), last, expression_string);
+            let expression =
+                self.apply_type_coercion(&mut coercion, return_ctx.ty(), last, expression);
             if !coercion.is_empty() {
                 statements.push(LoweredStatement::RawGo(coercion));
             }
-            statements.push(plain_return(expression_string));
+            statements.push(plain_return(expression.rendered()));
             statements
         }
     }

--- a/crates/emit/src/plan/placement.rs
+++ b/crates/emit/src/plan/placement.rs
@@ -358,7 +358,11 @@ impl Planner<'_> {
         }
         statements.push(simple_assign(
             var,
-            ValuePlan::opaque("struct{}{}".to_string()),
+            ValuePlan::computed(
+                Vec::new(),
+                GoExpression::empty_composite("struct{}".to_string()),
+                EvaluationEffect::Pure,
+            ),
         ));
         statements
     }
@@ -451,42 +455,47 @@ impl Planner<'_> {
                     }
                 };
                 if let Some(constructor_arg) = constructor_arg {
-                    let (arg_setup, call_str, argument_effect) = {
+                    let (arg_setup, call, argument_effect) = {
                         let mut fe = FalliblePlanner::new(self, &fallible);
                         let argument = fe
                             .planner
                             .lower_composite_value(constructor_arg, ExpressionContext::value());
                         let argument_effect = argument.evaluation.effect;
-                        let (arg_setup, arg) = argument.into_parts();
                         (
-                            arg_setup,
-                            fe.format_constructor_call(constructor_name, Some(&arg)),
+                            argument.setup,
+                            fe.format_constructor_call(constructor_name, Some(argument.expression)),
                             argument_effect,
                         )
                     };
                     let value = ValuePlan::plain_call(
                         arg_setup,
-                        GoExpression::opaque_with_deferred_evaluation(call_str, true),
+                        call,
                         EvaluationEffect::PureCall.combine(argument_effect),
                     );
                     vec![simple_assign(target_var, value)]
                 } else {
-                    let call_str = {
+                    let call = {
                         let mut fe = FalliblePlanner::new(self, &fallible);
                         fe.format_constructor_call(constructor_name, None)
                     };
-                    vec![simple_assign(target_var, ValuePlan::opaque(call_str))]
+                    vec![simple_assign(
+                        target_var,
+                        ValuePlan::computed(Vec::new(), call, EvaluationEffect::Pure),
+                    )]
                 }
             }
             Expression::Identifier { .. } => {
                 if fallible.classify_constructor(actual_expression)
                     == Some(ConstructorKind::Failure)
                 {
-                    let call_str = {
+                    let call = {
                         let mut fe = FalliblePlanner::new(self, &fallible);
                         fe.format_constructor_call(fallible.err_constructor(), None)
                     };
-                    vec![simple_assign(target_var, ValuePlan::opaque(call_str))]
+                    vec![simple_assign(
+                        target_var,
+                        ValuePlan::computed(Vec::new(), call, EvaluationEffect::Pure),
+                    )]
                 } else {
                     self.lower_plain_assign(target_var, expression)
                 }
@@ -590,24 +599,16 @@ impl Planner<'_> {
             return self.lower_branching_to_block(last, &place).statements;
         }
         let value = self.lower_value(last, ExpressionContext::value());
-        let value = value.map_rendered_as_computed(
-            |setup, expression_string, contains_deferred_evaluation| {
-                let mut coercion_buffer = String::new();
-                let expression_string = self.apply_type_coercion(
-                    &mut coercion_buffer,
-                    target_ty,
-                    last,
-                    expression_string,
-                );
-                if !coercion_buffer.is_empty() {
-                    setup.push(LoweredStatement::RawGo(coercion_buffer));
-                }
-                GoExpression::opaque_with_deferred_evaluation(
-                    expression_string,
-                    contains_deferred_evaluation,
-                )
-            },
-        );
+        let value = value.map_expression_as_computed(|setup, expression| {
+            let contains_deferred_evaluation = expression.contains_deferred_evaluation();
+            let mut coercion_buffer = String::new();
+            let expression =
+                self.apply_type_coercion(&mut coercion_buffer, target_ty, last, expression);
+            if !coercion_buffer.is_empty() {
+                setup.push(LoweredStatement::RawGo(coercion_buffer));
+            }
+            expression.with_deferred_evaluation(contains_deferred_evaluation)
+        });
         vec![simple_assign(var, value)]
     }
 
@@ -633,40 +634,44 @@ impl Planner<'_> {
             is_lvalue_chain(unwrapped) && !self.contains_newtype_access(unwrapped);
 
         let (value, mut statements) = if receiver_is_lvalue {
-            let arguments = self.lower_growth_args(func, args, spread.as_deref());
+            let (arguments, ordering) = self.lower_growth_args(func, args, spread.as_deref());
             let mut capture: Vec<LoweredStatement> = Vec::new();
             let receiver_lv =
-                self.emit_left_value_capturing(&mut capture, unwrapped, Some(&arguments));
-            let (args_setup, args_str) = arguments.into_parts();
-            let grows = !args_str.is_empty();
-            let receiver_lv = if grows && receiver_lv != var {
-                let clippable = if is_clip_safe_path(&receiver_lv) && args_setup.is_empty() {
+                self.emit_left_value_capturing(&mut capture, unwrapped, Some(&ordering));
+            let grows = !arguments.is_empty();
+            let receiver = if grows && receiver_lv != var {
+                let clippable = if is_clip_safe_path(&receiver_lv) && ordering.setup.is_empty() {
                     receiver_lv
                 } else {
                     self.hoist_tmp_value_statement(&mut capture, "recv", &receiver_lv)
                 };
-                clip_shared_capacity(&clippable)
+                clip_shared_capacity(GoExpression::opaque(clippable))
             } else {
-                receiver_lv
+                GoExpression::opaque(receiver_lv)
             };
-            capture.extend(args_setup);
+            capture.extend(ordering.setup);
             let value = if method == "reserve" {
                 self.require_slices();
-                format!("slices.Grow({}, {})", receiver_lv, args_str)
-            } else if args_str.is_empty() {
-                receiver_lv
+                let mut all = vec![receiver];
+                all.extend(arguments);
+                GoExpression::call(GoExpression::name("slices.Grow".to_string()), all)
+            } else if arguments.is_empty() {
+                receiver
             } else {
-                format!("append({}, {})", receiver_lv, args_str)
+                let mut all = vec![receiver];
+                all.extend(arguments);
+                GoExpression::call(GoExpression::name("append".to_string()), all)
             };
             (value, capture)
         } else {
-            let (setup, value) = self
-                .lower_value(last, ExpressionContext::value())
-                .into_parts();
-            (value, setup)
+            let plan = self.lower_value(last, ExpressionContext::value());
+            (plan.expression, plan.setup)
         };
 
-        statements.push(simple_assign(var, ValuePlan::opaque(value)));
+        statements.push(simple_assign(
+            var,
+            ValuePlan::computed(Vec::new(), value, EvaluationEffect::Pure),
+        ));
         Some(statements)
     }
 
@@ -682,12 +687,14 @@ impl Planner<'_> {
         None
     }
 
+    /// The growth arguments, plus their setup and effect as the plan the
+    /// receiver capture orders itself against.
     fn lower_growth_args(
         &mut self,
         function: &Expression,
         args: &[Expression],
         spread: Option<&Expression>,
-    ) -> ValuePlan {
+    ) -> (Vec<GoExpression>, ValuePlan) {
         let stages: Vec<ValuePlan> = args
             .iter()
             .map(|a| self.lower_composite_value(a, ExpressionContext::value()))
@@ -703,17 +710,9 @@ impl Planner<'_> {
                 boundary: CaptureBoundary::SiblingSequence,
             },
         );
-        let effect = sequenced.effect;
-        let contains_deferred_evaluation = sequenced.contains_deferred_evaluation();
-        let (setup, emitted_args) = sequenced.into_rendered();
-        ValuePlan::computed(
-            setup,
-            GoExpression::opaque_with_deferred_evaluation(
-                emitted_args.join(", "),
-                contains_deferred_evaluation,
-            ),
-            effect,
-        )
+        let ordering =
+            ValuePlan::computed(sequenced.setup, GoExpression::empty(), sequenced.effect);
+        (sequenced.values, ordering)
     }
 
     /// Lower `last` as a tail value. Tuple literals widen slot types to the
@@ -721,14 +720,13 @@ impl Planner<'_> {
     pub(crate) fn lower_tail_value(
         &mut self,
         last: &Expression,
-    ) -> (Vec<LoweredStatement>, String) {
-        if let Expression::Tuple { elements, ty, .. } = last {
-            let plan = self.plan_tuple_value(elements, ty, true);
-            plan.into_parts()
+    ) -> (Vec<LoweredStatement>, GoExpression) {
+        let plan = if let Expression::Tuple { elements, ty, .. } = last {
+            self.plan_tuple_value(elements, ty, true)
         } else {
             self.lower_value(last, ExpressionContext::value())
-                .into_parts()
-        }
+        };
+        (plan.setup, plan.expression)
     }
 
     pub(crate) fn lower_to_operand_temp(
@@ -744,7 +742,7 @@ impl Planner<'_> {
             {
                 return ValuePlan::computed(
                     self.lower_block_as_body(expression).statements,
-                    GoExpression::opaque(String::new()),
+                    GoExpression::empty(),
                     EvaluationEffect::Pure,
                 );
             }

--- a/crates/emit/src/plan/values.rs
+++ b/crates/emit/src/plan/values.rs
@@ -2,7 +2,7 @@ use crate::Planner;
 use crate::context::expression::ExpressionContext;
 use crate::names::go_name;
 use crate::plan::bodies::LoweredStatement;
-use crate::plan::go_expression::GoExpressionNode;
+use crate::plan::go_expression::{CompositeElement, CompositeLayout, GoExpressionNode};
 use std::fmt::{self, Display, Formatter};
 use syntax::ast::Expression;
 use syntax::types::SimpleKind;
@@ -126,6 +126,11 @@ impl GoExpression {
         Self::opaque_with_deferred_evaluation(rendered, false)
     }
 
+    /// The value of a lowering that produced only statements.
+    pub(crate) fn empty() -> Self {
+        Self::opaque(String::new())
+    }
+
     pub(crate) fn opaque_with_deferred_evaluation(
         rendered: String,
         contains_deferred_evaluation: bool,
@@ -144,6 +149,124 @@ impl GoExpression {
             false,
             false,
             OperandForm::Literal,
+        )
+    }
+
+    pub(crate) fn type_name(go_type: String) -> Self {
+        Self::new(
+            GoExpressionNode::Type(go_type),
+            false,
+            false,
+            OperandForm::Other,
+        )
+    }
+
+    pub(crate) fn composite(
+        go_type: Option<String>,
+        elements: Vec<(Option<String>, GoExpression)>,
+        layout: CompositeLayout,
+        contains_deferred_evaluation: bool,
+    ) -> Self {
+        let node = GoExpressionNode::CompositeLiteral {
+            go_type,
+            elements: elements
+                .into_iter()
+                .map(|(key, value)| CompositeElement {
+                    key,
+                    value: value.node,
+                })
+                .collect(),
+            layout,
+        };
+        Self::new(
+            node,
+            contains_deferred_evaluation,
+            true,
+            OperandForm::Literal,
+        )
+    }
+
+    /// `T{}` with no elements.
+    pub(crate) fn empty_composite(go_type: String) -> Self {
+        Self::composite(
+            Some(go_type),
+            Vec::new(),
+            CompositeLayout::Inline { padded: true },
+            false,
+        )
+    }
+
+    /// The callee without its type arguments, for a call site that re-instantiates.
+    pub(crate) fn without_instantiation(self) -> Self {
+        match self.node {
+            GoExpressionNode::Instantiation { base, .. } => Self::new(
+                *base,
+                self.contains_deferred_evaluation,
+                self.composite_literal,
+                self.syntax_form,
+            ),
+            _ => self,
+        }
+    }
+
+    /// Drop the type of a composite literal nested in a literal of `element_type`.
+    pub(crate) fn elide_composite_type(mut self, element_type: &str) -> Self {
+        if let GoExpressionNode::CompositeLiteral { go_type, .. } = &mut self.node
+            && go_type.as_deref() == Some(element_type)
+        {
+            *go_type = None;
+            self.rendered = self.node.print();
+        }
+        self
+    }
+
+    pub(crate) fn instantiation(base: GoExpression, type_arguments: String) -> Self {
+        if type_arguments.is_empty() {
+            return base;
+        }
+        let deferred = base.contains_deferred_evaluation();
+        let node = GoExpressionNode::Instantiation {
+            base: Box::new(base.node),
+            type_arguments,
+        };
+        Self::new(node, deferred, false, base.syntax_form)
+    }
+
+    pub(crate) fn type_assertion(base: GoExpression, go_type: String) -> Self {
+        let node = GoExpressionNode::TypeAssertion {
+            base: Box::new(base.node),
+            go_type,
+        };
+        Self::new(node, true, false, OperandForm::Other)
+    }
+
+    pub(crate) fn address_of(operand: GoExpression) -> Self {
+        let deferred = operand.contains_deferred_evaluation();
+        Self::new(
+            GoExpressionNode::AddressOf(Box::new(operand.node)),
+            deferred,
+            false,
+            OperandForm::Other,
+        )
+    }
+
+    pub(crate) fn dereference(operand: GoExpression) -> Self {
+        let deferred = operand.contains_deferred_evaluation();
+        Self::new(
+            GoExpressionNode::Dereference(Box::new(operand.node)),
+            deferred,
+            false,
+            OperandForm::Other,
+        )
+    }
+
+    pub(crate) fn spread(operand: GoExpression) -> Self {
+        let deferred = operand.contains_deferred_evaluation();
+        Self::new(
+            GoExpressionNode::Spread(Box::new(operand.node)),
+            deferred,
+            false,
+            OperandForm::Other,
         )
     }
 
@@ -209,7 +332,7 @@ impl GoExpression {
         Self::new(node, true, false, OperandForm::Other)
     }
 
-    fn parenthesized(value: GoExpression) -> Self {
+    pub(crate) fn parenthesized(value: GoExpression) -> Self {
         let constant = value.constant;
         Self::new(
             GoExpressionNode::Parenthesized(Box::new(value.node)),
@@ -220,7 +343,7 @@ impl GoExpression {
         .with_constant(constant)
     }
 
-    fn unary(operator: &str, value: GoExpression) -> Self {
+    pub(crate) fn unary(operator: &str, value: GoExpression) -> Self {
         let deferred = value.contains_deferred_evaluation();
         let constant = unary_constant(operator, value.constant);
         let node = GoExpressionNode::Unary {
@@ -252,13 +375,19 @@ impl GoExpression {
         Self::new(node, deferred, false, OperandForm::Other)
     }
 
-    pub(crate) fn composite_literal(rendered: String, contains_deferred_evaluation: bool) -> Self {
-        Self::new(
-            GoExpressionNode::CompositeLiteral(rendered),
-            contains_deferred_evaluation,
-            true,
-            OperandForm::Literal,
-        )
+    /// Lift a subtree taken out of another expression. The parent supplies the facts.
+    pub(crate) fn from_node(node: GoExpressionNode) -> Self {
+        Self::new(node, false, false, OperandForm::Other)
+    }
+
+    /// Override the derived flag where a lowering path computes it itself.
+    pub(crate) fn with_deferred_evaluation(mut self, contains_deferred_evaluation: bool) -> Self {
+        self.contains_deferred_evaluation = contains_deferred_evaluation;
+        self
+    }
+
+    pub(crate) fn node(&self) -> &GoExpressionNode {
+        &self.node
     }
 
     pub(crate) fn rendered(&self) -> String {
@@ -281,7 +410,7 @@ impl GoExpression {
         self.syntax_form
     }
 
-    fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.rendered.is_empty()
     }
 
@@ -543,47 +672,42 @@ impl ValuePlan {
         )
     }
 
-    pub(crate) fn map_rendered(
+    pub(crate) fn map_expression(
         self,
-        transform: impl FnOnce(&mut Vec<LoweredStatement>, String, bool) -> GoExpression,
+        transform: impl FnOnce(&mut Vec<LoweredStatement>, GoExpression) -> GoExpression,
     ) -> Self {
-        let contains_deferred_evaluation = self.expression.contains_deferred_evaluation();
         let Self {
             mut setup,
             expression,
             evaluation,
         } = self;
-        let expression = transform(
-            &mut setup,
-            expression.rendered(),
-            contains_deferred_evaluation,
-        );
+        let expression = transform(&mut setup, expression);
         Self::from_facts(setup, expression, evaluation)
     }
 
-    pub(crate) fn map_rendered_as_computed(
+    pub(crate) fn map_expression_as_computed(
         self,
-        transform: impl FnOnce(&mut Vec<LoweredStatement>, String, bool) -> GoExpression,
+        transform: impl FnOnce(&mut Vec<LoweredStatement>, GoExpression) -> GoExpression,
     ) -> Self {
-        let mut plan = self.map_rendered(transform);
+        let mut plan = self.map_expression(transform);
         plan.evaluation.form = OperandForm::Other;
         plan
     }
 
-    pub(crate) fn map_rendered_as_name(
+    pub(crate) fn map_expression_as_name(
         self,
-        transform: impl FnOnce(&mut Vec<LoweredStatement>, String, bool) -> GoExpression,
+        transform: impl FnOnce(&mut Vec<LoweredStatement>, GoExpression) -> GoExpression,
     ) -> Self {
-        let mut plan = self.map_rendered(transform);
+        let mut plan = self.map_expression(transform);
         plan.evaluation.form = OperandForm::Name;
         plan
     }
 
-    pub(crate) fn map_rendered_as_observable_computed(
+    pub(crate) fn map_expression_as_observable_computed(
         self,
-        transform: impl FnOnce(&mut Vec<LoweredStatement>, String, bool) -> GoExpression,
+        transform: impl FnOnce(&mut Vec<LoweredStatement>, GoExpression) -> GoExpression,
     ) -> Self {
-        let mut plan = self.map_rendered_as_computed(transform);
+        let mut plan = self.map_expression_as_computed(transform);
         plan.make_observable();
         plan
     }
@@ -697,11 +821,7 @@ impl Planner<'_> {
     ) -> ValuePlan {
         if self.is_test_log_call(expression) {
             let (setup, call) = self.lower_test_log_call(expression);
-            return ValuePlan::plain_call(
-                setup,
-                GoExpression::opaque_with_deferred_evaluation(call, true),
-                EvaluationEffect::EffectfulCall,
-            );
+            return ValuePlan::plain_call(setup, call, EvaluationEffect::EffectfulCall);
         }
         match expression {
             Expression::Paren { expression, .. } if self.is_conversion_cast(expression) => {
@@ -756,7 +876,7 @@ impl Planner<'_> {
             Expression::RecoverBlock { items, ty, .. } => self.lower_recover_block(items, ty),
             Expression::Propagate { expression, .. } => {
                 let (setup, value) = self.lower_propagate(expression, None);
-                ValuePlan::computed(setup, GoExpression::opaque(value), EvaluationEffect::Pure)
+                ValuePlan::computed(setup, value, EvaluationEffect::Pure)
             }
             Expression::If { ty, .. } => self.plan_branching_as_operand_temp(expression, ty),
             Expression::Loop { ty, .. } => self.plan_loop_as_operand_temp(expression, ty),

--- a/crates/emit/src/state/bindings.rs
+++ b/crates/emit/src/state/bindings.rs
@@ -1,34 +1,30 @@
+use crate::plan::values::GoExpression;
+
 #[derive(Clone, Debug)]
 pub(crate) struct InlineExpr {
-    text: String,
-    /// Emitter vars the text references, recorded as uses on substitution.
+    expression: GoExpression,
+    /// Emitter vars the expression references, recorded as uses on substitution.
     refs: Vec<String>,
-    contains_deferred_evaluation: bool,
 }
 
 impl InlineExpr {
     pub(crate) fn new(
-        text: impl Into<String>,
+        expression: GoExpression,
         refs: Vec<String>,
         contains_deferred_evaluation: bool,
     ) -> Self {
         Self {
-            text: text.into(),
+            expression: expression.with_deferred_evaluation(contains_deferred_evaluation),
             refs,
-            contains_deferred_evaluation,
         }
     }
 
-    pub(crate) fn as_str(&self) -> &str {
-        &self.text
+    pub(crate) fn expression(&self) -> &GoExpression {
+        &self.expression
     }
 
     pub(crate) fn refs(&self) -> &[String] {
         &self.refs
-    }
-
-    pub(crate) fn contains_deferred_evaluation(&self) -> bool {
-        self.contains_deferred_evaluation
     }
 }
 

--- a/crates/emit/src/state/scope.rs
+++ b/crates/emit/src/state/scope.rs
@@ -395,6 +395,11 @@ fn pop_keep_base<T>(stack: &mut Vec<T>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plan::values::GoExpression;
+
+    fn pair_first() -> GoExpression {
+        GoExpression::selector(GoExpression::name("pair".to_string()), "F0".to_string())
+    }
 
     #[test]
     fn exiting_block_restores_shadowed_binding() {
@@ -424,7 +429,7 @@ mod tests {
         scope.push_binding_frame();
         scope.bind_inline_expr(
             "value",
-            InlineExpr::new("pair.F0", vec!["pair".into()], false),
+            InlineExpr::new(pair_first(), vec!["pair".into()], false),
         );
         scope.enter_block();
         scope.bind("value", "inner");
@@ -432,7 +437,7 @@ mod tests {
         scope.exit_block();
         assert!(matches!(
             scope.resolve_identifier_binding("value"),
-            Some(BindingValue::InlineExpr(expr)) if expr.as_str() == "pair.F0"
+            Some(BindingValue::InlineExpr(expr)) if expr.expression().as_str() == "pair.F0"
         ));
         scope.pop_binding_frame();
         assert!(matches!(
@@ -465,7 +470,7 @@ mod tests {
         scope.enter_block();
         scope.bind("first", "inner");
         assert!(scope.has_binding_for_go_name("shared"));
-        scope.bind_inline_expr("second", InlineExpr::new("pair.F0", vec![], false));
+        scope.bind_inline_expr("second", InlineExpr::new(pair_first(), vec![], false));
         assert!(!scope.has_binding_for_go_name("shared"));
         scope.exit_block();
         assert!(scope.has_binding_for_go_name("shared"));

--- a/crates/emit/src/statements/assignments.rs
+++ b/crates/emit/src/statements/assignments.rs
@@ -76,16 +76,12 @@ impl Planner<'_> {
         } else {
             self.value_slot_coercion(value, &target.get_type())
         };
-        let value = right_hand_side.map_rendered_as_computed(
-            |value_setup, rhs_value, contains_deferred_evaluation| {
-                let (coercion_setup, final_value) = coercion.lower(self, rhs_value);
-                value_setup.extend(coercion_setup);
-                GoExpression::opaque_with_deferred_evaluation(
-                    final_value,
-                    contains_deferred_evaluation,
-                )
-            },
-        );
+        let value = right_hand_side.map_expression_as_computed(|value_setup, rhs_value| {
+            let contains_deferred_evaluation = rhs_value.contains_deferred_evaluation();
+            let (coercion_setup, final_value) = coercion.lower(self, rhs_value);
+            value_setup.extend(coercion_setup);
+            final_value.with_deferred_evaluation(contains_deferred_evaluation)
+        });
         LoweredStatement::Assign(AssignForm::Simple {
             target_capture,
             target_str,
@@ -133,18 +129,15 @@ impl Planner<'_> {
         });
         let parenthesize_rhs =
             pinned_left.is_some() && matches!(rhs.unwrap_parens(), Expression::Binary { .. });
-        let mut right_hand_side =
-            right_hand_side.map_rendered(|_, staged_value, contains_deferred_evaluation| {
-                let rhs_value = if parenthesize_rhs {
-                    format!("({})", staged_value)
-                } else {
-                    staged_value
-                };
-                GoExpression::opaque_with_deferred_evaluation(
-                    rhs_value,
-                    contains_deferred_evaluation,
-                )
-            });
+        let mut right_hand_side = right_hand_side.map_expression(|_, staged_value| {
+            if parenthesize_rhs {
+                let contains_deferred_evaluation = staged_value.contains_deferred_evaluation();
+                GoExpression::parenthesized(staged_value)
+                    .with_deferred_evaluation(contains_deferred_evaluation)
+            } else {
+                staged_value
+            }
+        });
         if parenthesize_rhs {
             right_hand_side.make_observable_computed();
         }

--- a/crates/emit/src/statements/let_binding.rs
+++ b/crates/emit/src/statements/let_binding.rs
@@ -234,11 +234,12 @@ impl Planner<'_> {
             ExpressionContext::value().with_function_slot_origin(origin),
         );
         let constant = plan.expression.constant_kind();
-        let (mut statements, value_expression) = plan.into_parts();
+        let mut statements = plan.setup;
         let coercion = self.value_slot_coercion(value, binding_ty);
         let constant_needs_type =
             coercion.is_identity() && self.constant_needs_go_type(constant, binding_ty).is_some();
-        let (coercion_setup, value_expression) = coercion.lower(self, value_expression);
+        let (coercion_setup, value_expression) = coercion.lower(self, plan.expression);
+        let value_expression = value_expression.rendered();
         statements.extend(coercion_setup);
 
         let bound = self.scope.bind(identifier, raw_go_name);


### PR DESCRIPTION
Expression producers in `emit` now build `GoExpressionNode` trees (calls, selectors, composite literals, conversions, instantiations, spreads) instead of putting together Go text, so that later passes can inspect and rewrite Go expressions by node shape, instead of by parsing emitted strings.

Follow-up to #1430